### PR TITLE
chore(build): comment on issues after release

### DIFF
--- a/.autorc
+++ b/.autorc
@@ -1,7 +1,18 @@
 {
   "plugins": [
-    ["conventional-commits", { "preset": "angular" }],
-    "git-tag"
+    [
+      "conventional-commits",
+      {
+        "preset": "angular"
+      }
+    ],
+    "git-tag",
+    [
+      "release",
+      {
+        "message": ":rocket: %TYPE was released in %VERSION :rocket:"
+      }
+    ]
   ],
   "owner": "winglang",
   "repo": "wing",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "devDependencies": {
         "@auto-it/conventional-commits": "^10.37.6",
         "@auto-it/git-tag": "^10.37.6",
+        "@auto-it/released": "^10.37.6",
         "@nxrs/cargo": "^0.3.3",
         "auto": "^10.37.6",
         "npm-run-all": "^4.1.5",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "devDependencies": {
     "@auto-it/conventional-commits": "^10.37.6",
     "@auto-it/git-tag": "^10.37.6",
+    "@auto-it/released": "^10.37.6",
     "@nxrs/cargo": "^0.3.3",
     "auto": "^10.37.6",
     "npm-run-all": "^4.1.5",


### PR DESCRIPTION
Fixes #404 (ha ha)

This plugin:

- comments on the merged PR with the new version
- comments on closed issues with the new version
- adds a `released` label to the pull request
- adds a `released` label to closed issues

I chose this plugin over other github actions / solutions just because we're already using "auto" for our releases (fewer dependencies). I feel like the `released` label is a bit extra, but I don't see an option to disable the issue labeling, so I think we can just try it for now.