### PR TITLE
fix(cli): upgrade now works as expected on mac

### DIFF
--- a/apps/wing/src/commands/upgrade.ts
+++ b/apps/wing/src/commands/upgrade.ts
@@ -17,7 +17,7 @@ export async function upgrade(options: IUpdateOptions) {
   const { force } = options;
 
   if (!force) {
-    log("package not installed globally and 'force' is not set, skipping.");
+    log("'force' is not set, skipping.");
     return;
   }
 


### PR DESCRIPTION
`tsc` incorrectly treated `is-installed-globally` as an actual ESM import instead of a synthetic default import. as a result, everywhere this value got passed, instead of a `boolean`, an `undefined` got thrown around. As a result, this lead to a subtle bug in the `update-notifier` package to cause it function as expected on Linux but break on Mac. All of this happened because of incorrect `d.ts` for `is-installed-globally`.