### PR TITLE
fix: prevent automatic focus of vscode extension output window

### DIFF
--- a/apps/vscode-wing/.vscode/launch.json
+++ b/apps/vscode-wing/.vscode/launch.json
@@ -10,9 +10,6 @@
             "type": "extensionHost",
             "request": "launch",
             "outFiles": ["${workspaceFolder}/lib/**/*.js"],
-            "env": {
-              "WING_LSP_SERVER_PATH": "${workspaceFolder}/../wing-language-server/target/debug/wing-language-server"
-            },
             "args": [
                 "--disable-extensions", "--extensionDevelopmentPath=${workspaceFolder}"
             ]

--- a/apps/vscode-wing/package-lock.json
+++ b/apps/vscode-wing/package-lock.json
@@ -2123,6 +2123,7 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
       "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+      "dev": true,
       "optional": true,
       "dependencies": {
         "iconv-lite": "^0.6.2"
@@ -3703,6 +3704,7 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
       "optional": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -6747,6 +6749,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
       "optional": true
     },
     "node_modules/sax": {
@@ -8860,8 +8863,7 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "acorn-walk": {
       "version": "8.2.0",
@@ -9638,6 +9640,7 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
       "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+      "dev": true,
       "optional": true,
       "requires": {
         "iconv-lite": "^0.6.2"
@@ -9983,8 +9986,7 @@
       "version": "8.5.0",
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz",
       "integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "eslint-import-resolver-node": {
       "version": "0.3.6",
@@ -10718,6 +10720,7 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
       "optional": true,
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -12897,6 +12900,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
       "optional": true
     },
     "sax": {

--- a/apps/vscode-wing/src/extension.ts
+++ b/apps/vscode-wing/src/extension.ts
@@ -50,9 +50,6 @@ export async function activate(context: ExtensionContext) {
 }
 
 async function startLanguageServer(context: ExtensionContext) {
-  const traceOutputChannel = window.createOutputChannel(LANGUAGE_SERVER_NAME);
-  traceOutputChannel.show();
-
   let serverPath = process.env.WING_LSP_SERVER_PATH;
   if (!serverPath) {
     serverPath = context.asAbsolutePath(
@@ -111,7 +108,6 @@ async function startLanguageServer(context: ExtensionContext) {
   };
   let clientOptions: LanguageClientOptions = {
     documentSelector: [{ scheme: "file", language: "wing", pattern: "**/*.w" }],
-    traceOutputChannel,
   };
 
   // Create the language client and start the client.


### PR DESCRIPTION
The output window created was automatically focused. This was a debugging feature that can be removed. In fact I removed the manual creation of an output window because vscode actually created its own for the language server anyways.

Side change: no need to set WING_LSP_SERVER_PATH for local debug, nx scripts set you up with an LSP build


fixes #235