### PR TITLE
chore: shell substitution for publish version failed

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,11 +26,11 @@ jobs:
     name: "Prepare"
     runs-on: ubuntu-latest
     outputs:
-      last-version: ${{ steps.tags.outputs.last-version }}
+      last-version: ${{ steps.tags.outputs.last-version || steps.pr_info.outputs.version }}
       version: ${{ steps.info.outputs.version || steps.pr_info.outputs.version }}
     steps:
       - name: Checkout
-        if: github.event_name == 'push' && github.repository == 'winglang/wing'
+        # if: github.event_name == 'push' && github.repository == 'winglang/wing'
         uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.ref || github.ref }}
@@ -38,7 +38,7 @@ jobs:
 
       - name: Get tags
         id: tags
-        if: github.event_name == 'push' && github.repository == 'winglang/wing'
+        # if: github.event_name == 'push' && github.repository == 'winglang/wing'
         run: |
           git fetch --unshallow --tags
           LAST_VERSION="$(git describe --tags `git rev-list --tags --max-count=1`)"
@@ -70,6 +70,7 @@ jobs:
         id: pr_info
         if: github.event_name != 'push' || github.repository != 'winglang/wing'
         run: |
+          echo "last-version=0.0.0" >> $GITHUB_OUTPUT
           echo "version=0.0.0-dev.${{ github.run_id }}.${{ github.run_attempt }}" >> $GITHUB_OUTPUT
           echo "Pull Request" > CHANGELOG.md
           cat CHANGELOG.md >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
       version: ${{ steps.info.outputs.version || steps.pr_info.outputs.version }}
     steps:
       - name: Checkout
-        # if: github.event_name == 'push' && github.repository == 'winglang/wing'
+        if: github.event_name == 'push' && github.repository == 'winglang/wing'
         uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.ref || github.ref }}
@@ -38,7 +38,7 @@ jobs:
 
       - name: Get tags
         id: tags
-        # if: github.event_name == 'push' && github.repository == 'winglang/wing'
+        if: github.event_name == 'push' && github.repository == 'winglang/wing'
         run: |
           git fetch --unshallow --tags
           LAST_VERSION="$(git describe --tags `git rev-list --tags --max-count=1`)"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,8 @@ jobs:
         if: github.event_name == 'push' && github.repository == 'winglang/wing'
         run: |
           git fetch --unshallow --tags
-          echo "last-version=${$(git describe --tags `git rev-list --tags --max-count=1`):1}" >> $GITHUB_OUTPUT
+          LAST_VERSION="$(git describe --tags `git rev-list --tags --max-count=1`)"
+          echo "last-version=${LAST_VERSION:1}" >> $GITHUB_OUTPUT
 
       - name: Install Dependencies
         if: github.event_name == 'push' && github.repository == 'winglang/wing'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,7 @@ jobs:
         run: |
           git fetch --unshallow --tags
           LAST_VERSION="$(git describe --tags `git rev-list --tags --max-count=1`)"
-          echo "last-version=${LAST_VERSION:1}" >> $GITHUB_OUTPUT
+          echo "last-version=${LAST_VERSION#?}" >> $GITHUB_OUTPUT
 
       - name: Install Dependencies
         if: github.event_name == 'push' && github.repository == 'winglang/wing'


### PR DESCRIPTION
TIL about `${...#?}` in POSIX terminals. The previous method was not completely portable (worked locally for me, not in the runner)

*By submitting this pull request, I confirm that my contribution is made under the terms of the 
[Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.
