### PR TITLE
chore: add update docsite ci job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -411,15 +411,3 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.ACTION_MONITORING_SLACK }}
         if: env.WORKFLOW_CONCLUSION == 'failure'
-
-  update-docsite:
-    needs:
-      - publish
-    if: github.ref == 'refs/heads/main'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Dispatch docsite workflow event
-        run: |
-          curl -X POST -H "Accept: application/vnd.github+json" -H "Authorization: Bearer $GITHUB_TOKEN" https://api.github.com/repos/winglang/docsite/actions/workflows/41365537/dispatches -d '{"ref":"main"}'
-        with:
-          GITHUB_TOKEN: ${{ secrets.DOCSITE_WORKFLOW_GITHUB_TOKEN }}

--- a/.github/workflows/update-docsite.yml
+++ b/.github/workflows/update-docsite.yml
@@ -1,0 +1,13 @@
+on:
+  release:
+    types: [published]
+
+jobs:
+  update-docsite:
+    name: Dispatch docsite update workflow event
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          curl -X POST -H "Accept: application/vnd.github+json" -H "Authorization: Bearer $GITHUB_TOKEN" https://api.github.com/repos/winglang/docsite/actions/workflows/41365537/dispatches -d '{"ref":"main"}'
+        with:
+          GITHUB_TOKEN: ${{ secrets.DOCSITE_WORKFLOW_GITHUB_TOKEN }}


### PR DESCRIPTION
This PR adds a job that will run after a successful publish, and will trigger the update workflow in the docsite repository.

Before merging, this job needs a GitHub secret named `DOCSITE_WORKFLOW_GITHUB_TOKEN` containing a GitHub token with the `repo` scope.

*By submitting this pull request, I confirm that my contribution is made under the terms of the 
[Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.
