### PR TITLE
chore: add debug information to release builds

### DIFF
--- a/wingc/Cargo.toml
+++ b/wingc/Cargo.toml
@@ -16,6 +16,9 @@ sha2 = "0.10"
 base16ct = { version = "0.1", features = ["alloc"] }
 tree-sitter-winglang = { path = "./grammar" }
 
+[profile.release]
+debug = true
+
 [lib]
 crate-type = ["staticlib", "rlib"]
 bench = false


### PR DESCRIPTION
When I was debugging with Yoav earlier today we noticed that we could not use dbg! macros since they get omitted from the release build in Rust. However, we can't use the regular build because wingrt does not link to it. To fix this, the PR includes debug information in the release version.