### PR TITLE
chore(repo): community note in issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -9,39 +9,40 @@ body:
 - type: textarea
   attributes:
     label: Community Note
-    description: "Please keep this note for the community:"
     value: |
+      <!-- Please keep this note for the community -->
       > Please vote by adding a 👍 reaction to the issue to help us prioritize.
       > If you are interested to work on this issue, please leave a comment.
+- type: markdown
+  attributes:
+    value: |
+       ## Bug Report
 - type: textarea
   id: i-tried-this
   attributes:
     label: "I tried this:"
-    description: "What did you try to do?"
-    placeholder: Code/explanation to reproduce bug
+    placeholder: "What did you try to do? A code snippet or exact command line is ideal."
   validations:
     required: true
 - type: textarea
   id: what-did-you-expect
   attributes:
     label: "I expected this:"
-    description: "What did you expect to happen?"
-    placeholder: Tell us what you expected to see
+    placeholder: "What did you expect to happen? Describe the output or behavior you expected to see."
   validations:
     required: true
 - type: textarea
   id: instead-what-happened
   attributes:
     label: "Instead, this happened:"
-    description: "What happend instead of what you've expected?"
-    placeholder: Tell us what did you see
+    placeholder: "What happend instead of what you've expected?"
   validations:
     required: true
 - type: dropdown
   id: Component
   attributes:
     label: "Component:"
-    description: "Which component is this related to? (one or more)"
+    description: "Which component(s) in the toolchain is this related to?"
     multiple: true
     options:
     - Language Design
@@ -52,33 +53,45 @@ body:
     - Documentation
     - Development Environment
     - Contributor Experience
+    - Other
   validations:
     required: true
+
+- type: markdown
+  attributes:
+    value: |
+       ## Environment
 - type: input
   id: version
   attributes:
     label: "Wing Version:"
-    description: "Which Wing version are you using (`wing --version`)?"
+    placeholder: "wing --version"
 - type: input
   id: node
   attributes:
     label: "Node.js Version:"
-    description: "Which Node.js version are you using (`node --version`)?"
-- type: checkboxes
+    placeholder: "node --version"
+- type: dropdown
   id: platform
   attributes:
-    label: "Platform:"
-    description: "Which operating system are you using?"
+    label: "Platform(s):"
+    multiple: true
     options:
-      - label: "MacOS"
-      - label: "Linux"
-      - label: "Windows"
-      - label: "Other"
+      - MacOS
+      - Linux
+      - Windows
+      - Other
+
+- type: markdown
+  attributes:
+    value: |
+       ## Misc
+
 - type: textarea
   attributes:
     label: Anything else?
-    description: |
+    placeholder: |
       Links? References? Logs? Anything that will give us more context about the issue you are encountering.
-      > Tip: You can attach images or log files by dragging files in.
+      Tip: You can attach images or log files by dragging files in.
   validations:
     required: false

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -5,11 +5,13 @@ body:
 - type: markdown
   attributes:
     value: |
-      Thanks for taking the time to fill out this bug report!
+       :pray: Thanks for taking the time to fill out this bug report!
+       We will to our best to review and respond as quickly as possible. 
+       Feel free to ping us on [Wing Slack](https://t.winglang.io/slack) if you have any questions or need help.
 - type: textarea
   id: i-tried-this
   attributes:
-    label: I tried this
+    label: I tried this:
     description: What did you try to do?
     placeholder: Code/explanation to reproduce bug
   validations:
@@ -17,7 +19,7 @@ body:
 - type: textarea
   id: what-did-you-expect
   attributes:
-    label: Expected
+    label: Expected:
     description: What did you expect to happen?
     placeholder: Tell us what you expected to see!
   validations:
@@ -25,7 +27,7 @@ body:
 - type: textarea
   id: instead-what-happened
   attributes:
-    label: Instead, this happened
+    label: Instead, this happened:
     description: What happend instead of what you've expected?
     placeholder: Tell us what did you see!
   validations:

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -5,38 +5,43 @@ body:
 - type: markdown
   attributes:
     value: |
-       :pray: Thanks for taking the time to fill out this bug report!
-       We will to our best to review and respond as quickly as possible. 
-       Feel free to ping us on [Wing Slack](https://t.winglang.io/slack) if you have any questions or need help.
+       :pray: Thanks for taking the time to fill out this bug report! Feel free to ping us on [Wing Slack](https://t.winglang.io/slack) if you have any questions or need help.
+- type: textarea
+  attributes:
+    label: Community Note
+    description: "Please keep this note for the community:"
+    value: |
+      > Please vote by adding a 👍 reaction to the issue to help us prioritize.
+      > If you are interested to work on this issue, please leave a comment.
 - type: textarea
   id: i-tried-this
   attributes:
-    label: I tried this:
-    description: What did you try to do?
+    label: "I tried this:"
+    description: "What did you try to do?"
     placeholder: Code/explanation to reproduce bug
   validations:
     required: true
 - type: textarea
   id: what-did-you-expect
   attributes:
-    label: Expected:
-    description: What did you expect to happen?
-    placeholder: Tell us what you expected to see!
+    label: "I expected this:"
+    description: "What did you expect to happen?"
+    placeholder: Tell us what you expected to see
   validations:
     required: true
 - type: textarea
   id: instead-what-happened
   attributes:
-    label: Instead, this happened:
-    description: What happend instead of what you've expected?
-    placeholder: Tell us what did you see!
+    label: "Instead, this happened:"
+    description: "What happend instead of what you've expected?"
+    placeholder: Tell us what did you see
   validations:
     required: true
 - type: dropdown
   id: Component
   attributes:
-    label: Component
-    description: Which component is this related to? (one or more)
+    label: "Component:"
+    description: "Which component is this related to? (one or more)"
     multiple: true
     options:
     - Language Design
@@ -49,27 +54,31 @@ body:
     - Contributor Experience
   validations:
     required: true
-- type: textarea
+- type: input
+  id: version
   attributes:
-    label: Environment
-    description: |
-      examples:
-      - **Wing Version (`wing --version`)**: <0.2.69>
-      - **OS**: MacOS 
-      - **Node version**: 13.14.0
-    value: |
-     - Wing Version:
-     - OS:
-     - Node version:
-    render: markdown
-  validations:
-    required: false
+    label: "Wing Version:"
+    description: "Which Wing version are you using (`wing --version`)?"
+- type: input
+  id: node
+  attributes:
+    label: "Node.js Version:"
+    description: "Which Node.js version are you using (`node --version`)?"
+- type: checkboxes
+  id: platform
+  attributes:
+    label: "Platform:"
+    description: "Which operating system are you using?"
+    options:
+      - label: "MacOS"
+      - label: "Linux"
+      - label: "Windows"
+      - label: "Other"
 - type: textarea
   attributes:
     label: Anything else?
     description: |
-      Links? References? Logs? Anything that will give us more context about the issue you are encountering!
-
-      tip: You can attach images or log files by clicking this area to highlight it and then dragging files in.
+      Links? References? Logs? Anything that will give us more context about the issue you are encountering.
+      > Tip: You can attach images or log files by dragging files in.
   validations:
     required: false

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -5,36 +5,44 @@ body:
 - type: markdown
   attributes:
     value: |
-      Thanks for taking the time to fill out this enhancement request 
+       :pray: Thanks for taking the time to fill out this enhancement request! Feel free to ping us on [Wing Slack](https://t.winglang.io/slack) if you have any questions or need help.
+- type: textarea
+  attributes:
+    label: Community Note
+    description: "Please keep this note for the community:"
+    value: |
+      > Please vote by adding a 👍 reaction to the issue to help us prioritize.
+      > If you are interested to work on this issue, please leave a comment.
 - type: textarea
   id: spec
   attributes:
     label: Feature Spec
-    description: Describe the feature docs
-    placeholder: hypothetical readme/changelog/contributing guide section for this new enhancement, code snippets and all
+    description: "Describe the feature as if it was already released:"
+    placeholder: |
+      Write a hypothetical doc/readme/changelog/contributing section for this new enhancement, code snippets and all.
   validations:
     required: true
 - type: textarea
   id: use-cases
   attributes:
     label: Use Cases
-    description: What problems does this solves?
-    placeholder: list of use cases for this enhancement
+    description: "What problems does this solves?"
+    placeholder: |
+      List of use cases this feature or enhancement is designed to address.
   validations:
     required: true
 - type: textarea
   id: implementation-notes
   attributes:
     label: Implementation Notes
-    description: Any thoughts regarding how this should be implemented
-    placeholder: ideas, references, pointers, thoughts
-  validations:
-    required: false
+    description: "Any thoughts regarding how this should be implemented?"
+    placeholder: |
+      Ideas, references, pointers, thoughts...
 - type: dropdown
   id: Component
   attributes:
     label: Component
-    description: Which component is this related to? (one or more)
+    description: "Which component is this related to? (one or more)"
     multiple: true
     options:
     - Language Design
@@ -46,4 +54,4 @@ body:
     - Development Environment
     - Contributor Experience
   validations:
-    required: true
+    required: false

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -13,36 +13,39 @@ body:
     value: |
       > Please vote by adding a 👍 reaction to the issue to help us prioritize.
       > If you are interested to work on this issue, please leave a comment.
+- type: markdown
+  attributes:
+    value: |
+      ## Enhancement Request
 - type: textarea
   id: spec
   attributes:
     label: Feature Spec
-    description: "Describe the feature as if it was already released:"
+    description:
     placeholder: |
-      Write a hypothetical doc/readme/changelog/contributing section for this new enhancement, code snippets and all.
+      Describe the feature as if it was already released. Write a hypothetical doc/readme/changelog/contributing section for this new enhancement, code snippets and all.
   validations:
     required: true
 - type: textarea
   id: use-cases
   attributes:
     label: Use Cases
-    description: "What problems does this solves?"
     placeholder: |
-      List of use cases this feature or enhancement is designed to address.
+      What problems does this solves? List of use cases this feature or enhancement is designed to address.
   validations:
     required: true
 - type: textarea
   id: implementation-notes
   attributes:
     label: Implementation Notes
-    description: "Any thoughts regarding how this should be implemented?"
+    description: 
     placeholder: |
-      Ideas, references, pointers, thoughts...
+      Any thoughts regarding how this should be implemented?
 - type: dropdown
   id: Component
   attributes:
     label: Component
-    description: "Which component is this related to? (one or more)"
+    description: "Which component(s) in the toolchain is this related to?"
     multiple: true
     options:
     - Language Design
@@ -53,5 +56,6 @@ body:
     - Documentation
     - Development Environment
     - Contributor Experience
+    - Other
   validations:
     required: false


### PR DESCRIPTION
Inspired by [CDK for Terraform](https://github.com/hashicorp/terraform-cdk/blob/main/.github/ISSUE_TEMPLATE/bug-report.md), adds a section at the beginning of the issue templates with some community guidelines.

Since we are using a form, this will look like this:

<img width="896" alt="Screenshot 2023-01-02 at 9 41 12" src="https://user-images.githubusercontent.com/598796/210204893-c88ac608-58c8-4c9f-815d-e65759cfa515.png">

The resulting issue looks like this:

<img width="937" alt="Screenshot 2023-01-02 at 9 42 48" src="https://user-images.githubusercontent.com/598796/210204922-1c01e450-7a8f-40b2-abb2-c6daac25e1d5.png">


*By submitting this pull request, I confirm that my contribution is made under the terms of the 
[Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.
