### PR TITLE
fix: missing wingsdk .jsii manifest in vscode

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -301,8 +301,9 @@ jobs:
       - name: Prepare WingSDK .jsii
         run: |
           tar -xzf wingsdk/*.tgz package/.jsii
-          mv wingsdk/package/.jsii libs/wingsdk
-          ls -al libs/wingsdk
+          ls -al wingsdk
+          ls -al .
+          mv .jsii libs/wingsdk
 
       - name: Setup Node
         uses: actions/setup-node@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -297,6 +297,12 @@ jobs:
       - name: Prepare language server binaries
         run: cp -r wing-language-server-* ./apps/vscode-wing/resources
 
+      - name: Prepare WingSDK .jsii
+        run: |
+          tar -xzf wingsdk/*.tgz package/.jsii
+          mv wingsdk/package/.jsii libs/wingsdk
+          ls -al libs/wingsdk
+
       - name: Setup Node
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -323,6 +323,9 @@ jobs:
           projects: "vscode-wing"
           args: "--configuration=release --output-style=stream --verbose"
 
+      - name: TEST
+        run: ls -al apps/vscode-wing/node_modules/@winglang/wingsdk
+
       - name: Upload extension
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -322,9 +322,6 @@ jobs:
           projects: "vscode-wing"
           args: "--configuration=release --output-style=stream --verbose"
 
-      - name: TEST
-        run: ls -al apps/vscode-wing/node_modules/@winglang/wingsdk
-
       - name: Upload extension
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -284,6 +284,7 @@ jobs:
     needs:
       - prepare
       - build-native
+      - build-wasm
     env:
       PROJEN_BUMP_VERSION: ${{ needs.prepare.outputs.version }}
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -301,9 +301,7 @@ jobs:
       - name: Prepare WingSDK .jsii
         run: |
           tar -xzf wingsdk/*.tgz package/.jsii
-          ls -al wingsdk
-          ls -al .
-          mv .jsii libs/wingsdk
+          mv package/.jsii libs/wingsdk
 
       - name: Setup Node
         uses: actions/setup-node@v3


### PR DESCRIPTION
The `.jsii` from wingsdk needs to be packaged with the vscode extension.

This works locally because we build wingsdk at the same time, but the vscode build here happens after (and separately from) the wingsdk build.

*By submitting this pull request, I confirm that my contribution is made under the terms of the 
[Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.
