### PR TITLE
chore: wrong version of slack notifier in workflow

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -1,4 +1,5 @@
-name: auto-approve
+name: Auto Approve
+
 on:
   pull_request_target:
     types:
@@ -7,6 +8,7 @@ on:
       - synchronize
       - reopened
       - ready_for_review
+
 jobs:
   approve:
     runs-on: ubuntu-latest

--- a/.github/workflows/close-stale.yml
+++ b/.github/workflows/close-stale.yml
@@ -1,4 +1,4 @@
-name: Close stale PR's and Issues
+name: Close Stale PR's and Issues
 
 on:
   schedule:

--- a/.github/workflows/failure_notification.yml
+++ b/.github/workflows/failure_notification.yml
@@ -1,4 +1,4 @@
-name: "Build Failure Notification"
+name: Build Failure Notification
 
 on:
   check_run:
@@ -10,11 +10,11 @@ jobs:
     runs-on: ubuntu-22.04
     if: |
       github.event.check_run.name != 'Build Failure Notification'
-      && github.event.check_run.conclusion == 'failure' 
       && github.event.check_run.check_suite.head_branch == 'main'
+      && github.event.check_run.conclusion == 'failure' 
     steps:
       - name: Send slack notification
-        uses: ravsamhq/notify-slack-action@v2.3.0
+        uses: ravsamhq/notify-slack-action@2.3.0
         with:
           status: failure
           notification_title: "${{ github.event.check_run.name }} has failed"

--- a/.github/workflows/issue-backlogger.yml
+++ b/.github/workflows/issue-backlogger.yml
@@ -1,3 +1,5 @@
+name: Issue Backlogger
+
 on:
   issues:
     types:

--- a/.github/workflows/pull-request-lint.yml
+++ b/.github/workflows/pull-request-lint.yml
@@ -1,4 +1,5 @@
-name: pull-request-lint
+name: Pull Request Lint
+
 on:
   pull_request_target:
     types:
@@ -8,6 +9,7 @@ on:
       - reopened
       - ready_for_review
       - edited
+
 jobs:
   validate:
     name: Validate PR title

--- a/.github/workflows/release-commenter.yml
+++ b/.github/workflows/release-commenter.yml
@@ -1,6 +1,9 @@
+name: Create Release Comment
+
 on:
   release:
-    types: [published]
+    types:
+      - published
 
 jobs:
   release:

--- a/.github/workflows/update-docsite.yml
+++ b/.github/workflows/update-docsite.yml
@@ -2,7 +2,8 @@ name: Trigger Docsite Update
 
 on:
   release:
-    types: [published]
+    types:
+      - published
 
 jobs:
   update-docsite:


### PR DESCRIPTION
The primary purpose of the PR was to change ravsamhq/notify-slack-action from "v2.3.0" to "2.3.0", which was preventing it from running.
Did some additional cleanup while I was around.


*By submitting this pull request, I confirm that my contribution is made under the terms of the 
[Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.
