### PR TITLE
fix(playground): compiler errors missing

### DIFF
--- a/apps/wing-playground/index.html
+++ b/apps/wing-playground/index.html
@@ -21,6 +21,7 @@
       const code = document.getElementById("code");
       const intermediateJS = document.getElementById("intermediateJS");
       const stdout = document.getElementById("stdout");
+      const stderr = document.getElementById("stderr");
       const example = document.getElementById("example");
       const lineCounter = document.getElementById("lineCounter")
 
@@ -65,11 +66,20 @@
           sendCodeToWorker(code.value);
         } else if(e.data) {
           stdout.textContent = e.data.stdout;
+          stderr.textContent = e.data.stderr;
           intermediateJS.textContent = e.data.intermediateJS;
           hljs.highlightAll();
         } else {
           stdout.textContent = "";
+          stderr.textContent = "";
           intermediateJS.textContent = "";
+        }
+
+        // hide intermediateJS if it's empty
+        if (intermediateJS.textContent === "") {
+          intermediateJS.style.display = "none";
+        } else {
+          intermediateJS.style.display = "block";
         }
       });
 
@@ -88,9 +98,8 @@
         <pre>
           <code class="language-javascript" id="intermediateJS"></code>
         </pre>
-        <pre>
-          <code id="stdout" class="no-highlight"></code>
-        </pre>
+          <pre id="stderr" class="stderr"></pre>
+          <pre id="stdout" class="stdout"></pre>
       </section>
     </main>
   </body>
@@ -143,6 +152,16 @@
     #js-side pre {
       /* counters the adjustments made by highlight.js to line up with the wing side */
       margin-top: -0.5em;
+    }
+
+    .stdout {
+      color: white;
+      background: black;
+    }
+
+    .stderr {
+      color: red;
+      background: black;
     }
   </style>
 </html>

--- a/apps/wing-playground/worker.js
+++ b/apps/wing-playground/worker.js
@@ -46,6 +46,11 @@ self.onmessage = async (event) => {
     file.writeString(event.data);
 
     await wingcInvoke(instance, WINGC_COMPILE, "code.w");
+    const stderr = wasi.getStderrString();
+    if (stderr) {
+      throw stderr;
+    }
+
     const stdout = wasi.getStdoutString();
     let intermediateJS = "";
 
@@ -66,13 +71,15 @@ self.onmessage = async (event) => {
 
     self.postMessage({
       stdout,
+      stderr: wasi.getStderrString(),
       intermediateJS,
     });
   } catch (error) {
     console.error(error);
     self.postMessage({
+      stderr: error,
       stdout: wasi.getStdoutString(),
-      intermediateJS: wasi.getStderrString(),
+      intermediateJS: null,
     });
   } finally {
     try {


### PR DESCRIPTION
regressions from https://github.com/winglang/wing/pull/1199

Writing to stderr from wingc was no longer causing an exception in the playground, which was hiding it. This does not affect the CLI, which uses the node WASI system rather than wasmer-js.

I also went ahead and made stderr more obvious, instead of showing it in where the user was expecting JS.

*By submitting this pull request, I confirm that my contribution is made under the terms of the 
[Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.
