### PR TITLE
fix(repo): release-commenter.yml has invalid configuration

### DIFF
--- a/.github/workflows/release-commenter.yml
+++ b/.github/workflows/release-commenter.yml
@@ -4,6 +4,8 @@ on:
 
 jobs:
   release:
+    name: "Post release comments"
+    runs-on: ubuntu-latest
     steps:
       - uses: apexskier/github-release-commenter@v1
         with:


### PR DESCRIPTION
> Invalid workflow file: .github/workflows/release-commenter.yml#L7
The workflow is not valid. .github/workflows/release-commenter.yml (Line: 7, Col: 5): Required property is missing: runs-on

*By submitting this pull request, I confirm that my contribution is made under the terms of the 
[Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.
