### PR TITLE
chore: fork-based workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,13 @@
 name: Build
 
 on:
+  pull_request_target:
+    types:
+      - opened
+      - synchronize
   push:
+    branches:
+      - main
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -31,7 +37,7 @@ jobs:
 
       - name: Login to Private NPM registry
         if: github.ref == 'refs/heads/main'
-        run: npm config set @winglang:registry https://npm.pkg.github.com && npm set //npm.pkg.github.com/:_authToken ${{ secrets.PROJEN_GITHUB_TOKEN }}
+        run: npm config set @winglang:registry https://npm.pkg.github.com && npm set //npm.pkg.github.com/:_authToken ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Dependencies
         if: github.ref == 'refs/heads/main'
@@ -44,7 +50,7 @@ jobs:
         id: info
         env:
           # Needed for `auto` cli
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.PROJEN_GITHUB_TOKEN }}
         run: |
           set -e
           echo "version=$(npx auto release -d | grep 'Would have created a release on GitHub for version: ' | sed 's/.*version: //')" >> $GITHUB_OUTPUT
@@ -110,7 +116,7 @@ jobs:
         run: scripts/setup_wasi.sh
 
       - name: Login to Private NPM registry
-        run: npm config set @winglang:registry https://npm.pkg.github.com && npm set //npm.pkg.github.com/:_authToken ${{ secrets.PROJEN_GITHUB_TOKEN }}
+        run: npm config set @winglang:registry https://npm.pkg.github.com && npm set //npm.pkg.github.com/:_authToken ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Dependencies
         uses: bahmutov/npm-install@v1
@@ -162,7 +168,7 @@ jobs:
         if: github.ref == 'refs/heads/main'
         uses: amondnet/vercel-action@v25.1.0
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.PROJEN_GITHUB_TOKEN }}
           vercel-token: ${{ secrets.VERCEL_TOKEN_WING_PLAYGROUND }}
           vercel-org-id: ${{ secrets.VERCEL_TEAM_ID }}
           vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID_WING_PLAYGROUND }}
@@ -209,7 +215,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
 
       - name: Login to Private NPM registry
-        run: npm config set @winglang:registry https://npm.pkg.github.com && npm set //npm.pkg.github.com/:_authToken ${{ secrets.PROJEN_GITHUB_TOKEN }}
+        run: npm config set @winglang:registry https://npm.pkg.github.com && npm set //npm.pkg.github.com/:_authToken ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Dependencies
         uses: bahmutov/npm-install@v1
@@ -272,7 +278,7 @@ jobs:
 
       - name: Run E2E Tests
         env:
-          NPM_TOKEN: ${{ secrets.PROJEN_GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           export HANGAR_WING_TGZ="$(pwd)/$(find wing/*.tgz)"
           export HANGAR_WINGSDK_TGZ="$(pwd)/$(find wingsdk/*.tgz)"
@@ -310,7 +316,7 @@ jobs:
           registry-url: https://npm.pkg.github.com
 
       - name: Login to Private NPM registry
-        run: npm config set @winglang:registry https://npm.pkg.github.com && npm set //npm.pkg.github.com/:_authToken ${{ secrets.PROJEN_GITHUB_TOKEN }}
+        run: npm config set @winglang:registry https://npm.pkg.github.com && npm set //npm.pkg.github.com/:_authToken ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Dependencies
         uses: bahmutov/npm-install@v1
@@ -397,7 +403,7 @@ jobs:
       - name: Tag commit
         uses: tvdias/github-tagger@v0.0.1
         with:
-          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          repo-token: "${{ secrets.PROJEN_GITHUB_TOKEN }}"
           tag: "v${{ needs.prepare.outputs.version }}"
 
       - name: Cut Development Release

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ on:
       - main
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 env:
@@ -28,29 +28,29 @@ jobs:
       version: ${{ steps.info.outputs.version || steps.pr_info.outputs.version }}
     steps:
       - name: Checkout
-        if: github.ref == 'refs/heads/main'
+        if: github.event_name == 'push'
         uses: actions/checkout@v3
 
       - name: Get tags
-        if: github.ref == 'refs/heads/main'
+        if: github.event_name == 'push'
         run: git fetch --unshallow --tags
 
       - name: Login to Private NPM registry
-        if: github.ref == 'refs/heads/main'
+        if: github.event_name == 'push'
         run: npm config set @winglang:registry https://npm.pkg.github.com && npm set //npm.pkg.github.com/:_authToken ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Dependencies
-        if: github.ref == 'refs/heads/main'
+        if: github.event_name == 'push'
         uses: bahmutov/npm-install@v1
         with:
           install-command: npm ci --ignore-scripts
 
       - name: Get Version Info
-        if: github.ref == 'refs/heads/main'
+        if: github.event_name == 'push'
         id: info
         env:
           # Needed for `auto` cli
-          GH_TOKEN: ${{ secrets.PROJEN_GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -e
           echo "version=$(npx auto release -d | grep 'Would have created a release on GitHub for version: ' | sed 's/.*version: //')" >> $GITHUB_OUTPUT
@@ -59,11 +59,11 @@ jobs:
 
       # newlines are easier to handle in single-line yaml
       - run: "echo '\n' >> CHANGELOG.md"
-        if: github.ref == 'refs/heads/main'
+        if: github.event_name == 'push'
 
       - name: PR Version Info
         id: pr_info
-        if: github.ref != 'refs/heads/main'
+        if: github.event_name != 'push'
         run: |
           echo "version=0.0.0-dev.${{ github.run_id }}.${{ github.run_attempt }}" >> $GITHUB_OUTPUT
           echo "Pull Request" > CHANGELOG.md
@@ -76,11 +76,11 @@ jobs:
           path: CHANGELOG.md
 
       - name: Compress Docs
-        if: github.ref == 'refs/heads/main'
+        if: github.event_name == 'push'
         run: tar -czvf docs.tgz docs/*
 
       - name: Upload Docs
-        if: github.ref == 'refs/heads/main'
+        if: github.event_name == 'push'
         uses: actions/upload-artifact@v2
         with:
           name: docs
@@ -165,7 +165,7 @@ jobs:
           path: target/wasm32-wasi/release/wingc.wasm
 
       - name: "Publish Wing Playground"
-        if: github.ref == 'refs/heads/main'
+        if: github.event_name == 'push' && github.repository == 'winglang/wing'
         uses: amondnet/vercel-action@v25.1.0
         with:
           github-token: ${{ secrets.PROJEN_GITHUB_TOKEN }}
@@ -348,7 +348,7 @@ jobs:
 
   publish:
     name: Publish
-    if: github.ref == 'refs/heads/main'
+    if: github.event_name == 'push' && github.repository == 'winglang/wing'
     needs:
       - build
       - prepare

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ on:
       - main
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.head.ref || github.ref }}
   cancel-in-progress: true
 
 env:
@@ -28,25 +28,28 @@ jobs:
       version: ${{ steps.info.outputs.version || steps.pr_info.outputs.version }}
     steps:
       - name: Checkout
-        if: github.event_name == 'push'
+        if: github.event_name == 'push' && github.repository == 'winglang/wing'
         uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.ref || github.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
 
       - name: Get tags
-        if: github.event_name == 'push'
+        if: github.event_name == 'push' && github.repository == 'winglang/wing'
         run: git fetch --unshallow --tags
 
       - name: Login to Private NPM registry
-        if: github.event_name == 'push'
+        if: github.event_name == 'push' && github.repository == 'winglang/wing'
         run: npm config set @winglang:registry https://npm.pkg.github.com && npm set //npm.pkg.github.com/:_authToken ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Dependencies
-        if: github.event_name == 'push'
+        if: github.event_name == 'push' && github.repository == 'winglang/wing'
         uses: bahmutov/npm-install@v1
         with:
           install-command: npm ci --ignore-scripts
 
       - name: Get Version Info
-        if: github.event_name == 'push'
+        if: github.event_name == 'push' && github.repository == 'winglang/wing'
         id: info
         env:
           # Needed for `auto` cli
@@ -59,11 +62,11 @@ jobs:
 
       # newlines are easier to handle in single-line yaml
       - run: "echo '\n' >> CHANGELOG.md"
-        if: github.event_name == 'push'
+        if: github.event_name == 'push' && github.repository == 'winglang/wing'
 
       - name: PR Version Info
         id: pr_info
-        if: github.event_name != 'push'
+        if: github.event_name != 'push' || github.repository != 'winglang/wing'
         run: |
           echo "version=0.0.0-dev.${{ github.run_id }}.${{ github.run_attempt }}" >> $GITHUB_OUTPUT
           echo "Pull Request" > CHANGELOG.md
@@ -76,11 +79,11 @@ jobs:
           path: CHANGELOG.md
 
       - name: Compress Docs
-        if: github.event_name == 'push'
+        if: github.event_name == 'push' && github.repository == 'winglang/wing'
         run: tar -czvf docs.tgz docs/*
 
       - name: Upload Docs
-        if: github.event_name == 'push'
+        if: github.event_name == 'push' && github.repository == 'winglang/wing'
         uses: actions/upload-artifact@v2
         with:
           name: docs
@@ -96,6 +99,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.ref || github.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
 
       - name: Setup Node
         uses: actions/setup-node@v3
@@ -198,6 +204,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.ref || github.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
 
       - name: Setup Node
         uses: actions/setup-node@v3
@@ -261,6 +270,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.ref || github.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
 
       - name: Download Build Artifacts
         uses: actions/download-artifact@v2
@@ -297,6 +309,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.ref || github.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
 
       - name: Download Build Artifacts
         uses: actions/download-artifact@v2

--- a/.github/workflows/wingsdk-mutation.yml
+++ b/.github/workflows/wingsdk-mutation.yml
@@ -8,6 +8,10 @@ on:
     paths:
       - libs/wingsdk/**
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 permissions:
   contents: write
 
@@ -16,8 +20,10 @@ defaults:
     working-directory: libs/wingsdk
 
 jobs:
-  build:
+  wingsdk-mutation:
     runs-on: ubuntu-latest
+    env:
+      CI: "true"
     outputs:
       self_mutation_happened: ${{ steps.self_mutation.outputs.self_mutation_happened }}
     steps:
@@ -43,26 +49,13 @@ jobs:
         name: Find mutations
         run: |-
           git add .
-          git diff --staged --patch --exit-code || echo "::set-output name=self_mutation_happened::true"
-      - name: Upload patch
-        if: steps.self_mutation.outputs.self_mutation_happened
-        uses: actions/upload-artifact@v2
-        with:
-          name: .repo.patch
-          path: libs/wingsdk/.repo.patch
-      - name: Set git identity
+          git diff --staged --patch --exit-code > /dev/null || echo "::set-output name=self_mutation_happened::true"
+      - name: Push changes
         if: steps.self_mutation.outputs.self_mutation_happened
         run: |-
           git config user.name "github-actions"
           git config user.email "github-actions@github.com"
-      - name: Push changes
-        if: steps.self_mutation.outputs.self_mutation_happened
-        run: |-
-          git add .
           git commit -s -m "chore: self mutation"
           git push origin HEAD:${{ github.event.ref }}
-      - name: Fail build on mutation
-        if: steps.self_mutation.outputs.self_mutation_happened
-        run: |-
           echo "::error::Files were changed during build (see build log)."
           exit 1

--- a/.github/workflows/wingsdk-mutation.yml
+++ b/.github/workflows/wingsdk-mutation.yml
@@ -20,14 +20,9 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       self_mutation_happened: ${{ steps.self_mutation.outputs.self_mutation_happened }}
-    env:
-      CI: "true"
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.ref }}
-          repository: ${{ github.event.repository.full_name }}
       - name: Login to private npm registry
         run: npm config set @winglang:registry https://npm.pkg.github.com && npm set //npm.pkg.github.com/:_authToken ${{ secrets.GITHUB_TOKEN }}
       - name: Setup Node.js
@@ -48,70 +43,26 @@ jobs:
         name: Find mutations
         run: |-
           git add .
-          git diff --staged --patch --exit-code > .repo.patch || echo "::set-output name=self_mutation_happened::true"
-      - if: steps.self_mutation.outputs.self_mutation_happened
-        name: Upload patch
+          git diff --staged --patch --exit-code || echo "::set-output name=self_mutation_happened::true"
+      - name: Upload patch
+        if: steps.self_mutation.outputs.self_mutation_happened
         uses: actions/upload-artifact@v2
         with:
           name: .repo.patch
           path: libs/wingsdk/.repo.patch
-
-      - name: Fail build on mutation
-        if: steps.self_mutation.outputs.self_mutation_happened
-        run: |-
-          echo "::error::Files were changed during build (see build log). If this was triggered from a fork, you will need to update your branch."
-          cat .repo.patch
-          exit 1
-      - name: Upload artifact
-        uses: actions/upload-artifact@v2.1.1
-        with:
-          name: wingsdk-build-artifact
-          path: libs/wingsdk/dist
-  self-mutation:
-    needs: build
-    runs-on: ubuntu-latest
-    if: always() && needs.build.outputs.self_mutation_happened
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.ref }}
-          repository: ${{ github.event.repository.full_name }}
-      - name: Download patch
-        uses: actions/download-artifact@v3
-        with:
-          name: .repo.patch
-          path: ${{ runner.temp }}
-      - name: Apply patch
-        run: '[ -s ${{ runner.temp }}/.repo.patch ] && git apply ${{ runner.temp }}/.repo.patch || echo "Empty patch. Skipping."'
       - name: Set git identity
+        if: steps.self_mutation.outputs.self_mutation_happened
         run: |-
           git config user.name "github-actions"
           git config user.email "github-actions@github.com"
       - name: Push changes
-        run: |2-
-            git add .
-            git commit -s -m "chore: self mutation"
-            git push origin HEAD:${{ github.event.ref }}
-  package-js:
-    needs: build
-    runs-on: ubuntu-latest
-    permissions: {}
-    if: "! needs.build.outputs.self_mutation_happened"
-    steps:
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 16.x
-      - name: Download build artifacts
-        uses: actions/download-artifact@v3
-        with:
-          name: wingsdk-build-artifact
-          path: libs/wingsdk/dist
-      - name: Prepare Repository
-        run: mv dist .repo && npm config set @winglang:registry https://npm.pkg.github.com && npm set //npm.pkg.github.com/:_authToken ${{ secrets.GITHUB_TOKEN }}
-      - name: Install Dependencies
-        run: cd .repo && npm ci
-      - name: Create js artifact
-        run: cd .repo && npx projen package:js
-      - name: Collect js Artifact
-        run: mv .repo/dist dist
+        if: steps.self_mutation.outputs.self_mutation_happened
+        run: |-
+          git add .
+          git commit -s -m "chore: self mutation"
+          git push origin HEAD:${{ github.event.ref }}
+      - name: Fail build on mutation
+        if: steps.self_mutation.outputs.self_mutation_happened
+        run: |-
+          echo "::error::Files were changed during build (see build log)."
+          exit 1

--- a/.github/workflows/wingsdk-mutation.yml
+++ b/.github/workflows/wingsdk-mutation.yml
@@ -1,11 +1,12 @@
 name: WingSDK Mutation
 
 on:
-  push:
-    branches-ignore:
-      - "main"
+  pull_request_target:
+    types:
+      - opened
+      - synchronize
     paths:
-      - "libs/wingsdk/**"
+      - libs/wingsdk/**
 
 permissions:
   contents: write
@@ -28,9 +29,7 @@ jobs:
           ref: ${{ github.event.ref }}
           repository: ${{ github.event.repository.full_name }}
       - name: Login to private npm registry
-        run: npm config set @winglang:registry https://npm.pkg.github.com && npm set //npm.pkg.github.com/:_authToken $PROJEN_GITHUB_TOKEN
-        env:
-          PROJEN_GITHUB_TOKEN: ${{ secrets.PROJEN_GITHUB_TOKEN }}
+        run: npm config set @winglang:registry https://npm.pkg.github.com && npm set //npm.pkg.github.com/:_authToken ${{ secrets.GITHUB_TOKEN }}
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
@@ -45,11 +44,6 @@ jobs:
         run: npm install
       - name: build
         run: npx projen build
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v1
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          directory: coverage
       - id: self_mutation
         name: Find mutations
         run: |-
@@ -76,12 +70,11 @@ jobs:
   self-mutation:
     needs: build
     runs-on: ubuntu-latest
-    if: always() && needs.build.outputs.self_mutation_happened && github.event.repository.full_name == github.repository && github.ref != 'refs/heads/main'
+    if: always() && needs.build.outputs.self_mutation_happened
     steps:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          token: ${{ secrets.PROJEN_GITHUB_TOKEN }}
           ref: ${{ github.event.ref }}
           repository: ${{ github.event.repository.full_name }}
       - name: Download patch
@@ -115,9 +108,7 @@ jobs:
           name: wingsdk-build-artifact
           path: libs/wingsdk/dist
       - name: Prepare Repository
-        run: mv dist .repo && npm config set @winglang:registry https://npm.pkg.github.com && npm set //npm.pkg.github.com/:_authToken $PROJEN_GITHUB_TOKEN
-        env:
-          PROJEN_GITHUB_TOKEN: ${{ secrets.PROJEN_GITHUB_TOKEN }}
+        run: mv dist .repo && npm config set @winglang:registry https://npm.pkg.github.com && npm set //npm.pkg.github.com/:_authToken ${{ secrets.GITHUB_TOKEN }}
       - name: Install Dependencies
         run: cd .repo && npm ci
       - name: Create js artifact

--- a/.github/workflows/wingsdk-mutation.yml
+++ b/.github/workflows/wingsdk-mutation.yml
@@ -9,7 +9,7 @@ on:
       - libs/wingsdk/**
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.head.ref }}
   cancel-in-progress: true
 
 permissions:
@@ -19,30 +19,34 @@ defaults:
   run:
     working-directory: libs/wingsdk
 
+env:
+  NODEJS_VERSION: "18.x"
+  CI: "true"
+
 jobs:
-  wingsdk-mutation:
+  build:
     runs-on: ubuntu-latest
-    env:
-      CI: "true"
-    outputs:
-      self_mutation_happened: ${{ steps.self_mutation.outputs.self_mutation_happened }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
       - name: Login to private npm registry
         run: npm config set @winglang:registry https://npm.pkg.github.com && npm set //npm.pkg.github.com/:_authToken ${{ secrets.GITHUB_TOKEN }}
-      - name: Setup Node.js
+      - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: ${{ env.NODEJS_VERSION }}
+          registry-url: https://npm.pkg.github.com
       - name: Build transitive dependency (wing-api-checker)
-        run: npm install && npm run build
+        run: npm ci && npm run build
         working-directory: apps/wing-api-checker
       - name: Build transitive dependency (jsii-docgen)
-        run: npm install && npm run build
+        run: npm ci && npm run build
         working-directory: apps/jsii-docgen
       - name: Install dependencies
-        run: npm install
+        run: npm ci
       - name: build
         run: npx projen build
       - id: self_mutation
@@ -56,6 +60,9 @@ jobs:
           git config user.name "github-actions"
           git config user.email "github-actions@github.com"
           git commit -s -m "chore: self mutation"
-          git push origin HEAD:${{ github.event.ref }}
+          git push origin HEAD:${{ github.event.pull_request.head.ref }}
+      - name: Fail if mutated
+        if: steps.self_mutation.outputs.self_mutation_happened
+        run: |
           echo "::error::Files were changed during build (see build log)."
           exit 1


### PR DESCRIPTION
## NOTE: This PR is not mergeable without admin override

Because the workflows won't run until merged to main. My fork at https://github.com/MarkMcCulloh/wing has example of the workflow running on a fork (AKA a place that doesn't have access to all the secrets). I propose an admin force merges this PR.

### What's going on here:
- build workflow now uses pull_request_target in addition to push (for `main` only)
- Ensured PROJEN_GITHUB_TOKEN is only used in places that would have access to it (pushes to main on our repo)
  - GITHUB_TOKEN should have all the permissions needed to do what we need in forks
- Simplified the self-mutation logic and verified it works in a fork. Eventually, the self mutator won't be specific to wingsdk :)

Fixes #256

*By submitting this pull request, I confirm that my contribution is made under the terms of the 
[Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.
