### PR TITLE
feat: mutable arrays and sets

### DIFF
--- a/examples/tests/invalid/container_types.w
+++ b/examples/tests/invalid/container_types.w
@@ -1,12 +1,20 @@
 //Array tests
 let arr1: Array<num> = [1, "2", 3];
 let arr2 = Array<num> {1, 2, 3};
+let arr3 = Array<str>["hello"];
+let arr4: Array<num> = arr3;
+arr1.some_random_method();
 
 //Map tests
 let m1: Map<num> = {"a":1, "b":"2", "c":3};
 let m2: Map<num> = ["a":1, "b":"2", "c":3];
+let m3 = Map<str>{"h":"h"};
+let m4: Map<num> = m3;m1.some_random_method();
 
 //Set tests
 let s1: Set<num> = {1, "2", 3};
 let s2 = Set<num> [1, "2", 3];
 let s3: Set<num> = [1, "2", 3];
+let s4 = Set<num>{1,2};
+let s5: Set<str> = s4;
+s1.some_random_method();

--- a/examples/tests/invalid/mut_container_types.w
+++ b/examples/tests/invalid/mut_container_types.w
@@ -1,0 +1,9 @@
+//Array tests
+let arr1 = MutArray<num>[1, "2", 3];
+let arr2 = MutArray<num>{1, 2, 3};
+let arr3: MutArray<num> = [1, 2, 3]; // https://github.com/winglang/wing/issues/1117
+
+//Set tests
+let s1 = MutSet<num>{1, "2", 3};
+let s2 = MutSet<num>[1, "2", 3];
+let s3: MutSet<num> = {1, 1, 3}; // https://github.com/winglang/wing/issues/1117

--- a/examples/tests/invalid/mut_container_types.w
+++ b/examples/tests/invalid/mut_container_types.w
@@ -2,8 +2,14 @@
 let arr1 = MutArray<num>[1, "2", 3];
 let arr2 = MutArray<num>{1, 2, 3};
 let arr3: MutArray<num> = [1, 2, 3]; // https://github.com/winglang/wing/issues/1117
+let arr4 = MutArray<str>["a","b"];
+let arr5: MutArray<num> = arr4;
+arr1.some_method();
 
 //Set tests
 let s1 = MutSet<num>{1, "2", 3};
 let s2 = MutSet<num>[1, "2", 3];
 let s3: MutSet<num> = {1, 1, 3}; // https://github.com/winglang/wing/issues/1117
+let s4 = MutSet<str>{"hi"};
+let s5: MutSet<num> = s4;
+s3.some_method();

--- a/examples/tests/valid/container_types.w
+++ b/examples/tests/valid/container_types.w
@@ -1,16 +1,19 @@
 bring cloud;
 
-//Array tests
-let arr1 = [1, 2, 3];
-let arr2: Array<num> = [1, 2, 3];
-let arr3 = Array<num>[1, 2, 3];
-let arr4: Array<num> = Array<num>[1, 2, 3];
-
 let bucket1 = new cloud.Bucket() as "bucket1";
 let bucket2 = new cloud.Bucket() as "bucket2";
 let bucket3 = new cloud.Bucket() as "bucket3";
+
+//Array tests
+let arr1 = [1, 2, 3];
+let arr2: Array<str> = ["1", "2", "3"];
+let arr3 = Array<num>[1, 2, 3];
+let arr4: Array<num> = Array<num>[1, 2, 3];
 let arr5 = [bucket1, bucket2, bucket3];
 let arr6: Array<cloud.Bucket> = [bucket1, bucket2, bucket3];
+let arr7: Array<num> = arr4;
+assert(arr1.length == 3);
+assert(arr2.at(1) == "2");
 
 //Map tests
 let m1 = {"a":1, "b":2, "c":3};
@@ -19,9 +22,14 @@ let m3 = Map<num> {"a":1, "b":2, "c":3};
 let m4: Map<num> = Map<num> {"a":1, "b":2, "c":3};
 let m5 = {"a":bucket1, "b":bucket2, "c":bucket3};
 let m6: Map<cloud.Bucket> = {"a":bucket1, "b":bucket2, "c":bucket3};
+let m7: Map<num> = m1;
+// TODO: add map API tests
 
 //Set tests
 let s2: Set<num> = {1, 2, 3};
 let s3 = Set<num> {1, 2, 3};
 let s4: Set<num> = Set<num> {1, 2, 3};
 let s6: Set<cloud.Bucket> = {bucket1, bucket2, bucket3};
+let s7: Set<num> = s2;
+assert(s2.size == 3);
+assert(s3.has(2));

--- a/examples/tests/valid/mut_container_types.w
+++ b/examples/tests/valid/mut_container_types.w
@@ -8,9 +8,13 @@ let bucket3 = new cloud.Bucket() as "bucket3";
 let arr1 = MutArray<str>["a", "b", "c"];
 let arr2: MutArray<num> = MutArray<num>[1, 2, 3];
 let arr3 = MutArray<cloud.Bucket>[bucket1, bucket2];
+let arr4: MutArray<str> = arr1;
 arr1.push("a");
 arr2.push(4);
 arr3.push(bucket3);
+assert(arr2.pop() == 4);
+assert(arr1.length == 4);
+assert(arr4.at(0) == "a");
 
 //Set tests
 let s1 = MutSet<num>{1, 2, 3, 3};
@@ -19,3 +23,6 @@ let s3 = MutSet<cloud.Bucket>{bucket1, bucket2, bucket2};
 s1.add(5);
 s2.add("bye");
 s3.add(bucket3);
+assert(s2.has("bye"));
+assert(s2.has("hello"));
+assert(s3.has(bucket2));

--- a/examples/tests/valid/mut_container_types.w
+++ b/examples/tests/valid/mut_container_types.w
@@ -1,0 +1,21 @@
+bring cloud;
+
+let bucket1 = new cloud.Bucket() as "bucket1";
+let bucket2 = new cloud.Bucket() as "bucket2";
+let bucket3 = new cloud.Bucket() as "bucket3";
+
+//Array tests
+let arr1 = MutArray<str>["a", "b", "c"];
+let arr2: MutArray<num> = MutArray<num>[1, 2, 3];
+let arr3 = MutArray<cloud.Bucket>[bucket1, bucket2];
+arr1.push("a");
+arr2.push(4);
+arr3.push(bucket3);
+
+//Set tests
+let s1 = MutSet<num>{1, 2, 3, 3};
+let s2: MutSet<str> = MutSet<str>{"hello", "world", "hello"};
+let s3 = MutSet<cloud.Bucket>{bucket1, bucket2, bucket2};
+s1.add(5);
+s2.add("bye");
+s3.add(bucket3);

--- a/libs/wingc/src/ast.rs
+++ b/libs/wingc/src/ast.rs
@@ -77,8 +77,10 @@ pub enum Type {
 	Duration,
 	Optional(Box<Type>),
 	Array(Box<Type>),
+	MutArray(Box<Type>),
 	Map(Box<Type>),
 	Set(Box<Type>),
+	MutSet(Box<Type>),
 	FunctionSignature(FunctionSignature),
 	CustomType { root: Symbol, fields: Vec<Symbol> },
 }
@@ -92,8 +94,10 @@ impl Display for Type {
 			Type::Duration => write!(f, "duration"),
 			Type::Optional(t) => write!(f, "{}?", t),
 			Type::Array(t) => write!(f, "Array<{}>", t),
+			Type::MutArray(t) => write!(f, "MutArray<{}>", t),
 			Type::Map(t) => write!(f, "Map<{}>", t),
 			Type::Set(t) => write!(f, "Set<{}>", t),
+			Type::MutSet(t) => write!(f, "MutSet<{}>", t),
 			Type::FunctionSignature(sig) => {
 				write!(
 					f,

--- a/libs/wingc/src/jsify.rs
+++ b/libs/wingc/src/jsify.rs
@@ -431,9 +431,9 @@ impl JSifier {
 					.join(", ");
 
 				if is_mutable_collection(expression) {
-					format!("new Set([{}])",	item_list)					
+					format!("new Set([{}])", item_list)
 				} else {
-					format!("Object.freeze(new Set([{}]))",	item_list)					
+					format!("Object.freeze(new Set([{}]))",	item_list)
 				}
 			}
 			ExprKind::FunctionClosure(func_def) => match func_def.signature.flight {

--- a/libs/wingc/src/lib.rs
+++ b/libs/wingc/src/lib.rs
@@ -31,7 +31,9 @@ const WINGSDK_ASSEMBLY_NAME: &'static str = "@winglang/wingsdk";
 
 const WINGSDK_DURATION: &'static str = "std.Duration";
 const WINGSDK_ARRAY: &'static str = "std.ImmutableArray";
+const WINGSDK_MUT_ARRAY: &'static str = "std.MutableArray";
 const WINGSDK_SET: &'static str = "std.ImmutableSet";
+const WINGSDK_MUT_SET: &'static str = "std.MutableSet";
 const WINGSDK_STRING: &'static str = "std.String";
 const WINGSDK_RESOURCE: &'static str = "core.Resource";
 const WINGSDK_INFLIGHT: &'static str = "core.Inflight";

--- a/libs/wingc/src/parser.rs
+++ b/libs/wingc/src/parser.rs
@@ -459,7 +459,9 @@ impl Parser<'_> {
 				match container_type {
 					"Map" => Ok(Type::Map(Box::new(self.build_type(&element_type)?))),
 					"Array" => Ok(Type::Array(Box::new(self.build_type(&element_type)?))),
+					"MutArray" => Ok(Type::MutArray(Box::new(self.build_type(&element_type)?))),
 					"Set" => Ok(Type::Set(Box::new(self.build_type(&element_type)?))),
+					"MutSet" => Ok(Type::MutSet(Box::new(self.build_type(&element_type)?))),
 					"ERROR" => self.add_error(format!("Expected builtin container type"), type_node)?,
 					other => self.report_unimplemented_grammar(other, "builtin container type", type_node),
 				}

--- a/libs/wingc/src/type_check.rs
+++ b/libs/wingc/src/type_check.rs
@@ -196,6 +196,12 @@ impl PartialEq for Type {
 				let r: &Type = &*r0;
 				l == r
 			}
+			(Self::MutArray(l0), Self::MutArray(r0)) => {
+				// Arrays are of the same type if they have the same value type
+				let l: &Type = &*l0;
+				let r: &Type = &*r0;
+				l == r
+			}
 			(Self::Map(l0), Self::Map(r0)) => {
 				// Maps are of the same type if they have the same value type
 				let l: &Type = &*l0;
@@ -206,6 +212,13 @@ impl PartialEq for Type {
 				// Sets are of the same type if they have the same value type
 				let l: &Type = &*l0;
 				let r: &Type = &*r0;
+				l == r
+			}
+			(Self::MutSet(l0), Self::MutSet(r0)) => {
+				// Sets are of the same type if they have the same value type
+				let l: &Type = &*l0;
+				let r: &Type = &*r0;
+				println!("MutSet-->{} == {}", l, r);
 				l == r
 			}
 			(Self::Optional(l0), Self::Optional(r0)) => {

--- a/libs/wingc/src/type_check.rs
+++ b/libs/wingc/src/type_check.rs
@@ -2,7 +2,7 @@ mod jsii_importer;
 pub mod symbol_env;
 use crate::ast::{Type as AstType, *};
 use crate::diagnostic::{Diagnostic, DiagnosticLevel, Diagnostics, TypeError, WingSpan};
-use crate::{debug, WINGSDK_ARRAY, WINGSDK_DURATION, WINGSDK_SET, WINGSDK_STRING};
+use crate::{debug, WINGSDK_ARRAY, WINGSDK_DURATION, WINGSDK_SET, WINGSDK_STRING, WINGSDK_MUT_ARRAY, WINGSDK_MUT_SET};
 use derivative::Derivative;
 use indexmap::IndexSet;
 use jsii_importer::JsiiImporter;
@@ -86,8 +86,10 @@ pub enum Type {
 	Boolean,
 	Optional(TypeRef),
 	Array(TypeRef),
+	MutArray(TypeRef),
 	Map(TypeRef),
 	Set(TypeRef),
+	MutSet(TypeRef),
 	Function(FunctionSignature),
 	Class(Class),
 	Resource(Class),
@@ -270,8 +272,10 @@ impl Display for Type {
 			Type::Resource(class) => write!(f, "{}", class.name),
 			Type::Struct(s) => write!(f, "{}", s.name),
 			Type::Array(v) => write!(f, "Array<{}>", v),
+			Type::MutArray(v) => write!(f, "MutArray<{}>", v),
 			Type::Map(v) => write!(f, "Map<{}>", v),
 			Type::Set(v) => write!(f, "Set<{}>", v),
+			Type::MutSet(v) => write!(f, "MutSet<{}>", v),
 			Type::Enum(s) => write!(f, "{}", s.name),
 		}
 	}
@@ -352,6 +356,14 @@ impl TypeRef {
 
 	pub fn is_immutable_collection(&self) -> bool {
 		if let Type::Array(_) | Type::Map(_) | Type::Set(_) = **self {
+			true
+		} else {
+			false
+		}
+	}
+
+	pub fn is_mutable_collection(&self) -> bool {
+		if let Type::MutArray(_) | Type::MutSet(_) = **self {
 			true
 		} else {
 			false
@@ -811,6 +823,7 @@ impl<'a> TypeChecker<'a> {
 
 				let element_type = match *container_type {
 					Type::Array(t) => t,
+					Type::MutArray(t) => t,
 					_ => self.expr_error(exp, format!("Expected \"Array\" type, found \"{}\"", container_type)),
 				};
 
@@ -900,6 +913,7 @@ impl<'a> TypeChecker<'a> {
 
 				let element_type = match *container_type {
 					Type::Set(t) => t,
+					Type::MutSet(t) => t,
 					_ => self.expr_error(exp, format!("Expected \"Set\" type, found \"{}\"", container_type)),
 				};
 
@@ -1085,10 +1099,20 @@ impl<'a> TypeChecker<'a> {
 				// TODO: avoid creating a new type for each array resolution
 				self.types.add_type(Type::Array(value_type))
 			}
+			AstType::MutArray(v) => {
+				let value_type = self.resolve_type(v, env, statement_idx);
+				// TODO: avoid creating a new type for each array resolution
+				self.types.add_type(Type::MutArray(value_type))
+			}
 			AstType::Set(v) => {
 				let value_type = self.resolve_type(v, env, statement_idx);
 				// TODO: avoid creating a new type for each set resolution
 				self.types.add_type(Type::Set(value_type))
+			}
+			AstType::MutSet(v) => {
+				let value_type = self.resolve_type(v, env, statement_idx);
+				// TODO: avoid creating a new type for each set resolution
+				self.types.add_type(Type::MutSet(value_type))
 			}
 			AstType::Map(v) => {
 				let value_type = self.resolve_type(v, env, statement_idx);
@@ -1714,8 +1738,16 @@ impl<'a> TypeChecker<'a> {
 						let new_class = self.hydrate_class_type_arguments(env, WINGSDK_ARRAY, t);
 						self.get_property_from_class(new_class.as_class().unwrap(), property)
 					}
+					Type::MutArray(t) => {
+						let new_class = self.hydrate_class_type_arguments(env, WINGSDK_MUT_ARRAY, t);
+						self.get_property_from_class(new_class.as_class().unwrap(), property)
+					}
 					Type::Set(t) => {
 						let new_class = self.hydrate_class_type_arguments(env, WINGSDK_SET, t);
+						self.get_property_from_class(new_class.as_class().unwrap(), property)
+					}
+					Type::MutSet(t) => {
+						let new_class = self.hydrate_class_type_arguments(env, WINGSDK_MUT_SET, t);
 						self.get_property_from_class(new_class.as_class().unwrap(), property)
 					}
 					Type::String => self.get_property_from_class(

--- a/libs/wingc/src/type_check.rs
+++ b/libs/wingc/src/type_check.rs
@@ -218,7 +218,6 @@ impl PartialEq for Type {
 				// Sets are of the same type if they have the same value type
 				let l: &Type = &*l0;
 				let r: &Type = &*r0;
-				println!("MutSet-->{} == {}", l, r);
 				l == r
 			}
 			(Self::Optional(l0), Self::Optional(r0)) => {

--- a/libs/wingsdk/src/std/set.ts
+++ b/libs/wingsdk/src/std/set.ts
@@ -13,6 +13,16 @@ export class ImmutableSet {
   public get size(): number {
     throw new Error("Abstract");
   }
+
+  /**
+   * Returns a boolean indicating whether an element with the specified value exists in the set.
+   * @param value The value to test for presence in the Set object.
+   * @returns Returns `true` if an element with the specified value exists in the set; otherwise `false`.
+   */
+  public has(value: any): boolean {
+    value;
+    throw new Error("Abstract");
+  }
 }
 
 /**
@@ -25,6 +35,23 @@ export class MutableSet extends ImmutableSet {
    * @returns true if the value was added, false if it was already in the set
    */
   public add(value: any): MutableSet {
+    value;
+    throw new Error("Abstract");
+  }
+
+  /**
+   * The clear() method removes all elements from a set.
+   */
+  public clear(): void {
+    throw new Error("Abstract");
+  }
+
+  /**
+   * Removes a specified value from a set, if it is in the set.
+   * @param value The value to remove from the set.
+   * @returns Returns `true` if `value` was already in the set; otherwise `false`.
+   */
+  public delete(value: any): boolean {
     value;
     throw new Error("Abstract");
   }

--- a/libs/wingsdk/test/target-sim/queue.test.ts
+++ b/libs/wingsdk/test/target-sim/queue.test.ts
@@ -2,7 +2,7 @@ import * as cloud from "../../src/cloud";
 import { SimApp, Testing } from "../../src/testing";
 import { listMessages } from "./util";
 
-jest.setTimeout(10_000); // 5 seconds
+jest.setTimeout(5 * 60 * 1000); // 5 minutes
 
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 

--- a/tools/hangar/src/__snapshots__/cli.test.ts.snap
+++ b/tools/hangar/src/__snapshots__/cli.test.ts.snap
@@ -2112,6 +2112,203 @@ constructor() {
 new MyApp().synth();"
 `;
 
+exports[`wing compile mut_container_types.w > cdk.tf.json 1`] = `
+{
+  "//": {
+    "metadata": {
+      "backend": "local",
+      "stackName": "root",
+      "version": "0.13.2",
+    },
+    "outputs": {},
+  },
+  "provider": {
+    "aws": [
+      {},
+    ],
+  },
+  "resource": {
+    "aws_s3_bucket": {
+      "root_bucket1_3A77B9B4": {
+        "//": {
+          "metadata": {
+            "path": "root/bucket1/Default",
+            "uniqueId": "root_bucket1_3A77B9B4",
+          },
+        },
+      },
+      "root_bucket2_E39F70EE": {
+        "//": {
+          "metadata": {
+            "path": "root/bucket2/Default",
+            "uniqueId": "root_bucket2_E39F70EE",
+          },
+        },
+      },
+      "root_bucket3_A0C568EA": {
+        "//": {
+          "metadata": {
+            "path": "root/bucket3/Default",
+            "uniqueId": "root_bucket3_A0C568EA",
+          },
+        },
+      },
+    },
+    "aws_s3_bucket_public_access_block": {
+      "root_bucket1_PublicAccessBlock_6C5071C0": {
+        "//": {
+          "metadata": {
+            "path": "root/bucket1/PublicAccessBlock",
+            "uniqueId": "root_bucket1_PublicAccessBlock_6C5071C0",
+          },
+        },
+        "block_public_acls": true,
+        "block_public_policy": true,
+        "bucket": "\${aws_s3_bucket.root_bucket1_3A77B9B4.bucket}",
+        "ignore_public_acls": true,
+        "restrict_public_buckets": true,
+      },
+      "root_bucket2_PublicAccessBlock_BC328E84": {
+        "//": {
+          "metadata": {
+            "path": "root/bucket2/PublicAccessBlock",
+            "uniqueId": "root_bucket2_PublicAccessBlock_BC328E84",
+          },
+        },
+        "block_public_acls": true,
+        "block_public_policy": true,
+        "bucket": "\${aws_s3_bucket.root_bucket2_E39F70EE.bucket}",
+        "ignore_public_acls": true,
+        "restrict_public_buckets": true,
+      },
+      "root_bucket3_PublicAccessBlock_CF2593D4": {
+        "//": {
+          "metadata": {
+            "path": "root/bucket3/PublicAccessBlock",
+            "uniqueId": "root_bucket3_PublicAccessBlock_CF2593D4",
+          },
+        },
+        "block_public_acls": true,
+        "block_public_policy": true,
+        "bucket": "\${aws_s3_bucket.root_bucket3_A0C568EA.bucket}",
+        "ignore_public_acls": true,
+        "restrict_public_buckets": true,
+      },
+    },
+    "aws_s3_bucket_server_side_encryption_configuration": {
+      "root_bucket1_Encryption_33CABC1A": {
+        "//": {
+          "metadata": {
+            "path": "root/bucket1/Encryption",
+            "uniqueId": "root_bucket1_Encryption_33CABC1A",
+          },
+        },
+        "bucket": "\${aws_s3_bucket.root_bucket1_3A77B9B4.bucket}",
+        "rule": [
+          {
+            "apply_server_side_encryption_by_default": {
+              "sse_algorithm": "AES256",
+            },
+          },
+        ],
+      },
+      "root_bucket2_Encryption_A83E82F9": {
+        "//": {
+          "metadata": {
+            "path": "root/bucket2/Encryption",
+            "uniqueId": "root_bucket2_Encryption_A83E82F9",
+          },
+        },
+        "bucket": "\${aws_s3_bucket.root_bucket2_E39F70EE.bucket}",
+        "rule": [
+          {
+            "apply_server_side_encryption_by_default": {
+              "sse_algorithm": "AES256",
+            },
+          },
+        ],
+      },
+      "root_bucket3_Encryption_A2A51E22": {
+        "//": {
+          "metadata": {
+            "path": "root/bucket3/Encryption",
+            "uniqueId": "root_bucket3_Encryption_A2A51E22",
+          },
+        },
+        "bucket": "\${aws_s3_bucket.root_bucket3_A0C568EA.bucket}",
+        "rule": [
+          {
+            "apply_server_side_encryption_by_default": {
+              "sse_algorithm": "AES256",
+            },
+          },
+        ],
+      },
+    },
+  },
+}
+`;
+
+exports[`wing compile mut_container_types.w > manifest.json 1`] = `
+{
+  "stacks": {
+    "root": {
+      "annotations": [],
+      "constructPath": "root",
+      "dependencies": [],
+      "name": "root",
+      "synthesizedStackPath": "stacks/root/cdk.tf.json",
+      "workingDirectory": "stacks/root",
+    },
+  },
+  "version": "0.13.2",
+}
+`;
+
+exports[`wing compile mut_container_types.w > preflight.js 1`] = `
+"const $stdlib = require('@winglang/wingsdk');
+const $outdir = process.env.WINGSDK_SYNTH_DIR ?? \\".\\";
+
+function __app(target) {
+	switch (target) {
+		case \\"sim\\":
+			return $stdlib.sim.App;
+		case \\"tfaws\\":
+		case \\"tf-aws\\":
+			return $stdlib.tfaws.App;
+    case \\"tf-azure\\":
+      return $stdlib.tfazure.App;
+		default:
+			throw new Error(\`Unknown WING_TARGET value: \\"\${process.env.WING_TARGET ?? \\"\\"}\\"\`);
+	}
+}
+const $App = __app(process.env.WING_TARGET);
+
+const cloud = require('@winglang/wingsdk').cloud;
+class MyApp extends $App {
+constructor() {
+  super({ outdir: $outdir, name: \\"mut_container_types\\" });
+  
+  const bucket1 = new cloud.Bucket(this,\\"bucket1\\");
+  const bucket2 = new cloud.Bucket(this,\\"bucket2\\");
+  const bucket3 = new cloud.Bucket(this,\\"bucket3\\");
+  const arr1 = [\\"a\\", \\"b\\", \\"c\\"];
+  const arr2 = [1, 2, 3];
+  const arr3 = [bucket1, bucket2];
+  (arr1.push(\\"a\\"));
+  (arr2.push(4));
+  (arr3.push(bucket3));
+  const s1 = new Set([1, 2, 3, 3]);
+  const s2 = new Set([\\"hello\\", \\"world\\", \\"hello\\"]);
+  const s3 = new Set([bucket1, bucket2, bucket2]);
+  (s1.add(5));
+  (s2.add(\\"bye\\"));
+  (s3.add(bucket3));
+}
+}
+new MyApp().synth();"
+`;
+
 exports[`wing compile primitive_methods.w > cdk.tf.json 1`] = `
 {
   "//": {

--- a/tools/hangar/src/__snapshots__/cli.test.ts.snap
+++ b/tools/hangar/src/__snapshots__/cli.test.ts.snap
@@ -1253,25 +1253,32 @@ class MyApp extends $App {
 constructor() {
   super({ outdir: $outdir, name: \\"container_types\\" });
   
-  const arr1 = Object.freeze([1, 2, 3]);
-  const arr2 = Object.freeze([1, 2, 3]);
-  const arr3 = Object.freeze([1, 2, 3]);
-  const arr4 = Object.freeze([1, 2, 3]);
   const bucket1 = new cloud.Bucket(this,\\"bucket1\\");
   const bucket2 = new cloud.Bucket(this,\\"bucket2\\");
   const bucket3 = new cloud.Bucket(this,\\"bucket3\\");
+  const arr1 = Object.freeze([1, 2, 3]);
+  const arr2 = Object.freeze([\\"1\\", \\"2\\", \\"3\\"]);
+  const arr3 = Object.freeze([1, 2, 3]);
+  const arr4 = Object.freeze([1, 2, 3]);
   const arr5 = Object.freeze([bucket1, bucket2, bucket3]);
   const arr6 = Object.freeze([bucket1, bucket2, bucket3]);
+  const arr7 = arr4;
+  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(arr1.length === 3)'\`)})((arr1.length === 3))};
+  {((cond) => {if (!cond) throw new Error(\`assertion failed: '((arr2.at(1)) === \\"2\\")'\`)})(((arr2.at(1)) === \\"2\\"))};
   const m1 = Object.freeze({\\"a\\": 1, \\"b\\": 2, \\"c\\": 3});
   const m2 = Object.freeze({\\"a\\": 1, \\"b\\": 2, \\"c\\": 3});
   const m3 = Object.freeze({\\"a\\": 1, \\"b\\": 2, \\"c\\": 3});
   const m4 = Object.freeze({\\"a\\": 1, \\"b\\": 2, \\"c\\": 3});
   const m5 = Object.freeze({\\"a\\": bucket1, \\"b\\": bucket2, \\"c\\": bucket3});
   const m6 = Object.freeze({\\"a\\": bucket1, \\"b\\": bucket2, \\"c\\": bucket3});
+  const m7 = m1;
   const s2 = Object.freeze(new Set([1, 2, 3]));
   const s3 = Object.freeze(new Set([1, 2, 3]));
   const s4 = Object.freeze(new Set([1, 2, 3]));
   const s6 = Object.freeze(new Set([bucket1, bucket2, bucket3]));
+  const s7 = s2;
+  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(s2.size === 3)'\`)})((s2.size === 3))};
+  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(s3.has(2))'\`)})((s3.has(2)))};
 }
 }
 new MyApp().synth();"
@@ -2295,15 +2302,22 @@ constructor() {
   const arr1 = [\\"a\\", \\"b\\", \\"c\\"];
   const arr2 = [1, 2, 3];
   const arr3 = [bucket1, bucket2];
+  const arr4 = arr1;
   (arr1.push(\\"a\\"));
   (arr2.push(4));
   (arr3.push(bucket3));
+  {((cond) => {if (!cond) throw new Error(\`assertion failed: '((arr2.pop()) === 4)'\`)})(((arr2.pop()) === 4))};
+  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(arr1.length === 4)'\`)})((arr1.length === 4))};
+  {((cond) => {if (!cond) throw new Error(\`assertion failed: '((arr4.at(0)) === \\"a\\")'\`)})(((arr4.at(0)) === \\"a\\"))};
   const s1 = new Set([1, 2, 3, 3]);
   const s2 = new Set([\\"hello\\", \\"world\\", \\"hello\\"]);
   const s3 = new Set([bucket1, bucket2, bucket2]);
   (s1.add(5));
   (s2.add(\\"bye\\"));
   (s3.add(bucket3));
+  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(s2.has(\\"bye\\"))'\`)})((s2.has(\\"bye\\")))};
+  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(s2.has(\\"hello\\"))'\`)})((s2.has(\\"hello\\")))};
+  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(s3.has(bucket2))'\`)})((s3.has(bucket2)))};
 }
 }
 new MyApp().synth();"


### PR DESCRIPTION
Adds support for mutable arrays and sets.

Misc:
- Add `Set.has()`, `MutSet.clear()` and `MutSet.delete()`.
- Add tests for all std APIs.
- Add some invalid tests for partial equality.

Resolves #852 
Resolves #663 

*By submitting this pull request, I confirm that my contribution is made under the terms of the 
[Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.
