### PR TITLE
fix(compiler): diagnostics show the file and line as part of the type name

### DIFF
--- a/examples/tests/invalid/resource_access_field_as_method.w
+++ b/examples/tests/invalid/resource_access_field_as_method.w
@@ -1,0 +1,8 @@
+resource ff {
+    name: str;
+    init() {
+    }
+}
+
+let y = new ff();
+y.name();

--- a/examples/tests/invalid/resource_access_field_as_method.w
+++ b/examples/tests/invalid/resource_access_field_as_method.w
@@ -1,8 +1,8 @@
-resource ff {
+resource SomeResource {
     name: str;
     init() {
     }
 }
 
-let y = new ff();
-y.name();
+let x = new SomeResource();
+x.name();

--- a/libs/wingc/src/ast.rs
+++ b/libs/wingc/src/ast.rs
@@ -48,7 +48,7 @@ impl PartialEq for Symbol {
 
 impl std::fmt::Display for Symbol {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-		write!(f, "`{}` (at {})", self.name, self.span)
+		write!(f, "{} (at {})", self.name, self.span)
 	}
 }
 

--- a/libs/wingc/src/ast.rs
+++ b/libs/wingc/src/ast.rs
@@ -48,7 +48,7 @@ impl PartialEq for Symbol {
 
 impl std::fmt::Display for Symbol {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-		write!(f, "{} {}", self.name, self.span)
+		write!(f, "`{}` (at {})", self.name, self.span)
 	}
 }
 

--- a/libs/wingc/src/type_check.rs
+++ b/libs/wingc/src/type_check.rs
@@ -724,7 +724,7 @@ impl<'a> TypeChecker<'a> {
 				} else {
 					self.expr_error(
 						exp,
-						format!("{} should be a function or method",function
+						format!("\"{}\" should be a function or method",function
 						)
 					);
 					return None;
@@ -1560,7 +1560,7 @@ impl<'a> TypeChecker<'a> {
 							if e.values.contains(property) {
 								return _type;
 							} else {
-								return self.general_type_error(format!("Enum {} does not contain value `{}`", _type, property.name));
+								return self.general_type_error(format!("Enum \"{}\" does not contain value \"{}\"", _type, property.name));
 							}
 						}
 						_ => {

--- a/libs/wingc/src/type_check.rs
+++ b/libs/wingc/src/type_check.rs
@@ -724,7 +724,7 @@ impl<'a> TypeChecker<'a> {
 				} else {
 					self.expr_error(
 						exp,
-						format!("\"{}\" should be a function or method",function
+						format!("\"{}\" should be a function or method", function
 						)
 					);
 					return None;

--- a/libs/wingc/src/type_check.rs
+++ b/libs/wingc/src/type_check.rs
@@ -719,9 +719,16 @@ impl<'a> TypeChecker<'a> {
 				}
 
 				// Make sure this is a function signature type
-				let func_sig = func_type
-					.as_function_sig()
-					.expect(&format!("{} should be a function or method", function));
+				let func_sig = if let Some(func_sig) = func_type.as_function_sig() {
+					func_sig
+				} else {
+					self.expr_error(
+						exp,
+						format!("{} should be a function or method",function
+						)
+					);
+					return None;
+				};
 
 				if !can_call_flight(func_sig.flight, env.flight) {
 					self.expr_error(
@@ -1553,7 +1560,7 @@ impl<'a> TypeChecker<'a> {
 							if e.values.contains(property) {
 								return _type;
 							} else {
-								return self.general_type_error(format!("Enum {} does not contain value {}", _type, property.name));
+								return self.general_type_error(format!("Enum {} does not contain value `{}`", _type, property.name));
 							}
 						}
 						_ => {
@@ -1587,7 +1594,7 @@ impl<'a> TypeChecker<'a> {
 						.unwrap(),
 
 					_ => self.general_type_error(format!(
-						"\"{}\" in {} does not resolve to a class or resource instance",
+						"{} in `{}` does not resolve to a class or resource instance",
 						instance_type, reference
 					)),
 				}


### PR DESCRIPTION
This PR fixes 2 things:

1. We're changing the error message to be as appears in issue #997.
Note a couple of changes from #997: 
  a. We used "at" instead of "declared in" because it makes more sense in different contexts where this diagnostic message appears.
  b. We used quotes instead of ticks, since this is the convention on our compiler error messages.
A test for this already exists at: https://github.com/winglang/wing/blob/main/examples/tests/invalid/enums.w 

2. Also fixed a different error where the compiler would panic when we access a field as if it was a method. For example:
```ts
resource SomeResource {
    name: str;
    init() {
    }
}

let x = new SomeResource();
x.name();
```
Added this as a test.

Fixes #997 

*By submitting this pull request, I confirm that my contribution is made under the terms of the 
[Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.
