### PR TITLE
fix(docs): Add a link to #intro slack channel in contributor handbook

### DIFF
--- a/docs/06-contributors/handbook.md
+++ b/docs/06-contributors/handbook.md
@@ -292,6 +292,6 @@ Please review it before contributing issues, pull requests, or joining the [Wing
 
 ## 🙋 Where can I go to ask questions about Wing?
 
-Come on down and hang out in the [Wing Slack]! We're a friendly bunch and we'd love to help you out. There are no stupid questions, so don't be afraid to ask! Don't forget to introduce yourself in the #intro channel.
+Come on down and hang out in the [Wing Slack]! We're a friendly bunch and we'd love to help you out. There are no stupid questions, so don't be afraid to ask! Don't forget to introduce yourself in the [#intro](https://winglang.slack.com/archives/C048QDSMC7L) channel.
 
 [Wing Slack]: https://join.slack.com/t/winglang/shared_invite/zt-1i7jb3pt3-lb0RKOSoLA1~pl6cBnP2tA


### PR DESCRIPTION

*By submitting this pull request, I confirm that my contribution is made under the terms of the 
[Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.
