### PR TITLE
fix(docs): installing from github packages throws error on npm 9+

### DIFF
--- a/docs/02-getting-started/02-installation.md
+++ b/docs/02-getting-started/02-installation.md
@@ -40,6 +40,8 @@ Username: "lowercase-github-username"
 Password: "the just created Github token"
 Email: "your github email"
 ```
+(note: npm 9+ needs the argument '--auth-type=legacy' to fix 'ERR! Web login not supported')
+
 :::
 
 Install the Wing CLI through npm:


### PR DESCRIPTION
This arg is needed for newer versions of NPM



*By submitting this pull request, I confirm that my contribution is made under the terms of the 
[Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.
