### PR TITLE
chore(compiler): throw error for more unimplemented grammar cases

### DIFF
--- a/examples/tests/invalid/unimplemented_grammar.w
+++ b/examples/tests/invalid/unimplemented_grammar.w
@@ -1,0 +1,5 @@
+let a: void = nil;
+let b: any = 0;
+let some_promise = Promise<str>{};
+let c = defer some_promise();
+let d = await c;

--- a/libs/tree-sitter-wing/grammar.js
+++ b/libs/tree-sitter-wing/grammar.js
@@ -232,6 +232,7 @@ module.exports = grammar({
         $.preflight_closure,
         $.inflight_closure,
         $.await_expression,
+        $.defer_expression,
         $._collection_literal,
         $.parenthesized_expression,
         $.structured_access_expression,
@@ -496,6 +497,7 @@ module.exports = grammar({
     ),
 
     await_expression: ($) => prec.right(seq("await", $.expression)),
+    defer_expression: ($) => prec.right(seq("defer", $.expression)),
     parenthesized_expression: ($) => seq("(", $.expression, ")"),
 
     _collection_literal: ($) =>

--- a/libs/wingc/src/parser.rs
+++ b/libs/wingc/src/parser.rs
@@ -28,8 +28,6 @@ static UNIMPLEMENTED_GRAMMARS: phf::Map<&'static str, &'static str> = phf_map! {
 	"any" => "see https://github.com/winglang/wing/issues/434",
 	"void" => "see https://github.com/winglang/wing/issues/432",
 	"nil" => "see https://github.com/winglang/wing/issues/433",
-	"MutSet" => "see https://github.com/winglang/wing/issues/98",
-	"MutArray" => "see https://github.com/winglang/wing/issues/663",
 	"Promise" => "see https://github.com/winglang/wing/issues/529",
 	"preflight_closure" => "see https://github.com/winglang/wing/issues/474",
 	"inflight_closure" => "see https://github.com/winglang/wing/issues/474",
@@ -37,6 +35,7 @@ static UNIMPLEMENTED_GRAMMARS: phf::Map<&'static str, &'static str> = phf_map! {
 	"storage_modifier" => "see https://github.com/winglang/wing/issues/107",
 	"access_modifier" => "see https://github.com/winglang/wing/issues/108",
 	"await_expression" => "see https://github.com/winglang/wing/issues/116",
+	"defer_expression" => "see https://github.com/winglang/wing/issues/116",
 	"for_in_loop" => "see https://github.com/winglang/wing/issues/118",
 	"=>" => "see https://github.com/winglang/wing/issues/474",
 };


### PR DESCRIPTION
The wing compiler throws error for unimplemented grammar.
Included in this PR:
1. Removed from the list of unimplemented grammar, features we already support (MutArray, MutSet).
2. Added `defer` to that list.
3. Added a test for grammar we intend to keep unsupported also after wing is in beta.

*By submitting this pull request, I confirm that my contribution is made under the terms of the 
[Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.
