### PR TITLE
fix: compiler prints preflight to stdout

### DIFF
--- a/libs/wingc/src/bin.rs
+++ b/libs/wingc/src/bin.rs
@@ -11,5 +11,5 @@ pub fn main() {
 	let source = &args[1];
 	let outdir = args.get(2).map(|s| s.as_str());
 
-	println!("{}", compile(source, outdir));
+	compile(source, outdir);
 }


### PR DESCRIPTION
Just remove the `println!` for now. We can reintroduce verbosity and debugging outputs later.

Fixes #263