### PR TITLE
fix(sdk): simulator crashes when executing panic() in a function

### DIFF
--- a/libs/wingsdk/src/target-sim/function.inflight.ts
+++ b/libs/wingsdk/src/target-sim/function.inflight.ts
@@ -49,7 +49,13 @@ export class Function implements IFunctionClient, ISimulatorResourceInstance {
       // https://stackoverflow.com/questions/59049140/is-it-possible-to-make-all-of-node-js-globals-available-in-nodes-vm-context
       fs: fs,
       path: path_,
-      process: process,
+      process: {
+        ...process,
+        // override process.exit to throw an exception instead of exiting the process
+        exit: () => {
+            throw new Error("process.exit() was called");
+        }
+      },
 
       // explicitly DO NOT propagate `console` because inflight
       // function bind console.log to the global $logger object.

--- a/libs/wingsdk/src/target-sim/function.inflight.ts
+++ b/libs/wingsdk/src/target-sim/function.inflight.ts
@@ -52,8 +52,8 @@ export class Function implements IFunctionClient, ISimulatorResourceInstance {
       process: {
         ...process,
         // override process.exit to throw an exception instead of exiting the process
-        exit: () => {
-            throw new Error("process.exit() was called");
+        exit: (code: number) => {
+            throw new Error("process.exit() was called with exit code " + code);
         }
       },
 

--- a/libs/wingsdk/test/target-sim/__snapshots__/function.test.ts.snap
+++ b/libs/wingsdk/test/target-sim/__snapshots__/function.test.ts.snap
@@ -623,3 +623,151 @@ exports.handler = async function(event) {
   },
 }
 `;
+
+exports[`invoke function with process.exit(1) 1`] = `
+Array [
+  "wingsdk.cloud.Logger created.",
+  "wingsdk.cloud.Function created.",
+  "Invoke (payload=\\"\\"{}\\"\\").",
+  "wingsdk.cloud.Function deleted.",
+  "wingsdk.cloud.Logger deleted.",
+]
+`;
+
+exports[`invoke function with process.exit(1) 2`] = `
+Object {
+  "app.wsim/simulator.json": Object {
+    "resources": Array [
+      Object {
+        "attrs": Object {},
+        "path": "root/WingLogger",
+        "props": Object {},
+        "type": "wingsdk.cloud.Logger",
+      },
+      Object {
+        "attrs": Object {},
+        "path": "root/my_function",
+        "props": Object {
+          "environmentVariables": Object {
+            "LOGGER_HANDLE_76f7e65b": "\${root/WingLogger#attrs.handle}",
+          },
+          "sourceCodeFile": "assets/my_function/index.js",
+          "sourceCodeLanguage": "javascript",
+        },
+        "type": "wingsdk.cloud.Function",
+      },
+    ],
+    "sdkVersion": "0.0.0",
+  },
+  "assets/my_function/index.js": "var $logger = function(env) {
+  let handle = process.env[env];
+  if (!handle) {
+    throw new Error(\\"Missing environment variable: \\" + env);
+  }
+  return $simulator.findInstance(handle);
+}(\\"LOGGER_HANDLE_76f7e65b\\");
+console.log = (...args) => $logger.print(...args);
+exports.handler = async function(event) {
+  return await new (function() {
+    return class Handler {
+      constructor(clients) {
+        for (const [name, client] of Object.entries(clients)) {
+          this[name] = client;
+        }
+      }
+      async handle() {
+        process.exit(1);
+      }
+    };
+  }())({}).handle(event);
+};
+",
+  "tree.json": Object {
+    "tree": Object {
+      "children": Object {
+        "Handler": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [],
+            "wing:resource:stateful": false,
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.0.130",
+          },
+          "display": Object {
+            "description": "An inflight resource",
+            "hidden": true,
+            "title": "Inflight",
+          },
+          "id": "Handler",
+          "path": "root/Handler",
+        },
+        "WingLogger": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [
+              Object {
+                "direction": "inbound",
+                "implicit": true,
+                "relationship": "print",
+                "resource": "root/my_function",
+              },
+            ],
+            "wing:resource:stateful": true,
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.0.130",
+          },
+          "display": Object {
+            "description": "A cloud logging facility",
+            "hidden": true,
+            "title": "Logger",
+          },
+          "id": "WingLogger",
+          "path": "root/WingLogger",
+        },
+        "my_function": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [
+              Object {
+                "direction": "outbound",
+                "implicit": true,
+                "relationship": "print",
+                "resource": "root/WingLogger",
+              },
+            ],
+            "wing:resource:stateful": false,
+          },
+          "children": Object {
+            "Code": Object {
+              "constructInfo": Object {
+                "fqn": "constructs.Construct",
+                "version": "10.0.130",
+              },
+              "id": "Code",
+              "path": "root/my_function/Code",
+            },
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.0.130",
+          },
+          "display": Object {
+            "description": "A cloud function (FaaS)",
+            "title": "Function",
+          },
+          "id": "my_function",
+          "path": "root/my_function",
+        },
+      },
+      "constructInfo": Object {
+        "fqn": "constructs.Construct",
+        "version": "10.0.130",
+      },
+      "id": "root",
+      "path": "root",
+    },
+    "version": "tree-0.1",
+  },
+}
+`;

--- a/libs/wingsdk/test/target-sim/function.test.ts
+++ b/libs/wingsdk/test/target-sim/function.test.ts
@@ -186,13 +186,13 @@ test("invoke function with process.exit(1)", async () => {
   // WHEN
   const PAYLOAD = { };
   await expect(client.invoke(JSON.stringify(PAYLOAD))).rejects.toThrow(
-      "process.exit() was called"
+      "process.exit() was called with exit code 1"
   );
   // THEN
   await s.stop();
   expect(listMessages(s)).toMatchSnapshot();
   expect(s.listTraces()[2].data.error).toMatchObject({
-    message: "process.exit() was called",
+    message: "process.exit() was called with exit code 1"
   });
   expect(app.snapshot()).toMatchSnapshot();
 });

--- a/libs/wingsdk/test/target-sim/function.test.ts
+++ b/libs/wingsdk/test/target-sim/function.test.ts
@@ -17,6 +17,12 @@ async handle(event) {
   return JSON.stringify({ msg });
 }`;
 
+const INFLIGHT_PANIC = `
+async handle() {
+  process.exit(1);
+}`;
+
+
 test("create a function", async () => {
   // GIVEN
   const app = new SimApp();
@@ -168,4 +174,25 @@ test("function has display title and description properties", async () => {
       },
     },
   });
+});
+
+test("invoke function with process.exit(1)", async () => {
+  // GIVEN
+  const app = new SimApp();
+  const handler = Testing.makeHandler(app, "Handler", INFLIGHT_PANIC);
+  new cloud.Function(app, "my_function", handler);
+  const s = await app.startSimulator();
+  const client = s.getResource("/my_function") as cloud.IFunctionClient;
+  // WHEN
+  const PAYLOAD = { };
+  await expect(client.invoke(JSON.stringify(PAYLOAD))).rejects.toThrow(
+      "process.exit() was called"
+  );
+  // THEN
+  await s.stop();
+  expect(listMessages(s)).toMatchSnapshot();
+  expect(s.listTraces()[2].data.error).toMatchObject({
+    message: "process.exit() was called",
+  });
+  expect(app.snapshot()).toMatchSnapshot();
 });


### PR DESCRIPTION
Executing `panic()` in a function is being translated to process.exit(1).
This causes the Simulator process to actually exist once the function is being invoked.

In order to prevent the Simulator process to exit we override the `process.exit` command when passing the `process` object to the VM context.

*By submitting this pull request, I confirm that my contribution is made under the terms of the 
[Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.
