### PR TITLE
chore: ensure build workflow only runs one-at-a-time per branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on:
   push:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 env:


### PR DESCRIPTION
`github.head_ref` is always null because we use push events.
`github.run_id` will be different for multiple pushes to the same branch, allowing for collision.

It's important to build serially when building main to ensure version integrity.

This may be reworked when we start using the pull_request_target trigger at some point.