### PR TITLE
fix(compiler): constants for wingsdk resource names and other cleanups

### DIFF
--- a/libs/wingc/src/lib.rs
+++ b/libs/wingc/src/lib.rs
@@ -27,6 +27,8 @@ pub mod parser;
 pub mod type_check;
 pub mod utilities;
 
+const WINGSDK_ASSEMBLY_NAME: &'static str = "@winglang/wingsdk";
+
 const WINGSDK_DURATION: &'static str = "std.Duration";
 const WINGSDK_RESOURCE: &'static str = "core.Resource";
 const WINGSDK_INFLIGHT: &'static str = "core.Inflight";

--- a/libs/wingc/src/lib.rs
+++ b/libs/wingc/src/lib.rs
@@ -27,6 +27,10 @@ pub mod parser;
 pub mod type_check;
 pub mod utilities;
 
+const WINGSDK_DURATION: &'static str = "std.Duration";
+const WINGSDK_RESOURCE: &'static str = "core.Resource";
+const WINGSDK_INFLIGHT: &'static str = "core.Inflight";
+
 pub struct CompilerOutput {
 	pub preflight: String,
 	// pub inflights: BTreeMap<String, String>,

--- a/libs/wingc/src/parser.rs
+++ b/libs/wingc/src/parser.rs
@@ -396,9 +396,11 @@ impl Parser<'_> {
 			statements: self.build_scope(&func_def_node.child_by_field_name("block").unwrap()),
 			signature: FunctionSignature {
 				parameters: parameters.iter().map(|p| p.1.clone()).collect(),
-				return_type: func_def_node
-					.child_by_field_name("type")
-					.map(|rt| Box::new(self.build_type(&rt).unwrap())),
+				return_type: if let Some(rt) = func_def_node.child_by_field_name("type") {
+					Some(Box::new(self.build_type(&rt)?))
+				} else {
+					None
+				},
 				flight,
 			},
 			captures: RefCell::new(None),
@@ -463,7 +465,7 @@ impl Parser<'_> {
 					"Map" => Ok(Type::Map(Box::new(self.build_type(&element_type)?))),
 					"Array" => Ok(Type::Array(Box::new(self.build_type(&element_type)?))),
 					"ERROR" => self.add_error(format!("Expected builtin container type"), type_node)?,
-					other => self.report_unimplemented_grammar(other, "bultin container type", type_node),
+					other => self.report_unimplemented_grammar(other, "builtin container type", type_node),
 				}
 			}
 			"ERROR" => self.add_error(format!("Expected type"), type_node),

--- a/libs/wingc/src/type_check.rs
+++ b/libs/wingc/src/type_check.rs
@@ -1,8 +1,8 @@
 mod jsii_importer;
 pub mod symbol_env;
 use crate::ast::{Type as AstType, *};
-use crate::debug;
 use crate::diagnostic::{Diagnostic, DiagnosticLevel, Diagnostics, TypeError, WingSpan};
+use crate::{debug, WINGSDK_DURATION};
 use derivative::Derivative;
 use indexmap::IndexSet;
 use jsii_importer::JsiiImporter;
@@ -1562,8 +1562,6 @@ impl<'a> TypeChecker<'a> {
 					}
 				}
 
-				let std_lookup = env.try_lookup("std", None).unwrap();
-				let std_namespace = &std_lookup.as_namespace().unwrap().env;
 				let instance_type = self.type_check_exp(object, env, statement_idx).unwrap();
 				match *instance_type {
 					Type::Class(ref class) | Type::Resource(ref class) => match class.env.lookup(property, None) {
@@ -1573,8 +1571,8 @@ impl<'a> TypeChecker<'a> {
 					Type::Anything => instance_type,
 
 					// get "std" primitives
-					Type::Duration => std_namespace
-						.try_lookup("Duration", None)
+					Type::Duration => env
+						.lookup_nested_str(WINGSDK_DURATION, None)
 						.unwrap()
 						.as_type()
 						.unwrap()

--- a/libs/wingc/src/type_check/jsii_importer.rs
+++ b/libs/wingc/src/type_check/jsii_importer.rs
@@ -7,13 +7,11 @@ use crate::{
 		symbol_env::StatementIdx, Class, FunctionSignature, Struct, SymbolKind, Type, TypeRef, Types, WING_CONSTRUCTOR_NAME,
 	},
 	utilities::camel_case_to_snake_case,
-	WINGSDK_DURATION, WINGSDK_INFLIGHT, WINGSDK_RESOURCE,
+	WINGSDK_ASSEMBLY_NAME, WINGSDK_DURATION, WINGSDK_INFLIGHT, WINGSDK_RESOURCE,
 };
 use colored::Colorize;
 use serde_json::Value;
 use wingii::jsii;
-
-const WINGSDK_ASSEMBLY: &'static str = "@winglang/wingsdk";
 
 trait JsiiInterface {
 	fn methods<'a>(&'a self) -> &'a Option<Vec<jsii::Method>>;
@@ -59,13 +57,13 @@ impl<'a> JsiiImporter<'a> {
 					_ => panic!("TODO: handle primitive type {}", primitive_name),
 				}
 			} else if let Some(Value::String(type_fqn)) = obj.get("fqn") {
-				if type_fqn == &format!("{}.{}", WINGSDK_ASSEMBLY, WINGSDK_INFLIGHT) {
+				if type_fqn == &format!("{}.{}", WINGSDK_ASSEMBLY_NAME, WINGSDK_INFLIGHT) {
 					Some(self.wing_types.add_type(Type::Function(FunctionSignature {
 						args: vec![self.wing_types.anything()],
 						return_type: Some(self.wing_types.anything()),
 						flight: Phase::Inflight,
 					})))
-				} else if type_fqn == &format!("{}.{}", WINGSDK_ASSEMBLY, WINGSDK_DURATION) {
+				} else if type_fqn == &format!("{}.{}", WINGSDK_ASSEMBLY_NAME, WINGSDK_DURATION) {
 					Some(self.wing_types.duration())
 				} else if type_fqn == "constructs.IConstruct" || type_fqn == "constructs.Construct" {
 					// TODO: this should be a special type that represents "any resource" https://github.com/winglang/wing/issues/261
@@ -116,7 +114,7 @@ impl<'a> JsiiImporter<'a> {
 
 	pub fn import_type(&mut self, type_fqn: &str) -> Option<TypeRef> {
 		// Hack: if the class name is RESOURCE_CLASS_FQN then we treat this class as a resource and don't need to define it
-		if type_fqn == format!("{}.{}", WINGSDK_ASSEMBLY, WINGSDK_RESOURCE) {
+		if type_fqn == format!("{}.{}", WINGSDK_ASSEMBLY_NAME, WINGSDK_RESOURCE) {
 			return None;
 		}
 
@@ -315,7 +313,7 @@ impl<'a> JsiiImporter<'a> {
 		// Get the base class of the JSII class, define it via recursive call if it's not define yet
 		let base_class = if let Some(base_class_fqn) = &jsii_class.base {
 			// Hack: if the base class name is RESOURCE_CLASS_FQN then we treat this class as a resource and don't need to define its parent
-			if base_class_fqn == &format!("{}.{}", WINGSDK_ASSEMBLY, WINGSDK_RESOURCE) {
+			if base_class_fqn == &format!("{}.{}", WINGSDK_ASSEMBLY_NAME, WINGSDK_RESOURCE) {
 				is_resource = true;
 				None
 			} else {

--- a/libs/wingc/src/type_check/jsii_importer.rs
+++ b/libs/wingc/src/type_check/jsii_importer.rs
@@ -7,14 +7,13 @@ use crate::{
 		symbol_env::StatementIdx, Class, FunctionSignature, Struct, SymbolKind, Type, TypeRef, Types, WING_CONSTRUCTOR_NAME,
 	},
 	utilities::camel_case_to_snake_case,
+	WINGSDK_DURATION, WINGSDK_INFLIGHT, WINGSDK_RESOURCE,
 };
 use colored::Colorize;
 use serde_json::Value;
 use wingii::jsii;
 
-const WINGSDK_DURATION_FQN: &'static str = "@winglang/wingsdk.std.Duration";
-const WINGSDK_RESOURCE_FQN: &'static str = "@winglang/wingsdk.core.Resource";
-const WINGSDK_INFLIGHT_FQN: &'static str = "@winglang/wingsdk.core.Inflight";
+const WINGSDK_ASSEMBLY: &'static str = "@winglang/wingsdk";
 
 trait JsiiInterface {
 	fn methods<'a>(&'a self) -> &'a Option<Vec<jsii::Method>>;
@@ -60,13 +59,13 @@ impl<'a> JsiiImporter<'a> {
 					_ => panic!("TODO: handle primitive type {}", primitive_name),
 				}
 			} else if let Some(Value::String(type_fqn)) = obj.get("fqn") {
-				if type_fqn == WINGSDK_INFLIGHT_FQN {
+				if type_fqn == &format!("{}.{}", WINGSDK_ASSEMBLY, WINGSDK_INFLIGHT) {
 					Some(self.wing_types.add_type(Type::Function(FunctionSignature {
 						args: vec![self.wing_types.anything()],
 						return_type: Some(self.wing_types.anything()),
 						flight: Phase::Inflight,
 					})))
-				} else if type_fqn == WINGSDK_DURATION_FQN {
+				} else if type_fqn == &format!("{}.{}", WINGSDK_ASSEMBLY, WINGSDK_DURATION) {
 					Some(self.wing_types.duration())
 				} else if type_fqn == "constructs.IConstruct" || type_fqn == "constructs.Construct" {
 					// TODO: this should be a special type that represents "any resource" https://github.com/winglang/wing/issues/261
@@ -117,7 +116,7 @@ impl<'a> JsiiImporter<'a> {
 
 	pub fn import_type(&mut self, type_fqn: &str) -> Option<TypeRef> {
 		// Hack: if the class name is RESOURCE_CLASS_FQN then we treat this class as a resource and don't need to define it
-		if type_fqn == WINGSDK_RESOURCE_FQN {
+		if type_fqn == format!("{}.{}", WINGSDK_ASSEMBLY, WINGSDK_RESOURCE) {
 			return None;
 		}
 
@@ -316,7 +315,7 @@ impl<'a> JsiiImporter<'a> {
 		// Get the base class of the JSII class, define it via recursive call if it's not define yet
 		let base_class = if let Some(base_class_fqn) = &jsii_class.base {
 			// Hack: if the base class name is RESOURCE_CLASS_FQN then we treat this class as a resource and don't need to define its parent
-			if base_class_fqn == WINGSDK_RESOURCE_FQN {
+			if base_class_fqn == &format!("{}.{}", WINGSDK_ASSEMBLY, WINGSDK_RESOURCE) {
 				is_resource = true;
 				None
 			} else {

--- a/libs/wingc/src/type_check/symbol_env.rs
+++ b/libs/wingc/src/type_check/symbol_env.rs
@@ -1,6 +1,6 @@
 use crate::{
 	ast::{Phase, Symbol},
-	diagnostic::TypeError,
+	diagnostic::{TypeError, WingSpan},
 	type_check::{SymbolKind, Type, TypeRef},
 };
 use std::collections::{hash_map, HashMap, HashSet};
@@ -143,6 +143,17 @@ impl SymbolEnv {
 				span: symbol.span.clone(),
 			}),
 		}
+	}
+
+	pub fn lookup_nested_str(&self, nested_str: &str, statement_idx: Option<usize>) -> Result<&SymbolKind, TypeError> {
+		let nested_vec = nested_str
+			.split('.')
+			.map(|s| Symbol {
+				name: s.to_string(),
+				span: WingSpan::global(),
+			})
+			.collect::<Vec<Symbol>>();
+		self.lookup_nested(&nested_vec.iter().collect::<Vec<&Symbol>>(), statement_idx)
 	}
 
 	pub fn lookup_nested(&self, nested_vec: &[&Symbol], statement_idx: Option<usize>) -> Result<&SymbolKind, TypeError> {


### PR DESCRIPTION
All constants for wingsdk resource names are now define in a single place in _lib.rs_. Also use nested lookup function to get these types from the env when needed.

Also in this PR there's a non related fix for correctly handling unknown builtin types in the return value of a closure during parsing. Before this paniced:
```wing
let a = (): Set<str> => {
}
```
Now it report an error:
```
Error at ../../tmp/tmp.w:1:13 | builtin container type 'Set' is not supported yet see https://github.com/winglang/wing/issues/530
```

*By submitting this pull request, I confirm that my contribution is made under the terms of the 
[Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.
