### PR TITLE
chore: fix wing run command in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ with Wing applications on the local machine.
 2. You will notice that `app.wx` was created, run the Wing Console:
 
     ```sh
-    wing run app.wx
+    wing run target/app.wx
     ```
 
     The **Wing Console** will start and in the main view you'll see two resources: a **Queue** and a **Function**. 


### PR DESCRIPTION
The file `app.wx` gets created under the `target` directory.