### PR TITLE
chore(docs): change wing run command to wing it

### DIFF
--- a/apps/wing/README.md
+++ b/apps/wing/README.md
@@ -29,11 +29,11 @@ To see scoped debug logs, use specific namespaces, e.g. `wing:commands:compile`.
 >   -t, --target <target>    Target platform (options: 'tf-aws', 'sim') (default: "tf-aws")
 > ```
 
-## `wing run`
+## `wing it`
 
 > ```sh
-> $ wing run --help
-> Usage: wing run [options] <entrypoint>.wsim
+> $ wing it --help
+> Usage: wing it [options] <entrypoint>.wsim
 > 
 > Runs a Wing simulator file in the Wing Console
 > 

--- a/docs/02-getting-started/04-console.md
+++ b/docs/02-getting-started/04-console.md
@@ -22,7 +22,7 @@ also test your application [programmatically](./simulator) or [deploy it to AWS]
 We can use the Wing CLI to start the console with our newly created Wing source file:
 
 ```sh
-wing run hello.w
+wing it hello.w
 ```
 
 The Wing Console will now compile hello.w source file to [the simulator target](./simulator#the-simulator-target-sim)

--- a/rfcs/epic-todo-app-compiler.md
+++ b/rfcs/epic-todo-app-compiler.md
@@ -159,7 +159,7 @@ After creating the `task-list.w` file he starts Wing Console by running the foll
 develop the application side by side with the console:
 
 ```sh
-wing run ./task-list.w
+wing it ./task-list.w
 ``` 
 
 While **Wing Console** is running in the background, it watches the .w file src dir for changes, 


### PR DESCRIPTION
Following the resolution of #968 - we decided to update the docs and use the cooler alias `wing it` instead of the soooooo boring `wing run`.

*By submitting this pull request, I confirm that my contribution is made under the terms of the 
[Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.
