### PR TITLE
chore: add openssl as prerequisite

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Wing Programming Language reference implementation.
 - [Rust](https://rustup.rs/)
 - [node.js](https://nodejs.org)
 - [CMake](https://cmake.org/)
+- [openssl](https://www.openssl.org/)
 
 You also need to `npm login` into `@monadahq`.
 


### PR DESCRIPTION
Not sure if this applies to other platforms, but I needed to install openssl in order to get wingrt to build on my Mac while following the instructions in the README.