### PR TITLE
fix(docs): make the build vsc extention compile example work

### DIFF
--- a/apps/vscode-wing/project.json
+++ b/apps/vscode-wing/project.json
@@ -40,7 +40,6 @@
     "build": {
       "executor": "nx:run-script",
       "dependsOn": [
-        "^build",
         "copy"
       ],
       "options": {

--- a/apps/vscode-wing/project.json
+++ b/apps/vscode-wing/project.json
@@ -40,6 +40,7 @@
     "build": {
       "executor": "nx:run-script",
       "dependsOn": [
+        "^build",
         "copy"
       ],
       "options": {

--- a/docs/06-contributors/handbook.md
+++ b/docs/06-contributors/handbook.md
@@ -59,8 +59,8 @@ separately).
 
 ## 🔨 How do I build the VSCode extension?
 
-The VSCode extension is located in `apps/vscode`. Most of the logic is in the language server, which
-is located in `apps/wing-language-server`. Running `nx build` from `apps/vscode` will ensure the
+The VSCode extension is located in `apps/vscode-wing`. Most of the logic is in the language server, which
+is located in `apps/vscode-wing`. Running `npx nx build` from `apps/vscode-wing` will ensure the
 language server is built first and the binary is available. This creates an installable VSIX file.
 
 A VSCode launch configuration is available to open a VSCode with a development version of the


### PR DESCRIPTION

*By submitting this pull request, I confirm that my contribution is made under the terms of the 
[Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.
