### PR TITLE
fix(sdk): azure share resources at app level

### DIFF
--- a/libs/wingsdk/src/target-tf-azure/bucket.inflight.ts
+++ b/libs/wingsdk/src/target-tf-azure/bucket.inflight.ts
@@ -33,7 +33,9 @@ export class BucketClient implements IBucketClient {
    * @param body string contents of the object
    */
   public async put(key: string, body: string): Promise<void> {
-    await this.containerClient.getBlockBlobClient(key).upload(body, body.length);
+    await this.containerClient
+      .getBlockBlobClient(key)
+      .upload(body, body.length);
   }
 
   /**

--- a/libs/wingsdk/src/target-tf-azure/bucket.inflight.ts
+++ b/libs/wingsdk/src/target-tf-azure/bucket.inflight.ts
@@ -1,10 +1,11 @@
 import { DefaultAzureCredential } from "@azure/identity";
-import { BlobServiceClient } from "@azure/storage-blob";
+import { BlobServiceClient, ContainerClient } from "@azure/storage-blob";
 import { BucketDeleteOptions, IBucketClient } from "../cloud";
 
 export class BucketClient implements IBucketClient {
   private readonly bucketName: string;
   private readonly blobServiceClient: BlobServiceClient;
+  private readonly containerClient: ContainerClient;
   private readonly defaultAzureCredential: DefaultAzureCredential =
     new DefaultAzureCredential();
 
@@ -20,6 +21,9 @@ export class BucketClient implements IBucketClient {
         `https://${storageAccount}.blob.core.windows.net`,
         this.defaultAzureCredential
       );
+    this.containerClient = this.blobServiceClient.getContainerClient(
+      this.bucketName
+    );
   }
 
   /**
@@ -29,10 +33,7 @@ export class BucketClient implements IBucketClient {
    * @param body string contents of the object
    */
   public async put(key: string, body: string): Promise<void> {
-    const containerClient = this.blobServiceClient.getContainerClient(
-      this.bucketName
-    );
-    await containerClient.getBlockBlobClient(key).upload(body, body.length);
+    await this.containerClient.getBlockBlobClient(key).upload(body, body.length);
   }
 
   /**
@@ -42,10 +43,7 @@ export class BucketClient implements IBucketClient {
    * @returns string content of the object as string
    */
   public async get(key: string): Promise<string> {
-    const containerClient = this.blobServiceClient.getContainerClient(
-      this.bucketName
-    );
-    const blobClient = containerClient.getBlobClient(key);
+    const blobClient = this.containerClient.getBlobClient(key);
 
     const downloadResponse = await blobClient.download();
     if (downloadResponse.readableStreamBody === undefined) {
@@ -68,11 +66,7 @@ export class BucketClient implements IBucketClient {
   public async list(prefix?: string): Promise<string[]> {
     const list: string[] = [];
 
-    const containerClient = this.blobServiceClient.getContainerClient(
-      this.bucketName
-    );
-
-    for await (const blob of containerClient.listBlobsFlat({ prefix })) {
+    for await (const blob of this.containerClient.listBlobsFlat({ prefix })) {
       list.push(blob.name);
     }
 
@@ -91,10 +85,7 @@ export class BucketClient implements IBucketClient {
   ): Promise<void> {
     const mustExist = opts.mustExist ?? false;
 
-    const containerClient = this.blobServiceClient.getContainerClient(
-      this.bucketName
-    );
-    const blockBlobClient = containerClient.getBlockBlobClient(key);
+    const blockBlobClient = this.containerClient.getBlockBlobClient(key);
 
     try {
       await blockBlobClient.delete();

--- a/libs/wingsdk/src/target-tf-azure/bucket.ts
+++ b/libs/wingsdk/src/target-tf-azure/bucket.ts
@@ -1,5 +1,3 @@
-import { ResourceGroup } from "@cdktf/provider-azurerm/lib/resource-group";
-import { StorageAccount } from "@cdktf/provider-azurerm/lib/storage-account";
 import { StorageBlob } from "@cdktf/provider-azurerm/lib/storage-blob";
 import { StorageContainer } from "@cdktf/provider-azurerm/lib/storage-container";
 import { Construct } from "constructs";
@@ -32,13 +30,14 @@ const BUCKET_NAME_OPTS: NameOptions = {
 export class Bucket extends cloud.BucketBase {
   private readonly storageContainer: StorageContainer;
   private readonly public: boolean;
+  private app: App;
 
   constructor(scope: Construct, id: string, props: cloud.BucketProps) {
     super(scope, id, props);
 
     this.public = props.public ?? false;
 
-    const app = App.of(this);
+    this.app = App.of(this);
 
     const storageContainerName = ResourceNames.generateName(
       this,
@@ -52,10 +51,9 @@ export class Bucket extends cloud.BucketBase {
       );
     }
 
-
     this.storageContainer = new StorageContainer(this, "Bucket", {
       name: storageContainerName,
-      storageAccountName: app.storageAccount.name,
+      storageAccountName: this.app.storageAccount.name,
       containerAccessType: this.public ? "public" : "private",
     });
   }
@@ -70,7 +68,7 @@ export class Bucket extends cloud.BucketBase {
 
     new StorageBlob(this, `Blob-${key}`, {
       name: blobName,
-      storageAccountName: this.storageAccount.name,
+      storageAccountName: this.app.storageAccount.name,
       storageContainerName: this.storageContainer.name,
       type: "Block",
       sourceContent: body,

--- a/libs/wingsdk/src/target-tf-azure/bucket.ts
+++ b/libs/wingsdk/src/target-tf-azure/bucket.ts
@@ -52,6 +52,7 @@ export class Bucket extends cloud.BucketBase {
       );
     }
 
+
     this.storageContainer = new StorageContainer(this, "Bucket", {
       name: storageContainerName,
       storageAccountName: app.storageAccount.name,

--- a/libs/wingsdk/src/target-tf-azure/bucket.ts
+++ b/libs/wingsdk/src/target-tf-azure/bucket.ts
@@ -13,27 +13,6 @@ import {
 } from "../utils/resource-names";
 
 /**
- * ResourceGroup names are limited to 90 characters.
- * You can use alphanumeric characters, hyphens, and underscores,
- * parentheses and periods.
- */
-const RESOURCEGROUP_NAME_OPTS: NameOptions = {
-  maxLen: 90,
-  disallowedRegex: /([^a-zA-Z0-9\-\_\(\)\.]+)/g,
-};
-
-/**
- * StorageAccount names are limited to 24 characters.
- * You can only use alphanumeric characters.
- */
-const STORAGEACCOUNT_NAME_OPTS: NameOptions = {
-  maxLen: 24,
-  case: CaseConventions.LOWERCASE,
-  disallowedRegex: /([^a-z0-9]+)/g,
-  sep: "",
-};
-
-/**
  * Bucket names must be between 3 and 63 characters.
  *
  * You can use lowercase alphanumeric characters, dash (-)
@@ -52,8 +31,6 @@ const BUCKET_NAME_OPTS: NameOptions = {
  */
 export class Bucket extends cloud.BucketBase {
   private readonly storageContainer: StorageContainer;
-  private readonly storageAccount: StorageAccount;
-  private readonly resourceGroup: ResourceGroup;
   private readonly public: boolean;
 
   constructor(scope: Construct, id: string, props: cloud.BucketProps) {
@@ -62,19 +39,6 @@ export class Bucket extends cloud.BucketBase {
     this.public = props.public ?? false;
 
     const app = App.of(this);
-
-    this.resourceGroup = new ResourceGroup(this, "ResourceGroup", {
-      location: app.location,
-      name: ResourceNames.generateName(this, RESOURCEGROUP_NAME_OPTS),
-    });
-
-    this.storageAccount = new StorageAccount(this, "StorageAccount", {
-      name: ResourceNames.generateName(this, STORAGEACCOUNT_NAME_OPTS),
-      resourceGroupName: this.resourceGroup.name,
-      location: this.resourceGroup.location,
-      accountTier: "Standard",
-      accountReplicationType: "LRS",
-    });
 
     const storageContainerName = ResourceNames.generateName(
       this,
@@ -90,7 +54,7 @@ export class Bucket extends cloud.BucketBase {
 
     this.storageContainer = new StorageContainer(this, "Bucket", {
       name: storageContainerName,
-      storageAccountName: this.storageAccount.name,
+      storageAccountName: app.storageAccount.name,
       containerAccessType: this.public ? "public" : "private",
     });
   }

--- a/libs/wingsdk/test/target-tf-azure/__snapshots__/bucket.test.ts.snap
+++ b/libs/wingsdk/test/target-tf-azure/__snapshots__/bucket.test.ts.snap
@@ -4,25 +4,25 @@ exports[`bucket is public 1`] = `
 "{
   \\"resource\\": {
     \\"azurerm_resource_group\\": {
-      \\"root_mybucket_ResourceGroup_C1D7AF27\\": {
+      \\"root_ResourceGroup_72A9AFB6\\": {
         \\"location\\": \\"East US\\",
-        \\"name\\": \\"my_bucket-c8045fcc\\"
+        \\"name\\": \\"root-c82bf964\\"
       }
     },
     \\"azurerm_storage_account\\": {
-      \\"root_mybucket_StorageAccount_A0150B8A\\": {
+      \\"root_StorageAccount_3B92EC74\\": {
         \\"account_replication_type\\": \\"LRS\\",
         \\"account_tier\\": \\"Standard\\",
-        \\"location\\": \\"\${azurerm_resource_group.root_mybucket_ResourceGroup_C1D7AF27.location}\\",
-        \\"name\\": \\"mybucketc8045fcc\\",
-        \\"resource_group_name\\": \\"\${azurerm_resource_group.root_mybucket_ResourceGroup_C1D7AF27.name}\\"
+        \\"location\\": \\"\${azurerm_resource_group.root_ResourceGroup_72A9AFB6.location}\\",
+        \\"name\\": \\"rootc82bf964\\",
+        \\"resource_group_name\\": \\"\${azurerm_resource_group.root_ResourceGroup_72A9AFB6.name}\\"
       }
     },
     \\"azurerm_storage_container\\": {
       \\"root_mybucket_Bucket_10512A98\\": {
         \\"container_access_type\\": \\"public\\",
         \\"name\\": \\"my-bucket-c8045fcc\\",
-        \\"storage_account_name\\": \\"\${azurerm_storage_account.root_mybucket_StorageAccount_A0150B8A.name}\\"
+        \\"storage_account_name\\": \\"\${azurerm_storage_account.root_StorageAccount_3B92EC74.name}\\"
       }
     }
   }
@@ -144,25 +144,25 @@ exports[`bucket name valid 1`] = `
 "{
   \\"resource\\": {
     \\"azurerm_resource_group\\": {
-      \\"root_TheUncannyBucket_ResourceGroup_056902E8\\": {
+      \\"root_ResourceGroup_72A9AFB6\\": {
         \\"location\\": \\"East US\\",
-        \\"name\\": \\"The-Uncanny-Bucket-c8ac4720\\"
+        \\"name\\": \\"root-c82bf964\\"
       }
     },
     \\"azurerm_storage_account\\": {
-      \\"root_TheUncannyBucket_StorageAccount_A894AF8E\\": {
+      \\"root_StorageAccount_3B92EC74\\": {
         \\"account_replication_type\\": \\"LRS\\",
         \\"account_tier\\": \\"Standard\\",
-        \\"location\\": \\"\${azurerm_resource_group.root_TheUncannyBucket_ResourceGroup_056902E8.location}\\",
-        \\"name\\": \\"theuncannybucketc8ac4720\\",
-        \\"resource_group_name\\": \\"\${azurerm_resource_group.root_TheUncannyBucket_ResourceGroup_056902E8.name}\\"
+        \\"location\\": \\"\${azurerm_resource_group.root_ResourceGroup_72A9AFB6.location}\\",
+        \\"name\\": \\"rootc82bf964\\",
+        \\"resource_group_name\\": \\"\${azurerm_resource_group.root_ResourceGroup_72A9AFB6.name}\\"
       }
     },
     \\"azurerm_storage_container\\": {
       \\"root_TheUncannyBucket_DDA021FB\\": {
         \\"container_access_type\\": \\"private\\",
         \\"name\\": \\"the-uncanny-bucket-c8ac4720\\",
-        \\"storage_account_name\\": \\"\${azurerm_storage_account.root_TheUncannyBucket_StorageAccount_A894AF8E.name}\\"
+        \\"storage_account_name\\": \\"\${azurerm_storage_account.root_StorageAccount_3B92EC74.name}\\"
       }
     }
   }
@@ -456,25 +456,25 @@ exports[`create a bucket 1`] = `
 "{
   \\"resource\\": {
     \\"azurerm_resource_group\\": {
-      \\"root_mybucket_ResourceGroup_C1D7AF27\\": {
+      \\"root_ResourceGroup_72A9AFB6\\": {
         \\"location\\": \\"East US\\",
-        \\"name\\": \\"my_bucket-c8045fcc\\"
+        \\"name\\": \\"root-c82bf964\\"
       }
     },
     \\"azurerm_storage_account\\": {
-      \\"root_mybucket_StorageAccount_A0150B8A\\": {
+      \\"root_StorageAccount_3B92EC74\\": {
         \\"account_replication_type\\": \\"LRS\\",
         \\"account_tier\\": \\"Standard\\",
-        \\"location\\": \\"\${azurerm_resource_group.root_mybucket_ResourceGroup_C1D7AF27.location}\\",
-        \\"name\\": \\"mybucketc8045fcc\\",
-        \\"resource_group_name\\": \\"\${azurerm_resource_group.root_mybucket_ResourceGroup_C1D7AF27.name}\\"
+        \\"location\\": \\"\${azurerm_resource_group.root_ResourceGroup_72A9AFB6.location}\\",
+        \\"name\\": \\"rootc82bf964\\",
+        \\"resource_group_name\\": \\"\${azurerm_resource_group.root_ResourceGroup_72A9AFB6.name}\\"
       }
     },
     \\"azurerm_storage_container\\": {
       \\"root_mybucket_Bucket_10512A98\\": {
         \\"container_access_type\\": \\"private\\",
         \\"name\\": \\"my-bucket-c8045fcc\\",
-        \\"storage_account_name\\": \\"\${azurerm_storage_account.root_mybucket_StorageAccount_A0150B8A.name}\\"
+        \\"storage_account_name\\": \\"\${azurerm_storage_account.root_StorageAccount_3B92EC74.name}\\"
       }
     }
   }

--- a/libs/wingsdk/test/target-tf-azure/__snapshots__/bucket.test.ts.snap
+++ b/libs/wingsdk/test/target-tf-azure/__snapshots__/bucket.test.ts.snap
@@ -591,3 +591,164 @@ Object {
   "version": "tree-0.1",
 }
 `;
+
+exports[`create multiple buckets 1`] = `
+"{
+  \\"resource\\": {
+    \\"azurerm_resource_group\\": {
+      \\"root_ResourceGroup_72A9AFB6\\": {
+        \\"location\\": \\"East US\\",
+        \\"name\\": \\"root-c82bf964\\"
+      }
+    },
+    \\"azurerm_storage_account\\": {
+      \\"root_StorageAccount_3B92EC74\\": {
+        \\"account_replication_type\\": \\"LRS\\",
+        \\"account_tier\\": \\"Standard\\",
+        \\"location\\": \\"\${azurerm_resource_group.root_ResourceGroup_72A9AFB6.location}\\",
+        \\"name\\": \\"rootc82bf964\\",
+        \\"resource_group_name\\": \\"\${azurerm_resource_group.root_ResourceGroup_72A9AFB6.name}\\"
+      }
+    },
+    \\"azurerm_storage_container\\": {
+      \\"root_mybucket2_Bucket_C2147F5F\\": {
+        \\"container_access_type\\": \\"private\\",
+        \\"name\\": \\"my-bucket2-c87f4817\\",
+        \\"storage_account_name\\": \\"\${azurerm_storage_account.root_StorageAccount_3B92EC74.name}\\"
+      },
+      \\"root_mybucket_Bucket_10512A98\\": {
+        \\"container_access_type\\": \\"private\\",
+        \\"name\\": \\"my-bucket-c8045fcc\\",
+        \\"storage_account_name\\": \\"\${azurerm_storage_account.root_StorageAccount_3B92EC74.name}\\"
+      }
+    }
+  }
+}"
+`;
+
+exports[`create multiple buckets 2`] = `
+Object {
+  "tree": Object {
+    "children": Object {
+      "root": Object {
+        "children": Object {
+          "ResourceGroup": Object {
+            "constructInfo": Object {
+              "fqn": "@cdktf/provider-azurerm.resourceGroup.ResourceGroup",
+              "version": "5.0.1",
+            },
+            "id": "ResourceGroup",
+            "path": "root/ResourceGroup",
+          },
+          "StorageAccount": Object {
+            "constructInfo": Object {
+              "fqn": "@cdktf/provider-azurerm.storageAccount.StorageAccount",
+              "version": "5.0.1",
+            },
+            "id": "StorageAccount",
+            "path": "root/StorageAccount",
+          },
+          "WingLogger": Object {
+            "attributes": Object {
+              "wing:resource:connections": Array [],
+              "wing:resource:stateful": true,
+            },
+            "constructInfo": Object {
+              "fqn": "constructs.Construct",
+              "version": "10.0.130",
+            },
+            "display": Object {
+              "description": "A cloud logging facility",
+              "hidden": true,
+              "title": "Logger",
+            },
+            "id": "WingLogger",
+            "path": "root/WingLogger",
+          },
+          "azure": Object {
+            "constructInfo": Object {
+              "fqn": "@cdktf/provider-azurerm.provider.AzurermProvider",
+              "version": "5.0.1",
+            },
+            "id": "azure",
+            "path": "root/azure",
+          },
+          "backend": Object {
+            "constructInfo": Object {
+              "fqn": "cdktf.LocalBackend",
+              "version": "0.15.0",
+            },
+            "id": "backend",
+            "path": "root/backend",
+          },
+          "my_bucket": Object {
+            "attributes": Object {
+              "wing:resource:connections": Array [],
+              "wing:resource:stateful": true,
+            },
+            "children": Object {
+              "Bucket": Object {
+                "constructInfo": Object {
+                  "fqn": "@cdktf/provider-azurerm.storageContainer.StorageContainer",
+                  "version": "5.0.1",
+                },
+                "id": "Bucket",
+                "path": "root/my_bucket/Bucket",
+              },
+            },
+            "constructInfo": Object {
+              "fqn": "constructs.Construct",
+              "version": "10.0.130",
+            },
+            "display": Object {
+              "description": "A cloud object store",
+              "title": "Bucket",
+            },
+            "id": "my_bucket",
+            "path": "root/my_bucket",
+          },
+          "my_bucket2": Object {
+            "attributes": Object {
+              "wing:resource:connections": Array [],
+              "wing:resource:stateful": true,
+            },
+            "children": Object {
+              "Bucket": Object {
+                "constructInfo": Object {
+                  "fqn": "@cdktf/provider-azurerm.storageContainer.StorageContainer",
+                  "version": "5.0.1",
+                },
+                "id": "Bucket",
+                "path": "root/my_bucket2/Bucket",
+              },
+            },
+            "constructInfo": Object {
+              "fqn": "constructs.Construct",
+              "version": "10.0.130",
+            },
+            "display": Object {
+              "description": "A cloud object store",
+              "title": "Bucket",
+            },
+            "id": "my_bucket2",
+            "path": "root/my_bucket2",
+          },
+        },
+        "constructInfo": Object {
+          "fqn": "cdktf.TerraformStack",
+          "version": "0.15.0",
+        },
+        "id": "root",
+        "path": "root",
+      },
+    },
+    "constructInfo": Object {
+      "fqn": "cdktf.App",
+      "version": "0.15.0",
+    },
+    "id": "App",
+    "path": "",
+  },
+  "version": "tree-0.1",
+}
+`;

--- a/libs/wingsdk/test/target-tf-azure/__snapshots__/bucket.test.ts.snap
+++ b/libs/wingsdk/test/target-tf-azure/__snapshots__/bucket.test.ts.snap
@@ -6,7 +6,7 @@ exports[`bucket is public 1`] = `
     \\"azurerm_resource_group\\": {
       \\"root_ResourceGroup_72A9AFB6\\": {
         \\"location\\": \\"East US\\",
-        \\"name\\": \\"root-c82bf964\\"
+        \\"name\\": \\"Default-c82bf964\\"
       }
     },
     \\"azurerm_storage_account\\": {
@@ -14,7 +14,7 @@ exports[`bucket is public 1`] = `
         \\"account_replication_type\\": \\"LRS\\",
         \\"account_tier\\": \\"Standard\\",
         \\"location\\": \\"\${azurerm_resource_group.root_ResourceGroup_72A9AFB6.location}\\",
-        \\"name\\": \\"rootc82bf964\\",
+        \\"name\\": \\"defaultc82bf964\\",
         \\"resource_group_name\\": \\"\${azurerm_resource_group.root_ResourceGroup_72A9AFB6.name}\\"
       }
     },
@@ -37,6 +37,22 @@ Object {
         "children": Object {
           "Default": Object {
             "children": Object {
+              "ResourceGroup": Object {
+                "constructInfo": Object {
+                  "fqn": "@cdktf/provider-azurerm.resourceGroup.ResourceGroup",
+                  "version": "5.0.1",
+                },
+                "id": "ResourceGroup",
+                "path": "root/Default/ResourceGroup",
+              },
+              "StorageAccount": Object {
+                "constructInfo": Object {
+                  "fqn": "@cdktf/provider-azurerm.storageAccount.StorageAccount",
+                  "version": "5.0.1",
+                },
+                "id": "StorageAccount",
+                "path": "root/Default/StorageAccount",
+              },
               "WingLogger": Object {
                 "attributes": Object {
                   "wing:resource:connections": Array [],
@@ -75,22 +91,6 @@ Object {
                     },
                     "id": "Bucket",
                     "path": "root/Default/my_bucket/Bucket",
-                  },
-                  "ResourceGroup": Object {
-                    "constructInfo": Object {
-                      "fqn": "@cdktf/provider-azurerm.resourceGroup.ResourceGroup",
-                      "version": "5.0.1",
-                    },
-                    "id": "ResourceGroup",
-                    "path": "root/Default/my_bucket/ResourceGroup",
-                  },
-                  "StorageAccount": Object {
-                    "constructInfo": Object {
-                      "fqn": "@cdktf/provider-azurerm.storageAccount.StorageAccount",
-                      "version": "5.0.1",
-                    },
-                    "id": "StorageAccount",
-                    "path": "root/Default/my_bucket/StorageAccount",
                   },
                 },
                 "constructInfo": Object {
@@ -146,7 +146,7 @@ exports[`bucket name valid 1`] = `
     \\"azurerm_resource_group\\": {
       \\"root_ResourceGroup_72A9AFB6\\": {
         \\"location\\": \\"East US\\",
-        \\"name\\": \\"root-c82bf964\\"
+        \\"name\\": \\"Default-c82bf964\\"
       }
     },
     \\"azurerm_storage_account\\": {
@@ -154,7 +154,7 @@ exports[`bucket name valid 1`] = `
         \\"account_replication_type\\": \\"LRS\\",
         \\"account_tier\\": \\"Standard\\",
         \\"location\\": \\"\${azurerm_resource_group.root_ResourceGroup_72A9AFB6.location}\\",
-        \\"name\\": \\"rootc82bf964\\",
+        \\"name\\": \\"defaultc82bf964\\",
         \\"resource_group_name\\": \\"\${azurerm_resource_group.root_ResourceGroup_72A9AFB6.name}\\"
       }
     },
@@ -177,6 +177,22 @@ Object {
         "children": Object {
           "Default": Object {
             "children": Object {
+              "ResourceGroup": Object {
+                "constructInfo": Object {
+                  "fqn": "@cdktf/provider-azurerm.resourceGroup.ResourceGroup",
+                  "version": "5.0.1",
+                },
+                "id": "ResourceGroup",
+                "path": "root/Default/ResourceGroup",
+              },
+              "StorageAccount": Object {
+                "constructInfo": Object {
+                  "fqn": "@cdktf/provider-azurerm.storageAccount.StorageAccount",
+                  "version": "5.0.1",
+                },
+                "id": "StorageAccount",
+                "path": "root/Default/StorageAccount",
+              },
               "The-Uncanny-Bucket": Object {
                 "attributes": Object {
                   "wing:resource:connections": Array [],
@@ -190,22 +206,6 @@ Object {
                     },
                     "id": "Bucket",
                     "path": "root/Default/The-Uncanny-Bucket/Bucket",
-                  },
-                  "ResourceGroup": Object {
-                    "constructInfo": Object {
-                      "fqn": "@cdktf/provider-azurerm.resourceGroup.ResourceGroup",
-                      "version": "5.0.1",
-                    },
-                    "id": "ResourceGroup",
-                    "path": "root/Default/The-Uncanny-Bucket/ResourceGroup",
-                  },
-                  "StorageAccount": Object {
-                    "constructInfo": Object {
-                      "fqn": "@cdktf/provider-azurerm.storageAccount.StorageAccount",
-                      "version": "5.0.1",
-                    },
-                    "id": "StorageAccount",
-                    "path": "root/Default/The-Uncanny-Bucket/StorageAccount",
                   },
                 },
                 "constructInfo": Object {
@@ -284,32 +284,32 @@ exports[`bucket with two preflight objects 1`] = `
 "{
   \\"resource\\": {
     \\"azurerm_resource_group\\": {
-      \\"root_mybucket_ResourceGroup_C1D7AF27\\": {
+      \\"root_ResourceGroup_72A9AFB6\\": {
         \\"location\\": \\"East US\\",
-        \\"name\\": \\"my_bucket-c8045fcc\\"
+        \\"name\\": \\"Default-c82bf964\\"
       }
     },
     \\"azurerm_storage_account\\": {
-      \\"root_mybucket_StorageAccount_A0150B8A\\": {
+      \\"root_StorageAccount_3B92EC74\\": {
         \\"account_replication_type\\": \\"LRS\\",
         \\"account_tier\\": \\"Standard\\",
-        \\"location\\": \\"\${azurerm_resource_group.root_mybucket_ResourceGroup_C1D7AF27.location}\\",
-        \\"name\\": \\"mybucketc8045fcc\\",
-        \\"resource_group_name\\": \\"\${azurerm_resource_group.root_mybucket_ResourceGroup_C1D7AF27.name}\\"
+        \\"location\\": \\"\${azurerm_resource_group.root_ResourceGroup_72A9AFB6.location}\\",
+        \\"name\\": \\"defaultc82bf964\\",
+        \\"resource_group_name\\": \\"\${azurerm_resource_group.root_ResourceGroup_72A9AFB6.name}\\"
       }
     },
     \\"azurerm_storage_blob\\": {
       \\"root_mybucket_Blobfile1txt_5100BBF1\\": {
         \\"name\\": \\"file1.txt\\",
         \\"source_content\\": \\"hello world\\",
-        \\"storage_account_name\\": \\"\${azurerm_storage_account.root_mybucket_StorageAccount_A0150B8A.name}\\",
+        \\"storage_account_name\\": \\"\${azurerm_storage_account.root_StorageAccount_3B92EC74.name}\\",
         \\"storage_container_name\\": \\"\${azurerm_storage_container.root_mybucket_Bucket_10512A98.name}\\",
         \\"type\\": \\"Block\\"
       },
       \\"root_mybucket_Blobfile2txt_D2544996\\": {
         \\"name\\": \\"file2.txt\\",
         \\"source_content\\": \\"boom bam\\",
-        \\"storage_account_name\\": \\"\${azurerm_storage_account.root_mybucket_StorageAccount_A0150B8A.name}\\",
+        \\"storage_account_name\\": \\"\${azurerm_storage_account.root_StorageAccount_3B92EC74.name}\\",
         \\"storage_container_name\\": \\"\${azurerm_storage_container.root_mybucket_Bucket_10512A98.name}\\",
         \\"type\\": \\"Block\\"
       }
@@ -318,7 +318,7 @@ exports[`bucket with two preflight objects 1`] = `
       \\"root_mybucket_Bucket_10512A98\\": {
         \\"container_access_type\\": \\"public\\",
         \\"name\\": \\"my-bucket-c8045fcc\\",
-        \\"storage_account_name\\": \\"\${azurerm_storage_account.root_mybucket_StorageAccount_A0150B8A.name}\\"
+        \\"storage_account_name\\": \\"\${azurerm_storage_account.root_StorageAccount_3B92EC74.name}\\"
       }
     }
   }
@@ -333,6 +333,22 @@ Object {
         "children": Object {
           "Default": Object {
             "children": Object {
+              "ResourceGroup": Object {
+                "constructInfo": Object {
+                  "fqn": "@cdktf/provider-azurerm.resourceGroup.ResourceGroup",
+                  "version": "5.0.1",
+                },
+                "id": "ResourceGroup",
+                "path": "root/Default/ResourceGroup",
+              },
+              "StorageAccount": Object {
+                "constructInfo": Object {
+                  "fqn": "@cdktf/provider-azurerm.storageAccount.StorageAccount",
+                  "version": "5.0.1",
+                },
+                "id": "StorageAccount",
+                "path": "root/Default/StorageAccount",
+              },
               "WingLogger": Object {
                 "attributes": Object {
                   "wing:resource:connections": Array [],
@@ -388,22 +404,6 @@ Object {
                     "id": "Bucket",
                     "path": "root/Default/my_bucket/Bucket",
                   },
-                  "ResourceGroup": Object {
-                    "constructInfo": Object {
-                      "fqn": "@cdktf/provider-azurerm.resourceGroup.ResourceGroup",
-                      "version": "5.0.1",
-                    },
-                    "id": "ResourceGroup",
-                    "path": "root/Default/my_bucket/ResourceGroup",
-                  },
-                  "StorageAccount": Object {
-                    "constructInfo": Object {
-                      "fqn": "@cdktf/provider-azurerm.storageAccount.StorageAccount",
-                      "version": "5.0.1",
-                    },
-                    "id": "StorageAccount",
-                    "path": "root/Default/my_bucket/StorageAccount",
-                  },
                 },
                 "constructInfo": Object {
                   "fqn": "constructs.Construct",
@@ -458,7 +458,7 @@ exports[`create a bucket 1`] = `
     \\"azurerm_resource_group\\": {
       \\"root_ResourceGroup_72A9AFB6\\": {
         \\"location\\": \\"East US\\",
-        \\"name\\": \\"root-c82bf964\\"
+        \\"name\\": \\"Default-c82bf964\\"
       }
     },
     \\"azurerm_storage_account\\": {
@@ -466,7 +466,7 @@ exports[`create a bucket 1`] = `
         \\"account_replication_type\\": \\"LRS\\",
         \\"account_tier\\": \\"Standard\\",
         \\"location\\": \\"\${azurerm_resource_group.root_ResourceGroup_72A9AFB6.location}\\",
-        \\"name\\": \\"rootc82bf964\\",
+        \\"name\\": \\"defaultc82bf964\\",
         \\"resource_group_name\\": \\"\${azurerm_resource_group.root_ResourceGroup_72A9AFB6.name}\\"
       }
     },
@@ -489,6 +489,22 @@ Object {
         "children": Object {
           "Default": Object {
             "children": Object {
+              "ResourceGroup": Object {
+                "constructInfo": Object {
+                  "fqn": "@cdktf/provider-azurerm.resourceGroup.ResourceGroup",
+                  "version": "5.0.1",
+                },
+                "id": "ResourceGroup",
+                "path": "root/Default/ResourceGroup",
+              },
+              "StorageAccount": Object {
+                "constructInfo": Object {
+                  "fqn": "@cdktf/provider-azurerm.storageAccount.StorageAccount",
+                  "version": "5.0.1",
+                },
+                "id": "StorageAccount",
+                "path": "root/Default/StorageAccount",
+              },
               "WingLogger": Object {
                 "attributes": Object {
                   "wing:resource:connections": Array [],
@@ -527,22 +543,6 @@ Object {
                     },
                     "id": "Bucket",
                     "path": "root/Default/my_bucket/Bucket",
-                  },
-                  "ResourceGroup": Object {
-                    "constructInfo": Object {
-                      "fqn": "@cdktf/provider-azurerm.resourceGroup.ResourceGroup",
-                      "version": "5.0.1",
-                    },
-                    "id": "ResourceGroup",
-                    "path": "root/Default/my_bucket/ResourceGroup",
-                  },
-                  "StorageAccount": Object {
-                    "constructInfo": Object {
-                      "fqn": "@cdktf/provider-azurerm.storageAccount.StorageAccount",
-                      "version": "5.0.1",
-                    },
-                    "id": "StorageAccount",
-                    "path": "root/Default/my_bucket/StorageAccount",
                   },
                 },
                 "constructInfo": Object {
@@ -598,7 +598,7 @@ exports[`create multiple buckets 1`] = `
     \\"azurerm_resource_group\\": {
       \\"root_ResourceGroup_72A9AFB6\\": {
         \\"location\\": \\"East US\\",
-        \\"name\\": \\"root-c82bf964\\"
+        \\"name\\": \\"Default-c82bf964\\"
       }
     },
     \\"azurerm_storage_account\\": {
@@ -606,7 +606,7 @@ exports[`create multiple buckets 1`] = `
         \\"account_replication_type\\": \\"LRS\\",
         \\"account_tier\\": \\"Standard\\",
         \\"location\\": \\"\${azurerm_resource_group.root_ResourceGroup_72A9AFB6.location}\\",
-        \\"name\\": \\"rootc82bf964\\",
+        \\"name\\": \\"defaultc82bf964\\",
         \\"resource_group_name\\": \\"\${azurerm_resource_group.root_ResourceGroup_72A9AFB6.name}\\"
       }
     },
@@ -632,111 +632,121 @@ Object {
     "children": Object {
       "root": Object {
         "children": Object {
-          "ResourceGroup": Object {
-            "constructInfo": Object {
-              "fqn": "@cdktf/provider-azurerm.resourceGroup.ResourceGroup",
-              "version": "5.0.1",
-            },
-            "id": "ResourceGroup",
-            "path": "root/ResourceGroup",
-          },
-          "StorageAccount": Object {
-            "constructInfo": Object {
-              "fqn": "@cdktf/provider-azurerm.storageAccount.StorageAccount",
-              "version": "5.0.1",
-            },
-            "id": "StorageAccount",
-            "path": "root/StorageAccount",
-          },
-          "WingLogger": Object {
-            "attributes": Object {
-              "wing:resource:connections": Array [],
-              "wing:resource:stateful": true,
+          "Default": Object {
+            "children": Object {
+              "ResourceGroup": Object {
+                "constructInfo": Object {
+                  "fqn": "@cdktf/provider-azurerm.resourceGroup.ResourceGroup",
+                  "version": "5.0.1",
+                },
+                "id": "ResourceGroup",
+                "path": "root/Default/ResourceGroup",
+              },
+              "StorageAccount": Object {
+                "constructInfo": Object {
+                  "fqn": "@cdktf/provider-azurerm.storageAccount.StorageAccount",
+                  "version": "5.0.1",
+                },
+                "id": "StorageAccount",
+                "path": "root/Default/StorageAccount",
+              },
+              "WingLogger": Object {
+                "attributes": Object {
+                  "wing:resource:connections": Array [],
+                  "wing:resource:stateful": true,
+                },
+                "constructInfo": Object {
+                  "fqn": "constructs.Construct",
+                  "version": "10.1.228",
+                },
+                "display": Object {
+                  "description": "A cloud logging facility",
+                  "hidden": true,
+                  "title": "Logger",
+                },
+                "id": "WingLogger",
+                "path": "root/Default/WingLogger",
+              },
+              "azure": Object {
+                "constructInfo": Object {
+                  "fqn": "@cdktf/provider-azurerm.provider.AzurermProvider",
+                  "version": "5.0.1",
+                },
+                "id": "azure",
+                "path": "root/Default/azure",
+              },
+              "my_bucket": Object {
+                "attributes": Object {
+                  "wing:resource:connections": Array [],
+                  "wing:resource:stateful": true,
+                },
+                "children": Object {
+                  "Bucket": Object {
+                    "constructInfo": Object {
+                      "fqn": "@cdktf/provider-azurerm.storageContainer.StorageContainer",
+                      "version": "5.0.1",
+                    },
+                    "id": "Bucket",
+                    "path": "root/Default/my_bucket/Bucket",
+                  },
+                },
+                "constructInfo": Object {
+                  "fqn": "constructs.Construct",
+                  "version": "10.1.228",
+                },
+                "display": Object {
+                  "description": "A cloud object store",
+                  "title": "Bucket",
+                },
+                "id": "my_bucket",
+                "path": "root/Default/my_bucket",
+              },
+              "my_bucket2": Object {
+                "attributes": Object {
+                  "wing:resource:connections": Array [],
+                  "wing:resource:stateful": true,
+                },
+                "children": Object {
+                  "Bucket": Object {
+                    "constructInfo": Object {
+                      "fqn": "@cdktf/provider-azurerm.storageContainer.StorageContainer",
+                      "version": "5.0.1",
+                    },
+                    "id": "Bucket",
+                    "path": "root/Default/my_bucket2/Bucket",
+                  },
+                },
+                "constructInfo": Object {
+                  "fqn": "constructs.Construct",
+                  "version": "10.1.228",
+                },
+                "display": Object {
+                  "description": "A cloud object store",
+                  "title": "Bucket",
+                },
+                "id": "my_bucket2",
+                "path": "root/Default/my_bucket2",
+              },
             },
             "constructInfo": Object {
               "fqn": "constructs.Construct",
-              "version": "10.0.130",
+              "version": "10.1.228",
             },
-            "display": Object {
-              "description": "A cloud logging facility",
-              "hidden": true,
-              "title": "Logger",
-            },
-            "id": "WingLogger",
-            "path": "root/WingLogger",
-          },
-          "azure": Object {
-            "constructInfo": Object {
-              "fqn": "@cdktf/provider-azurerm.provider.AzurermProvider",
-              "version": "5.0.1",
-            },
-            "id": "azure",
-            "path": "root/azure",
+            "id": "Default",
+            "path": "root/Default",
           },
           "backend": Object {
             "constructInfo": Object {
               "fqn": "cdktf.LocalBackend",
-              "version": "0.15.0",
+              "version": "0.15.2",
             },
             "id": "backend",
             "path": "root/backend",
           },
-          "my_bucket": Object {
-            "attributes": Object {
-              "wing:resource:connections": Array [],
-              "wing:resource:stateful": true,
-            },
-            "children": Object {
-              "Bucket": Object {
-                "constructInfo": Object {
-                  "fqn": "@cdktf/provider-azurerm.storageContainer.StorageContainer",
-                  "version": "5.0.1",
-                },
-                "id": "Bucket",
-                "path": "root/my_bucket/Bucket",
-              },
-            },
-            "constructInfo": Object {
-              "fqn": "constructs.Construct",
-              "version": "10.0.130",
-            },
-            "display": Object {
-              "description": "A cloud object store",
-              "title": "Bucket",
-            },
-            "id": "my_bucket",
-            "path": "root/my_bucket",
-          },
-          "my_bucket2": Object {
-            "attributes": Object {
-              "wing:resource:connections": Array [],
-              "wing:resource:stateful": true,
-            },
-            "children": Object {
-              "Bucket": Object {
-                "constructInfo": Object {
-                  "fqn": "@cdktf/provider-azurerm.storageContainer.StorageContainer",
-                  "version": "5.0.1",
-                },
-                "id": "Bucket",
-                "path": "root/my_bucket2/Bucket",
-              },
-            },
-            "constructInfo": Object {
-              "fqn": "constructs.Construct",
-              "version": "10.0.130",
-            },
-            "display": Object {
-              "description": "A cloud object store",
-              "title": "Bucket",
-            },
-            "id": "my_bucket2",
-            "path": "root/my_bucket2",
-          },
         },
         "constructInfo": Object {
           "fqn": "cdktf.TerraformStack",
-          "version": "0.15.0",
+          "version": "0.15.2",
         },
         "id": "root",
         "path": "root",
@@ -744,7 +754,7 @@ Object {
     },
     "constructInfo": Object {
       "fqn": "cdktf.App",
-      "version": "0.15.0",
+      "version": "0.15.2",
     },
     "id": "App",
     "path": "",

--- a/libs/wingsdk/test/target-tf-azure/bucket.test.ts
+++ b/libs/wingsdk/test/target-tf-azure/bucket.test.ts
@@ -92,7 +92,7 @@ test("bucket name valid", () => {
       output,
       "azurerm_resource_group",
       {
-        name: `root-${app.node.addr.substring(0, 8)}`,
+        name: `Default-${app.node.addr.substring(0, 8)}`,
       }
     )
   ).toEqual(true);
@@ -102,7 +102,7 @@ test("bucket name valid", () => {
       output,
       "azurerm_storage_account",
       {
-        name: `root${app.node.addr.substring(0, 8)}`,
+        name: `default${app.node.addr.substring(0, 8)}`,
       }
     )
   ).toEqual(true);

--- a/libs/wingsdk/test/target-tf-azure/bucket.test.ts
+++ b/libs/wingsdk/test/target-tf-azure/bucket.test.ts
@@ -26,6 +26,24 @@ test("create a bucket", () => {
   expect(treeJsonOf(app.outdir)).toMatchSnapshot();
 });
 
+test("create multiple buckets", () => {
+  // GIVEN
+  const app = new tfazure.App({ outdir: mkdtemp(), location: "East US" });
+  new cloud.Bucket(app, "my_bucket");
+  new cloud.Bucket(app, "my_bucket2");
+  const output = app.synth();
+
+  // THEN
+  expect(tfResourcesOf(output)).toEqual([
+    "azurerm_resource_group",
+    "azurerm_storage_account",
+    "azurerm_storage_container",
+  ]);
+  expect(tfResourcesOfCount(output, "azurerm_storage_container")).toEqual(2);
+  expect(tfSanitize(output)).toMatchSnapshot();
+  expect(treeJsonOf(app.outdir)).toMatchSnapshot();
+});
+
 test("bucket is public", () => {
   // GIVEN
   const app = new tfazure.App({ outdir: mkdtemp(), location: "East US" });
@@ -68,8 +86,6 @@ test("bucket name valid", () => {
   const app = new tfazure.App({ outdir: mkdtemp(), location: "East US" });
   const bucket = new cloud.Bucket(app, "The-Uncanny-Bucket");
   const output = app.synth();
-  console.log(output);
-  console.log(bucket.node.addr.substring(0, 8));
 
   expect(
     cdktf.Testing.toHaveResourceWithProperties(

--- a/libs/wingsdk/test/target-tf-azure/bucket.test.ts
+++ b/libs/wingsdk/test/target-tf-azure/bucket.test.ts
@@ -68,13 +68,15 @@ test("bucket name valid", () => {
   const app = new tfazure.App({ outdir: mkdtemp(), location: "East US" });
   const bucket = new cloud.Bucket(app, "The-Uncanny-Bucket");
   const output = app.synth();
+  console.log(output);
+  console.log(bucket.node.addr.substring(0, 8));
 
   expect(
     cdktf.Testing.toHaveResourceWithProperties(
       output,
       "azurerm_resource_group",
       {
-        name: `The-Uncanny-Bucket-${bucket.node.addr.substring(0, 8)}`,
+        name: `root-${app.node.addr.substring(0, 8)}`,
       }
     )
   ).toEqual(true);
@@ -84,7 +86,7 @@ test("bucket name valid", () => {
       output,
       "azurerm_storage_account",
       {
-        name: `theuncannybucket${bucket.node.addr.substring(0, 8)}`,
+        name: `root${app.node.addr.substring(0, 8)}`,
       }
     )
   ).toEqual(true);


### PR DESCRIPTION
This PR moves storage account and resource group resources to the app level to be shared across all resources defined within the app.

Also minor refactor on inflight client to only create 1 instance of containerClient.

*By submitting this pull request, I confirm that my contribution is made under the terms of the 
[Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.
