### PR TITLE
chore(docs): add missing link to nvm in "contributing" guide

### DIFF
--- a/docs/06-contributors/handbook.md
+++ b/docs/06-contributors/handbook.md
@@ -82,6 +82,7 @@ npm run test
 [Rust]: https://www.rust-lang.org/tools/install
 [AWS CLI]: https://aws.amazon.com/cli/
 [Terraform CLI]: https://learn.hashicorp.com/terraform/getting-started/install.html
+[nvm]: https://github.com/nvm-sh/nvm
 
 ## 🔨 How do I build just the SDK?
 


### PR DESCRIPTION
Right now, it's just `[nvm]`, without pointing to anything.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the 
[Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.
