### PR TITLE
fix: Implement Send for AST structs with raw pointers for use in async

### DIFF
--- a/libs/wingc/src/type_check.rs
+++ b/libs/wingc/src/type_check.rs
@@ -20,6 +20,9 @@ pub enum Type {
 	ClassInstance(TypeRef),  // Reference to a Class type
 }
 
+// TODO See TypeRef for why this is necessary
+unsafe impl Send for Type {}
+
 #[derive(Derivative)]
 #[derivative(Debug)]
 pub struct Class {
@@ -149,6 +152,10 @@ impl Display for Type {
 
 #[derive(Clone, Copy)]
 pub struct TypeRef(*const Type);
+
+// TODO Allows for use in async runtime
+// TODO either avoid shared memory or use Arc<Mutex<...>> instead
+unsafe impl Send for TypeRef {}
 
 impl From<&Box<Type>> for TypeRef {
 	fn from(t: &Box<Type>) -> Self {

--- a/libs/wingc/src/type_env.rs
+++ b/libs/wingc/src/type_env.rs
@@ -13,6 +13,9 @@ pub struct TypeEnv {
 	pub flight: Flight,
 }
 
+// TODO See TypeRef for why this is necessary
+unsafe impl Send for TypeEnv {}
+
 impl TypeEnv {
 	pub fn new(parent: Option<*const TypeEnv>, return_type: Option<TypeRef>, is_class: bool, flight: Flight) -> Self {
 		assert!(return_type.is_none() || (return_type.is_some() && parent.is_some()));


### PR DESCRIPTION
In order to use these structs in an async context, TypeRef and TypeEnv needed to implement send. I'm not actually sure if this is bad, or even if my comments are unwarranted and this is actually totally ok. Let me know if you know.

On the bright side, it does allow me to use `Scope` in the language server :)