### PR TITLE
chore: add proposed Wing example - deny-list.w

### DIFF
--- a/corpus/proposed/deny-list.w
+++ b/corpus/proposed/deny-list.w
@@ -41,7 +41,7 @@ resource DenyList {
   }
 
   ~ lookup(name: str, version: str): DenyListRule? {
-    return this._rules.get(name) ?? this.rules.get("${name}/v${version}")];
+    return this._rules.get(name) ?? this.rules.get("${name}/v${version}");
   }
 
   ~ add_rule(rule: DenyListRule) {


### PR DESCRIPTION
This PR adds a proposed code example to the corpus, based on wingified-construct-hub. I thought this example could be interesting since it includes a resource with its own client. We can probably do something similar with the [image extractor](https://github.com/monadahq/rfcs/blob/demo-v0.1/docs/product/demo-v0.1.md) app for our MVP.

If anything in the example looks out of sync with the language spec, feel free to suggest fixes!