### PR TITLE
chore(docs): update topic.on_message docs

### DIFF
--- a/docs/04-reference/wingsdk-api.md
+++ b/docs/04-reference/wingsdk-api.md
@@ -928,7 +928,7 @@ new cloud.Topic(props?: TopicProps)
 | **Name** | **Description** |
 | --- | --- |
 | <code><a href="#@winglang/sdk.cloud.Topic.toString">to_string</a></code> | Returns a string representation of this construct. |
-| <code><a href="#@winglang/sdk.cloud.Topic.onMessage">on_message</a></code> | Creates function to send messages when published. |
+| <code><a href="#@winglang/sdk.cloud.Topic.onMessage">on_message</a></code> | Run an inflight whenever an message is published to the topic. |
 
 ---
 
@@ -946,7 +946,7 @@ Returns a string representation of this construct.
 on_message(inflight: ~Inflight, props?: TopicOnMessageProps): Function
 ```
 
-Creates function to send messages when published.
+Run an inflight whenever an message is published to the topic.
 
 ###### `inflight`<sup>Required</sup> <a name="inflight" id="@winglang/sdk.cloud.Topic.onMessage.parameter.inflight"></a>
 
@@ -2143,7 +2143,7 @@ They will be joined with newline characters.
 
 ### TopicOnMessageProps <a name="TopicOnMessageProps" id="@winglang/sdk.cloud.TopicOnMessageProps"></a>
 
-Options for Topic.onMessage.
+Options for `Topic.onMessage`.
 
 #### Initializer <a name="Initializer" id="@winglang/sdk.cloud.TopicOnMessageProps.Initializer"></a>
 

--- a/docs/04-reference/wingsdk-spec.md
+++ b/docs/04-reference/wingsdk-spec.md
@@ -645,7 +645,7 @@ resource Topic {
   on_message(fn: inflight (message: Json) => void, opts: TopicOnPublishProps?): void;
 
   /**
-   * Publish an message to the topic.
+   * Publish a message to the topic.
    */
   inflight publish(message: Json): void;
 }

--- a/docs/04-reference/wingsdk-spec.md
+++ b/docs/04-reference/wingsdk-spec.md
@@ -184,7 +184,7 @@ resource CounterWithThreshold extends cloud.Counter {
 
   // or: on_threshold(handler: EventHandler<ThresholdReachedEvent>)
   on_threshold(handler: inflight (event: ThresholdReachedEvent) => void) {
-    return this._topic.on_event(handler);
+    return this._topic.on_message(handler);
   }
 }
 
@@ -640,22 +640,17 @@ resource Topic {
   init(props: TopicProps = {});
 
   /**
-   * Run an inflight whenever an event is published to the topic.
+   * Run an inflight whenever an message is published to the topic.
    */
-  on_event(fn: inflight (event: Json) => void, opts: TopicOnPublishProps?): void;
+  on_message(fn: inflight (message: Json) => void, opts: TopicOnPublishProps?): void;
 
   /**
-   * Alias for `Topic.on_event`.
+   * Publish an message to the topic.
    */
-  subscribe(fn: inflight (event: Json) => void, opts: TopicOnPublishProps?): void;
-
-  /**
-   * Publish an event to the topic.
-   */
-  inflight publish(event: Json): void;
+  inflight publish(message: Json): void;
 }
 
-struct TopicOnPublishProps { /* elided */ }
+struct TopicOnMessageProps { /* elided */ }
 ```
 
 ## Schedule

--- a/docs/04-reference/wingsdk-spec.md
+++ b/docs/04-reference/wingsdk-spec.md
@@ -640,7 +640,7 @@ resource Topic {
   init(props: TopicProps = {});
 
   /**
-   * Run an inflight whenever an message is published to the topic.
+   * Run an inflight whenever a message is published to the topic.
    */
   on_message(fn: inflight (message: Json) => void, opts: TopicOnPublishProps?): void;
 

--- a/libs/wingsdk/API.md
+++ b/libs/wingsdk/API.md
@@ -921,7 +921,7 @@ new cloud.Topic(props?: TopicProps)
 | **Name** | **Description** |
 | --- | --- |
 | <code><a href="#@winglang/sdk.cloud.Topic.toString">to_string</a></code> | Returns a string representation of this construct. |
-| <code><a href="#@winglang/sdk.cloud.Topic.onMessage">on_message</a></code> | Creates function to send messages when published. |
+| <code><a href="#@winglang/sdk.cloud.Topic.onMessage">on_message</a></code> | Run an inflight whenever an message is published to the topic. |
 
 ---
 
@@ -939,7 +939,7 @@ Returns a string representation of this construct.
 on_message(inflight: ~Inflight, props?: TopicOnMessageProps): Function
 ```
 
-Creates function to send messages when published.
+Run an inflight whenever an message is published to the topic.
 
 ###### `inflight`<sup>Required</sup> <a name="inflight" id="@winglang/sdk.cloud.Topic.onMessage.parameter.inflight"></a>
 
@@ -2136,7 +2136,7 @@ They will be joined with newline characters.
 
 ### TopicOnMessageProps <a name="TopicOnMessageProps" id="@winglang/sdk.cloud.TopicOnMessageProps"></a>
 
-Options for Topic.onMessage.
+Options for `Topic.onMessage`.
 
 #### Initializer <a name="Initializer" id="@winglang/sdk.cloud.TopicOnMessageProps.Initializer"></a>
 

--- a/libs/wingsdk/src/cloud/topic.ts
+++ b/libs/wingsdk/src/cloud/topic.ts
@@ -29,7 +29,7 @@ export abstract class TopicBase extends Resource {
   }
 
   /**
-   * Creates function to send messages when published
+   * Run an inflight whenever an message is published to the topic.
    */
   public abstract onMessage(
     inflight: Inflight,
@@ -38,7 +38,7 @@ export abstract class TopicBase extends Resource {
 }
 
 /**
- * Options for Topic.onMessage
+ * Options for `Topic.onMessage`.
  */
 export interface TopicOnMessageProps {}
 


### PR DESCRIPTION
Closes #1390 
Closes #1389 

Updates the spec to use the `on_message` name / be consistent with the current API (`on_event` didn't seem any clearer).

Removed `subscribe` from the spec since it didn't add any new functionality and I think the API doesn't read as clearly:

```
// topic is not subscribing to the handler - it's the other way around
topic.subscribe(handler);
```

*By submitting this pull request, I confirm that my contribution is made under the terms of the 
[Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.
