### PR TITLE
rfc: typos in story 11 preventing compilation

### DIFF
--- a/docs/05-rfcs/stories/story-11.md
+++ b/docs/05-rfcs/stories/story-11.md
@@ -107,7 +107,7 @@ resource TaskList {
 let tasks = new TaskList();
 
 let clear_tasks = new cloud.Function(inflight (s: str): str => {
-  for (id in tasks.list_task_ids()) {
+  for id in tasks.list_task_ids() {
     tasks.remove_tasks(id);
   }
 }) as "utility:clear tasks";
@@ -125,13 +125,13 @@ new cloud.Function(inflight (s: str): str => {
   tasks.add_task("clean the dishes");
   let result = tasks.find_tasks_with("clean the dishes");
   assert(result.len == 1);
-  assert("clean the dishes" == tasks.get_task(result.at(0));
+  assert("clean the dishes" == tasks.get_task(result.at(0)));
 }) as "test:get and find task";
 
 new cloud.Function(inflight (s: str): str => {
   clear_tasks.invoke("");
   add_tasks.invoke("");
-  tasks.remove_tasks(tasks.find_tasks_with("clean the dish").at(0))
+  tasks.remove_tasks(tasks.find_tasks_with("clean the dish").at(0));
   let result = tasks.find_tasks_with("clean the dish");
   assert(result.len == 0);
 }) as "test:get, remove and find task";


### PR DESCRIPTION
Just fixing some typos (missing `)`, `;` and extra `()`) in story 11.

*By submitting this pull request, I confirm that my contribution is made under the terms of the 
[Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.
