### PR TITLE
feat: support for custom resource id

### DIFF
--- a/libs/wingc/src/ast.rs
+++ b/libs/wingc/src/ast.rs
@@ -137,7 +137,7 @@ pub struct ClassMember {
 pub enum ExprType {
 	New {
 		class: Type,
-		obj_id: Option<Symbol>,
+		obj_id: Option<String>,
 		obj_scope: Option<Box<Expr>>,
 		arg_list: ArgList,
 	},

--- a/libs/wingc/src/jsify.rs
+++ b/libs/wingc/src/jsify.rs
@@ -158,7 +158,7 @@ fn jsify_expression(expression: &Expr) -> String {
 	match &expression.variant {
 		ExprType::New {
 			class,
-			obj_id: _, // TODO
+			obj_id,
 			arg_list,
 			obj_scope: _, // TODO
 		} => {
@@ -175,8 +175,11 @@ fn jsify_expression(expression: &Expr) -> String {
 				format!(
 					"new {}({})",
 					jsify_type(class),
-					// TODO: get actual scope and id
-					jsify_arg_list(&arg_list, Some("this.root"), Some(&format!("{}", jsify_type(class))))
+					jsify_arg_list(
+						&arg_list,
+						Some("this.root"), // TODO: get actual scope
+						Some(&format!("{}", obj_id.as_ref().unwrap_or(&jsify_type(class))))
+					)
 				)
 			} else {
 				format!("new {}({})", jsify_type(&class), jsify_arg_list(&arg_list, None, None))

--- a/libs/wingc/src/parser.rs
+++ b/libs/wingc/src/parser.rs
@@ -411,9 +411,10 @@ impl Parser<'_> {
 					Ok(ArgList::new())
 				};
 
-				let obj_id = expression_node
-					.child_by_field_name("id")
-					.map(|n| self.node_symbol(&n).unwrap());
+				let obj_id = expression_node.child_by_field_name("id").map(|n| {
+					let id_str = self.node_text(&n.named_child(0).unwrap());
+					id_str[1..id_str.len() - 1].to_string()
+				});
 				let obj_scope = if let Some(scope_expr_node) = expression_node.child_by_field_name("scope") {
 					Some(Box::new(self.build_expression(&scope_expr_node)?))
 				} else {


### PR DESCRIPTION
Support custom resource id, previously ignored during jsification:
```
let x = cloud.Bucket() as "my_bucket";
```