### PR TITLE
fix(docs): lack of clarity regarding npm v9

### DIFF
--- a/.github/workflows/pull-request-lint.yml
+++ b/.github/workflows/pull-request-lint.yml
@@ -32,6 +32,7 @@ jobs:
           types: |-
             feat
             fix
+            docs
             chore
             rfc
           subjectPattern: ^[^A-Z]+[^.]$

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,3 @@
+# We make use of symlinks between several projects but we do not use workspaces
+# This setting is the default in npm@8 but is `true` in npm@9
+install-links=false

--- a/docs/02-getting-started/02-installation.md
+++ b/docs/02-getting-started/02-installation.md
@@ -16,13 +16,15 @@ The toolchain includes three tools:
 
 To install Wing, you will need the following setup:
 
-* [Node.js](https://nodejs.org/en/) version 18.x (we recommend [volta](https://volta.sh)).
-* [VSCode] (recommended).
+* [Node.js](https://nodejs.org/en/) (v18 or later)
+  * We recommend [volta](https://volta.sh) to manage node tools
+* [VSCode]
+  * Not required, but currently supported with an [extension](#wing-ide-extension)
 
 In order to deploy to AWS, you will also need:
 
-* [Terraform](https://terraform.io/downloads).
-* [AWS account] and the [AWS CLI] with [AWS credentials].
+* [Terraform](https://terraform.io/downloads)
+* [AWS account] and the [AWS CLI] with [AWS credentials]
 
 ## Wing CLI
 

--- a/docs/06-contributors/handbook.md
+++ b/docs/06-contributors/handbook.md
@@ -168,6 +168,8 @@ changelog. To that end, pull request titles must follow this convention:
   * `docs`
   * `cli`
   * `examples`
+  * `playground`
+  * `vscode`
   * `build` - change related to development environment, build system, build tools, etc.
   * `repo` - change related to repository behavior (e.g. pull request templates, issue templates,
     etc).

--- a/docs/06-contributors/workflows.md
+++ b/docs/06-contributors/workflows.md
@@ -11,12 +11,13 @@ This topic includes a description of common development workflows for the Wing p
 Here is a list of minimal tools you should install to build the Wing repo in your development
 environment:
 
-* [Node.js] version 18.x (we recommend [volta]) (currently npm 9 is [not
-  supported](https://github.com/winglang/wing/issues/1103))
+* [Node.js] v18 and npm v8
+  * We recommend [volta] to manage node tools
 * [Rust]
-* [AWS CLI] (only needed for integration tests - make sure to do the setup part to create
-  credentials)
-* [Terraform CLI] (only needed for integration tests)
+* [AWS CLI]
+  * Only needed for integration tests - make sure to do the setup part to create credentials
+* [Terraform CLI]
+  * Only needed for integration tests
 
 Installation:
 
@@ -26,11 +27,14 @@ cd wing
 npm install
 ```
 
-This is required once:
+:::note
 
-```sh
-sudo ./scripts/setup_wasi.sh
-```
+The first time you run `npm install` you may be asked to enter your system password, this is because
+it's taking care of installing the [wasi-sdk](https://github.com/WebAssembly/wasi-sdk) for you.
+
+If you wish to install it manually, you may do so by running `scripts/setup_wasi.sh`
+
+:::
 
 [Nx]: https://nx.dev/
 [Node.js]: https://nodejs.org/en/


### PR DESCRIPTION
To clarify the situation:
- npm 9 works fine as a consumer of wing (e.g. you run `npx winglang compile ...` or `npm install -g winglang`)
- npm 9 did **not** work as a developer of wing (`npm install` at the root)

This PR fixes that second issue with the additional npmrc file. So now we support npm 9, however the contributor docs will still specify 8 because we should all be using the same version if possible. If you decide to use 9 anyways, it will still work but it may cause lockfile thrashing until we all make the switch.

The regular getting started guide doesn't need to mention npm, if you're at least using node 18 then your npm version should work as a consumer.

While in the docs, I also made some other random tweaks.

Fixes #1103

*By submitting this pull request, I confirm that my contribution is made under the terms of the 
[Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.
