### PR TITLE
feat: wing docs

### DIFF
--- a/apps/wing/src/commands/docs.ts
+++ b/apps/wing/src/commands/docs.ts
@@ -1,0 +1,5 @@
+import * as open from "open";
+
+export async function docs() {
+  await open("https://docs.winglang.io");
+}

--- a/apps/wing/src/commands/index.ts
+++ b/apps/wing/src/commands/index.ts
@@ -1,2 +1,3 @@
 export * from "./compile";
 export * from "./upgrade";
+export * from "./docs";

--- a/apps/wing/src/index.ts
+++ b/apps/wing/src/index.ts
@@ -1,7 +1,7 @@
 // for WebAssembly typings:
 /// <reference lib="dom" />
 
-import { compile, upgrade } from "./commands";
+import { compile, docs, upgrade } from "./commands";
 import { join, resolve } from "path";
 import { satisfies } from 'compare-versions';
 
@@ -52,6 +52,11 @@ async function main() {
       "tf-aws"
     )
     .action(compile);
+
+  program
+    .command("docs")
+    .description("Open the Wing documentation")
+    .action(docs);
 
   program
     .command("upgrade")


### PR DESCRIPTION
The `wing docs` command will open https://docs.winglang.io.

In the future it will support showing docs for libraries and other fun things.



*By submitting this pull request, I confirm that my contribution is made under the terms of the 
[Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.
