### PR TITLE
fix(compiler): support for `this` in resource/class init

### DIFF
--- a/examples/tests/valid/resource.w
+++ b/examples/tests/valid/resource.w
@@ -5,3 +5,6 @@ resource R {
     this.name = name;
   }
 }
+
+let res = new R("Arr");
+print(resource.name);

--- a/examples/tests/valid/resource.w
+++ b/examples/tests/valid/resource.w
@@ -1,0 +1,7 @@
+resource R {
+  name: str;
+  
+  init(name: str) {
+    this.name = name;
+  }
+}

--- a/examples/tests/valid/resource.w
+++ b/examples/tests/valid/resource.w
@@ -7,4 +7,4 @@ resource R {
 }
 
 let res = new R("Arr");
-print(resource.name);
+print(res.name);

--- a/tools/hangar/src/__snapshots__/cli.test.ts.snap
+++ b/tools/hangar/src/__snapshots__/cli.test.ts.snap
@@ -1743,6 +1743,8 @@ constructor() {
   name;
   
   }
+  const res = new R(this,\\"R\\",\\"Arr\\");
+  console.log(res.name);
 }
 }
 new MyApp().synth();"

--- a/tools/hangar/src/__snapshots__/cli.test.ts.snap
+++ b/tools/hangar/src/__snapshots__/cli.test.ts.snap
@@ -1680,6 +1680,74 @@ constructor() {
 new MyApp().synth();"
 `;
 
+exports[`wing compile resource.w > cdk.tf.json 1`] = `
+{
+  "//": {
+    "metadata": {
+      "backend": "local",
+      "stackName": "root",
+      "version": "0.13.3",
+    },
+    "outputs": {},
+  },
+  "provider": {
+    "aws": [
+      {},
+    ],
+  },
+}
+`;
+
+exports[`wing compile resource.w > manifest.json 1`] = `
+{
+  "stacks": {
+    "root": {
+      "annotations": [],
+      "constructPath": "root",
+      "dependencies": [],
+      "name": "root",
+      "synthesizedStackPath": "stacks/root/cdk.tf.json",
+      "workingDirectory": "stacks/root",
+    },
+  },
+  "version": "0.13.3",
+}
+`;
+
+exports[`wing compile resource.w > preflight.js 1`] = `
+"const $stdlib = require('@winglang/wingsdk');
+const $outdir = process.env.WINGSDK_SYNTH_DIR ?? \\".\\";
+
+function __app(target) {
+	switch (target) {
+		case \\"sim\\":
+			return $stdlib.sim.App;
+		case \\"tfaws\\":
+		case \\"tf-aws\\":
+			return $stdlib.tfaws.App;
+		default:
+			throw new Error(\`Unknown WING_TARGET value: \\"\${process.env.WING_TARGET ?? \\"\\"}\\"\`);
+	}
+}
+const $App = __app(process.env.WING_TARGET);
+
+class MyApp extends $App {
+constructor() {
+  super({ outdir: $outdir, name: \\"resource\\" });
+  
+  class R
+  {
+  constructor(name) {
+    this.name = name;
+  }
+  name;
+  
+  }
+}
+}
+new MyApp().synth();"
+`;
+
 exports[`wing compile statements_if.w > cdk.tf.json 1`] = `
 {
   "//": {


### PR DESCRIPTION
This is the bare minimum just to make `init` useful. We still don't have verification that all fields are initialized etc.
See #542 
See #864

```wing
bring cloud;

resource R {
  name: str;

  init(name: str) {
    this.name = name; // This should now work, before `this` was an unknown symbol
  }
}

let r = new R("foo");
```

*By submitting this pull request, I confirm that my contribution is made under the terms of the 
[Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.
