### PR TITLE
fix(docs): failure to migrate from closed alpha

### DIFF
--- a/docs/02-getting-started/02-installation.md
+++ b/docs/02-getting-started/02-installation.md
@@ -26,6 +26,32 @@ In order to deploy to AWS, you will also need:
 
 ## Wing CLI
 
+:::caution If you were in our closed alpha
+
+If you installed Wing as part of our closed alpha, please make sure to uninstall the existing version
+and clean up your `~/.npmrc` before continuing. Otherwise you will see the following error when trying
+to install `winglang`:
+
+```
+Not Found - GET https://npm.pkg.github.com/@winglang%2fsdk
+```
+
+First, uninstall Wing from your system:
+
+```sh
+npm uninstall -g @winglang/wing
+```
+
+Now, edit `~/.npmrc` and remove this line:
+
+```
+@winglang:registry=https://npm.pkg.github.com/
+```
+
+You can also just delete `~/.npmrc` if there are no other registries that you are signed into.
+
+:::
+
 Install the Wing CLI through npm:
 
 ```sh

--- a/docs/02-getting-started/02-installation.md
+++ b/docs/02-getting-started/02-installation.md
@@ -26,8 +26,10 @@ In order to deploy to AWS, you will also need:
 
 ## Wing CLI
 
+</br>
 <details>
-  <summary>caution If you were in our closed alpha</summary>
+  <summary><b>!Caution If you were in our closed alpha</b></summary>
+</br>
 
 If you installed Wing as part of our closed alpha, please make sure to uninstall the existing version
 and clean up your `~/.npmrc` before continuing. Otherwise you will see the following error when trying
@@ -53,6 +55,7 @@ You can also just delete `~/.npmrc` if there are no other registries that you ar
 
 </details>
 
+</br>
 Install the Wing CLI through npm:
 
 ```sh

--- a/docs/02-getting-started/02-installation.md
+++ b/docs/02-getting-started/02-installation.md
@@ -26,7 +26,8 @@ In order to deploy to AWS, you will also need:
 
 ## Wing CLI
 
-:::caution If you were in our closed alpha
+<details>
+  <summary>caution If you were in our closed alpha</summary>
 
 If you installed Wing as part of our closed alpha, please make sure to uninstall the existing version
 and clean up your `~/.npmrc` before continuing. Otherwise you will see the following error when trying
@@ -50,7 +51,7 @@ Now, edit `~/.npmrc` and remove this line:
 
 You can also just delete `~/.npmrc` if there are no other registries that you are signed into.
 
-:::
+</details>
 
 Install the Wing CLI through npm:
 

--- a/docs/99-status.md
+++ b/docs/99-status.md
@@ -27,5 +27,7 @@ sufficient surface area across the various components.
 We manage our project roadmap through GitHub projects, which should offer an
 up-to-date view on what we've completed, what we are working on and our backlog.
 
-You will need to [sign up](https://t.winglang.io/alpha) for repository access to view.
+* [Compiler Roadmap](https://github.com/orgs/winglang/projects/1)
+* [SDK Roadmap](https://github.com/orgs/winglang/projects/3)
+* [Beta Roadmap](https://github.com/orgs/winglang/projects/2)
 


### PR DESCRIPTION
Update the getting started guide to instruct users on how to upgrade from the closed alpha version (`@winglang/wing`).

Fixes #1174 


*By submitting this pull request, I confirm that my contribution is made under the terms of the 
[Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.
