### PR TITLE
fix(vscode): retrieve latest version from latest release rather than specific tag

### DIFF
--- a/apps/vscode-wing/.projenrc.ts
+++ b/apps/vscode-wing/.projenrc.ts
@@ -99,11 +99,6 @@ const contributes: VSCodeExtensionContributions = {
         description:
           "PAT to check for and download new versions of this extension from the winglang repo. Leave empty to disable automatic updates.\nNOTE: PAT must have private repo permission.",
       },
-      "wing.updates.sourceTag": {
-        type: "string",
-        default: "development",
-        description: "Release tag to retrieve updates from.",
-      },
     },
   },
 };

--- a/apps/vscode-wing/package-lock.json
+++ b/apps/vscode-wing/package-lock.json
@@ -2123,7 +2123,6 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
       "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "iconv-lite": "^0.6.2"
@@ -3704,7 +3703,6 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -6749,7 +6747,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true,
       "optional": true
     },
     "node_modules/sax": {
@@ -8863,7 +8860,8 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "acorn-walk": {
       "version": "8.2.0",
@@ -9640,7 +9638,6 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
       "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-      "dev": true,
       "optional": true,
       "requires": {
         "iconv-lite": "^0.6.2"
@@ -9986,7 +9983,8 @@
       "version": "8.5.0",
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz",
       "integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "eslint-import-resolver-node": {
       "version": "0.3.6",
@@ -10720,7 +10718,6 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "dev": true,
       "optional": true,
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -12900,7 +12897,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true,
       "optional": true
     },
     "sax": {

--- a/apps/vscode-wing/package.json
+++ b/apps/vscode-wing/package.json
@@ -112,11 +112,6 @@
           "type": "string",
           "default": "",
           "description": "PAT to check for and download new versions of this extension from the winglang repo. Leave empty to disable automatic updates.\nNOTE: PAT must have private repo permission."
-        },
-        "wing.updates.sourceTag": {
-          "type": "string",
-          "default": "development",
-          "description": "Release tag to retrieve updates from."
         }
       }
     }

--- a/apps/vscode-wing/src/extension.ts
+++ b/apps/vscode-wing/src/extension.ts
@@ -27,7 +27,6 @@ const WINGLANG_REPO_OWNER = "monadahq";
 const UPDATE_RATE_LIMIT_MS = 1 * 60 * 60 * 1000; // 1 hour
 
 const CFG_UPDATES_GITHUB_TOKEN = "updates.githubToken";
-const CFG_UPDATES_SOURCE_TAG = "updates.sourceTag";
 const STATE_INSTALLED_RELEASE_CHECKSUM = "wing.installedReleaseChecksum";
 const STATE_LAST_UPDATE_CHECK = "wing.lastUpdateCheck";
 
@@ -140,14 +139,12 @@ export async function checkForUpdates(context: ExtensionContext) {
 
   const configuration = workspace.getConfiguration(EXTENSION_NAME);
   const githubToken = configuration.get<string>(CFG_UPDATES_GITHUB_TOKEN);
-  const sourceTag = configuration.get<string>(CFG_UPDATES_SOURCE_TAG);
 
-  if (githubToken && sourceTag) {
+  if (githubToken) {
     const octokit = new Octokit({ auth: githubToken });
-    const latestRelease = await octokit.rest.repos.getReleaseByTag({
+    const latestRelease = await octokit.rest.repos.getLatestRelease({
       owner: WINGLANG_REPO_OWNER,
       repo: WINGLANG_REPO_NAME,
-      tag: sourceTag,
     });
 
     if (latestRelease.status !== 200) {


### PR DESCRIPTION
Once we start having actual versions, we can't rely on a specific tag