### PR TITLE
fix(wingii): optimized performance of wingii

### DIFF
--- a/libs/wingc/src/type_check.rs
+++ b/libs/wingc/src/type_check.rs
@@ -804,7 +804,11 @@ impl<'a> TypeChecker<'a> {
 					// TODO Hack: treat "cloud" as "cloud in wingsdk" until I figure out the path issue
 					if module_name.name == "cloud" {
 						let mut wingii_types = wingii::type_system::TypeSystem::new();
-						let name = wingii_types.load("../wingsdk").unwrap();
+						let wingii_loader_options = wingii::type_system::AssemblyLoadOptions {
+							root: true,
+							deps: false,
+						};
+						let name = wingii_types.load("../wingsdk", Some(wingii_loader_options)).unwrap();
 						let prefix = format!("{}.{}.", name, module_name.name);
 						println!("Loaded JSII assembly {}", name);
 						let assembly = wingii_types.find_assembly(&name).unwrap();

--- a/libs/wingii/src/test.rs
+++ b/libs/wingii/src/test.rs
@@ -51,7 +51,7 @@ mod tests {
 			.join("src")
 			.join("fixtures")
 			.join("constructs");
-		let name = type_system.load(fixture_path.to_str().unwrap()).unwrap();
+		let name = type_system.load(fixture_path.to_str().unwrap(), None).unwrap();
 		assert_eq!(name, "constructs");
 		let assembly = type_system.find_assembly(&name).unwrap();
 		assert_eq!(assembly.name, "constructs");
@@ -64,7 +64,7 @@ mod tests {
 			.join("src")
 			.join("fixtures")
 			.join("constructs");
-		let name = type_system.load(fixture_path.to_str().unwrap()).unwrap();
+		let name = type_system.load(fixture_path.to_str().unwrap(), None).unwrap();
 		assert_eq!(name, "constructs");
 		// find class with fqn "constructs.Construct"
 		let construct = type_system.find_class("constructs.Construct").unwrap();


### PR DESCRIPTION
This PR addresses the performance bottleneck of wingii. After evaluation of the flamegraphs below, I spoke with @Chriscbr and it turned out for our compiler's purposes, recursively loading a JSII manifest is not a requirement. Since wingii is a port of the original jsii-reflect npm package, it carried that functionality with it. With this change, compiler can now opt out of that behavior.

On my system, the following improvement is observed (reduction of about 86% on wingsdk's JSII manifest):

```sh
# old behavior
$ time cargo run -- ../../examples/simple/sdk_capture_test.w
cargo run -- ../../examples/simple/sdk_capture_test.w  7.60s user 0.43s system 100% cpu 8.014 total

# opt out behavior
$ time cargo run -- ../../examples/simple/sdk_capture_test.w
cargo run -- ../../examples/simple/sdk_capture_test.w  1.00s user 0.19s system 104% cpu 1.137 total
```

Flamegraph of old behavior:

![image](https://user-images.githubusercontent.com/5657848/196055588-ee58e93a-d2f4-4bca-bf79-46b6bba0c5e2.png)

Flamegraph of new behavior:

![image](https://user-images.githubusercontent.com/5657848/196055661-21a61042-7cd6-4503-8001-fc56afc76b5a.png)

The flamegraphs indicate that we still have the same divide between wingc and serde code, which is good! it means we are not leaking memory or have other hidden costs somewhere. It's simply a matter of # of serde calls.