### PR TITLE
fix: remove confusing text from installation docs

### DIFF
--- a/docs/02-getting-started/02-installation.md
+++ b/docs/02-getting-started/02-installation.md
@@ -15,7 +15,7 @@ The toolchain includes three tools:
 
 To install Wing, you will need the following setup:
 
-* [Node.js](https://nodejs.org/en/) version 18.x or above (we recommend [nvm](https://github.com/nvm-sh/nvm)).
+* [Node.js](https://nodejs.org/en/) version 18.x (we recommend [nvm](https://github.com/nvm-sh/nvm)).
 * [VSCode] (recommended).
 
 In order to deploy to AWS, you will also need:


### PR DESCRIPTION
Remove the 'or above' text from the node installation guide, as the compiler doesn't support node 19.x right now.



*By submitting this pull request, I confirm that my contribution is made under the terms of the 
[Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.
