### PR TITLE
chore(sdk): remove exports files

### DIFF
--- a/docs/simulator.md
+++ b/docs/simulator.md
@@ -31,7 +31,7 @@ Let's create a file in the directory named `main.ts`:
 import { testing } from '@winglang/wingsdk';
 
 async function main() {
-  const mySim = new testing.Simulator("app.wx");
+  const mySim = new testing.Simulator({ simfile: "app.wx" });
   await mySim.start();
 
   // (1)

--- a/libs/wingsdk/.projenrc.ts
+++ b/libs/wingsdk/.projenrc.ts
@@ -101,7 +101,7 @@ const tsconfigNonJsii = new JsonFile(project, "tsconfig.nonjsii.json", {
     compilerOptions: {
       esModuleInterop: true,
     },
-    include: ["src/**/*.inflight.ts", "src/**/*.sim.ts", "src/**/exports.ts"],
+    include: ["src/**/*.inflight.ts", "src/**/*.sim.ts"],
     exclude: ["node_modules"],
   },
 });
@@ -192,18 +192,6 @@ const bumpTask = project.tasks.tryFind("bump")!;
 bumpTask.reset(
   "npm version ${PROJEN_BUMP_VERSION:-0.0.0} --allow-same-version"
 );
-
-// Add custom export declarations that supersede the default export structure of
-// `index.ts` files. This allows us to export APIs that aren't compiled
-// with JSII without the JSII compiler noticing.
-project.package.addField("exports", {
-  ".": "./lib/exports.js",
-  "./cloud": "./lib/cloud/exports.js",
-  "./fs": "./lib/fs/exports.js",
-  "./sim": "./lib/sim/exports.js",
-  "./testing": "./lib/testing/exports.js",
-  "./tf-aws": "./lib/tf-aws/exports.js",
-});
 
 project.preCompileTask.exec("patch-package");
 

--- a/libs/wingsdk/package.json
+++ b/libs/wingsdk/package.json
@@ -170,14 +170,6 @@
       "src/**/exports.ts"
     ]
   },
-  "exports": {
-    ".": "./lib/exports.js",
-    "./cloud": "./lib/cloud/exports.js",
-    "./fs": "./lib/fs/exports.js",
-    "./sim": "./lib/sim/exports.js",
-    "./testing": "./lib/testing/exports.js",
-    "./tf-aws": "./lib/tf-aws/exports.js"
-  },
   "overrides": {
     "@types/responselike": "1.0.0",
     "got": "12.3.1",

--- a/libs/wingsdk/src/cloud/exports.ts
+++ b/libs/wingsdk/src/cloud/exports.ts
@@ -1,1 +1,0 @@
-export * from "./index";

--- a/libs/wingsdk/src/core/exports.ts
+++ b/libs/wingsdk/src/core/exports.ts
@@ -1,1 +1,0 @@
-export * from "./index";

--- a/libs/wingsdk/src/exports.ts
+++ b/libs/wingsdk/src/exports.ts
@@ -1,6 +1,0 @@
-export * as tfaws from "./tf-aws/exports";
-export * as core from "./core/exports";
-export * as fs from "./fs/exports";
-export * as cloud from "./cloud/exports";
-export * as sim from "./sim/exports";
-export * as testing from "./testing/exports";

--- a/libs/wingsdk/src/fs/exports.ts
+++ b/libs/wingsdk/src/fs/exports.ts
@@ -1,1 +1,0 @@
-export * from "./index";

--- a/libs/wingsdk/src/sim/exports.ts
+++ b/libs/wingsdk/src/sim/exports.ts
@@ -1,2 +1,0 @@
-export * from "./index";
-export * from "./schema-resources";

--- a/libs/wingsdk/src/testing/exports.ts
+++ b/libs/wingsdk/src/testing/exports.ts
@@ -1,1 +1,0 @@
-export * from "./index";

--- a/libs/wingsdk/src/tf-aws/exports.ts
+++ b/libs/wingsdk/src/tf-aws/exports.ts
@@ -1,5 +1,0 @@
-export * from "./index";
-export * from "./queue.inflight";
-export * from "./bucket.inflight";
-export * from "./function.inflight";
-export * from "./logger.inflight";

--- a/libs/wingsdk/tsconfig.nonjsii.json
+++ b/libs/wingsdk/tsconfig.nonjsii.json
@@ -5,8 +5,7 @@
   },
   "include": [
     "src/**/*.inflight.ts",
-    "src/**/*.sim.ts",
-    "src/**/exports.ts"
+    "src/**/*.sim.ts"
   ],
   "exclude": [
     "node_modules"


### PR DESCRIPTION
Remove the "exports" files in the SDK. These were added to provide a way to export APIs in a way that didn't require them to be analyzed by JSII, as JSII only looks at `index.ts` files. But the package.json `exports` field is not universally supported by all tools, so some folks are still getting errors where importing from a path like "@winglang/wingsdk/sim" wasn't recognized as a valid import.

For now, the only valid import paths are "@winglang/wingsdk" or barrel import inside lib like "@winglang/wingsdk/lib/tf-aws/bucket.inflight".

Also, fixed a typo in our docs.

Fixes #326 
Fixes #431