### PR TITLE
fix: Add build/publish for vscode extension

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,8 +31,7 @@ jobs:
         working-directory: wing-analyzer/vscode-extension
         run: npm run package
       - name: Upload extension
-        # TODO Always running rn, just for testing
-        # if: ${{ github.ref == 'refs/heads/main' }}
+        if: ${{ github.ref == 'refs/heads/main' }}
         uses: actions/upload-artifact@v2
         with:
           name: vscode-wing.vsix
@@ -136,10 +135,12 @@ jobs:
         run: |
           mkdir dist
           mv ./*/*.tgz ./dist
+          mv ./*/*.vsix ./dist
           cd dist
           echo '## SHA-1 Checksums' > ../checksums.md
           echo '```' >> ../checksums.md
           sha1sum --binary *.tgz >> ../checksums.md
+          sha1sum --binary *.vsix >> ../checksums.md
           echo '```' >> ../checksums.md
 
       - name: Cut Development Release
@@ -148,7 +149,9 @@ jobs:
           tag_name: development
           body_path: checksums.md
           prerelease: true
-          files: dist/*.tgz
+          files: |
+            dist/*.tgz
+            dist/*.vsix
 
   wrapper:
     needs:


### PR DESCRIPTION
Just creates a vsix and adds it to the release. Added it to the checksums list cause why not :)

Soon the language server will also be included here, which depends directly on wingc.