### PR TITLE
feat(cli): make target required from choices

### DIFF
--- a/apps/wing/src/index.ts
+++ b/apps/wing/src/index.ts
@@ -5,7 +5,7 @@ import { compile, docs, test, upgrade, run } from "./commands";
 import { join } from "path";
 import { satisfies } from 'compare-versions';
 
-import { Command } from "commander";
+import { Command, Option } from "commander";
 import debug from "debug";
 
 const PACKAGE_VERSION = require("../package.json").version as string;
@@ -41,10 +41,13 @@ async function main() {
       "Output directory",
       join(process.cwd(), "target")
     )
-    .option(
-      "-t, --target <target>",
-      "Target platform (options: 'tf-aws', 'tf-azure', 'tf-gcp', 'sim')",
-      "tf-aws"
+    .addOption(
+      new Option(
+        "-t, --target <target>",
+        "Target platform"
+      )
+      .choices(["tf-aws", "tf-azure", "tf-gcp", "sim"])
+      .makeOptionMandatory()
     )
     .action(compile);
 


### PR DESCRIPTION
Made --target required, and only allow supported options.

**note** that with commander the only way (as per documentation) to make required choices mandatory is to use the `new Option()` convention rather than the `.option()`

See: https://www.npmjs.com/package/commander#more-configuration

Compile Help Message:
```
Usage: wing compile [options] <entrypoint>

Compiles a Wing program

Arguments:
  entrypoint               program .w entrypoint

Options:
  -o, --out-dir <out-dir>  Output directory (default: "/Users/hasan/repos/leena/target")
  -t, --target <target>    Target platform (choices: "tf-aws", "tf-azure", "tf-gcp", "sim")
  -h, --help               display help for command
```

No target given
```
wing compile app.w   
error: required option '-t, --target <target>' not specified
```

Invalid target given
```
wing compile app.w -t apple
error: option '-t, --target <target>' argument 'apple' is invalid. Allowed choices are tf-aws, tf-azure, tf-gcp, sim.
```
*By submitting this pull request, I confirm that my contribution is made under the terms of the 
[Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.
