### PR TITLE
rfc: added missing semicolon

### DIFF
--- a/rfcs/story10.md
+++ b/rfcs/story10.md
@@ -77,7 +77,7 @@ new cloud.Function(inflight (s: str): str => {
 }) as "test: add a new task";
 
 new cloud.Function(inflight (s: str): str => {
-    let expected = "task 42"
+    let expected = "task 42";
     let id = add_task.invoke(expected);
     print("added new task with id ${id}");
     let content = get_task.invoke(id);


### PR DESCRIPTION
Added a missing semicolon on this line:
```ts
let expected = "task 42"
```
Credit to @schosterbarak for reporting this issue.

*By submitting this pull request, I confirm that my contribution is made under the terms of the 
[Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.
