### PR TITLE
fix(sdk): type identifiers aren't part of public API

### DIFF
--- a/libs/wingsdk/API.md
+++ b/libs/wingsdk/API.md
@@ -357,6 +357,25 @@ with a fresh copy without any consequences.
 
 ---
 
+#### Constants <a name="Constants" id="Constants"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#@monadahq/wingsdk.cloud.Bucket.property.TYPE">TYPE</a></code> | <code>string</code> | Type identifier for implementing `Bucket` as a polycon. |
+
+---
+
+##### `TYPE`<sup>Required</sup> <a name="TYPE" id="@monadahq/wingsdk.cloud.Bucket.property.TYPE"></a>
+
+```typescript
+public readonly TYPE: string;
+```
+
+- *Type:* string
+
+Type identifier for implementing `Bucket` as a polycon.
+
+---
 
 ### Bucket <a name="Bucket" id="@monadahq/wingsdk.sim.Bucket"></a>
 
@@ -994,6 +1013,25 @@ with a fresh copy without any consequences.
 
 ---
 
+#### Constants <a name="Constants" id="Constants"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#@monadahq/wingsdk.cloud.Function.property.TYPE">TYPE</a></code> | <code>string</code> | Type identifier for implementing `Function` as a polycon. |
+
+---
+
+##### `TYPE`<sup>Required</sup> <a name="TYPE" id="@monadahq/wingsdk.cloud.Function.property.TYPE"></a>
+
+```typescript
+public readonly TYPE: string;
+```
+
+- *Type:* string
+
+Type identifier for implementing `Function` as a polycon.
+
+---
 
 ### Function <a name="Function" id="@monadahq/wingsdk.sim.Function"></a>
 
@@ -1724,6 +1762,25 @@ with a fresh copy without any consequences.
 
 ---
 
+#### Constants <a name="Constants" id="Constants"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#@monadahq/wingsdk.cloud.Queue.property.TYPE">TYPE</a></code> | <code>string</code> | Type identifier for implementing `Queue` as a polycon. |
+
+---
+
+##### `TYPE`<sup>Required</sup> <a name="TYPE" id="@monadahq/wingsdk.cloud.Queue.property.TYPE"></a>
+
+```typescript
+public readonly TYPE: string;
+```
+
+- *Type:* string
+
+Type identifier for implementing `Queue` as a polycon.
+
+---
 
 ### Queue <a name="Queue" id="@monadahq/wingsdk.sim.Queue"></a>
 
@@ -3753,7 +3810,7 @@ The code contents.
 
 - *Implements:* @monadahq/polycons.IPolyconFactory
 
-Polycon factory which resolves `cloud` resources into simulated resources.
+Polycon factory which resolves cloud resources into simulated resources.
 
 #### Initializers <a name="Initializers" id="@monadahq/wingsdk.sim.PolyconFactory.Initializer"></a>
 
@@ -3815,7 +3872,7 @@ Resolve the parameters needed for creating a specific polycon into a concrete co
 
 - *Implements:* @monadahq/polycons.IPolyconFactory
 
-Polycon factory which resolves `cloud` resources into AWS resources.
+Polycon factory which resolves cloud resources into AWS resources.
 
 #### Initializers <a name="Initializers" id="@monadahq/wingsdk.tfaws.PolyconFactory.Initializer"></a>
 

--- a/libs/wingsdk/src/cloud/bucket.ts
+++ b/libs/wingsdk/src/cloud/bucket.ts
@@ -4,11 +4,6 @@ import { CaptureMetadata, Code } from "../core";
 import { Resource } from "./resource";
 
 /**
- * Global identifier for `Bucket`.
- */
-export const BUCKET_TYPE = "wingsdk.cloud.Bucket";
-
-/**
  * Properties for `Bucket`.
  */
 export interface BucketProps {
@@ -38,9 +33,14 @@ export abstract class BucketBase extends Resource {
  * Represents a cloud object store.
  */
 export class Bucket extends BucketBase {
+  /**
+   * Type identifier for implementing `Bucket` as a polycon.
+   */
+  public static readonly TYPE = "wingsdk.cloud.Bucket";
+
   constructor(scope: Construct, id: string, props: BucketProps = {}) {
     super(null as any, id, props);
-    return Polycons.newInstance(BUCKET_TYPE, scope, id, props) as Bucket;
+    return Polycons.newInstance(Bucket.TYPE, scope, id, props) as Bucket;
   }
 
   /**

--- a/libs/wingsdk/src/cloud/function.ts
+++ b/libs/wingsdk/src/cloud/function.ts
@@ -4,11 +4,6 @@ import { CaptureMetadata, Code, Inflight } from "../core";
 import { Resource } from "./resource";
 
 /**
- * Global identifier for `Function`.
- */
-export const FUNCTION_TYPE = "wingsdk.cloud.Function";
-
-/**
  * Properties for `Function`.
  *
  * This is the type users see when constructing a cloud.Function instance.
@@ -51,6 +46,11 @@ export abstract class FunctionBase extends Resource {
  * Represents a serverless function.
  */
 export class Function extends FunctionBase {
+  /**
+   * Type identifier for implementing `Function` as a polycon.
+   */
+  public static readonly TYPE = "wingsdk.cloud.Function";
+
   constructor(
     scope: Construct,
     id: string,
@@ -59,7 +59,7 @@ export class Function extends FunctionBase {
   ) {
     super(null as any, id, inflight, props);
     return Polycons.newInstance(
-      FUNCTION_TYPE,
+      Function.TYPE,
       scope,
       id,
       inflight,

--- a/libs/wingsdk/src/cloud/queue.ts
+++ b/libs/wingsdk/src/cloud/queue.ts
@@ -5,11 +5,6 @@ import { Function, FunctionProps } from "./function";
 import { Resource } from "./resource";
 
 /**
- * Global identifier for `Queue`.
- */
-export const QUEUE_TYPE = "wingsdk.cloud.Queue";
-
-/**
  * Properties for `Queue`.
  */
 export interface QueueProps {
@@ -58,9 +53,14 @@ export interface QueueOnMessageProps extends FunctionProps {
  * Represents a serverless queue.
  */
 export class Queue extends QueueBase {
+  /**
+   * Type identifier for implementing `Queue` as a polycon.
+   */
+  public static readonly TYPE = "wingsdk.cloud.Queue";
+
   constructor(scope: Construct, id: string, props: QueueProps = {}) {
     super(null as any, id, props);
-    return Polycons.newInstance(QUEUE_TYPE, scope, id, props) as Queue;
+    return Polycons.newInstance(Queue.TYPE, scope, id, props) as Queue;
   }
 
   /**

--- a/libs/wingsdk/src/sim/bucket.ts
+++ b/libs/wingsdk/src/sim/bucket.ts
@@ -1,6 +1,5 @@
 import { Construct, IConstruct } from "constructs";
 import * as cloud from "../cloud";
-import { BUCKET_TYPE } from "../cloud";
 import { CaptureMetadata, Code, InflightClient } from "../core";
 import { Function } from "./function";
 import { IResource } from "./resource";
@@ -22,7 +21,7 @@ export class Bucket extends cloud.BucketBase implements IResource {
   /** @internal */
   public _toResourceSchema(): BucketSchema {
     return {
-      type: BUCKET_TYPE,
+      type: cloud.Bucket.TYPE,
       props: {
         public: this.public,
       },

--- a/libs/wingsdk/src/sim/factory.sim.ts
+++ b/libs/wingsdk/src/sim/factory.sim.ts
@@ -10,11 +10,11 @@ import { init as initQueue, cleanup as cleanupQueue } from "./queue.sim";
 export class DefaultSimulatorFactory implements ISimulatorFactory {
   async init(type: string, props: any): Promise<any> {
     switch (type) {
-      case cloud.BUCKET_TYPE:
+      case cloud.Bucket.TYPE:
         return initBucket(props);
-      case cloud.FUNCTION_TYPE:
+      case cloud.Function.TYPE:
         return initFunction(props);
-      case cloud.QUEUE_TYPE:
+      case cloud.Queue.TYPE:
         return initQueue(props);
       case "constructs.Construct":
         return {};
@@ -25,13 +25,13 @@ export class DefaultSimulatorFactory implements ISimulatorFactory {
 
   async cleanup(type: string, attrs: any): Promise<void> {
     switch (type) {
-      case cloud.BUCKET_TYPE:
+      case cloud.Bucket.TYPE:
         await cleanupBucket(attrs);
         return;
-      case cloud.FUNCTION_TYPE:
+      case cloud.Function.TYPE:
         await cleanupFunction(attrs);
         return;
-      case cloud.QUEUE_TYPE:
+      case cloud.Queue.TYPE:
         await cleanupQueue(attrs);
         return;
       case "constructs.Construct":

--- a/libs/wingsdk/src/sim/factory.ts
+++ b/libs/wingsdk/src/sim/factory.ts
@@ -6,7 +6,7 @@ import { Function } from "./function";
 import { Queue } from "./queue";
 
 /**
- * Polycon factory which resolves `cloud` resources into simulated resources.
+ * Polycon factory which resolves cloud resources into simulated resources.
  */
 export class PolyconFactory implements IPolyconFactory {
   resolve(
@@ -16,11 +16,11 @@ export class PolyconFactory implements IPolyconFactory {
     ...args: any[]
   ): IConstruct {
     switch (polyconId) {
-      case cloud.BUCKET_TYPE:
+      case cloud.Bucket.TYPE:
         return new Bucket(scope, id, args[0]);
-      case cloud.FUNCTION_TYPE:
+      case cloud.Function.TYPE:
         return new Function(scope, id, args[0], args[1]);
-      case cloud.QUEUE_TYPE:
+      case cloud.Queue.TYPE:
         return new Queue(scope, id, args[0]);
       default:
         throw new Error(`Type ${polyconId} not implemented.`);

--- a/libs/wingsdk/src/sim/function.ts
+++ b/libs/wingsdk/src/sim/function.ts
@@ -1,6 +1,5 @@
 import { Construct, IConstruct } from "constructs";
 import * as cloud from "../cloud";
-import { FunctionProps, FUNCTION_TYPE } from "../cloud";
 import {
   Code,
   Language,
@@ -26,7 +25,7 @@ export class Function extends cloud.FunctionBase implements IResource {
     scope: Construct,
     id: string,
     inflight: Inflight,
-    props: FunctionProps
+    props: cloud.FunctionProps
   ) {
     super(scope, id, inflight, props);
 
@@ -84,7 +83,7 @@ export class Function extends cloud.FunctionBase implements IResource {
   /** @internal */
   public _toResourceSchema(): FunctionSchema {
     return {
-      type: FUNCTION_TYPE,
+      type: cloud.Function.TYPE,
       props: {
         sourceCodeFile: this.code.path,
         sourceCodeLanguage: "javascript",

--- a/libs/wingsdk/src/sim/queue.ts
+++ b/libs/wingsdk/src/sim/queue.ts
@@ -65,7 +65,7 @@ export class Queue extends cloud.QueueBase implements IResource {
   /** @internal */
   public _toResourceSchema(): QueueSchema {
     return {
-      type: cloud.QUEUE_TYPE,
+      type: cloud.Queue.TYPE,
       props: {
         timeout: this.timeout.seconds,
         subscribers: this.subscribers,

--- a/libs/wingsdk/src/sim/schema.ts
+++ b/libs/wingsdk/src/sim/schema.ts
@@ -1,4 +1,4 @@
-import { BUCKET_TYPE, FUNCTION_TYPE, QUEUE_TYPE } from "../cloud";
+import * as cloud from "../cloud";
 
 /** Schema for simulator.json */
 export interface WingSimulatorSchema {
@@ -33,7 +33,7 @@ export type FunctionId = string;
 
 /** Schema for cloud.Function */
 export interface FunctionSchema extends BaseResourceSchema {
-  readonly type: typeof FUNCTION_TYPE;
+  readonly type: typeof cloud.Function.TYPE;
   readonly props: {
     /** The path to a file containing source code to be run when invoked. */
     readonly sourceCodeFile: string;
@@ -58,7 +58,7 @@ export interface QueueSubscriber {
 
 /** Schema for cloud.Queue */
 export interface QueueSchema extends BaseResourceSchema {
-  readonly type: typeof QUEUE_TYPE;
+  readonly type: typeof cloud.Queue.TYPE;
   readonly props: {
     /** How long a queue's consumers have to process a message, in milliseconds */
     readonly timeout: number;
@@ -83,7 +83,7 @@ export interface QueueSubscriber {
 
 /** Schema for cloud.Bucket */
 export interface BucketSchema extends BaseResourceSchema {
-  readonly type: typeof BUCKET_TYPE;
+  readonly type: typeof cloud.Bucket.TYPE;
   readonly props: {};
   readonly attrs: {
     /** The address of the bucket on the local file system. */

--- a/libs/wingsdk/src/tf-aws/factory.ts
+++ b/libs/wingsdk/src/tf-aws/factory.ts
@@ -1,12 +1,12 @@
 import { IPolyconFactory } from "@monadahq/polycons";
 import { IConstruct } from "constructs";
-import { BUCKET_TYPE, FUNCTION_TYPE, QUEUE_TYPE } from "../cloud";
+import * as cloud from "../cloud";
 import { Bucket } from "./bucket";
 import { Function } from "./function";
 import { Queue } from "./queue";
 
 /**
- * Polycon factory which resolves `cloud` resources into AWS resources.
+ * Polycon factory which resolves cloud resources into AWS resources.
  */
 export class PolyconFactory implements IPolyconFactory {
   public resolve(
@@ -16,11 +16,11 @@ export class PolyconFactory implements IPolyconFactory {
     ...args: any[]
   ): IConstruct {
     switch (type) {
-      case BUCKET_TYPE:
+      case cloud.Bucket.TYPE:
         return new Bucket(scope, id, args[0]);
-      case FUNCTION_TYPE:
+      case cloud.Function.TYPE:
         return new Function(scope, id, args[0], args[1]);
-      case QUEUE_TYPE:
+      case cloud.Queue.TYPE:
         return new Queue(scope, id, args[0]);
       default:
         throw new Error(`Type ${type} not implemented.`);


### PR DESCRIPTION
DO NOT MERGE until static members are supported in Wing compiler

Each polycon resource has a type name that is used to globally identify it for the purpose of polycon resolution / dependency injection. This value should be part of the public API so that users can add their own implementations of polycons.

Previously these names were const values exported in the TypeScript code -- but free-floating consts are not translitered by JSII to other languages, they need to be added to a class instead. To that end, this PR makes them static class members so that they're also available in other languages.
