### PR TITLE
fix: cross-platform wing cli shebang

### DIFF
--- a/apps/wing/bin/wing
+++ b/apps/wing/bin/wing
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S node --experimental-wasi-unstable-preview1 --no-warnings
+#!/usr/bin/env node
 
 // Only certain builds and versions of Node support WASI.
 // We first assume this script is loaded in the correct runtime environment, and


### PR DESCRIPTION
This simplified shebang should be able to run anywhere. The downside is the now-required `spawn`, but I think that's worth revisiting later.

Note: this PR **does not** confirm windows support (although windows may work now 😁), but it does resolve #1157

*By submitting this pull request, I confirm that my contribution is made under the terms of the 
[Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.
