### PR TITLE
chore: trying new issue github issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/experimental_template.yml
+++ b/.github/ISSUE_TEMPLATE/experimental_template.yml
@@ -1,0 +1,72 @@
+name: Bug Report 🐞
+description: Create a bug report
+labels: ["bug","untriaged"]
+body:
+- type: markdown
+  attributes:
+    value: |
+      Thanks for taking the time to fill out this bug report!
+- type: textarea
+  id: i-tried-this
+  attributes:
+    label: I tried this
+    description: What did you try to do?
+    placeholder: Code/explanation to reproduce bug
+  validations:
+    required: true
+- type: textarea
+  id: what-did-you-expect
+  attributes:
+    label: Expected
+    description: What did you expect to happen?
+    placeholder: Tell us what you expected to see!
+  validations:
+    required: true
+- type: textarea
+  id: instead-what-happened
+  attributes:
+    label: Instead, this happened
+    description: What happend instead of what you've expected?
+    placeholder: Tell us what did you see!
+  validations:
+    required: true
+- type: dropdown
+  id: Component
+  attributes:
+    label: Component
+    description: Which component is this related to? (one or more)
+    multiple: true
+    options:
+    - Language Design
+    - Compiler
+    - SDK
+    - IDE Extension
+    - Documentation
+    - Development Environment
+    - Contributor Experience
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Environment
+    description: |
+      examples:
+      - **Wing Version (`wing --version`)**: <0.2.69>
+      - **OS**: MacOS 
+      - **Node version**: 13.14.0
+    value: |
+     - Wing Version:
+     - OS:
+     - Node version:
+    render: markdown
+  validations:
+    required: false
+- type: textarea
+  attributes:
+    label: Anything else?
+    description: |
+      Links? References? Logs? Anything that will give us more context about the issue you are encountering!
+
+      tip: You can attach images or log files by clicking this area to highlight it and then dragging files in.
+  validations:
+    required: false


### PR DESCRIPTION
It seems that the new issue template is not supported for private repositories, but there is a PM @ github that is opening this capabilities to people who request it, I've asked her

Trying to see if it works