### PR TITLE
fix: missing wingsdk in vscode extension (again)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -298,11 +298,6 @@ jobs:
       - name: Prepare language server binaries
         run: cp -r wing-language-server-* ./apps/vscode-wing/resources
 
-      - name: Prepare WingSDK .jsii
-        run: |
-          tar -xzf wingsdk/*.tgz package/.jsii
-          mv package/.jsii libs/wingsdk
-
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
@@ -314,6 +309,11 @@ jobs:
 
       - name: Install Dependencies
         uses: bahmutov/npm-install@v1
+
+      - name: Prepare WingSDK resource
+        run: |
+          tar -xzf wingsdk/*.tgz
+          mv package apps/vscode-wing/resources/wingsdk
 
       - name: Build
         uses: MansaGroup/nrwl-nx-action@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -298,6 +298,11 @@ jobs:
       - name: Prepare language server binaries
         run: cp -r wing-language-server-* ./apps/vscode-wing/resources
 
+      - name: Prepare WingSDK files
+        run: |
+          mkdir -p apps/vscode-wing/resources/wingsdk
+          tar -xzf wingsdk/*.tgz -C apps/vscode-wing/resources/wingsdk --strip-components=1 package/package.json package/.jsii
+
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
@@ -310,14 +315,10 @@ jobs:
       - name: Install Dependencies
         uses: bahmutov/npm-install@v1
 
-      - name: Prepare WingSDK resource
-        run: |
-          tar -xzf wingsdk/*.tgz
-          mv package apps/vscode-wing/resources/wingsdk
-
       - name: Build
         uses: MansaGroup/nrwl-nx-action@v2
         with:
+          # build-multi assumes all required resources are present
           targets: "build-multi"
           projects: "vscode-wing"
           args: "--configuration=release --output-style=stream --verbose"

--- a/apps/vscode-wing/.gitignore
+++ b/apps/vscode-wing/.gitignore
@@ -38,3 +38,5 @@ jspm_packages/
 !/.eslintrc.json
 *.vsix
 !/.vscodeignore
+resources/wingsdk/
+resources/native/

--- a/apps/vscode-wing/.projenrc.ts
+++ b/apps/vscode-wing/.projenrc.ts
@@ -63,10 +63,10 @@ vscodeIgnore.addPatterns(
   "!resources/",
   "!syntaxes/",
   "!language-configuration.json",
-  "!LICENSE",
-  "!node_modules/@winglang/wingsdk/package.json",
-  "!node_modules/@winglang/wingsdk/.jsii"
+  "!LICENSE"
 );
+project.addGitIgnore("resources/wingsdk/");
+project.addGitIgnore("resources/native/");
 
 const contributes: VSCodeExtensionContributions = {
   languages: [

--- a/apps/vscode-wing/.vscodeignore
+++ b/apps/vscode-wing/.vscodeignore
@@ -7,5 +7,3 @@
 !syntaxes/
 !language-configuration.json
 !LICENSE
-!node_modules/@winglang/wingsdk/package.json
-!node_modules/@winglang/wingsdk/.jsii

--- a/apps/vscode-wing/project.json
+++ b/apps/vscode-wing/project.json
@@ -19,8 +19,12 @@
       "options": {
         "commands": [
           "mkdir -p resources/native",
+          "mkdir -p resources/wingsdk",
           "rm -f resources/native/*",
-          "cp -v ../../target/debug/wing-language-server resources/native"
+          "rm -f resources/wingsdk/*",
+          "cp -v ../../target/debug/wing-language-server resources/native",
+          "cp -v node_modules/@winglang/wingsdk/package.json resources/wingsdk/package.json",
+          "cp -v node_modules/@winglang/wingsdk/.jsii resources/wingsdk/.jsii"
         ],
         "cwd": "apps/vscode-wing",
         "parallel": false

--- a/apps/vscode-wing/src/extension.ts
+++ b/apps/vscode-wing/src/extension.ts
@@ -1,7 +1,6 @@
 import { execSync } from "child_process";
 import { existsSync } from "fs";
 import { platform } from "os";
-import { dirname } from "path";
 import { ExtensionContext, window } from "vscode";
 import {
   Executable,

--- a/apps/vscode-wing/src/extension.ts
+++ b/apps/vscode-wing/src/extension.ts
@@ -67,9 +67,7 @@ async function startLanguageServer(context: ExtensionContext) {
     execSync(`chmod +x ${serverPath}`);
   }
 
-  const wingsdkManifestRoot = dirname(
-    require.resolve("@winglang/wingsdk/.jsii")
-  );
+  const wingsdkManifestRoot = context.asAbsolutePath("resources/wingsdk");
 
   const run: Executable = {
     command: serverPath,


### PR DESCRIPTION
https://github.com/winglang/wing/pull/832 moved wingsdk to be a devDep, which no longer included any of its files in the final vscode vsix file. This moves the required `package.json` and `.jsii` to be treated more like the language server binaries instead.

*By submitting this pull request, I confirm that my contribution is made under the terms of the 
[Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.
