### PR TITLE
chore(repo): remove separator from pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,4 @@
 
 
-----
-
 *By submitting this pull request, I confirm that my contribution is made under the terms of the 
 [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.


### PR DESCRIPTION
If there isn't an empty line before it, it becomes a header ([example](https://github.com/winglang/wing/pull/742)).



----

*By submitting this pull request, I confirm that my contribution is made under the terms of the 
[Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.
