### PR TITLE
chore: vscode extension tweaks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,10 +24,7 @@ jobs:
         uses: bahmutov/npm-install@v1
         with:
           working-directory: wing-analyzer/vscode-extension
-      - name: Bundle
-        working-directory: wing-analyzer/vscode-extension
-        run: npm run bundle
-      - name: Package
+      - name: Create VSIX
         working-directory: wing-analyzer/vscode-extension
         run: npm run package
       - name: Upload extension
@@ -35,7 +32,7 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: vscode-wing.vsix
-          path: wing-analyzer/vscode-extension/wing.vsix
+          path: wing-analyzer/vscode-extension/vscode-wing.vsix
   build-native:
     strategy:
       fail-fast: false
@@ -139,8 +136,7 @@ jobs:
           cd dist
           echo '## SHA-1 Checksums' > ../checksums.md
           echo '```' >> ../checksums.md
-          sha1sum --binary *.tgz >> ../checksums.md
-          sha1sum --binary *.vsix >> ../checksums.md
+          sha1sum --binary * >> ../checksums.md
           echo '```' >> ../checksums.md
 
       - name: Cut Development Release
@@ -149,9 +145,8 @@ jobs:
           tag_name: development
           body_path: checksums.md
           prerelease: true
-          files: |
-            dist/*.tgz
-            dist/*.vsix
+          files: dist/*
+          
 
   wrapper:
     needs:

--- a/README.md
+++ b/README.md
@@ -88,6 +88,10 @@ repository and released as a private npm module called
 The `wing` folder in this repository has a `package.json` file that simply takes
 a dependency on the SDK package, so running `npm install` will bring it over.
 
+## VSCode Language Support
+
+The extension located in [wing-analyzer/vscode-extension](wing-analyzer/vscode-extension). An [installable](https://code.visualstudio.com/docs/editor/extension-marketplace#_install-from-a-vsix) VSIX is published on every push to main and is available in the [artifacts](https://github.com/monadahq/winglang/releases/download/development/vscode-wing.vsix) on the release page.
+
 ### Local SDK Development
 
 If you wish to develop the SDK alongside the compiler, simply clone the SDK

--- a/wing-analyzer/vscode-extension/.vscodeignore
+++ b/wing-analyzer/vscode-extension/.vscodeignore
@@ -1,3 +1,6 @@
-.vscode/**
-.vscode-test/**
+.vscode/
+.vscode-test/
+src/
+*.vsix
 .gitignore
+node_modules/

--- a/wing-analyzer/vscode-extension/LICENSE
+++ b/wing-analyzer/vscode-extension/LICENSE
@@ -1,0 +1,1 @@
+You can't have this.

--- a/wing-analyzer/vscode-extension/README.md
+++ b/wing-analyzer/vscode-extension/README.md
@@ -16,5 +16,5 @@ Use the included launch configuration to debug the extension.
 npm run package
 ```
 
-Create a `wing.vsix` file in the root that can be installed into VSCode.
+Creates a `wing.vsix` file in the root. [This can be installed manually in VSCode.](https://code.visualstudio.com/docs/editor/extension-marketplace#_install-from-a-vsix)
 

--- a/wing-analyzer/vscode-extension/package.json
+++ b/wing-analyzer/vscode-extension/package.json
@@ -11,8 +11,8 @@
     "url": "https://github.com/monadahq/winglang.git"
   },
   "scripts": {
-    "bundle": "esbuild ./src/extension.ts --outfile=lib/index.js --external:node-gyp --external:vscode --format=cjs --platform=node --bundle",
-    "package": "vsce package -o wing.vsix"
+    "bundle": "esbuild src/extension.ts --outfile=lib/index.js --external:node-gyp --external:vscode --format=cjs --platform=node --bundle",
+    "package": "npm run bundle && vsce package -o wing.vsix"
   },
   "categories": [
     "Programming Languages"
@@ -20,7 +20,9 @@
   "activationEvents": [
     "onLanguage:wing"
   ],
+  "publisher": "Monada",
   "main": "lib/index.js",
+  "icon": "resources/logo.png",
   "contributes": {
     "languages": [
       {

--- a/wing-analyzer/vscode-extension/src/extension.ts
+++ b/wing-analyzer/vscode-extension/src/extension.ts
@@ -1,1 +1,6 @@
-// nothing to see here
+import { ExtensionContext } from 'vscode';
+
+// activate extension
+export function activate(context: ExtensionContext) {
+    // TODO activate language server
+}


### PR DESCRIPTION
- Add dummy file for extension.ts
- Ensure minimal size for extension with vscodeignore
- Add publisher and logo for extension
- Improve readme with link to download/install extension
- Add dummy license to avoid warning during publish