### PR TITLE
fix: minor tweaks for wingc and vscode extension

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,7 +9,10 @@
             "name": "Debug Extension",
             "type": "extensionHost",
             "request": "launch",
-            "outFiles": ["${workspaceFolder}/lib/**/*.js"],
+            "outFiles": ["${workspaceFolder}/wing-analyzer/vscode-extension/lib/**/*.js"],
+            "env": {
+              "SERVER_PATH": "${workspaceRoot}/wing-analyzer/language-server/target/debug/wing-language-server"
+            },
             "args": [
                 "--disable-extensions", "--extensionDevelopmentPath=${workspaceFolder}/wing-analyzer/vscode-extension"
             ]

--- a/wing-analyzer/vscode-extension/package.json
+++ b/wing-analyzer/vscode-extension/package.json
@@ -11,12 +11,16 @@
     "url": "https://github.com/monadahq/winglang.git"
   },
   "scripts": {
-    "bundle": "esbuild ./src/extension.ts --outfile=lib/extension.js --external:node-gyp --external:vscode --format=cjs --platform=node --bundle",
+    "bundle": "esbuild ./src/extension.ts --outfile=lib/index.js --external:node-gyp --external:vscode --format=cjs --platform=node --bundle",
     "package": "vsce package -o wing.vsix"
   },
   "categories": [
     "Programming Languages"
   ],
+  "activationEvents": [
+    "onLanguage:wing"
+  ],
+  "main": "lib/index.js",
   "contributes": {
     "languages": [
       {

--- a/wingc/Cargo.toml
+++ b/wingc/Cargo.toml
@@ -17,5 +17,5 @@ base16ct = { version = "0.1", features = ["alloc"] }
 tree-sitter-winglang = { path = "./grammar" }
 
 [lib]
-crate-type = ["staticlib"]
+crate-type = ["staticlib", "rlib"]
 bench = false


### PR DESCRIPTION
Some small changes that came up while working on other bigger changes

- avoids a few more panics in wingc
- fixes the launch.json for the extension, if you need to run the language server
- Adds the actual activation config for the vscode extension
- exposes wingc as a rust lib