### PR TITLE
fix(docs): update cloudwatch -> s3 to reflect current hello wing code

### DIFF
--- a/docs/02-getting-started/05-aws.md
+++ b/docs/02-getting-started/05-aws.md
@@ -107,6 +107,8 @@ through the AWS Management Console.
 3. You should be able to see that you have a queue there
 4. Click **Send and receive messages**.
 5. In the **Message Body** box type `cloud` and hit **Send message**.
-6. Jump over to the [CloudWatch Console](https://console.aws.amazon.com/cloudwatch) 
-7. Under **Log groups** you should see a log group called `/aws/lambda/...`. 
-8. Click on it and you should see the log message `Hello, cloud!`.
+6. Jump over to the [S3 Console](https://s3.console.aws.amazon.com/s3/buckets) 
+7. There should be some buckets prefixed with `terraform-202`. 
+8. Cycle through the buckets until you find one that contains `wing.txt`.
+9. Click `wing.txt` then click the `Open` button.
+10. The file should contain `Hello, cloud`.


### PR DESCRIPTION
The docs are inconsistent with the current hello wing code.  The code only writes the message to an s3 bucket. I believe this iteration is referring to an earlier version that wrote to a cloudwatch log.



*By submitting this pull request, I confirm that my contribution is made under the terms of the 
[Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.
