### PR TITLE
chore: strictly pin and update cdktf version in sdk

### DIFF
--- a/apps/vscode-wing/package-lock.json
+++ b/apps/vscode-wing/package-lock.json
@@ -74,7 +74,7 @@
         "@azure/storage-blob": "12.12.0",
         "@cdktf/provider-aws": "^12.0.1",
         "@cdktf/provider-azurerm": "^5.0.1",
-        "cdktf": "~0.15.0",
+        "cdktf": "0.15.2",
         "constructs": "~10.1.228",
         "debug": "^4.3.4",
         "esbuild-wasm": "^0.17.4",
@@ -125,7 +125,7 @@
       "peerDependencies": {
         "@cdktf/provider-aws": "^12.0.1",
         "@cdktf/provider-azurerm": "^5.0.1",
-        "cdktf": "~0.15.0",
+        "cdktf": "0.15.2",
         "constructs": "~10.1.228",
         "polycons": "^0.1.1"
       }
@@ -10551,7 +10551,7 @@
         "@winglang/wing-api-checker": "file:../../apps/wing-api-checker",
         "aws-sdk-client-mock": "^2.0.1",
         "aws-sdk-client-mock-jest": "^2.0.1",
-        "cdktf": "~0.15.0",
+        "cdktf": "0.15.2",
         "cdktf-cli": "^0.15.0",
         "constructs": "~10.1.228",
         "debug": "^4.3.4",

--- a/apps/wing-playground/package-lock.json
+++ b/apps/wing-playground/package-lock.json
@@ -55,7 +55,7 @@
         "@azure/storage-blob": "12.12.0",
         "@cdktf/provider-aws": "^12.0.1",
         "@cdktf/provider-azurerm": "^5.0.1",
-        "cdktf": "~0.15.0",
+        "cdktf": "0.15.2",
         "constructs": "~10.1.228",
         "debug": "^4.3.4",
         "esbuild-wasm": "^0.17.4",
@@ -106,7 +106,7 @@
       "peerDependencies": {
         "@cdktf/provider-aws": "^12.0.1",
         "@cdktf/provider-azurerm": "^5.0.1",
-        "cdktf": "~0.15.0",
+        "cdktf": "0.15.2",
         "constructs": "~10.1.228",
         "polycons": "^0.1.1"
       }
@@ -1595,7 +1595,7 @@
         "@winglang/wing-api-checker": "file:../../apps/wing-api-checker",
         "aws-sdk-client-mock": "^2.0.1",
         "aws-sdk-client-mock-jest": "^2.0.1",
-        "cdktf": "~0.15.0",
+        "cdktf": "0.15.2",
         "cdktf-cli": "^0.15.0",
         "constructs": "~10.1.228",
         "debug": "^4.3.4",

--- a/apps/wing/package-lock.json
+++ b/apps/wing/package-lock.json
@@ -72,7 +72,7 @@
         "@azure/storage-blob": "12.12.0",
         "@cdktf/provider-aws": "^12.0.1",
         "@cdktf/provider-azurerm": "^5.0.1",
-        "cdktf": "~0.15.0",
+        "cdktf": "0.15.2",
         "constructs": "~10.1.228",
         "debug": "^4.3.4",
         "esbuild-wasm": "^0.17.4",
@@ -123,7 +123,7 @@
       "peerDependencies": {
         "@cdktf/provider-aws": "^12.0.1",
         "@cdktf/provider-azurerm": "^5.0.1",
-        "cdktf": "~0.15.0",
+        "cdktf": "0.15.2",
         "constructs": "~10.1.228",
         "polycons": "^0.1.1"
       }
@@ -5580,7 +5580,7 @@
         "@winglang/wing-api-checker": "file:../../apps/wing-api-checker",
         "aws-sdk-client-mock": "^2.0.1",
         "aws-sdk-client-mock-jest": "^2.0.1",
-        "cdktf": "~0.15.0",
+        "cdktf": "0.15.2",
         "cdktf-cli": "^0.15.0",
         "constructs": "~10.1.228",
         "debug": "^4.3.4",

--- a/libs/wingsdk/.projen/deps.json
+++ b/libs/wingsdk/.projen/deps.json
@@ -249,7 +249,7 @@
     },
     {
       "name": "cdktf",
-      "version": "~0.15.0",
+      "version": "0.15.2",
       "type": "peer"
     },
     {
@@ -273,7 +273,7 @@
     },
     {
       "name": "cdktf",
-      "version": "~0.15.0",
+      "version": "0.15.2",
       "type": "runtime"
     },
     {

--- a/libs/wingsdk/.projenrc.ts
+++ b/libs/wingsdk/.projenrc.ts
@@ -3,7 +3,7 @@ import { JsonFile, cdk, javascript } from "projen";
 const JSII_DEPS = [
   "constructs@~10.1.228",
   "polycons",
-  "cdktf@~0.15.0",
+  "cdktf@0.15.2",
   "@cdktf/provider-aws@^12.0.1",
   "@cdktf/provider-azurerm@^5.0.1",
 ];

--- a/libs/wingsdk/package-lock.json
+++ b/libs/wingsdk/package-lock.json
@@ -41,7 +41,7 @@
         "@azure/storage-blob": "12.12.0",
         "@cdktf/provider-aws": "^12.0.1",
         "@cdktf/provider-azurerm": "^5.0.1",
-        "cdktf": "~0.15.0",
+        "cdktf": "0.15.2",
         "constructs": "~10.1.228",
         "debug": "^4.3.4",
         "esbuild-wasm": "^0.17.4",
@@ -92,13 +92,12 @@
       "peerDependencies": {
         "@cdktf/provider-aws": "^12.0.1",
         "@cdktf/provider-azurerm": "^5.0.1",
-        "cdktf": "~0.15.0",
+        "cdktf": "0.15.2",
         "constructs": "~10.1.228",
         "polycons": "^0.1.1"
       }
     },
     "../../apps/jsii-docgen": {
-      "name": "@winglang/jsii-docgen",
       "version": "0.0.0",
       "dev": true,
       "license": "Apache-2.0",
@@ -142,6 +141,7 @@
       }
     },
     "../../apps/wing-api-checker": {
+      "name": "wing-api-checker",
       "version": "0.0.0",
       "dev": true,
       "license": "Apache-2.0",
@@ -2709,6 +2709,601 @@
         "zod": "^1.11.17"
       }
     },
+    "node_modules/@cdktf/cli-core/node_modules/cdktf": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/cdktf/-/cdktf-0.15.0.tgz",
+      "integrity": "sha512-Dzv/pfJWTFzxMxjcgI3cttK7hPLy69bUPzcZgUK0sI+k3kY4I67pmxKuXDh1XVK9AX+pCaiZT7wzQbCznTrQkQ==",
+      "bundleDependencies": [
+        "archiver",
+        "json-stable-stringify",
+        "semver"
+      ],
+      "dev": true,
+      "dependencies": {
+        "archiver": "5.3.1",
+        "json-stable-stringify": "^1.0.2",
+        "semver": "^7.3.8"
+      },
+      "peerDependencies": {
+        "constructs": "^10.0.25"
+      }
+    },
+    "node_modules/@cdktf/cli-core/node_modules/cdktf/node_modules/archiver": {
+      "version": "5.3.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "archiver-utils": "^2.1.0",
+        "async": "^3.2.3",
+        "buffer-crc32": "^0.2.1",
+        "readable-stream": "^3.6.0",
+        "readdir-glob": "^1.0.0",
+        "tar-stream": "^2.2.0",
+        "zip-stream": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@cdktf/cli-core/node_modules/cdktf/node_modules/archiver-utils": {
+      "version": "2.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "glob": "^7.1.4",
+        "graceful-fs": "^4.2.0",
+        "lazystream": "^1.0.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.difference": "^4.5.0",
+        "lodash.flatten": "^4.4.0",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.union": "^4.6.0",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@cdktf/cli-core/node_modules/cdktf/node_modules/archiver-utils/node_modules/readable-stream": {
+      "version": "2.3.7",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/@cdktf/cli-core/node_modules/cdktf/node_modules/archiver-utils/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/@cdktf/cli-core/node_modules/cdktf/node_modules/async": {
+      "version": "3.2.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@cdktf/cli-core/node_modules/cdktf/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@cdktf/cli-core/node_modules/cdktf/node_modules/base64-js": {
+      "version": "1.5.1",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@cdktf/cli-core/node_modules/cdktf/node_modules/bl": {
+      "version": "4.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/@cdktf/cli-core/node_modules/cdktf/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@cdktf/cli-core/node_modules/cdktf/node_modules/buffer": {
+      "version": "5.7.1",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/@cdktf/cli-core/node_modules/cdktf/node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@cdktf/cli-core/node_modules/cdktf/node_modules/compress-commons": {
+      "version": "4.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "^0.2.13",
+        "crc32-stream": "^4.0.2",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@cdktf/cli-core/node_modules/cdktf/node_modules/concat-map": {
+      "version": "0.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@cdktf/cli-core/node_modules/cdktf/node_modules/core-util-is": {
+      "version": "1.0.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@cdktf/cli-core/node_modules/cdktf/node_modules/crc-32": {
+      "version": "1.2.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/@cdktf/cli-core/node_modules/cdktf/node_modules/crc32-stream": {
+      "version": "4.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "crc-32": "^1.2.0",
+        "readable-stream": "^3.4.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@cdktf/cli-core/node_modules/cdktf/node_modules/end-of-stream": {
+      "version": "1.4.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/@cdktf/cli-core/node_modules/cdktf/node_modules/fs-constants": {
+      "version": "1.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@cdktf/cli-core/node_modules/cdktf/node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/@cdktf/cli-core/node_modules/cdktf/node_modules/glob": {
+      "version": "7.2.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@cdktf/cli-core/node_modules/cdktf/node_modules/glob/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@cdktf/cli-core/node_modules/cdktf/node_modules/glob/node_modules/minimatch": {
+      "version": "3.1.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@cdktf/cli-core/node_modules/cdktf/node_modules/graceful-fs": {
+      "version": "4.2.10",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/@cdktf/cli-core/node_modules/cdktf/node_modules/ieee754": {
+      "version": "1.2.1",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "inBundle": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@cdktf/cli-core/node_modules/cdktf/node_modules/inflight": {
+      "version": "1.0.6",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/@cdktf/cli-core/node_modules/cdktf/node_modules/inherits": {
+      "version": "2.0.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/@cdktf/cli-core/node_modules/cdktf/node_modules/isarray": {
+      "version": "1.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@cdktf/cli-core/node_modules/cdktf/node_modules/json-stable-stringify": {
+      "version": "1.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "jsonify": "^0.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/@cdktf/cli-core/node_modules/cdktf/node_modules/jsonify": {
+      "version": "0.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "Public Domain",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/@cdktf/cli-core/node_modules/cdktf/node_modules/lazystream": {
+      "version": "1.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "^2.0.5"
+      },
+      "engines": {
+        "node": ">= 0.6.3"
+      }
+    },
+    "node_modules/@cdktf/cli-core/node_modules/cdktf/node_modules/lazystream/node_modules/readable-stream": {
+      "version": "2.3.7",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/@cdktf/cli-core/node_modules/cdktf/node_modules/lazystream/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/@cdktf/cli-core/node_modules/cdktf/node_modules/lodash.defaults": {
+      "version": "4.2.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@cdktf/cli-core/node_modules/cdktf/node_modules/lodash.difference": {
+      "version": "4.5.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@cdktf/cli-core/node_modules/cdktf/node_modules/lodash.flatten": {
+      "version": "4.4.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@cdktf/cli-core/node_modules/cdktf/node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@cdktf/cli-core/node_modules/cdktf/node_modules/lodash.union": {
+      "version": "4.6.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@cdktf/cli-core/node_modules/cdktf/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@cdktf/cli-core/node_modules/cdktf/node_modules/minimatch": {
+      "version": "5.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@cdktf/cli-core/node_modules/cdktf/node_modules/normalize-path": {
+      "version": "3.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@cdktf/cli-core/node_modules/cdktf/node_modules/once": {
+      "version": "1.4.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/@cdktf/cli-core/node_modules/cdktf/node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@cdktf/cli-core/node_modules/cdktf/node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@cdktf/cli-core/node_modules/cdktf/node_modules/readable-stream": {
+      "version": "3.6.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@cdktf/cli-core/node_modules/cdktf/node_modules/readdir-glob": {
+      "version": "1.1.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "minimatch": "^5.1.0"
+      }
+    },
+    "node_modules/@cdktf/cli-core/node_modules/cdktf/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@cdktf/cli-core/node_modules/cdktf/node_modules/semver": {
+      "version": "7.3.8",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@cdktf/cli-core/node_modules/cdktf/node_modules/string_decoder": {
+      "version": "1.3.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/@cdktf/cli-core/node_modules/cdktf/node_modules/string_decoder/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@cdktf/cli-core/node_modules/cdktf/node_modules/tar-stream": {
+      "version": "2.2.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@cdktf/cli-core/node_modules/cdktf/node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@cdktf/cli-core/node_modules/cdktf/node_modules/wrappy": {
+      "version": "1.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/@cdktf/cli-core/node_modules/cdktf/node_modules/yallist": {
+      "version": "4.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/@cdktf/cli-core/node_modules/cdktf/node_modules/zip-stream": {
+      "version": "4.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "archiver-utils": "^2.1.0",
+        "compress-commons": "^4.1.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/@cdktf/commons": {
       "version": "0.15.0",
       "resolved": "https://registry.npmjs.org/@cdktf/commons/-/commons-0.15.0.tgz",
@@ -2726,6 +3321,601 @@
         "is-valid-domain": "^0.1.6",
         "log4js": "^6.7.0",
         "uuid": "^8.3.2"
+      }
+    },
+    "node_modules/@cdktf/commons/node_modules/cdktf": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/cdktf/-/cdktf-0.15.0.tgz",
+      "integrity": "sha512-Dzv/pfJWTFzxMxjcgI3cttK7hPLy69bUPzcZgUK0sI+k3kY4I67pmxKuXDh1XVK9AX+pCaiZT7wzQbCznTrQkQ==",
+      "bundleDependencies": [
+        "archiver",
+        "json-stable-stringify",
+        "semver"
+      ],
+      "dev": true,
+      "dependencies": {
+        "archiver": "5.3.1",
+        "json-stable-stringify": "^1.0.2",
+        "semver": "^7.3.8"
+      },
+      "peerDependencies": {
+        "constructs": "^10.0.25"
+      }
+    },
+    "node_modules/@cdktf/commons/node_modules/cdktf/node_modules/archiver": {
+      "version": "5.3.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "archiver-utils": "^2.1.0",
+        "async": "^3.2.3",
+        "buffer-crc32": "^0.2.1",
+        "readable-stream": "^3.6.0",
+        "readdir-glob": "^1.0.0",
+        "tar-stream": "^2.2.0",
+        "zip-stream": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@cdktf/commons/node_modules/cdktf/node_modules/archiver-utils": {
+      "version": "2.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "glob": "^7.1.4",
+        "graceful-fs": "^4.2.0",
+        "lazystream": "^1.0.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.difference": "^4.5.0",
+        "lodash.flatten": "^4.4.0",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.union": "^4.6.0",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@cdktf/commons/node_modules/cdktf/node_modules/archiver-utils/node_modules/readable-stream": {
+      "version": "2.3.7",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/@cdktf/commons/node_modules/cdktf/node_modules/archiver-utils/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/@cdktf/commons/node_modules/cdktf/node_modules/async": {
+      "version": "3.2.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@cdktf/commons/node_modules/cdktf/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@cdktf/commons/node_modules/cdktf/node_modules/base64-js": {
+      "version": "1.5.1",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@cdktf/commons/node_modules/cdktf/node_modules/bl": {
+      "version": "4.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/@cdktf/commons/node_modules/cdktf/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@cdktf/commons/node_modules/cdktf/node_modules/buffer": {
+      "version": "5.7.1",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/@cdktf/commons/node_modules/cdktf/node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@cdktf/commons/node_modules/cdktf/node_modules/compress-commons": {
+      "version": "4.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "^0.2.13",
+        "crc32-stream": "^4.0.2",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@cdktf/commons/node_modules/cdktf/node_modules/concat-map": {
+      "version": "0.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@cdktf/commons/node_modules/cdktf/node_modules/core-util-is": {
+      "version": "1.0.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@cdktf/commons/node_modules/cdktf/node_modules/crc-32": {
+      "version": "1.2.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/@cdktf/commons/node_modules/cdktf/node_modules/crc32-stream": {
+      "version": "4.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "crc-32": "^1.2.0",
+        "readable-stream": "^3.4.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@cdktf/commons/node_modules/cdktf/node_modules/end-of-stream": {
+      "version": "1.4.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/@cdktf/commons/node_modules/cdktf/node_modules/fs-constants": {
+      "version": "1.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@cdktf/commons/node_modules/cdktf/node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/@cdktf/commons/node_modules/cdktf/node_modules/glob": {
+      "version": "7.2.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@cdktf/commons/node_modules/cdktf/node_modules/glob/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@cdktf/commons/node_modules/cdktf/node_modules/glob/node_modules/minimatch": {
+      "version": "3.1.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@cdktf/commons/node_modules/cdktf/node_modules/graceful-fs": {
+      "version": "4.2.10",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/@cdktf/commons/node_modules/cdktf/node_modules/ieee754": {
+      "version": "1.2.1",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "inBundle": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@cdktf/commons/node_modules/cdktf/node_modules/inflight": {
+      "version": "1.0.6",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/@cdktf/commons/node_modules/cdktf/node_modules/inherits": {
+      "version": "2.0.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/@cdktf/commons/node_modules/cdktf/node_modules/isarray": {
+      "version": "1.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@cdktf/commons/node_modules/cdktf/node_modules/json-stable-stringify": {
+      "version": "1.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "jsonify": "^0.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/@cdktf/commons/node_modules/cdktf/node_modules/jsonify": {
+      "version": "0.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "Public Domain",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/@cdktf/commons/node_modules/cdktf/node_modules/lazystream": {
+      "version": "1.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "^2.0.5"
+      },
+      "engines": {
+        "node": ">= 0.6.3"
+      }
+    },
+    "node_modules/@cdktf/commons/node_modules/cdktf/node_modules/lazystream/node_modules/readable-stream": {
+      "version": "2.3.7",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/@cdktf/commons/node_modules/cdktf/node_modules/lazystream/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/@cdktf/commons/node_modules/cdktf/node_modules/lodash.defaults": {
+      "version": "4.2.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@cdktf/commons/node_modules/cdktf/node_modules/lodash.difference": {
+      "version": "4.5.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@cdktf/commons/node_modules/cdktf/node_modules/lodash.flatten": {
+      "version": "4.4.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@cdktf/commons/node_modules/cdktf/node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@cdktf/commons/node_modules/cdktf/node_modules/lodash.union": {
+      "version": "4.6.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@cdktf/commons/node_modules/cdktf/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@cdktf/commons/node_modules/cdktf/node_modules/minimatch": {
+      "version": "5.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@cdktf/commons/node_modules/cdktf/node_modules/normalize-path": {
+      "version": "3.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@cdktf/commons/node_modules/cdktf/node_modules/once": {
+      "version": "1.4.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/@cdktf/commons/node_modules/cdktf/node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@cdktf/commons/node_modules/cdktf/node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@cdktf/commons/node_modules/cdktf/node_modules/readable-stream": {
+      "version": "3.6.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@cdktf/commons/node_modules/cdktf/node_modules/readdir-glob": {
+      "version": "1.1.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "minimatch": "^5.1.0"
+      }
+    },
+    "node_modules/@cdktf/commons/node_modules/cdktf/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@cdktf/commons/node_modules/cdktf/node_modules/semver": {
+      "version": "7.3.8",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@cdktf/commons/node_modules/cdktf/node_modules/string_decoder": {
+      "version": "1.3.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/@cdktf/commons/node_modules/cdktf/node_modules/string_decoder/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@cdktf/commons/node_modules/cdktf/node_modules/tar-stream": {
+      "version": "2.2.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@cdktf/commons/node_modules/cdktf/node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@cdktf/commons/node_modules/cdktf/node_modules/wrappy": {
+      "version": "1.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/@cdktf/commons/node_modules/cdktf/node_modules/yallist": {
+      "version": "4.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/@cdktf/commons/node_modules/cdktf/node_modules/zip-stream": {
+      "version": "4.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "archiver-utils": "^2.1.0",
+        "compress-commons": "^4.1.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/@cdktf/commons/node_modules/fs-extra": {
@@ -6361,9 +7551,9 @@
       }
     },
     "node_modules/cdktf": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/cdktf/-/cdktf-0.15.0.tgz",
-      "integrity": "sha512-Dzv/pfJWTFzxMxjcgI3cttK7hPLy69bUPzcZgUK0sI+k3kY4I67pmxKuXDh1XVK9AX+pCaiZT7wzQbCznTrQkQ==",
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/cdktf/-/cdktf-0.15.2.tgz",
+      "integrity": "sha512-1V8u4nMtcgwfHq7V7+a+VkotMDDZUk6JJQ7BKPZyraN7MfiBjkUQUQo9PYJQdRONABFugwyggjy1Aqw8dto7Vw==",
       "bundleDependencies": [
         "archiver",
         "json-stable-stringify",
@@ -6409,6 +7599,601 @@
       },
       "bin": {
         "cdktf": "bundle/bin/cdktf"
+      }
+    },
+    "node_modules/cdktf-cli/node_modules/cdktf": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/cdktf/-/cdktf-0.15.0.tgz",
+      "integrity": "sha512-Dzv/pfJWTFzxMxjcgI3cttK7hPLy69bUPzcZgUK0sI+k3kY4I67pmxKuXDh1XVK9AX+pCaiZT7wzQbCznTrQkQ==",
+      "bundleDependencies": [
+        "archiver",
+        "json-stable-stringify",
+        "semver"
+      ],
+      "dev": true,
+      "dependencies": {
+        "archiver": "5.3.1",
+        "json-stable-stringify": "^1.0.2",
+        "semver": "^7.3.8"
+      },
+      "peerDependencies": {
+        "constructs": "^10.0.25"
+      }
+    },
+    "node_modules/cdktf-cli/node_modules/cdktf/node_modules/archiver": {
+      "version": "5.3.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "archiver-utils": "^2.1.0",
+        "async": "^3.2.3",
+        "buffer-crc32": "^0.2.1",
+        "readable-stream": "^3.6.0",
+        "readdir-glob": "^1.0.0",
+        "tar-stream": "^2.2.0",
+        "zip-stream": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/cdktf-cli/node_modules/cdktf/node_modules/archiver-utils": {
+      "version": "2.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "glob": "^7.1.4",
+        "graceful-fs": "^4.2.0",
+        "lazystream": "^1.0.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.difference": "^4.5.0",
+        "lodash.flatten": "^4.4.0",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.union": "^4.6.0",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/cdktf-cli/node_modules/cdktf/node_modules/archiver-utils/node_modules/readable-stream": {
+      "version": "2.3.7",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/cdktf-cli/node_modules/cdktf/node_modules/archiver-utils/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/cdktf-cli/node_modules/cdktf/node_modules/async": {
+      "version": "3.2.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/cdktf-cli/node_modules/cdktf/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/cdktf-cli/node_modules/cdktf/node_modules/base64-js": {
+      "version": "1.5.1",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/cdktf-cli/node_modules/cdktf/node_modules/bl": {
+      "version": "4.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/cdktf-cli/node_modules/cdktf/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/cdktf-cli/node_modules/cdktf/node_modules/buffer": {
+      "version": "5.7.1",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/cdktf-cli/node_modules/cdktf/node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/cdktf-cli/node_modules/cdktf/node_modules/compress-commons": {
+      "version": "4.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "^0.2.13",
+        "crc32-stream": "^4.0.2",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/cdktf-cli/node_modules/cdktf/node_modules/concat-map": {
+      "version": "0.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/cdktf-cli/node_modules/cdktf/node_modules/core-util-is": {
+      "version": "1.0.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/cdktf-cli/node_modules/cdktf/node_modules/crc-32": {
+      "version": "1.2.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/cdktf-cli/node_modules/cdktf/node_modules/crc32-stream": {
+      "version": "4.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "crc-32": "^1.2.0",
+        "readable-stream": "^3.4.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/cdktf-cli/node_modules/cdktf/node_modules/end-of-stream": {
+      "version": "1.4.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/cdktf-cli/node_modules/cdktf/node_modules/fs-constants": {
+      "version": "1.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/cdktf-cli/node_modules/cdktf/node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/cdktf-cli/node_modules/cdktf/node_modules/glob": {
+      "version": "7.2.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/cdktf-cli/node_modules/cdktf/node_modules/glob/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/cdktf-cli/node_modules/cdktf/node_modules/glob/node_modules/minimatch": {
+      "version": "3.1.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/cdktf-cli/node_modules/cdktf/node_modules/graceful-fs": {
+      "version": "4.2.10",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/cdktf-cli/node_modules/cdktf/node_modules/ieee754": {
+      "version": "1.2.1",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "inBundle": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/cdktf-cli/node_modules/cdktf/node_modules/inflight": {
+      "version": "1.0.6",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/cdktf-cli/node_modules/cdktf/node_modules/inherits": {
+      "version": "2.0.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/cdktf-cli/node_modules/cdktf/node_modules/isarray": {
+      "version": "1.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/cdktf-cli/node_modules/cdktf/node_modules/json-stable-stringify": {
+      "version": "1.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "jsonify": "^0.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/cdktf-cli/node_modules/cdktf/node_modules/jsonify": {
+      "version": "0.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "Public Domain",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/cdktf-cli/node_modules/cdktf/node_modules/lazystream": {
+      "version": "1.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "^2.0.5"
+      },
+      "engines": {
+        "node": ">= 0.6.3"
+      }
+    },
+    "node_modules/cdktf-cli/node_modules/cdktf/node_modules/lazystream/node_modules/readable-stream": {
+      "version": "2.3.7",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/cdktf-cli/node_modules/cdktf/node_modules/lazystream/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/cdktf-cli/node_modules/cdktf/node_modules/lodash.defaults": {
+      "version": "4.2.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/cdktf-cli/node_modules/cdktf/node_modules/lodash.difference": {
+      "version": "4.5.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/cdktf-cli/node_modules/cdktf/node_modules/lodash.flatten": {
+      "version": "4.4.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/cdktf-cli/node_modules/cdktf/node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/cdktf-cli/node_modules/cdktf/node_modules/lodash.union": {
+      "version": "4.6.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/cdktf-cli/node_modules/cdktf/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/cdktf-cli/node_modules/cdktf/node_modules/minimatch": {
+      "version": "5.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/cdktf-cli/node_modules/cdktf/node_modules/normalize-path": {
+      "version": "3.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/cdktf-cli/node_modules/cdktf/node_modules/once": {
+      "version": "1.4.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/cdktf-cli/node_modules/cdktf/node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/cdktf-cli/node_modules/cdktf/node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/cdktf-cli/node_modules/cdktf/node_modules/readable-stream": {
+      "version": "3.6.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/cdktf-cli/node_modules/cdktf/node_modules/readdir-glob": {
+      "version": "1.1.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "minimatch": "^5.1.0"
+      }
+    },
+    "node_modules/cdktf-cli/node_modules/cdktf/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/cdktf-cli/node_modules/cdktf/node_modules/semver": {
+      "version": "7.3.8",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/cdktf-cli/node_modules/cdktf/node_modules/string_decoder": {
+      "version": "1.3.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/cdktf-cli/node_modules/cdktf/node_modules/string_decoder/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/cdktf-cli/node_modules/cdktf/node_modules/tar-stream": {
+      "version": "2.2.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/cdktf-cli/node_modules/cdktf/node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/cdktf-cli/node_modules/cdktf/node_modules/wrappy": {
+      "version": "1.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/cdktf-cli/node_modules/cdktf/node_modules/yallist": {
+      "version": "4.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/cdktf-cli/node_modules/cdktf/node_modules/zip-stream": {
+      "version": "4.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "archiver-utils": "^2.1.0",
+        "compress-commons": "^4.1.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/cdktf/node_modules/archiver": {
@@ -7161,20 +8946,6 @@
       },
       "engines": {
         "node": ">= 14.6.0"
-      }
-    },
-    "node_modules/codemaker/node_modules/fs-extra": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
-      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-      "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/collect-v8-coverage": {
@@ -9716,6 +11487,20 @@
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
       "dev": true
+    },
+    "node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/fs-minipass": {
       "version": "2.1.0",
@@ -13402,20 +15187,6 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
-    "node_modules/jsii-diff/node_modules/fs-extra": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
-      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-      "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/jsii-diff/node_modules/wrap-ansi": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
@@ -13534,20 +15305,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/jsii-pacmak/node_modules/fs-extra": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
-      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-      "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/jsii-pacmak/node_modules/wrap-ansi": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
@@ -13662,20 +15419,6 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
-    },
-    "node_modules/jsii-reflect/node_modules/fs-extra": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
-      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-      "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
     },
     "node_modules/jsii-reflect/node_modules/has-flag": {
       "version": "4.0.0",
@@ -14062,20 +15805,6 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
-    },
-    "node_modules/jsii/node_modules/fs-extra": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
-      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-      "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
     },
     "node_modules/jsii/node_modules/has-flag": {
       "version": "4.0.0",
@@ -22370,6 +24099,429 @@
         "yargs": "^17.6",
         "yoga-layout-prebuilt": "^1.10.0",
         "zod": "^1.11.17"
+      },
+      "dependencies": {
+        "cdktf": {
+          "version": "0.15.0",
+          "resolved": "https://registry.npmjs.org/cdktf/-/cdktf-0.15.0.tgz",
+          "integrity": "sha512-Dzv/pfJWTFzxMxjcgI3cttK7hPLy69bUPzcZgUK0sI+k3kY4I67pmxKuXDh1XVK9AX+pCaiZT7wzQbCznTrQkQ==",
+          "dev": true,
+          "requires": {
+            "archiver": "5.3.1",
+            "json-stable-stringify": "^1.0.2",
+            "semver": "^7.3.8"
+          },
+          "dependencies": {
+            "archiver": {
+              "version": "5.3.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "archiver-utils": "^2.1.0",
+                "async": "^3.2.3",
+                "buffer-crc32": "^0.2.1",
+                "readable-stream": "^3.6.0",
+                "readdir-glob": "^1.0.0",
+                "tar-stream": "^2.2.0",
+                "zip-stream": "^4.1.0"
+              }
+            },
+            "archiver-utils": {
+              "version": "2.1.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "glob": "^7.1.4",
+                "graceful-fs": "^4.2.0",
+                "lazystream": "^1.0.0",
+                "lodash.defaults": "^4.2.0",
+                "lodash.difference": "^4.5.0",
+                "lodash.flatten": "^4.4.0",
+                "lodash.isplainobject": "^4.0.6",
+                "lodash.union": "^4.6.0",
+                "normalize-path": "^3.0.0",
+                "readable-stream": "^2.0.0"
+              },
+              "dependencies": {
+                "readable-stream": {
+                  "version": "2.3.7",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "core-util-is": "~1.0.0",
+                    "inherits": "~2.0.3",
+                    "isarray": "~1.0.0",
+                    "process-nextick-args": "~2.0.0",
+                    "safe-buffer": "~5.1.1",
+                    "string_decoder": "~1.1.1",
+                    "util-deprecate": "~1.0.1"
+                  }
+                },
+                "string_decoder": {
+                  "version": "1.1.1",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "safe-buffer": "~5.1.0"
+                  }
+                }
+              }
+            },
+            "async": {
+              "version": "3.2.4",
+              "bundled": true,
+              "dev": true
+            },
+            "balanced-match": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true
+            },
+            "base64-js": {
+              "version": "1.5.1",
+              "bundled": true,
+              "dev": true
+            },
+            "bl": {
+              "version": "4.1.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "buffer": "^5.5.0",
+                "inherits": "^2.0.4",
+                "readable-stream": "^3.4.0"
+              }
+            },
+            "brace-expansion": {
+              "version": "2.0.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "balanced-match": "^1.0.0"
+              }
+            },
+            "buffer": {
+              "version": "5.7.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "base64-js": "^1.3.1",
+                "ieee754": "^1.1.13"
+              }
+            },
+            "buffer-crc32": {
+              "version": "0.2.13",
+              "bundled": true,
+              "dev": true
+            },
+            "compress-commons": {
+              "version": "4.1.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "buffer-crc32": "^0.2.13",
+                "crc32-stream": "^4.0.2",
+                "normalize-path": "^3.0.0",
+                "readable-stream": "^3.6.0"
+              }
+            },
+            "concat-map": {
+              "version": "0.0.1",
+              "bundled": true,
+              "dev": true
+            },
+            "core-util-is": {
+              "version": "1.0.3",
+              "bundled": true,
+              "dev": true
+            },
+            "crc-32": {
+              "version": "1.2.2",
+              "bundled": true,
+              "dev": true
+            },
+            "crc32-stream": {
+              "version": "4.0.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "crc-32": "^1.2.0",
+                "readable-stream": "^3.4.0"
+              }
+            },
+            "end-of-stream": {
+              "version": "1.4.4",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "once": "^1.4.0"
+              }
+            },
+            "fs-constants": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "fs.realpath": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "glob": {
+              "version": "7.2.3",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.1.1",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+              },
+              "dependencies": {
+                "brace-expansion": {
+                  "version": "1.1.11",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "balanced-match": "^1.0.0",
+                    "concat-map": "0.0.1"
+                  }
+                },
+                "minimatch": {
+                  "version": "3.1.2",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "brace-expansion": "^1.1.7"
+                  }
+                }
+              }
+            },
+            "graceful-fs": {
+              "version": "4.2.10",
+              "bundled": true,
+              "dev": true
+            },
+            "ieee754": {
+              "version": "1.2.1",
+              "bundled": true,
+              "dev": true
+            },
+            "inflight": {
+              "version": "1.0.6",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "once": "^1.3.0",
+                "wrappy": "1"
+              }
+            },
+            "inherits": {
+              "version": "2.0.4",
+              "bundled": true,
+              "dev": true
+            },
+            "isarray": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "json-stable-stringify": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "jsonify": "^0.0.1"
+              }
+            },
+            "jsonify": {
+              "version": "0.0.1",
+              "bundled": true,
+              "dev": true
+            },
+            "lazystream": {
+              "version": "1.0.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "readable-stream": "^2.0.5"
+              },
+              "dependencies": {
+                "readable-stream": {
+                  "version": "2.3.7",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "core-util-is": "~1.0.0",
+                    "inherits": "~2.0.3",
+                    "isarray": "~1.0.0",
+                    "process-nextick-args": "~2.0.0",
+                    "safe-buffer": "~5.1.1",
+                    "string_decoder": "~1.1.1",
+                    "util-deprecate": "~1.0.1"
+                  }
+                },
+                "string_decoder": {
+                  "version": "1.1.1",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "safe-buffer": "~5.1.0"
+                  }
+                }
+              }
+            },
+            "lodash.defaults": {
+              "version": "4.2.0",
+              "bundled": true,
+              "dev": true
+            },
+            "lodash.difference": {
+              "version": "4.5.0",
+              "bundled": true,
+              "dev": true
+            },
+            "lodash.flatten": {
+              "version": "4.4.0",
+              "bundled": true,
+              "dev": true
+            },
+            "lodash.isplainobject": {
+              "version": "4.0.6",
+              "bundled": true,
+              "dev": true
+            },
+            "lodash.union": {
+              "version": "4.6.0",
+              "bundled": true,
+              "dev": true
+            },
+            "lru-cache": {
+              "version": "6.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "yallist": "^4.0.0"
+              }
+            },
+            "minimatch": {
+              "version": "5.1.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "brace-expansion": "^2.0.1"
+              }
+            },
+            "normalize-path": {
+              "version": "3.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "once": {
+              "version": "1.4.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "wrappy": "1"
+              }
+            },
+            "path-is-absolute": {
+              "version": "1.0.1",
+              "bundled": true,
+              "dev": true
+            },
+            "process-nextick-args": {
+              "version": "2.0.1",
+              "bundled": true,
+              "dev": true
+            },
+            "readable-stream": {
+              "version": "3.6.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "inherits": "^2.0.3",
+                "string_decoder": "^1.1.1",
+                "util-deprecate": "^1.0.1"
+              }
+            },
+            "readdir-glob": {
+              "version": "1.1.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "minimatch": "^5.1.0"
+              }
+            },
+            "safe-buffer": {
+              "version": "5.1.2",
+              "bundled": true,
+              "dev": true
+            },
+            "semver": {
+              "version": "7.3.8",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "lru-cache": "^6.0.0"
+              }
+            },
+            "string_decoder": {
+              "version": "1.3.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "safe-buffer": "~5.2.0"
+              },
+              "dependencies": {
+                "safe-buffer": {
+                  "version": "5.2.1",
+                  "bundled": true,
+                  "dev": true
+                }
+              }
+            },
+            "tar-stream": {
+              "version": "2.2.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "bl": "^4.0.3",
+                "end-of-stream": "^1.4.1",
+                "fs-constants": "^1.0.0",
+                "inherits": "^2.0.3",
+                "readable-stream": "^3.1.1"
+              }
+            },
+            "util-deprecate": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true
+            },
+            "wrappy": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true
+            },
+            "yallist": {
+              "version": "4.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "zip-stream": {
+              "version": "4.1.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "archiver-utils": "^2.1.0",
+                "compress-commons": "^4.1.0",
+                "readable-stream": "^3.6.0"
+              }
+            }
+          }
+        }
       }
     },
     "@cdktf/commons": {
@@ -22391,6 +24543,427 @@
         "uuid": "^8.3.2"
       },
       "dependencies": {
+        "cdktf": {
+          "version": "0.15.0",
+          "resolved": "https://registry.npmjs.org/cdktf/-/cdktf-0.15.0.tgz",
+          "integrity": "sha512-Dzv/pfJWTFzxMxjcgI3cttK7hPLy69bUPzcZgUK0sI+k3kY4I67pmxKuXDh1XVK9AX+pCaiZT7wzQbCznTrQkQ==",
+          "dev": true,
+          "requires": {
+            "archiver": "5.3.1",
+            "json-stable-stringify": "^1.0.2",
+            "semver": "^7.3.8"
+          },
+          "dependencies": {
+            "archiver": {
+              "version": "5.3.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "archiver-utils": "^2.1.0",
+                "async": "^3.2.3",
+                "buffer-crc32": "^0.2.1",
+                "readable-stream": "^3.6.0",
+                "readdir-glob": "^1.0.0",
+                "tar-stream": "^2.2.0",
+                "zip-stream": "^4.1.0"
+              }
+            },
+            "archiver-utils": {
+              "version": "2.1.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "glob": "^7.1.4",
+                "graceful-fs": "^4.2.0",
+                "lazystream": "^1.0.0",
+                "lodash.defaults": "^4.2.0",
+                "lodash.difference": "^4.5.0",
+                "lodash.flatten": "^4.4.0",
+                "lodash.isplainobject": "^4.0.6",
+                "lodash.union": "^4.6.0",
+                "normalize-path": "^3.0.0",
+                "readable-stream": "^2.0.0"
+              },
+              "dependencies": {
+                "readable-stream": {
+                  "version": "2.3.7",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "core-util-is": "~1.0.0",
+                    "inherits": "~2.0.3",
+                    "isarray": "~1.0.0",
+                    "process-nextick-args": "~2.0.0",
+                    "safe-buffer": "~5.1.1",
+                    "string_decoder": "~1.1.1",
+                    "util-deprecate": "~1.0.1"
+                  }
+                },
+                "string_decoder": {
+                  "version": "1.1.1",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "safe-buffer": "~5.1.0"
+                  }
+                }
+              }
+            },
+            "async": {
+              "version": "3.2.4",
+              "bundled": true,
+              "dev": true
+            },
+            "balanced-match": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true
+            },
+            "base64-js": {
+              "version": "1.5.1",
+              "bundled": true,
+              "dev": true
+            },
+            "bl": {
+              "version": "4.1.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "buffer": "^5.5.0",
+                "inherits": "^2.0.4",
+                "readable-stream": "^3.4.0"
+              }
+            },
+            "brace-expansion": {
+              "version": "2.0.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "balanced-match": "^1.0.0"
+              }
+            },
+            "buffer": {
+              "version": "5.7.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "base64-js": "^1.3.1",
+                "ieee754": "^1.1.13"
+              }
+            },
+            "buffer-crc32": {
+              "version": "0.2.13",
+              "bundled": true,
+              "dev": true
+            },
+            "compress-commons": {
+              "version": "4.1.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "buffer-crc32": "^0.2.13",
+                "crc32-stream": "^4.0.2",
+                "normalize-path": "^3.0.0",
+                "readable-stream": "^3.6.0"
+              }
+            },
+            "concat-map": {
+              "version": "0.0.1",
+              "bundled": true,
+              "dev": true
+            },
+            "core-util-is": {
+              "version": "1.0.3",
+              "bundled": true,
+              "dev": true
+            },
+            "crc-32": {
+              "version": "1.2.2",
+              "bundled": true,
+              "dev": true
+            },
+            "crc32-stream": {
+              "version": "4.0.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "crc-32": "^1.2.0",
+                "readable-stream": "^3.4.0"
+              }
+            },
+            "end-of-stream": {
+              "version": "1.4.4",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "once": "^1.4.0"
+              }
+            },
+            "fs-constants": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "fs.realpath": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "glob": {
+              "version": "7.2.3",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.1.1",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+              },
+              "dependencies": {
+                "brace-expansion": {
+                  "version": "1.1.11",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "balanced-match": "^1.0.0",
+                    "concat-map": "0.0.1"
+                  }
+                },
+                "minimatch": {
+                  "version": "3.1.2",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "brace-expansion": "^1.1.7"
+                  }
+                }
+              }
+            },
+            "graceful-fs": {
+              "version": "4.2.10",
+              "bundled": true,
+              "dev": true
+            },
+            "ieee754": {
+              "version": "1.2.1",
+              "bundled": true,
+              "dev": true
+            },
+            "inflight": {
+              "version": "1.0.6",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "once": "^1.3.0",
+                "wrappy": "1"
+              }
+            },
+            "inherits": {
+              "version": "2.0.4",
+              "bundled": true,
+              "dev": true
+            },
+            "isarray": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "json-stable-stringify": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "jsonify": "^0.0.1"
+              }
+            },
+            "jsonify": {
+              "version": "0.0.1",
+              "bundled": true,
+              "dev": true
+            },
+            "lazystream": {
+              "version": "1.0.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "readable-stream": "^2.0.5"
+              },
+              "dependencies": {
+                "readable-stream": {
+                  "version": "2.3.7",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "core-util-is": "~1.0.0",
+                    "inherits": "~2.0.3",
+                    "isarray": "~1.0.0",
+                    "process-nextick-args": "~2.0.0",
+                    "safe-buffer": "~5.1.1",
+                    "string_decoder": "~1.1.1",
+                    "util-deprecate": "~1.0.1"
+                  }
+                },
+                "string_decoder": {
+                  "version": "1.1.1",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "safe-buffer": "~5.1.0"
+                  }
+                }
+              }
+            },
+            "lodash.defaults": {
+              "version": "4.2.0",
+              "bundled": true,
+              "dev": true
+            },
+            "lodash.difference": {
+              "version": "4.5.0",
+              "bundled": true,
+              "dev": true
+            },
+            "lodash.flatten": {
+              "version": "4.4.0",
+              "bundled": true,
+              "dev": true
+            },
+            "lodash.isplainobject": {
+              "version": "4.0.6",
+              "bundled": true,
+              "dev": true
+            },
+            "lodash.union": {
+              "version": "4.6.0",
+              "bundled": true,
+              "dev": true
+            },
+            "lru-cache": {
+              "version": "6.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "yallist": "^4.0.0"
+              }
+            },
+            "minimatch": {
+              "version": "5.1.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "brace-expansion": "^2.0.1"
+              }
+            },
+            "normalize-path": {
+              "version": "3.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "once": {
+              "version": "1.4.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "wrappy": "1"
+              }
+            },
+            "path-is-absolute": {
+              "version": "1.0.1",
+              "bundled": true,
+              "dev": true
+            },
+            "process-nextick-args": {
+              "version": "2.0.1",
+              "bundled": true,
+              "dev": true
+            },
+            "readable-stream": {
+              "version": "3.6.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "inherits": "^2.0.3",
+                "string_decoder": "^1.1.1",
+                "util-deprecate": "^1.0.1"
+              }
+            },
+            "readdir-glob": {
+              "version": "1.1.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "minimatch": "^5.1.0"
+              }
+            },
+            "safe-buffer": {
+              "version": "5.1.2",
+              "bundled": true,
+              "dev": true
+            },
+            "semver": {
+              "version": "7.3.8",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "lru-cache": "^6.0.0"
+              }
+            },
+            "string_decoder": {
+              "version": "1.3.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "safe-buffer": "~5.2.0"
+              },
+              "dependencies": {
+                "safe-buffer": {
+                  "version": "5.2.1",
+                  "bundled": true,
+                  "dev": true
+                }
+              }
+            },
+            "tar-stream": {
+              "version": "2.2.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "bl": "^4.0.3",
+                "end-of-stream": "^1.4.1",
+                "fs-constants": "^1.0.0",
+                "inherits": "^2.0.3",
+                "readable-stream": "^3.1.1"
+              }
+            },
+            "util-deprecate": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true
+            },
+            "wrappy": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true
+            },
+            "yallist": {
+              "version": "4.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "zip-stream": {
+              "version": "4.1.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "archiver-utils": "^2.1.0",
+                "compress-commons": "^4.1.0",
+                "readable-stream": "^3.6.0"
+              }
+            }
+          }
+        },
         "fs-extra": {
           "version": "8.1.0",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
@@ -25245,9 +27818,9 @@
       "dev": true
     },
     "cdktf": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/cdktf/-/cdktf-0.15.0.tgz",
-      "integrity": "sha512-Dzv/pfJWTFzxMxjcgI3cttK7hPLy69bUPzcZgUK0sI+k3kY4I67pmxKuXDh1XVK9AX+pCaiZT7wzQbCznTrQkQ==",
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/cdktf/-/cdktf-0.15.2.tgz",
+      "integrity": "sha512-1V8u4nMtcgwfHq7V7+a+VkotMDDZUk6JJQ7BKPZyraN7MfiBjkUQUQo9PYJQdRONABFugwyggjy1Aqw8dto7Vw==",
       "requires": {
         "archiver": "5.3.1",
         "json-stable-stringify": "^1.0.2",
@@ -25638,6 +28211,429 @@
         "yargs": "^17.6",
         "yoga-layout-prebuilt": "^1.10.0",
         "zod": "^1.11.17"
+      },
+      "dependencies": {
+        "cdktf": {
+          "version": "0.15.0",
+          "resolved": "https://registry.npmjs.org/cdktf/-/cdktf-0.15.0.tgz",
+          "integrity": "sha512-Dzv/pfJWTFzxMxjcgI3cttK7hPLy69bUPzcZgUK0sI+k3kY4I67pmxKuXDh1XVK9AX+pCaiZT7wzQbCznTrQkQ==",
+          "dev": true,
+          "requires": {
+            "archiver": "5.3.1",
+            "json-stable-stringify": "^1.0.2",
+            "semver": "^7.3.8"
+          },
+          "dependencies": {
+            "archiver": {
+              "version": "5.3.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "archiver-utils": "^2.1.0",
+                "async": "^3.2.3",
+                "buffer-crc32": "^0.2.1",
+                "readable-stream": "^3.6.0",
+                "readdir-glob": "^1.0.0",
+                "tar-stream": "^2.2.0",
+                "zip-stream": "^4.1.0"
+              }
+            },
+            "archiver-utils": {
+              "version": "2.1.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "glob": "^7.1.4",
+                "graceful-fs": "^4.2.0",
+                "lazystream": "^1.0.0",
+                "lodash.defaults": "^4.2.0",
+                "lodash.difference": "^4.5.0",
+                "lodash.flatten": "^4.4.0",
+                "lodash.isplainobject": "^4.0.6",
+                "lodash.union": "^4.6.0",
+                "normalize-path": "^3.0.0",
+                "readable-stream": "^2.0.0"
+              },
+              "dependencies": {
+                "readable-stream": {
+                  "version": "2.3.7",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "core-util-is": "~1.0.0",
+                    "inherits": "~2.0.3",
+                    "isarray": "~1.0.0",
+                    "process-nextick-args": "~2.0.0",
+                    "safe-buffer": "~5.1.1",
+                    "string_decoder": "~1.1.1",
+                    "util-deprecate": "~1.0.1"
+                  }
+                },
+                "string_decoder": {
+                  "version": "1.1.1",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "safe-buffer": "~5.1.0"
+                  }
+                }
+              }
+            },
+            "async": {
+              "version": "3.2.4",
+              "bundled": true,
+              "dev": true
+            },
+            "balanced-match": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true
+            },
+            "base64-js": {
+              "version": "1.5.1",
+              "bundled": true,
+              "dev": true
+            },
+            "bl": {
+              "version": "4.1.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "buffer": "^5.5.0",
+                "inherits": "^2.0.4",
+                "readable-stream": "^3.4.0"
+              }
+            },
+            "brace-expansion": {
+              "version": "2.0.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "balanced-match": "^1.0.0"
+              }
+            },
+            "buffer": {
+              "version": "5.7.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "base64-js": "^1.3.1",
+                "ieee754": "^1.1.13"
+              }
+            },
+            "buffer-crc32": {
+              "version": "0.2.13",
+              "bundled": true,
+              "dev": true
+            },
+            "compress-commons": {
+              "version": "4.1.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "buffer-crc32": "^0.2.13",
+                "crc32-stream": "^4.0.2",
+                "normalize-path": "^3.0.0",
+                "readable-stream": "^3.6.0"
+              }
+            },
+            "concat-map": {
+              "version": "0.0.1",
+              "bundled": true,
+              "dev": true
+            },
+            "core-util-is": {
+              "version": "1.0.3",
+              "bundled": true,
+              "dev": true
+            },
+            "crc-32": {
+              "version": "1.2.2",
+              "bundled": true,
+              "dev": true
+            },
+            "crc32-stream": {
+              "version": "4.0.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "crc-32": "^1.2.0",
+                "readable-stream": "^3.4.0"
+              }
+            },
+            "end-of-stream": {
+              "version": "1.4.4",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "once": "^1.4.0"
+              }
+            },
+            "fs-constants": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "fs.realpath": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "glob": {
+              "version": "7.2.3",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.1.1",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+              },
+              "dependencies": {
+                "brace-expansion": {
+                  "version": "1.1.11",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "balanced-match": "^1.0.0",
+                    "concat-map": "0.0.1"
+                  }
+                },
+                "minimatch": {
+                  "version": "3.1.2",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "brace-expansion": "^1.1.7"
+                  }
+                }
+              }
+            },
+            "graceful-fs": {
+              "version": "4.2.10",
+              "bundled": true,
+              "dev": true
+            },
+            "ieee754": {
+              "version": "1.2.1",
+              "bundled": true,
+              "dev": true
+            },
+            "inflight": {
+              "version": "1.0.6",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "once": "^1.3.0",
+                "wrappy": "1"
+              }
+            },
+            "inherits": {
+              "version": "2.0.4",
+              "bundled": true,
+              "dev": true
+            },
+            "isarray": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "json-stable-stringify": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "jsonify": "^0.0.1"
+              }
+            },
+            "jsonify": {
+              "version": "0.0.1",
+              "bundled": true,
+              "dev": true
+            },
+            "lazystream": {
+              "version": "1.0.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "readable-stream": "^2.0.5"
+              },
+              "dependencies": {
+                "readable-stream": {
+                  "version": "2.3.7",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "core-util-is": "~1.0.0",
+                    "inherits": "~2.0.3",
+                    "isarray": "~1.0.0",
+                    "process-nextick-args": "~2.0.0",
+                    "safe-buffer": "~5.1.1",
+                    "string_decoder": "~1.1.1",
+                    "util-deprecate": "~1.0.1"
+                  }
+                },
+                "string_decoder": {
+                  "version": "1.1.1",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "safe-buffer": "~5.1.0"
+                  }
+                }
+              }
+            },
+            "lodash.defaults": {
+              "version": "4.2.0",
+              "bundled": true,
+              "dev": true
+            },
+            "lodash.difference": {
+              "version": "4.5.0",
+              "bundled": true,
+              "dev": true
+            },
+            "lodash.flatten": {
+              "version": "4.4.0",
+              "bundled": true,
+              "dev": true
+            },
+            "lodash.isplainobject": {
+              "version": "4.0.6",
+              "bundled": true,
+              "dev": true
+            },
+            "lodash.union": {
+              "version": "4.6.0",
+              "bundled": true,
+              "dev": true
+            },
+            "lru-cache": {
+              "version": "6.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "yallist": "^4.0.0"
+              }
+            },
+            "minimatch": {
+              "version": "5.1.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "brace-expansion": "^2.0.1"
+              }
+            },
+            "normalize-path": {
+              "version": "3.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "once": {
+              "version": "1.4.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "wrappy": "1"
+              }
+            },
+            "path-is-absolute": {
+              "version": "1.0.1",
+              "bundled": true,
+              "dev": true
+            },
+            "process-nextick-args": {
+              "version": "2.0.1",
+              "bundled": true,
+              "dev": true
+            },
+            "readable-stream": {
+              "version": "3.6.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "inherits": "^2.0.3",
+                "string_decoder": "^1.1.1",
+                "util-deprecate": "^1.0.1"
+              }
+            },
+            "readdir-glob": {
+              "version": "1.1.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "minimatch": "^5.1.0"
+              }
+            },
+            "safe-buffer": {
+              "version": "5.1.2",
+              "bundled": true,
+              "dev": true
+            },
+            "semver": {
+              "version": "7.3.8",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "lru-cache": "^6.0.0"
+              }
+            },
+            "string_decoder": {
+              "version": "1.3.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "safe-buffer": "~5.2.0"
+              },
+              "dependencies": {
+                "safe-buffer": {
+                  "version": "5.2.1",
+                  "bundled": true,
+                  "dev": true
+                }
+              }
+            },
+            "tar-stream": {
+              "version": "2.2.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "bl": "^4.0.3",
+                "end-of-stream": "^1.4.1",
+                "fs-constants": "^1.0.0",
+                "inherits": "^2.0.3",
+                "readable-stream": "^3.1.1"
+              }
+            },
+            "util-deprecate": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true
+            },
+            "wrappy": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true
+            },
+            "yallist": {
+              "version": "4.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "zip-stream": {
+              "version": "4.1.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "archiver-utils": "^2.1.0",
+                "compress-commons": "^4.1.0",
+                "readable-stream": "^3.6.0"
+              }
+            }
+          }
+        }
       }
     },
     "chalk": {
@@ -25805,19 +28801,6 @@
         "camelcase": "^6.3.0",
         "decamelize": "^5.0.1",
         "fs-extra": "^10.1.0"
-      },
-      "dependencies": {
-        "fs-extra": {
-          "version": "10.1.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
-          "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.2.0",
-            "jsonfile": "^6.0.1",
-            "universalify": "^2.0.0"
-          }
-        }
       }
     },
     "collect-v8-coverage": {
@@ -27637,6 +30620,17 @@
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
       "dev": true
+    },
+    "fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      }
     },
     "fs-minipass": {
       "version": "2.1.0",
@@ -30347,17 +33341,6 @@
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "dev": true
         },
-        "fs-extra": {
-          "version": "10.1.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
-          "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.2.0",
-            "jsonfile": "^6.0.1",
-            "universalify": "^2.0.0"
-          }
-        },
         "has-flag": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -30456,17 +33439,6 @@
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "dev": true
         },
-        "fs-extra": {
-          "version": "10.1.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
-          "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.2.0",
-            "jsonfile": "^6.0.1",
-            "universalify": "^2.0.0"
-          }
-        },
         "wrap-ansi": {
           "version": "7.0.0",
           "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
@@ -30557,17 +33529,6 @@
           "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
           "dev": true
         },
-        "fs-extra": {
-          "version": "10.1.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
-          "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.2.0",
-            "jsonfile": "^6.0.1",
-            "universalify": "^2.0.0"
-          }
-        },
         "wrap-ansi": {
           "version": "7.0.0",
           "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
@@ -30654,17 +33615,6 @@
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "dev": true
-        },
-        "fs-extra": {
-          "version": "10.1.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
-          "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.2.0",
-            "jsonfile": "^6.0.1",
-            "universalify": "^2.0.0"
-          }
         },
         "has-flag": {
           "version": "4.0.0",

--- a/libs/wingsdk/package.json
+++ b/libs/wingsdk/package.json
@@ -79,7 +79,7 @@
   "peerDependencies": {
     "@cdktf/provider-aws": "^12.0.1",
     "@cdktf/provider-azurerm": "^5.0.1",
-    "cdktf": "~0.15.0",
+    "cdktf": "0.15.2",
     "constructs": "~10.1.228",
     "polycons": "^0.1.1"
   },
@@ -98,7 +98,7 @@
     "@azure/storage-blob": "12.12.0",
     "@cdktf/provider-aws": "^12.0.1",
     "@cdktf/provider-azurerm": "^5.0.1",
-    "cdktf": "~0.15.0",
+    "cdktf": "0.15.2",
     "constructs": "~10.1.228",
     "debug": "^4.3.4",
     "esbuild-wasm": "^0.17.4",

--- a/libs/wingsdk/test/target-tf-aws/__snapshots__/bucket.test.ts.snap
+++ b/libs/wingsdk/test/target-tf-aws/__snapshots__/bucket.test.ts.snap
@@ -64,7 +64,7 @@ Object {
           "backend": Object {
             "constructInfo": Object {
               "fqn": "cdktf.LocalBackend",
-              "version": "0.15.0",
+              "version": "0.15.2",
             },
             "id": "backend",
             "path": "root/backend",
@@ -114,7 +114,7 @@ Object {
         },
         "constructInfo": Object {
           "fqn": "cdktf.TerraformStack",
-          "version": "0.15.0",
+          "version": "0.15.2",
         },
         "id": "root",
         "path": "root",
@@ -122,7 +122,7 @@ Object {
     },
     "constructInfo": Object {
       "fqn": "cdktf.App",
-      "version": "0.15.0",
+      "version": "0.15.2",
     },
     "id": "App",
     "path": "",
@@ -240,7 +240,7 @@ Object {
           "backend": Object {
             "constructInfo": Object {
               "fqn": "cdktf.LocalBackend",
-              "version": "0.15.0",
+              "version": "0.15.2",
             },
             "id": "backend",
             "path": "root/backend",
@@ -248,7 +248,7 @@ Object {
         },
         "constructInfo": Object {
           "fqn": "cdktf.TerraformStack",
-          "version": "0.15.0",
+          "version": "0.15.2",
         },
         "id": "root",
         "path": "root",
@@ -256,7 +256,7 @@ Object {
     },
     "constructInfo": Object {
       "fqn": "cdktf.App",
-      "version": "0.15.0",
+      "version": "0.15.2",
     },
     "id": "App",
     "path": "",
@@ -332,7 +332,7 @@ Object {
           "backend": Object {
             "constructInfo": Object {
               "fqn": "cdktf.LocalBackend",
-              "version": "0.15.0",
+              "version": "0.15.2",
             },
             "id": "backend",
             "path": "root/backend",
@@ -382,7 +382,7 @@ Object {
         },
         "constructInfo": Object {
           "fqn": "cdktf.TerraformStack",
-          "version": "0.15.0",
+          "version": "0.15.2",
         },
         "id": "root",
         "path": "root",
@@ -390,7 +390,7 @@ Object {
     },
     "constructInfo": Object {
       "fqn": "cdktf.App",
-      "version": "0.15.0",
+      "version": "0.15.2",
     },
     "id": "App",
     "path": "",
@@ -475,7 +475,7 @@ Object {
           "backend": Object {
             "constructInfo": Object {
               "fqn": "cdktf.LocalBackend",
-              "version": "0.15.0",
+              "version": "0.15.2",
             },
             "id": "backend",
             "path": "root/backend",
@@ -541,7 +541,7 @@ Object {
         },
         "constructInfo": Object {
           "fqn": "cdktf.TerraformStack",
-          "version": "0.15.0",
+          "version": "0.15.2",
         },
         "id": "root",
         "path": "root",
@@ -549,7 +549,7 @@ Object {
     },
     "constructInfo": Object {
       "fqn": "cdktf.App",
-      "version": "0.15.0",
+      "version": "0.15.2",
     },
     "id": "App",
     "path": "",
@@ -625,7 +625,7 @@ Object {
           "backend": Object {
             "constructInfo": Object {
               "fqn": "cdktf.LocalBackend",
-              "version": "0.15.0",
+              "version": "0.15.2",
             },
             "id": "backend",
             "path": "root/backend",
@@ -675,7 +675,7 @@ Object {
         },
         "constructInfo": Object {
           "fqn": "cdktf.TerraformStack",
-          "version": "0.15.0",
+          "version": "0.15.2",
         },
         "id": "root",
         "path": "root",
@@ -683,7 +683,7 @@ Object {
     },
     "constructInfo": Object {
       "fqn": "cdktf.App",
-      "version": "0.15.0",
+      "version": "0.15.2",
     },
     "id": "App",
     "path": "",

--- a/libs/wingsdk/test/target-tf-aws/__snapshots__/counter.test.ts.snap
+++ b/libs/wingsdk/test/target-tf-aws/__snapshots__/counter.test.ts.snap
@@ -80,7 +80,7 @@ Object {
           "backend": Object {
             "constructInfo": Object {
               "fqn": "cdktf.LocalBackend",
-              "version": "0.15.0",
+              "version": "0.15.2",
             },
             "id": "backend",
             "path": "root/backend",
@@ -88,7 +88,7 @@ Object {
         },
         "constructInfo": Object {
           "fqn": "cdktf.TerraformStack",
-          "version": "0.15.0",
+          "version": "0.15.2",
         },
         "id": "root",
         "path": "root",
@@ -96,7 +96,7 @@ Object {
     },
     "constructInfo": Object {
       "fqn": "cdktf.App",
-      "version": "0.15.0",
+      "version": "0.15.2",
     },
     "id": "App",
     "path": "",
@@ -185,7 +185,7 @@ Object {
           "backend": Object {
             "constructInfo": Object {
               "fqn": "cdktf.LocalBackend",
-              "version": "0.15.0",
+              "version": "0.15.2",
             },
             "id": "backend",
             "path": "root/backend",
@@ -193,7 +193,7 @@ Object {
         },
         "constructInfo": Object {
           "fqn": "cdktf.TerraformStack",
-          "version": "0.15.0",
+          "version": "0.15.2",
         },
         "id": "root",
         "path": "root",
@@ -201,7 +201,7 @@ Object {
     },
     "constructInfo": Object {
       "fqn": "cdktf.App",
-      "version": "0.15.0",
+      "version": "0.15.2",
     },
     "id": "App",
     "path": "",
@@ -375,7 +375,7 @@ Object {
               "Asset": Object {
                 "constructInfo": Object {
                   "fqn": "cdktf.TerraformAsset",
-                  "version": "0.15.0",
+                  "version": "0.15.2",
                 },
                 "id": "Asset",
                 "path": "root/Function/Asset",
@@ -492,7 +492,7 @@ Object {
           "backend": Object {
             "constructInfo": Object {
               "fqn": "cdktf.LocalBackend",
-              "version": "0.15.0",
+              "version": "0.15.2",
             },
             "id": "backend",
             "path": "root/backend",
@@ -500,7 +500,7 @@ Object {
         },
         "constructInfo": Object {
           "fqn": "cdktf.TerraformStack",
-          "version": "0.15.0",
+          "version": "0.15.2",
         },
         "id": "root",
         "path": "root",
@@ -508,7 +508,7 @@ Object {
     },
     "constructInfo": Object {
       "fqn": "cdktf.App",
-      "version": "0.15.0",
+      "version": "0.15.2",
     },
     "id": "App",
     "path": "",
@@ -644,7 +644,7 @@ Object {
               "Asset": Object {
                 "constructInfo": Object {
                   "fqn": "cdktf.TerraformAsset",
-                  "version": "0.15.0",
+                  "version": "0.15.2",
                 },
                 "id": "Asset",
                 "path": "root/Function/Asset",
@@ -761,7 +761,7 @@ Object {
           "backend": Object {
             "constructInfo": Object {
               "fqn": "cdktf.LocalBackend",
-              "version": "0.15.0",
+              "version": "0.15.2",
             },
             "id": "backend",
             "path": "root/backend",
@@ -769,7 +769,7 @@ Object {
         },
         "constructInfo": Object {
           "fqn": "cdktf.TerraformStack",
-          "version": "0.15.0",
+          "version": "0.15.2",
         },
         "id": "root",
         "path": "root",
@@ -777,7 +777,7 @@ Object {
     },
     "constructInfo": Object {
       "fqn": "cdktf.App",
-      "version": "0.15.0",
+      "version": "0.15.2",
     },
     "id": "App",
     "path": "",
@@ -913,7 +913,7 @@ Object {
               "Asset": Object {
                 "constructInfo": Object {
                   "fqn": "cdktf.TerraformAsset",
-                  "version": "0.15.0",
+                  "version": "0.15.2",
                 },
                 "id": "Asset",
                 "path": "root/Function/Asset",
@@ -1030,7 +1030,7 @@ Object {
           "backend": Object {
             "constructInfo": Object {
               "fqn": "cdktf.LocalBackend",
-              "version": "0.15.0",
+              "version": "0.15.2",
             },
             "id": "backend",
             "path": "root/backend",
@@ -1038,7 +1038,7 @@ Object {
         },
         "constructInfo": Object {
           "fqn": "cdktf.TerraformStack",
-          "version": "0.15.0",
+          "version": "0.15.2",
         },
         "id": "root",
         "path": "root",
@@ -1046,7 +1046,7 @@ Object {
     },
     "constructInfo": Object {
       "fqn": "cdktf.App",
-      "version": "0.15.0",
+      "version": "0.15.2",
     },
     "id": "App",
     "path": "",
@@ -1135,7 +1135,7 @@ Object {
           "backend": Object {
             "constructInfo": Object {
               "fqn": "cdktf.LocalBackend",
-              "version": "0.15.0",
+              "version": "0.15.2",
             },
             "id": "backend",
             "path": "root/backend",
@@ -1143,7 +1143,7 @@ Object {
         },
         "constructInfo": Object {
           "fqn": "cdktf.TerraformStack",
-          "version": "0.15.0",
+          "version": "0.15.2",
         },
         "id": "root",
         "path": "root",
@@ -1151,7 +1151,7 @@ Object {
     },
     "constructInfo": Object {
       "fqn": "cdktf.App",
-      "version": "0.15.0",
+      "version": "0.15.2",
     },
     "id": "App",
     "path": "",

--- a/libs/wingsdk/test/target-tf-aws/__snapshots__/function.test.ts.snap
+++ b/libs/wingsdk/test/target-tf-aws/__snapshots__/function.test.ts.snap
@@ -74,7 +74,7 @@ Object {
               "Asset": Object {
                 "constructInfo": Object {
                   "fqn": "cdktf.TerraformAsset",
-                  "version": "0.15.0",
+                  "version": "0.15.2",
                 },
                 "id": "Asset",
                 "path": "root/Function/Asset",
@@ -191,7 +191,7 @@ Object {
           "backend": Object {
             "constructInfo": Object {
               "fqn": "cdktf.LocalBackend",
-              "version": "0.15.0",
+              "version": "0.15.2",
             },
             "id": "backend",
             "path": "root/backend",
@@ -199,7 +199,7 @@ Object {
         },
         "constructInfo": Object {
           "fqn": "cdktf.TerraformStack",
-          "version": "0.15.0",
+          "version": "0.15.2",
         },
         "id": "root",
         "path": "root",
@@ -207,7 +207,7 @@ Object {
     },
     "constructInfo": Object {
       "fqn": "cdktf.App",
-      "version": "0.15.0",
+      "version": "0.15.2",
     },
     "id": "App",
     "path": "",
@@ -292,7 +292,7 @@ Object {
               "Asset": Object {
                 "constructInfo": Object {
                   "fqn": "cdktf.TerraformAsset",
-                  "version": "0.15.0",
+                  "version": "0.15.2",
                 },
                 "id": "Asset",
                 "path": "root/Function/Asset",
@@ -409,7 +409,7 @@ Object {
           "backend": Object {
             "constructInfo": Object {
               "fqn": "cdktf.LocalBackend",
-              "version": "0.15.0",
+              "version": "0.15.2",
             },
             "id": "backend",
             "path": "root/backend",
@@ -417,7 +417,7 @@ Object {
         },
         "constructInfo": Object {
           "fqn": "cdktf.TerraformStack",
-          "version": "0.15.0",
+          "version": "0.15.2",
         },
         "id": "root",
         "path": "root",
@@ -425,7 +425,7 @@ Object {
     },
     "constructInfo": Object {
       "fqn": "cdktf.App",
-      "version": "0.15.0",
+      "version": "0.15.2",
     },
     "id": "App",
     "path": "",
@@ -508,7 +508,7 @@ Object {
               "Asset": Object {
                 "constructInfo": Object {
                   "fqn": "cdktf.TerraformAsset",
-                  "version": "0.15.0",
+                  "version": "0.15.2",
                 },
                 "id": "Asset",
                 "path": "root/Function/Asset",
@@ -625,7 +625,7 @@ Object {
           "backend": Object {
             "constructInfo": Object {
               "fqn": "cdktf.LocalBackend",
-              "version": "0.15.0",
+              "version": "0.15.2",
             },
             "id": "backend",
             "path": "root/backend",
@@ -633,7 +633,7 @@ Object {
         },
         "constructInfo": Object {
           "fqn": "cdktf.TerraformStack",
-          "version": "0.15.0",
+          "version": "0.15.2",
         },
         "id": "root",
         "path": "root",
@@ -641,7 +641,7 @@ Object {
     },
     "constructInfo": Object {
       "fqn": "cdktf.App",
-      "version": "0.15.0",
+      "version": "0.15.2",
     },
     "id": "App",
     "path": "",
@@ -741,7 +741,7 @@ Object {
               "Asset": Object {
                 "constructInfo": Object {
                   "fqn": "cdktf.TerraformAsset",
-                  "version": "0.15.0",
+                  "version": "0.15.2",
                 },
                 "id": "Asset",
                 "path": "root/The-Mighty_Function-01/Asset",
@@ -841,7 +841,7 @@ Object {
           "backend": Object {
             "constructInfo": Object {
               "fqn": "cdktf.LocalBackend",
-              "version": "0.15.0",
+              "version": "0.15.2",
             },
             "id": "backend",
             "path": "root/backend",
@@ -849,7 +849,7 @@ Object {
         },
         "constructInfo": Object {
           "fqn": "cdktf.TerraformStack",
-          "version": "0.15.0",
+          "version": "0.15.2",
         },
         "id": "root",
         "path": "root",
@@ -857,7 +857,7 @@ Object {
     },
     "constructInfo": Object {
       "fqn": "cdktf.App",
-      "version": "0.15.0",
+      "version": "0.15.2",
     },
     "id": "App",
     "path": "",
@@ -957,7 +957,7 @@ Object {
               "Asset": Object {
                 "constructInfo": Object {
                   "fqn": "cdktf.TerraformAsset",
-                  "version": "0.15.0",
+                  "version": "0.15.2",
                 },
                 "id": "Asset",
                 "path": "root/The%Mighty$Function/Asset",
@@ -1057,7 +1057,7 @@ Object {
           "backend": Object {
             "constructInfo": Object {
               "fqn": "cdktf.LocalBackend",
-              "version": "0.15.0",
+              "version": "0.15.2",
             },
             "id": "backend",
             "path": "root/backend",
@@ -1065,7 +1065,7 @@ Object {
         },
         "constructInfo": Object {
           "fqn": "cdktf.TerraformStack",
-          "version": "0.15.0",
+          "version": "0.15.2",
         },
         "id": "root",
         "path": "root",
@@ -1073,7 +1073,7 @@ Object {
     },
     "constructInfo": Object {
       "fqn": "cdktf.App",
-      "version": "0.15.0",
+      "version": "0.15.2",
     },
     "id": "App",
     "path": "",

--- a/libs/wingsdk/test/target-tf-aws/__snapshots__/queue.test.ts.snap
+++ b/libs/wingsdk/test/target-tf-aws/__snapshots__/queue.test.ts.snap
@@ -72,7 +72,7 @@ Object {
           "backend": Object {
             "constructInfo": Object {
               "fqn": "cdktf.LocalBackend",
-              "version": "0.15.0",
+              "version": "0.15.2",
             },
             "id": "backend",
             "path": "root/backend",
@@ -80,7 +80,7 @@ Object {
         },
         "constructInfo": Object {
           "fqn": "cdktf.TerraformStack",
-          "version": "0.15.0",
+          "version": "0.15.2",
         },
         "id": "root",
         "path": "root",
@@ -88,7 +88,7 @@ Object {
     },
     "constructInfo": Object {
       "fqn": "cdktf.App",
-      "version": "0.15.0",
+      "version": "0.15.2",
     },
     "id": "App",
     "path": "",
@@ -169,7 +169,7 @@ Object {
           "backend": Object {
             "constructInfo": Object {
               "fqn": "cdktf.LocalBackend",
-              "version": "0.15.0",
+              "version": "0.15.2",
             },
             "id": "backend",
             "path": "root/backend",
@@ -177,7 +177,7 @@ Object {
         },
         "constructInfo": Object {
           "fqn": "cdktf.TerraformStack",
-          "version": "0.15.0",
+          "version": "0.15.2",
         },
         "id": "root",
         "path": "root",
@@ -185,7 +185,7 @@ Object {
     },
     "constructInfo": Object {
       "fqn": "cdktf.App",
-      "version": "0.15.0",
+      "version": "0.15.2",
     },
     "id": "App",
     "path": "",
@@ -360,7 +360,7 @@ Object {
               "Asset": Object {
                 "constructInfo": Object {
                   "fqn": "cdktf.TerraformAsset",
-                  "version": "0.15.0",
+                  "version": "0.15.2",
                 },
                 "id": "Asset",
                 "path": "root/Queue-OnMessage-c5395e41/Asset",
@@ -472,7 +472,7 @@ Object {
           "backend": Object {
             "constructInfo": Object {
               "fqn": "cdktf.LocalBackend",
-              "version": "0.15.0",
+              "version": "0.15.2",
             },
             "id": "backend",
             "path": "root/backend",
@@ -480,7 +480,7 @@ Object {
         },
         "constructInfo": Object {
           "fqn": "cdktf.TerraformStack",
-          "version": "0.15.0",
+          "version": "0.15.2",
         },
         "id": "root",
         "path": "root",
@@ -488,7 +488,7 @@ Object {
     },
     "constructInfo": Object {
       "fqn": "cdktf.App",
-      "version": "0.15.0",
+      "version": "0.15.2",
     },
     "id": "App",
     "path": "",
@@ -570,7 +570,7 @@ Object {
           "backend": Object {
             "constructInfo": Object {
               "fqn": "cdktf.LocalBackend",
-              "version": "0.15.0",
+              "version": "0.15.2",
             },
             "id": "backend",
             "path": "root/backend",
@@ -578,7 +578,7 @@ Object {
         },
         "constructInfo": Object {
           "fqn": "cdktf.TerraformStack",
-          "version": "0.15.0",
+          "version": "0.15.2",
         },
         "id": "root",
         "path": "root",
@@ -586,7 +586,7 @@ Object {
     },
     "constructInfo": Object {
       "fqn": "cdktf.App",
-      "version": "0.15.0",
+      "version": "0.15.2",
     },
     "id": "App",
     "path": "",
@@ -667,7 +667,7 @@ Object {
           "backend": Object {
             "constructInfo": Object {
               "fqn": "cdktf.LocalBackend",
-              "version": "0.15.0",
+              "version": "0.15.2",
             },
             "id": "backend",
             "path": "root/backend",
@@ -675,7 +675,7 @@ Object {
         },
         "constructInfo": Object {
           "fqn": "cdktf.TerraformStack",
-          "version": "0.15.0",
+          "version": "0.15.2",
         },
         "id": "root",
         "path": "root",
@@ -683,7 +683,7 @@ Object {
     },
     "constructInfo": Object {
       "fqn": "cdktf.App",
-      "version": "0.15.0",
+      "version": "0.15.2",
     },
     "id": "App",
     "path": "",

--- a/libs/wingsdk/test/target-tf-aws/__snapshots__/topic.test.ts.snap
+++ b/libs/wingsdk/test/target-tf-aws/__snapshots__/topic.test.ts.snap
@@ -72,7 +72,7 @@ Object {
           "backend": Object {
             "constructInfo": Object {
               "fqn": "cdktf.LocalBackend",
-              "version": "0.15.0",
+              "version": "0.15.2",
             },
             "id": "backend",
             "path": "root/backend",
@@ -80,7 +80,7 @@ Object {
         },
         "constructInfo": Object {
           "fqn": "cdktf.TerraformStack",
-          "version": "0.15.0",
+          "version": "0.15.2",
         },
         "id": "root",
         "path": "root",
@@ -88,7 +88,7 @@ Object {
     },
     "constructInfo": Object {
       "fqn": "cdktf.App",
-      "version": "0.15.0",
+      "version": "0.15.2",
     },
     "id": "App",
     "path": "",
@@ -169,7 +169,7 @@ Object {
           "backend": Object {
             "constructInfo": Object {
               "fqn": "cdktf.LocalBackend",
-              "version": "0.15.0",
+              "version": "0.15.2",
             },
             "id": "backend",
             "path": "root/backend",
@@ -177,7 +177,7 @@ Object {
         },
         "constructInfo": Object {
           "fqn": "cdktf.TerraformStack",
-          "version": "0.15.0",
+          "version": "0.15.2",
         },
         "id": "root",
         "path": "root",
@@ -185,7 +185,7 @@ Object {
     },
     "constructInfo": Object {
       "fqn": "cdktf.App",
-      "version": "0.15.0",
+      "version": "0.15.2",
     },
     "id": "App",
     "path": "",
@@ -266,7 +266,7 @@ Object {
           "backend": Object {
             "constructInfo": Object {
               "fqn": "cdktf.LocalBackend",
-              "version": "0.15.0",
+              "version": "0.15.2",
             },
             "id": "backend",
             "path": "root/backend",
@@ -274,7 +274,7 @@ Object {
         },
         "constructInfo": Object {
           "fqn": "cdktf.TerraformStack",
-          "version": "0.15.0",
+          "version": "0.15.2",
         },
         "id": "root",
         "path": "root",
@@ -282,7 +282,7 @@ Object {
     },
     "constructInfo": Object {
       "fqn": "cdktf.App",
-      "version": "0.15.0",
+      "version": "0.15.2",
     },
     "id": "App",
     "path": "",
@@ -485,7 +485,7 @@ Object {
               "Asset": Object {
                 "constructInfo": Object {
                   "fqn": "cdktf.TerraformAsset",
-                  "version": "0.15.0",
+                  "version": "0.15.2",
                 },
                 "id": "Asset",
                 "path": "root/Topic-OnMessage-c5395e41/Asset",
@@ -597,7 +597,7 @@ Object {
           "backend": Object {
             "constructInfo": Object {
               "fqn": "cdktf.LocalBackend",
-              "version": "0.15.0",
+              "version": "0.15.2",
             },
             "id": "backend",
             "path": "root/backend",
@@ -605,7 +605,7 @@ Object {
         },
         "constructInfo": Object {
           "fqn": "cdktf.TerraformStack",
-          "version": "0.15.0",
+          "version": "0.15.2",
         },
         "id": "root",
         "path": "root",
@@ -613,7 +613,7 @@ Object {
     },
     "constructInfo": Object {
       "fqn": "cdktf.App",
-      "version": "0.15.0",
+      "version": "0.15.2",
     },
     "id": "App",
     "path": "",

--- a/libs/wingsdk/test/target-tf-azure/__snapshots__/bucket.test.ts.snap
+++ b/libs/wingsdk/test/target-tf-azure/__snapshots__/bucket.test.ts.snap
@@ -63,7 +63,7 @@ Object {
           "backend": Object {
             "constructInfo": Object {
               "fqn": "cdktf.LocalBackend",
-              "version": "0.15.0",
+              "version": "0.15.2",
             },
             "id": "backend",
             "path": "root/backend",
@@ -113,7 +113,7 @@ Object {
         },
         "constructInfo": Object {
           "fqn": "cdktf.TerraformStack",
-          "version": "0.15.0",
+          "version": "0.15.2",
         },
         "id": "root",
         "path": "root",
@@ -121,7 +121,7 @@ Object {
     },
     "constructInfo": Object {
       "fqn": "cdktf.App",
-      "version": "0.15.0",
+      "version": "0.15.2",
     },
     "id": "App",
     "path": "",
@@ -235,7 +235,7 @@ Object {
           "backend": Object {
             "constructInfo": Object {
               "fqn": "cdktf.LocalBackend",
-              "version": "0.15.0",
+              "version": "0.15.2",
             },
             "id": "backend",
             "path": "root/backend",
@@ -243,7 +243,7 @@ Object {
         },
         "constructInfo": Object {
           "fqn": "cdktf.TerraformStack",
-          "version": "0.15.0",
+          "version": "0.15.2",
         },
         "id": "root",
         "path": "root",
@@ -251,7 +251,7 @@ Object {
     },
     "constructInfo": Object {
       "fqn": "cdktf.App",
-      "version": "0.15.0",
+      "version": "0.15.2",
     },
     "id": "App",
     "path": "",
@@ -339,7 +339,7 @@ Object {
           "backend": Object {
             "constructInfo": Object {
               "fqn": "cdktf.LocalBackend",
-              "version": "0.15.0",
+              "version": "0.15.2",
             },
             "id": "backend",
             "path": "root/backend",
@@ -405,7 +405,7 @@ Object {
         },
         "constructInfo": Object {
           "fqn": "cdktf.TerraformStack",
-          "version": "0.15.0",
+          "version": "0.15.2",
         },
         "id": "root",
         "path": "root",
@@ -413,7 +413,7 @@ Object {
     },
     "constructInfo": Object {
       "fqn": "cdktf.App",
-      "version": "0.15.0",
+      "version": "0.15.2",
     },
     "id": "App",
     "path": "",
@@ -485,7 +485,7 @@ Object {
           "backend": Object {
             "constructInfo": Object {
               "fqn": "cdktf.LocalBackend",
-              "version": "0.15.0",
+              "version": "0.15.2",
             },
             "id": "backend",
             "path": "root/backend",
@@ -535,7 +535,7 @@ Object {
         },
         "constructInfo": Object {
           "fqn": "cdktf.TerraformStack",
-          "version": "0.15.0",
+          "version": "0.15.2",
         },
         "id": "root",
         "path": "root",
@@ -543,7 +543,7 @@ Object {
     },
     "constructInfo": Object {
       "fqn": "cdktf.App",
-      "version": "0.15.0",
+      "version": "0.15.2",
     },
     "id": "App",
     "path": "",

--- a/tools/hangar/src/__snapshots__/cli.test.ts.snap
+++ b/tools/hangar/src/__snapshots__/cli.test.ts.snap
@@ -6,7 +6,7 @@ exports[`wing compile --target tf-aws anon_function.w > cdk.tf.json 1`] = `
     "metadata": {
       "backend": "local",
       "stackName": "root",
-      "version": "0.15.1",
+      "version": "0.15.2",
     },
     "outputs": {},
   },
@@ -30,7 +30,7 @@ exports[`wing compile --target tf-aws anon_function.w > manifest.json 1`] = `
       "workingDirectory": "stacks/root",
     },
   },
-  "version": "0.15.1",
+  "version": "0.15.2",
 }
 `;
 
@@ -77,7 +77,7 @@ exports[`wing compile --target tf-aws asynchronous_model_implicit_await_in_funct
     "metadata": {
       "backend": "local",
       "stackName": "root",
-      "version": "0.15.1",
+      "version": "0.15.2",
     },
     "outputs": {},
   },
@@ -254,7 +254,7 @@ exports[`wing compile --target tf-aws asynchronous_model_implicit_await_in_funct
       "workingDirectory": "stacks/root",
     },
   },
-  "version": "0.15.1",
+  "version": "0.15.2",
 }
 `;
 
@@ -313,7 +313,7 @@ exports[`wing compile --target tf-aws capture_containers.w > cdk.tf.json 1`] = `
     "metadata": {
       "backend": "local",
       "stackName": "root",
-      "version": "0.15.1",
+      "version": "0.15.2",
     },
     "outputs": {},
   },
@@ -432,7 +432,7 @@ exports[`wing compile --target tf-aws capture_containers.w > manifest.json 1`] =
       "workingDirectory": "stacks/root",
     },
   },
-  "version": "0.15.1",
+  "version": "0.15.2",
 }
 `;
 
@@ -488,7 +488,7 @@ exports[`wing compile --target tf-aws capture_containers_of_resources.w > cdk.tf
     "metadata": {
       "backend": "local",
       "stackName": "root",
-      "version": "0.15.1",
+      "version": "0.15.2",
     },
     "outputs": {},
   },
@@ -691,7 +691,7 @@ exports[`wing compile --target tf-aws capture_containers_of_resources.w > manife
       "workingDirectory": "stacks/root",
     },
   },
-  "version": "0.15.1",
+  "version": "0.15.2",
 }
 `;
 
@@ -744,7 +744,7 @@ exports[`wing compile --target tf-aws capture_in_binary.w > cdk.tf.json 1`] = `
     "metadata": {
       "backend": "local",
       "stackName": "root",
-      "version": "0.15.1",
+      "version": "0.15.2",
     },
     "outputs": {},
   },
@@ -901,7 +901,7 @@ exports[`wing compile --target tf-aws capture_in_binary.w > manifest.json 1`] = 
       "workingDirectory": "stacks/root",
     },
   },
-  "version": "0.15.1",
+  "version": "0.15.2",
 }
 `;
 
@@ -957,7 +957,7 @@ exports[`wing compile --target tf-aws capture_primitives.w > cdk.tf.json 1`] = `
     "metadata": {
       "backend": "local",
       "stackName": "root",
-      "version": "0.15.1",
+      "version": "0.15.2",
     },
     "outputs": {},
   },
@@ -1082,7 +1082,7 @@ exports[`wing compile --target tf-aws capture_primitives.w > manifest.json 1`] =
       "workingDirectory": "stacks/root",
     },
   },
-  "version": "0.15.1",
+  "version": "0.15.2",
 }
 `;
 
@@ -1140,7 +1140,7 @@ exports[`wing compile --target tf-aws capture_resource_and_data.w > cdk.tf.json 
     "metadata": {
       "backend": "local",
       "stackName": "root",
-      "version": "0.15.1",
+      "version": "0.15.2",
     },
     "outputs": {},
   },
@@ -1299,7 +1299,7 @@ exports[`wing compile --target tf-aws capture_resource_and_data.w > manifest.jso
       "workingDirectory": "stacks/root",
     },
   },
-  "version": "0.15.1",
+  "version": "0.15.2",
 }
 `;
 
@@ -1360,7 +1360,7 @@ exports[`wing compile --target tf-aws captures.w > cdk.tf.json 1`] = `
     "metadata": {
       "backend": "local",
       "stackName": "root",
-      "version": "0.15.1",
+      "version": "0.15.2",
     },
     "outputs": {},
   },
@@ -1730,7 +1730,7 @@ exports[`wing compile --target tf-aws captures.w > manifest.json 1`] = `
       "workingDirectory": "stacks/root",
     },
   },
-  "version": "0.15.1",
+  "version": "0.15.2",
 }
 `;
 
@@ -1799,7 +1799,7 @@ exports[`wing compile --target tf-aws container_types.w > cdk.tf.json 1`] = `
     "metadata": {
       "backend": "local",
       "stackName": "root",
-      "version": "0.15.1",
+      "version": "0.15.2",
     },
     "outputs": {},
   },
@@ -1945,7 +1945,7 @@ exports[`wing compile --target tf-aws container_types.w > manifest.json 1`] = `
       "workingDirectory": "stacks/root",
     },
   },
-  "version": "0.15.1",
+  "version": "0.15.2",
 }
 `;
 
@@ -2058,7 +2058,7 @@ exports[`wing compile --target tf-aws enums.w > cdk.tf.json 1`] = `
     "metadata": {
       "backend": "local",
       "stackName": "root",
-      "version": "0.15.1",
+      "version": "0.15.2",
     },
     "outputs": {},
   },
@@ -2082,7 +2082,7 @@ exports[`wing compile --target tf-aws enums.w > manifest.json 1`] = `
       "workingDirectory": "stacks/root",
     },
   },
-  "version": "0.15.1",
+  "version": "0.15.2",
 }
 `;
 
@@ -2128,7 +2128,7 @@ exports[`wing compile --target tf-aws expressions_binary_operators.w > cdk.tf.js
     "metadata": {
       "backend": "local",
       "stackName": "root",
-      "version": "0.15.1",
+      "version": "0.15.2",
     },
     "outputs": {},
   },
@@ -2152,7 +2152,7 @@ exports[`wing compile --target tf-aws expressions_binary_operators.w > manifest.
       "workingDirectory": "stacks/root",
     },
   },
-  "version": "0.15.1",
+  "version": "0.15.2",
 }
 `;
 
@@ -2197,7 +2197,7 @@ exports[`wing compile --target tf-aws expressions_string_interpolation.w > cdk.t
     "metadata": {
       "backend": "local",
       "stackName": "root",
-      "version": "0.15.1",
+      "version": "0.15.2",
     },
     "outputs": {},
   },
@@ -2221,7 +2221,7 @@ exports[`wing compile --target tf-aws expressions_string_interpolation.w > manif
       "workingDirectory": "stacks/root",
     },
   },
-  "version": "0.15.1",
+  "version": "0.15.2",
 }
 `;
 
@@ -2266,7 +2266,7 @@ exports[`wing compile --target tf-aws file_counter.w > cdk.tf.json 1`] = `
     "metadata": {
       "backend": "local",
       "stackName": "root",
-      "version": "0.15.1",
+      "version": "0.15.2",
     },
     "outputs": {},
   },
@@ -2456,7 +2456,7 @@ exports[`wing compile --target tf-aws file_counter.w > manifest.json 1`] = `
       "workingDirectory": "stacks/root",
     },
   },
-  "version": "0.15.1",
+  "version": "0.15.2",
 }
 `;
 
@@ -2515,7 +2515,7 @@ exports[`wing compile --target tf-aws forward_decl.w > cdk.tf.json 1`] = `
     "metadata": {
       "backend": "local",
       "stackName": "root",
-      "version": "0.15.1",
+      "version": "0.15.2",
     },
     "outputs": {},
   },
@@ -2539,7 +2539,7 @@ exports[`wing compile --target tf-aws forward_decl.w > manifest.json 1`] = `
       "workingDirectory": "stacks/root",
     },
   },
-  "version": "0.15.1",
+  "version": "0.15.2",
 }
 `;
 
@@ -2595,7 +2595,7 @@ exports[`wing compile --target tf-aws hello.w > cdk.tf.json 1`] = `
     "metadata": {
       "backend": "local",
       "stackName": "root",
-      "version": "0.15.1",
+      "version": "0.15.2",
     },
     "outputs": {},
   },
@@ -2764,7 +2764,7 @@ exports[`wing compile --target tf-aws hello.w > manifest.json 1`] = `
       "workingDirectory": "stacks/root",
     },
   },
-  "version": "0.15.1",
+  "version": "0.15.2",
 }
 `;
 
@@ -2818,7 +2818,7 @@ exports[`wing compile --target tf-aws identical_inflights.w > cdk.tf.json 1`] = 
     "metadata": {
       "backend": "local",
       "stackName": "root",
-      "version": "0.15.1",
+      "version": "0.15.2",
     },
     "outputs": {},
   },
@@ -2847,7 +2847,7 @@ exports[`wing compile --target tf-aws identical_inflights.w > manifest.json 1`] 
       "workingDirectory": "stacks/root",
     },
   },
-  "version": "0.15.1",
+  "version": "0.15.2",
 }
 `;
 
@@ -2899,7 +2899,7 @@ exports[`wing compile --target tf-aws mut_container_types.w > cdk.tf.json 1`] = 
     "metadata": {
       "backend": "local",
       "stackName": "root",
-      "version": "0.15.1",
+      "version": "0.15.2",
     },
     "outputs": {},
   },
@@ -3045,7 +3045,7 @@ exports[`wing compile --target tf-aws mut_container_types.w > manifest.json 1`] 
       "workingDirectory": "stacks/root",
     },
   },
-  "version": "0.15.1",
+  "version": "0.15.2",
 }
 `;
 
@@ -3114,7 +3114,7 @@ exports[`wing compile --target tf-aws primitive_methods.w > cdk.tf.json 1`] = `
     "metadata": {
       "backend": "local",
       "stackName": "root",
-      "version": "0.15.1",
+      "version": "0.15.2",
     },
     "outputs": {},
   },
@@ -3138,7 +3138,7 @@ exports[`wing compile --target tf-aws primitive_methods.w > manifest.json 1`] = 
       "workingDirectory": "stacks/root",
     },
   },
-  "version": "0.15.1",
+  "version": "0.15.2",
 }
 `;
 
@@ -3182,7 +3182,7 @@ exports[`wing compile --target tf-aws print.w > cdk.tf.json 1`] = `
     "metadata": {
       "backend": "local",
       "stackName": "root",
-      "version": "0.15.1",
+      "version": "0.15.2",
     },
     "outputs": {},
   },
@@ -3336,7 +3336,7 @@ exports[`wing compile --target tf-aws print.w > manifest.json 1`] = `
       "workingDirectory": "stacks/root",
     },
   },
-  "version": "0.15.1",
+  "version": "0.15.2",
 }
 `;
 
@@ -3384,7 +3384,7 @@ exports[`wing compile --target tf-aws reassignment.w > cdk.tf.json 1`] = `
     "metadata": {
       "backend": "local",
       "stackName": "root",
-      "version": "0.15.1",
+      "version": "0.15.2",
     },
     "outputs": {},
   },
@@ -3408,7 +3408,7 @@ exports[`wing compile --target tf-aws reassignment.w > manifest.json 1`] = `
       "workingDirectory": "stacks/root",
     },
   },
-  "version": "0.15.1",
+  "version": "0.15.2",
 }
 `;
 
@@ -3474,7 +3474,7 @@ exports[`wing compile --target tf-aws resource.w > cdk.tf.json 1`] = `
     "metadata": {
       "backend": "local",
       "stackName": "root",
-      "version": "0.15.1",
+      "version": "0.15.2",
     },
     "outputs": {},
   },
@@ -3498,7 +3498,7 @@ exports[`wing compile --target tf-aws resource.w > manifest.json 1`] = `
       "workingDirectory": "stacks/root",
     },
   },
-  "version": "0.15.1",
+  "version": "0.15.2",
 }
 `;
 
@@ -3546,7 +3546,7 @@ exports[`wing compile --target tf-aws statements_if.w > cdk.tf.json 1`] = `
     "metadata": {
       "backend": "local",
       "stackName": "root",
-      "version": "0.15.1",
+      "version": "0.15.2",
     },
     "outputs": {},
   },
@@ -3673,7 +3673,7 @@ exports[`wing compile --target tf-aws statements_if.w > manifest.json 1`] = `
       "workingDirectory": "stacks/root",
     },
   },
-  "version": "0.15.1",
+  "version": "0.15.2",
 }
 `;
 
@@ -3738,7 +3738,7 @@ exports[`wing compile --target tf-aws statements_variable_declarations.w > cdk.t
     "metadata": {
       "backend": "local",
       "stackName": "root",
-      "version": "0.15.1",
+      "version": "0.15.2",
     },
     "outputs": {},
   },
@@ -3762,7 +3762,7 @@ exports[`wing compile --target tf-aws statements_variable_declarations.w > manif
       "workingDirectory": "stacks/root",
     },
   },
-  "version": "0.15.1",
+  "version": "0.15.2",
 }
 `;
 
@@ -3802,7 +3802,7 @@ exports[`wing compile --target tf-aws std_containers.w > cdk.tf.json 1`] = `
     "metadata": {
       "backend": "local",
       "stackName": "root",
-      "version": "0.15.1",
+      "version": "0.15.2",
     },
     "outputs": {},
   },
@@ -3833,7 +3833,7 @@ exports[`wing compile --target tf-aws std_containers.w > manifest.json 1`] = `
       "workingDirectory": "stacks/root",
     },
   },
-  "version": "0.15.1",
+  "version": "0.15.2",
 }
 `;
 
@@ -3882,7 +3882,7 @@ exports[`wing compile --target tf-aws test_bucket.w > cdk.tf.json 1`] = `
     "metadata": {
       "backend": "local",
       "stackName": "root",
-      "version": "0.15.1",
+      "version": "0.15.2",
     },
     "outputs": {},
   },
@@ -4105,7 +4105,7 @@ exports[`wing compile --target tf-aws test_bucket.w > manifest.json 1`] = `
       "workingDirectory": "stacks/root",
     },
   },
-  "version": "0.15.1",
+  "version": "0.15.2",
 }
 `;
 
@@ -4169,7 +4169,7 @@ exports[`wing compile --target tf-aws while.w > cdk.tf.json 1`] = `
     "metadata": {
       "backend": "local",
       "stackName": "root",
-      "version": "0.15.1",
+      "version": "0.15.2",
     },
     "outputs": {},
   },
@@ -4193,7 +4193,7 @@ exports[`wing compile --target tf-aws while.w > manifest.json 1`] = `
       "workingDirectory": "stacks/root",
     },
   },
-  "version": "0.15.1",
+  "version": "0.15.2",
 }
 `;
 
@@ -4238,7 +4238,7 @@ exports[`wing compile --target tf-aws while_loop_await.w > cdk.tf.json 1`] = `
     "metadata": {
       "backend": "local",
       "stackName": "root",
-      "version": "0.15.1",
+      "version": "0.15.2",
     },
     "outputs": {},
   },
@@ -4372,7 +4372,7 @@ exports[`wing compile --target tf-aws while_loop_await.w > manifest.json 1`] = `
       "workingDirectory": "stacks/root",
     },
   },
-  "version": "0.15.1",
+  "version": "0.15.2",
 }
 `;
 


### PR DESCRIPTION
The purpose of this is to stop snapshots from changing with new versions of cdktf. Originally I was just going to sanitize the snapshot, but I feel like it's entirely reasonable to pin cdktf very strictly. 

cdktf is pretty important and we may not want consumers of the SDK to freely choose the version.

*By submitting this pull request, I confirm that my contribution is made under the terms of the 
[Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.
