### PR TITLE
fix(compiler): unable to call `any` typed expression

### DIFF
--- a/libs/wingc/src/jsify.rs
+++ b/libs/wingc/src/jsify.rs
@@ -333,6 +333,8 @@ impl JSifier {
 							return ac.replace_all(js_override, replace_with);
 						}
 					} else {
+						// The type is not a function signature so we should not call it.
+						// If it's `anything`, we will still allow it.
 						if !function_type.is_anything() {
 							panic!("Expressions at {} is not callable", function.span);
 						}

--- a/libs/wingc/src/jsify.rs
+++ b/libs/wingc/src/jsify.rs
@@ -333,7 +333,9 @@ impl JSifier {
 							return ac.replace_all(js_override, replace_with);
 						}
 					} else {
-						panic!("Expressions at {} is not callable", function.span);
+						if !function_type.is_anything() {
+							panic!("Expressions at {} is not callable", function.span);
+						}
 					}
 
 					format!("({}{}({}))", auto_await, expr_string, arg_string)


### PR DESCRIPTION
Technically we do not currently have a way to produce an `any` without error, but I suspect with will come in handy soon.

afaik there's no good way to add a test for this yet.

*By submitting this pull request, I confirm that my contribution is made under the terms of the 
[Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.
