### PR TITLE
chore(docs): reintroduce omitted slack link change

### DIFF
--- a/docs/01-welcome.md
+++ b/docs/01-welcome.md
@@ -24,6 +24,11 @@ organized like a book, so you can read it by going from top to bottom by
 clicking "Next" at the bottom of each page. Alternatively, you can browse topics
 through the left-hand navigation bar. You know, the regular structure...
 
+You are invited to join the [Wing Community Slack]. We would love to get to know you!
+Come say hi, hang out, geek out, help friends and share your experience ❤️
+
+[Wing Community Slack]: https://t.winglang.io/slack
+
 TL;DR: if you can't be bothered with all the philosophical blabber, feel free to
 jump right in and [get started](./getting-started).
 

--- a/docs/02-getting-started/01-index.md
+++ b/docs/02-getting-started/01-index.md
@@ -14,14 +14,13 @@ We want this guide to be really fun, easy to read and to offer exactly the
 confusing or overwhelming. Naturally, it will take us some time to make this an
 awesome experience, and we would love you feedback and help! :pray:
 
-New experiences are always better with friends and support, so jump right into
-[#getting-started](https://winglang.slack.com/archives/C04BBDQUWQP) channel on
-the Wing Slack. Say :wave: and feel free to ask questions, post rants and offer
-advice to your fellow Wingians.
+New experiences are always better with friends and support, [join](https://t.winglang.io/slack) 
+the **Wing Community Slack** and jump right into the [#getting-started](https://winglang.slack.com/archives/C04BBDQUWQP) 
+channel. Say :wave: and feel free to ask questions, post rants and 
+offer advice to your fellow Wingians.
 
 If you run into issues, please submit a [new
 issue](https://github.com/winglang/wing/issues/new/choose) on GitHub and let us
 know as soon as possible.
 
 So without further ado, let this party started!
-

--- a/docs/06-contributors/handbook.md
+++ b/docs/06-contributors/handbook.md
@@ -37,7 +37,7 @@ If you aren't sure where to start, check out issues tagged with the [good first 
 [pull requests]: #-how-do-i-submit-a-pull-request
 [RFC]: #-what-is-an-rfc
 [good first issue]: https://github.com/winglang/wing/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22+no%3Aassignee+sort%3Aupdated-desc+
-[Wing Slack]: https://join.slack.com/t/winglang/shared_invite/zt-1i7jb3pt3-lb0RKOSoLA1~pl6cBnP2tA
+[Wing Slack]: https://t.winglang.io/slack
 [Wing Discussions]: https://github.com/winglang/wing/discussions
 
 ## 🌳 How is this repository structured?
@@ -287,7 +287,7 @@ To that end, pull request titles must follow this convention:
 
 The Wing community follows the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md).
 
-Please review it before contributing issues, pull requests, or joining the Wing Slack.
+Please review it before contributing issues, pull requests, or joining the [Wing Slack].
 
 ## 🙋 Where can I go to ask questions about Wing?
 


### PR DESCRIPTION
This [PR](https://github.com/winglang/docsite/pull/115) was somehow overrun. I'm putting it back where it belongs.
----
*By submitting this pull request, I confirm that my contribution is made under the terms of [Monada contribution license](https://docs.winglang.io/terms-and-policies/contribution-license.html)*
