### PR TITLE
feat(cli): wing it does not require a file name for single file folders

### DIFF
--- a/apps/wing/src/commands/index.ts
+++ b/apps/wing/src/commands/index.ts
@@ -2,3 +2,4 @@ export * from "./compile";
 export * from "./upgrade";
 export * from "./test";
 export * from "./docs";
+export * from "./run";

--- a/apps/wing/src/commands/run.test.ts
+++ b/apps/wing/src/commands/run.test.ts
@@ -1,0 +1,72 @@
+import * as open from "open";
+import { run } from "./run";
+import { mkdtemp } from "fs/promises";
+import { join } from "path";
+import { tmpdir } from "os";
+import { writeFileSync } from "fs";
+import { resolve } from "path";
+
+jest.mock("open");
+
+test("wing it runs the only .w file", async () => {  
+  const workdir = await mkdtemp(join(tmpdir(), "-wing-it-test"));
+  const prevdir = process.cwd();
+  try {
+    process.chdir(workdir);
+
+    writeFileSync("foo.w", "bring cloud;");
+
+    await run();
+    expect(open).toBeCalledWith("wing-console://" + resolve("foo.w"));
+  
+  } finally {
+    process.chdir(prevdir);
+  }
+});
+
+test("wing it with no file throws error for a directory with more than 1 .w file", async () => {  
+    const workdir = await mkdtemp(join(tmpdir(), "-wing-it-test"));
+    const prevdir = process.cwd();
+    try {
+      process.chdir(workdir);
+  
+      writeFileSync("foo.w", "bring cloud;");
+      writeFileSync("bar.w", "bring cloud;");
+  
+      await expect(run).rejects.toThrow("Please specify which file you want to run");
+    
+    } finally {
+      process.chdir(prevdir);
+    }
+});
+  
+test("wing it with a file runs", async () => {  
+    const workdir = await mkdtemp(join(tmpdir(), "-wing-it-test"));
+    const prevdir = process.cwd();
+    try {
+      process.chdir(workdir);
+  
+      writeFileSync("foo.w", "bring cloud;");
+  
+      await run("foo.w");
+      expect(open).toBeCalledWith("wing-console://" + resolve("foo.w"));
+    
+    } finally {
+      process.chdir(prevdir);
+    }
+});
+
+test("wing it with an invalid file throws exception", async () => {  
+    const workdir = await mkdtemp(join(tmpdir(), "-wing-it-test"));
+    const prevdir = process.cwd();
+    try {
+      process.chdir(workdir);
+  
+      writeFileSync("foo.w", "bring cloud;");
+  
+      await expect(run("bar.w")).rejects.toThrow("bar.w doesn't exist");
+    
+    } finally {
+      process.chdir(prevdir);
+    }
+});

--- a/apps/wing/src/commands/run.ts
+++ b/apps/wing/src/commands/run.ts
@@ -1,0 +1,20 @@
+import { readdirSync  } from "fs";
+import { debug } from "debug";
+import { resolve } from "path";
+import open = require("open");
+
+export async function run(simfile?: string) {
+    const wingFiles = readdirSync('.').filter(item => item.endsWith('.w'));
+    if (!simfile) {
+        if (wingFiles.length !== 1) {
+            throw new Error('Please specify which file you want to run');
+        }
+        simfile = wingFiles[0];
+    } else if (!wingFiles.includes(simfile)) {
+        throw new Error(simfile + " doesn't exist");
+    }
+
+    simfile = resolve(simfile);
+    debug("calling wing console protocol with:" + simfile);
+    open("wing-console://" + simfile);
+}

--- a/apps/wing/src/index.ts
+++ b/apps/wing/src/index.ts
@@ -1,13 +1,12 @@
 // for WebAssembly typings:
 /// <reference lib="dom" />
 
-import { compile, docs, test, upgrade } from "./commands";
-import { join, resolve } from "path";
+import { compile, docs, test, upgrade, run } from "./commands";
+import { join } from "path";
 import { satisfies } from 'compare-versions';
 
 import { Command } from "commander";
 import debug from "debug";
-import open = require("open");
 
 const PACKAGE_VERSION = require("../package.json").version as string;
 const SUPPORTED_NODE_VERSION = require("../package.json").engines.node as string;
@@ -30,12 +29,8 @@ async function main() {
     .command("run")
     .alias("it")
     .description("Runs a Wing simulator file in the Wing Console")
-    .argument("<simfile>", ".wsim simulator file")
-    .action(async (simfile: string) => {
-      simfile = resolve(simfile);
-      debug("calling wing console protocol with:" + simfile);
-      open("wing-console://" + simfile).catch(log);
-    });
+    .argument("[simfile]", ".wsim simulator file")
+    .action(run);
 
   program
     .command("compile")


### PR DESCRIPTION
This PR resolves #1112
command `wing it` with no file name will work if there's a single .w file in the directory

*By submitting this pull request, I confirm that my contribution is made under the terms of the 
[Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.
