### PR TITLE
fix: add closures to grammar (only)

### DIFF
--- a/wingc/grammar/grammar.js
+++ b/wingc/grammar/grammar.js
@@ -155,9 +155,9 @@ module.exports = grammar({
         $.reference,
         $.function_call,
         $.method_call,
-        $.preflight_anonymous_closure,
-        $.inflight_anonymous_closure,
-        $.pure_anonymous_closure,
+        $.preflight_closure,
+        $.inflight_closure,
+        $.pure_closure,
         $.parenthesized_expression
       ),
 
@@ -346,9 +346,9 @@ module.exports = grammar({
       );
     },
 
-    preflight_anonymous_closure: ($) => anonymousClosure($, "->"),
-    inflight_anonymous_closure: ($) => anonymousClosure($, "~>"),
-    pure_anonymous_closure: ($) => anonymousClosure($, "=>"),
+    preflight_closure: ($) => anonymousClosure($, "->"),
+    inflight_closure: ($) => anonymousClosure($, "~>"),
+    pure_closure: ($) => anonymousClosure($, "=>"),
 
     parenthesized_expression: ($) => seq("(", $.expression, ")"),
   },

--- a/wingc/grammar/test/corpus/expressions.txt
+++ b/wingc/grammar/test/corpus/expressions.txt
@@ -153,7 +153,7 @@ preflight anonymous closure
 
 (source
     (expression_statement
-        (preflight_anonymous_closure
+        (preflight_closure
             (parameter_list
                 (parameter_definition
                     (identifier)
@@ -181,7 +181,7 @@ inflight anonymous closure
 
 (source
     (expression_statement
-        (inflight_anonymous_closure
+        (inflight_closure
             (parameter_list)
             (block
                 (return_statement

--- a/wingc/src/parser.rs
+++ b/wingc/src/parser.rs
@@ -458,13 +458,9 @@ impl Parser<'_> {
 				args: self.build_arg_list(&expression_node.child_by_field_name("args").unwrap())?,
 			}))),
 			"parenthesized_expression" => self.build_expression(&expression_node.named_child(0).unwrap()),
-			"preflight_anonymous_closure" => {
-				self.add_error(format!("Anonymous closures not implemented yet"), expression_node)
-			}
-			"inflight_anonymous_closure" => {
-				self.add_error(format!("Anonymous closures not implemented yet"), expression_node)
-			}
-			"pure_anonymous_closure" => self.add_error(format!("Anonymous closures not implemented yet"), expression_node),
+			"preflight_closure" => self.add_error(format!("Anonymous closures not implemented yet"), expression_node),
+			"inflight_closure" => self.add_error(format!("Anonymous closures not implemented yet"), expression_node),
+			"pure_closure" => self.add_error(format!("Anonymous closures not implemented yet"), expression_node),
 			other => {
 				if expression_node.has_error() {
 					self.add_error(format!("Expected expression"), expression_node)


### PR DESCRIPTION
`() => {}` added to tree sitter grammar, along with its arrow variants.

This is only the grammar, no other piece of the implementation. The benefit of having this now is that the vscode extension can use it. Should help to visualize a future wing.