### PR TITLE
fix(compiler): should show errors for missing semicolons or braces

### DIFF
--- a/examples/tests/invalid/missing_semicolon.w
+++ b/examples/tests/invalid/missing_semicolon.w
@@ -11,3 +11,9 @@ q1.on_message(inflight (m:str): str => {
 q2.on_message(inflight (m:str): str => {
   b.put("2.txt", "Hello, ${m}"); 
 });
+
+let x = 5
+//       ^ ';' expected
+
+if (x > 10) {
+//           ^ '}' expected

--- a/examples/tests/valid/primitive_methods.w
+++ b/examples/tests/valid/primitive_methods.w
@@ -3,5 +3,5 @@ let stringy = "${dur.minutes}:${dur.seconds}";
 print(stringy);
 
 if stringy.includes("60") && stringy.split(":").at(0) == "60" {
-  print("${stringy.length}!")
+  print("${stringy.length}!");
 }

--- a/examples/tests/valid/reassignment.w
+++ b/examples/tests/valid/reassignment.w
@@ -28,7 +28,7 @@ assert(r.f == 2);
 let f = (var arg: num):num => {
   arg = 0;
   return arg;
-}
+};
 
 let y = 1;
 assert(f(y) == 0);

--- a/examples/tests/valid/while_loop_await.w
+++ b/examples/tests/valid/while_loop_await.w
@@ -4,7 +4,7 @@ let queue = new cloud.Queue();
 
 let iterator = inflight (j: num): num => {
     return j+1;
-}
+};
 
 let handler = inflight (body: str): str => {
     let i = 0;

--- a/libs/wingc/project.json
+++ b/libs/wingc/project.json
@@ -5,7 +5,6 @@
   "targets": {
     "build-native": {
       "executor": "nx:run-commands",
-      "dependsOn": ["^build"],
       "options": {
         "commands": ["cargo build", "cargo fmt -- --check"],
         "cwd": "libs/wingc"
@@ -32,7 +31,6 @@
     },
     "build-wasm": {
       "executor": "nx:run-commands",
-      "dependsOn": ["^build"],
       "options": {
         "command": "cargo wasi build",
         "cwd": "libs/wingc"

--- a/libs/wingc/project.json
+++ b/libs/wingc/project.json
@@ -1,9 +1,11 @@
 {
   "name": "wingc",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "implicitDependencies": ["sdk"],
   "targets": {
     "build-native": {
       "executor": "nx:run-commands",
+      "dependsOn": ["^build"],
       "options": {
         "commands": ["cargo build", "cargo fmt -- --check"],
         "cwd": "libs/wingc"
@@ -16,6 +18,7 @@
     },
     "test": {
       "executor": "nx:run-commands",
+      "dependsOn": ["^build"],
       "inputs": ["src", "examples-tests"],
       "options": {
         "command": "cargo test",
@@ -29,6 +32,7 @@
     },
     "build-wasm": {
       "executor": "nx:run-commands",
+      "dependsOn": ["^build"],
       "options": {
         "command": "cargo wasi build",
         "cwd": "libs/wingc"
@@ -40,7 +44,7 @@
       }
     },
     "dev": {
-      "dependsOn": ["build-native"],
+      "dependsOn": ["^build", "build-native"],
       "executor": "nx:run-commands",
       "options": {
         "command": "cargo run --example compile",


### PR DESCRIPTION
Fixes #1266

After making the fix work, I discovered there were many syntax errors in our valid examples, so I fixed all of them as well.

I also noticed this sequence of commands were failing on a fresh repo:

```
npm i
cd libs/wingc
npx nx run build-native
npx nx run test
...
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: "Expected to find .jsii file in ../wingsdk, but no such file found"', libs/wingc/src/type_check.rs:1729:18
```

The same issue applies with `npx nx run dev`.

To fix this I've added the sdk as a dependency of `wingc:dev` and `wingc:test`.

*By submitting this pull request, I confirm that my contribution is made under the terms of the 
[Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.
