### PR TITLE
chore(repo): add mergify to handle merge queue

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,29 @@
+# See https://doc.mergify.io
+queue_rules:
+  - name: default
+    conditions:
+      - status-success=build
+      - status-success=Validate PR title
+
+pull_request_rules:
+  - name: automatic merge
+    actions:
+      comment:
+        message: Thank you for contributing! Your pull request will be updated from main and then merged automatically (do not update manually, and be sure to [allow changes to be pushed to your fork](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)).
+      queue:
+        name: default
+        method: squash
+        commit_message_template: |-
+          {{ title }} (#{{ number }})
+          {{ body }}
+    conditions:
+      - -title~=(WIP|wip)
+      - -label~=(do-not-merge)
+      - -merged
+      - -closed
+      - "#approved-reviews-by>=1"
+      - "#changes-requested-reviews-by=0"
+      - "#review-threads-unresolved=0"
+      - -approved-reviews-by~=author
+      - check-success=build
+      - check-success=Validate PR title


### PR DESCRIPTION
This is a very bare-bones mergify config. This is just enough to handle a merge queue. After this gets merged, we should be able to make the "mergify summary check" the only required check. Then we can start getting fancy.

Fixes #698

*By submitting this pull request, I confirm that my contribution is made under the terms of the 
[Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.
