### PR TITLE
fix: vscode token saved in workspace config instead of global

### DIFF
--- a/apps/vscode-wing/src/extension.ts
+++ b/apps/vscode-wing/src/extension.ts
@@ -11,6 +11,7 @@ import {
   commands,
   window,
   workspace,
+  ConfigurationTarget,
 } from "vscode";
 import {
   Executable,
@@ -59,7 +60,7 @@ async function addCommands(context: ExtensionContext) {
       if (token) {
         await workspace
           .getConfiguration(EXTENSION_NAME)
-          .update(CFG_UPDATES_GITHUB_TOKEN, token);
+          .update(CFG_UPDATES_GITHUB_TOKEN, token, ConfigurationTarget.Global);
         await checkForUpdates(context, true);
       }
     })


### PR DESCRIPTION

*By submitting this pull request, I confirm that my contribution is made under the terms of the 
[Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.
