### PR TITLE
fix(docs): use transparency on dark backgrounds

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <p align="center">
   <a href="https://winglang.io">
     <picture>
-      <source media="(prefers-color-scheme: dark)" srcset="https://github.com/monadahq/winglang/raw/main/logo/1x/Symbol-Turq-Dark.png">
+      <source media="(prefers-color-scheme: dark)" srcset="https://github.com/monadahq/winglang/raw/main/logo/1x/Symbol-Turq-LightTransparent.png">
       <source media="(prefers-color-scheme: light)" srcset="https://github.com/monadahq/winglang/raw/main/logo/1x/Symbol-Black-Light.png">
       <img alt="" src="https://github.com/monadahq/winglang/raw/main/logo/1x/Symbol-Black-Light.png" height="110pt">
     </picture>


### PR DESCRIPTION
Not all dark modes have a pure black background (#000) so use the transparent logo instead.

Here's screenshots of my GitHub to show how it looks:

(old)
<img width="571" alt="Screenshot 2022-11-02 at 3 22 24 PM" src="https://user-images.githubusercontent.com/5008987/199582590-a0b8310c-b2ec-41e3-8e59-31616d8d5296.png">

(fixed)
<img width="585" alt="Screenshot 2022-11-02 at 3 22 28 PM" src="https://user-images.githubusercontent.com/5008987/199582586-2e676660-cfa1-4642-8f53-f56ab891bd75.png">