### PR TITLE
chore: add volta

### DIFF
--- a/docs/02-getting-started/02-installation.md
+++ b/docs/02-getting-started/02-installation.md
@@ -15,7 +15,7 @@ The toolchain includes three tools:
 
 To install Wing, you will need the following setup:
 
-* [Node.js](https://nodejs.org/en/) version 18.x (we recommend [nvm](https://github.com/nvm-sh/nvm)).
+* [Node.js](https://nodejs.org/en/) version 18.x (we recommend [volta](https://volta.sh)).
 * [VSCode] (recommended).
 
 In order to deploy to AWS, you will also need:

--- a/docs/06-contributors/handbook.md
+++ b/docs/06-contributors/handbook.md
@@ -57,7 +57,7 @@ Nx will be installed alongside the rest of the project's dependencies after you 
 
 Here is a list of minimal tools you should install to build the Wing repo in your development environment:
 
-* [Node.js] version 18.x or above (we recommend [nvm])
+* [Node.js] version 18.x or above (we recommend [volta])
 * [Rust]
 * [AWS CLI] (only needed for integration tests - make sure to do the setup part to create credentials)
 * [Terraform CLI] (only needed for integration tests)
@@ -81,7 +81,7 @@ npm run test
 [Rust]: https://www.rust-lang.org/tools/install
 [AWS CLI]: https://aws.amazon.com/cli/
 [Terraform CLI]: https://learn.hashicorp.com/terraform/getting-started/install.html
-[nvm]: https://github.com/nvm-sh/nvm
+[volta]: https://volta.sh
 
 ## 🔨 How do I build just the SDK?
 

--- a/package.json
+++ b/package.json
@@ -20,5 +20,9 @@
     "install:wing": "npm --prefix apps/wing install",
     "install:wingsdk": "npm --prefix libs/wingsdk install",
     "install:hangar": "npm --prefix tools/hangar install"
+  },
+  "volta": {
+    "node": "18.12.1",
+    "npm": "8.19.3"
   }
 }


### PR DESCRIPTION
volta is so much better than nvm, it really needs to be more popular.

Why volta:
- It works automatically (no need to run a `use` command)
- Better cross-platform support
- Can also manage any node tool version

Fixes #369

*By submitting this pull request, I confirm that my contribution is made under the terms of the 
[Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.
