### PR TITLE
fix(docs): dangled `let` modifier for a `var` variable

### DIFF
--- a/docs/04-reference/winglang-spec.md
+++ b/docs/04-reference/winglang-spec.md
@@ -406,7 +406,7 @@ Variables can be reassigned to by adding the `var` modifier:
 
 ```ts
 // wing
-let var sum = 0;
+var sum = 0;
 for item in [1,2,3] {
   sum = sum + item;
 }


### PR DESCRIPTION

*By submitting this pull request, I confirm that my contribution is made under the terms of the 
[Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.
