### PR TITLE
fix(repo): wrong event name that triggers the workflow

### DIFF
--- a/.github/workflows/issue-backlogger.yml
+++ b/.github/workflows/issue-backlogger.yml
@@ -1,5 +1,5 @@
 on:
-  issue:
+  issues:
     types: [opened]
 
 jobs:


### PR DESCRIPTION
There was a missing `s` at `on: issues` that is the event that trigger the workflow

*By submitting this pull request, I confirm that my contribution is made under the terms of the 
[Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.
