### PR TITLE
chore(repo): ensure `auto` cli can generate a new version for all commits

### DIFF
--- a/.autorc
+++ b/.autorc
@@ -3,6 +3,26 @@
     ["conventional-commits", { "preset": "angular" }],
     "git-tag"
   ],
+  "labels": [
+    {
+      "name": "documentation",
+      "releaseType": "patch"
+    },
+    {
+      "name": "internal",
+      "releaseType": "patch"
+    },
+    {
+      "name": "tests",
+      "releaseType": "patch"
+    },
+    {
+      "name": "dependencies",
+      "releaseType": "patch"
+    }
+  ],
+  "onlyPublishWithReleaseLabel": false,
+  "baseBranch": "main",
   "owner": "winglang",
   "repo": "wing",
   "name": "MonadaBot",


### PR DESCRIPTION
Even though `auto` is set up to use conventional commits for versioning, it seems like certain labels on the source PRs by default will cause no version increment. These settings will exclude those labels.

Was able to replicate and resolve source issue locally.

Fixes #752

*By submitting this pull request, I confirm that my contribution is made under the terms of the 
[Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.
