### PR TITLE
chore: alerting workflow triggered by check_run event

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -408,20 +408,3 @@ jobs:
           body_path: CHANGELOG.md
           files: dist/*
           token: ${{ secrets.PROJEN_GITHUB_TOKEN }}
-
-  alert:
-    needs:
-      - publish
-    if: always() && github.ref == 'refs/heads/main'
-    runs-on: ubuntu-latest
-    steps:
-      # sets WORKFLOW_CONCLUSION variable
-      - uses: technote-space/workflow-conclusion-action@v3
-      - name: Send slack notification
-        uses: ravsamhq/notify-slack-action@v1
-        with:
-          status: ${{ env.WORKFLOW_CONCLUSION }}
-          notification_title: "{workflow} has {status_message}"
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.ACTION_MONITORING_SLACK }}
-        if: env.WORKFLOW_CONCLUSION == 'failure'

--- a/.github/workflows/failure_notification.yml
+++ b/.github/workflows/failure_notification.yml
@@ -12,7 +12,6 @@ jobs:
       github.event.check_run.name != 'Build Failure Notification'
       && github.event.check_run.conclusion == 'failure' 
       && github.event.check_run.check_suite.head_branch == 'main'
-      && github.event.check_run.check_suite.status == 'completed'
     steps:
       - name: Send slack notification
         uses: ravsamhq/notify-slack-action@v2.3.0

--- a/.github/workflows/failure_notification.yml
+++ b/.github/workflows/failure_notification.yml
@@ -1,0 +1,25 @@
+name: "Build Failure Notification"
+
+on:
+  check_run:
+    types:
+      - completed
+
+jobs:
+  notify:
+    runs-on: ubuntu-22.04
+    if: |
+      github.event.check_run.name != 'Build Failure Notification'
+      && github.event.check_run.conclusion == 'failure' 
+      && github.event.check_run.check_suite.head_branch == 'main'
+      && github.event.check_run.check_suite.status == 'completed'
+    steps:
+      - name: Send slack notification
+        uses: ravsamhq/notify-slack-action@v2.3.0
+        with:
+          status: ${{ github.event.check_run.conclusion }}
+          notification_title: "${{ github.event.check_run.name }} has failed"
+          message_format: "{emoji} *${{ github.event.check_run.name }}* {status_message} in <{repo_url}|{repo}@{branch}> on <{commit_url}|{commit_sha}>"
+          footer: "<${{ github.event.check_run.details_url }}|Details>"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.ACTION_MONITORING_SLACK }}

--- a/.github/workflows/failure_notification.yml
+++ b/.github/workflows/failure_notification.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           status: ${{ github.event.check_run.conclusion }}
           notification_title: "${{ github.event.check_run.name }} has failed"
-          message_format: "{emoji} *${{ github.event.check_run.name }}* {status_message} in <{repo_url}|{repo}@{branch}> on <{commit_url}|{commit_sha}>"
+          message_format: ":x *${{ github.event.check_run.name }}* failed in <{repo_url}|{repo}@{branch}> on <{commit_url}|{commit_sha}>"
           footer: "<${{ github.event.check_run.details_url }}|Details>"
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.ACTION_MONITORING_SLACK }}

--- a/.github/workflows/failure_notification.yml
+++ b/.github/workflows/failure_notification.yml
@@ -16,9 +16,9 @@ jobs:
       - name: Send slack notification
         uses: ravsamhq/notify-slack-action@v2.3.0
         with:
-          status: ${{ github.event.check_run.conclusion }}
+          status: failure
           notification_title: "${{ github.event.check_run.name }} has failed"
-          message_format: ":x *${{ github.event.check_run.name }}* failed in <{repo_url}|{repo}@{branch}> on <{commit_url}|{commit_sha}>"
+          message_format: ":x *${{ github.event.check_run.name }}* failed on <{commit_url}|{commit_sha}>"
           footer: "<${{ github.event.check_run.details_url }}|Details>"
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.ACTION_MONITORING_SLACK }}


### PR DESCRIPTION
The `build` workflow needs to be simplified/split-up in preparation for https://github.com/winglang/wing/issues/256. The alert workflow doesn't need to run in forks, nor does it even need to run on push. This is one less thing to worry about in forks (check_run events should not be triggered by forks AFAIK)


*By submitting this pull request, I confirm that my contribution is made under the terms of the 
[Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.
