### PR TITLE
fix(docs): dangled wx reference

### DIFF
--- a/docs/02-getting-started/04-compile.md
+++ b/docs/02-getting-started/04-compile.md
@@ -35,10 +35,6 @@ wing compile -t sim hello.w
 This would create a new file called `target/hello.wsim` which is the simulated
 version of your entire cloud application.
 
-:::info
-The "wsim" extension stands for "wing simulated".
-:::
-
 Now that we have an `hello.wsim` file, we can either interact with through the Wing
 Console or load it into a `Simulator` class and use it programmatically.
 


### PR DESCRIPTION
Update dangled `wx` reference to `wsim` that was missed in commit (https://github.com/winglang/wing/commit/05ece594e98a3cf58137175336330f54218261f3)

But, I do see it may be a bit verbose to keep it. Let me know if we should just remove it instead

*By submitting this pull request, I confirm that my contribution is made under the terms of the 
[Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.
