### PR TITLE
fix(compiler): removing duplicate string when interpolating

### DIFF
--- a/examples/tests/valid/expressions_string_interpolation.w
+++ b/examples/tests/valid/expressions_string_interpolation.w
@@ -4,3 +4,6 @@ let number = 1;
 
 let cool_string = "cool \"\${${regular_string}}\" test";
 let really_cool_string = "${number}${empty_string}\n${cool_string}\n\${empty_string}${"string-in-string"}!";
+
+let begining_with_cool_strings = "${regular_string} ${number} <- cool";
+let ending_with_cool_strings = "cool -> ${regular_string} ${number}";

--- a/libs/wingc/src/parser.rs
+++ b/libs/wingc/src/parser.rs
@@ -633,18 +633,18 @@ impl Parser<'_> {
 							start_from = last_start;
 						}
 
-						if interpolation_start != last_start {							
+						if interpolation_start != last_start {
 							parts.push(InterpolatedStringPart::Static(
 								str::from_utf8(&self.source[start_from..interpolation_start])
-								.unwrap()
-								.into(),
+									.unwrap()
+									.into(),
 							));
 						}
-						
+
 						parts.push(InterpolatedStringPart::Expr(
 							self.build_expression(&interpolation_node.named_child(0).unwrap())?,
 						));
-						
+
 						last_start = interpolation_start;
 						last_end = interpolation_end;
 						start_from = last_end;

--- a/libs/wingc/src/parser.rs
+++ b/libs/wingc/src/parser.rs
@@ -617,8 +617,10 @@ impl Parser<'_> {
 
 					// Skip first and last quote
 					let end = expression_node.end_byte() - 1;
-					let mut last_start = expression_node.start_byte() + 1;
+					let start = expression_node.start_byte() + 1;
+					let mut last_start = start;
 					let mut last_end = end;
+					let mut start_from = last_end;
 
 					for interpolation_node in expression_node.named_children(&mut cursor) {
 						if interpolation_node.is_extra() {
@@ -627,20 +629,25 @@ impl Parser<'_> {
 						let interpolation_start = interpolation_node.start_byte();
 						let interpolation_end = interpolation_node.end_byte();
 
-						if interpolation_start != last_start {
-							parts.push(InterpolatedStringPart::Static(
-								str::from_utf8(&self.source[last_start..interpolation_start])
-									.unwrap()
-									.into(),
-							));
+						if start == last_start && interpolation_start < last_end {
+							start_from = last_start;
 						}
 
+						if interpolation_start != last_start {							
+							parts.push(InterpolatedStringPart::Static(
+								str::from_utf8(&self.source[start_from..interpolation_start])
+								.unwrap()
+								.into(),
+							));
+						}
+						
 						parts.push(InterpolatedStringPart::Expr(
 							self.build_expression(&interpolation_node.named_child(0).unwrap())?,
 						));
-
+						
 						last_start = interpolation_start;
 						last_end = interpolation_end;
+						start_from = last_end;
 					}
 
 					if last_end != end {

--- a/tools/hangar/src/__snapshots__/cli.test.ts.snap
+++ b/tools/hangar/src/__snapshots__/cli.test.ts.snap
@@ -883,7 +883,9 @@ constructor() {
   const empty_string = \\"\\";
   const number = 1;
   const cool_string = \`cool \\\\\\"\\\\\${\${regular_string}}\\\\\\" test\`;
-  const really_cool_string = \`\${number}\${number}\${empty_string}\${empty_string}\\\\n\${cool_string}\${cool_string}\\\\n\\\\\${empty_string}\${\\"string-in-string\\"}!\`;
+  const really_cool_string = \`\${number}\${empty_string}\\\\n\${cool_string}\\\\n\\\\\${empty_string}\${\\"string-in-string\\"}!\`;
+  const begining_with_cool_strings = \`\${regular_string} \${number} <- cool\`;
+  const ending_with_cool_strings = \`cool -> \${regular_string} \${number}\`;
 }
 }
 new MyApp().synth();"


### PR DESCRIPTION
When interpolate a string with more than one variable, all variables except the last one are duplicated

I create a simple validation on string parser file to remove the duplicated value

Please review this solution carefully as I do not program in Rust, but when I run the current test with this command

```bash
$ npx nx dev -- wing/examples/tests/valid/expressions_string_interpolation.w
```
the resulting file was created correctly and can be found in the folder
`wing/examples/tests/valid/expressions_string_interpolation.w.out/preflight.js`


Closes #1041 

*By submitting this pull request, I confirm that my contribution is made under the terms of the 
[Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.
