### PR TITLE
chore(docs): consistant use of `sh` and `$` in docs

### DIFF
--- a/docs/02-getting-started/02-installation.md
+++ b/docs/02-getting-started/02-installation.md
@@ -31,8 +31,8 @@ During the private alpha period, Wing is distributed through a private npm
 repository. You will need to obtain a [personal access token] from GitHub with a
 **packages:read** scope and then login your npm client like this:
 
-```terminal
-$ npm login --scope=@winglang --registry=https://npm.pkg.github.com
+```sh
+npm login --scope=@winglang --registry=https://npm.pkg.github.com
 ```
 
 :::

--- a/docs/02-getting-started/03-hello.md
+++ b/docs/02-getting-started/03-hello.md
@@ -10,8 +10,8 @@ OK, we are ready for our first Wing program!
 Let's create an empty directory for our project.
 
 ```sh
-$ mkdir hello-wing
-$ cd hello-wing
+mkdir hello-wing
+cd hello-wing
 ```
 
 ## Your application entrypoint

--- a/docs/02-getting-started/07-aws.md
+++ b/docs/02-getting-started/07-aws.md
@@ -47,9 +47,9 @@ Let's change the working directory to where our Terraform configuration is and
 initialize the state file:
 
 ```sh
-$ cd ./target/cdktf.out/stacks/root
-$ export AWS_REGION=us-east-1 # or any other region
-$ terraform init
+cd ./target/cdktf.out/stacks/root
+export AWS_REGION=us-east-1 # or any other region
+terraform init
 ```
 
 ## Terraform deploy

--- a/docs/06-contributors/handbook.md
+++ b/docs/06-contributors/handbook.md
@@ -64,7 +64,7 @@ Here is a list of minimal tools you should install to build the Wing repo in you
 
 To build the repo locally:
 
-```bash
+```sh
 sudo bash scripts/setup_wasi.sh # one-time setup
 npm install
 npm run build
@@ -72,7 +72,7 @@ npm run build
 
 To run all tests:
 
-```bash
+```sh
 cargo install cargo-insta # one-time setup
 npm run test
 ```
@@ -166,19 +166,19 @@ All features and bug fixes should have tests! They're easy to forget, but they p
 
 All tests can be run by running the following command from `libs/wingsdk`:
 
-```shell
+```sh
 npm run test
 ```
 
 During development, you might find it useful to watch for changes and automatically re-run the tests:
 
-```shell
+```sh
 npm run test:watch
 ```
 
 To re-run individual tests, you can directly use the `jest` command -- for example:
 
-```shell
+```sh
 npx jest test/tf-aws/bucket.test.ts
 ```
 
@@ -208,7 +208,7 @@ This allows spun-up registry to pull down @winglang/polycons from the private gi
 
 To run the tests (and update snapshots), run the following commands from the root of the Hangar project:
 
-```shell
+```sh
 npx nx test
 ```
 

--- a/libs/wingc/CONTRIBUTING.md
+++ b/libs/wingc/CONTRIBUTING.md
@@ -88,7 +88,7 @@ otherwise, `cargo test` fails if snapshots are out of date.
 
 Install the dependencies using npm:
 
-```shell
+```sh
 cargo something
 ```
 


### PR DESCRIPTION
IMO, `$` should only be used if you don't expect the user to copy the block and it's being shown for display purposes. This already messed me up with the npm login command.

----
*By submitting this pull request, I confirm that my contribution is made under the terms of [Monada contribution license](https://docs.winglang.io/terms-and-policies/contribution-license.html)*
