### PR TITLE
chore(repo): add close-stale-issues-prs workflow

### DIFF
--- a/.github/workflows/close-stale.yml
+++ b/.github/workflows/close-stale.yml
@@ -18,13 +18,13 @@ jobs:
           stale-issue-message: |
             Hi,
 
-            This issue hasn't seen activity in 60 days. Therefore, we are closing this issue for now.
+            This issue hasn't seen activity in 60 days. Therefore, we are marking this issue as stale for now. It will be closed after 7 days.
             Feel free to re-open this issue when there's an update or relevant information to be added.
             Thanks!
           stale-pr-message: |
             Hi,
 
-            This PR has not seen activity in 20 days. Therefore, we are closing the PR for now.
+            This PR has not seen activity in 20 days. Therefore, we are marking the PR as stale for now. It will be closed after 7 days.
             If you need help with the PR, do not hesitate to reach out in the winglang community slack at [winglang.slack.com](https://winglang.slack.com).
             Feel free to re-open this PR when it is still relevant and ready to be worked on again.
             Thanks!


### PR DESCRIPTION
In this PR, I add a new GitHub workflow that closes stale issues with no activity in 60 days and PR's with no activity in 20 days. I've also added custom messages for both the `stale issues` and `stale pr`.
The workfow runs on a schedule everyday at 6am UTC.

This PR closes Issue #829 
*By submitting this pull request, I confirm that my contribution is made under the terms of the 
[Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.
