### PR TITLE
fix(docs): wrong permissions for private auth token mentioned on getting started guide

### DIFF
--- a/docs/02-getting-started/02-installation.md
+++ b/docs/02-getting-started/02-installation.md
@@ -83,5 +83,5 @@ Wing applications running locally on the cloud simulator.
 [AWS account]: https://portal.aws.amazon.com/billing/signup
 [AWS CLI]: https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html
 [AWS credentials]: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html
-[personal access token]: https://github.com/settings/tokens/new?description=Winglang%20Beta&scopes=read:packages
+[personal access token]: https://github.com/settings/tokens/new?description=Winglang%20Beta&scopes=repo,read:packages
 [VSCode]: https://code.visualstudio.com/


### PR DESCRIPTION
According to https://github.com/winglang/docsite/issues/207 we need to revert the work done on #988 and increase back the scope of the PAT used to fetch Wing from github package registry.

Resolves https://github.com/winglang/docsite/issues/207

*By submitting this pull request, I confirm that my contribution is made under the terms of the 
[Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.
