### PR TITLE
chore(compiler): deterministic output for maps and structs

### DIFF
--- a/examples/tests/valid/container_types.w
+++ b/examples/tests/valid/container_types.w
@@ -13,10 +13,9 @@ let arr5 = [bucket1, bucket2, bucket3];
 //let arr6: Array<cloud.Bucket> = [bucket1, bucket2, bucket3];
 
 //Map tests
-/* let m1 = {"a":1, "b":2, "c":3};
+let m1 = {"a":1, "b":2, "c":3};
 let m2: Map<num> = {"a":1, "b":2, "c":3};
 let m3 = Map<num> {"a":1, "b":2, "c":3};
 let m4: Map<num> = Map<num> {"a":1, "b":2, "c":3};
 let m5 = {"a":bucket1, "b":bucket2, "c":bucket3};
-*/
 //let m6: Map<cloud.Bucket> = {"a":bucket1, "b":bucket2, "c":bucket3};

--- a/libs/wingc/src/ast.rs
+++ b/libs/wingc/src/ast.rs
@@ -1,5 +1,5 @@
 use std::cell::RefCell;
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::fmt::{Debug, Display};
 use std::hash::{Hash, Hasher};
 
@@ -197,11 +197,13 @@ pub enum ExprKind {
 	},
 	StructLiteral {
 		type_: Type,
-		fields: HashMap<Symbol, Expr>,
+		// We're using an ordered map implementation to guarantee deterministic compiler output. See discussion: https://github.com/winglang/wing/discussions/887.
+		fields: BTreeMap<Symbol, Expr>,
 	},
 	MapLiteral {
 		type_: Option<Type>,
-		fields: HashMap<String, Expr>,
+		// We're using an ordered map implementation to guarantee deterministic compiler output. See discussion: https://github.com/winglang/wing/discussions/887.
+		fields: BTreeMap<String, Expr>,
 	},
 	FunctionClosure(FunctionDefinition),
 }

--- a/libs/wingc/src/parser.rs
+++ b/libs/wingc/src/parser.rs
@@ -1,6 +1,6 @@
 use phf::phf_map;
 use std::cell::RefCell;
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::{str, vec};
 use tree_sitter::Node;
 use tree_sitter_traversal::{traverse, Order};
@@ -83,7 +83,7 @@ impl Parser<'_> {
 		if let Some(entry) = UNIMPLEMENTED_GRAMMARS.get(&grammar_element) {
 			self.add_error(
 				format!(
-					"{} '{}' is not yet supported {}",
+					"{} '{}' is not supported yet {}",
 					grammar_context, grammar_element, entry
 				),
 				node,
@@ -692,7 +692,7 @@ impl Parser<'_> {
 					None
 				};
 
-				let mut fields = HashMap::new();
+				let mut fields = BTreeMap::new();
 				let mut cursor = expression_node.walk();
 				for field_node in expression_node.children_by_field_name("member", &mut cursor) {
 					if field_node.is_extra() {
@@ -726,7 +726,7 @@ impl Parser<'_> {
 			}
 			"struct_literal" => {
 				let type_ = self.build_type(&expression_node.child_by_field_name("type").unwrap());
-				let mut fields = HashMap::new();
+				let mut fields = BTreeMap::new();
 				let mut cursor = expression_node.walk();
 				for field in expression_node.children_by_field_name("fields", &mut cursor) {
 					if !field.is_named() || field.is_extra() {

--- a/tools/hangar/src/__snapshots__/cli.test.ts.snap
+++ b/tools/hangar/src/__snapshots__/cli.test.ts.snap
@@ -678,6 +678,11 @@ constructor() {
   const bucket2 = new cloud.Bucket(this,\\"bucket2\\");
   const bucket3 = new cloud.Bucket(this,\\"bucket3\\");
   const arr5 = Object.freeze([bucket1, bucket2, bucket3]);
+  const m1 = Object.freeze({\\"a\\": 1, \\"b\\": 2, \\"c\\": 3});
+  const m2 = Object.freeze({\\"a\\": 1, \\"b\\": 2, \\"c\\": 3});
+  const m3 = Object.freeze({\\"a\\": 1, \\"b\\": 2, \\"c\\": 3});
+  const m4 = Object.freeze({\\"a\\": 1, \\"b\\": 2, \\"c\\": 3});
+  const m5 = Object.freeze({\\"a\\": bucket1, \\"b\\": bucket2, \\"c\\": bucket3});
 }
 }
 new MyApp().synth();"


### PR DESCRIPTION
We decided to use an ordered map implementation for our `Map`s and `Struct`s to guarantee deterministic compiler output. See discussion: https://github.com/winglang/wing/discussions/887.

*By submitting this pull request, I confirm that my contribution is made under the terms of the 
[Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.