### PR TITLE
feat(sdk): `print`s are displayed in wing console

### DIFF
--- a/apps/vscode-wing/package-lock.json
+++ b/apps/vscode-wing/package-lock.json
@@ -9729,7 +9729,8 @@
     "@cdktf/provider-aws": {
       "version": "10.0.12",
       "resolved": "https://registry.npmjs.org/@cdktf/provider-aws/-/provider-aws-10.0.12.tgz",
-      "integrity": "sha512-JI38MbjjQ5xjza1uoAcwdfqvYmj1wAGdOYRROvm5+QOFX1qowCtyngWhywzLEIMchu2NXbIbf1SqpGBbH6J6lw=="
+      "integrity": "sha512-JI38MbjjQ5xjza1uoAcwdfqvYmj1wAGdOYRROvm5+QOFX1qowCtyngWhywzLEIMchu2NXbIbf1SqpGBbH6J6lw==",
+      "requires": {}
     },
     "@cspotcode/source-map-support": {
       "version": "0.8.1",
@@ -11478,7 +11479,8 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "acorn-walk": {
       "version": "8.2.0",
@@ -12936,7 +12938,8 @@
       "version": "8.5.0",
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz",
       "integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "eslint-import-resolver-node": {
       "version": "0.3.6",
@@ -14866,7 +14869,8 @@
     "polycons": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/polycons/-/polycons-0.1.3.tgz",
-      "integrity": "sha512-0Yi7CgVwIzWSTAQ7P2APDUGvaQ+stfJ7zDlPXie0/EyETHLg6tk8S20iwcirxrkxA0UDphZnEuBtyLUbn6TdfQ=="
+      "integrity": "sha512-0Yi7CgVwIzWSTAQ7P2APDUGvaQ+stfJ7zDlPXie0/EyETHLg6tk8S20iwcirxrkxA0UDphZnEuBtyLUbn6TdfQ==",
+      "requires": {}
     },
     "prebuild-install": {
       "version": "7.1.1",

--- a/apps/vscode-wing/package-lock.json
+++ b/apps/vscode-wing/package-lock.json
@@ -9729,8 +9729,7 @@
     "@cdktf/provider-aws": {
       "version": "10.0.12",
       "resolved": "https://registry.npmjs.org/@cdktf/provider-aws/-/provider-aws-10.0.12.tgz",
-      "integrity": "sha512-JI38MbjjQ5xjza1uoAcwdfqvYmj1wAGdOYRROvm5+QOFX1qowCtyngWhywzLEIMchu2NXbIbf1SqpGBbH6J6lw==",
-      "requires": {}
+      "integrity": "sha512-JI38MbjjQ5xjza1uoAcwdfqvYmj1wAGdOYRROvm5+QOFX1qowCtyngWhywzLEIMchu2NXbIbf1SqpGBbH6J6lw=="
     },
     "@cspotcode/source-map-support": {
       "version": "0.8.1",
@@ -11479,8 +11478,7 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "acorn-walk": {
       "version": "8.2.0",
@@ -12938,8 +12936,7 @@
       "version": "8.5.0",
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz",
       "integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "eslint-import-resolver-node": {
       "version": "0.3.6",
@@ -14869,8 +14866,7 @@
     "polycons": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/polycons/-/polycons-0.1.3.tgz",
-      "integrity": "sha512-0Yi7CgVwIzWSTAQ7P2APDUGvaQ+stfJ7zDlPXie0/EyETHLg6tk8S20iwcirxrkxA0UDphZnEuBtyLUbn6TdfQ==",
-      "requires": {}
+      "integrity": "sha512-0Yi7CgVwIzWSTAQ7P2APDUGvaQ+stfJ7zDlPXie0/EyETHLg6tk8S20iwcirxrkxA0UDphZnEuBtyLUbn6TdfQ=="
     },
     "prebuild-install": {
       "version": "7.1.1",

--- a/docs/04-reference/wingsdk-api.md
+++ b/docs/04-reference/wingsdk-api.md
@@ -390,6 +390,7 @@ Any object.
 | --- | --- | --- |
 | <code><a href="#@winglang/wingsdk.cloud.Function.property.node">node</a></code> | <code>constructs.Node</code> | The tree node. |
 | <code><a href="#@winglang/wingsdk.cloud.Function.property.stateful">stateful</a></code> | <code>bool</code> | Whether a resource is stateful, i.e. it stores information that is not defined by your application. |
+| <code><a href="#@winglang/wingsdk.cloud.Function.property.env">env</a></code> | <code>MutMap&lt;str&gt;</code> | Returns the set of environment variables for this function. |
 
 ---
 
@@ -418,6 +419,18 @@ Whether a resource is stateful, i.e. it stores information that is not defined b
 A non-stateful resource does not remember information about past
 transactions or events, and can typically be replaced by a cloud provider
 with a fresh copy without any consequences.
+
+---
+
+##### `env`<sup>Required</sup> <a name="env" id="@winglang/wingsdk.cloud.Function.property.env"></a>
+
+```wing
+env: MutMap<str>;
+```
+
+- *Type:* MutMap&lt;str&gt;
+
+Returns the set of environment variables for this function.
 
 ---
 

--- a/docs/04-reference/wingsdk-api.md
+++ b/docs/04-reference/wingsdk-api.md
@@ -428,19 +428,6 @@ with a fresh copy without any consequences.
 
 A cloud logging facility.
 
-#### Initializers <a name="Initializers" id="@winglang/wingsdk.cloud.Logger.Initializer"></a>
-
-```wing
-bring cloud;
-
-new cloud.Logger()
-```
-
-| **Name** | **Type** | **Description** |
-| --- | --- | --- |
-
----
-
 #### Methods <a name="Methods" id="Methods"></a>
 
 | **Name** | **Description** |
@@ -497,6 +484,8 @@ The message to log.
 | **Name** | **Description** |
 | --- | --- |
 | <code><a href="#@winglang/wingsdk.cloud.Logger.isConstruct">is_construct</a></code> | Checks if `x` is a construct. |
+| <code><a href="#@winglang/wingsdk.cloud.Logger.of">of</a></code> | Returns the logger registered to the given scope, throwing an error if there is none. |
+| <code><a href="#@winglang/wingsdk.cloud.Logger.register">register</a></code> | Create a logger and register it to the given scope. |
 
 ---
 
@@ -517,6 +506,26 @@ Checks if `x` is a construct.
 Any object.
 
 ---
+
+##### `of` <a name="of" id="@winglang/wingsdk.cloud.Logger.of"></a>
+
+```wing
+bring cloud;
+
+cloud.Logger.of()
+```
+
+Returns the logger registered to the given scope, throwing an error if there is none.
+
+##### `register` <a name="register" id="@winglang/wingsdk.cloud.Logger.register"></a>
+
+```wing
+bring cloud;
+
+cloud.Logger.register()
+```
+
+Create a logger and register it to the given scope.
 
 #### Properties <a name="Properties" id="Properties"></a>
 
@@ -2174,7 +2183,6 @@ Synthesize the app into an artifact.
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
 | <code><a href="#@winglang/wingsdk.core.IApp.property.node">node</a></code> | <code>constructs.Node</code> | The tree node. |
-| <code><a href="#@winglang/wingsdk.core.IApp.property.logger">logger</a></code> | <code>cloud.Logger</code> | Returns a logger instance that can be used to emit traces and logs throughout the system. |
 | <code><a href="#@winglang/wingsdk.core.IApp.property.outdir">outdir</a></code> | <code>str</code> | Directory where artifacts are synthesized to. |
 
 ---
@@ -2188,18 +2196,6 @@ node: Node;
 - *Type:* constructs.Node
 
 The tree node.
-
----
-
-##### `logger`<sup>Required</sup> <a name="logger" id="@winglang/wingsdk.core.IApp.property.logger"></a>
-
-```wing
-logger: Logger;
-```
-
-- *Type:* cloud.Logger
-
-Returns a logger instance that can be used to emit traces and logs throughout the system.
 
 ---
 
@@ -2494,7 +2490,7 @@ Inflight interface for `Logger`.
 
 | **Name** | **Description** |
 | --- | --- |
-| <code><a href="#@winglang/wingsdk.cloud.ILoggerClient.print">print</a></code> | Logs a message. |
+| <code><a href="#@winglang/wingsdk.cloud.ILoggerClient.print">print</a></code> | Logs a message. The log will be associated with whichever resource is running the inflight code. |
 
 ---
 
@@ -2506,10 +2502,9 @@ print(message: str): void
 
 **Inflight client:** [true](#true)
 
-Logs a message.
+Logs a message. The log will be associated with whichever resource is running the inflight code.
 
-The log will be associated with whichever resource is
-running the inflight code.
+NOTICE: this is not an async function because it is wrapped by `console.log()`.
 
 ###### `message`<sup>Required</sup> <a name="message" id="@winglang/wingsdk.cloud.ILoggerClient.print.parameter.message"></a>
 

--- a/docs/04-reference/wingsdk-api.md
+++ b/docs/04-reference/wingsdk-api.md
@@ -428,6 +428,19 @@ with a fresh copy without any consequences.
 
 A cloud logging facility.
 
+#### Initializers <a name="Initializers" id="@winglang/wingsdk.cloud.Logger.Initializer"></a>
+
+```wing
+bring cloud;
+
+new cloud.Logger()
+```
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+
+---
+
 #### Methods <a name="Methods" id="Methods"></a>
 
 | **Name** | **Description** |
@@ -484,8 +497,6 @@ The message to log.
 | **Name** | **Description** |
 | --- | --- |
 | <code><a href="#@winglang/wingsdk.cloud.Logger.isConstruct">is_construct</a></code> | Checks if `x` is a construct. |
-| <code><a href="#@winglang/wingsdk.cloud.Logger.of">of</a></code> | Returns the logger registered to the given scope, throwing an error if there is none. |
-| <code><a href="#@winglang/wingsdk.cloud.Logger.register">register</a></code> | Create a logger and register it to the given scope. |
 
 ---
 
@@ -506,26 +517,6 @@ Checks if `x` is a construct.
 Any object.
 
 ---
-
-##### `of` <a name="of" id="@winglang/wingsdk.cloud.Logger.of"></a>
-
-```wing
-bring cloud;
-
-cloud.Logger.of()
-```
-
-Returns the logger registered to the given scope, throwing an error if there is none.
-
-##### `register` <a name="register" id="@winglang/wingsdk.cloud.Logger.register"></a>
-
-```wing
-bring cloud;
-
-cloud.Logger.register()
-```
-
-Create a logger and register it to the given scope.
 
 #### Properties <a name="Properties" id="Properties"></a>
 
@@ -2183,6 +2174,7 @@ Synthesize the app into an artifact.
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
 | <code><a href="#@winglang/wingsdk.core.IApp.property.node">node</a></code> | <code>constructs.Node</code> | The tree node. |
+| <code><a href="#@winglang/wingsdk.core.IApp.property.logger">logger</a></code> | <code>cloud.Logger</code> | Returns a logger instance that can be used to emit traces and logs throughout the system. |
 | <code><a href="#@winglang/wingsdk.core.IApp.property.outdir">outdir</a></code> | <code>str</code> | Directory where artifacts are synthesized to. |
 
 ---
@@ -2196,6 +2188,18 @@ node: Node;
 - *Type:* constructs.Node
 
 The tree node.
+
+---
+
+##### `logger`<sup>Required</sup> <a name="logger" id="@winglang/wingsdk.core.IApp.property.logger"></a>
+
+```wing
+logger: Logger;
+```
+
+- *Type:* cloud.Logger
+
+Returns a logger instance that can be used to emit traces and logs throughout the system.
 
 ---
 

--- a/docs/04-reference/wingsdk-api.md
+++ b/docs/04-reference/wingsdk-api.md
@@ -434,7 +434,7 @@ A cloud logging facility.
 | --- | --- |
 | <code><a href="#@winglang/wingsdk.cloud.Logger.toString">to_string</a></code> | Returns a string representation of this construct. |
 | <code><a href="#@winglang/wingsdk.cloud.Logger.addConnection">add_connection</a></code> | Adds a connection to this resource. |
-| <code><a href="#@winglang/wingsdk.cloud.Logger.print">print</a></code> | Logs a message. |
+| <code><a href="#@winglang/wingsdk.cloud.Logger.print">print</a></code> | Logs a message (preflight). |
 
 ---
 
@@ -469,7 +469,7 @@ describing how this resource is related to another resource.
 print(message: str): void
 ```
 
-Logs a message.
+Logs a message (preflight).
 
 ###### `message`<sup>Required</sup> <a name="message" id="@winglang/wingsdk.cloud.Logger.print.parameter.message"></a>
 

--- a/libs/wingc/src/jsify.rs
+++ b/libs/wingc/src/jsify.rs
@@ -548,7 +548,6 @@ impl JSifier {
 		let procid = base16ct::lower::encode_string(&Sha256::new().chain_update(&block).finalize());
 		let mut bindings = vec![];
 		let mut capture_names = vec![];
-		
 		for (obj, cap_def) in func_def.captures.borrow().as_ref().unwrap().iter() {
 			capture_names.push(obj.clone());
 			bindings.push(format!(

--- a/libs/wingc/src/jsify.rs
+++ b/libs/wingc/src/jsify.rs
@@ -284,14 +284,7 @@ impl JSifier {
 			ExprKind::Call { function, args } => {
 				let mut needs_case_conversion = false;
 				if matches!(&function, Reference::Identifier(Symbol { name, .. }) if name == "print") {
-					match phase {
-						Phase::Inflight => {
-							return format!("$logger.print({})", self.jsify_arg_list(args, None, None, false));
-						}
-						_ => {
-							return format!("console.log({})", self.jsify_arg_list(args, None, None, false));
-						}
-					}
+					return format!("console.log({})", self.jsify_arg_list(args, None, None, false));
 				} else if let Reference::NestedIdentifier { object, .. } = function {
 					let object_type = object.evaluated_type.borrow().unwrap();
 					needs_case_conversion = object_type.as_class_or_resource().unwrap().should_case_convert_jsii;
@@ -556,9 +549,6 @@ impl JSifier {
 		let mut bindings = vec![];
 		let mut capture_names = vec![];
 		
-		// always capture the application logger via $logger
-		capture_names.push("$logger".into());
-
 		for (obj, cap_def) in func_def.captures.borrow().as_ref().unwrap().iter() {
 			capture_names.push(obj.clone());
 			bindings.push(format!(

--- a/libs/wingsdk/API.md
+++ b/libs/wingsdk/API.md
@@ -427,7 +427,7 @@ A cloud logging facility.
 | --- | --- |
 | <code><a href="#@winglang/wingsdk.cloud.Logger.toString">to_string</a></code> | Returns a string representation of this construct. |
 | <code><a href="#@winglang/wingsdk.cloud.Logger.addConnection">add_connection</a></code> | Adds a connection to this resource. |
-| <code><a href="#@winglang/wingsdk.cloud.Logger.print">print</a></code> | Logs a message. |
+| <code><a href="#@winglang/wingsdk.cloud.Logger.print">print</a></code> | Logs a message (preflight). |
 
 ---
 
@@ -462,7 +462,7 @@ describing how this resource is related to another resource.
 print(message: str): void
 ```
 
-Logs a message.
+Logs a message (preflight).
 
 ###### `message`<sup>Required</sup> <a name="message" id="@winglang/wingsdk.cloud.Logger.print.parameter.message"></a>
 

--- a/libs/wingsdk/API.md
+++ b/libs/wingsdk/API.md
@@ -459,14 +459,16 @@ describing how this resource is related to another resource.
 ##### `print` <a name="print" id="@winglang/wingsdk.cloud.Logger.print"></a>
 
 ```wing
-print(args: any): void
+print(message: str): void
 ```
 
 Logs a message.
 
-###### `args`<sup>Required</sup> <a name="args" id="@winglang/wingsdk.cloud.Logger.print.parameter.args"></a>
+###### `message`<sup>Required</sup> <a name="message" id="@winglang/wingsdk.cloud.Logger.print.parameter.message"></a>
 
-- *Type:* any
+- *Type:* str
+
+The message to log.
 
 ---
 
@@ -2488,7 +2490,7 @@ Inflight interface for `Logger`.
 ##### `print` <a name="print" id="@winglang/wingsdk.cloud.ILoggerClient.print"></a>
 
 ```wing
-print(args: any): void
+print(message: str): void
 ```
 
 **Inflight client:** [true](#true)
@@ -2497,9 +2499,11 @@ Logs a message. The log will be associated with whichever resource is running th
 
 NOTICE: this is not an async function because it is wrapped by `console.log()`.
 
-###### `args`<sup>Required</sup> <a name="args" id="@winglang/wingsdk.cloud.ILoggerClient.print.parameter.args"></a>
+###### `message`<sup>Required</sup> <a name="message" id="@winglang/wingsdk.cloud.ILoggerClient.print.parameter.message"></a>
 
-- *Type:* any
+- *Type:* str
+
+The message to print.
 
 ---
 

--- a/libs/wingsdk/API.md
+++ b/libs/wingsdk/API.md
@@ -421,19 +421,6 @@ with a fresh copy without any consequences.
 
 A cloud logging facility.
 
-#### Initializers <a name="Initializers" id="@winglang/wingsdk.cloud.Logger.Initializer"></a>
-
-```wing
-bring cloud;
-
-new cloud.Logger()
-```
-
-| **Name** | **Type** | **Description** |
-| --- | --- | --- |
-
----
-
 #### Methods <a name="Methods" id="Methods"></a>
 
 | **Name** | **Description** |
@@ -472,16 +459,14 @@ describing how this resource is related to another resource.
 ##### `print` <a name="print" id="@winglang/wingsdk.cloud.Logger.print"></a>
 
 ```wing
-print(message: str): void
+print(args: any): void
 ```
 
 Logs a message.
 
-###### `message`<sup>Required</sup> <a name="message" id="@winglang/wingsdk.cloud.Logger.print.parameter.message"></a>
+###### `args`<sup>Required</sup> <a name="args" id="@winglang/wingsdk.cloud.Logger.print.parameter.args"></a>
 
-- *Type:* str
-
-The message to log.
+- *Type:* any
 
 ---
 
@@ -490,6 +475,8 @@ The message to log.
 | **Name** | **Description** |
 | --- | --- |
 | <code><a href="#@winglang/wingsdk.cloud.Logger.isConstruct">is_construct</a></code> | Checks if `x` is a construct. |
+| <code><a href="#@winglang/wingsdk.cloud.Logger.of">of</a></code> | Returns the logger registered to the given scope, throwing an error if there is none. |
+| <code><a href="#@winglang/wingsdk.cloud.Logger.register">register</a></code> | Create a logger and register it to the given scope. |
 
 ---
 
@@ -510,6 +497,26 @@ Checks if `x` is a construct.
 Any object.
 
 ---
+
+##### `of` <a name="of" id="@winglang/wingsdk.cloud.Logger.of"></a>
+
+```wing
+bring cloud;
+
+cloud.Logger.of()
+```
+
+Returns the logger registered to the given scope, throwing an error if there is none.
+
+##### `register` <a name="register" id="@winglang/wingsdk.cloud.Logger.register"></a>
+
+```wing
+bring cloud;
+
+cloud.Logger.register()
+```
+
+Create a logger and register it to the given scope.
 
 #### Properties <a name="Properties" id="Properties"></a>
 
@@ -2167,7 +2174,6 @@ Synthesize the app into an artifact.
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
 | <code><a href="#@winglang/wingsdk.core.IApp.property.node">node</a></code> | <code>constructs.Node</code> | The tree node. |
-| <code><a href="#@winglang/wingsdk.core.IApp.property.logger">logger</a></code> | <code>cloud.Logger</code> | Returns a logger instance that can be used to emit traces and logs throughout the system. |
 | <code><a href="#@winglang/wingsdk.core.IApp.property.outdir">outdir</a></code> | <code>str</code> | Directory where artifacts are synthesized to. |
 
 ---
@@ -2181,18 +2187,6 @@ node: Node;
 - *Type:* constructs.Node
 
 The tree node.
-
----
-
-##### `logger`<sup>Required</sup> <a name="logger" id="@winglang/wingsdk.core.IApp.property.logger"></a>
-
-```wing
-logger: Logger;
-```
-
-- *Type:* cloud.Logger
-
-Returns a logger instance that can be used to emit traces and logs throughout the system.
 
 ---
 
@@ -2487,28 +2481,25 @@ Inflight interface for `Logger`.
 
 | **Name** | **Description** |
 | --- | --- |
-| <code><a href="#@winglang/wingsdk.cloud.ILoggerClient.print">print</a></code> | Logs a message. |
+| <code><a href="#@winglang/wingsdk.cloud.ILoggerClient.print">print</a></code> | Logs a message. The log will be associated with whichever resource is running the inflight code. |
 
 ---
 
 ##### `print` <a name="print" id="@winglang/wingsdk.cloud.ILoggerClient.print"></a>
 
 ```wing
-print(message: str): void
+print(args: any): void
 ```
 
 **Inflight client:** [true](#true)
 
-Logs a message.
+Logs a message. The log will be associated with whichever resource is running the inflight code.
 
-The log will be associated with whichever resource is
-running the inflight code.
+NOTICE: this is not an async function because it is wrapped by `console.log()`.
 
-###### `message`<sup>Required</sup> <a name="message" id="@winglang/wingsdk.cloud.ILoggerClient.print.parameter.message"></a>
+###### `args`<sup>Required</sup> <a name="args" id="@winglang/wingsdk.cloud.ILoggerClient.print.parameter.args"></a>
 
-- *Type:* str
-
-The message to print.
+- *Type:* any
 
 ---
 

--- a/libs/wingsdk/API.md
+++ b/libs/wingsdk/API.md
@@ -383,6 +383,7 @@ Any object.
 | --- | --- | --- |
 | <code><a href="#@winglang/wingsdk.cloud.Function.property.node">node</a></code> | <code>constructs.Node</code> | The tree node. |
 | <code><a href="#@winglang/wingsdk.cloud.Function.property.stateful">stateful</a></code> | <code>bool</code> | Whether a resource is stateful, i.e. it stores information that is not defined by your application. |
+| <code><a href="#@winglang/wingsdk.cloud.Function.property.env">env</a></code> | <code>MutMap&lt;str&gt;</code> | Returns the set of environment variables for this function. |
 
 ---
 
@@ -411,6 +412,18 @@ Whether a resource is stateful, i.e. it stores information that is not defined b
 A non-stateful resource does not remember information about past
 transactions or events, and can typically be replaced by a cloud provider
 with a fresh copy without any consequences.
+
+---
+
+##### `env`<sup>Required</sup> <a name="env" id="@winglang/wingsdk.cloud.Function.property.env"></a>
+
+```wing
+env: MutMap<str>;
+```
+
+- *Type:* MutMap&lt;str&gt;
+
+Returns the set of environment variables for this function.
 
 ---
 

--- a/libs/wingsdk/API.md
+++ b/libs/wingsdk/API.md
@@ -421,6 +421,19 @@ with a fresh copy without any consequences.
 
 A cloud logging facility.
 
+#### Initializers <a name="Initializers" id="@winglang/wingsdk.cloud.Logger.Initializer"></a>
+
+```wing
+bring cloud;
+
+new cloud.Logger()
+```
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+
+---
+
 #### Methods <a name="Methods" id="Methods"></a>
 
 | **Name** | **Description** |
@@ -477,8 +490,6 @@ The message to log.
 | **Name** | **Description** |
 | --- | --- |
 | <code><a href="#@winglang/wingsdk.cloud.Logger.isConstruct">is_construct</a></code> | Checks if `x` is a construct. |
-| <code><a href="#@winglang/wingsdk.cloud.Logger.of">of</a></code> | Returns the logger registered to the given scope, throwing an error if there is none. |
-| <code><a href="#@winglang/wingsdk.cloud.Logger.register">register</a></code> | Create a logger and register it to the given scope. |
 
 ---
 
@@ -499,26 +510,6 @@ Checks if `x` is a construct.
 Any object.
 
 ---
-
-##### `of` <a name="of" id="@winglang/wingsdk.cloud.Logger.of"></a>
-
-```wing
-bring cloud;
-
-cloud.Logger.of()
-```
-
-Returns the logger registered to the given scope, throwing an error if there is none.
-
-##### `register` <a name="register" id="@winglang/wingsdk.cloud.Logger.register"></a>
-
-```wing
-bring cloud;
-
-cloud.Logger.register()
-```
-
-Create a logger and register it to the given scope.
 
 #### Properties <a name="Properties" id="Properties"></a>
 
@@ -2176,6 +2167,7 @@ Synthesize the app into an artifact.
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
 | <code><a href="#@winglang/wingsdk.core.IApp.property.node">node</a></code> | <code>constructs.Node</code> | The tree node. |
+| <code><a href="#@winglang/wingsdk.core.IApp.property.logger">logger</a></code> | <code>cloud.Logger</code> | Returns a logger instance that can be used to emit traces and logs throughout the system. |
 | <code><a href="#@winglang/wingsdk.core.IApp.property.outdir">outdir</a></code> | <code>str</code> | Directory where artifacts are synthesized to. |
 
 ---
@@ -2189,6 +2181,18 @@ node: Node;
 - *Type:* constructs.Node
 
 The tree node.
+
+---
+
+##### `logger`<sup>Required</sup> <a name="logger" id="@winglang/wingsdk.core.IApp.property.logger"></a>
+
+```wing
+logger: Logger;
+```
+
+- *Type:* cloud.Logger
+
+Returns a logger instance that can be used to emit traces and logs throughout the system.
 
 ---
 

--- a/libs/wingsdk/src/cloud/function.ts
+++ b/libs/wingsdk/src/cloud/function.ts
@@ -60,8 +60,8 @@ export abstract class FunctionBase extends Resource {
     const inflightClient = inflight._toInflight();
     const loggerClientCode = Logger.of(this)._toInflight();
     const lines = new Array<string>();
-    lines.push(`const __$logger = ${loggerClientCode.text};`);
-    lines.push(`console.log = (...args) => __$logger.print(...args);`);
+    lines.push(`const $wing_logger = ${loggerClientCode.text};`);
+    lines.push(`console.log = (...args) => $wing_logger.print(...args);`);
     lines.push("exports.handler = async function(event) {");
     lines.push(`  return await ${inflightClient.text}.handle(event);`);
     lines.push("};");

--- a/libs/wingsdk/src/cloud/function.ts
+++ b/libs/wingsdk/src/cloud/function.ts
@@ -32,7 +32,10 @@ export abstract class FunctionBase extends Resource {
 
   public readonly stateful = false;
 
-  protected readonly handlerFileAsset: string;
+  /**
+   * The path to the file asset that contains the handler code.
+   */
+  protected readonly assetPath: string;
 
   constructor(
     scope: Construct,
@@ -43,7 +46,7 @@ export abstract class FunctionBase extends Resource {
     super(scope, id);
 
     if (!scope) {
-      this.handlerFileAsset = undefined as any;
+      this.assetPath = undefined as any;
       return;
     }
 
@@ -81,7 +84,7 @@ export abstract class FunctionBase extends Resource {
       external: ["aws-sdk"],
     });
 
-    this.handlerFileAsset = outfile;
+    this.assetPath = outfile;
   }
 
   /**
@@ -97,7 +100,7 @@ export abstract class FunctionBase extends Resource {
   /**
    * Returns the set of environment variables for this function.
    */
-  public get env() {
+  public get env(): Record<string, string> {
     return { ...this._env };
   }
 }

--- a/libs/wingsdk/src/cloud/logger.ts
+++ b/libs/wingsdk/src/cloud/logger.ts
@@ -1,4 +1,3 @@
-import * as util from "util";
 import { Construct, IConstruct } from "constructs";
 import { Polycons } from "polycons";
 import { Code } from "../core/inflight";
@@ -16,9 +15,9 @@ export abstract class LoggerBase extends Resource {
    * Logs a message.
    * @param message The message to log.
    */
-  public print(...args: any[]): void {
+  public print(message: string): void {
     // default implementation, can be overridden
-    console.log(util.format(...args));
+    console.log(message);
   }
 }
 
@@ -88,7 +87,7 @@ export interface ILoggerClient {
    * @param message The message to print
    * @inflight
    */
-  print(...args: any[]): void;
+  print(message: string): void;
 }
 
 /**

--- a/libs/wingsdk/src/cloud/logger.ts
+++ b/libs/wingsdk/src/cloud/logger.ts
@@ -11,8 +11,9 @@ export const LOGGER_SYMBOL = Symbol.for(LOGGER_TYPE);
  */
 export abstract class LoggerBase extends Resource {
   public readonly stateful = true;
+
   /**
-   * Logs a message.
+   * Logs a message (preflight).
    * @param message The message to log.
    */
   public print(message: string): void {

--- a/libs/wingsdk/src/cloud/logger.ts
+++ b/libs/wingsdk/src/cloud/logger.ts
@@ -1,6 +1,8 @@
+import * as util from "util";
 import { Construct, IConstruct } from "constructs";
 import { Polycons } from "polycons";
-import { Code, Resource } from "../core";
+import { Code } from "../core/inflight";
+import { Resource } from "../core/resource";
 
 export const LOGGER_TYPE = "wingsdk.cloud.Logger";
 export const LOGGER_SYMBOL = Symbol.for(LOGGER_TYPE);
@@ -14,9 +16,9 @@ export abstract class LoggerBase extends Resource {
    * Logs a message.
    * @param message The message to log.
    */
-  public print(message: string): void {
+  public print(...args: any[]): void {
     // default implementation, can be overridden
-    console.log(message);
+    console.log(util.format(...args));
   }
 }
 
@@ -81,10 +83,12 @@ export interface ILoggerClient {
    * Logs a message. The log will be associated with whichever resource is
    * running the inflight code.
    *
+   * NOTICE: this is not an async function because it is wrapped by `console.log()`.
+   *
    * @param message The message to print
    * @inflight
    */
-  print(message: string): Promise<void>;
+  print(...args: any[]): void;
 }
 
 /**

--- a/libs/wingsdk/src/core/app.ts
+++ b/libs/wingsdk/src/core/app.ts
@@ -1,8 +1,9 @@
 import { join } from "path";
 import * as cdktf from "cdktf";
 import { Construct, IConstruct } from "constructs";
-import { IPolyconFactory } from "polycons";
+import { IPolyconFactory, Polycons } from "polycons";
 import stringify from "safe-stable-stringify";
+import { Logger } from "../cloud/logger";
 import { Files } from "./files";
 import { synthesizeTree } from "./tree";
 
@@ -69,6 +70,7 @@ export class CdktfApp extends Construct implements IApp {
 
     class InnerApp extends cdktf.TerraformStack {
       public readonly outdir: string;
+
       private readonly cdktfApp: cdktf.App;
       private readonly files: Files;
 
@@ -78,12 +80,21 @@ export class CdktfApp extends Construct implements IApp {
 
         super(root, "root");
 
+        if (!props.customFactory) {
+          throw new Error("A polycons factory is required for a cdktf app.");
+        }
+
+        Polycons.register(this, props.customFactory);
+
         this.outdir = outdir;
         this.cdktfApp = root;
         this.files = new Files({
           app: this,
           stateFile: props.stateFile,
         });
+
+        // register a logger for this app.
+        Logger.register(this);
       }
 
       public synth(): string {

--- a/libs/wingsdk/src/core/internal.ts
+++ b/libs/wingsdk/src/core/internal.ts
@@ -6,16 +6,20 @@ export function makeHandler(
   scope: IConstruct,
   id: string,
   code: string,
-  bindings: { [key: string]: InflightBinding } = {}
+  bindings?: { [key: string]: InflightBinding }
 ): Resource {
   const resources = Object.fromEntries(
-    Object.entries(bindings).map(([name, binding]) => [name, binding.resource])
+    Object.entries(bindings ?? {}).map(([name, binding]) => [
+      name,
+      binding.resource,
+    ])
   );
 
   // implements IFunctionHandler
   class Handler extends Resource {
     public readonly stateful = false;
-    public readonly $resourceNames = Object.keys(bindings);
+
+    public readonly $resourceNames = Object.keys(bindings ?? {});
 
     constructor() {
       super(scope, id);
@@ -29,22 +33,21 @@ export function makeHandler(
       for (const resource of this.$resourceNames) {
         clients[resource] = (this as any)[resource]._toInflight();
       }
-
       return NodeJsCode.fromInline(
         `new ((function(){
-  return class Handler {
-    constructor(clients) {
-      for (const [name, client] of Object.entries(clients)) {
-        this[name] = client;
-      }
+return class Handler {
+  constructor(clients) {
+    for (const [name, client] of Object.entries(clients)) {
+      this[name] = client;
     }
-    ${code}
-  };
-  })())({
-  ${Object.entries(clients)
-    .map(([name, client]) => `${name}: ${client.text}`)
-    .join(",\n")}
-  })`
+  }
+  ${code}
+};
+})())({
+${Object.entries(clients)
+  .map(([name, client]) => `${name}: ${client.text}`)
+  .join(",\n")}
+})`
       );
     }
   }

--- a/libs/wingsdk/src/core/internal.ts
+++ b/libs/wingsdk/src/core/internal.ts
@@ -1,5 +1,4 @@
 import { IConstruct } from "constructs";
-import { Logger, LoggerInflightMethods } from "../cloud/logger";
 import { Code, InflightBinding, NodeJsCode } from "./inflight";
 import { Resource } from "./resource";
 
@@ -7,18 +6,8 @@ export function makeHandler(
   scope: IConstruct,
   id: string,
   code: string,
-  userBindings?: { [key: string]: InflightBinding }
+  bindings: { [key: string]: InflightBinding } = {}
 ): Resource {
-  const bindings = {
-    ...userBindings,
-
-    // implicit binding between `$logger` and the logger registered for this scope
-    $logger: {
-      resource: Logger.of(scope),
-      ops: [LoggerInflightMethods.PRINT],
-    },
-  };
-
   const resources = Object.fromEntries(
     Object.entries(bindings).map(([name, binding]) => [name, binding.resource])
   );

--- a/libs/wingsdk/src/core/internal.ts
+++ b/libs/wingsdk/src/core/internal.ts
@@ -9,11 +9,12 @@ export function makeHandler(
   code: string,
   userBindings?: { [key: string]: InflightBinding }
 ): Resource {
-  const logger = Logger.of(scope);
   const bindings = {
     ...userBindings,
+
+    // implicit binding between `$logger` and the logger registered for this scope
     $logger: {
-      resource: logger,
+      resource: Logger.of(scope),
       ops: [LoggerInflightMethods.PRINT],
     },
   };

--- a/libs/wingsdk/src/core/internal.ts
+++ b/libs/wingsdk/src/core/internal.ts
@@ -46,21 +46,22 @@ export function makeHandler(
         .join(",\n");
 
       return NodeJsCode.fromInline(`
-      (function(clients) {
-        console.log = (...args) => clients.$logger.print(...args);
+        (function(clients) {
+          console.log = (...args) => clients.$logger.print(...args);
 
-        class Handler {
-          constructor(clients) {
-            for (const [name, client] of Object.entries(clients)) {
-              this[name] = client;
-            }            
+          class Handler {
+            constructor() {
+              for (const [name, client] of Object.entries(clients)) {
+                this[name] = client;
+              }            
+            }
+
+            ${code}
           }
 
-          ${code}
-        }
-
-        return new Handler(clients);
-      })({${clientMap}})`);
+          return new Handler();
+        })({${clientMap}})
+      `);
     }
   }
 

--- a/libs/wingsdk/src/target-sim/app.ts
+++ b/libs/wingsdk/src/target-sim/app.ts
@@ -3,6 +3,7 @@ import * as path from "path";
 import { Construct } from "constructs";
 import { Polycons } from "polycons";
 import * as tar from "tar";
+import { Logger } from "../cloud";
 import { SDK_VERSION } from "../constants";
 import * as core from "../core";
 import { mkdtemp, SIMULATOR_FILE_PATH } from "../util";
@@ -26,8 +27,9 @@ export class App extends Construct implements core.IApp {
     super(undefined as any, "root");
     this.name = props.name ?? "app";
     this.outdir = props.outdir ?? ".";
-    this.files = new core.Files({ app: this, stateFile: props.stateFile });
     Polycons.register(this, props.customFactory ?? new PolyconFactory());
+    Logger.register(this);
+    this.files = new core.Files({ app: this, stateFile: props.stateFile });
   }
 
   /**

--- a/libs/wingsdk/src/target-sim/function.ts
+++ b/libs/wingsdk/src/target-sim/function.ts
@@ -31,7 +31,7 @@ export class Function extends cloud.FunctionBase implements ISimulatorResource {
 
     const assetPath = `assets/${this.node.id}/index.js`;
     new TextFile(this, "Code", assetPath, {
-      lines: [readFileSync(this.handlerFileAsset, "utf-8")],
+      lines: [readFileSync(this.assetPath, "utf-8")],
     });
     this.code = core.NodeJsCode.fromFile(assetPath);
   }

--- a/libs/wingsdk/src/target-sim/function.ts
+++ b/libs/wingsdk/src/target-sim/function.ts
@@ -1,11 +1,8 @@
 import { readFileSync } from "fs";
-import { join } from "path";
 import { Construct } from "constructs";
-import * as esbuild from "esbuild-wasm";
 import * as cloud from "../cloud";
 import * as core from "../core";
 import { TextFile } from "../fs";
-import { mkdtemp } from "../util";
 import { ISimulatorResource } from "./resource";
 import { BaseResourceSchema } from "./schema";
 import { FunctionSchema } from "./schema-resources";
@@ -22,7 +19,6 @@ export const ENV_WING_SIM_INFLIGHT_RESOURCE_TYPE =
  * @inflight `@winglang/wingsdk.cloud.IFunctionClient`
  */
 export class Function extends cloud.FunctionBase implements ISimulatorResource {
-  private readonly env: Record<string, string> = {};
   private readonly code: core.Code;
 
   constructor(
@@ -33,48 +29,11 @@ export class Function extends cloud.FunctionBase implements ISimulatorResource {
   ) {
     super(scope, id, inflight, props);
 
-    inflight._bind(this, ["handle"]);
-
-    const inflightClient = inflight._toInflight();
-    const lines = new Array<string>();
-    lines.push("exports.handler = async function(event) {");
-    lines.push(`  return await ${inflightClient.text}.handle(event);`);
-    lines.push("};");
-
-    const tempdir = mkdtemp();
-    const outfile = join(tempdir, "index.js");
-
-    esbuild.buildSync({
-      bundle: true,
-      stdin: {
-        contents: lines.join("\n"),
-        resolveDir: tempdir,
-        sourcefile: "inflight.js",
-      },
-      target: "node16",
-      platform: "node",
-      absWorkingDir: tempdir,
-      outfile,
-      minify: false,
-      external: ["aws-sdk"],
-    });
-
     const assetPath = `assets/${this.node.id}/index.js`;
     new TextFile(this, "Code", assetPath, {
-      lines: [readFileSync(outfile, "utf-8")],
+      lines: [readFileSync(this.handlerFileAsset, "utf-8")],
     });
     this.code = core.NodeJsCode.fromFile(assetPath);
-
-    for (const [name, value] of Object.entries(props.env ?? {})) {
-      this.addEnvironment(name, value);
-    }
-  }
-
-  public addEnvironment(name: string, value: string) {
-    if (this.env[name] !== undefined) {
-      throw new Error(`Environment variable "${name}" already set.`);
-    }
-    this.env[name] = value;
   }
 
   public toSimulator(): BaseResourceSchema {

--- a/libs/wingsdk/src/target-tf-aws/app.ts
+++ b/libs/wingsdk/src/target-tf-aws/app.ts
@@ -1,5 +1,4 @@
 import { AwsProvider } from "@cdktf/provider-aws/lib/provider";
-import { Polycons } from "polycons";
 import { IApp, CdktfApp, AppProps } from "../core";
 import { PolyconFactory } from "./factory";
 
@@ -9,8 +8,10 @@ import { PolyconFactory } from "./factory";
  */
 export class App extends CdktfApp implements IApp {
   constructor(props: AppProps = {}) {
-    super(props);
-    Polycons.register(this, props.customFactory ?? new PolyconFactory());
+    super({
+      ...props,
+      customFactory: props.customFactory ?? new PolyconFactory(),
+    });
     new AwsProvider(this, "aws", {});
   }
 }

--- a/libs/wingsdk/src/target-tf-aws/function.ts
+++ b/libs/wingsdk/src/target-tf-aws/function.ts
@@ -34,12 +34,12 @@ export class Function extends cloud.FunctionBase {
     super(scope, id, inflight, props);
 
     // bundled code is guaranteed to be in a fresh directory
-    const codeDir = resolve(this.handlerFileAsset, "..");
+    const codeDir = resolve(this.assetPath, "..");
 
     // calculate a md5 hash of the contents of asset.path
     const codeHash = crypto
       .createHash("md5")
-      .update(readFileSync(this.handlerFileAsset))
+      .update(readFileSync(this.assetPath))
       .digest("hex");
 
     // Create Lambda executable

--- a/libs/wingsdk/src/target-tf-aws/function.ts
+++ b/libs/wingsdk/src/target-tf-aws/function.ts
@@ -1,6 +1,6 @@
 import * as crypto from "crypto";
 import { readFileSync } from "fs";
-import { join, resolve } from "path";
+import { resolve } from "path";
 import { IamRole } from "@cdktf/provider-aws/lib/iam-role";
 import { IamRolePolicy } from "@cdktf/provider-aws/lib/iam-role-policy";
 import { IamRolePolicyAttachment } from "@cdktf/provider-aws/lib/iam-role-policy-attachment";
@@ -9,10 +9,8 @@ import { S3Bucket } from "@cdktf/provider-aws/lib/s3-bucket";
 import { S3Object } from "@cdktf/provider-aws/lib/s3-object";
 import { AssetType, Lazy, TerraformAsset } from "cdktf";
 import { Construct } from "constructs";
-import * as esbuild from "esbuild-wasm";
 import * as cloud from "../cloud";
 import * as core from "../core";
-import { mkdtemp } from "../util";
 import { addConnections } from "./util";
 
 /**
@@ -22,9 +20,8 @@ import { addConnections } from "./util";
  */
 export class Function extends cloud.FunctionBase {
   private readonly function: LambdaFunction;
-  private readonly env: Record<string, string> = {};
   private readonly role: IamRole;
-  private readonly policyStatements: any[] = [];
+  private policyStatements?: any[];
   /** Function ARN */
   public readonly arn: string;
 
@@ -36,43 +33,13 @@ export class Function extends cloud.FunctionBase {
   ) {
     super(scope, id, inflight, props);
 
-    for (const [key, value] of Object.entries(props.env ?? {})) {
-      this.addEnvironment(key, value);
-    }
-
-    inflight._bind(this, ["handle"]);
-    const inflightClient = inflight._toInflight();
-
-    const lines = new Array<string>();
-    lines.push("exports.handler = async function(event) {");
-    lines.push(`  return await ${inflightClient.text}.handle(event);`);
-    lines.push("};");
-
-    const tempdir = mkdtemp();
-    const outfile = join(tempdir, "index.js");
-
-    esbuild.buildSync({
-      bundle: true,
-      stdin: {
-        contents: lines.join("\n"),
-        resolveDir: tempdir,
-        sourcefile: "inflight.js",
-      },
-      target: "node16",
-      platform: "node",
-      absWorkingDir: tempdir,
-      outfile,
-      minify: false,
-      external: ["aws-sdk"],
-    });
-
     // bundled code is guaranteed to be in a fresh directory
-    const codeDir = resolve(outfile, "..");
+    const codeDir = resolve(this.handlerFileAsset, "..");
 
     // calculate a md5 hash of the contents of asset.path
     const codeHash = crypto
       .createHash("md5")
-      .update(readFileSync(outfile))
+      .update(readFileSync(this.handlerFileAsset))
       .digest("hex");
 
     // Create Lambda executable
@@ -119,7 +86,7 @@ export class Function extends cloud.FunctionBase {
       role: this.role.name,
       policy: Lazy.stringValue({
         produce: () => {
-          if (this.policyStatements.length > 0) {
+          if ((this.policyStatements ?? []).length > 0) {
             return JSON.stringify({
               Version: "2012-10-17",
               Statement: this.policyStatements,
@@ -157,7 +124,7 @@ export class Function extends cloud.FunctionBase {
       runtime: "nodejs16.x",
       role: this.role.arn,
       environment: {
-        variables: this.env,
+        variables: Lazy.anyValue({ produce: () => this.env }) as any,
       },
     });
 
@@ -206,17 +173,17 @@ export class Function extends cloud.FunctionBase {
     ]);
   }
 
-  public addEnvironment(name: string, value: string) {
-    if (this.env[name] !== undefined) {
-      throw new Error(`Environment variable "${name}" already set.`);
-    }
-    this.env[name] = value;
-  }
-
   /**
    * Add a policy statement to the Lambda role.
    */
   public addPolicyStatements(...statements: PolicyStatement[]) {
+    // we do lazy initialization here because addPolicyStatements() might be called through the
+    // constructor chain of the Function base class which means that our constructor might not have
+    // been called yet... yes, ugly.
+    if (!this.policyStatements) {
+      this.policyStatements = [];
+    }
+
     this.policyStatements.push(
       ...statements.map((s) => ({
         Action: s.action,

--- a/libs/wingsdk/src/target-tf-aws/logger.inflight.ts
+++ b/libs/wingsdk/src/target-tf-aws/logger.inflight.ts
@@ -3,7 +3,7 @@ import { ILoggerClient } from "../cloud";
 export class LoggerClient implements ILoggerClient {
   constructor() {}
 
-  public async print(message: string): Promise<void> {
+  public async print(message: string): void {
     // anything console.log'd in a lambda will be logged to cloudwatch
     console.log(message);
   }

--- a/libs/wingsdk/src/target-tf-aws/logger.inflight.ts
+++ b/libs/wingsdk/src/target-tf-aws/logger.inflight.ts
@@ -3,7 +3,7 @@ import { ILoggerClient } from "../cloud";
 export class LoggerClient implements ILoggerClient {
   constructor() {}
 
-  public async print(message: string): void {
+  public print(message: string): void {
     // anything console.log'd in a lambda will be logged to cloudwatch
     console.log(message);
   }

--- a/libs/wingsdk/src/testing/testing.ts
+++ b/libs/wingsdk/src/testing/testing.ts
@@ -1,6 +1,5 @@
 import { IConstruct } from "constructs";
-import { InflightBinding, Resource } from "../core";
-import { makeHandler } from "../core/internal";
+import { Inflight, InflightBinding, IResource, NodeJsCode } from "../core";
 
 /**
  * Test utilities.
@@ -24,7 +23,10 @@ export class Testing {
     id: string,
     code: string,
     bindings?: { [key: string]: InflightBinding }
-  ): Resource {
-    return makeHandler(scope, id, code, bindings);
+  ): IResource {
+    return new Inflight(scope, id, {
+      code: NodeJsCode.fromInline(code),
+      bindings,
+    });
   }
 }

--- a/libs/wingsdk/test/core/file.test.ts
+++ b/libs/wingsdk/test/core/file.test.ts
@@ -67,7 +67,7 @@ describe("state file", () => {
     });
   });
 
-  test("files are deleted if they were in the state file but no in the new app", () => {
+  test("files are deleted if they were in the state file but not in the new app", () => {
     const workdir = mkdtemp();
     const stateFileName = "state.file";
     writeFileSync(join(workdir, "delete-me.txt"), "hello");

--- a/libs/wingsdk/test/sandbox/main.ts
+++ b/libs/wingsdk/test/sandbox/main.ts
@@ -66,6 +66,5 @@ class HelloWorld extends Construct {
 }
 
 const app = new sim.App({ outdir: __dirname });
-cloud.Logger.register(app);
 new HelloWorld(app, "HelloWorld");
 app.synth();

--- a/libs/wingsdk/test/target-sim/__snapshots__/bucket.test.ts.snap
+++ b/libs/wingsdk/test/target-sim/__snapshots__/bucket.test.ts.snap
@@ -6,6 +6,12 @@ Object {
     "resources": Array [
       Object {
         "attrs": Object {},
+        "path": "root/WingLogger",
+        "props": Object {},
+        "type": "wingsdk.cloud.Logger",
+      },
+      Object {
+        "attrs": Object {},
         "path": "root/my_bucket",
         "props": Object {
           "public": false,
@@ -18,6 +24,18 @@ Object {
   "tree.json": Object {
     "tree": Object {
       "children": Object {
+        "WingLogger": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [],
+            "wing:resource:stateful": true,
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.0.25",
+          },
+          "id": "WingLogger",
+          "path": "root/WingLogger",
+        },
         "my_bucket": Object {
           "attributes": Object {
             "wing:resource:connections": Array [],
@@ -49,6 +67,12 @@ Object {
     "resources": Array [
       Object {
         "attrs": Object {},
+        "path": "root/WingLogger",
+        "props": Object {},
+        "type": "wingsdk.cloud.Logger",
+      },
+      Object {
+        "attrs": Object {},
         "path": "root/my_bucket",
         "props": Object {
           "public": false,
@@ -61,6 +85,18 @@ Object {
   "tree.json": Object {
     "tree": Object {
       "children": Object {
+        "WingLogger": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [],
+            "wing:resource:stateful": true,
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.0.25",
+          },
+          "id": "WingLogger",
+          "path": "root/WingLogger",
+        },
         "my_bucket": Object {
           "attributes": Object {
             "wing:resource:connections": Array [],
@@ -92,6 +128,12 @@ Object {
     "resources": Array [
       Object {
         "attrs": Object {},
+        "path": "root/WingLogger",
+        "props": Object {},
+        "type": "wingsdk.cloud.Logger",
+      },
+      Object {
+        "attrs": Object {},
         "path": "root/my_bucket",
         "props": Object {
           "public": false,
@@ -104,6 +146,18 @@ Object {
   "tree.json": Object {
     "tree": Object {
       "children": Object {
+        "WingLogger": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [],
+            "wing:resource:stateful": true,
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.0.25",
+          },
+          "id": "WingLogger",
+          "path": "root/WingLogger",
+        },
         "my_bucket": Object {
           "attributes": Object {
             "wing:resource:connections": Array [],
@@ -135,6 +189,12 @@ Object {
     "resources": Array [
       Object {
         "attrs": Object {},
+        "path": "root/WingLogger",
+        "props": Object {},
+        "type": "wingsdk.cloud.Logger",
+      },
+      Object {
+        "attrs": Object {},
         "path": "root/my_bucket",
         "props": Object {
           "public": false,
@@ -147,6 +207,18 @@ Object {
   "tree.json": Object {
     "tree": Object {
       "children": Object {
+        "WingLogger": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [],
+            "wing:resource:stateful": true,
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.0.25",
+          },
+          "id": "WingLogger",
+          "path": "root/WingLogger",
+        },
         "my_bucket": Object {
           "attributes": Object {
             "wing:resource:connections": Array [],
@@ -178,6 +250,12 @@ Object {
     "resources": Array [
       Object {
         "attrs": Object {},
+        "path": "root/WingLogger",
+        "props": Object {},
+        "type": "wingsdk.cloud.Logger",
+      },
+      Object {
+        "attrs": Object {},
         "path": "root/my_bucket",
         "props": Object {
           "public": false,
@@ -190,6 +268,18 @@ Object {
   "tree.json": Object {
     "tree": Object {
       "children": Object {
+        "WingLogger": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [],
+            "wing:resource:stateful": true,
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.0.25",
+          },
+          "id": "WingLogger",
+          "path": "root/WingLogger",
+        },
         "my_bucket": Object {
           "attributes": Object {
             "wing:resource:connections": Array [],
@@ -221,6 +311,12 @@ Object {
     "resources": Array [
       Object {
         "attrs": Object {},
+        "path": "root/WingLogger",
+        "props": Object {},
+        "type": "wingsdk.cloud.Logger",
+      },
+      Object {
+        "attrs": Object {},
         "path": "root/my_bucket",
         "props": Object {
           "public": false,
@@ -233,6 +329,18 @@ Object {
   "tree.json": Object {
     "tree": Object {
       "children": Object {
+        "WingLogger": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [],
+            "wing:resource:stateful": true,
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.0.25",
+          },
+          "id": "WingLogger",
+          "path": "root/WingLogger",
+        },
         "my_bucket": Object {
           "attributes": Object {
             "wing:resource:connections": Array [],

--- a/libs/wingsdk/test/target-sim/__snapshots__/bucket.test.ts.snap
+++ b/libs/wingsdk/test/target-sim/__snapshots__/bucket.test.ts.snap
@@ -62,6 +62,16 @@ Object {
 `;
 
 exports[`get invalid object throws an error 1`] = `
+Array [
+  "wingsdk.cloud.Logger created.",
+  "wingsdk.cloud.Bucket created.",
+  "Get (key=unknown.txt).",
+  "wingsdk.cloud.Bucket deleted.",
+  "wingsdk.cloud.Logger deleted.",
+]
+`;
+
+exports[`get invalid object throws an error 2`] = `
 Object {
   "app.wsim": Object {
     "resources": Array [
@@ -123,6 +133,17 @@ Object {
 `;
 
 exports[`put and get objects from bucket 1`] = `
+Array [
+  "wingsdk.cloud.Logger created.",
+  "wingsdk.cloud.Bucket created.",
+  "Put (key=greeting.txt).",
+  "Get (key=greeting.txt).",
+  "wingsdk.cloud.Bucket deleted.",
+  "wingsdk.cloud.Logger deleted.",
+]
+`;
+
+exports[`put and get objects from bucket 2`] = `
 Object {
   "app.wsim": Object {
     "resources": Array [
@@ -184,6 +205,19 @@ Object {
 `;
 
 exports[`put multiple objects and list all from bucket 1`] = `
+Array [
+  "wingsdk.cloud.Logger created.",
+  "wingsdk.cloud.Bucket created.",
+  "Put (key=greeting1.txt).",
+  "Put (key=greeting2.txt).",
+  "Put (key=greeting3.txt).",
+  "List (prefix=null).",
+  "wingsdk.cloud.Bucket deleted.",
+  "wingsdk.cloud.Logger deleted.",
+]
+`;
+
+exports[`put multiple objects and list all from bucket 2`] = `
 Object {
   "app.wsim": Object {
     "resources": Array [
@@ -245,6 +279,17 @@ Object {
 `;
 
 exports[`remove object from a bucket 1`] = `
+Array [
+  "wingsdk.cloud.Logger created.",
+  "wingsdk.cloud.Bucket created.",
+  "Put (key=unknown.txt).",
+  "Delete (key=unknown.txt).",
+  "wingsdk.cloud.Bucket deleted.",
+  "wingsdk.cloud.Logger deleted.",
+]
+`;
+
+exports[`remove object from a bucket 2`] = `
 Object {
   "app.wsim": Object {
     "resources": Array [
@@ -306,6 +351,17 @@ Object {
 `;
 
 exports[`remove object from a bucket with mustExist as option 1`] = `
+Array [
+  "wingsdk.cloud.Logger created.",
+  "wingsdk.cloud.Bucket created.",
+  "Put (key=unknown.txt).",
+  "Delete (key=unknown.txt).",
+  "wingsdk.cloud.Bucket deleted.",
+  "wingsdk.cloud.Logger deleted.",
+]
+`;
+
+exports[`remove object from a bucket with mustExist as option 2`] = `
 Object {
   "app.wsim": Object {
     "resources": Array [

--- a/libs/wingsdk/test/target-sim/__snapshots__/counter.test.ts.snap
+++ b/libs/wingsdk/test/target-sim/__snapshots__/counter.test.ts.snap
@@ -6,6 +6,12 @@ Object {
     "resources": Array [
       Object {
         "attrs": Object {},
+        "path": "root/WingLogger",
+        "props": Object {},
+        "type": "wingsdk.cloud.Logger",
+      },
+      Object {
+        "attrs": Object {},
         "path": "root/my_counter",
         "props": Object {
           "initial": 123,
@@ -18,6 +24,18 @@ Object {
   "tree.json": Object {
     "tree": Object {
       "children": Object {
+        "WingLogger": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [],
+            "wing:resource:stateful": true,
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.0.25",
+          },
+          "id": "WingLogger",
+          "path": "root/WingLogger",
+        },
         "my_counter": Object {
           "attributes": Object {
             "wing:resource:connections": Array [],
@@ -49,6 +67,12 @@ Object {
     "resources": Array [
       Object {
         "attrs": Object {},
+        "path": "root/WingLogger",
+        "props": Object {},
+        "type": "wingsdk.cloud.Logger",
+      },
+      Object {
+        "attrs": Object {},
         "path": "root/my_counter",
         "props": Object {
           "initial": 123,
@@ -61,6 +85,18 @@ Object {
   "tree.json": Object {
     "tree": Object {
       "children": Object {
+        "WingLogger": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [],
+            "wing:resource:stateful": true,
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.0.25",
+          },
+          "id": "WingLogger",
+          "path": "root/WingLogger",
+        },
         "my_counter": Object {
           "attributes": Object {
             "wing:resource:connections": Array [],

--- a/libs/wingsdk/test/target-sim/__snapshots__/file-counter.test.ts.snap
+++ b/libs/wingsdk/test/target-sim/__snapshots__/file-counter.test.ts.snap
@@ -6,12 +6,6 @@ Object {
     "resources": Array [
       Object {
         "attrs": Object {},
-        "path": "root/WingLogger",
-        "props": Object {},
-        "type": "wingsdk.cloud.Logger",
-      },
-      Object {
-        "attrs": Object {},
         "path": "root/HelloWorld/Counter",
         "props": Object {
           "initial": 1000,
@@ -28,11 +22,18 @@ Object {
       },
       Object {
         "attrs": Object {},
+        "path": "root/WingLogger",
+        "props": Object {},
+        "type": "wingsdk.cloud.Logger",
+      },
+      Object {
+        "attrs": Object {},
         "path": "root/HelloWorld/Queue-OnMessage-401ee792",
         "props": Object {
           "environmentVariables": Object {
             "BUCKET_HANDLE_5f2a41c8": "\${root/HelloWorld/Bucket#attrs.handle}",
             "COUNTER_HANDLE_4ecd8d46": "\${root/HelloWorld/Counter#attrs.handle}",
+            "LOGGER_HANDLE_76f7e65b": "\${root/WingLogger#attrs.handle}",
           },
           "sourceCodeFile": "assets/Queue-OnMessage-401ee792/index.js",
           "sourceCodeLanguage": "javascript",
@@ -142,6 +143,11 @@ Object {
                     "resource": "root/HelloWorld/Bucket",
                   },
                   Object {
+                    "direction": "outbound",
+                    "relationship": "inflight-reference",
+                    "resource": "root/WingLogger",
+                  },
+                  Object {
                     "direction": "inbound",
                     "relationship": "on_message",
                     "resource": "root/HelloWorld/Queue",
@@ -188,7 +194,13 @@ Object {
         },
         "WingLogger": Object {
           "attributes": Object {
-            "wing:resource:connections": Array [],
+            "wing:resource:connections": Array [
+              Object {
+                "direction": "inbound",
+                "relationship": "inflight-reference",
+                "resource": "root/HelloWorld/Queue-OnMessage-401ee792",
+              },
+            ],
             "wing:resource:stateful": true,
           },
           "constructInfo": Object {

--- a/libs/wingsdk/test/target-sim/__snapshots__/function.test.ts.snap
+++ b/libs/wingsdk/test/target-sim/__snapshots__/function.test.ts.snap
@@ -6,10 +6,17 @@ Object {
     "resources": Array [
       Object {
         "attrs": Object {},
+        "path": "root/WingLogger",
+        "props": Object {},
+        "type": "wingsdk.cloud.Logger",
+      },
+      Object {
+        "attrs": Object {},
         "path": "root/my_function",
         "props": Object {
           "environmentVariables": Object {
             "ENV_VAR1": "true",
+            "LOGGER_HANDLE_76f7e65b": "\${root/WingLogger#attrs.handle}",
           },
           "sourceCodeFile": "assets/my_function/index.js",
           "sourceCodeLanguage": "javascript",
@@ -34,9 +41,33 @@ Object {
           "id": "Handler",
           "path": "root/Handler",
         },
+        "WingLogger": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [
+              Object {
+                "direction": "inbound",
+                "relationship": "inflight-reference",
+                "resource": "root/my_function",
+              },
+            ],
+            "wing:resource:stateful": true,
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.0.25",
+          },
+          "id": "WingLogger",
+          "path": "root/WingLogger",
+        },
         "my_function": Object {
           "attributes": Object {
-            "wing:resource:connections": Array [],
+            "wing:resource:connections": Array [
+              Object {
+                "direction": "outbound",
+                "relationship": "inflight-reference",
+                "resource": "root/WingLogger",
+              },
+            ],
             "wing:resource:stateful": false,
           },
           "children": Object {
@@ -75,9 +106,17 @@ Object {
     "resources": Array [
       Object {
         "attrs": Object {},
+        "path": "root/WingLogger",
+        "props": Object {},
+        "type": "wingsdk.cloud.Logger",
+      },
+      Object {
+        "attrs": Object {},
         "path": "root/my_function",
         "props": Object {
-          "environmentVariables": Object {},
+          "environmentVariables": Object {
+            "LOGGER_HANDLE_76f7e65b": "\${root/WingLogger#attrs.handle}",
+          },
           "sourceCodeFile": "assets/my_function/index.js",
           "sourceCodeLanguage": "javascript",
         },
@@ -101,9 +140,33 @@ Object {
           "id": "Handler",
           "path": "root/Handler",
         },
+        "WingLogger": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [
+              Object {
+                "direction": "inbound",
+                "relationship": "inflight-reference",
+                "resource": "root/my_function",
+              },
+            ],
+            "wing:resource:stateful": true,
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.0.25",
+          },
+          "id": "WingLogger",
+          "path": "root/WingLogger",
+        },
         "my_function": Object {
           "attributes": Object {
-            "wing:resource:connections": Array [],
+            "wing:resource:connections": Array [
+              Object {
+                "direction": "outbound",
+                "relationship": "inflight-reference",
+                "resource": "root/WingLogger",
+              },
+            ],
             "wing:resource:stateful": false,
           },
           "children": Object {
@@ -142,9 +205,17 @@ Object {
     "resources": Array [
       Object {
         "attrs": Object {},
+        "path": "root/WingLogger",
+        "props": Object {},
+        "type": "wingsdk.cloud.Logger",
+      },
+      Object {
+        "attrs": Object {},
         "path": "root/my_function",
         "props": Object {
-          "environmentVariables": Object {},
+          "environmentVariables": Object {
+            "LOGGER_HANDLE_76f7e65b": "\${root/WingLogger#attrs.handle}",
+          },
           "sourceCodeFile": "assets/my_function/index.js",
           "sourceCodeLanguage": "javascript",
         },
@@ -168,9 +239,33 @@ Object {
           "id": "Handler",
           "path": "root/Handler",
         },
+        "WingLogger": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [
+              Object {
+                "direction": "inbound",
+                "relationship": "inflight-reference",
+                "resource": "root/my_function",
+              },
+            ],
+            "wing:resource:stateful": true,
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.0.25",
+          },
+          "id": "WingLogger",
+          "path": "root/WingLogger",
+        },
         "my_function": Object {
           "attributes": Object {
-            "wing:resource:connections": Array [],
+            "wing:resource:connections": Array [
+              Object {
+                "direction": "outbound",
+                "relationship": "inflight-reference",
+                "resource": "root/WingLogger",
+              },
+            ],
             "wing:resource:stateful": false,
           },
           "children": Object {
@@ -209,9 +304,16 @@ Object {
     "resources": Array [
       Object {
         "attrs": Object {},
+        "path": "root/WingLogger",
+        "props": Object {},
+        "type": "wingsdk.cloud.Logger",
+      },
+      Object {
+        "attrs": Object {},
         "path": "root/my_function",
         "props": Object {
           "environmentVariables": Object {
+            "LOGGER_HANDLE_76f7e65b": "\${root/WingLogger#attrs.handle}",
             "PIG_LATIN": "true",
           },
           "sourceCodeFile": "assets/my_function/index.js",
@@ -237,9 +339,33 @@ Object {
           "id": "Handler",
           "path": "root/Handler",
         },
+        "WingLogger": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [
+              Object {
+                "direction": "inbound",
+                "relationship": "inflight-reference",
+                "resource": "root/my_function",
+              },
+            ],
+            "wing:resource:stateful": true,
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.0.25",
+          },
+          "id": "WingLogger",
+          "path": "root/WingLogger",
+        },
         "my_function": Object {
           "attributes": Object {
-            "wing:resource:connections": Array [],
+            "wing:resource:connections": Array [
+              Object {
+                "direction": "outbound",
+                "relationship": "inflight-reference",
+                "resource": "root/WingLogger",
+              },
+            ],
             "wing:resource:stateful": false,
           },
           "children": Object {

--- a/libs/wingsdk/test/target-sim/__snapshots__/function.test.ts.snap
+++ b/libs/wingsdk/test/target-sim/__snapshots__/function.test.ts.snap
@@ -101,6 +101,16 @@ Object {
 `;
 
 exports[`invoke function fails 1`] = `
+Array [
+  "wingsdk.cloud.Logger created.",
+  "wingsdk.cloud.Function created.",
+  "Invoke (payload=\\"{\\"name\\":\\"alice\\"}\\").",
+  "wingsdk.cloud.Function deleted.",
+  "wingsdk.cloud.Logger deleted.",
+]
+`;
+
+exports[`invoke function fails 2`] = `
 Object {
   "app.wsim": Object {
     "resources": Array [
@@ -200,6 +210,16 @@ Object {
 `;
 
 exports[`invoke function succeeds 1`] = `
+Array [
+  "wingsdk.cloud.Logger created.",
+  "wingsdk.cloud.Function created.",
+  "Invoke (payload=\\"{\\"name\\":\\"Alice\\"}\\").",
+  "wingsdk.cloud.Function deleted.",
+  "wingsdk.cloud.Logger deleted.",
+]
+`;
+
+exports[`invoke function succeeds 2`] = `
 Object {
   "app.wsim": Object {
     "resources": Array [
@@ -299,6 +319,16 @@ Object {
 `;
 
 exports[`invoke function with environment variables 1`] = `
+Array [
+  "wingsdk.cloud.Logger created.",
+  "wingsdk.cloud.Function created.",
+  "Invoke (payload=\\"{\\"name\\":\\"Alice\\"}\\").",
+  "wingsdk.cloud.Function deleted.",
+  "wingsdk.cloud.Logger deleted.",
+]
+`;
+
+exports[`invoke function with environment variables 2`] = `
 Object {
   "app.wsim": Object {
     "resources": Array [

--- a/libs/wingsdk/test/target-sim/__snapshots__/logger.test.ts.snap
+++ b/libs/wingsdk/test/target-sim/__snapshots__/logger.test.ts.snap
@@ -1,6 +1,18 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`inflight uses a logger 1`] = `
+Array [
+  "wingsdk.cloud.Logger created.",
+  "wingsdk.cloud.Function created.",
+  "Hello, Alice",
+  "Wahoo!",
+  "Invoke (payload=\\"Alice\\").",
+  "wingsdk.cloud.Function deleted.",
+  "wingsdk.cloud.Logger deleted.",
+]
+`;
+
+exports[`inflight uses a logger 2`] = `
 Object {
   "app.wsim": Object {
     "resources": Array [

--- a/libs/wingsdk/test/target-sim/__snapshots__/queue.test.ts.snap
+++ b/libs/wingsdk/test/target-sim/__snapshots__/queue.test.ts.snap
@@ -64,6 +64,24 @@ Object {
 `;
 
 exports[`messages are requeued if the function fails 1`] = `
+Array [
+  "wingsdk.cloud.Logger created.",
+  "wingsdk.cloud.Function created.",
+  "wingsdk.cloud.Queue created.",
+  "Push (message=BAD MESSAGE).",
+  "Sending messages (messages=[\\"BAD MESSAGE\\"], subscriber=sim-1).",
+  "Invoke (payload=\\"{\\"messages\\":[\\"BAD MESSAGE\\"]}\\").",
+  "Subscriber error - returning 1 messages to queue.",
+  "Sending messages (messages=[\\"BAD MESSAGE\\"], subscriber=sim-1).",
+  "Invoke (payload=\\"{\\"messages\\":[\\"BAD MESSAGE\\"]}\\").",
+  "Subscriber error - returning 1 messages to queue.",
+  "wingsdk.cloud.Queue deleted.",
+  "wingsdk.cloud.Function deleted.",
+  "wingsdk.cloud.Logger deleted.",
+]
+`;
+
+exports[`messages are requeued if the function fails 2`] = `
 Object {
   "app.wsim": Object {
     "resources": Array [
@@ -213,6 +231,21 @@ Object {
 `;
 
 exports[`queue with one subscriber, batch size of 5 1`] = `
+Array [
+  "wingsdk.cloud.Logger created.",
+  "wingsdk.cloud.Function created.",
+  "wingsdk.cloud.Queue created.",
+  "Sending messages (messages=[\\"A\\",\\"B\\",\\"C\\",\\"D\\",\\"E\\"], subscriber=sim-1).",
+  "Sending messages (messages=[\\"F\\"], subscriber=sim-1).",
+  "Invoke (payload=\\"{\\"messages\\":[\\"F\\"]}\\").",
+  "Invoke (payload=\\"{\\"messages\\":[\\"A\\",\\"B\\",\\"C\\",\\"D\\",\\"E\\"]}\\").",
+  "wingsdk.cloud.Queue deleted.",
+  "wingsdk.cloud.Function deleted.",
+  "wingsdk.cloud.Logger deleted.",
+]
+`;
+
+exports[`queue with one subscriber, batch size of 5 2`] = `
 Object {
   "app.wsim": Object {
     "resources": Array [
@@ -369,6 +402,23 @@ Object {
 `;
 
 exports[`queue with one subscriber, default batch size of 1 1`] = `
+Array [
+  "wingsdk.cloud.Logger created.",
+  "wingsdk.cloud.Function created.",
+  "wingsdk.cloud.Queue created.",
+  "Push (message=A).",
+  "Push (message=B).",
+  "Sending messages (messages=[\\"A\\"], subscriber=sim-1).",
+  "Sending messages (messages=[\\"B\\"], subscriber=sim-1).",
+  "Invoke (payload=\\"{\\"messages\\":[\\"A\\"]}\\").",
+  "Invoke (payload=\\"{\\"messages\\":[\\"B\\"]}\\").",
+  "wingsdk.cloud.Queue deleted.",
+  "wingsdk.cloud.Function deleted.",
+  "wingsdk.cloud.Logger deleted.",
+]
+`;
+
+exports[`queue with one subscriber, default batch size of 1 2`] = `
 Object {
   "app.wsim": Object {
     "resources": Array [

--- a/libs/wingsdk/test/target-sim/__snapshots__/queue.test.ts.snap
+++ b/libs/wingsdk/test/target-sim/__snapshots__/queue.test.ts.snap
@@ -6,6 +6,12 @@ Object {
     "resources": Array [
       Object {
         "attrs": Object {},
+        "path": "root/WingLogger",
+        "props": Object {},
+        "type": "wingsdk.cloud.Logger",
+      },
+      Object {
+        "attrs": Object {},
         "path": "root/my_queue",
         "props": Object {
           "initialMessages": Array [],
@@ -20,6 +26,18 @@ Object {
   "tree.json": Object {
     "tree": Object {
       "children": Object {
+        "WingLogger": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [],
+            "wing:resource:stateful": true,
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.0.25",
+          },
+          "id": "WingLogger",
+          "path": "root/WingLogger",
+        },
         "my_queue": Object {
           "attributes": Object {
             "wing:resource:connections": Array [],
@@ -51,9 +69,17 @@ Object {
     "resources": Array [
       Object {
         "attrs": Object {},
+        "path": "root/WingLogger",
+        "props": Object {},
+        "type": "wingsdk.cloud.Logger",
+      },
+      Object {
+        "attrs": Object {},
         "path": "root/my_queue-OnMessage-e645076f",
         "props": Object {
-          "environmentVariables": Object {},
+          "environmentVariables": Object {
+            "LOGGER_HANDLE_76f7e65b": "\${root/WingLogger#attrs.handle}",
+          },
           "sourceCodeFile": "assets/my_queue-OnMessage-e645076f/index.js",
           "sourceCodeLanguage": "javascript",
         },
@@ -92,6 +118,24 @@ Object {
           "id": "Handler",
           "path": "root/Handler",
         },
+        "WingLogger": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [
+              Object {
+                "direction": "inbound",
+                "relationship": "inflight-reference",
+                "resource": "root/my_queue-OnMessage-e645076f",
+              },
+            ],
+            "wing:resource:stateful": true,
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.0.25",
+          },
+          "id": "WingLogger",
+          "path": "root/WingLogger",
+        },
         "my_queue": Object {
           "attributes": Object {
             "wing:resource:connections": Array [
@@ -113,6 +157,11 @@ Object {
         "my_queue-OnMessage-e645076f": Object {
           "attributes": Object {
             "wing:resource:connections": Array [
+              Object {
+                "direction": "outbound",
+                "relationship": "inflight-reference",
+                "resource": "root/WingLogger",
+              },
               Object {
                 "direction": "inbound",
                 "relationship": "on_message",
@@ -169,9 +218,17 @@ Object {
     "resources": Array [
       Object {
         "attrs": Object {},
+        "path": "root/WingLogger",
+        "props": Object {},
+        "type": "wingsdk.cloud.Logger",
+      },
+      Object {
+        "attrs": Object {},
         "path": "root/my_queue-OnMessage-e645076f",
         "props": Object {
-          "environmentVariables": Object {},
+          "environmentVariables": Object {
+            "LOGGER_HANDLE_76f7e65b": "\${root/WingLogger#attrs.handle}",
+          },
           "sourceCodeFile": "assets/my_queue-OnMessage-e645076f/index.js",
           "sourceCodeLanguage": "javascript",
         },
@@ -217,6 +274,24 @@ Object {
           "id": "Handler",
           "path": "root/Handler",
         },
+        "WingLogger": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [
+              Object {
+                "direction": "inbound",
+                "relationship": "inflight-reference",
+                "resource": "root/my_queue-OnMessage-e645076f",
+              },
+            ],
+            "wing:resource:stateful": true,
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.0.25",
+          },
+          "id": "WingLogger",
+          "path": "root/WingLogger",
+        },
         "my_queue": Object {
           "attributes": Object {
             "wing:resource:connections": Array [
@@ -238,6 +313,11 @@ Object {
         "my_queue-OnMessage-e645076f": Object {
           "attributes": Object {
             "wing:resource:connections": Array [
+              Object {
+                "direction": "outbound",
+                "relationship": "inflight-reference",
+                "resource": "root/WingLogger",
+              },
               Object {
                 "direction": "inbound",
                 "relationship": "on_message",
@@ -294,9 +374,17 @@ Object {
     "resources": Array [
       Object {
         "attrs": Object {},
+        "path": "root/WingLogger",
+        "props": Object {},
+        "type": "wingsdk.cloud.Logger",
+      },
+      Object {
+        "attrs": Object {},
         "path": "root/my_queue-OnMessage-e645076f",
         "props": Object {
-          "environmentVariables": Object {},
+          "environmentVariables": Object {
+            "LOGGER_HANDLE_76f7e65b": "\${root/WingLogger#attrs.handle}",
+          },
           "sourceCodeFile": "assets/my_queue-OnMessage-e645076f/index.js",
           "sourceCodeLanguage": "javascript",
         },
@@ -335,6 +423,24 @@ Object {
           "id": "Handler",
           "path": "root/Handler",
         },
+        "WingLogger": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [
+              Object {
+                "direction": "inbound",
+                "relationship": "inflight-reference",
+                "resource": "root/my_queue-OnMessage-e645076f",
+              },
+            ],
+            "wing:resource:stateful": true,
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.0.25",
+          },
+          "id": "WingLogger",
+          "path": "root/WingLogger",
+        },
         "my_queue": Object {
           "attributes": Object {
             "wing:resource:connections": Array [
@@ -356,6 +462,11 @@ Object {
         "my_queue-OnMessage-e645076f": Object {
           "attributes": Object {
             "wing:resource:connections": Array [
+              Object {
+                "direction": "outbound",
+                "relationship": "inflight-reference",
+                "resource": "root/WingLogger",
+              },
               Object {
                 "direction": "inbound",
                 "relationship": "on_message",

--- a/libs/wingsdk/test/target-sim/__snapshots__/topic-producer.test.ts.snap
+++ b/libs/wingsdk/test/target-sim/__snapshots__/topic-producer.test.ts.snap
@@ -1,0 +1,18 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`publishing messages to topic 1`] = `
+Array [
+  "wingsdk.cloud.Logger created.",
+  "wingsdk.cloud.Function created.",
+  "wingsdk.cloud.Topic created.",
+  "wingsdk.cloud.Function created.",
+  "Publish (message=ABC).",
+  "Sending message (message=ABC, subscriber=sim-1).",
+  "Invoke (payload=\\"ABC\\").",
+  "Invoke (payload=\\"ABC\\").",
+  "wingsdk.cloud.Function deleted.",
+  "wingsdk.cloud.Topic deleted.",
+  "wingsdk.cloud.Function deleted.",
+  "wingsdk.cloud.Logger deleted.",
+]
+`;

--- a/libs/wingsdk/test/target-sim/__snapshots__/topic.test.ts.snap
+++ b/libs/wingsdk/test/target-sim/__snapshots__/topic.test.ts.snap
@@ -6,6 +6,12 @@ Object {
     "resources": Array [
       Object {
         "attrs": Object {},
+        "path": "root/WingLogger",
+        "props": Object {},
+        "type": "wingsdk.cloud.Logger",
+      },
+      Object {
+        "attrs": Object {},
         "path": "root/my_topic",
         "props": Object {
           "subscribers": Array [],
@@ -18,6 +24,18 @@ Object {
   "tree.json": Object {
     "tree": Object {
       "children": Object {
+        "WingLogger": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [],
+            "wing:resource:stateful": true,
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.0.25",
+          },
+          "id": "WingLogger",
+          "path": "root/WingLogger",
+        },
         "my_topic": Object {
           "attributes": Object {
             "wing:resource:connections": Array [],

--- a/libs/wingsdk/test/target-sim/__snapshots__/topic.test.ts.snap
+++ b/libs/wingsdk/test/target-sim/__snapshots__/topic.test.ts.snap
@@ -60,3 +60,42 @@ Object {
   },
 }
 `;
+
+exports[`topic publishes messages as they are received 1`] = `
+Array [
+  "wingsdk.cloud.Logger created.",
+  "wingsdk.cloud.Function created.",
+  "wingsdk.cloud.Topic created.",
+  "Publish (message=Alpha).",
+  "Sending message (message=Alpha, subscriber=sim-1).",
+  "Received Alpha",
+  "Invoke (payload=\\"Alpha\\").",
+  "Publish (message=Beta).",
+  "Sending message (message=Beta, subscriber=sim-1).",
+  "Received Beta",
+  "Invoke (payload=\\"Beta\\").",
+  "wingsdk.cloud.Topic deleted.",
+  "wingsdk.cloud.Function deleted.",
+  "wingsdk.cloud.Logger deleted.",
+]
+`;
+
+exports[`topic publishes messages to multiple subscribers 1`] = `
+Array [
+  "wingsdk.cloud.Logger created.",
+  "wingsdk.cloud.Function created.",
+  "wingsdk.cloud.Function created.",
+  "wingsdk.cloud.Topic created.",
+  "Publish (message=Alpha).",
+  "Sending message (message=Alpha, subscriber=sim-1).",
+  "Received Alpha",
+  "Invoke (payload=\\"Alpha\\").",
+  "Sending message (message=Alpha, subscriber=sim-2).",
+  "Also received Alpha",
+  "Invoke (payload=\\"Alpha\\").",
+  "wingsdk.cloud.Topic deleted.",
+  "wingsdk.cloud.Function deleted.",
+  "wingsdk.cloud.Function deleted.",
+  "wingsdk.cloud.Logger deleted.",
+]
+`;

--- a/libs/wingsdk/test/target-sim/bucket.test.ts
+++ b/libs/wingsdk/test/target-sim/bucket.test.ts
@@ -43,14 +43,7 @@ test("put and get objects from bucket", async () => {
   await s.stop();
 
   expect(response).toEqual(VALUE);
-  expect(listMessages(s)).toEqual([
-    "wingsdk.cloud.Logger created.",
-    "wingsdk.cloud.Bucket created.",
-    "Put (key=greeting.txt).",
-    "Get (key=greeting.txt).",
-    "wingsdk.cloud.Bucket deleted.",
-    "wingsdk.cloud.Logger deleted.",
-  ]);
+  expect(listMessages(s)).toMatchSnapshot();
   expect(app.snapshot()).toMatchSnapshot();
 });
 
@@ -79,16 +72,7 @@ test("put multiple objects and list all from bucket", async () => {
   await s.stop();
 
   expect(response).toEqual([KEY1, KEY2, KEY3]);
-  expect(listMessages(s)).toEqual([
-    "wingsdk.cloud.Logger created.",
-    "wingsdk.cloud.Bucket created.",
-    "Put (key=greeting1.txt).",
-    "Put (key=greeting2.txt).",
-    "Put (key=greeting3.txt).",
-    "List (prefix=null).",
-    "wingsdk.cloud.Bucket deleted.",
-    "wingsdk.cloud.Logger deleted.",
-  ]);
+  expect(listMessages(s)).toMatchSnapshot();
   expect(app.snapshot()).toMatchSnapshot();
 });
 
@@ -105,13 +89,7 @@ test("get invalid object throws an error", async () => {
   await expect(() => client.get("unknown.txt")).rejects.toThrowError();
   await s.stop();
 
-  expect(listMessages(s)).toEqual([
-    "wingsdk.cloud.Logger created.",
-    "wingsdk.cloud.Bucket created.",
-    "Get (key=unknown.txt).",
-    "wingsdk.cloud.Bucket deleted.",
-    "wingsdk.cloud.Logger deleted.",
-  ]);
+  expect(listMessages(s)).toMatchSnapshot();
   expect(s.listTraces()[2].data.status).toEqual("failure");
   expect(app.snapshot()).toMatchSnapshot();
 });
@@ -139,14 +117,7 @@ test("remove object from a bucket with mustExist as option", async () => {
   await s.stop();
 
   expect(response).toEqual(undefined);
-  expect(listMessages(s)).toEqual([
-    "wingsdk.cloud.Logger created.",
-    "wingsdk.cloud.Bucket created.",
-    `Put (key=${fileName}).`,
-    `Delete (key=${fileName}).`,
-    "wingsdk.cloud.Bucket deleted.",
-    "wingsdk.cloud.Logger deleted.",
-  ]);
+  expect(listMessages(s)).toMatchSnapshot();
   expect(app.snapshot()).toMatchSnapshot();
 });
 
@@ -173,14 +144,7 @@ test("remove object from a bucket", async () => {
   await s.stop();
 
   expect(response).toEqual(undefined);
-  expect(listMessages(s)).toEqual([
-    "wingsdk.cloud.Logger created.",
-    "wingsdk.cloud.Bucket created.",
-    `Put (key=${fileName}).`,
-    `Delete (key=${fileName}).`,
-    "wingsdk.cloud.Bucket deleted.",
-    "wingsdk.cloud.Logger deleted.",
-  ]);
+  expect(listMessages(s)).toMatchSnapshot();
   expect(app.snapshot()).toMatchSnapshot();
 });
 

--- a/libs/wingsdk/test/target-sim/bucket.test.ts
+++ b/libs/wingsdk/test/target-sim/bucket.test.ts
@@ -44,10 +44,12 @@ test("put and get objects from bucket", async () => {
 
   expect(response).toEqual(VALUE);
   expect(listMessages(s)).toEqual([
+    "wingsdk.cloud.Logger created.",
     "wingsdk.cloud.Bucket created.",
     "Put (key=greeting.txt).",
     "Get (key=greeting.txt).",
     "wingsdk.cloud.Bucket deleted.",
+    "wingsdk.cloud.Logger deleted.",
   ]);
   expect(app.snapshot()).toMatchSnapshot();
 });
@@ -78,12 +80,14 @@ test("put multiple objects and list all from bucket", async () => {
 
   expect(response).toEqual([KEY1, KEY2, KEY3]);
   expect(listMessages(s)).toEqual([
+    "wingsdk.cloud.Logger created.",
     "wingsdk.cloud.Bucket created.",
     "Put (key=greeting1.txt).",
     "Put (key=greeting2.txt).",
     "Put (key=greeting3.txt).",
     "List (prefix=null).",
     "wingsdk.cloud.Bucket deleted.",
+    "wingsdk.cloud.Logger deleted.",
   ]);
   expect(app.snapshot()).toMatchSnapshot();
 });
@@ -102,11 +106,13 @@ test("get invalid object throws an error", async () => {
   await s.stop();
 
   expect(listMessages(s)).toEqual([
+    "wingsdk.cloud.Logger created.",
     "wingsdk.cloud.Bucket created.",
     "Get (key=unknown.txt).",
     "wingsdk.cloud.Bucket deleted.",
+    "wingsdk.cloud.Logger deleted.",
   ]);
-  expect(s.listTraces()[1].data.status).toEqual("failure");
+  expect(s.listTraces()[2].data.status).toEqual("failure");
   expect(app.snapshot()).toMatchSnapshot();
 });
 
@@ -134,10 +140,12 @@ test("remove object from a bucket with mustExist as option", async () => {
 
   expect(response).toEqual(undefined);
   expect(listMessages(s)).toEqual([
+    "wingsdk.cloud.Logger created.",
     "wingsdk.cloud.Bucket created.",
     `Put (key=${fileName}).`,
     `Delete (key=${fileName}).`,
     "wingsdk.cloud.Bucket deleted.",
+    "wingsdk.cloud.Logger deleted.",
   ]);
   expect(app.snapshot()).toMatchSnapshot();
 });
@@ -166,10 +174,12 @@ test("remove object from a bucket", async () => {
 
   expect(response).toEqual(undefined);
   expect(listMessages(s)).toEqual([
+    "wingsdk.cloud.Logger created.",
     "wingsdk.cloud.Bucket created.",
     `Put (key=${fileName}).`,
     `Delete (key=${fileName}).`,
     "wingsdk.cloud.Bucket deleted.",
+    "wingsdk.cloud.Logger deleted.",
   ]);
   expect(app.snapshot()).toMatchSnapshot();
 });

--- a/libs/wingsdk/test/target-sim/counter.test.ts
+++ b/libs/wingsdk/test/target-sim/counter.test.ts
@@ -53,12 +53,14 @@ test("inc", async () => {
   await s.stop();
 
   expect(listMessages(s)).toEqual([
+    "wingsdk.cloud.Logger created.",
     "wingsdk.cloud.Counter created.",
     "Inc (amount=1).",
     "Inc (amount=1).",
     "Inc (amount=10).",
     "Inc (amount=10).",
     "wingsdk.cloud.Counter deleted.",
+    "wingsdk.cloud.Logger deleted.",
   ]);
   expect(app.snapshot()).toMatchSnapshot();
 });

--- a/libs/wingsdk/test/target-sim/file-counter.test.ts
+++ b/libs/wingsdk/test/target-sim/file-counter.test.ts
@@ -2,6 +2,8 @@ import { Construct } from "constructs";
 import * as cloud from "../../src/cloud";
 import { SimApp, Testing } from "../../src/testing";
 
+jest.setTimeout(30_1000);
+
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
 test("can create sequential files in a bucket", async () => {
@@ -39,7 +41,6 @@ test("can create sequential files in a bucket", async () => {
   }
 
   const app = new SimApp();
-  cloud.Logger.register(app);
   new HelloWorld(app, "HelloWorld");
 
   const s = await app.startSimulator();

--- a/libs/wingsdk/test/target-sim/function.test.ts
+++ b/libs/wingsdk/test/target-sim/function.test.ts
@@ -67,13 +67,7 @@ test("invoke function succeeds", async () => {
   expect(response).toEqual(JSON.stringify({ msg: `Hello, ${PAYLOAD.name}!` }));
   await s.stop();
 
-  expect(listMessages(s)).toEqual([
-    "wingsdk.cloud.Logger created.",
-    "wingsdk.cloud.Function created.",
-    'Invoke (payload="{"name":"Alice"}").',
-    "wingsdk.cloud.Function deleted.",
-    "wingsdk.cloud.Logger deleted.",
-  ]);
+  expect(listMessages(s)).toMatchSnapshot();
   expect(app.snapshot()).toMatchSnapshot();
 });
 
@@ -103,13 +97,7 @@ test("invoke function with environment variables", async () => {
   );
   await s.stop();
 
-  expect(listMessages(s)).toEqual([
-    "wingsdk.cloud.Logger created.",
-    "wingsdk.cloud.Function created.",
-    'Invoke (payload="{"name":"Alice"}").',
-    "wingsdk.cloud.Function deleted.",
-    "wingsdk.cloud.Logger deleted.",
-  ]);
+  expect(listMessages(s)).toMatchSnapshot();
   expect(app.snapshot()).toMatchSnapshot();
 });
 
@@ -131,13 +119,7 @@ test("invoke function fails", async () => {
   // THEN
   await s.stop();
 
-  expect(listMessages(s)).toEqual([
-    "wingsdk.cloud.Logger created.",
-    "wingsdk.cloud.Function created.",
-    'Invoke (payload="{"name":"alice"}").',
-    "wingsdk.cloud.Function deleted.",
-    "wingsdk.cloud.Logger deleted.",
-  ]);
+  expect(listMessages(s)).toMatchSnapshot();
   expect(s.listTraces()[2].data.error).toMatchObject({
     message: "Name must start with uppercase letter",
   });

--- a/libs/wingsdk/test/target-sim/function.test.ts
+++ b/libs/wingsdk/test/target-sim/function.test.ts
@@ -39,6 +39,7 @@ test("create a function", async () => {
       sourceCodeLanguage: "javascript",
       environmentVariables: {
         ENV_VAR1: "true",
+        LOGGER_HANDLE_76f7e65b: "${root/WingLogger#attrs.handle}",
       },
     },
     type: "wingsdk.cloud.Function",
@@ -67,9 +68,11 @@ test("invoke function succeeds", async () => {
   await s.stop();
 
   expect(listMessages(s)).toEqual([
+    "wingsdk.cloud.Logger created.",
     "wingsdk.cloud.Function created.",
     'Invoke (payload="{"name":"Alice"}").',
     "wingsdk.cloud.Function deleted.",
+    "wingsdk.cloud.Logger deleted.",
   ]);
   expect(app.snapshot()).toMatchSnapshot();
 });
@@ -101,9 +104,11 @@ test("invoke function with environment variables", async () => {
   await s.stop();
 
   expect(listMessages(s)).toEqual([
+    "wingsdk.cloud.Logger created.",
     "wingsdk.cloud.Function created.",
     'Invoke (payload="{"name":"Alice"}").',
     "wingsdk.cloud.Function deleted.",
+    "wingsdk.cloud.Logger deleted.",
   ]);
   expect(app.snapshot()).toMatchSnapshot();
 });
@@ -127,11 +132,13 @@ test("invoke function fails", async () => {
   await s.stop();
 
   expect(listMessages(s)).toEqual([
+    "wingsdk.cloud.Logger created.",
     "wingsdk.cloud.Function created.",
     'Invoke (payload="{"name":"alice"}").',
     "wingsdk.cloud.Function deleted.",
+    "wingsdk.cloud.Logger deleted.",
   ]);
-  expect(s.listTraces()[1].data.error).toMatchObject({
+  expect(s.listTraces()[2].data.error).toMatchObject({
     message: "Name must start with uppercase letter",
   });
   expect(app.snapshot()).toMatchSnapshot();

--- a/libs/wingsdk/test/target-sim/logger.test.ts
+++ b/libs/wingsdk/test/target-sim/logger.test.ts
@@ -6,20 +6,15 @@ const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
 const INFLIGHT_CODE = `
 async handle(event) {
-  this.logger.print("Hello, " + event);
-  this.logger.print("Wahoo!");
+  console.log("Hello, " + event);
+  console.log("Wahoo!");
 }`;
 
 test("inflight uses a logger", async () => {
   // GIVEN
   const app = new SimApp();
-  cloud.Logger.register(app);
-  const handler = Testing.makeHandler(app, "Handler", INFLIGHT_CODE, {
-    logger: {
-      resource: cloud.Logger.of(app),
-      ops: [cloud.LoggerInflightMethods.PRINT],
-    },
-  });
+  const handler = Testing.makeHandler(app, "Handler", INFLIGHT_CODE);
+
   new cloud.Function(app, "my_function", handler);
 
   const s = await app.startSimulator();

--- a/libs/wingsdk/test/target-sim/logger.test.ts
+++ b/libs/wingsdk/test/target-sim/logger.test.ts
@@ -7,7 +7,7 @@ const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 const INFLIGHT_CODE = `
 async handle(event) {
   console.log("Hello, " + event);
-  console.log("Wahoo!");
+  this.$logger.print("Wahoo!");
 }`;
 
 test("inflight uses a logger", async () => {

--- a/libs/wingsdk/test/target-sim/logger.test.ts
+++ b/libs/wingsdk/test/target-sim/logger.test.ts
@@ -7,7 +7,7 @@ const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 const INFLIGHT_CODE = `
 async handle(event) {
   console.log("Hello, " + event);
-  this.$logger.print("Wahoo!");
+  console.log("Wahoo!");
 }`;
 
 test("inflight uses a logger", async () => {

--- a/libs/wingsdk/test/target-sim/logger.test.ts
+++ b/libs/wingsdk/test/target-sim/logger.test.ts
@@ -30,14 +30,6 @@ test("inflight uses a logger", async () => {
   // THEN
   await s.stop();
 
-  expect(listMessages(s)).toEqual([
-    "wingsdk.cloud.Logger created.",
-    "wingsdk.cloud.Function created.",
-    "Hello, Alice",
-    "Wahoo!",
-    'Invoke (payload="Alice").',
-    "wingsdk.cloud.Function deleted.",
-    "wingsdk.cloud.Logger deleted.",
-  ]);
+  expect(listMessages(s)).toMatchSnapshot();
   expect(app.snapshot()).toMatchSnapshot();
 });

--- a/libs/wingsdk/test/target-sim/queue-consumer.test.ts
+++ b/libs/wingsdk/test/target-sim/queue-consumer.test.ts
@@ -2,6 +2,7 @@ import { Construct } from "constructs";
 import * as cloud from "../../src/cloud";
 import { SimApp, Testing, TraceType } from "../../src/testing";
 
+jest.setTimeout(30_1000);
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
 test("pushing messages through a queue", async () => {
@@ -15,14 +16,10 @@ test("pushing messages through a queue", async () => {
         app,
         "Pusher",
         `async handle(event) {
-          await this.logger.print("Hello, world!");
+          console.log("Hello, world!");
           await this.queue.push(event);
         }`,
         {
-          logger: {
-            resource: cloud.Logger.of(this),
-            ops: [cloud.LoggerInflightMethods.PRINT],
-          },
           queue: {
             resource: queue,
             ops: [cloud.QueueInflightMethods.PUSH],
@@ -35,21 +32,14 @@ test("pushing messages through a queue", async () => {
         app,
         "Processor",
         `async handle(event) {
-          await this.logger.print("Received " + event);
-        }`,
-        {
-          logger: {
-            resource: cloud.Logger.of(this),
-            ops: [cloud.LoggerInflightMethods.PRINT],
-          },
-        }
+          console.log("Received " + event);
+        }`
       );
       queue.onMessage(processor);
     }
   }
 
   const app = new SimApp();
-  cloud.Logger.register(app);
   new HelloWorld(app, "HelloWorld");
 
   const s = await app.startSimulator();

--- a/libs/wingsdk/test/target-sim/queue.test.ts
+++ b/libs/wingsdk/test/target-sim/queue.test.ts
@@ -57,20 +57,7 @@ test("queue with one subscriber, default batch size of 1", async () => {
   // THEN
   await s.stop();
 
-  expect(listMessages(s)).toEqual([
-    "wingsdk.cloud.Logger created.",
-    "wingsdk.cloud.Function created.",
-    "wingsdk.cloud.Queue created.",
-    "Push (message=A).",
-    "Push (message=B).",
-    'Sending messages (messages=["A"], subscriber=sim-1).',
-    'Sending messages (messages=["B"], subscriber=sim-1).',
-    'Invoke (payload="{"messages":["A"]}").',
-    'Invoke (payload="{"messages":["B"]}").',
-    "wingsdk.cloud.Queue deleted.",
-    "wingsdk.cloud.Function deleted.",
-    "wingsdk.cloud.Logger deleted.",
-  ]);
+  expect(listMessages(s)).toMatchSnapshot();
   expect(app.snapshot()).toMatchSnapshot();
 });
 
@@ -90,18 +77,7 @@ test("queue with one subscriber, batch size of 5", async () => {
   // THEN
   await s.stop();
 
-  expect(listMessages(s)).toEqual([
-    "wingsdk.cloud.Logger created.",
-    "wingsdk.cloud.Function created.",
-    "wingsdk.cloud.Queue created.",
-    'Sending messages (messages=["A","B","C","D","E"], subscriber=sim-1).',
-    'Sending messages (messages=["F"], subscriber=sim-1).',
-    'Invoke (payload="{"messages":["F"]}").',
-    'Invoke (payload="{"messages":["A","B","C","D","E"]}").',
-    "wingsdk.cloud.Queue deleted.",
-    "wingsdk.cloud.Function deleted.",
-    "wingsdk.cloud.Logger deleted.",
-  ]);
+  expect(listMessages(s)).toMatchSnapshot();
   expect(app.snapshot()).toMatchSnapshot();
 });
 
@@ -122,20 +98,6 @@ test("messages are requeued if the function fails", async () => {
   // THEN
   await s.stop();
 
-  expect(listMessages(s)).toEqual([
-    "wingsdk.cloud.Logger created.",
-    "wingsdk.cloud.Function created.",
-    "wingsdk.cloud.Queue created.",
-    "Push (message=BAD MESSAGE).",
-    'Sending messages (messages=["BAD MESSAGE"], subscriber=sim-1).',
-    'Invoke (payload="{"messages":["BAD MESSAGE"]}").',
-    "Subscriber error - returning 1 messages to queue.",
-    'Sending messages (messages=["BAD MESSAGE"], subscriber=sim-1).',
-    'Invoke (payload="{"messages":["BAD MESSAGE"]}").',
-    "Subscriber error - returning 1 messages to queue.",
-    "wingsdk.cloud.Queue deleted.",
-    "wingsdk.cloud.Function deleted.",
-    "wingsdk.cloud.Logger deleted.",
-  ]);
+  expect(listMessages(s)).toMatchSnapshot();
   expect(app.snapshot()).toMatchSnapshot();
 });

--- a/libs/wingsdk/test/target-sim/queue.test.ts
+++ b/libs/wingsdk/test/target-sim/queue.test.ts
@@ -2,7 +2,7 @@ import * as cloud from "../../src/cloud";
 import { SimApp, Testing } from "../../src/testing";
 import { listMessages } from "./util";
 
-jest.setTimeout(5_000); // 5 seconds
+jest.setTimeout(10_000); // 5 seconds
 
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
@@ -58,16 +58,18 @@ test("queue with one subscriber, default batch size of 1", async () => {
   await s.stop();
 
   expect(listMessages(s)).toEqual([
+    "wingsdk.cloud.Logger created.",
     "wingsdk.cloud.Function created.",
     "wingsdk.cloud.Queue created.",
     "Push (message=A).",
     "Push (message=B).",
-    'Sending messages (messages=["A"], subscriber=sim-0).',
-    'Sending messages (messages=["B"], subscriber=sim-0).',
+    'Sending messages (messages=["A"], subscriber=sim-1).',
+    'Sending messages (messages=["B"], subscriber=sim-1).',
     'Invoke (payload="{"messages":["A"]}").',
     'Invoke (payload="{"messages":["B"]}").',
     "wingsdk.cloud.Queue deleted.",
     "wingsdk.cloud.Function deleted.",
+    "wingsdk.cloud.Logger deleted.",
   ]);
   expect(app.snapshot()).toMatchSnapshot();
 });
@@ -89,14 +91,16 @@ test("queue with one subscriber, batch size of 5", async () => {
   await s.stop();
 
   expect(listMessages(s)).toEqual([
+    "wingsdk.cloud.Logger created.",
     "wingsdk.cloud.Function created.",
     "wingsdk.cloud.Queue created.",
-    'Sending messages (messages=["A","B","C","D","E"], subscriber=sim-0).',
-    'Sending messages (messages=["F"], subscriber=sim-0).',
+    'Sending messages (messages=["A","B","C","D","E"], subscriber=sim-1).',
+    'Sending messages (messages=["F"], subscriber=sim-1).',
     'Invoke (payload="{"messages":["F"]}").',
     'Invoke (payload="{"messages":["A","B","C","D","E"]}").',
     "wingsdk.cloud.Queue deleted.",
     "wingsdk.cloud.Function deleted.",
+    "wingsdk.cloud.Logger deleted.",
   ]);
   expect(app.snapshot()).toMatchSnapshot();
 });
@@ -118,20 +122,20 @@ test("messages are requeued if the function fails", async () => {
   // THEN
   await s.stop();
 
-  expect(listMessages(s).slice(0, 6)).toEqual([
+  expect(listMessages(s)).toEqual([
+    "wingsdk.cloud.Logger created.",
     "wingsdk.cloud.Function created.",
     "wingsdk.cloud.Queue created.",
     "Push (message=BAD MESSAGE).",
-    'Sending messages (messages=["BAD MESSAGE"], subscriber=sim-0).',
+    'Sending messages (messages=["BAD MESSAGE"], subscriber=sim-1).',
     'Invoke (payload="{"messages":["BAD MESSAGE"]}").',
     "Subscriber error - returning 1 messages to queue.",
-  ]);
-  expect(listMessages(s).slice(-5)).toEqual([
-    'Sending messages (messages=["BAD MESSAGE"], subscriber=sim-0).',
+    'Sending messages (messages=["BAD MESSAGE"], subscriber=sim-1).',
     'Invoke (payload="{"messages":["BAD MESSAGE"]}").',
     "Subscriber error - returning 1 messages to queue.",
     "wingsdk.cloud.Queue deleted.",
     "wingsdk.cloud.Function deleted.",
+    "wingsdk.cloud.Logger deleted.",
   ]);
   expect(app.snapshot()).toMatchSnapshot();
 });

--- a/libs/wingsdk/test/target-sim/topic-producer.test.ts
+++ b/libs/wingsdk/test/target-sim/topic-producer.test.ts
@@ -51,18 +51,5 @@ test("publishing messages to topic", async () => {
   // THEN
   await s.stop();
 
-  expect(listMessages(s)).toEqual([
-    "wingsdk.cloud.Logger created.",
-    "wingsdk.cloud.Function created.",
-    "wingsdk.cloud.Topic created.",
-    "wingsdk.cloud.Function created.",
-    "Publish (message=ABC).",
-    `Sending message (message=ABC, subscriber=sim-1).`,
-    `Invoke (payload="ABC").`,
-    `Invoke (payload="ABC").`,
-    `wingsdk.cloud.Function deleted.`,
-    `wingsdk.cloud.Topic deleted.`,
-    `wingsdk.cloud.Function deleted.`,
-    `wingsdk.cloud.Logger deleted.`,
-  ]);
+  expect(listMessages(s)).toMatchSnapshot();
 });

--- a/libs/wingsdk/test/target-sim/topic-producer.test.ts
+++ b/libs/wingsdk/test/target-sim/topic-producer.test.ts
@@ -52,15 +52,17 @@ test("publishing messages to topic", async () => {
   await s.stop();
 
   expect(listMessages(s)).toEqual([
+    "wingsdk.cloud.Logger created.",
     "wingsdk.cloud.Function created.",
     "wingsdk.cloud.Topic created.",
     "wingsdk.cloud.Function created.",
     "Publish (message=ABC).",
-    `Sending message (message=ABC, subscriber=sim-0).`,
+    `Sending message (message=ABC, subscriber=sim-1).`,
     `Invoke (payload="ABC").`,
     `Invoke (payload="ABC").`,
     `wingsdk.cloud.Function deleted.`,
     `wingsdk.cloud.Topic deleted.`,
     `wingsdk.cloud.Function deleted.`,
+    `wingsdk.cloud.Logger deleted.`,
   ]);
 });

--- a/libs/wingsdk/test/target-sim/topic.test.ts
+++ b/libs/wingsdk/test/target-sim/topic.test.ts
@@ -47,22 +47,7 @@ test("topic publishes messages as they are received", async () => {
 
   // THEN
   await s.stop();
-  expect(listMessages(s)).toEqual([
-    "wingsdk.cloud.Logger created.",
-    "wingsdk.cloud.Function created.",
-    "wingsdk.cloud.Topic created.",
-    "Publish (message=Alpha).",
-    "Sending message (message=Alpha, subscriber=sim-1).",
-    "Received Alpha",
-    'Invoke (payload="Alpha").',
-    "Publish (message=Beta).",
-    "Sending message (message=Beta, subscriber=sim-1).",
-    "Received Beta",
-    'Invoke (payload="Beta").',
-    "wingsdk.cloud.Topic deleted.",
-    "wingsdk.cloud.Function deleted.",
-    "wingsdk.cloud.Logger deleted.",
-  ]);
+  expect(listMessages(s)).toMatchSnapshot();
 });
 
 test("topic publishes messages to multiple subscribers", async () => {
@@ -90,21 +75,5 @@ test("topic publishes messages to multiple subscribers", async () => {
 
   // THEN
   await s.stop();
-  expect(listMessages(s)).toEqual([
-    "wingsdk.cloud.Logger created.",
-    "wingsdk.cloud.Function created.",
-    "wingsdk.cloud.Function created.",
-    "wingsdk.cloud.Topic created.",
-    "Publish (message=Alpha).",
-    "Sending message (message=Alpha, subscriber=sim-1).",
-    "Received Alpha",
-    'Invoke (payload="Alpha").',
-    "Sending message (message=Alpha, subscriber=sim-2).",
-    "Also received Alpha",
-    'Invoke (payload="Alpha").',
-    "wingsdk.cloud.Topic deleted.",
-    "wingsdk.cloud.Function deleted.",
-    "wingsdk.cloud.Function deleted.",
-    "wingsdk.cloud.Logger deleted.",
-  ]);
+  expect(listMessages(s)).toMatchSnapshot();
 });

--- a/libs/wingsdk/test/target-sim/topic.test.ts
+++ b/libs/wingsdk/test/target-sim/topic.test.ts
@@ -33,7 +33,7 @@ test("topic publishes messages as they are received", async () => {
   const handler = Testing.makeHandler(
     app,
     "Handler",
-    `async handle(message) { this.$logger.print("Received " + message); }`
+    `async handle(message) { console.log("Received " + message); }`
   );
   const topic = new cloud.Topic(app, "my_topic");
   topic.onMessage(handler);
@@ -56,12 +56,12 @@ test("topic publishes messages to multiple subscribers", async () => {
   const handler = Testing.makeHandler(
     app,
     "Handler1",
-    `async handle(message) { this.$logger.print("Received " + message); }`
+    `async handle(message) { console.log("Received " + message); }`
   );
   const otherHandler = Testing.makeHandler(
     app,
     "Handler2",
-    `async handle(message) { this.$logger.print("Also received " + message); }`
+    `async handle(message) { console.log("Also received " + message); }`
   );
   const topic = new cloud.Topic(app, "my_topic");
   topic.onMessage(handler);

--- a/libs/wingsdk/test/target-sim/topic.test.ts
+++ b/libs/wingsdk/test/target-sim/topic.test.ts
@@ -1,5 +1,4 @@
 import * as cloud from "../../src/cloud";
-import * as core from "../../src/core";
 import * as testing from "../../src/testing";
 import { Testing } from "../../src/testing";
 import { listMessages } from "./util";
@@ -31,11 +30,10 @@ test("create a topic", async () => {
 test("topic publishes messages as they are received", async () => {
   // GIVEN
   const app = new testing.SimApp();
-  cloud.Logger.register(app);
-  const handler = makeInflight(
+  const handler = Testing.makeHandler(
+    app,
     "Handler",
-    `async handle(message) { this.logger.print("Received " + message); }`,
-    app
+    `async handle(message) { this.$logger.print("Received " + message); }`
   );
   const topic = new cloud.Topic(app, "my_topic");
   topic.onMessage(handler);
@@ -70,16 +68,15 @@ test("topic publishes messages as they are received", async () => {
 test("topic publishes messages to multiple subscribers", async () => {
   // GIVEN
   const app = new testing.SimApp();
-  cloud.Logger.register(app);
-  const handler = makeInflight(
+  const handler = Testing.makeHandler(
+    app,
     "Handler1",
-    `async handle(message) { this.logger.print("Received " + message); }`,
-    app
+    `async handle(message) { this.$logger.print("Received " + message); }`
   );
-  const otherHandler = makeInflight(
+  const otherHandler = Testing.makeHandler(
+    app,
     "Handler2",
-    `async handle(message) { this.logger.print("Also received " + message); }`,
-    app
+    `async handle(message) { this.$logger.print("Also received " + message); }`
   );
   const topic = new cloud.Topic(app, "my_topic");
   topic.onMessage(handler);
@@ -111,12 +108,3 @@ test("topic publishes messages to multiple subscribers", async () => {
     "wingsdk.cloud.Logger deleted.",
   ]);
 });
-
-function makeInflight(id: string, code: string, app: core.IApp) {
-  return Testing.makeHandler(app, id, code, {
-    logger: {
-      resource: cloud.Logger.of(app),
-      ops: [cloud.LoggerInflightMethods.PRINT],
-    },
-  });
-}

--- a/libs/wingsdk/test/target-tf-aws/__snapshots__/bucket.test.ts.snap
+++ b/libs/wingsdk/test/target-tf-aws/__snapshots__/bucket.test.ts.snap
@@ -34,6 +34,18 @@ Object {
     "children": Object {
       "root": Object {
         "children": Object {
+          "WingLogger": Object {
+            "attributes": Object {
+              "wing:resource:connections": Array [],
+              "wing:resource:stateful": true,
+            },
+            "constructInfo": Object {
+              "fqn": "constructs.Construct",
+              "version": "10.0.25",
+            },
+            "id": "WingLogger",
+            "path": "root/WingLogger",
+          },
           "aws": Object {
             "constructInfo": Object {
               "fqn": "@cdktf/provider-aws.provider.AwsProvider",
@@ -145,6 +157,18 @@ Object {
     "children": Object {
       "root": Object {
         "children": Object {
+          "WingLogger": Object {
+            "attributes": Object {
+              "wing:resource:connections": Array [],
+              "wing:resource:stateful": true,
+            },
+            "constructInfo": Object {
+              "fqn": "constructs.Construct",
+              "version": "10.0.25",
+            },
+            "id": "WingLogger",
+            "path": "root/WingLogger",
+          },
           "aws": Object {
             "constructInfo": Object {
               "fqn": "@cdktf/provider-aws.provider.AwsProvider",

--- a/libs/wingsdk/test/target-tf-aws/__snapshots__/captures.test.ts.snap
+++ b/libs/wingsdk/test/target-tf-aws/__snapshots__/captures.test.ts.snap
@@ -2,22 +2,23 @@
 
 exports[`function with a bucket binding 1`] = `
 "
-      (function(clients) {
-        console.log = (...args) => clients.$logger.print(...args);
+        (function(clients) {
+          console.log = (...args) => clients.$logger.print(...args);
 
-        class Handler {
-          constructor(clients) {
-            for (const [name, client] of Object.entries(clients)) {
-              this[name] = client;
-            }            
+          class Handler {
+            constructor() {
+              for (const [name, client] of Object.entries(clients)) {
+                this[name] = client;
+              }            
+            }
+
+            async handle(event) { await this.bucket.put(\\"hello.txt\\", event); }
           }
 
-          async handle(event) { await this.bucket.put(\\"hello.txt\\", event); }
-        }
-
-        return new Handler(clients);
-      })({bucket: new (require(\\"[REDACTED]/wingsdk/src/target-tf-aws/bucket.inflight.ts\\")).BucketClient(process.env[\\"BUCKET_NAME_1357ca3a\\"]),
-$logger: new (require(\\"[REDACTED]/wingsdk/src/target-tf-aws/logger.inflight.ts\\")).LoggerClient()})"
+          return new Handler();
+        })({bucket: new (require(\\"[REDACTED]/wingsdk/src/target-tf-aws/bucket.inflight.ts\\")).BucketClient(process.env[\\"BUCKET_NAME_1357ca3a\\"]),
+$logger: new (require(\\"[REDACTED]/wingsdk/src/target-tf-aws/logger.inflight.ts\\")).LoggerClient()})
+      "
 `;
 
 exports[`function with a bucket binding 2`] = `
@@ -94,44 +95,46 @@ exports[`function with a bucket binding 2`] = `
 
 exports[`function with a function binding 1`] = `
 "
-      (function(clients) {
-        console.log = (...args) => clients.$logger.print(...args);
+        (function(clients) {
+          console.log = (...args) => clients.$logger.print(...args);
 
-        class Handler {
-          constructor(clients) {
-            for (const [name, client] of Object.entries(clients)) {
-              this[name] = client;
-            }            
+          class Handler {
+            constructor() {
+              for (const [name, client] of Object.entries(clients)) {
+                this[name] = client;
+              }            
+            }
+
+            async handle(event) { console.log(event); }
           }
 
-          async handle(event) { console.log(event); }
-        }
-
-        return new Handler(clients);
-      })({$logger: new (require(\\"[REDACTED]/wingsdk/src/target-tf-aws/logger.inflight.ts\\")).LoggerClient()})"
+          return new Handler();
+        })({$logger: new (require(\\"[REDACTED]/wingsdk/src/target-tf-aws/logger.inflight.ts\\")).LoggerClient()})
+      "
 `;
 
 exports[`function with a function binding 2`] = `
 "
-      (function(clients) {
-        console.log = (...args) => clients.$logger.print(...args);
+        (function(clients) {
+          console.log = (...args) => clients.$logger.print(...args);
 
-        class Handler {
-          constructor(clients) {
-            for (const [name, client] of Object.entries(clients)) {
-              this[name] = client;
-            }            
-          }
+          class Handler {
+            constructor() {
+              for (const [name, client] of Object.entries(clients)) {
+                this[name] = client;
+              }            
+            }
 
-          async handle(event) {
+            async handle(event) {
       console.log(\\"Event: \\" + event);
       await this.function.invoke(JSON.stringify({ hello: \\"world\\" }));
     }
-        }
+          }
 
-        return new Handler(clients);
-      })({function: new (require(\\"[REDACTED]/wingsdk/src/target-tf-aws/function.inflight.ts\\")).FunctionClient(process.env[\\"FUNCTION_NAME_50735b21\\"]),
-$logger: new (require(\\"[REDACTED]/wingsdk/src/target-tf-aws/logger.inflight.ts\\")).LoggerClient()})"
+          return new Handler();
+        })({function: new (require(\\"[REDACTED]/wingsdk/src/target-tf-aws/function.inflight.ts\\")).FunctionClient(process.env[\\"FUNCTION_NAME_50735b21\\"]),
+$logger: new (require(\\"[REDACTED]/wingsdk/src/target-tf-aws/logger.inflight.ts\\")).LoggerClient()})
+      "
 `;
 
 exports[`function with a function binding 3`] = `
@@ -216,41 +219,43 @@ exports[`function with a function binding 3`] = `
 
 exports[`function with a queue binding 1`] = `
 "
-      (function(clients) {
-        console.log = (...args) => clients.$logger.print(...args);
+        (function(clients) {
+          console.log = (...args) => clients.$logger.print(...args);
 
-        class Handler {
-          constructor(clients) {
-            for (const [name, client] of Object.entries(clients)) {
-              this[name] = client;
-            }            
+          class Handler {
+            constructor() {
+              for (const [name, client] of Object.entries(clients)) {
+                this[name] = client;
+              }            
+            }
+
+            async handle(event) { await this.queue.push(\\"info\\"); }
           }
 
-          async handle(event) { await this.queue.push(\\"info\\"); }
-        }
-
-        return new Handler(clients);
-      })({queue: new (require(\\"[REDACTED]/wingsdk/src/target-tf-aws/queue.inflight.ts\\")).QueueClient(process.env[\\"QUEUE_URL_1cfcc997\\"]),
-$logger: new (require(\\"[REDACTED]/wingsdk/src/target-tf-aws/logger.inflight.ts\\")).LoggerClient()})"
+          return new Handler();
+        })({queue: new (require(\\"[REDACTED]/wingsdk/src/target-tf-aws/queue.inflight.ts\\")).QueueClient(process.env[\\"QUEUE_URL_1cfcc997\\"]),
+$logger: new (require(\\"[REDACTED]/wingsdk/src/target-tf-aws/logger.inflight.ts\\")).LoggerClient()})
+      "
 `;
 
 exports[`function with a queue binding 2`] = `
 "
-      (function(clients) {
-        console.log = (...args) => clients.$logger.print(...args);
+        (function(clients) {
+          console.log = (...args) => clients.$logger.print(...args);
 
-        class Handler {
-          constructor(clients) {
-            for (const [name, client] of Object.entries(clients)) {
-              this[name] = client;
-            }            
+          class Handler {
+            constructor() {
+              for (const [name, client] of Object.entries(clients)) {
+                this[name] = client;
+              }            
+            }
+
+            async handle(event) { console.log(\\"Received\\" + event); }
           }
 
-          async handle(event) { console.log(\\"Received\\" + event); }
-        }
-
-        return new Handler(clients);
-      })({$logger: new (require(\\"[REDACTED]/wingsdk/src/target-tf-aws/logger.inflight.ts\\")).LoggerClient()})"
+          return new Handler();
+        })({$logger: new (require(\\"[REDACTED]/wingsdk/src/target-tf-aws/logger.inflight.ts\\")).LoggerClient()})
+      "
 `;
 
 exports[`function with a queue binding 3`] = `

--- a/libs/wingsdk/test/target-tf-aws/__snapshots__/captures.test.ts.snap
+++ b/libs/wingsdk/test/target-tf-aws/__snapshots__/captures.test.ts.snap
@@ -1,18 +1,23 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`function with a bucket binding 1`] = `
-"new ((function(){
-return class Handler {
-  constructor(clients) {
-    for (const [name, client] of Object.entries(clients)) {
-      this[name] = client;
-    }
-  }
-  async handle(event) { await this.bucket.put(\\"hello.txt\\", event); }
-};
-})())({
-bucket: new (require(\\"[REDACTED]/wingsdk/src/target-tf-aws/bucket.inflight.ts\\")).BucketClient(process.env[\\"BUCKET_NAME_1357ca3a\\"])
-})"
+"
+      (function(clients) {
+        console.log = (...args) => clients.$logger.print(...args);
+
+        class Handler {
+          constructor(clients) {
+            for (const [name, client] of Object.entries(clients)) {
+              this[name] = client;
+            }            
+          }
+
+          async handle(event) { await this.bucket.put(\\"hello.txt\\", event); }
+        }
+
+        return new Handler(clients);
+      })({bucket: new (require(\\"[REDACTED]/wingsdk/src/target-tf-aws/bucket.inflight.ts\\")).BucketClient(process.env[\\"BUCKET_NAME_1357ca3a\\"]),
+$logger: new (require(\\"[REDACTED]/wingsdk/src/target-tf-aws/logger.inflight.ts\\")).LoggerClient()})"
 `;
 
 exports[`function with a bucket binding 2`] = `
@@ -88,36 +93,45 @@ exports[`function with a bucket binding 2`] = `
 `;
 
 exports[`function with a function binding 1`] = `
-"new ((function(){
-return class Handler {
-  constructor(clients) {
-    for (const [name, client] of Object.entries(clients)) {
-      this[name] = client;
-    }
-  }
-  async handle(event) { console.log(event); }
-};
-})())({
+"
+      (function(clients) {
+        console.log = (...args) => clients.$logger.print(...args);
 
-})"
+        class Handler {
+          constructor(clients) {
+            for (const [name, client] of Object.entries(clients)) {
+              this[name] = client;
+            }            
+          }
+
+          async handle(event) { console.log(event); }
+        }
+
+        return new Handler(clients);
+      })({$logger: new (require(\\"[REDACTED]/wingsdk/src/target-tf-aws/logger.inflight.ts\\")).LoggerClient()})"
 `;
 
 exports[`function with a function binding 2`] = `
-"new ((function(){
-return class Handler {
-  constructor(clients) {
-    for (const [name, client] of Object.entries(clients)) {
-      this[name] = client;
-    }
-  }
-  async handle(event) {
+"
+      (function(clients) {
+        console.log = (...args) => clients.$logger.print(...args);
+
+        class Handler {
+          constructor(clients) {
+            for (const [name, client] of Object.entries(clients)) {
+              this[name] = client;
+            }            
+          }
+
+          async handle(event) {
       console.log(\\"Event: \\" + event);
       await this.function.invoke(JSON.stringify({ hello: \\"world\\" }));
     }
-};
-})())({
-function: new (require(\\"[REDACTED]/wingsdk/src/target-tf-aws/function.inflight.ts\\")).FunctionClient(process.env[\\"FUNCTION_NAME_50735b21\\"])
-})"
+        }
+
+        return new Handler(clients);
+      })({function: new (require(\\"[REDACTED]/wingsdk/src/target-tf-aws/function.inflight.ts\\")).FunctionClient(process.env[\\"FUNCTION_NAME_50735b21\\"]),
+$logger: new (require(\\"[REDACTED]/wingsdk/src/target-tf-aws/logger.inflight.ts\\")).LoggerClient()})"
 `;
 
 exports[`function with a function binding 3`] = `
@@ -201,33 +215,42 @@ exports[`function with a function binding 3`] = `
 `;
 
 exports[`function with a queue binding 1`] = `
-"new ((function(){
-return class Handler {
-  constructor(clients) {
-    for (const [name, client] of Object.entries(clients)) {
-      this[name] = client;
-    }
-  }
-  async handle(event) { await this.queue.push(\\"info\\"); }
-};
-})())({
-queue: new (require(\\"[REDACTED]/wingsdk/src/target-tf-aws/queue.inflight.ts\\")).QueueClient(process.env[\\"QUEUE_URL_1cfcc997\\"])
-})"
+"
+      (function(clients) {
+        console.log = (...args) => clients.$logger.print(...args);
+
+        class Handler {
+          constructor(clients) {
+            for (const [name, client] of Object.entries(clients)) {
+              this[name] = client;
+            }            
+          }
+
+          async handle(event) { await this.queue.push(\\"info\\"); }
+        }
+
+        return new Handler(clients);
+      })({queue: new (require(\\"[REDACTED]/wingsdk/src/target-tf-aws/queue.inflight.ts\\")).QueueClient(process.env[\\"QUEUE_URL_1cfcc997\\"]),
+$logger: new (require(\\"[REDACTED]/wingsdk/src/target-tf-aws/logger.inflight.ts\\")).LoggerClient()})"
 `;
 
 exports[`function with a queue binding 2`] = `
-"new ((function(){
-return class Handler {
-  constructor(clients) {
-    for (const [name, client] of Object.entries(clients)) {
-      this[name] = client;
-    }
-  }
-  async handle(event) { console.log(\\"Received\\" + event); }
-};
-})())({
+"
+      (function(clients) {
+        console.log = (...args) => clients.$logger.print(...args);
 
-})"
+        class Handler {
+          constructor(clients) {
+            for (const [name, client] of Object.entries(clients)) {
+              this[name] = client;
+            }            
+          }
+
+          async handle(event) { console.log(\\"Received\\" + event); }
+        }
+
+        return new Handler(clients);
+      })({$logger: new (require(\\"[REDACTED]/wingsdk/src/target-tf-aws/logger.inflight.ts\\")).LoggerClient()})"
 `;
 
 exports[`function with a queue binding 3`] = `

--- a/libs/wingsdk/test/target-tf-aws/__snapshots__/captures.test.ts.snap
+++ b/libs/wingsdk/test/target-tf-aws/__snapshots__/captures.test.ts.snap
@@ -1,24 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`function with a bucket binding 1`] = `
-"
-        (function(clients) {
-          console.log = (...args) => clients.$logger.print(...args);
-
-          class Handler {
-            constructor() {
-              for (const [name, client] of Object.entries(clients)) {
-                this[name] = client;
-              }            
-            }
-
-            async handle(event) { await this.bucket.put(\\"hello.txt\\", event); }
-          }
-
-          return new Handler();
-        })({bucket: new (require(\\"[REDACTED]/wingsdk/src/target-tf-aws/bucket.inflight.ts\\")).BucketClient(process.env[\\"BUCKET_NAME_1357ca3a\\"]),
-$logger: new (require(\\"[REDACTED]/wingsdk/src/target-tf-aws/logger.inflight.ts\\")).LoggerClient()})
-      "
+"new ((function(){
+  return class Handler {
+    constructor(clients) {
+      for (const [name, client] of Object.entries(clients)) {
+        this[name] = client;
+      }
+    }
+    async handle(event) { await this.bucket.put(\\"hello.txt\\", event); }
+  };
+  })())({
+  bucket: new (require(\\"[REDACTED]/wingsdk/src/target-tf-aws/bucket.inflight.ts\\")).BucketClient(process.env[\\"BUCKET_NAME_1357ca3a\\"]),
+$logger: new (require(\\"[REDACTED]/wingsdk/src/target-tf-aws/logger.inflight.ts\\")).LoggerClient()
+  })"
 `;
 
 exports[`function with a bucket binding 2`] = `
@@ -94,47 +89,37 @@ exports[`function with a bucket binding 2`] = `
 `;
 
 exports[`function with a function binding 1`] = `
-"
-        (function(clients) {
-          console.log = (...args) => clients.$logger.print(...args);
-
-          class Handler {
-            constructor() {
-              for (const [name, client] of Object.entries(clients)) {
-                this[name] = client;
-              }            
-            }
-
-            async handle(event) { console.log(event); }
-          }
-
-          return new Handler();
-        })({$logger: new (require(\\"[REDACTED]/wingsdk/src/target-tf-aws/logger.inflight.ts\\")).LoggerClient()})
-      "
+"new ((function(){
+  return class Handler {
+    constructor(clients) {
+      for (const [name, client] of Object.entries(clients)) {
+        this[name] = client;
+      }
+    }
+    async handle(event) { console.log(event); }
+  };
+  })())({
+  $logger: new (require(\\"[REDACTED]/wingsdk/src/target-tf-aws/logger.inflight.ts\\")).LoggerClient()
+  })"
 `;
 
 exports[`function with a function binding 2`] = `
-"
-        (function(clients) {
-          console.log = (...args) => clients.$logger.print(...args);
-
-          class Handler {
-            constructor() {
-              for (const [name, client] of Object.entries(clients)) {
-                this[name] = client;
-              }            
-            }
-
-            async handle(event) {
+"new ((function(){
+  return class Handler {
+    constructor(clients) {
+      for (const [name, client] of Object.entries(clients)) {
+        this[name] = client;
+      }
+    }
+    async handle(event) {
       console.log(\\"Event: \\" + event);
       await this.function.invoke(JSON.stringify({ hello: \\"world\\" }));
     }
-          }
-
-          return new Handler();
-        })({function: new (require(\\"[REDACTED]/wingsdk/src/target-tf-aws/function.inflight.ts\\")).FunctionClient(process.env[\\"FUNCTION_NAME_50735b21\\"]),
-$logger: new (require(\\"[REDACTED]/wingsdk/src/target-tf-aws/logger.inflight.ts\\")).LoggerClient()})
-      "
+  };
+  })())({
+  function: new (require(\\"[REDACTED]/wingsdk/src/target-tf-aws/function.inflight.ts\\")).FunctionClient(process.env[\\"FUNCTION_NAME_50735b21\\"]),
+$logger: new (require(\\"[REDACTED]/wingsdk/src/target-tf-aws/logger.inflight.ts\\")).LoggerClient()
+  })"
 `;
 
 exports[`function with a function binding 3`] = `
@@ -218,44 +203,34 @@ exports[`function with a function binding 3`] = `
 `;
 
 exports[`function with a queue binding 1`] = `
-"
-        (function(clients) {
-          console.log = (...args) => clients.$logger.print(...args);
-
-          class Handler {
-            constructor() {
-              for (const [name, client] of Object.entries(clients)) {
-                this[name] = client;
-              }            
-            }
-
-            async handle(event) { await this.queue.push(\\"info\\"); }
-          }
-
-          return new Handler();
-        })({queue: new (require(\\"[REDACTED]/wingsdk/src/target-tf-aws/queue.inflight.ts\\")).QueueClient(process.env[\\"QUEUE_URL_1cfcc997\\"]),
-$logger: new (require(\\"[REDACTED]/wingsdk/src/target-tf-aws/logger.inflight.ts\\")).LoggerClient()})
-      "
+"new ((function(){
+  return class Handler {
+    constructor(clients) {
+      for (const [name, client] of Object.entries(clients)) {
+        this[name] = client;
+      }
+    }
+    async handle(event) { await this.queue.push(\\"info\\"); }
+  };
+  })())({
+  queue: new (require(\\"[REDACTED]/wingsdk/src/target-tf-aws/queue.inflight.ts\\")).QueueClient(process.env[\\"QUEUE_URL_1cfcc997\\"]),
+$logger: new (require(\\"[REDACTED]/wingsdk/src/target-tf-aws/logger.inflight.ts\\")).LoggerClient()
+  })"
 `;
 
 exports[`function with a queue binding 2`] = `
-"
-        (function(clients) {
-          console.log = (...args) => clients.$logger.print(...args);
-
-          class Handler {
-            constructor() {
-              for (const [name, client] of Object.entries(clients)) {
-                this[name] = client;
-              }            
-            }
-
-            async handle(event) { console.log(\\"Received\\" + event); }
-          }
-
-          return new Handler();
-        })({$logger: new (require(\\"[REDACTED]/wingsdk/src/target-tf-aws/logger.inflight.ts\\")).LoggerClient()})
-      "
+"new ((function(){
+  return class Handler {
+    constructor(clients) {
+      for (const [name, client] of Object.entries(clients)) {
+        this[name] = client;
+      }
+    }
+    async handle(event) { console.log(\\"Received\\" + event); }
+  };
+  })())({
+  $logger: new (require(\\"[REDACTED]/wingsdk/src/target-tf-aws/logger.inflight.ts\\")).LoggerClient()
+  })"
 `;
 
 exports[`function with a queue binding 3`] = `

--- a/libs/wingsdk/test/target-tf-aws/__snapshots__/captures.test.ts.snap
+++ b/libs/wingsdk/test/target-tf-aws/__snapshots__/captures.test.ts.snap
@@ -2,18 +2,17 @@
 
 exports[`function with a bucket binding 1`] = `
 "new ((function(){
-  return class Handler {
-    constructor(clients) {
-      for (const [name, client] of Object.entries(clients)) {
-        this[name] = client;
-      }
+return class Handler {
+  constructor(clients) {
+    for (const [name, client] of Object.entries(clients)) {
+      this[name] = client;
     }
-    async handle(event) { await this.bucket.put(\\"hello.txt\\", event); }
-  };
-  })())({
-  bucket: new (require(\\"[REDACTED]/wingsdk/src/target-tf-aws/bucket.inflight.ts\\")).BucketClient(process.env[\\"BUCKET_NAME_1357ca3a\\"]),
-$logger: new (require(\\"[REDACTED]/wingsdk/src/target-tf-aws/logger.inflight.ts\\")).LoggerClient()
-  })"
+  }
+  async handle(event) { await this.bucket.put(\\"hello.txt\\", event); }
+};
+})())({
+bucket: new (require(\\"[REDACTED]/wingsdk/src/target-tf-aws/bucket.inflight.ts\\")).BucketClient(process.env[\\"BUCKET_NAME_1357ca3a\\"])
+})"
 `;
 
 exports[`function with a bucket binding 2`] = `
@@ -90,36 +89,35 @@ exports[`function with a bucket binding 2`] = `
 
 exports[`function with a function binding 1`] = `
 "new ((function(){
-  return class Handler {
-    constructor(clients) {
-      for (const [name, client] of Object.entries(clients)) {
-        this[name] = client;
-      }
+return class Handler {
+  constructor(clients) {
+    for (const [name, client] of Object.entries(clients)) {
+      this[name] = client;
     }
-    async handle(event) { console.log(event); }
-  };
-  })())({
-  $logger: new (require(\\"[REDACTED]/wingsdk/src/target-tf-aws/logger.inflight.ts\\")).LoggerClient()
-  })"
+  }
+  async handle(event) { console.log(event); }
+};
+})())({
+
+})"
 `;
 
 exports[`function with a function binding 2`] = `
 "new ((function(){
-  return class Handler {
-    constructor(clients) {
-      for (const [name, client] of Object.entries(clients)) {
-        this[name] = client;
-      }
+return class Handler {
+  constructor(clients) {
+    for (const [name, client] of Object.entries(clients)) {
+      this[name] = client;
     }
-    async handle(event) {
+  }
+  async handle(event) {
       console.log(\\"Event: \\" + event);
       await this.function.invoke(JSON.stringify({ hello: \\"world\\" }));
     }
-  };
-  })())({
-  function: new (require(\\"[REDACTED]/wingsdk/src/target-tf-aws/function.inflight.ts\\")).FunctionClient(process.env[\\"FUNCTION_NAME_50735b21\\"]),
-$logger: new (require(\\"[REDACTED]/wingsdk/src/target-tf-aws/logger.inflight.ts\\")).LoggerClient()
-  })"
+};
+})())({
+function: new (require(\\"[REDACTED]/wingsdk/src/target-tf-aws/function.inflight.ts\\")).FunctionClient(process.env[\\"FUNCTION_NAME_50735b21\\"])
+})"
 `;
 
 exports[`function with a function binding 3`] = `
@@ -204,33 +202,32 @@ exports[`function with a function binding 3`] = `
 
 exports[`function with a queue binding 1`] = `
 "new ((function(){
-  return class Handler {
-    constructor(clients) {
-      for (const [name, client] of Object.entries(clients)) {
-        this[name] = client;
-      }
+return class Handler {
+  constructor(clients) {
+    for (const [name, client] of Object.entries(clients)) {
+      this[name] = client;
     }
-    async handle(event) { await this.queue.push(\\"info\\"); }
-  };
-  })())({
-  queue: new (require(\\"[REDACTED]/wingsdk/src/target-tf-aws/queue.inflight.ts\\")).QueueClient(process.env[\\"QUEUE_URL_1cfcc997\\"]),
-$logger: new (require(\\"[REDACTED]/wingsdk/src/target-tf-aws/logger.inflight.ts\\")).LoggerClient()
-  })"
+  }
+  async handle(event) { await this.queue.push(\\"info\\"); }
+};
+})())({
+queue: new (require(\\"[REDACTED]/wingsdk/src/target-tf-aws/queue.inflight.ts\\")).QueueClient(process.env[\\"QUEUE_URL_1cfcc997\\"])
+})"
 `;
 
 exports[`function with a queue binding 2`] = `
 "new ((function(){
-  return class Handler {
-    constructor(clients) {
-      for (const [name, client] of Object.entries(clients)) {
-        this[name] = client;
-      }
+return class Handler {
+  constructor(clients) {
+    for (const [name, client] of Object.entries(clients)) {
+      this[name] = client;
     }
-    async handle(event) { console.log(\\"Received\\" + event); }
-  };
-  })())({
-  $logger: new (require(\\"[REDACTED]/wingsdk/src/target-tf-aws/logger.inflight.ts\\")).LoggerClient()
-  })"
+  }
+  async handle(event) { console.log(\\"Received\\" + event); }
+};
+})())({
+
+})"
 `;
 
 exports[`function with a queue binding 3`] = `

--- a/libs/wingsdk/test/target-tf-aws/__snapshots__/counter.test.ts.snap
+++ b/libs/wingsdk/test/target-tf-aws/__snapshots__/counter.test.ts.snap
@@ -118,21 +118,20 @@ exports[`default counter behavior 1`] = `
 
 exports[`function with a counter binding 1`] = `
 "new ((function(){
-  return class Handler {
-    constructor(clients) {
-      for (const [name, client] of Object.entries(clients)) {
-        this[name] = client;
-      }
+return class Handler {
+  constructor(clients) {
+    for (const [name, client] of Object.entries(clients)) {
+      this[name] = client;
     }
-    async handle(event) {
+  }
+  async handle(event) {
   const val = await this.my_counter.inc(2);
   console.log(val);
 }
-  };
-  })())({
-  my_counter: new (require(\\"[REDACTED]/wingsdk/src/target-tf-aws/counter.inflight.ts\\")).CounterClient(process.env[\\"DYNAMODB_TABLE_NAME_6cb5a3a4\\"], 0),
-$logger: new (require(\\"[REDACTED]/wingsdk/src/target-tf-aws/logger.inflight.ts\\")).LoggerClient()
-  })"
+};
+})())({
+my_counter: new (require(\\"[REDACTED]/wingsdk/src/target-tf-aws/counter.inflight.ts\\")).CounterClient(process.env[\\"DYNAMODB_TABLE_NAME_6cb5a3a4\\"], 0)
+})"
 `;
 
 exports[`function with a counter binding 2`] = `

--- a/libs/wingsdk/test/target-tf-aws/__snapshots__/counter.test.ts.snap
+++ b/libs/wingsdk/test/target-tf-aws/__snapshots__/counter.test.ts.snap
@@ -48,6 +48,18 @@ Object {
             "id": "Counter",
             "path": "root/Counter",
           },
+          "WingLogger": Object {
+            "attributes": Object {
+              "wing:resource:connections": Array [],
+              "wing:resource:stateful": true,
+            },
+            "constructInfo": Object {
+              "fqn": "constructs.Construct",
+              "version": "10.0.25",
+            },
+            "id": "WingLogger",
+            "path": "root/WingLogger",
+          },
           "aws": Object {
             "constructInfo": Object {
               "fqn": "@cdktf/provider-aws.provider.AwsProvider",
@@ -105,21 +117,26 @@ exports[`default counter behavior 1`] = `
 `;
 
 exports[`function with a counter binding 1`] = `
-"new ((function(){
-return class Handler {
-  constructor(clients) {
-    for (const [name, client] of Object.entries(clients)) {
-      this[name] = client;
-    }
-  }
-  async handle(event) {
+"
+      (function(clients) {
+        console.log = (...args) => clients.$logger.print(...args);
+
+        class Handler {
+          constructor(clients) {
+            for (const [name, client] of Object.entries(clients)) {
+              this[name] = client;
+            }            
+          }
+
+          async handle(event) {
   const val = await this.my_counter.inc(2);
   console.log(val);
 }
-};
-})())({
-my_counter: new (require(\\"[REDACTED]/wingsdk/src/target-tf-aws/counter.inflight.ts\\")).CounterClient(process.env[\\"DYNAMODB_TABLE_NAME_6cb5a3a4\\"], 0)
-})"
+        }
+
+        return new Handler(clients);
+      })({my_counter: new (require(\\"[REDACTED]/wingsdk/src/target-tf-aws/counter.inflight.ts\\")).CounterClient(process.env[\\"DYNAMODB_TABLE_NAME_6cb5a3a4\\"], 0),
+$logger: new (require(\\"[REDACTED]/wingsdk/src/target-tf-aws/logger.inflight.ts\\")).LoggerClient()})"
 `;
 
 exports[`function with a counter binding 2`] = `
@@ -227,6 +244,11 @@ Object {
                   "relationship": "inflight-reference",
                   "resource": "root/Counter",
                 },
+                Object {
+                  "direction": "outbound",
+                  "relationship": "inflight-reference",
+                  "resource": "root/WingLogger",
+                },
               ],
               "wing:resource:stateful": false,
             },
@@ -306,6 +328,24 @@ Object {
             },
             "id": "Handler",
             "path": "root/Handler",
+          },
+          "WingLogger": Object {
+            "attributes": Object {
+              "wing:resource:connections": Array [
+                Object {
+                  "direction": "inbound",
+                  "relationship": "inflight-reference",
+                  "resource": "root/Function",
+                },
+              ],
+              "wing:resource:stateful": true,
+            },
+            "constructInfo": Object {
+              "fqn": "constructs.Construct",
+              "version": "10.0.25",
+            },
+            "id": "WingLogger",
+            "path": "root/WingLogger",
           },
           "aws": Object {
             "constructInfo": Object {

--- a/libs/wingsdk/test/target-tf-aws/__snapshots__/counter.test.ts.snap
+++ b/libs/wingsdk/test/target-tf-aws/__snapshots__/counter.test.ts.snap
@@ -117,27 +117,22 @@ exports[`default counter behavior 1`] = `
 `;
 
 exports[`function with a counter binding 1`] = `
-"
-        (function(clients) {
-          console.log = (...args) => clients.$logger.print(...args);
-
-          class Handler {
-            constructor() {
-              for (const [name, client] of Object.entries(clients)) {
-                this[name] = client;
-              }            
-            }
-
-            async handle(event) {
+"new ((function(){
+  return class Handler {
+    constructor(clients) {
+      for (const [name, client] of Object.entries(clients)) {
+        this[name] = client;
+      }
+    }
+    async handle(event) {
   const val = await this.my_counter.inc(2);
   console.log(val);
 }
-          }
-
-          return new Handler();
-        })({my_counter: new (require(\\"[REDACTED]/wingsdk/src/target-tf-aws/counter.inflight.ts\\")).CounterClient(process.env[\\"DYNAMODB_TABLE_NAME_6cb5a3a4\\"], 0),
-$logger: new (require(\\"[REDACTED]/wingsdk/src/target-tf-aws/logger.inflight.ts\\")).LoggerClient()})
-      "
+  };
+  })())({
+  my_counter: new (require(\\"[REDACTED]/wingsdk/src/target-tf-aws/counter.inflight.ts\\")).CounterClient(process.env[\\"DYNAMODB_TABLE_NAME_6cb5a3a4\\"], 0),
+$logger: new (require(\\"[REDACTED]/wingsdk/src/target-tf-aws/logger.inflight.ts\\")).LoggerClient()
+  })"
 `;
 
 exports[`function with a counter binding 2`] = `

--- a/libs/wingsdk/test/target-tf-aws/__snapshots__/counter.test.ts.snap
+++ b/libs/wingsdk/test/target-tf-aws/__snapshots__/counter.test.ts.snap
@@ -118,25 +118,26 @@ exports[`default counter behavior 1`] = `
 
 exports[`function with a counter binding 1`] = `
 "
-      (function(clients) {
-        console.log = (...args) => clients.$logger.print(...args);
+        (function(clients) {
+          console.log = (...args) => clients.$logger.print(...args);
 
-        class Handler {
-          constructor(clients) {
-            for (const [name, client] of Object.entries(clients)) {
-              this[name] = client;
-            }            
-          }
+          class Handler {
+            constructor() {
+              for (const [name, client] of Object.entries(clients)) {
+                this[name] = client;
+              }            
+            }
 
-          async handle(event) {
+            async handle(event) {
   const val = await this.my_counter.inc(2);
   console.log(val);
 }
-        }
+          }
 
-        return new Handler(clients);
-      })({my_counter: new (require(\\"[REDACTED]/wingsdk/src/target-tf-aws/counter.inflight.ts\\")).CounterClient(process.env[\\"DYNAMODB_TABLE_NAME_6cb5a3a4\\"], 0),
-$logger: new (require(\\"[REDACTED]/wingsdk/src/target-tf-aws/logger.inflight.ts\\")).LoggerClient()})"
+          return new Handler();
+        })({my_counter: new (require(\\"[REDACTED]/wingsdk/src/target-tf-aws/counter.inflight.ts\\")).CounterClient(process.env[\\"DYNAMODB_TABLE_NAME_6cb5a3a4\\"], 0),
+$logger: new (require(\\"[REDACTED]/wingsdk/src/target-tf-aws/logger.inflight.ts\\")).LoggerClient()})
+      "
 `;
 
 exports[`function with a counter binding 2`] = `

--- a/libs/wingsdk/test/target-tf-aws/__snapshots__/function.test.ts.snap
+++ b/libs/wingsdk/test/target-tf-aws/__snapshots__/function.test.ts.snap
@@ -57,7 +57,13 @@ Object {
         "children": Object {
           "Function": Object {
             "attributes": Object {
-              "wing:resource:connections": Array [],
+              "wing:resource:connections": Array [
+                Object {
+                  "direction": "outbound",
+                  "relationship": "inflight-reference",
+                  "resource": "root/WingLogger",
+                },
+              ],
               "wing:resource:stateful": false,
             },
             "children": Object {
@@ -136,6 +142,24 @@ Object {
             },
             "id": "Handler",
             "path": "root/Handler",
+          },
+          "WingLogger": Object {
+            "attributes": Object {
+              "wing:resource:connections": Array [
+                Object {
+                  "direction": "inbound",
+                  "relationship": "inflight-reference",
+                  "resource": "root/Function",
+                },
+              ],
+              "wing:resource:stateful": true,
+            },
+            "constructInfo": Object {
+              "fqn": "constructs.Construct",
+              "version": "10.0.25",
+            },
+            "id": "WingLogger",
+            "path": "root/WingLogger",
           },
           "aws": Object {
             "constructInfo": Object {
@@ -232,7 +256,13 @@ Object {
         "children": Object {
           "Function": Object {
             "attributes": Object {
-              "wing:resource:connections": Array [],
+              "wing:resource:connections": Array [
+                Object {
+                  "direction": "outbound",
+                  "relationship": "inflight-reference",
+                  "resource": "root/WingLogger",
+                },
+              ],
               "wing:resource:stateful": false,
             },
             "children": Object {
@@ -311,6 +341,24 @@ Object {
             },
             "id": "Handler",
             "path": "root/Handler",
+          },
+          "WingLogger": Object {
+            "attributes": Object {
+              "wing:resource:connections": Array [
+                Object {
+                  "direction": "inbound",
+                  "relationship": "inflight-reference",
+                  "resource": "root/Function",
+                },
+              ],
+              "wing:resource:stateful": true,
+            },
+            "constructInfo": Object {
+              "fqn": "constructs.Construct",
+              "version": "10.0.25",
+            },
+            "id": "WingLogger",
+            "path": "root/WingLogger",
           },
           "aws": Object {
             "constructInfo": Object {

--- a/libs/wingsdk/test/target-tf-aws/__snapshots__/logger.test.ts.snap
+++ b/libs/wingsdk/test/target-tf-aws/__snapshots__/logger.test.ts.snap
@@ -1,20 +1,24 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`inflight function uses a logger 1`] = `
-"new ((function(){
-return class Handler {
-  constructor(clients) {
-    for (const [name, client] of Object.entries(clients)) {
-      this[name] = client;
-    }
-  }
-  async handle() {
-  await this.logger.print(\\"hello world!\\");
-}
-};
-})())({
-logger: new (require(\\"[REDACTED]/wingsdk/src/target-tf-aws/logger.inflight.ts\\")).LoggerClient()
-})"
+"
+      (function(clients) {
+        console.log = (...args) => clients.$logger.print(...args);
+
+        class Handler {
+          constructor(clients) {
+            for (const [name, client] of Object.entries(clients)) {
+              this[name] = client;
+            }            
+          }
+
+          async handle() {
+        console.log(\\"hello world!\\");
+      }
+        }
+
+        return new Handler(clients);
+      })({$logger: new (require(\\"[REDACTED]/wingsdk/src/target-tf-aws/logger.inflight.ts\\")).LoggerClient()})"
 `;
 
 exports[`inflight function uses a logger 2`] = `

--- a/libs/wingsdk/test/target-tf-aws/__snapshots__/logger.test.ts.snap
+++ b/libs/wingsdk/test/target-tf-aws/__snapshots__/logger.test.ts.snap
@@ -2,23 +2,24 @@
 
 exports[`inflight function uses a logger 1`] = `
 "
-      (function(clients) {
-        console.log = (...args) => clients.$logger.print(...args);
+        (function(clients) {
+          console.log = (...args) => clients.$logger.print(...args);
 
-        class Handler {
-          constructor(clients) {
-            for (const [name, client] of Object.entries(clients)) {
-              this[name] = client;
-            }            
-          }
+          class Handler {
+            constructor() {
+              for (const [name, client] of Object.entries(clients)) {
+                this[name] = client;
+              }            
+            }
 
-          async handle() {
+            async handle() {
         console.log(\\"hello world!\\");
       }
-        }
+          }
 
-        return new Handler(clients);
-      })({$logger: new (require(\\"[REDACTED]/wingsdk/src/target-tf-aws/logger.inflight.ts\\")).LoggerClient()})"
+          return new Handler();
+        })({$logger: new (require(\\"[REDACTED]/wingsdk/src/target-tf-aws/logger.inflight.ts\\")).LoggerClient()})
+      "
 `;
 
 exports[`inflight function uses a logger 2`] = `

--- a/libs/wingsdk/test/target-tf-aws/__snapshots__/logger.test.ts.snap
+++ b/libs/wingsdk/test/target-tf-aws/__snapshots__/logger.test.ts.snap
@@ -1,25 +1,20 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`inflight function uses a logger 1`] = `
-"
-        (function(clients) {
-          console.log = (...args) => clients.$logger.print(...args);
-
-          class Handler {
-            constructor() {
-              for (const [name, client] of Object.entries(clients)) {
-                this[name] = client;
-              }            
-            }
-
-            async handle() {
+"new ((function(){
+  return class Handler {
+    constructor(clients) {
+      for (const [name, client] of Object.entries(clients)) {
+        this[name] = client;
+      }
+    }
+    async handle() {
         console.log(\\"hello world!\\");
       }
-          }
-
-          return new Handler();
-        })({$logger: new (require(\\"[REDACTED]/wingsdk/src/target-tf-aws/logger.inflight.ts\\")).LoggerClient()})
-      "
+  };
+  })())({
+  $logger: new (require(\\"[REDACTED]/wingsdk/src/target-tf-aws/logger.inflight.ts\\")).LoggerClient()
+  })"
 `;
 
 exports[`inflight function uses a logger 2`] = `

--- a/libs/wingsdk/test/target-tf-aws/__snapshots__/logger.test.ts.snap
+++ b/libs/wingsdk/test/target-tf-aws/__snapshots__/logger.test.ts.snap
@@ -2,19 +2,19 @@
 
 exports[`inflight function uses a logger 1`] = `
 "new ((function(){
-  return class Handler {
-    constructor(clients) {
-      for (const [name, client] of Object.entries(clients)) {
-        this[name] = client;
-      }
+return class Handler {
+  constructor(clients) {
+    for (const [name, client] of Object.entries(clients)) {
+      this[name] = client;
     }
-    async handle() {
+  }
+  async handle() {
         console.log(\\"hello world!\\");
       }
-  };
-  })())({
-  $logger: new (require(\\"[REDACTED]/wingsdk/src/target-tf-aws/logger.inflight.ts\\")).LoggerClient()
-  })"
+};
+})())({
+
+})"
 `;
 
 exports[`inflight function uses a logger 2`] = `

--- a/libs/wingsdk/test/target-tf-aws/__snapshots__/queue.test.ts.snap
+++ b/libs/wingsdk/test/target-tf-aws/__snapshots__/queue.test.ts.snap
@@ -38,6 +38,18 @@ Object {
             "id": "Queue",
             "path": "root/Queue",
           },
+          "WingLogger": Object {
+            "attributes": Object {
+              "wing:resource:connections": Array [],
+              "wing:resource:stateful": true,
+            },
+            "constructInfo": Object {
+              "fqn": "constructs.Construct",
+              "version": "10.0.25",
+            },
+            "id": "WingLogger",
+            "path": "root/WingLogger",
+          },
           "aws": Object {
             "constructInfo": Object {
               "fqn": "@cdktf/provider-aws.provider.AwsProvider",
@@ -195,6 +207,11 @@ Object {
             "attributes": Object {
               "wing:resource:connections": Array [
                 Object {
+                  "direction": "outbound",
+                  "relationship": "inflight-reference",
+                  "resource": "root/WingLogger",
+                },
+                Object {
                   "direction": "inbound",
                   "relationship": "on_message",
                   "resource": "root/Queue",
@@ -279,6 +296,24 @@ Object {
             "id": "Queue-OnMessageHandler-c5395e41",
             "path": "root/Queue-OnMessageHandler-c5395e41",
           },
+          "WingLogger": Object {
+            "attributes": Object {
+              "wing:resource:connections": Array [
+                Object {
+                  "direction": "inbound",
+                  "relationship": "inflight-reference",
+                  "resource": "root/Queue-OnMessage-c5395e41",
+                },
+              ],
+              "wing:resource:stateful": true,
+            },
+            "constructInfo": Object {
+              "fqn": "constructs.Construct",
+              "version": "10.0.25",
+            },
+            "id": "WingLogger",
+            "path": "root/WingLogger",
+          },
           "aws": Object {
             "constructInfo": Object {
               "fqn": "@cdktf/provider-aws.provider.AwsProvider",
@@ -354,6 +389,18 @@ Object {
             },
             "id": "Queue",
             "path": "root/Queue",
+          },
+          "WingLogger": Object {
+            "attributes": Object {
+              "wing:resource:connections": Array [],
+              "wing:resource:stateful": true,
+            },
+            "constructInfo": Object {
+              "fqn": "constructs.Construct",
+              "version": "10.0.25",
+            },
+            "id": "WingLogger",
+            "path": "root/WingLogger",
           },
           "aws": Object {
             "constructInfo": Object {

--- a/libs/wingsdk/test/target-tf-aws/__snapshots__/topic.test.ts.snap
+++ b/libs/wingsdk/test/target-tf-aws/__snapshots__/topic.test.ts.snap
@@ -87,23 +87,18 @@ Object {
 `;
 
 exports[`topic with subscriber function 1`] = `
-"
-        (function(clients) {
-          console.log = (...args) => clients.$logger.print(...args);
-
-          class Handler {
-            constructor() {
-              for (const [name, client] of Object.entries(clients)) {
-                this[name] = client;
-              }            
-            }
-
-            async handle(event) { console.log(\\"Received: \\", event); }
-          }
-
-          return new Handler();
-        })({$logger: new (require(\\"[REDACTED]/wingsdk/src/target-tf-aws/logger.inflight.ts\\")).LoggerClient()})
-      "
+"new ((function(){
+  return class Handler {
+    constructor(clients) {
+      for (const [name, client] of Object.entries(clients)) {
+        this[name] = client;
+      }
+    }
+    async handle(event) { console.log(\\"Received: \\", event); }
+  };
+  })())({
+  $logger: new (require(\\"[REDACTED]/wingsdk/src/target-tf-aws/logger.inflight.ts\\")).LoggerClient()
+  })"
 `;
 
 exports[`topic with subscriber function 2`] = `

--- a/libs/wingsdk/test/target-tf-aws/__snapshots__/topic.test.ts.snap
+++ b/libs/wingsdk/test/target-tf-aws/__snapshots__/topic.test.ts.snap
@@ -88,21 +88,22 @@ Object {
 
 exports[`topic with subscriber function 1`] = `
 "
-      (function(clients) {
-        console.log = (...args) => clients.$logger.print(...args);
+        (function(clients) {
+          console.log = (...args) => clients.$logger.print(...args);
 
-        class Handler {
-          constructor(clients) {
-            for (const [name, client] of Object.entries(clients)) {
-              this[name] = client;
-            }            
+          class Handler {
+            constructor() {
+              for (const [name, client] of Object.entries(clients)) {
+                this[name] = client;
+              }            
+            }
+
+            async handle(event) { console.log(\\"Received: \\", event); }
           }
 
-          async handle(event) { console.log(\\"Received: \\", event); }
-        }
-
-        return new Handler(clients);
-      })({$logger: new (require(\\"[REDACTED]/wingsdk/src/target-tf-aws/logger.inflight.ts\\")).LoggerClient()})"
+          return new Handler();
+        })({$logger: new (require(\\"[REDACTED]/wingsdk/src/target-tf-aws/logger.inflight.ts\\")).LoggerClient()})
+      "
 `;
 
 exports[`topic with subscriber function 2`] = `

--- a/libs/wingsdk/test/target-tf-aws/__snapshots__/topic.test.ts.snap
+++ b/libs/wingsdk/test/target-tf-aws/__snapshots__/topic.test.ts.snap
@@ -88,17 +88,17 @@ Object {
 
 exports[`topic with subscriber function 1`] = `
 "new ((function(){
-  return class Handler {
-    constructor(clients) {
-      for (const [name, client] of Object.entries(clients)) {
-        this[name] = client;
-      }
+return class Handler {
+  constructor(clients) {
+    for (const [name, client] of Object.entries(clients)) {
+      this[name] = client;
     }
-    async handle(event) { console.log(\\"Received: \\", event); }
-  };
-  })())({
-  $logger: new (require(\\"[REDACTED]/wingsdk/src/target-tf-aws/logger.inflight.ts\\")).LoggerClient()
-  })"
+  }
+  async handle(event) { console.log(\\"Received: \\", event); }
+};
+})())({
+
+})"
 `;
 
 exports[`topic with subscriber function 2`] = `

--- a/libs/wingsdk/test/target-tf-aws/__snapshots__/topic.test.ts.snap
+++ b/libs/wingsdk/test/target-tf-aws/__snapshots__/topic.test.ts.snap
@@ -38,6 +38,18 @@ Object {
             "id": "Topic",
             "path": "root/Topic",
           },
+          "WingLogger": Object {
+            "attributes": Object {
+              "wing:resource:connections": Array [],
+              "wing:resource:stateful": true,
+            },
+            "constructInfo": Object {
+              "fqn": "constructs.Construct",
+              "version": "10.0.25",
+            },
+            "id": "WingLogger",
+            "path": "root/WingLogger",
+          },
           "aws": Object {
             "constructInfo": Object {
               "fqn": "@cdktf/provider-aws.provider.AwsProvider",
@@ -75,18 +87,22 @@ Object {
 `;
 
 exports[`topic with subscriber function 1`] = `
-"new ((function(){
-return class Handler {
-  constructor(clients) {
-    for (const [name, client] of Object.entries(clients)) {
-      this[name] = client;
-    }
-  }
-  async handle(event) { console.log(\\"Received: \\", event); }
-};
-})())({
+"
+      (function(clients) {
+        console.log = (...args) => clients.$logger.print(...args);
 
-})"
+        class Handler {
+          constructor(clients) {
+            for (const [name, client] of Object.entries(clients)) {
+              this[name] = client;
+            }            
+          }
+
+          async handle(event) { console.log(\\"Received: \\", event); }
+        }
+
+        return new Handler(clients);
+      })({$logger: new (require(\\"[REDACTED]/wingsdk/src/target-tf-aws/logger.inflight.ts\\")).LoggerClient()})"
 `;
 
 exports[`topic with subscriber function 2`] = `
@@ -225,7 +241,13 @@ Object {
           },
           "Topic-OnMessage-c5395e41": Object {
             "attributes": Object {
-              "wing:resource:connections": Array [],
+              "wing:resource:connections": Array [
+                Object {
+                  "direction": "outbound",
+                  "relationship": "inflight-reference",
+                  "resource": "root/WingLogger",
+                },
+              ],
               "wing:resource:stateful": false,
             },
             "children": Object {
@@ -304,6 +326,24 @@ Object {
             },
             "id": "Topic-OnMessageHandler-c5395e41",
             "path": "root/Topic-OnMessageHandler-c5395e41",
+          },
+          "WingLogger": Object {
+            "attributes": Object {
+              "wing:resource:connections": Array [
+                Object {
+                  "direction": "inbound",
+                  "relationship": "inflight-reference",
+                  "resource": "root/Topic-OnMessage-c5395e41",
+                },
+              ],
+              "wing:resource:stateful": true,
+            },
+            "constructInfo": Object {
+              "fqn": "constructs.Construct",
+              "version": "10.0.25",
+            },
+            "id": "WingLogger",
+            "path": "root/WingLogger",
           },
           "aws": Object {
             "constructInfo": Object {

--- a/libs/wingsdk/test/target-tf-aws/logger.test.ts
+++ b/libs/wingsdk/test/target-tf-aws/logger.test.ts
@@ -1,6 +1,7 @@
 import * as cdktf from "cdktf";
 import { Polycons } from "polycons";
 import * as cloud from "../../src/cloud";
+import { Logger } from "../../src/cloud";
 import * as tfaws from "../../src/target-tf-aws";
 import { Testing } from "../../src/testing";
 import { tfResourcesOf, tfSanitize } from "../util";
@@ -9,20 +10,14 @@ test("inflight function uses a logger", () => {
   const output = cdktf.Testing.synthScope((scope) => {
     const factory = new tfaws.PolyconFactory();
     Polycons.register(scope, factory);
+    Logger.register(scope);
 
-    cloud.Logger.register(scope);
     const inflight = Testing.makeHandler(
       scope,
       "Handler",
       `async handle() {
-  await this.logger.print("hello world!");
-}`,
-      {
-        logger: {
-          resource: cloud.Logger.of(scope),
-          ops: [cloud.LoggerInflightMethods.PRINT],
-        },
-      }
+        console.log("hello world!");
+      }`
     );
     new cloud.Function(scope, "Function", inflight);
 

--- a/libs/wingsdk/test/testing/on-trace.test.ts
+++ b/libs/wingsdk/test/testing/on-trace.test.ts
@@ -27,5 +27,5 @@ test("onTrace", async () => {
   await s.stop();
 
   // THEN
-  expect(numTraces).toEqual(3); // create resource, put operation, delete resource
+  expect(numTraces).toEqual(5); // create resource, put operation, delete resource
 });

--- a/tools/hangar/src/__snapshots__/cli.test.ts.snap
+++ b/tools/hangar/src/__snapshots__/cli.test.ts.snap
@@ -416,7 +416,7 @@ exports[`wing compile captures.w > cdk.tf.json 1`] = `
 `;
 
 exports[`wing compile captures.w > index.js 1`] = `
-"async handle(event) { const { bucket1, bucket2, bucket3 } = this; {
+"async handle(event) { const { $logger, bucket1, bucket2, bucket3 } = this; {
   (await bucket1.put(\\"file.txt\\",\\"data\\"));
   (await bucket2.get(\\"file.txt\\"));
   (await bucket2.get(\\"file2.txt\\"));
@@ -1063,7 +1063,7 @@ exports[`wing compile file_counter.w > cdk.tf.json 1`] = `
 `;
 
 exports[`wing compile file_counter.w > index.js 1`] = `
-"async handle(body) { const { bucket, counter } = this; {
+"async handle(body) { const { $logger, bucket, counter } = this; {
   const next = (await counter.inc());
   const key = \`myfile-\${\\"hi\\"}.txt\`;
   (await bucket.put(key,body));
@@ -1362,7 +1362,7 @@ exports[`wing compile hello.w > cdk.tf.json 1`] = `
 `;
 
 exports[`wing compile hello.w > index.js 1`] = `
-"async handle(message) { const { bucket } = this; {
+"async handle(message) { const { $logger, bucket } = this; {
   (await bucket.put(\\"hello.txt\\",\`Hello, \${message}!\`));
   return message;
 } };"
@@ -1626,8 +1626,8 @@ exports[`wing compile print.w > cdk.tf.json 1`] = `
 `;
 
 exports[`wing compile print.w > index.js 1`] = `
-"async handle(event) { const {  } = this; {
-  console.log(event);
+"async handle(event) { const { $logger } = this; {
+  $logger.print(event);
 } };"
 `;
 
@@ -1671,8 +1671,8 @@ constructor() {
   
   const bucket1 = new cloud.Bucket(this,\\"cloud.Bucket\\");
   console.log(\\"Hello world!\\");
-  new cloud.Function(this,\\"cloud.Function\\",new $stdlib.core.Inflight(this, \\"$Inflight81b7f66c\\", {
-    code: $stdlib.core.NodeJsCode.fromFile(require('path').resolve(__dirname, \\"proc.91c1f1c94279b3e82aa792c681ccb4640c7a071a1b60763fc83e70bf81b7f66c/index.js\\")),
+  new cloud.Function(this,\\"cloud.Function\\",new $stdlib.core.Inflight(this, \\"$Inflightf1fe8c00\\", {
+    code: $stdlib.core.NodeJsCode.fromFile(require('path').resolve(__dirname, \\"proc.a86ae274df51d040f33d811a9509a02ce876d76b028e42e45e34f3eaf1fe8c00/index.js\\")),
     
   }));
 }
@@ -1959,38 +1959,38 @@ exports[`wing compile while_loop_await.w > cdk.tf.json 1`] = `
   },
   "resource": {
     "aws_iam_role": {
-      "root_cloudQueueOnMessagef4c47031_IamRole_8B17B071": {
+      "root_cloudQueueOnMessage083ccab6_IamRole_B0474617": {
         "//": {
           "metadata": {
-            "path": "root/cloud.Queue-OnMessage-f4c47031/IamRole",
-            "uniqueId": "root_cloudQueueOnMessagef4c47031_IamRole_8B17B071",
+            "path": "root/cloud.Queue-OnMessage-083ccab6/IamRole",
+            "uniqueId": "root_cloudQueueOnMessage083ccab6_IamRole_B0474617",
           },
         },
         "assume_role_policy": "{\\"Version\\":\\"2012-10-17\\",\\"Statement\\":[{\\"Action\\":\\"sts:AssumeRole\\",\\"Principal\\":{\\"Service\\":\\"lambda.amazonaws.com\\"},\\"Effect\\":\\"Allow\\"}]}",
       },
     },
     "aws_iam_role_policy": {
-      "root_cloudQueueOnMessagef4c47031_IamRolePolicy_DDAFC198": {
+      "root_cloudQueueOnMessage083ccab6_IamRolePolicy_1AF7DEF8": {
         "//": {
           "metadata": {
-            "path": "root/cloud.Queue-OnMessage-f4c47031/IamRolePolicy",
-            "uniqueId": "root_cloudQueueOnMessagef4c47031_IamRolePolicy_DDAFC198",
+            "path": "root/cloud.Queue-OnMessage-083ccab6/IamRolePolicy",
+            "uniqueId": "root_cloudQueueOnMessage083ccab6_IamRolePolicy_1AF7DEF8",
           },
         },
         "policy": "{\\"Version\\":\\"2012-10-17\\",\\"Statement\\":[{\\"Action\\":[\\"sqs:ReceiveMessage\\",\\"sqs:ChangeMessageVisibility\\",\\"sqs:GetQueueUrl\\",\\"sqs:DeleteMessage\\",\\"sqs:GetQueueAttributes\\"],\\"Resource\\":\\"\${aws_sqs_queue.root_cloudQueue_E3597F7A.arn}\\",\\"Effect\\":\\"Allow\\"}]}",
-        "role": "\${aws_iam_role.root_cloudQueueOnMessagef4c47031_IamRole_8B17B071.name}",
+        "role": "\${aws_iam_role.root_cloudQueueOnMessage083ccab6_IamRole_B0474617.name}",
       },
     },
     "aws_iam_role_policy_attachment": {
-      "root_cloudQueueOnMessagef4c47031_IamRolePolicyAttachment_4FD119FD": {
+      "root_cloudQueueOnMessage083ccab6_IamRolePolicyAttachment_673DF221": {
         "//": {
           "metadata": {
-            "path": "root/cloud.Queue-OnMessage-f4c47031/IamRolePolicyAttachment",
-            "uniqueId": "root_cloudQueueOnMessagef4c47031_IamRolePolicyAttachment_4FD119FD",
+            "path": "root/cloud.Queue-OnMessage-083ccab6/IamRolePolicyAttachment",
+            "uniqueId": "root_cloudQueueOnMessage083ccab6_IamRolePolicyAttachment_673DF221",
           },
         },
         "policy_arn": "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
-        "role": "\${aws_iam_role.root_cloudQueueOnMessagef4c47031_IamRole_8B17B071.name}",
+        "role": "\${aws_iam_role.root_cloudQueueOnMessage083ccab6_IamRole_B0474617.name}",
       },
     },
     "aws_lambda_event_source_mapping": {
@@ -2003,49 +2003,49 @@ exports[`wing compile while_loop_await.w > cdk.tf.json 1`] = `
         },
         "batch_size": 1,
         "event_source_arn": "\${aws_sqs_queue.root_cloudQueue_E3597F7A.arn}",
-        "function_name": "\${aws_lambda_function.root_cloudQueueOnMessagef4c47031_CD0E768A.function_name}",
+        "function_name": "\${aws_lambda_function.root_cloudQueueOnMessage083ccab6_64A29DE5.function_name}",
       },
     },
     "aws_lambda_function": {
-      "root_cloudQueueOnMessagef4c47031_CD0E768A": {
+      "root_cloudQueueOnMessage083ccab6_64A29DE5": {
         "//": {
           "metadata": {
-            "path": "root/cloud.Queue-OnMessage-f4c47031/Default",
-            "uniqueId": "root_cloudQueueOnMessagef4c47031_CD0E768A",
+            "path": "root/cloud.Queue-OnMessage-083ccab6/Default",
+            "uniqueId": "root_cloudQueueOnMessage083ccab6_64A29DE5",
           },
         },
         "environment": {
           "variables": {
-            "WING_FUNCTION_NAME": "cloud.Queue-OnMessage-f4c47031",
+            "WING_FUNCTION_NAME": "cloud.Queue-OnMessage-083ccab6",
           },
         },
-        "function_name": "cloud_Queue-OnMessage-f4c47031",
+        "function_name": "cloud_Queue-OnMessage-083ccab6",
         "handler": "index.handler",
-        "role": "\${aws_iam_role.root_cloudQueueOnMessagef4c47031_IamRole_8B17B071.arn}",
+        "role": "\${aws_iam_role.root_cloudQueueOnMessage083ccab6_IamRole_B0474617.arn}",
         "runtime": "nodejs16.x",
-        "s3_bucket": "\${aws_s3_bucket.root_cloudQueueOnMessagef4c47031_Bucket_0CA349F3.bucket}",
-        "s3_key": "\${aws_s3_object.root_cloudQueueOnMessagef4c47031_S3Object_D833ADD0.key}",
+        "s3_bucket": "\${aws_s3_bucket.root_cloudQueueOnMessage083ccab6_Bucket_653498B7.bucket}",
+        "s3_key": "\${aws_s3_object.root_cloudQueueOnMessage083ccab6_S3Object_3F6E4E7A.key}",
       },
     },
     "aws_s3_bucket": {
-      "root_cloudQueueOnMessagef4c47031_Bucket_0CA349F3": {
+      "root_cloudQueueOnMessage083ccab6_Bucket_653498B7": {
         "//": {
           "metadata": {
-            "path": "root/cloud.Queue-OnMessage-f4c47031/Bucket",
-            "uniqueId": "root_cloudQueueOnMessagef4c47031_Bucket_0CA349F3",
+            "path": "root/cloud.Queue-OnMessage-083ccab6/Bucket",
+            "uniqueId": "root_cloudQueueOnMessage083ccab6_Bucket_653498B7",
           },
         },
       },
     },
     "aws_s3_object": {
-      "root_cloudQueueOnMessagef4c47031_S3Object_D833ADD0": {
+      "root_cloudQueueOnMessage083ccab6_S3Object_3F6E4E7A": {
         "//": {
           "metadata": {
-            "path": "root/cloud.Queue-OnMessage-f4c47031/S3Object",
-            "uniqueId": "root_cloudQueueOnMessagef4c47031_S3Object_D833ADD0",
+            "path": "root/cloud.Queue-OnMessage-083ccab6/S3Object",
+            "uniqueId": "root_cloudQueueOnMessage083ccab6_S3Object_3F6E4E7A",
           },
         },
-        "bucket": "\${aws_s3_bucket.root_cloudQueueOnMessagef4c47031_Bucket_0CA349F3.bucket}",
+        "bucket": "\${aws_s3_bucket.root_cloudQueueOnMessage083ccab6_Bucket_653498B7.bucket}",
         "key": "<ASSET_KEY>",
       },
     },
@@ -2054,17 +2054,17 @@ exports[`wing compile while_loop_await.w > cdk.tf.json 1`] = `
 `;
 
 exports[`wing compile while_loop_await.w > index.js 1`] = `
-"async handle(j) { const {  } = this; {
-  return (j + 1);
+"async handle(body) { const { $logger } = this; {
+  const i = 0;
+  while (((await iterator(i)) < 3)) {
+    $logger.print(\`\${i}\`);
+  }
 } };"
 `;
 
 exports[`wing compile while_loop_await.w > index.js 2`] = `
-"async handle(body) { const {  } = this; {
-  const i = 0;
-  while (((await iterator(i)) < 3)) {
-    console.log(\`\${i}\`);
-  }
+"async handle(j) { const { $logger } = this; {
+  return (j + 1);
 } };"
 `;
 
@@ -2111,8 +2111,8 @@ constructor() {
     code: $stdlib.core.NodeJsCode.fromFile(require('path').resolve(__dirname, \\"proc.82d0059fdbaebaab6d1be68f497052f9d5b8662f4333952a6e9ad55f564e0c97/index.js\\")),
     
   });
-  const handler = new $stdlib.core.Inflight(this, \\"$Inflightb4bafca8\\", {
-    code: $stdlib.core.NodeJsCode.fromFile(require('path').resolve(__dirname, \\"proc.e8d90d64617a4a5aa70aa6036e97b9cfeb1aaf243d75239f62c3f16bb4bafca8/index.js\\")),
+  const handler = new $stdlib.core.Inflight(this, \\"$Inflight40983308\\", {
+    code: $stdlib.core.NodeJsCode.fromFile(require('path').resolve(__dirname, \\"proc.a5dc8c73459ce5522f0d8aea722480472143e81c2d5dc9b99039e98c40983308/index.js\\")),
     
   });
   (queue.onMessage(handler));


### PR DESCRIPTION
All applications now have a `Logger` registered to them.

In order to allow inflight code to emit logs, we introduced an *implicit binding* of the application logger's inflight client to the `$logger` symbol during inflight. This means that `this.$logger` always points to the application logger.

Additionally, in order to capture logs that come from 3rd party libraries, we replace `console.log` with `$logger.print`. So basically, any `console.log` call will be included.

NOTE: The `print()` method of `ILogger` is now a synchronous method (all inflight functions are async by default). Not sure exactly what the implications of this are and if it's a safe assumption but for now it seems like it will work.

Refactored the `Function` classes so that all common code (the stuff the produces the handler asset) is now in `FunctionBase` (as well as handling environment variables). This is where I could implement the common behavior that captured `console.log` and mapped it into the logger.

In preflight, we still just emit `console.log` instead of `print`. At a later stage it might make sense to actually call `Logger.of(this).print()` (in *preflight*) instead.

Resolves #991
Resolves #591



*By submitting this pull request, I confirm that my contribution is made under the terms of the 
[Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.
