### PR TITLE
chore(vscode): nx config missing sdk dependency

### DIFF
--- a/apps/vscode-wing/project.json
+++ b/apps/vscode-wing/project.json
@@ -2,7 +2,8 @@
   "name": "vscode-wing",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "implicitDependencies": [
-    "wing-language-server"
+    "wing-language-server",
+    "sdk"
   ],
   "targets": {
     "copy": {
@@ -14,7 +15,8 @@
         "{projectRoot}/resources/native/wing-language-server"
       ],
       "dependsOn": [
-        "^build-native"
+        "^build-native",
+        "^build"
       ],
       "options": {
         "commands": [
@@ -39,10 +41,7 @@
     },
     "build": {
       "executor": "nx:run-script",
-      "dependsOn": [
-        "^build",
-        "copy"
-      ],
+      "dependsOn": ["copy"],
       "options": {
         "cwd": "apps/vscode-wing",
         "script": "build"


### PR DESCRIPTION
The SDK .jsii is copied during the build process so it needs to be available.

*By submitting this pull request, I confirm that my contribution is made under the terms of the 
[Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.
