### PR TITLE
chore(docs): remove ref to general feedback pull-request

### DIFF
--- a/docs/04-reference/winglang-spec.md
+++ b/docs/04-reference/winglang-spec.md
@@ -6,8 +6,7 @@ description: The Wing Language Specification
 
 :::tip Feedback?
 
-📝 Do you want to leave comments directly on this doc? Submit comments
-[here](https://github.com/winglang/wing/pull/497/files#diff-46a5d9ee8e0085d047c39f03dfda67a39f5087ce50f9b16a8103e0073a0d3d78).
+📝 You're more than welcome to [open a new discussion](https://github.com/winglang/wing/discussions/new) or just go ahead and submit a PR against [this doc](https://github.com/winglang/wing/blob/main/docs/04-reference/winglang-spec.md).
  
 :::
 


### PR DESCRIPTION
Removing reference to general feedback PR in our docs prior to closing this PR altogether.
We decided the general feedback PR is not very useful.

*By submitting this pull request, I confirm that my contribution is made under the terms of the 
[Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.
