### PR TITLE
fix(repo): build is failing due to invalid nx action config

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -127,8 +127,7 @@ jobs:
         with:
           targets: "build"
           all: true
-          exclude: "wing-language-server,vscode-wing"
-          args: "--configuration=release --output-style=stream --verbose"
+          args: "--exclude=wing-language-server,vscode-wing --configuration=release --output-style=stream --verbose"
 
       # wingc require wingsdk to be built first in order to run
       - name: Test
@@ -136,8 +135,7 @@ jobs:
         with:
           targets: "test"
           all: true
-          exclude: "hangar"
-          args: "--configuration=release --output-style=stream --verbose"
+          args: "--exclude=hangar --configuration=release --output-style=stream --verbose"
 
       - name: Create NPM packages
         uses: MansaGroup/nrwl-nx-action@v2


### PR DESCRIPTION
Fix build workflow to use `args` to pass `--exclude` because the action doesn't support it as a first class



*By submitting this pull request, I confirm that my contribution is made under the terms of the 
[Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.
