### PR TITLE
feat!: compile artifacts into target-specific directories

### DIFF
--- a/apps/wing/project.json
+++ b/apps/wing/project.json
@@ -31,6 +31,16 @@
         "script": "build"
       }
     },
+    "test": {
+      "executor": "nx:run-script",
+      "dependsOn": [
+        "build",
+        "copy"
+      ],
+      "options": {
+        "script": "test"
+      }
+    },
     "package": {
       "executor": "nx:run-commands",
       "dependsOn": [

--- a/apps/wing/src/commands/compile.test.ts
+++ b/apps/wing/src/commands/compile.test.ts
@@ -1,28 +1,55 @@
 import { Target, compile } from "./compile";
-import { readdir, rmdir, stat } from "fs/promises";
+import { readdir, stat } from "fs/promises";
 
-import { resolve } from "path";
+import { join, resolve } from "path";
+import { mkdtempSync } from "fs";
+import { tmpdir } from "os";
 
 jest.setTimeout(1000 * 60 * 5);
 
 describe("compile command tests", () => {
-  const cdktfOutDir = resolve(process.cwd(), "cdktf.out");
-  beforeEach(async () => {
-    await rmdir(cdktfOutDir, { recursive: true }).catch(() => {});
-  });
-  it("should be able to compile the SDK capture test", async () => {
-    const sdkCaptureExample = resolve(
-      __dirname,
-      "../../../../examples/tests/valid/captures.w"
-    );
-    await compile(sdkCaptureExample, {
-      outDir: process.cwd(),
+  const exampleWingFile = resolve(
+    __dirname,
+    "../../../../examples/tests/valid/captures.w"
+  );
+
+  it("should be able to compile the SDK capture test to tf-aws", async () => {
+    const tmpdir = mkdtemp();
+    await compile(exampleWingFile, {
+      outDir: tmpdir,
       target: Target.TF_AWS,
     });
-    // ensure cdktfOutDir exists and has files
-    const stats = await stat(cdktfOutDir);
+
+    const artifactDir = join(tmpdir, "captures.tfaws");
+
+    // expect files to be generated in outDir/captures.tfaws
+    const stats = await stat(artifactDir);
     expect(stats.isDirectory()).toBeTruthy();
-    const files = await readdir(cdktfOutDir);
+    const files = await readdir(artifactDir);
     expect(files.length).toBeGreaterThan(0);
+    expect(files).toContain("main.tf.json");
+    expect(files).toContain("tree.json");
+  });
+
+  it("should be able to compile the SDK capture test to sim", async () => {
+    const tmpdir = mkdtemp();
+    await compile(exampleWingFile, {
+      outDir: tmpdir,
+      target: Target.SIM,
+    });
+
+    const artifactDir = join(tmpdir, "captures.sim");
+
+    // expect files to be generated in outDir/captures.sim
+    const stats = await stat(artifactDir);
+    expect(stats.isDirectory()).toBeTruthy();
+    const files = await readdir(artifactDir);
+    expect(files.length).toBeGreaterThan(0);
+    expect(files).toContain("captures.wsim");
+    expect(files).toContain("tree.json");
   });
 });
+
+function mkdtemp() {
+  return mkdtempSync(join(tmpdir(), "wingcli-tests."));
+}

--- a/apps/wing/src/commands/compile.test.ts
+++ b/apps/wing/src/commands/compile.test.ts
@@ -14,15 +14,15 @@ describe("compile command tests", () => {
   );
 
   it("should be able to compile the SDK capture test to tf-aws", async () => {
-    const tmpdir = mkdtemp();
+    const outDir = mkdtemp();
     await compile(exampleWingFile, {
-      outDir: tmpdir,
+      outDir,
       target: Target.TF_AWS,
     });
 
-    const artifactDir = join(tmpdir, "captures.tfaws");
-
     // expect files to be generated in outDir/captures.tfaws
+    const artifactDir = join(outDir, "captures.tfaws");
+
     const stats = await stat(artifactDir);
     expect(stats.isDirectory()).toBeTruthy();
     const files = await readdir(artifactDir);
@@ -32,15 +32,15 @@ describe("compile command tests", () => {
   });
 
   it("should be able to compile the SDK capture test to sim", async () => {
-    const tmpdir = mkdtemp();
+    const outDir = mkdtemp();
     await compile(exampleWingFile, {
-      outDir: tmpdir,
+      outDir: outDir,
       target: Target.SIM,
     });
 
-    const artifactDir = join(tmpdir, "captures.sim");
+    // expect files to be generated in outDir
+    const artifactDir = outDir;
 
-    // expect files to be generated in outDir/captures.sim
     const stats = await stat(artifactDir);
     expect(stats.isDirectory()).toBeTruthy();
     const files = await readdir(artifactDir);

--- a/apps/wing/src/commands/compile.ts
+++ b/apps/wing/src/commands/compile.ts
@@ -32,11 +32,11 @@ export enum Target {
   SIM = "sim",
 }
 
-const DEFAULT_ARTIFACT_DIR_SUFFIX: Record<Target, string> = {
+const DEFAULT_ARTIFACT_DIR_SUFFIX: Record<Target, string | undefined> = {
   [Target.TF_AWS]: "tfaws",
   [Target.TF_AZURE]: "tfazure",
   [Target.TF_GCP]: "tfgcp",
-  [Target.SIM]: "sim",
+  [Target.SIM]: undefined,
 }
 
 /**
@@ -55,6 +55,10 @@ export interface ICompileOptions {
  */
 function resolveArtifactDir(outDir: string, entrypoint: string, target: Target) {
   const targetDirSuffix = DEFAULT_ARTIFACT_DIR_SUFFIX[target];
+  if (targetDirSuffix === undefined) {
+    // this target produces a single artifact, so we don't need a subdirectory
+    return outDir;
+  }
   const entrypointName = basename(entrypoint, ".w");
   return join(outDir, `${entrypointName}.${targetDirSuffix}`);
 }

--- a/apps/wing/src/commands/compile.ts
+++ b/apps/wing/src/commands/compile.ts
@@ -32,7 +32,7 @@ export enum Target {
   SIM = "sim",
 }
 
-const DEFAULT_ARTIFACT_DIR_SUFFIX: Record<Target, string | undefined> = {
+const DEFAULT_SYNTH_DIR_SUFFIX: Record<Target, string | undefined> = {
   [Target.TF_AWS]: "tfaws",
   [Target.TF_AZURE]: "tfazure",
   [Target.TF_GCP]: "tfgcp",
@@ -54,7 +54,7 @@ export interface ICompileOptions {
  * for the given target.
  */
 function resolveSynthDir(outDir: string, entrypoint: string, target: Target) {
-  const targetDirSuffix = DEFAULT_ARTIFACT_DIR_SUFFIX[target];
+  const targetDirSuffix = DEFAULT_SYNTH_DIR_SUFFIX[target];
   if (targetDirSuffix === undefined) {
     // this target produces a single artifact, so we don't need a subdirectory
     return outDir;

--- a/apps/wing/src/index.ts
+++ b/apps/wing/src/index.ts
@@ -38,7 +38,7 @@ async function main() {
     .argument("<entrypoint>", "program .w entrypoint")
     .option(
       "-o, --out-dir <out-dir>",
-      "Output directory",
+      "Output directory - where to place all generated artifacts",
       join(process.cwd(), "target")
     )
     .addOption(

--- a/docs/02-getting-started/02-installation.md
+++ b/docs/02-getting-started/02-installation.md
@@ -72,8 +72,8 @@ wing --version
 
 ## Wing IDE Extension
 
-This extension adds support for the Wing language to [VSCode]. You don't *have*
-to use it, but it's great. It's available on the [VSCode Marketplace](https://marketplace.visualstudio.com/items?itemName=Monada.vscode-wing)
+This extension adds syntax highlighting and other conveniences for the Wing language in [VSCode]. You don't *have*
+to use it, but it's great. It's available through the [VSCode Marketplace](https://marketplace.visualstudio.com/items?itemName=Monada.vscode-wing).
 
 ## Wing Console
 

--- a/docs/02-getting-started/03-hello.md
+++ b/docs/02-getting-started/03-hello.md
@@ -8,7 +8,7 @@ OK, we are ready for our first Wing program!
 
 ## Create your project directory
 
-Let's create an empty directory for our project.
+Let's create an empty directory for your project.
 
 ```sh
 mkdir hello-wing

--- a/docs/02-getting-started/05-aws.md
+++ b/docs/02-getting-started/05-aws.md
@@ -16,9 +16,14 @@ SQS](https://aws.amazon.com/sqs/) by [Azure Queue
 Storage](https://azure.microsoft.com/en-us/products/storage/queues/) or by
 [RabbitMQ by CloudAMQP](https://www.cloudamqp.com/).
 
+A target represents both the cloud provider and the provisioning engine. For
+example, the `tf-aws` target will compile your program to a set of AWS
+resources, using Terraform as the provisioning engine.
+
+
 :::info Under Construction
 
-:construction: We plan to support AWS, Azure and Google Cloud as targets out of
+:construction: We plan to support [AWS](https://github.com/winglang/wing/issues?q=is:issue+is:open+sort:updated-desc+label:aws), [Azure](https://github.com/winglang/wing/issues?q=is:issue+is:open+sort:updated-desc+label:azure) and [Google Cloud](https://github.com/winglang/wing/issues?q=is:issue+is:open+sort:updated-desc+label:gcp) as targets out of
 the box. In addition, we are planning support for other provisioning engines
 such as AWS CloudFormation and Kubernetes.
 
@@ -57,7 +62,7 @@ Let's change the working directory to where our Terraform configuration is and
 initialize the state file:
 
 ```sh
-cd ./target/cdktf.out/stacks/root
+cd ./target/hello.tfaws
 export AWS_REGION=us-east-1 # or any other region
 terraform init
 ```

--- a/docs/02-getting-started/06-simulator.md
+++ b/docs/02-getting-started/06-simulator.md
@@ -25,7 +25,7 @@ wing compile -t sim hello.w
 
 ## Compilation output
 
-This would create a new file at `target/hello.sim/hello.wsim` which is the simulated
+This would create a new file at `target/hello.wsim` which is the simulated
 version of your entire cloud application.
 
 Now that we have an `hello.wsim` file, we can either interact with through the Wing

--- a/docs/02-getting-started/06-simulator.md
+++ b/docs/02-getting-started/06-simulator.md
@@ -25,7 +25,7 @@ wing compile -t sim hello.w
 
 ## Compilation output
 
-This would create a new file called `target/hello.wsim` which is the simulated
+This would create a new file at `target/hello.sim/hello.wsim` which is the simulated
 version of your entire cloud application.
 
 Now that we have an `hello.wsim` file, we can either interact with through the Wing
@@ -59,7 +59,7 @@ Now, we import the Wing SDK library:
 
 ```js
 const sdk = require("@winglang/sdk"); // import the wing sdk library
-const simulator = new sdk.testing.Simulator({ simfile : "./target/hello.wsim"}); // create an instance of the Simulator
+const simulator = new sdk.testing.Simulator({ simfile : "./target/hello.sim/hello.wsim"}); // create an instance of the Simulator
 await simulator.start(); // start the simulator 
 ```
 
@@ -83,6 +83,7 @@ await bucket.get("wing.txt") // will show the file content
 ```
 
 The result of the last two function calls will be
+
 ```
 [ 'wing.txt' ]
 'Hello, Wing'

--- a/docs/02-getting-started/06-simulator.md
+++ b/docs/02-getting-started/06-simulator.md
@@ -59,7 +59,7 @@ Now, we import the Wing SDK library:
 
 ```js
 const sdk = require("@winglang/sdk"); // import the wing sdk library
-const simulator = new sdk.testing.Simulator({ simfile : "./target/hello.sim/hello.wsim"}); // create an instance of the Simulator
+const simulator = new sdk.testing.Simulator({ simfile : "./target/hello.wsim"}); // create an instance of the Simulator
 await simulator.start(); // start the simulator 
 ```
 

--- a/libs/wingsdk/.projen/deps.json
+++ b/libs/wingsdk/.projen/deps.json
@@ -55,10 +55,6 @@
       "type": "build"
     },
     {
-      "name": "cdktf-cli",
-      "type": "build"
-    },
-    {
       "name": "eslint-config-prettier",
       "type": "build"
     },

--- a/libs/wingsdk/.projen/tasks.json
+++ b/libs/wingsdk/.projen/tasks.json
@@ -235,16 +235,22 @@
       "name": "sandbox:deploy",
       "steps": [
         {
-          "exec": "cdktf deploy"
+          "spawn": "sandbox:synth"
+        },
+        {
+          "exec": "terraform init"
+        },
+        {
+          "exec": "terraform apply"
         }
       ],
-      "cwd": "test/sandbox"
+      "cwd": "test/sandbox/target"
     },
     "sandbox:destroy": {
       "name": "sandbox:destroy",
       "steps": [
         {
-          "exec": "cdktf destroy"
+          "exec": "terraform destroy"
         }
       ],
       "cwd": "test/sandbox"

--- a/libs/wingsdk/package-lock.json
+++ b/libs/wingsdk/package-lock.json
@@ -64,7 +64,6 @@
         "@winglang/wing-api-checker": "file:../../apps/wing-api-checker",
         "aws-sdk-client-mock": "^2.0.1",
         "aws-sdk-client-mock-jest": "^2.0.1",
-        "cdktf-cli": "^0.15.0",
         "eslint": "^8",
         "eslint-config-prettier": "^8.6.0",
         "eslint-import-resolver-node": "^0.3.7",
@@ -2683,1359 +2682,6 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
     },
-    "node_modules/@cdktf/cli-core": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@cdktf/cli-core/-/cli-core-0.15.0.tgz",
-      "integrity": "sha512-1N1N66dMl1kfAXcxTgKgePO9RfhB/p5T4dCAhfMCzLe+R0rOO1xfYQcIEXWqoORwRiIE2EyW9O9OSkxLx0DuyQ==",
-      "dev": true,
-      "dependencies": {
-        "@cdktf/commons": "0.15.0",
-        "@cdktf/hcl2cdk": "0.15.0",
-        "@cdktf/hcl2json": "0.15.0",
-        "@cdktf/node-pty-prebuilt-multiarch": "0.10.1-pre.10",
-        "@sentry/node": "^6.19.7",
-        "cdktf": "0.15.0",
-        "codemaker": "^1.73.0",
-        "constructs": "^10.0.25",
-        "cross-spawn": "^7.0.3",
-        "https-proxy-agent": "^5.0.1",
-        "ink-select-input": "^4.2.1",
-        "jsii": "^1.73.0",
-        "jsii-pacmak": "^1.73.0",
-        "minimatch": "^5.1.0",
-        "node-abort-controller": "^3.0.1",
-        "node-fetch": "^2.6.7",
-        "tunnel-agent": "^0.6.0",
-        "xml-js": "^1.6.11",
-        "xstate": "^4.34.0",
-        "yargs": "^17.6",
-        "yoga-layout-prebuilt": "^1.10.0",
-        "zod": "^1.11.17"
-      }
-    },
-    "node_modules/@cdktf/cli-core/node_modules/cdktf": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/cdktf/-/cdktf-0.15.0.tgz",
-      "integrity": "sha512-Dzv/pfJWTFzxMxjcgI3cttK7hPLy69bUPzcZgUK0sI+k3kY4I67pmxKuXDh1XVK9AX+pCaiZT7wzQbCznTrQkQ==",
-      "bundleDependencies": [
-        "archiver",
-        "json-stable-stringify",
-        "semver"
-      ],
-      "dev": true,
-      "dependencies": {
-        "archiver": "5.3.1",
-        "json-stable-stringify": "^1.0.2",
-        "semver": "^7.3.8"
-      },
-      "peerDependencies": {
-        "constructs": "^10.0.25"
-      }
-    },
-    "node_modules/@cdktf/cli-core/node_modules/cdktf/node_modules/archiver": {
-      "version": "5.3.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "archiver-utils": "^2.1.0",
-        "async": "^3.2.3",
-        "buffer-crc32": "^0.2.1",
-        "readable-stream": "^3.6.0",
-        "readdir-glob": "^1.0.0",
-        "tar-stream": "^2.2.0",
-        "zip-stream": "^4.1.0"
-      },
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@cdktf/cli-core/node_modules/cdktf/node_modules/archiver-utils": {
-      "version": "2.1.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "glob": "^7.1.4",
-        "graceful-fs": "^4.2.0",
-        "lazystream": "^1.0.0",
-        "lodash.defaults": "^4.2.0",
-        "lodash.difference": "^4.5.0",
-        "lodash.flatten": "^4.4.0",
-        "lodash.isplainobject": "^4.0.6",
-        "lodash.union": "^4.6.0",
-        "normalize-path": "^3.0.0",
-        "readable-stream": "^2.0.0"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/@cdktf/cli-core/node_modules/cdktf/node_modules/archiver-utils/node_modules/readable-stream": {
-      "version": "2.3.7",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/@cdktf/cli-core/node_modules/cdktf/node_modules/archiver-utils/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
-    "node_modules/@cdktf/cli-core/node_modules/cdktf/node_modules/async": {
-      "version": "3.2.4",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/@cdktf/cli-core/node_modules/cdktf/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/@cdktf/cli-core/node_modules/cdktf/node_modules/base64-js": {
-      "version": "1.5.1",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/@cdktf/cli-core/node_modules/cdktf/node_modules/bl": {
-      "version": "4.1.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "buffer": "^5.5.0",
-        "inherits": "^2.0.4",
-        "readable-stream": "^3.4.0"
-      }
-    },
-    "node_modules/@cdktf/cli-core/node_modules/cdktf/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/@cdktf/cli-core/node_modules/cdktf/node_modules/buffer": {
-      "version": "5.7.1",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.1.13"
-      }
-    },
-    "node_modules/@cdktf/cli-core/node_modules/cdktf/node_modules/buffer-crc32": {
-      "version": "0.2.13",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/@cdktf/cli-core/node_modules/cdktf/node_modules/compress-commons": {
-      "version": "4.1.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "buffer-crc32": "^0.2.13",
-        "crc32-stream": "^4.0.2",
-        "normalize-path": "^3.0.0",
-        "readable-stream": "^3.6.0"
-      },
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@cdktf/cli-core/node_modules/cdktf/node_modules/concat-map": {
-      "version": "0.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/@cdktf/cli-core/node_modules/cdktf/node_modules/core-util-is": {
-      "version": "1.0.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/@cdktf/cli-core/node_modules/cdktf/node_modules/crc-32": {
-      "version": "1.2.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "crc32": "bin/crc32.njs"
-      },
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
-    "node_modules/@cdktf/cli-core/node_modules/cdktf/node_modules/crc32-stream": {
-      "version": "4.0.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "crc-32": "^1.2.0",
-        "readable-stream": "^3.4.0"
-      },
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@cdktf/cli-core/node_modules/cdktf/node_modules/end-of-stream": {
-      "version": "1.4.4",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "once": "^1.4.0"
-      }
-    },
-    "node_modules/@cdktf/cli-core/node_modules/cdktf/node_modules/fs-constants": {
-      "version": "1.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/@cdktf/cli-core/node_modules/cdktf/node_modules/fs.realpath": {
-      "version": "1.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/@cdktf/cli-core/node_modules/cdktf/node_modules/glob": {
-      "version": "7.2.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@cdktf/cli-core/node_modules/cdktf/node_modules/glob/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/@cdktf/cli-core/node_modules/cdktf/node_modules/glob/node_modules/minimatch": {
-      "version": "3.1.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/@cdktf/cli-core/node_modules/cdktf/node_modules/graceful-fs": {
-      "version": "4.2.10",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/@cdktf/cli-core/node_modules/cdktf/node_modules/ieee754": {
-      "version": "1.2.1",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "inBundle": true,
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@cdktf/cli-core/node_modules/cdktf/node_modules/inflight": {
-      "version": "1.0.6",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "once": "^1.3.0",
-        "wrappy": "1"
-      }
-    },
-    "node_modules/@cdktf/cli-core/node_modules/cdktf/node_modules/inherits": {
-      "version": "2.0.4",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/@cdktf/cli-core/node_modules/cdktf/node_modules/isarray": {
-      "version": "1.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/@cdktf/cli-core/node_modules/cdktf/node_modules/json-stable-stringify": {
-      "version": "1.0.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "jsonify": "^0.0.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/@cdktf/cli-core/node_modules/cdktf/node_modules/jsonify": {
-      "version": "0.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "Public Domain",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/@cdktf/cli-core/node_modules/cdktf/node_modules/lazystream": {
-      "version": "1.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "readable-stream": "^2.0.5"
-      },
-      "engines": {
-        "node": ">= 0.6.3"
-      }
-    },
-    "node_modules/@cdktf/cli-core/node_modules/cdktf/node_modules/lazystream/node_modules/readable-stream": {
-      "version": "2.3.7",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/@cdktf/cli-core/node_modules/cdktf/node_modules/lazystream/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
-    "node_modules/@cdktf/cli-core/node_modules/cdktf/node_modules/lodash.defaults": {
-      "version": "4.2.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/@cdktf/cli-core/node_modules/cdktf/node_modules/lodash.difference": {
-      "version": "4.5.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/@cdktf/cli-core/node_modules/cdktf/node_modules/lodash.flatten": {
-      "version": "4.4.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/@cdktf/cli-core/node_modules/cdktf/node_modules/lodash.isplainobject": {
-      "version": "4.0.6",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/@cdktf/cli-core/node_modules/cdktf/node_modules/lodash.union": {
-      "version": "4.6.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/@cdktf/cli-core/node_modules/cdktf/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@cdktf/cli-core/node_modules/cdktf/node_modules/minimatch": {
-      "version": "5.1.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@cdktf/cli-core/node_modules/cdktf/node_modules/normalize-path": {
-      "version": "3.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@cdktf/cli-core/node_modules/cdktf/node_modules/once": {
-      "version": "1.4.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "wrappy": "1"
-      }
-    },
-    "node_modules/@cdktf/cli-core/node_modules/cdktf/node_modules/path-is-absolute": {
-      "version": "1.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@cdktf/cli-core/node_modules/cdktf/node_modules/process-nextick-args": {
-      "version": "2.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/@cdktf/cli-core/node_modules/cdktf/node_modules/readable-stream": {
-      "version": "3.6.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/@cdktf/cli-core/node_modules/cdktf/node_modules/readdir-glob": {
-      "version": "1.1.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "minimatch": "^5.1.0"
-      }
-    },
-    "node_modules/@cdktf/cli-core/node_modules/cdktf/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/@cdktf/cli-core/node_modules/cdktf/node_modules/semver": {
-      "version": "7.3.8",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@cdktf/cli-core/node_modules/cdktf/node_modules/string_decoder": {
-      "version": "1.3.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.2.0"
-      }
-    },
-    "node_modules/@cdktf/cli-core/node_modules/cdktf/node_modules/string_decoder/node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/@cdktf/cli-core/node_modules/cdktf/node_modules/tar-stream": {
-      "version": "2.2.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "bl": "^4.0.3",
-        "end-of-stream": "^1.4.1",
-        "fs-constants": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^3.1.1"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@cdktf/cli-core/node_modules/cdktf/node_modules/util-deprecate": {
-      "version": "1.0.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/@cdktf/cli-core/node_modules/cdktf/node_modules/wrappy": {
-      "version": "1.0.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/@cdktf/cli-core/node_modules/cdktf/node_modules/yallist": {
-      "version": "4.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/@cdktf/cli-core/node_modules/cdktf/node_modules/zip-stream": {
-      "version": "4.1.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "archiver-utils": "^2.1.0",
-        "compress-commons": "^4.1.0",
-        "readable-stream": "^3.6.0"
-      },
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@cdktf/commons": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@cdktf/commons/-/commons-0.15.0.tgz",
-      "integrity": "sha512-c3NB2X4OsUGUicpUMJSV9MGnmU+/nYNs0n7G98c/N7nctxWpm1oPoXkoSC8GsDbc3n44cuokBDgW2JiscB/YRA==",
-      "dev": true,
-      "dependencies": {
-        "@npmcli/ci-detect": "^1.4.0",
-        "@sentry/node": "^6.19.7",
-        "cdktf": "0.15.0",
-        "codemaker": "^1.73.0",
-        "constructs": "^10.0.25",
-        "cross-spawn": "^7.0.3",
-        "follow-redirects": "^1.15.2",
-        "fs-extra": "^8.1.0",
-        "is-valid-domain": "^0.1.6",
-        "log4js": "^6.7.0",
-        "uuid": "^8.3.2"
-      }
-    },
-    "node_modules/@cdktf/commons/node_modules/cdktf": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/cdktf/-/cdktf-0.15.0.tgz",
-      "integrity": "sha512-Dzv/pfJWTFzxMxjcgI3cttK7hPLy69bUPzcZgUK0sI+k3kY4I67pmxKuXDh1XVK9AX+pCaiZT7wzQbCznTrQkQ==",
-      "bundleDependencies": [
-        "archiver",
-        "json-stable-stringify",
-        "semver"
-      ],
-      "dev": true,
-      "dependencies": {
-        "archiver": "5.3.1",
-        "json-stable-stringify": "^1.0.2",
-        "semver": "^7.3.8"
-      },
-      "peerDependencies": {
-        "constructs": "^10.0.25"
-      }
-    },
-    "node_modules/@cdktf/commons/node_modules/cdktf/node_modules/archiver": {
-      "version": "5.3.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "archiver-utils": "^2.1.0",
-        "async": "^3.2.3",
-        "buffer-crc32": "^0.2.1",
-        "readable-stream": "^3.6.0",
-        "readdir-glob": "^1.0.0",
-        "tar-stream": "^2.2.0",
-        "zip-stream": "^4.1.0"
-      },
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@cdktf/commons/node_modules/cdktf/node_modules/archiver-utils": {
-      "version": "2.1.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "glob": "^7.1.4",
-        "graceful-fs": "^4.2.0",
-        "lazystream": "^1.0.0",
-        "lodash.defaults": "^4.2.0",
-        "lodash.difference": "^4.5.0",
-        "lodash.flatten": "^4.4.0",
-        "lodash.isplainobject": "^4.0.6",
-        "lodash.union": "^4.6.0",
-        "normalize-path": "^3.0.0",
-        "readable-stream": "^2.0.0"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/@cdktf/commons/node_modules/cdktf/node_modules/archiver-utils/node_modules/readable-stream": {
-      "version": "2.3.7",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/@cdktf/commons/node_modules/cdktf/node_modules/archiver-utils/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
-    "node_modules/@cdktf/commons/node_modules/cdktf/node_modules/async": {
-      "version": "3.2.4",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/@cdktf/commons/node_modules/cdktf/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/@cdktf/commons/node_modules/cdktf/node_modules/base64-js": {
-      "version": "1.5.1",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/@cdktf/commons/node_modules/cdktf/node_modules/bl": {
-      "version": "4.1.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "buffer": "^5.5.0",
-        "inherits": "^2.0.4",
-        "readable-stream": "^3.4.0"
-      }
-    },
-    "node_modules/@cdktf/commons/node_modules/cdktf/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/@cdktf/commons/node_modules/cdktf/node_modules/buffer": {
-      "version": "5.7.1",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.1.13"
-      }
-    },
-    "node_modules/@cdktf/commons/node_modules/cdktf/node_modules/buffer-crc32": {
-      "version": "0.2.13",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/@cdktf/commons/node_modules/cdktf/node_modules/compress-commons": {
-      "version": "4.1.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "buffer-crc32": "^0.2.13",
-        "crc32-stream": "^4.0.2",
-        "normalize-path": "^3.0.0",
-        "readable-stream": "^3.6.0"
-      },
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@cdktf/commons/node_modules/cdktf/node_modules/concat-map": {
-      "version": "0.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/@cdktf/commons/node_modules/cdktf/node_modules/core-util-is": {
-      "version": "1.0.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/@cdktf/commons/node_modules/cdktf/node_modules/crc-32": {
-      "version": "1.2.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "crc32": "bin/crc32.njs"
-      },
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
-    "node_modules/@cdktf/commons/node_modules/cdktf/node_modules/crc32-stream": {
-      "version": "4.0.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "crc-32": "^1.2.0",
-        "readable-stream": "^3.4.0"
-      },
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@cdktf/commons/node_modules/cdktf/node_modules/end-of-stream": {
-      "version": "1.4.4",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "once": "^1.4.0"
-      }
-    },
-    "node_modules/@cdktf/commons/node_modules/cdktf/node_modules/fs-constants": {
-      "version": "1.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/@cdktf/commons/node_modules/cdktf/node_modules/fs.realpath": {
-      "version": "1.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/@cdktf/commons/node_modules/cdktf/node_modules/glob": {
-      "version": "7.2.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@cdktf/commons/node_modules/cdktf/node_modules/glob/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/@cdktf/commons/node_modules/cdktf/node_modules/glob/node_modules/minimatch": {
-      "version": "3.1.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/@cdktf/commons/node_modules/cdktf/node_modules/graceful-fs": {
-      "version": "4.2.10",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/@cdktf/commons/node_modules/cdktf/node_modules/ieee754": {
-      "version": "1.2.1",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "inBundle": true,
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@cdktf/commons/node_modules/cdktf/node_modules/inflight": {
-      "version": "1.0.6",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "once": "^1.3.0",
-        "wrappy": "1"
-      }
-    },
-    "node_modules/@cdktf/commons/node_modules/cdktf/node_modules/inherits": {
-      "version": "2.0.4",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/@cdktf/commons/node_modules/cdktf/node_modules/isarray": {
-      "version": "1.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/@cdktf/commons/node_modules/cdktf/node_modules/json-stable-stringify": {
-      "version": "1.0.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "jsonify": "^0.0.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/@cdktf/commons/node_modules/cdktf/node_modules/jsonify": {
-      "version": "0.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "Public Domain",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/@cdktf/commons/node_modules/cdktf/node_modules/lazystream": {
-      "version": "1.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "readable-stream": "^2.0.5"
-      },
-      "engines": {
-        "node": ">= 0.6.3"
-      }
-    },
-    "node_modules/@cdktf/commons/node_modules/cdktf/node_modules/lazystream/node_modules/readable-stream": {
-      "version": "2.3.7",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/@cdktf/commons/node_modules/cdktf/node_modules/lazystream/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
-    "node_modules/@cdktf/commons/node_modules/cdktf/node_modules/lodash.defaults": {
-      "version": "4.2.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/@cdktf/commons/node_modules/cdktf/node_modules/lodash.difference": {
-      "version": "4.5.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/@cdktf/commons/node_modules/cdktf/node_modules/lodash.flatten": {
-      "version": "4.4.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/@cdktf/commons/node_modules/cdktf/node_modules/lodash.isplainobject": {
-      "version": "4.0.6",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/@cdktf/commons/node_modules/cdktf/node_modules/lodash.union": {
-      "version": "4.6.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/@cdktf/commons/node_modules/cdktf/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@cdktf/commons/node_modules/cdktf/node_modules/minimatch": {
-      "version": "5.1.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@cdktf/commons/node_modules/cdktf/node_modules/normalize-path": {
-      "version": "3.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@cdktf/commons/node_modules/cdktf/node_modules/once": {
-      "version": "1.4.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "wrappy": "1"
-      }
-    },
-    "node_modules/@cdktf/commons/node_modules/cdktf/node_modules/path-is-absolute": {
-      "version": "1.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@cdktf/commons/node_modules/cdktf/node_modules/process-nextick-args": {
-      "version": "2.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/@cdktf/commons/node_modules/cdktf/node_modules/readable-stream": {
-      "version": "3.6.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/@cdktf/commons/node_modules/cdktf/node_modules/readdir-glob": {
-      "version": "1.1.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "minimatch": "^5.1.0"
-      }
-    },
-    "node_modules/@cdktf/commons/node_modules/cdktf/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/@cdktf/commons/node_modules/cdktf/node_modules/semver": {
-      "version": "7.3.8",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@cdktf/commons/node_modules/cdktf/node_modules/string_decoder": {
-      "version": "1.3.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.2.0"
-      }
-    },
-    "node_modules/@cdktf/commons/node_modules/cdktf/node_modules/string_decoder/node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/@cdktf/commons/node_modules/cdktf/node_modules/tar-stream": {
-      "version": "2.2.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "bl": "^4.0.3",
-        "end-of-stream": "^1.4.1",
-        "fs-constants": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^3.1.1"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@cdktf/commons/node_modules/cdktf/node_modules/util-deprecate": {
-      "version": "1.0.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/@cdktf/commons/node_modules/cdktf/node_modules/wrappy": {
-      "version": "1.0.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/@cdktf/commons/node_modules/cdktf/node_modules/yallist": {
-      "version": "4.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/@cdktf/commons/node_modules/cdktf/node_modules/zip-stream": {
-      "version": "4.1.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "archiver-utils": "^2.1.0",
-        "compress-commons": "^4.1.0",
-        "readable-stream": "^3.6.0"
-      },
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@cdktf/commons/node_modules/fs-extra": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-      "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=6 <7 || >=8"
-      }
-    },
-    "node_modules/@cdktf/commons/node_modules/jsonfile": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
-      "dev": true,
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/@cdktf/commons/node_modules/universalify": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-      "dev": true,
-      "engines": {
-        "node": ">= 4.0.0"
-      }
-    },
-    "node_modules/@cdktf/hcl2cdk": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@cdktf/hcl2cdk/-/hcl2cdk-0.15.0.tgz",
-      "integrity": "sha512-X88IejdGoYpB7DkAf09v8YLMQiYu1VTKWVvggiGkS0q7DgFb79Q/S9aFfC5RfPrMNhZSV01Jrt/pDCQdcFJQ1A==",
-      "dev": true,
-      "dependencies": {
-        "@babel/generator": "^7.20.4",
-        "@babel/template": "^7.18.10",
-        "@babel/types": "^7.20.2",
-        "@cdktf/commons": "0.15.0",
-        "@cdktf/hcl2json": "0.15.0",
-        "@cdktf/provider-generator": "0.15.0",
-        "camelcase": "^6.3.0",
-        "glob": "7.2.3",
-        "graphology": "^0.25.1",
-        "graphology-types": "^0.21.2",
-        "jsii-rosetta": "^1.73.0",
-        "prettier": "^2.7.1",
-        "reserved-words": "^0.1.2",
-        "zod": "^1.11.17"
-      }
-    },
-    "node_modules/@cdktf/hcl2cdk/node_modules/graphology-types": {
-      "version": "0.21.2",
-      "resolved": "https://registry.npmjs.org/graphology-types/-/graphology-types-0.21.2.tgz",
-      "integrity": "sha512-KNdgwG0dbVjhJqRUw0OivJ5pkUHunbk4vDatwdfITfNvPugX0xR327ZKsaOcr3snbiBJfyGu7lCrXeYp4KF8YA==",
-      "dev": true
-    },
-    "node_modules/@cdktf/hcl2json": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@cdktf/hcl2json/-/hcl2json-0.15.0.tgz",
-      "integrity": "sha512-pVYjTosthO0Mro/VD5x4iUM6TcVk0hdeNzk8uaaxk49/XnJB4DiwHbvIdjKJk4BuY2YuW+bCsz6X2QjKJmz2jA==",
-      "dev": true,
-      "dependencies": {
-        "@types/node-fetch": "^2.6.2",
-        "fs-extra": "^8.1.0",
-        "node-fetch": "^2.6.7"
-      }
-    },
-    "node_modules/@cdktf/hcl2json/node_modules/fs-extra": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-      "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=6 <7 || >=8"
-      }
-    },
-    "node_modules/@cdktf/hcl2json/node_modules/jsonfile": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
-      "dev": true,
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/@cdktf/hcl2json/node_modules/universalify": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-      "dev": true,
-      "engines": {
-        "node": ">= 4.0.0"
-      }
-    },
-    "node_modules/@cdktf/node-pty-prebuilt-multiarch": {
-      "version": "0.10.1-pre.10",
-      "resolved": "https://registry.npmjs.org/@cdktf/node-pty-prebuilt-multiarch/-/node-pty-prebuilt-multiarch-0.10.1-pre.10.tgz",
-      "integrity": "sha512-5ysQrHJvqYLYg407KvaDNu+xx68ZGaqeF0SohXe5e4yNqJhPFPUQ536rkReQcPc2yZiF5PDmmvf5T9MOacHpSQ==",
-      "dev": true,
-      "hasInstallScript": true,
-      "dependencies": {
-        "nan": "^2.14.2",
-        "prebuild-install": "^7.1.1"
-      }
-    },
     "node_modules/@cdktf/provider-aws": {
       "version": "12.0.1",
       "resolved": "https://registry.npmjs.org/@cdktf/provider-aws/-/provider-aws-12.0.1.tgz",
@@ -4058,52 +2704,6 @@
       "peerDependencies": {
         "cdktf": "^0.15.0",
         "constructs": "^10.0.0"
-      }
-    },
-    "node_modules/@cdktf/provider-generator": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@cdktf/provider-generator/-/provider-generator-0.15.0.tgz",
-      "integrity": "sha512-YY2ANbC9xuhq1yXc6dhVPvMCCKMjcXNRBUP6BqvlE2smD0RWx1s0uWKAG5Tw4D4kx4Nb6EXYpvFHRIEnjVJ4wA==",
-      "dev": true,
-      "dependencies": {
-        "@cdktf/commons": "0.15.0",
-        "@cdktf/hcl2json": "0.15.0",
-        "codemaker": "^1.73.0",
-        "deepmerge": "^4.2.2",
-        "fs-extra": "^8.1.0",
-        "jsii-srcmak": "^0.1.790"
-      }
-    },
-    "node_modules/@cdktf/provider-generator/node_modules/fs-extra": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-      "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=6 <7 || >=8"
-      }
-    },
-    "node_modules/@cdktf/provider-generator/node_modules/jsonfile": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
-      "dev": true,
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/@cdktf/provider-generator/node_modules/universalify": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-      "dev": true,
-      "engines": {
-        "node": ">= 4.0.0"
       }
     },
     "node_modules/@cdktf/provider-google": {
@@ -5309,12 +3909,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/@npmcli/ci-detect": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@npmcli/ci-detect/-/ci-detect-1.4.0.tgz",
-      "integrity": "sha512-3BGrt6FLjqM6br5AhWRKTr3u5GIVkjRYeAFrMp3HjnfICrg4xOrVRwFavKT6tsp++bq5dluL5t8ME/Nha/6c1Q==",
-      "dev": true
-    },
     "node_modules/@npmcli/fs": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-3.1.0.tgz",
@@ -5538,121 +4132,6 @@
       "engines": {
         "node": ">=12"
       }
-    },
-    "node_modules/@sentry/core": {
-      "version": "6.19.7",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.19.7.tgz",
-      "integrity": "sha512-tOfZ/umqB2AcHPGbIrsFLcvApdTm9ggpi/kQZFkej7kMphjT+SGBiQfYtjyg9jcRW+ilAR4JXC9BGKsdEQ+8Vw==",
-      "dev": true,
-      "dependencies": {
-        "@sentry/hub": "6.19.7",
-        "@sentry/minimal": "6.19.7",
-        "@sentry/types": "6.19.7",
-        "@sentry/utils": "6.19.7",
-        "tslib": "^1.9.3"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@sentry/core/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true
-    },
-    "node_modules/@sentry/hub": {
-      "version": "6.19.7",
-      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.19.7.tgz",
-      "integrity": "sha512-y3OtbYFAqKHCWezF0EGGr5lcyI2KbaXW2Ik7Xp8Mu9TxbSTuwTe4rTntwg8ngPjUQU3SUHzgjqVB8qjiGqFXCA==",
-      "dev": true,
-      "dependencies": {
-        "@sentry/types": "6.19.7",
-        "@sentry/utils": "6.19.7",
-        "tslib": "^1.9.3"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@sentry/hub/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true
-    },
-    "node_modules/@sentry/minimal": {
-      "version": "6.19.7",
-      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.19.7.tgz",
-      "integrity": "sha512-wcYmSJOdvk6VAPx8IcmZgN08XTXRwRtB1aOLZm+MVHjIZIhHoBGZJYTVQS/BWjldsamj2cX3YGbGXNunaCfYJQ==",
-      "dev": true,
-      "dependencies": {
-        "@sentry/hub": "6.19.7",
-        "@sentry/types": "6.19.7",
-        "tslib": "^1.9.3"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@sentry/minimal/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true
-    },
-    "node_modules/@sentry/node": {
-      "version": "6.19.7",
-      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-6.19.7.tgz",
-      "integrity": "sha512-gtmRC4dAXKODMpHXKfrkfvyBL3cI8y64vEi3fDD046uqYcrWdgoQsffuBbxMAizc6Ez1ia+f0Flue6p15Qaltg==",
-      "dev": true,
-      "dependencies": {
-        "@sentry/core": "6.19.7",
-        "@sentry/hub": "6.19.7",
-        "@sentry/types": "6.19.7",
-        "@sentry/utils": "6.19.7",
-        "cookie": "^0.4.1",
-        "https-proxy-agent": "^5.0.0",
-        "lru_map": "^0.3.3",
-        "tslib": "^1.9.3"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@sentry/node/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true
-    },
-    "node_modules/@sentry/types": {
-      "version": "6.19.7",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.19.7.tgz",
-      "integrity": "sha512-jH84pDYE+hHIbVnab3Hr+ZXr1v8QABfhx39KknxqKWr2l0oEItzepV0URvbEhB446lk/S/59230dlUUIBGsXbg==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@sentry/utils": {
-      "version": "6.19.7",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.19.7.tgz",
-      "integrity": "sha512-z95ECmE3i9pbWoXQrD/7PgkBAzJYR+iXtPuTkpBjDKs86O3mT+PXOT3BAn79w2wkn7/i3vOGD2xVr1uiMl26dA==",
-      "dev": true,
-      "dependencies": {
-        "@sentry/types": "6.19.7",
-        "tslib": "^1.9.3"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@sentry/utils/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.24.51",
@@ -6040,12 +4519,6 @@
       "version": "21.0.0",
       "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.0.tgz",
       "integrity": "sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==",
-      "dev": true
-    },
-    "node_modules/@types/yoga-layout": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@types/yoga-layout/-/yoga-layout-1.9.2.tgz",
-      "integrity": "sha512-S9q47ByT2pPvD65IvrWp7qppVMpk9WGMbVq9wbWZOHg6tnXSD4vyhao6nOSBwwfDdV2p3Kx9evA9vI+XWTfDvw==",
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -6468,15 +4941,6 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true
     },
-    "node_modules/arr-rotate": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/arr-rotate/-/arr-rotate-1.0.0.tgz",
-      "integrity": "sha512-yOzOZcR9Tn7enTF66bqKorGGH0F36vcPaSWg8fO0c0UYb3LX3VMXj5ZxEqQLNOecAhlRJ7wYZja5i4jTlnbIfQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/array-ify": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz",
@@ -6556,16 +5020,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/astral-regex": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
-      "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
-      "dev": true,
-      "peer": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -6579,19 +5033,6 @@
       "dev": true,
       "engines": {
         "node": ">= 4.0.0"
-      }
-    },
-    "node_modules/auto-bind": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/auto-bind/-/auto-bind-4.0.0.tgz",
-      "integrity": "sha512-Hdw8qdNiqdJ8LqT0iK0sVzkFbzg6fhnQqqfWhBDxcHZvU75+B+ayzTy8x+k5Ix0Y92XOhOUlx74ps+bA6BeYMQ==",
-      "dev": true,
-      "peer": true,
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/available-typed-arrays": {
@@ -7038,37 +5479,6 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
-    "node_modules/base64-js": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
-    },
-    "node_modules/bl": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
-      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-      "dev": true,
-      "dependencies": {
-        "buffer": "^5.5.0",
-        "inherits": "^2.0.4",
-        "readable-stream": "^3.4.0"
-      }
-    },
     "node_modules/bowser": {
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
@@ -7313,30 +5723,6 @@
       "dev": true,
       "dependencies": {
         "node-int64": "^0.4.0"
-      }
-    },
-    "node_modules/buffer": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.1.13"
       }
     },
     "node_modules/buffer-equal-constant-time": {
@@ -7594,634 +5980,6 @@
       },
       "peerDependencies": {
         "constructs": "^10.0.25"
-      }
-    },
-    "node_modules/cdktf-cli": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/cdktf-cli/-/cdktf-cli-0.15.0.tgz",
-      "integrity": "sha512-wPVkiuoId7u1Jy1C1d+D4ktfQde5GfHkZBMppmkO/daZXsI2kH7yIFZpJ81/0k9hNRHvoK1d0/gDMMywqwWcmg==",
-      "dev": true,
-      "dependencies": {
-        "@cdktf/cli-core": "0.15.0",
-        "@cdktf/commons": "0.15.0",
-        "@cdktf/hcl2cdk": "0.15.0",
-        "@cdktf/hcl2json": "0.15.0",
-        "@sentry/node": "^6.19.7",
-        "cdktf": "0.15.0",
-        "codemaker": "^1.73.0",
-        "constructs": "^10.0.25",
-        "cross-spawn": "^7.0.3",
-        "https-proxy-agent": "^5.0.1",
-        "ink-select-input": "^4.2.1",
-        "ink-table": "^3.0.0",
-        "jsii": "^1.73.0",
-        "jsii-pacmak": "^1.73.0",
-        "minimatch": "^5.1.0",
-        "node-abort-controller": "^3.0.1",
-        "node-fetch": "^2.6.7",
-        "tunnel-agent": "^0.6.0",
-        "xml-js": "^1.6.11",
-        "yargs": "^17.6",
-        "yoga-layout-prebuilt": "^1.10.0",
-        "zod": "^1.11.17"
-      },
-      "bin": {
-        "cdktf": "bundle/bin/cdktf"
-      }
-    },
-    "node_modules/cdktf-cli/node_modules/cdktf": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/cdktf/-/cdktf-0.15.0.tgz",
-      "integrity": "sha512-Dzv/pfJWTFzxMxjcgI3cttK7hPLy69bUPzcZgUK0sI+k3kY4I67pmxKuXDh1XVK9AX+pCaiZT7wzQbCznTrQkQ==",
-      "bundleDependencies": [
-        "archiver",
-        "json-stable-stringify",
-        "semver"
-      ],
-      "dev": true,
-      "dependencies": {
-        "archiver": "5.3.1",
-        "json-stable-stringify": "^1.0.2",
-        "semver": "^7.3.8"
-      },
-      "peerDependencies": {
-        "constructs": "^10.0.25"
-      }
-    },
-    "node_modules/cdktf-cli/node_modules/cdktf/node_modules/archiver": {
-      "version": "5.3.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "archiver-utils": "^2.1.0",
-        "async": "^3.2.3",
-        "buffer-crc32": "^0.2.1",
-        "readable-stream": "^3.6.0",
-        "readdir-glob": "^1.0.0",
-        "tar-stream": "^2.2.0",
-        "zip-stream": "^4.1.0"
-      },
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/cdktf-cli/node_modules/cdktf/node_modules/archiver-utils": {
-      "version": "2.1.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "glob": "^7.1.4",
-        "graceful-fs": "^4.2.0",
-        "lazystream": "^1.0.0",
-        "lodash.defaults": "^4.2.0",
-        "lodash.difference": "^4.5.0",
-        "lodash.flatten": "^4.4.0",
-        "lodash.isplainobject": "^4.0.6",
-        "lodash.union": "^4.6.0",
-        "normalize-path": "^3.0.0",
-        "readable-stream": "^2.0.0"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/cdktf-cli/node_modules/cdktf/node_modules/archiver-utils/node_modules/readable-stream": {
-      "version": "2.3.7",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/cdktf-cli/node_modules/cdktf/node_modules/archiver-utils/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
-    "node_modules/cdktf-cli/node_modules/cdktf/node_modules/async": {
-      "version": "3.2.4",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/cdktf-cli/node_modules/cdktf/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/cdktf-cli/node_modules/cdktf/node_modules/base64-js": {
-      "version": "1.5.1",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/cdktf-cli/node_modules/cdktf/node_modules/bl": {
-      "version": "4.1.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "buffer": "^5.5.0",
-        "inherits": "^2.0.4",
-        "readable-stream": "^3.4.0"
-      }
-    },
-    "node_modules/cdktf-cli/node_modules/cdktf/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/cdktf-cli/node_modules/cdktf/node_modules/buffer": {
-      "version": "5.7.1",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.1.13"
-      }
-    },
-    "node_modules/cdktf-cli/node_modules/cdktf/node_modules/buffer-crc32": {
-      "version": "0.2.13",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/cdktf-cli/node_modules/cdktf/node_modules/compress-commons": {
-      "version": "4.1.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "buffer-crc32": "^0.2.13",
-        "crc32-stream": "^4.0.2",
-        "normalize-path": "^3.0.0",
-        "readable-stream": "^3.6.0"
-      },
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/cdktf-cli/node_modules/cdktf/node_modules/concat-map": {
-      "version": "0.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/cdktf-cli/node_modules/cdktf/node_modules/core-util-is": {
-      "version": "1.0.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/cdktf-cli/node_modules/cdktf/node_modules/crc-32": {
-      "version": "1.2.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "crc32": "bin/crc32.njs"
-      },
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
-    "node_modules/cdktf-cli/node_modules/cdktf/node_modules/crc32-stream": {
-      "version": "4.0.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "crc-32": "^1.2.0",
-        "readable-stream": "^3.4.0"
-      },
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/cdktf-cli/node_modules/cdktf/node_modules/end-of-stream": {
-      "version": "1.4.4",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "once": "^1.4.0"
-      }
-    },
-    "node_modules/cdktf-cli/node_modules/cdktf/node_modules/fs-constants": {
-      "version": "1.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/cdktf-cli/node_modules/cdktf/node_modules/fs.realpath": {
-      "version": "1.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/cdktf-cli/node_modules/cdktf/node_modules/glob": {
-      "version": "7.2.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/cdktf-cli/node_modules/cdktf/node_modules/glob/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/cdktf-cli/node_modules/cdktf/node_modules/glob/node_modules/minimatch": {
-      "version": "3.1.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/cdktf-cli/node_modules/cdktf/node_modules/graceful-fs": {
-      "version": "4.2.10",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/cdktf-cli/node_modules/cdktf/node_modules/ieee754": {
-      "version": "1.2.1",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "inBundle": true,
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/cdktf-cli/node_modules/cdktf/node_modules/inflight": {
-      "version": "1.0.6",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "once": "^1.3.0",
-        "wrappy": "1"
-      }
-    },
-    "node_modules/cdktf-cli/node_modules/cdktf/node_modules/inherits": {
-      "version": "2.0.4",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/cdktf-cli/node_modules/cdktf/node_modules/isarray": {
-      "version": "1.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/cdktf-cli/node_modules/cdktf/node_modules/json-stable-stringify": {
-      "version": "1.0.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "jsonify": "^0.0.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/cdktf-cli/node_modules/cdktf/node_modules/jsonify": {
-      "version": "0.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "Public Domain",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/cdktf-cli/node_modules/cdktf/node_modules/lazystream": {
-      "version": "1.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "readable-stream": "^2.0.5"
-      },
-      "engines": {
-        "node": ">= 0.6.3"
-      }
-    },
-    "node_modules/cdktf-cli/node_modules/cdktf/node_modules/lazystream/node_modules/readable-stream": {
-      "version": "2.3.7",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/cdktf-cli/node_modules/cdktf/node_modules/lazystream/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
-    "node_modules/cdktf-cli/node_modules/cdktf/node_modules/lodash.defaults": {
-      "version": "4.2.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/cdktf-cli/node_modules/cdktf/node_modules/lodash.difference": {
-      "version": "4.5.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/cdktf-cli/node_modules/cdktf/node_modules/lodash.flatten": {
-      "version": "4.4.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/cdktf-cli/node_modules/cdktf/node_modules/lodash.isplainobject": {
-      "version": "4.0.6",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/cdktf-cli/node_modules/cdktf/node_modules/lodash.union": {
-      "version": "4.6.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/cdktf-cli/node_modules/cdktf/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/cdktf-cli/node_modules/cdktf/node_modules/minimatch": {
-      "version": "5.1.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/cdktf-cli/node_modules/cdktf/node_modules/normalize-path": {
-      "version": "3.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/cdktf-cli/node_modules/cdktf/node_modules/once": {
-      "version": "1.4.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "wrappy": "1"
-      }
-    },
-    "node_modules/cdktf-cli/node_modules/cdktf/node_modules/path-is-absolute": {
-      "version": "1.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/cdktf-cli/node_modules/cdktf/node_modules/process-nextick-args": {
-      "version": "2.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/cdktf-cli/node_modules/cdktf/node_modules/readable-stream": {
-      "version": "3.6.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/cdktf-cli/node_modules/cdktf/node_modules/readdir-glob": {
-      "version": "1.1.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "minimatch": "^5.1.0"
-      }
-    },
-    "node_modules/cdktf-cli/node_modules/cdktf/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/cdktf-cli/node_modules/cdktf/node_modules/semver": {
-      "version": "7.3.8",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/cdktf-cli/node_modules/cdktf/node_modules/string_decoder": {
-      "version": "1.3.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.2.0"
-      }
-    },
-    "node_modules/cdktf-cli/node_modules/cdktf/node_modules/string_decoder/node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/cdktf-cli/node_modules/cdktf/node_modules/tar-stream": {
-      "version": "2.2.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "bl": "^4.0.3",
-        "end-of-stream": "^1.4.1",
-        "fs-constants": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^3.1.1"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/cdktf-cli/node_modules/cdktf/node_modules/util-deprecate": {
-      "version": "1.0.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/cdktf-cli/node_modules/cdktf/node_modules/wrappy": {
-      "version": "1.0.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/cdktf-cli/node_modules/cdktf/node_modules/yallist": {
-      "version": "4.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/cdktf-cli/node_modules/cdktf/node_modules/zip-stream": {
-      "version": "4.1.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "archiver-utils": "^2.1.0",
-        "compress-commons": "^4.1.0",
-        "readable-stream": "^3.6.0"
-      },
-      "engines": {
-        "node": ">= 10"
       }
     },
     "node_modules/cdktf/node_modules/archiver": {
@@ -8799,32 +6557,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/cli-boxes": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-2.2.1.tgz",
-      "integrity": "sha512-y4coMcylgSCdVinjiDBuR8PCC2bLjyGTwEmPb9NHR/QaNU6EUOXcTY/s6VjGMD6ENSEaeQYHCY0GNGS5jfMwPw==",
-      "dev": true,
-      "peer": true,
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/cli-cursor": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
-      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "restore-cursor": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/cli-table": {
       "version": "0.3.11",
       "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.11.tgz",
@@ -8835,87 +6567,6 @@
       },
       "engines": {
         "node": ">= 0.2.0"
-      }
-    },
-    "node_modules/cli-truncate": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-2.1.0.tgz",
-      "integrity": "sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "slice-ansi": "^3.0.0",
-        "string-width": "^4.2.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/cliui": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
-      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-      "dev": true,
-      "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.1",
-        "wrap-ansi": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/cliui/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/cliui/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/cliui/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
-    },
-    "node_modules/cliui/node_modules/wrap-ansi": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/clone": {
@@ -8947,19 +6598,6 @@
       "engines": {
         "iojs": ">= 1.0.0",
         "node": ">= 0.12.0"
-      }
-    },
-    "node_modules/code-excerpt": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/code-excerpt/-/code-excerpt-3.0.0.tgz",
-      "integrity": "sha512-VHNTVhd7KsLGOqfX3SyeO8RyYPMp1GJOg194VITk04WMYCv4plV68YWe6TJZxd9MhobjtpMRnVky01gqZsalaw==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "convert-to-spaces": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/codemaker": {
@@ -9455,25 +7093,6 @@
       "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
       "dev": true
     },
-    "node_modules/convert-to-spaces": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/convert-to-spaces/-/convert-to-spaces-1.0.2.tgz",
-      "integrity": "sha512-cj09EBuObp9gZNQCzc7hByQyrs6jVGE+o9kSJmeUoj+GiPiJvi5LYqEH/Hmme4+MTLHM+Ejtq+FChpjjEnsPdQ==",
-      "dev": true,
-      "peer": true,
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "node_modules/cookie": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
-      "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/core-util-is": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
@@ -9783,15 +7402,6 @@
       "dev": true,
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/detect-libc": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.1.tgz",
-      "integrity": "sha512-463v3ZeIrcWtdgIg6vI6XUncguvr2TnGl4SzDXinkt9mSLpBJKXT3mW6xT3VQdDN11+WVs29pgvivTc4Lp8v+w==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/detect-newline": {
@@ -11250,15 +8860,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/expand-template": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
-      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/expect": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/expect/-/expect-27.5.1.tgz",
@@ -11449,26 +9050,6 @@
       "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
       "dev": true
     },
-    "node_modules/follow-redirects": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
-      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/for-each": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
@@ -11509,12 +9090,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/fs-constants": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-      "dev": true
     },
     "node_modules/fs-extra": {
       "version": "10.1.0",
@@ -11943,12 +9518,6 @@
         "ini": "^1.3.2"
       }
     },
-    "node_modules/github-from-package": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
-      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
-      "dev": true
-    },
     "node_modules/glob": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -12139,26 +9708,6 @@
       "resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
       "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
       "dev": true
-    },
-    "node_modules/graphology": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/graphology/-/graphology-0.25.1.tgz",
-      "integrity": "sha512-yYA7BJCcXN2DrKNQQ9Qf22zBHm/yTbyBR71T1MYBbGtywNHsv0QZtk8zaR6zxNcp2hCCZayUkHp9DyMSZCpoxQ==",
-      "dev": true,
-      "dependencies": {
-        "events": "^3.3.0",
-        "obliterator": "^2.0.2"
-      },
-      "peerDependencies": {
-        "graphology-types": ">=0.24.0"
-      }
-    },
-    "node_modules/graphology-types": {
-      "version": "0.24.7",
-      "resolved": "https://registry.npmjs.org/graphology-types/-/graphology-types-0.24.7.tgz",
-      "integrity": "sha512-tdcqOOpwArNjEr0gNQKCXwaNCWnQJrog14nJNQPeemcLnXQUUGrsCWpWkVKt46zLjcS6/KGoayeJfHHyPDlvwA==",
-      "dev": true,
-      "peer": true
     },
     "node_modules/handlebars": {
       "version": "4.7.7",
@@ -12417,26 +9966,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/ieee754": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
-    },
     "node_modules/ignore": {
       "version": "5.2.4",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
@@ -12547,170 +10076,6 @@
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "dev": true
-    },
-    "node_modules/ink": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/ink/-/ink-3.2.0.tgz",
-      "integrity": "sha512-firNp1q3xxTzoItj/eOOSZQnYSlyrWks5llCTVX37nJ59K3eXbQ8PtzCguqo8YI19EELo5QxaKnJd4VxzhU8tg==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "ansi-escapes": "^4.2.1",
-        "auto-bind": "4.0.0",
-        "chalk": "^4.1.0",
-        "cli-boxes": "^2.2.0",
-        "cli-cursor": "^3.1.0",
-        "cli-truncate": "^2.1.0",
-        "code-excerpt": "^3.0.0",
-        "indent-string": "^4.0.0",
-        "is-ci": "^2.0.0",
-        "lodash": "^4.17.20",
-        "patch-console": "^1.0.0",
-        "react-devtools-core": "^4.19.1",
-        "react-reconciler": "^0.26.2",
-        "scheduler": "^0.20.2",
-        "signal-exit": "^3.0.2",
-        "slice-ansi": "^3.0.0",
-        "stack-utils": "^2.0.2",
-        "string-width": "^4.2.2",
-        "type-fest": "^0.12.0",
-        "widest-line": "^3.1.0",
-        "wrap-ansi": "^6.2.0",
-        "ws": "^7.5.5",
-        "yoga-layout-prebuilt": "^1.9.6"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "@types/react": ">=16.8.0",
-        "react": ">=16.8.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/ink-select-input": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/ink-select-input/-/ink-select-input-4.2.1.tgz",
-      "integrity": "sha512-WvlrYdwmdnD6/nE/9mNhaaanTQOKmwy/hT/vuAqbDec3PUQBQ8Pkwszii/8eGvDTx5bGiUHu18P9D5IoB/ERaw==",
-      "dev": true,
-      "dependencies": {
-        "arr-rotate": "^1.0.0",
-        "figures": "^3.2.0",
-        "lodash.isequal": "^4.5.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "ink": "^3.0.5",
-        "react": "^16.5.2 || ^17.0.0"
-      }
-    },
-    "node_modules/ink-table": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/ink-table/-/ink-table-3.0.0.tgz",
-      "integrity": "sha512-RtcYjenHKZWjnwVNQ6zSYWMOLKwkWscDAJsqUQXftyjkYho1gGrluGss87NOoIzss0IKr74lKasd6MtlQYALiA==",
-      "dev": true,
-      "dependencies": {
-        "object-hash": "^2.0.3"
-      },
-      "peerDependencies": {
-        "ink": ">=3.0.0",
-        "react": ">=16.8.0"
-      }
-    },
-    "node_modules/ink/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/ink/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/ink/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/ink/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
-      "peer": true
-    },
-    "node_modules/ink/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
-      "peer": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/ink/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/ink/node_modules/type-fest": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.12.0.tgz",
-      "integrity": "sha512-53RyidyjvkGpnWPMF9bQgFtWp+Sl8O2Rp13VavmJgfAP9WWG6q6TkrKU8iyJdnwnfgHI6k2hTlgqH4aSdjoTbg==",
-      "dev": true,
-      "peer": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/internal-slot": {
       "version": "1.0.4",
@@ -13093,15 +10458,6 @@
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
       "dev": true
-    },
-    "node_modules/is-valid-domain": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/is-valid-domain/-/is-valid-domain-0.1.6.tgz",
-      "integrity": "sha512-ZKtq737eFkZr71At8NxOFcP9O1K89gW3DkdrGMpp1upr/ueWjj+Weh4l9AI4rN0Gt8W2M1w7jrG2b/Yv83Ljpg==",
-      "dev": true,
-      "dependencies": {
-        "punycode": "^2.1.1"
-      }
     },
     "node_modules/is-weakref": {
       "version": "1.0.2",
@@ -15621,159 +12977,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/jsii-srcmak": {
-      "version": "0.1.802",
-      "resolved": "https://registry.npmjs.org/jsii-srcmak/-/jsii-srcmak-0.1.802.tgz",
-      "integrity": "sha512-oPbnaU1YL0Wp3NucRYGihoor/kS2NzpJnQB/fo7FUBtXg6xWa7abJ8b98oiaaj6jiPsePyMC0s7QEHhNIx0TDw==",
-      "dev": true,
-      "dependencies": {
-        "fs-extra": "^9.1.0",
-        "jsii": "^1.73.0",
-        "jsii-pacmak": "^1.73.0",
-        "ncp": "^2.0.0",
-        "yargs": "^15.4.1"
-      },
-      "bin": {
-        "jsii-srcmak": "bin/jsii-srcmak"
-      }
-    },
-    "node_modules/jsii-srcmak/node_modules/camelcase": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/jsii-srcmak/node_modules/cliui": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
-      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
-      "dev": true,
-      "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0",
-        "wrap-ansi": "^6.2.0"
-      }
-    },
-    "node_modules/jsii-srcmak/node_modules/decamelize": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/jsii-srcmak/node_modules/find-up": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-      "dev": true,
-      "dependencies": {
-        "locate-path": "^5.0.0",
-        "path-exists": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/jsii-srcmak/node_modules/fs-extra": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
-      "dev": true,
-      "dependencies": {
-        "at-least-node": "^1.0.0",
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/jsii-srcmak/node_modules/locate-path": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-      "dev": true,
-      "dependencies": {
-        "p-locate": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/jsii-srcmak/node_modules/p-limit": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-      "dev": true,
-      "dependencies": {
-        "p-try": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/jsii-srcmak/node_modules/p-locate": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-      "dev": true,
-      "dependencies": {
-        "p-limit": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/jsii-srcmak/node_modules/y18n": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
-      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
-      "dev": true
-    },
-    "node_modules/jsii-srcmak/node_modules/yargs": {
-      "version": "15.4.1",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
-      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
-      "dev": true,
-      "dependencies": {
-        "cliui": "^6.0.0",
-        "decamelize": "^1.2.0",
-        "find-up": "^4.1.0",
-        "get-caller-file": "^2.0.1",
-        "require-directory": "^2.1.1",
-        "require-main-filename": "^2.0.0",
-        "set-blocking": "^2.0.0",
-        "string-width": "^4.2.0",
-        "which-module": "^2.0.0",
-        "y18n": "^4.0.0",
-        "yargs-parser": "^18.1.2"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/jsii-srcmak/node_modules/yargs-parser": {
-      "version": "18.1.3",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
-      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
-      "dev": true,
-      "dependencies": {
-        "camelcase": "^5.0.0",
-        "decamelize": "^1.2.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/jsii/node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -16219,12 +13422,6 @@
       "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
       "dev": true
     },
-    "node_modules/lodash.isequal": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
-      "dev": true
-    },
     "node_modules/lodash.ismatch": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.ismatch/-/lodash.ismatch-4.4.0.tgz",
@@ -16259,19 +13456,6 @@
         "node": ">=8.0"
       }
     },
-    "node_modules/loose-envify": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
-      },
-      "bin": {
-        "loose-envify": "cli.js"
-      }
-    },
     "node_modules/lowercase-keys": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-3.0.0.tgz",
@@ -16283,12 +13467,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/lru_map": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/lru_map/-/lru_map-0.3.3.tgz",
-      "integrity": "sha512-Pn9cox5CsMYngeDbmChANltQl+5pi6XmTrraMSzhPmMBbmgcxmqWry0U3PGapCU1yB4/LqCcom7qhHZiF/jGfQ==",
-      "dev": true
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",
@@ -16935,12 +14113,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/mkdirp-classic": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
-      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
-      "dev": true
-    },
     "node_modules/mnemonist": {
       "version": "0.38.3",
       "resolved": "https://registry.npmjs.org/mnemonist/-/mnemonist-0.38.3.tgz",
@@ -16971,18 +14143,6 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "inBundle": true
     },
-    "node_modules/nan": {
-      "version": "2.17.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
-      "integrity": "sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ==",
-      "dev": true
-    },
-    "node_modules/napi-build-utils": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
-      "integrity": "sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg==",
-      "dev": true
-    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -16994,15 +14154,6 @@
       "resolved": "https://registry.npmjs.org/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz",
       "integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
       "dev": true
-    },
-    "node_modules/ncp": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
-      "integrity": "sha512-zIdGUrPRFTUELUvr3Gmc7KZ2Sw/h1PiVM0Af/oHB6zgnV1ikqSfRk+TOufi79aHYCW3NiOXmr1BP5nWbzojLaA==",
-      "dev": true,
-      "bin": {
-        "ncp": "bin/ncp"
-      }
     },
     "node_modules/negotiator": {
       "version": "0.6.3",
@@ -17055,24 +14206,6 @@
       "dependencies": {
         "@sinonjs/commons": "^2.0.0"
       }
-    },
-    "node_modules/node-abi": {
-      "version": "3.31.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.31.0.tgz",
-      "integrity": "sha512-eSKV6s+APenqVh8ubJyiu/YhZgxQpGP66ntzUb3lY1xB9ukSRaGnx0AIxI+IM+1+IVYC1oWobgG5L3Lt9ARykQ==",
-      "dev": true,
-      "dependencies": {
-        "semver": "^7.3.5"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/node-abort-controller": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/node-abort-controller/-/node-abort-controller-3.0.1.tgz",
-      "integrity": "sha512-/ujIVxthRs+7q6hsdjHMaj8hRG9NuWmwrz+JdRwZ14jdFoKSkm+vDsCbF9PLpnSqjaWQJuTmVtcWHNLr+vrOFw==",
-      "dev": true
     },
     "node_modules/node-fetch": {
       "version": "2.6.7",
@@ -17507,25 +14640,6 @@
       "integrity": "sha512-90yv+6538zuvUMnN+zCr8LuV6bPFdq50304114vJYJ8RDyK8D5O9Phpbd6SZWgI7PwzmmfN1upeOJlvybDSgCw==",
       "dev": true
     },
-    "node_modules/object-assign": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
-      "peer": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/object-hash": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.2.0.tgz",
-      "integrity": "sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==",
-      "dev": true,
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/object-inspect": {
       "version": "1.12.2",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz",
@@ -17578,12 +14692,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/obliterator": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/obliterator/-/obliterator-2.0.4.tgz",
-      "integrity": "sha512-lgHwxlxV1qIg1Eap7LgIeoBWIMFibOjbrYPIPJZcI1mmGAI2m3lNYpK12Y+GBdPQ0U1hRwSord7GIaawz962qQ==",
-      "dev": true
     },
     "node_modules/once": {
       "version": "1.4.0",
@@ -17849,16 +14957,6 @@
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
       "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
       "dev": true
-    },
-    "node_modules/patch-console": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/patch-console/-/patch-console-1.0.0.tgz",
-      "integrity": "sha512-nxl9nrnLQmh64iTzMfyylSlRozL7kAXIaxw1fVcLYdyhNkJCRUzirRZTikXGJsg+hc4fqpneTK6iU2H1Q8THSA==",
-      "dev": true,
-      "peer": true,
-      "engines": {
-        "node": ">=10"
-      }
     },
     "node_modules/patch-package": {
       "version": "6.5.1",
@@ -18228,32 +15326,6 @@
       "integrity": "sha512-E8OSdh76mpen1rRwGWoPRQ5E11hkuqzcjzWFHQxNgxa4aYgnIPT4/IZPcZNZ7Y5v2iaxKaczhw1cxnWhaZoxNw==",
       "peerDependencies": {
         "constructs": "^10.0.25"
-      }
-    },
-    "node_modules/prebuild-install": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.1.tgz",
-      "integrity": "sha512-jAXscXWMcCK8GgCoHOfIr0ODh5ai8mj63L2nWrjuAgXE6tDyYGnx4/8o/rCgU+B4JSyZBKbeZqzhtwtC3ovxjw==",
-      "dev": true,
-      "dependencies": {
-        "detect-libc": "^2.0.0",
-        "expand-template": "^2.0.3",
-        "github-from-package": "0.0.0",
-        "minimist": "^1.2.3",
-        "mkdirp-classic": "^0.5.3",
-        "napi-build-utils": "^1.0.1",
-        "node-abi": "^3.3.0",
-        "pump": "^3.0.0",
-        "rc": "^1.2.7",
-        "simple-get": "^4.0.0",
-        "tar-fs": "^2.0.0",
-        "tunnel-agent": "^0.6.0"
-      },
-      "bin": {
-        "prebuild-install": "bin.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/prelude-ls": {
@@ -19356,54 +16428,11 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/react": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
-      "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/react-devtools-core": {
-      "version": "4.27.1",
-      "resolved": "https://registry.npmjs.org/react-devtools-core/-/react-devtools-core-4.27.1.tgz",
-      "integrity": "sha512-qXhcxxDWiFmFAOq48jts9YQYe1+wVoUXzJTlY4jbaATzyio6dd6CUGu3dXBhREeVgpZ+y4kg6vFJzIOZh6vY2w==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "shell-quote": "^1.6.1",
-        "ws": "^7"
-      }
-    },
     "node_modules/react-is": {
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
       "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
       "dev": true
-    },
-    "node_modules/react-reconciler": {
-      "version": "0.26.2",
-      "resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.26.2.tgz",
-      "integrity": "sha512-nK6kgY28HwrMNwDnMui3dvm3rCFjZrcGiuwLc5COUipBK5hWHLOxMJhSnSomirqWwjPBJKV1QcbkI0VJr7Gl1Q==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "scheduler": "^0.20.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      },
-      "peerDependencies": {
-        "react": "^17.0.2"
-      }
     },
     "node_modules/read-package-json": {
       "version": "6.0.0",
@@ -19722,23 +16751,11 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/require-main-filename": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
-      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
-      "dev": true
-    },
     "node_modules/requires-port": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
       "inBundle": true
-    },
-    "node_modules/reserved-words": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/reserved-words/-/reserved-words-0.1.2.tgz",
-      "integrity": "sha512-0S5SrIUJ9LfpbVl4Yzij6VipUdafHrOTzvmfazSw/jeZrZtQK303OPZW+obtkaw7jQlTQppy0UvZWm9872PbRw==",
-      "dev": true
     },
     "node_modules/resolve": {
       "version": "1.22.1",
@@ -19819,20 +16836,6 @@
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
       "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
       "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/restore-cursor": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
-      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "onetime": "^5.1.0",
-        "signal-exit": "^3.0.2"
-      },
       "engines": {
         "node": ">=8"
       }
@@ -19968,17 +16971,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/scheduler": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
-      "integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
-      }
-    },
     "node_modules/semver": {
       "version": "7.3.8",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
@@ -20078,16 +17070,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/shell-quote": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.4.tgz",
-      "integrity": "sha512-8o/QEhSSRb1a5i7TFR0iM4G16Z0vYB2OQVs4G3aAFXjn3T6yEx8AZxy1PgDF7I00LZHYA3WxaSYIf5e5sAX8Rw==",
-      "dev": true,
-      "peer": true,
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/side-channel": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
@@ -20107,51 +17089,6 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
-    },
-    "node_modules/simple-concat": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
-      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
-    },
-    "node_modules/simple-get": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
-      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "dependencies": {
-        "decompress-response": "^6.0.0",
-        "once": "^1.3.1",
-        "simple-concat": "^1.0.0"
-      }
     },
     "node_modules/sinon": {
       "version": "14.0.2",
@@ -20215,57 +17152,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/slice-ansi": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-3.0.0.tgz",
-      "integrity": "sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "astral-regex": "^2.0.0",
-        "is-fullwidth-code-point": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/slice-ansi/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/slice-ansi/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/slice-ansi/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
-      "peer": true
     },
     "node_modules/smart-buffer": {
       "version": "4.2.0",
@@ -20897,40 +17783,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/tar-fs": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
-      "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
-      "dev": true,
-      "dependencies": {
-        "chownr": "^1.1.1",
-        "mkdirp-classic": "^0.5.2",
-        "pump": "^3.0.0",
-        "tar-stream": "^2.1.4"
-      }
-    },
-    "node_modules/tar-fs/node_modules/chownr": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-      "dev": true
-    },
-    "node_modules/tar-stream": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
-      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
-      "dev": true,
-      "dependencies": {
-        "bl": "^4.0.3",
-        "end-of-stream": "^1.4.1",
-        "fs-constants": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^3.1.1"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/tar/node_modules/minipass": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.0.0.tgz",
@@ -21319,18 +18171,6 @@
       "inBundle": true,
       "engines": {
         "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
-      }
-    },
-    "node_modules/tunnel-agent": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
-      "dev": true,
-      "dependencies": {
-        "safe-buffer": "^5.0.1"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/type-check": {
@@ -21783,12 +18623,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/which-module": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-      "integrity": "sha512-B+enWhmw6cjfVC7kS8Pj9pCrKSc5txArRyaYGe088shv/FGWH+0Rjx/xPgtsWfsUtS27FkP697E4DDhgrgoc0Q==",
-      "dev": true
-    },
     "node_modules/which-typed-array": {
       "version": "1.1.9",
       "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.9.tgz",
@@ -21818,19 +18652,6 @@
         "string-width": "^1.0.2 || 2 || 3 || 4"
       }
     },
-    "node_modules/widest-line": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-3.1.0.tgz",
-      "integrity": "sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "string-width": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/word-wrap": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
@@ -21850,53 +18671,6 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.3.1.tgz",
       "integrity": "sha512-0x7gJm1rhpn5SPG9NENOxPtbfUZZtK/qOg6gEdSqeDBA3dTeR91RJqSPjccPRCkhNfrnnl/dWxSSj5w9CtdzNA==",
-      "dev": true
-    },
-    "node_modules/wrap-ansi": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
     "node_modules/wrappy": {
@@ -21956,18 +18730,6 @@
       "integrity": "sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw==",
       "dev": true
     },
-    "node_modules/xml-js": {
-      "version": "1.6.11",
-      "resolved": "https://registry.npmjs.org/xml-js/-/xml-js-1.6.11.tgz",
-      "integrity": "sha512-7rVi2KMfwfWFl+GpPg6m80IVMWXLRjO+PxTq7V2CDhoGak0wzYzFgUY2m4XJ47OGdXd8eLE8EmwfAmdjw7lC1g==",
-      "dev": true,
-      "dependencies": {
-        "sax": "^1.2.4"
-      },
-      "bin": {
-        "xml-js": "bin/cli.js"
-      }
-    },
     "node_modules/xml-name-validator": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
@@ -22011,16 +18773,6 @@
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true
     },
-    "node_modules/xstate": {
-      "version": "4.35.2",
-      "resolved": "https://registry.npmjs.org/xstate/-/xstate-4.35.2.tgz",
-      "integrity": "sha512-5X7EyJv5OHHtGQwN7DsmCAbSnDs3Mxl1cXQ4PVaLwi+7p/RRapERnd1dFyHjYin+KQoLLfuXpl1dPBThgyIGNg==",
-      "dev": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/xstate"
-      }
-    },
     "node_modules/xtend": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
@@ -22054,24 +18806,6 @@
         "node": ">= 14"
       }
     },
-    "node_modules/yargs": {
-      "version": "17.6.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.6.2.tgz",
-      "integrity": "sha512-1/9UrdHjDZc0eOU0HxOHoS78C69UD3JRMvzlJ7S79S2nTaWRA/whGCTV8o9e/N/1Va9YIV7Q4sOxD8VV4pCWOw==",
-      "dev": true,
-      "dependencies": {
-        "cliui": "^8.0.1",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.3",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^21.1.1"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/yargs-parser": {
       "version": "20.2.9",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
@@ -22079,15 +18813,6 @@
       "dev": true,
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/yargs/node_modules/yargs-parser": {
-      "version": "21.1.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/yn": {
@@ -22110,24 +18835,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/yoga-layout-prebuilt": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/yoga-layout-prebuilt/-/yoga-layout-prebuilt-1.10.0.tgz",
-      "integrity": "sha512-YnOmtSbv4MTf7RGJMK0FvZ+KD8OEe/J5BNnR0GHhD8J/XcG/Qvxgszm0Un6FTHWW4uHlTgP0IztiXQnGyIR45g==",
-      "dev": true,
-      "dependencies": {
-        "@types/yoga-layout": "1.9.2"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/zod": {
-      "version": "1.11.17",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-1.11.17.tgz",
-      "integrity": "sha512-UzIwO92D0dSFwIRyyqAfRXICITLjF0IP8tRbEK/un7adirMssWZx8xF/1hZNE7t61knWZ+lhEuUvxlu2MO8qqA==",
-      "dev": true
     }
   },
   "dependencies": {
@@ -24099,1006 +20806,6 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
     },
-    "@cdktf/cli-core": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@cdktf/cli-core/-/cli-core-0.15.0.tgz",
-      "integrity": "sha512-1N1N66dMl1kfAXcxTgKgePO9RfhB/p5T4dCAhfMCzLe+R0rOO1xfYQcIEXWqoORwRiIE2EyW9O9OSkxLx0DuyQ==",
-      "dev": true,
-      "requires": {
-        "@cdktf/commons": "0.15.0",
-        "@cdktf/hcl2cdk": "0.15.0",
-        "@cdktf/hcl2json": "0.15.0",
-        "@cdktf/node-pty-prebuilt-multiarch": "0.10.1-pre.10",
-        "@sentry/node": "^6.19.7",
-        "cdktf": "0.15.0",
-        "codemaker": "^1.73.0",
-        "constructs": "^10.0.25",
-        "cross-spawn": "^7.0.3",
-        "https-proxy-agent": "^5.0.1",
-        "ink-select-input": "^4.2.1",
-        "jsii": "^1.73.0",
-        "jsii-pacmak": "^1.73.0",
-        "minimatch": "^5.1.0",
-        "node-abort-controller": "^3.0.1",
-        "node-fetch": "^2.6.7",
-        "tunnel-agent": "^0.6.0",
-        "xml-js": "^1.6.11",
-        "xstate": "^4.34.0",
-        "yargs": "^17.6",
-        "yoga-layout-prebuilt": "^1.10.0",
-        "zod": "^1.11.17"
-      },
-      "dependencies": {
-        "cdktf": {
-          "version": "0.15.0",
-          "resolved": "https://registry.npmjs.org/cdktf/-/cdktf-0.15.0.tgz",
-          "integrity": "sha512-Dzv/pfJWTFzxMxjcgI3cttK7hPLy69bUPzcZgUK0sI+k3kY4I67pmxKuXDh1XVK9AX+pCaiZT7wzQbCznTrQkQ==",
-          "dev": true,
-          "requires": {
-            "archiver": "5.3.1",
-            "json-stable-stringify": "^1.0.2",
-            "semver": "^7.3.8"
-          },
-          "dependencies": {
-            "archiver": {
-              "version": "5.3.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "archiver-utils": "^2.1.0",
-                "async": "^3.2.3",
-                "buffer-crc32": "^0.2.1",
-                "readable-stream": "^3.6.0",
-                "readdir-glob": "^1.0.0",
-                "tar-stream": "^2.2.0",
-                "zip-stream": "^4.1.0"
-              }
-            },
-            "archiver-utils": {
-              "version": "2.1.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "glob": "^7.1.4",
-                "graceful-fs": "^4.2.0",
-                "lazystream": "^1.0.0",
-                "lodash.defaults": "^4.2.0",
-                "lodash.difference": "^4.5.0",
-                "lodash.flatten": "^4.4.0",
-                "lodash.isplainobject": "^4.0.6",
-                "lodash.union": "^4.6.0",
-                "normalize-path": "^3.0.0",
-                "readable-stream": "^2.0.0"
-              },
-              "dependencies": {
-                "readable-stream": {
-                  "version": "2.3.7",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "core-util-is": "~1.0.0",
-                    "inherits": "~2.0.3",
-                    "isarray": "~1.0.0",
-                    "process-nextick-args": "~2.0.0",
-                    "safe-buffer": "~5.1.1",
-                    "string_decoder": "~1.1.1",
-                    "util-deprecate": "~1.0.1"
-                  }
-                },
-                "string_decoder": {
-                  "version": "1.1.1",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "safe-buffer": "~5.1.0"
-                  }
-                }
-              }
-            },
-            "async": {
-              "version": "3.2.4",
-              "bundled": true,
-              "dev": true
-            },
-            "balanced-match": {
-              "version": "1.0.2",
-              "bundled": true,
-              "dev": true
-            },
-            "base64-js": {
-              "version": "1.5.1",
-              "bundled": true,
-              "dev": true
-            },
-            "bl": {
-              "version": "4.1.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "buffer": "^5.5.0",
-                "inherits": "^2.0.4",
-                "readable-stream": "^3.4.0"
-              }
-            },
-            "brace-expansion": {
-              "version": "2.0.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "balanced-match": "^1.0.0"
-              }
-            },
-            "buffer": {
-              "version": "5.7.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "base64-js": "^1.3.1",
-                "ieee754": "^1.1.13"
-              }
-            },
-            "buffer-crc32": {
-              "version": "0.2.13",
-              "bundled": true,
-              "dev": true
-            },
-            "compress-commons": {
-              "version": "4.1.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "buffer-crc32": "^0.2.13",
-                "crc32-stream": "^4.0.2",
-                "normalize-path": "^3.0.0",
-                "readable-stream": "^3.6.0"
-              }
-            },
-            "concat-map": {
-              "version": "0.0.1",
-              "bundled": true,
-              "dev": true
-            },
-            "core-util-is": {
-              "version": "1.0.3",
-              "bundled": true,
-              "dev": true
-            },
-            "crc-32": {
-              "version": "1.2.2",
-              "bundled": true,
-              "dev": true
-            },
-            "crc32-stream": {
-              "version": "4.0.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "crc-32": "^1.2.0",
-                "readable-stream": "^3.4.0"
-              }
-            },
-            "end-of-stream": {
-              "version": "1.4.4",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "once": "^1.4.0"
-              }
-            },
-            "fs-constants": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "fs.realpath": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "glob": {
-              "version": "7.2.3",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.1.1",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
-              },
-              "dependencies": {
-                "brace-expansion": {
-                  "version": "1.1.11",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "balanced-match": "^1.0.0",
-                    "concat-map": "0.0.1"
-                  }
-                },
-                "minimatch": {
-                  "version": "3.1.2",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "brace-expansion": "^1.1.7"
-                  }
-                }
-              }
-            },
-            "graceful-fs": {
-              "version": "4.2.10",
-              "bundled": true,
-              "dev": true
-            },
-            "ieee754": {
-              "version": "1.2.1",
-              "bundled": true,
-              "dev": true
-            },
-            "inflight": {
-              "version": "1.0.6",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "once": "^1.3.0",
-                "wrappy": "1"
-              }
-            },
-            "inherits": {
-              "version": "2.0.4",
-              "bundled": true,
-              "dev": true
-            },
-            "isarray": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "json-stable-stringify": {
-              "version": "1.0.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "jsonify": "^0.0.1"
-              }
-            },
-            "jsonify": {
-              "version": "0.0.1",
-              "bundled": true,
-              "dev": true
-            },
-            "lazystream": {
-              "version": "1.0.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "readable-stream": "^2.0.5"
-              },
-              "dependencies": {
-                "readable-stream": {
-                  "version": "2.3.7",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "core-util-is": "~1.0.0",
-                    "inherits": "~2.0.3",
-                    "isarray": "~1.0.0",
-                    "process-nextick-args": "~2.0.0",
-                    "safe-buffer": "~5.1.1",
-                    "string_decoder": "~1.1.1",
-                    "util-deprecate": "~1.0.1"
-                  }
-                },
-                "string_decoder": {
-                  "version": "1.1.1",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "safe-buffer": "~5.1.0"
-                  }
-                }
-              }
-            },
-            "lodash.defaults": {
-              "version": "4.2.0",
-              "bundled": true,
-              "dev": true
-            },
-            "lodash.difference": {
-              "version": "4.5.0",
-              "bundled": true,
-              "dev": true
-            },
-            "lodash.flatten": {
-              "version": "4.4.0",
-              "bundled": true,
-              "dev": true
-            },
-            "lodash.isplainobject": {
-              "version": "4.0.6",
-              "bundled": true,
-              "dev": true
-            },
-            "lodash.union": {
-              "version": "4.6.0",
-              "bundled": true,
-              "dev": true
-            },
-            "lru-cache": {
-              "version": "6.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "yallist": "^4.0.0"
-              }
-            },
-            "minimatch": {
-              "version": "5.1.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "brace-expansion": "^2.0.1"
-              }
-            },
-            "normalize-path": {
-              "version": "3.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "once": {
-              "version": "1.4.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "wrappy": "1"
-              }
-            },
-            "path-is-absolute": {
-              "version": "1.0.1",
-              "bundled": true,
-              "dev": true
-            },
-            "process-nextick-args": {
-              "version": "2.0.1",
-              "bundled": true,
-              "dev": true
-            },
-            "readable-stream": {
-              "version": "3.6.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "inherits": "^2.0.3",
-                "string_decoder": "^1.1.1",
-                "util-deprecate": "^1.0.1"
-              }
-            },
-            "readdir-glob": {
-              "version": "1.1.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "minimatch": "^5.1.0"
-              }
-            },
-            "safe-buffer": {
-              "version": "5.1.2",
-              "bundled": true,
-              "dev": true
-            },
-            "semver": {
-              "version": "7.3.8",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "lru-cache": "^6.0.0"
-              }
-            },
-            "string_decoder": {
-              "version": "1.3.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "safe-buffer": "~5.2.0"
-              },
-              "dependencies": {
-                "safe-buffer": {
-                  "version": "5.2.1",
-                  "bundled": true,
-                  "dev": true
-                }
-              }
-            },
-            "tar-stream": {
-              "version": "2.2.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "bl": "^4.0.3",
-                "end-of-stream": "^1.4.1",
-                "fs-constants": "^1.0.0",
-                "inherits": "^2.0.3",
-                "readable-stream": "^3.1.1"
-              }
-            },
-            "util-deprecate": {
-              "version": "1.0.2",
-              "bundled": true,
-              "dev": true
-            },
-            "wrappy": {
-              "version": "1.0.2",
-              "bundled": true,
-              "dev": true
-            },
-            "yallist": {
-              "version": "4.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "zip-stream": {
-              "version": "4.1.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "archiver-utils": "^2.1.0",
-                "compress-commons": "^4.1.0",
-                "readable-stream": "^3.6.0"
-              }
-            }
-          }
-        }
-      }
-    },
-    "@cdktf/commons": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@cdktf/commons/-/commons-0.15.0.tgz",
-      "integrity": "sha512-c3NB2X4OsUGUicpUMJSV9MGnmU+/nYNs0n7G98c/N7nctxWpm1oPoXkoSC8GsDbc3n44cuokBDgW2JiscB/YRA==",
-      "dev": true,
-      "requires": {
-        "@npmcli/ci-detect": "^1.4.0",
-        "@sentry/node": "^6.19.7",
-        "cdktf": "0.15.0",
-        "codemaker": "^1.73.0",
-        "constructs": "^10.0.25",
-        "cross-spawn": "^7.0.3",
-        "follow-redirects": "^1.15.2",
-        "fs-extra": "^8.1.0",
-        "is-valid-domain": "^0.1.6",
-        "log4js": "^6.7.0",
-        "uuid": "^8.3.2"
-      },
-      "dependencies": {
-        "cdktf": {
-          "version": "0.15.0",
-          "resolved": "https://registry.npmjs.org/cdktf/-/cdktf-0.15.0.tgz",
-          "integrity": "sha512-Dzv/pfJWTFzxMxjcgI3cttK7hPLy69bUPzcZgUK0sI+k3kY4I67pmxKuXDh1XVK9AX+pCaiZT7wzQbCznTrQkQ==",
-          "dev": true,
-          "requires": {
-            "archiver": "5.3.1",
-            "json-stable-stringify": "^1.0.2",
-            "semver": "^7.3.8"
-          },
-          "dependencies": {
-            "archiver": {
-              "version": "5.3.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "archiver-utils": "^2.1.0",
-                "async": "^3.2.3",
-                "buffer-crc32": "^0.2.1",
-                "readable-stream": "^3.6.0",
-                "readdir-glob": "^1.0.0",
-                "tar-stream": "^2.2.0",
-                "zip-stream": "^4.1.0"
-              }
-            },
-            "archiver-utils": {
-              "version": "2.1.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "glob": "^7.1.4",
-                "graceful-fs": "^4.2.0",
-                "lazystream": "^1.0.0",
-                "lodash.defaults": "^4.2.0",
-                "lodash.difference": "^4.5.0",
-                "lodash.flatten": "^4.4.0",
-                "lodash.isplainobject": "^4.0.6",
-                "lodash.union": "^4.6.0",
-                "normalize-path": "^3.0.0",
-                "readable-stream": "^2.0.0"
-              },
-              "dependencies": {
-                "readable-stream": {
-                  "version": "2.3.7",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "core-util-is": "~1.0.0",
-                    "inherits": "~2.0.3",
-                    "isarray": "~1.0.0",
-                    "process-nextick-args": "~2.0.0",
-                    "safe-buffer": "~5.1.1",
-                    "string_decoder": "~1.1.1",
-                    "util-deprecate": "~1.0.1"
-                  }
-                },
-                "string_decoder": {
-                  "version": "1.1.1",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "safe-buffer": "~5.1.0"
-                  }
-                }
-              }
-            },
-            "async": {
-              "version": "3.2.4",
-              "bundled": true,
-              "dev": true
-            },
-            "balanced-match": {
-              "version": "1.0.2",
-              "bundled": true,
-              "dev": true
-            },
-            "base64-js": {
-              "version": "1.5.1",
-              "bundled": true,
-              "dev": true
-            },
-            "bl": {
-              "version": "4.1.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "buffer": "^5.5.0",
-                "inherits": "^2.0.4",
-                "readable-stream": "^3.4.0"
-              }
-            },
-            "brace-expansion": {
-              "version": "2.0.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "balanced-match": "^1.0.0"
-              }
-            },
-            "buffer": {
-              "version": "5.7.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "base64-js": "^1.3.1",
-                "ieee754": "^1.1.13"
-              }
-            },
-            "buffer-crc32": {
-              "version": "0.2.13",
-              "bundled": true,
-              "dev": true
-            },
-            "compress-commons": {
-              "version": "4.1.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "buffer-crc32": "^0.2.13",
-                "crc32-stream": "^4.0.2",
-                "normalize-path": "^3.0.0",
-                "readable-stream": "^3.6.0"
-              }
-            },
-            "concat-map": {
-              "version": "0.0.1",
-              "bundled": true,
-              "dev": true
-            },
-            "core-util-is": {
-              "version": "1.0.3",
-              "bundled": true,
-              "dev": true
-            },
-            "crc-32": {
-              "version": "1.2.2",
-              "bundled": true,
-              "dev": true
-            },
-            "crc32-stream": {
-              "version": "4.0.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "crc-32": "^1.2.0",
-                "readable-stream": "^3.4.0"
-              }
-            },
-            "end-of-stream": {
-              "version": "1.4.4",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "once": "^1.4.0"
-              }
-            },
-            "fs-constants": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "fs.realpath": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "glob": {
-              "version": "7.2.3",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.1.1",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
-              },
-              "dependencies": {
-                "brace-expansion": {
-                  "version": "1.1.11",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "balanced-match": "^1.0.0",
-                    "concat-map": "0.0.1"
-                  }
-                },
-                "minimatch": {
-                  "version": "3.1.2",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "brace-expansion": "^1.1.7"
-                  }
-                }
-              }
-            },
-            "graceful-fs": {
-              "version": "4.2.10",
-              "bundled": true,
-              "dev": true
-            },
-            "ieee754": {
-              "version": "1.2.1",
-              "bundled": true,
-              "dev": true
-            },
-            "inflight": {
-              "version": "1.0.6",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "once": "^1.3.0",
-                "wrappy": "1"
-              }
-            },
-            "inherits": {
-              "version": "2.0.4",
-              "bundled": true,
-              "dev": true
-            },
-            "isarray": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "json-stable-stringify": {
-              "version": "1.0.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "jsonify": "^0.0.1"
-              }
-            },
-            "jsonify": {
-              "version": "0.0.1",
-              "bundled": true,
-              "dev": true
-            },
-            "lazystream": {
-              "version": "1.0.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "readable-stream": "^2.0.5"
-              },
-              "dependencies": {
-                "readable-stream": {
-                  "version": "2.3.7",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "core-util-is": "~1.0.0",
-                    "inherits": "~2.0.3",
-                    "isarray": "~1.0.0",
-                    "process-nextick-args": "~2.0.0",
-                    "safe-buffer": "~5.1.1",
-                    "string_decoder": "~1.1.1",
-                    "util-deprecate": "~1.0.1"
-                  }
-                },
-                "string_decoder": {
-                  "version": "1.1.1",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "safe-buffer": "~5.1.0"
-                  }
-                }
-              }
-            },
-            "lodash.defaults": {
-              "version": "4.2.0",
-              "bundled": true,
-              "dev": true
-            },
-            "lodash.difference": {
-              "version": "4.5.0",
-              "bundled": true,
-              "dev": true
-            },
-            "lodash.flatten": {
-              "version": "4.4.0",
-              "bundled": true,
-              "dev": true
-            },
-            "lodash.isplainobject": {
-              "version": "4.0.6",
-              "bundled": true,
-              "dev": true
-            },
-            "lodash.union": {
-              "version": "4.6.0",
-              "bundled": true,
-              "dev": true
-            },
-            "lru-cache": {
-              "version": "6.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "yallist": "^4.0.0"
-              }
-            },
-            "minimatch": {
-              "version": "5.1.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "brace-expansion": "^2.0.1"
-              }
-            },
-            "normalize-path": {
-              "version": "3.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "once": {
-              "version": "1.4.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "wrappy": "1"
-              }
-            },
-            "path-is-absolute": {
-              "version": "1.0.1",
-              "bundled": true,
-              "dev": true
-            },
-            "process-nextick-args": {
-              "version": "2.0.1",
-              "bundled": true,
-              "dev": true
-            },
-            "readable-stream": {
-              "version": "3.6.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "inherits": "^2.0.3",
-                "string_decoder": "^1.1.1",
-                "util-deprecate": "^1.0.1"
-              }
-            },
-            "readdir-glob": {
-              "version": "1.1.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "minimatch": "^5.1.0"
-              }
-            },
-            "safe-buffer": {
-              "version": "5.1.2",
-              "bundled": true,
-              "dev": true
-            },
-            "semver": {
-              "version": "7.3.8",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "lru-cache": "^6.0.0"
-              }
-            },
-            "string_decoder": {
-              "version": "1.3.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "safe-buffer": "~5.2.0"
-              },
-              "dependencies": {
-                "safe-buffer": {
-                  "version": "5.2.1",
-                  "bundled": true,
-                  "dev": true
-                }
-              }
-            },
-            "tar-stream": {
-              "version": "2.2.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "bl": "^4.0.3",
-                "end-of-stream": "^1.4.1",
-                "fs-constants": "^1.0.0",
-                "inherits": "^2.0.3",
-                "readable-stream": "^3.1.1"
-              }
-            },
-            "util-deprecate": {
-              "version": "1.0.2",
-              "bundled": true,
-              "dev": true
-            },
-            "wrappy": {
-              "version": "1.0.2",
-              "bundled": true,
-              "dev": true
-            },
-            "yallist": {
-              "version": "4.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "zip-stream": {
-              "version": "4.1.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "archiver-utils": "^2.1.0",
-                "compress-commons": "^4.1.0",
-                "readable-stream": "^3.6.0"
-              }
-            }
-          }
-        },
-        "fs-extra": {
-          "version": "8.1.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-          "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.2.0",
-            "jsonfile": "^4.0.0",
-            "universalify": "^0.1.0"
-          }
-        },
-        "jsonfile": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-          "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.6"
-          }
-        },
-        "universalify": {
-          "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-          "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-          "dev": true
-        }
-      }
-    },
-    "@cdktf/hcl2cdk": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@cdktf/hcl2cdk/-/hcl2cdk-0.15.0.tgz",
-      "integrity": "sha512-X88IejdGoYpB7DkAf09v8YLMQiYu1VTKWVvggiGkS0q7DgFb79Q/S9aFfC5RfPrMNhZSV01Jrt/pDCQdcFJQ1A==",
-      "dev": true,
-      "requires": {
-        "@babel/generator": "^7.20.4",
-        "@babel/template": "^7.18.10",
-        "@babel/types": "^7.20.2",
-        "@cdktf/commons": "0.15.0",
-        "@cdktf/hcl2json": "0.15.0",
-        "@cdktf/provider-generator": "0.15.0",
-        "camelcase": "^6.3.0",
-        "glob": "7.2.3",
-        "graphology": "^0.25.1",
-        "graphology-types": "^0.21.2",
-        "jsii-rosetta": "^1.73.0",
-        "prettier": "^2.7.1",
-        "reserved-words": "^0.1.2",
-        "zod": "^1.11.17"
-      },
-      "dependencies": {
-        "graphology-types": {
-          "version": "0.21.2",
-          "resolved": "https://registry.npmjs.org/graphology-types/-/graphology-types-0.21.2.tgz",
-          "integrity": "sha512-KNdgwG0dbVjhJqRUw0OivJ5pkUHunbk4vDatwdfITfNvPugX0xR327ZKsaOcr3snbiBJfyGu7lCrXeYp4KF8YA==",
-          "dev": true
-        }
-      }
-    },
-    "@cdktf/hcl2json": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@cdktf/hcl2json/-/hcl2json-0.15.0.tgz",
-      "integrity": "sha512-pVYjTosthO0Mro/VD5x4iUM6TcVk0hdeNzk8uaaxk49/XnJB4DiwHbvIdjKJk4BuY2YuW+bCsz6X2QjKJmz2jA==",
-      "dev": true,
-      "requires": {
-        "@types/node-fetch": "^2.6.2",
-        "fs-extra": "^8.1.0",
-        "node-fetch": "^2.6.7"
-      },
-      "dependencies": {
-        "fs-extra": {
-          "version": "8.1.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-          "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.2.0",
-            "jsonfile": "^4.0.0",
-            "universalify": "^0.1.0"
-          }
-        },
-        "jsonfile": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-          "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.6"
-          }
-        },
-        "universalify": {
-          "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-          "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-          "dev": true
-        }
-      }
-    },
-    "@cdktf/node-pty-prebuilt-multiarch": {
-      "version": "0.10.1-pre.10",
-      "resolved": "https://registry.npmjs.org/@cdktf/node-pty-prebuilt-multiarch/-/node-pty-prebuilt-multiarch-0.10.1-pre.10.tgz",
-      "integrity": "sha512-5ysQrHJvqYLYg407KvaDNu+xx68ZGaqeF0SohXe5e4yNqJhPFPUQ536rkReQcPc2yZiF5PDmmvf5T9MOacHpSQ==",
-      "dev": true,
-      "requires": {
-        "nan": "^2.14.2",
-        "prebuild-install": "^7.1.1"
-      }
-    },
     "@cdktf/provider-aws": {
       "version": "12.0.1",
       "resolved": "https://registry.npmjs.org/@cdktf/provider-aws/-/provider-aws-12.0.1.tgz",
@@ -25110,48 +20817,6 @@
       "resolved": "https://registry.npmjs.org/@cdktf/provider-azurerm/-/provider-azurerm-5.0.1.tgz",
       "integrity": "sha512-c4KLzi3zttYlJjizWZb5dYhysyPRWNepVP6veIsY5lJKQWmd2RaNIGK6zXKNJKvgVzCDNTmf0CHTJwlGTK1RQw==",
       "requires": {}
-    },
-    "@cdktf/provider-generator": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@cdktf/provider-generator/-/provider-generator-0.15.0.tgz",
-      "integrity": "sha512-YY2ANbC9xuhq1yXc6dhVPvMCCKMjcXNRBUP6BqvlE2smD0RWx1s0uWKAG5Tw4D4kx4Nb6EXYpvFHRIEnjVJ4wA==",
-      "dev": true,
-      "requires": {
-        "@cdktf/commons": "0.15.0",
-        "@cdktf/hcl2json": "0.15.0",
-        "codemaker": "^1.73.0",
-        "deepmerge": "^4.2.2",
-        "fs-extra": "^8.1.0",
-        "jsii-srcmak": "^0.1.790"
-      },
-      "dependencies": {
-        "fs-extra": {
-          "version": "8.1.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-          "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.2.0",
-            "jsonfile": "^4.0.0",
-            "universalify": "^0.1.0"
-          }
-        },
-        "jsonfile": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-          "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.6"
-          }
-        },
-        "universalify": {
-          "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-          "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-          "dev": true
-        }
-      }
     },
     "@cdktf/provider-google": {
       "version": "5.0.2",
@@ -26078,12 +21743,6 @@
         "fastq": "^1.6.0"
       }
     },
-    "@npmcli/ci-detect": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@npmcli/ci-detect/-/ci-detect-1.4.0.tgz",
-      "integrity": "sha512-3BGrt6FLjqM6br5AhWRKTr3u5GIVkjRYeAFrMp3HjnfICrg4xOrVRwFavKT6tsp++bq5dluL5t8ME/Nha/6c1Q==",
-      "dev": true
-    },
     "@npmcli/fs": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-3.1.0.tgz",
@@ -26246,113 +21905,6 @@
       "requires": {
         "@pnpm/network.ca-file": "^1.0.1",
         "config-chain": "^1.1.11"
-      }
-    },
-    "@sentry/core": {
-      "version": "6.19.7",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.19.7.tgz",
-      "integrity": "sha512-tOfZ/umqB2AcHPGbIrsFLcvApdTm9ggpi/kQZFkej7kMphjT+SGBiQfYtjyg9jcRW+ilAR4JXC9BGKsdEQ+8Vw==",
-      "dev": true,
-      "requires": {
-        "@sentry/hub": "6.19.7",
-        "@sentry/minimal": "6.19.7",
-        "@sentry/types": "6.19.7",
-        "@sentry/utils": "6.19.7",
-        "tslib": "^1.9.3"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-          "dev": true
-        }
-      }
-    },
-    "@sentry/hub": {
-      "version": "6.19.7",
-      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.19.7.tgz",
-      "integrity": "sha512-y3OtbYFAqKHCWezF0EGGr5lcyI2KbaXW2Ik7Xp8Mu9TxbSTuwTe4rTntwg8ngPjUQU3SUHzgjqVB8qjiGqFXCA==",
-      "dev": true,
-      "requires": {
-        "@sentry/types": "6.19.7",
-        "@sentry/utils": "6.19.7",
-        "tslib": "^1.9.3"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-          "dev": true
-        }
-      }
-    },
-    "@sentry/minimal": {
-      "version": "6.19.7",
-      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.19.7.tgz",
-      "integrity": "sha512-wcYmSJOdvk6VAPx8IcmZgN08XTXRwRtB1aOLZm+MVHjIZIhHoBGZJYTVQS/BWjldsamj2cX3YGbGXNunaCfYJQ==",
-      "dev": true,
-      "requires": {
-        "@sentry/hub": "6.19.7",
-        "@sentry/types": "6.19.7",
-        "tslib": "^1.9.3"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-          "dev": true
-        }
-      }
-    },
-    "@sentry/node": {
-      "version": "6.19.7",
-      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-6.19.7.tgz",
-      "integrity": "sha512-gtmRC4dAXKODMpHXKfrkfvyBL3cI8y64vEi3fDD046uqYcrWdgoQsffuBbxMAizc6Ez1ia+f0Flue6p15Qaltg==",
-      "dev": true,
-      "requires": {
-        "@sentry/core": "6.19.7",
-        "@sentry/hub": "6.19.7",
-        "@sentry/types": "6.19.7",
-        "@sentry/utils": "6.19.7",
-        "cookie": "^0.4.1",
-        "https-proxy-agent": "^5.0.0",
-        "lru_map": "^0.3.3",
-        "tslib": "^1.9.3"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-          "dev": true
-        }
-      }
-    },
-    "@sentry/types": {
-      "version": "6.19.7",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.19.7.tgz",
-      "integrity": "sha512-jH84pDYE+hHIbVnab3Hr+ZXr1v8QABfhx39KknxqKWr2l0oEItzepV0URvbEhB446lk/S/59230dlUUIBGsXbg==",
-      "dev": true
-    },
-    "@sentry/utils": {
-      "version": "6.19.7",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.19.7.tgz",
-      "integrity": "sha512-z95ECmE3i9pbWoXQrD/7PgkBAzJYR+iXtPuTkpBjDKs86O3mT+PXOT3BAn79w2wkn7/i3vOGD2xVr1uiMl26dA==",
-      "dev": true,
-      "requires": {
-        "@sentry/types": "6.19.7",
-        "tslib": "^1.9.3"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-          "dev": true
-        }
       }
     },
     "@sinclair/typebox": {
@@ -26727,12 +22279,6 @@
       "integrity": "sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==",
       "dev": true
     },
-    "@types/yoga-layout": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@types/yoga-layout/-/yoga-layout-1.9.2.tgz",
-      "integrity": "sha512-S9q47ByT2pPvD65IvrWp7qppVMpk9WGMbVq9wbWZOHg6tnXSD4vyhao6nOSBwwfDdV2p3Kx9evA9vI+XWTfDvw==",
-      "dev": true
-    },
     "@typescript-eslint/eslint-plugin": {
       "version": "5.48.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.48.0.tgz",
@@ -27072,12 +22618,6 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true
     },
-    "arr-rotate": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/arr-rotate/-/arr-rotate-1.0.0.tgz",
-      "integrity": "sha512-yOzOZcR9Tn7enTF66bqKorGGH0F36vcPaSWg8fO0c0UYb3LX3VMXj5ZxEqQLNOecAhlRJ7wYZja5i4jTlnbIfQ==",
-      "dev": true
-    },
     "array-ify": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz",
@@ -27133,13 +22673,6 @@
       "integrity": "sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==",
       "dev": true
     },
-    "astral-regex": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
-      "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
-      "dev": true,
-      "peer": true
-    },
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -27150,13 +22683,6 @@
       "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
       "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
       "dev": true
-    },
-    "auto-bind": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/auto-bind/-/auto-bind-4.0.0.tgz",
-      "integrity": "sha512-Hdw8qdNiqdJ8LqT0iK0sVzkFbzg6fhnQqqfWhBDxcHZvU75+B+ayzTy8x+k5Ix0Y92XOhOUlx74ps+bA6BeYMQ==",
-      "dev": true,
-      "peer": true
     },
     "available-typed-arrays": {
       "version": "1.0.5",
@@ -27494,23 +23020,6 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
-    "base64-js": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "dev": true
-    },
-    "bl": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
-      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-      "dev": true,
-      "requires": {
-        "buffer": "^5.5.0",
-        "inherits": "^2.0.4",
-        "readable-stream": "^3.4.0"
-      }
-    },
     "bowser": {
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
@@ -27668,16 +23177,6 @@
       "dev": true,
       "requires": {
         "node-int64": "^0.4.0"
-      }
-    },
-    "buffer": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-      "dev": true,
-      "requires": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.1.13"
       }
     },
     "buffer-equal-constant-time": {
@@ -28223,459 +23722,6 @@
         }
       }
     },
-    "cdktf-cli": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/cdktf-cli/-/cdktf-cli-0.15.0.tgz",
-      "integrity": "sha512-wPVkiuoId7u1Jy1C1d+D4ktfQde5GfHkZBMppmkO/daZXsI2kH7yIFZpJ81/0k9hNRHvoK1d0/gDMMywqwWcmg==",
-      "dev": true,
-      "requires": {
-        "@cdktf/cli-core": "0.15.0",
-        "@cdktf/commons": "0.15.0",
-        "@cdktf/hcl2cdk": "0.15.0",
-        "@cdktf/hcl2json": "0.15.0",
-        "@sentry/node": "^6.19.7",
-        "cdktf": "0.15.0",
-        "codemaker": "^1.73.0",
-        "constructs": "^10.0.25",
-        "cross-spawn": "^7.0.3",
-        "https-proxy-agent": "^5.0.1",
-        "ink-select-input": "^4.2.1",
-        "ink-table": "^3.0.0",
-        "jsii": "^1.73.0",
-        "jsii-pacmak": "^1.73.0",
-        "minimatch": "^5.1.0",
-        "node-abort-controller": "^3.0.1",
-        "node-fetch": "^2.6.7",
-        "tunnel-agent": "^0.6.0",
-        "xml-js": "^1.6.11",
-        "yargs": "^17.6",
-        "yoga-layout-prebuilt": "^1.10.0",
-        "zod": "^1.11.17"
-      },
-      "dependencies": {
-        "cdktf": {
-          "version": "0.15.0",
-          "resolved": "https://registry.npmjs.org/cdktf/-/cdktf-0.15.0.tgz",
-          "integrity": "sha512-Dzv/pfJWTFzxMxjcgI3cttK7hPLy69bUPzcZgUK0sI+k3kY4I67pmxKuXDh1XVK9AX+pCaiZT7wzQbCznTrQkQ==",
-          "dev": true,
-          "requires": {
-            "archiver": "5.3.1",
-            "json-stable-stringify": "^1.0.2",
-            "semver": "^7.3.8"
-          },
-          "dependencies": {
-            "archiver": {
-              "version": "5.3.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "archiver-utils": "^2.1.0",
-                "async": "^3.2.3",
-                "buffer-crc32": "^0.2.1",
-                "readable-stream": "^3.6.0",
-                "readdir-glob": "^1.0.0",
-                "tar-stream": "^2.2.0",
-                "zip-stream": "^4.1.0"
-              }
-            },
-            "archiver-utils": {
-              "version": "2.1.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "glob": "^7.1.4",
-                "graceful-fs": "^4.2.0",
-                "lazystream": "^1.0.0",
-                "lodash.defaults": "^4.2.0",
-                "lodash.difference": "^4.5.0",
-                "lodash.flatten": "^4.4.0",
-                "lodash.isplainobject": "^4.0.6",
-                "lodash.union": "^4.6.0",
-                "normalize-path": "^3.0.0",
-                "readable-stream": "^2.0.0"
-              },
-              "dependencies": {
-                "readable-stream": {
-                  "version": "2.3.7",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "core-util-is": "~1.0.0",
-                    "inherits": "~2.0.3",
-                    "isarray": "~1.0.0",
-                    "process-nextick-args": "~2.0.0",
-                    "safe-buffer": "~5.1.1",
-                    "string_decoder": "~1.1.1",
-                    "util-deprecate": "~1.0.1"
-                  }
-                },
-                "string_decoder": {
-                  "version": "1.1.1",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "safe-buffer": "~5.1.0"
-                  }
-                }
-              }
-            },
-            "async": {
-              "version": "3.2.4",
-              "bundled": true,
-              "dev": true
-            },
-            "balanced-match": {
-              "version": "1.0.2",
-              "bundled": true,
-              "dev": true
-            },
-            "base64-js": {
-              "version": "1.5.1",
-              "bundled": true,
-              "dev": true
-            },
-            "bl": {
-              "version": "4.1.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "buffer": "^5.5.0",
-                "inherits": "^2.0.4",
-                "readable-stream": "^3.4.0"
-              }
-            },
-            "brace-expansion": {
-              "version": "2.0.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "balanced-match": "^1.0.0"
-              }
-            },
-            "buffer": {
-              "version": "5.7.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "base64-js": "^1.3.1",
-                "ieee754": "^1.1.13"
-              }
-            },
-            "buffer-crc32": {
-              "version": "0.2.13",
-              "bundled": true,
-              "dev": true
-            },
-            "compress-commons": {
-              "version": "4.1.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "buffer-crc32": "^0.2.13",
-                "crc32-stream": "^4.0.2",
-                "normalize-path": "^3.0.0",
-                "readable-stream": "^3.6.0"
-              }
-            },
-            "concat-map": {
-              "version": "0.0.1",
-              "bundled": true,
-              "dev": true
-            },
-            "core-util-is": {
-              "version": "1.0.3",
-              "bundled": true,
-              "dev": true
-            },
-            "crc-32": {
-              "version": "1.2.2",
-              "bundled": true,
-              "dev": true
-            },
-            "crc32-stream": {
-              "version": "4.0.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "crc-32": "^1.2.0",
-                "readable-stream": "^3.4.0"
-              }
-            },
-            "end-of-stream": {
-              "version": "1.4.4",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "once": "^1.4.0"
-              }
-            },
-            "fs-constants": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "fs.realpath": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "glob": {
-              "version": "7.2.3",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.1.1",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
-              },
-              "dependencies": {
-                "brace-expansion": {
-                  "version": "1.1.11",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "balanced-match": "^1.0.0",
-                    "concat-map": "0.0.1"
-                  }
-                },
-                "minimatch": {
-                  "version": "3.1.2",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "brace-expansion": "^1.1.7"
-                  }
-                }
-              }
-            },
-            "graceful-fs": {
-              "version": "4.2.10",
-              "bundled": true,
-              "dev": true
-            },
-            "ieee754": {
-              "version": "1.2.1",
-              "bundled": true,
-              "dev": true
-            },
-            "inflight": {
-              "version": "1.0.6",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "once": "^1.3.0",
-                "wrappy": "1"
-              }
-            },
-            "inherits": {
-              "version": "2.0.4",
-              "bundled": true,
-              "dev": true
-            },
-            "isarray": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "json-stable-stringify": {
-              "version": "1.0.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "jsonify": "^0.0.1"
-              }
-            },
-            "jsonify": {
-              "version": "0.0.1",
-              "bundled": true,
-              "dev": true
-            },
-            "lazystream": {
-              "version": "1.0.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "readable-stream": "^2.0.5"
-              },
-              "dependencies": {
-                "readable-stream": {
-                  "version": "2.3.7",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "core-util-is": "~1.0.0",
-                    "inherits": "~2.0.3",
-                    "isarray": "~1.0.0",
-                    "process-nextick-args": "~2.0.0",
-                    "safe-buffer": "~5.1.1",
-                    "string_decoder": "~1.1.1",
-                    "util-deprecate": "~1.0.1"
-                  }
-                },
-                "string_decoder": {
-                  "version": "1.1.1",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "safe-buffer": "~5.1.0"
-                  }
-                }
-              }
-            },
-            "lodash.defaults": {
-              "version": "4.2.0",
-              "bundled": true,
-              "dev": true
-            },
-            "lodash.difference": {
-              "version": "4.5.0",
-              "bundled": true,
-              "dev": true
-            },
-            "lodash.flatten": {
-              "version": "4.4.0",
-              "bundled": true,
-              "dev": true
-            },
-            "lodash.isplainobject": {
-              "version": "4.0.6",
-              "bundled": true,
-              "dev": true
-            },
-            "lodash.union": {
-              "version": "4.6.0",
-              "bundled": true,
-              "dev": true
-            },
-            "lru-cache": {
-              "version": "6.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "yallist": "^4.0.0"
-              }
-            },
-            "minimatch": {
-              "version": "5.1.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "brace-expansion": "^2.0.1"
-              }
-            },
-            "normalize-path": {
-              "version": "3.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "once": {
-              "version": "1.4.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "wrappy": "1"
-              }
-            },
-            "path-is-absolute": {
-              "version": "1.0.1",
-              "bundled": true,
-              "dev": true
-            },
-            "process-nextick-args": {
-              "version": "2.0.1",
-              "bundled": true,
-              "dev": true
-            },
-            "readable-stream": {
-              "version": "3.6.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "inherits": "^2.0.3",
-                "string_decoder": "^1.1.1",
-                "util-deprecate": "^1.0.1"
-              }
-            },
-            "readdir-glob": {
-              "version": "1.1.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "minimatch": "^5.1.0"
-              }
-            },
-            "safe-buffer": {
-              "version": "5.1.2",
-              "bundled": true,
-              "dev": true
-            },
-            "semver": {
-              "version": "7.3.8",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "lru-cache": "^6.0.0"
-              }
-            },
-            "string_decoder": {
-              "version": "1.3.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "safe-buffer": "~5.2.0"
-              },
-              "dependencies": {
-                "safe-buffer": {
-                  "version": "5.2.1",
-                  "bundled": true,
-                  "dev": true
-                }
-              }
-            },
-            "tar-stream": {
-              "version": "2.2.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "bl": "^4.0.3",
-                "end-of-stream": "^1.4.1",
-                "fs-constants": "^1.0.0",
-                "inherits": "^2.0.3",
-                "readable-stream": "^3.1.1"
-              }
-            },
-            "util-deprecate": {
-              "version": "1.0.2",
-              "bundled": true,
-              "dev": true
-            },
-            "wrappy": {
-              "version": "1.0.2",
-              "bundled": true,
-              "dev": true
-            },
-            "yallist": {
-              "version": "4.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "zip-stream": {
-              "version": "4.1.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "archiver-utils": "^2.1.0",
-                "compress-commons": "^4.1.0",
-                "readable-stream": "^3.6.0"
-              }
-            }
-          }
-        }
-      }
-    },
     "chalk": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -28716,23 +23762,6 @@
       "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
       "dev": true
     },
-    "cli-boxes": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-2.2.1.tgz",
-      "integrity": "sha512-y4coMcylgSCdVinjiDBuR8PCC2bLjyGTwEmPb9NHR/QaNU6EUOXcTY/s6VjGMD6ENSEaeQYHCY0GNGS5jfMwPw==",
-      "dev": true,
-      "peer": true
-    },
-    "cli-cursor": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
-      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "restore-cursor": "^3.1.0"
-      }
-    },
     "cli-table": {
       "version": "0.3.11",
       "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.11.tgz",
@@ -28740,65 +23769,6 @@
       "dev": true,
       "requires": {
         "colors": "1.0.3"
-      }
-    },
-    "cli-truncate": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-2.1.0.tgz",
-      "integrity": "sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "slice-ansi": "^3.0.0",
-        "string-width": "^4.2.0"
-      }
-    },
-    "cliui": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
-      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-      "dev": true,
-      "requires": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.1",
-        "wrap-ansi": "^7.0.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true
-        },
-        "wrap-ansi": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-          "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.0.0",
-            "string-width": "^4.1.0",
-            "strip-ansi": "^6.0.0"
-          }
-        }
       }
     },
     "clone": {
@@ -28821,16 +23791,6 @@
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
       "integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
       "dev": true
-    },
-    "code-excerpt": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/code-excerpt/-/code-excerpt-3.0.0.tgz",
-      "integrity": "sha512-VHNTVhd7KsLGOqfX3SyeO8RyYPMp1GJOg194VITk04WMYCv4plV68YWe6TJZxd9MhobjtpMRnVky01gqZsalaw==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "convert-to-spaces": "^1.0.1"
-      }
     },
     "codemaker": {
       "version": "1.73.0",
@@ -29222,19 +24182,6 @@
       "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
       "dev": true
     },
-    "convert-to-spaces": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/convert-to-spaces/-/convert-to-spaces-1.0.2.tgz",
-      "integrity": "sha512-cj09EBuObp9gZNQCzc7hByQyrs6jVGE+o9kSJmeUoj+GiPiJvi5LYqEH/Hmme4+MTLHM+Ejtq+FChpjjEnsPdQ==",
-      "dev": true,
-      "peer": true
-    },
-    "cookie": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
-      "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
-      "dev": true
-    },
     "core-util-is": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
@@ -29454,12 +24401,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-5.0.0.tgz",
       "integrity": "sha512-rlpvsxUtM0PQvy9iZe640/IWwWYyBsTApREbA1pHOpmOUIl9MkP/U4z7vTtg4Oaojvqhxt7sdufnT0EzGaR31g==",
-      "dev": true
-    },
-    "detect-libc": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.1.tgz",
-      "integrity": "sha512-463v3ZeIrcWtdgIg6vI6XUncguvr2TnGl4SzDXinkt9mSLpBJKXT3mW6xT3VQdDN11+WVs29pgvivTc4Lp8v+w==",
       "dev": true
     },
     "detect-newline": {
@@ -30458,12 +25399,6 @@
       "integrity": "sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==",
       "dev": true
     },
-    "expand-template": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
-      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
-      "dev": true
-    },
     "expect": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/expect/-/expect-27.5.1.tgz",
@@ -30618,12 +25553,6 @@
       "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
       "dev": true
     },
-    "follow-redirects": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
-      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
-      "dev": true
-    },
     "for-each": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
@@ -30653,12 +25582,6 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/fp-and-or/-/fp-and-or-0.1.3.tgz",
       "integrity": "sha512-wJaE62fLaB3jCYvY2ZHjZvmKK2iiLiiehX38rz5QZxtdN8fVPJDeZUiVvJrHStdTc+23LHlyZuSEKgFc0pxi2g==",
-      "dev": true
-    },
-    "fs-constants": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
       "dev": true
     },
     "fs-extra": {
@@ -30985,12 +25908,6 @@
         "ini": "^1.3.2"
       }
     },
-    "github-from-package": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
-      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
-      "dev": true
-    },
     "glob": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -31137,23 +26054,6 @@
       "resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
       "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
       "dev": true
-    },
-    "graphology": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/graphology/-/graphology-0.25.1.tgz",
-      "integrity": "sha512-yYA7BJCcXN2DrKNQQ9Qf22zBHm/yTbyBR71T1MYBbGtywNHsv0QZtk8zaR6zxNcp2hCCZayUkHp9DyMSZCpoxQ==",
-      "dev": true,
-      "requires": {
-        "events": "^3.3.0",
-        "obliterator": "^2.0.2"
-      }
-    },
-    "graphology-types": {
-      "version": "0.24.7",
-      "resolved": "https://registry.npmjs.org/graphology-types/-/graphology-types-0.24.7.tgz",
-      "integrity": "sha512-tdcqOOpwArNjEr0gNQKCXwaNCWnQJrog14nJNQPeemcLnXQUUGrsCWpWkVKt46zLjcS6/KGoayeJfHHyPDlvwA==",
-      "dev": true,
-      "peer": true
     },
     "handlebars": {
       "version": "4.7.7",
@@ -31336,12 +26236,6 @@
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       }
     },
-    "ieee754": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "dev": true
-    },
     "ignore": {
       "version": "5.2.4",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
@@ -31422,122 +26316,6 @@
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "dev": true
-    },
-    "ink": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/ink/-/ink-3.2.0.tgz",
-      "integrity": "sha512-firNp1q3xxTzoItj/eOOSZQnYSlyrWks5llCTVX37nJ59K3eXbQ8PtzCguqo8YI19EELo5QxaKnJd4VxzhU8tg==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "ansi-escapes": "^4.2.1",
-        "auto-bind": "4.0.0",
-        "chalk": "^4.1.0",
-        "cli-boxes": "^2.2.0",
-        "cli-cursor": "^3.1.0",
-        "cli-truncate": "^2.1.0",
-        "code-excerpt": "^3.0.0",
-        "indent-string": "^4.0.0",
-        "is-ci": "^2.0.0",
-        "lodash": "^4.17.20",
-        "patch-console": "^1.0.0",
-        "react-devtools-core": "^4.19.1",
-        "react-reconciler": "^0.26.2",
-        "scheduler": "^0.20.2",
-        "signal-exit": "^3.0.2",
-        "slice-ansi": "^3.0.0",
-        "stack-utils": "^2.0.2",
-        "string-width": "^4.2.2",
-        "type-fest": "^0.12.0",
-        "widest-line": "^3.1.0",
-        "wrap-ansi": "^6.2.0",
-        "ws": "^7.5.5",
-        "yoga-layout-prebuilt": "^1.9.6"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "chalk": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true,
-          "peer": true
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true,
-          "peer": true
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        },
-        "type-fest": {
-          "version": "0.12.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.12.0.tgz",
-          "integrity": "sha512-53RyidyjvkGpnWPMF9bQgFtWp+Sl8O2Rp13VavmJgfAP9WWG6q6TkrKU8iyJdnwnfgHI6k2hTlgqH4aSdjoTbg==",
-          "dev": true,
-          "peer": true
-        }
-      }
-    },
-    "ink-select-input": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/ink-select-input/-/ink-select-input-4.2.1.tgz",
-      "integrity": "sha512-WvlrYdwmdnD6/nE/9mNhaaanTQOKmwy/hT/vuAqbDec3PUQBQ8Pkwszii/8eGvDTx5bGiUHu18P9D5IoB/ERaw==",
-      "dev": true,
-      "requires": {
-        "arr-rotate": "^1.0.0",
-        "figures": "^3.2.0",
-        "lodash.isequal": "^4.5.0"
-      }
-    },
-    "ink-table": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/ink-table/-/ink-table-3.0.0.tgz",
-      "integrity": "sha512-RtcYjenHKZWjnwVNQ6zSYWMOLKwkWscDAJsqUQXftyjkYho1gGrluGss87NOoIzss0IKr74lKasd6MtlQYALiA==",
-      "dev": true,
-      "requires": {
-        "object-hash": "^2.0.3"
-      }
     },
     "internal-slot": {
       "version": "1.0.4",
@@ -31793,15 +26571,6 @@
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
       "dev": true
-    },
-    "is-valid-domain": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/is-valid-domain/-/is-valid-domain-0.1.6.tgz",
-      "integrity": "sha512-ZKtq737eFkZr71At8NxOFcP9O1K89gW3DkdrGMpp1upr/ueWjj+Weh4l9AI4rN0Gt8W2M1w7jrG2b/Yv83Ljpg==",
-      "dev": true,
-      "requires": {
-        "punycode": "^2.1.1"
-      }
     },
     "is-weakref": {
       "version": "1.0.2",
@@ -33787,128 +28556,6 @@
         }
       }
     },
-    "jsii-srcmak": {
-      "version": "0.1.802",
-      "resolved": "https://registry.npmjs.org/jsii-srcmak/-/jsii-srcmak-0.1.802.tgz",
-      "integrity": "sha512-oPbnaU1YL0Wp3NucRYGihoor/kS2NzpJnQB/fo7FUBtXg6xWa7abJ8b98oiaaj6jiPsePyMC0s7QEHhNIx0TDw==",
-      "dev": true,
-      "requires": {
-        "fs-extra": "^9.1.0",
-        "jsii": "^1.73.0",
-        "jsii-pacmak": "^1.73.0",
-        "ncp": "^2.0.0",
-        "yargs": "^15.4.1"
-      },
-      "dependencies": {
-        "camelcase": {
-          "version": "5.3.1",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-          "dev": true
-        },
-        "cliui": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
-          "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
-          "dev": true,
-          "requires": {
-            "string-width": "^4.2.0",
-            "strip-ansi": "^6.0.0",
-            "wrap-ansi": "^6.2.0"
-          }
-        },
-        "decamelize": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-          "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
-          "dev": true
-        },
-        "find-up": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-          "dev": true,
-          "requires": {
-            "locate-path": "^5.0.0",
-            "path-exists": "^4.0.0"
-          }
-        },
-        "fs-extra": {
-          "version": "9.1.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-          "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
-          "dev": true,
-          "requires": {
-            "at-least-node": "^1.0.0",
-            "graceful-fs": "^4.2.0",
-            "jsonfile": "^6.0.1",
-            "universalify": "^2.0.0"
-          }
-        },
-        "locate-path": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-          "dev": true,
-          "requires": {
-            "p-locate": "^4.1.0"
-          }
-        },
-        "p-limit": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-          "dev": true,
-          "requires": {
-            "p-try": "^2.0.0"
-          }
-        },
-        "p-locate": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-          "dev": true,
-          "requires": {
-            "p-limit": "^2.2.0"
-          }
-        },
-        "y18n": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
-          "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
-          "dev": true
-        },
-        "yargs": {
-          "version": "15.4.1",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
-          "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
-          "dev": true,
-          "requires": {
-            "cliui": "^6.0.0",
-            "decamelize": "^1.2.0",
-            "find-up": "^4.1.0",
-            "get-caller-file": "^2.0.1",
-            "require-directory": "^2.1.1",
-            "require-main-filename": "^2.0.0",
-            "set-blocking": "^2.0.0",
-            "string-width": "^4.2.0",
-            "which-module": "^2.0.0",
-            "y18n": "^4.0.0",
-            "yargs-parser": "^18.1.2"
-          }
-        },
-        "yargs-parser": {
-          "version": "18.1.3",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
-          "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
-          "dev": true,
-          "requires": {
-            "camelcase": "^5.0.0",
-            "decamelize": "^1.2.0"
-          }
-        }
-      }
-    },
     "json-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
@@ -34166,12 +28813,6 @@
       "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
       "dev": true
     },
-    "lodash.isequal": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
-      "dev": true
-    },
     "lodash.ismatch": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.ismatch/-/lodash.ismatch-4.4.0.tgz",
@@ -34203,26 +28844,10 @@
         "streamroller": "^3.1.3"
       }
     },
-    "loose-envify": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
-      }
-    },
     "lowercase-keys": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-3.0.0.tgz",
       "integrity": "sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ==",
-      "dev": true
-    },
-    "lru_map": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/lru_map/-/lru_map-0.3.3.tgz",
-      "integrity": "sha512-Pn9cox5CsMYngeDbmChANltQl+5pi6XmTrraMSzhPmMBbmgcxmqWry0U3PGapCU1yB4/LqCcom7qhHZiF/jGfQ==",
       "dev": true
     },
     "lru-cache": {
@@ -34722,12 +29347,6 @@
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
       "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
     },
-    "mkdirp-classic": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
-      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
-      "dev": true
-    },
     "mnemonist": {
       "version": "0.38.3",
       "resolved": "https://registry.npmjs.org/mnemonist/-/mnemonist-0.38.3.tgz",
@@ -34754,18 +29373,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
-    "nan": {
-      "version": "2.17.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
-      "integrity": "sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ==",
-      "dev": true
-    },
-    "napi-build-utils": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
-      "integrity": "sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg==",
-      "dev": true
-    },
     "natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -34776,12 +29383,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz",
       "integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
-      "dev": true
-    },
-    "ncp": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
-      "integrity": "sha512-zIdGUrPRFTUELUvr3Gmc7KZ2Sw/h1PiVM0Af/oHB6zgnV1ikqSfRk+TOufi79aHYCW3NiOXmr1BP5nWbzojLaA==",
       "dev": true
     },
     "negotiator": {
@@ -34834,21 +29435,6 @@
           }
         }
       }
-    },
-    "node-abi": {
-      "version": "3.31.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.31.0.tgz",
-      "integrity": "sha512-eSKV6s+APenqVh8ubJyiu/YhZgxQpGP66ntzUb3lY1xB9ukSRaGnx0AIxI+IM+1+IVYC1oWobgG5L3Lt9ARykQ==",
-      "dev": true,
-      "requires": {
-        "semver": "^7.3.5"
-      }
-    },
-    "node-abort-controller": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/node-abort-controller/-/node-abort-controller-3.0.1.tgz",
-      "integrity": "sha512-/ujIVxthRs+7q6hsdjHMaj8hRG9NuWmwrz+JdRwZ14jdFoKSkm+vDsCbF9PLpnSqjaWQJuTmVtcWHNLr+vrOFw==",
-      "dev": true
     },
     "node-fetch": {
       "version": "2.6.7",
@@ -35185,19 +29771,6 @@
       "integrity": "sha512-90yv+6538zuvUMnN+zCr8LuV6bPFdq50304114vJYJ8RDyK8D5O9Phpbd6SZWgI7PwzmmfN1upeOJlvybDSgCw==",
       "dev": true
     },
-    "object-assign": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
-      "peer": true
-    },
-    "object-hash": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.2.0.tgz",
-      "integrity": "sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==",
-      "dev": true
-    },
     "object-inspect": {
       "version": "1.12.2",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz",
@@ -35232,12 +29805,6 @@
         "define-properties": "^1.1.4",
         "es-abstract": "^1.20.4"
       }
-    },
-    "obliterator": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/obliterator/-/obliterator-2.0.4.tgz",
-      "integrity": "sha512-lgHwxlxV1qIg1Eap7LgIeoBWIMFibOjbrYPIPJZcI1mmGAI2m3lNYpK12Y+GBdPQ0U1hRwSord7GIaawz962qQ==",
-      "dev": true
     },
     "once": {
       "version": "1.4.0",
@@ -35427,13 +29994,6 @@
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
       "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
       "dev": true
-    },
-    "patch-console": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/patch-console/-/patch-console-1.0.0.tgz",
-      "integrity": "sha512-nxl9nrnLQmh64iTzMfyylSlRozL7kAXIaxw1fVcLYdyhNkJCRUzirRZTikXGJsg+hc4fqpneTK6iU2H1Q8THSA==",
-      "dev": true,
-      "peer": true
     },
     "patch-package": {
       "version": "6.5.1",
@@ -35706,26 +30266,6 @@
       "resolved": "https://registry.npmjs.org/polycons/-/polycons-0.1.8.tgz",
       "integrity": "sha512-E8OSdh76mpen1rRwGWoPRQ5E11hkuqzcjzWFHQxNgxa4aYgnIPT4/IZPcZNZ7Y5v2iaxKaczhw1cxnWhaZoxNw==",
       "requires": {}
-    },
-    "prebuild-install": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.1.tgz",
-      "integrity": "sha512-jAXscXWMcCK8GgCoHOfIr0ODh5ai8mj63L2nWrjuAgXE6tDyYGnx4/8o/rCgU+B4JSyZBKbeZqzhtwtC3ovxjw==",
-      "dev": true,
-      "requires": {
-        "detect-libc": "^2.0.0",
-        "expand-template": "^2.0.3",
-        "github-from-package": "0.0.0",
-        "minimist": "^1.2.3",
-        "mkdirp-classic": "^0.5.3",
-        "napi-build-utils": "^1.0.1",
-        "node-abi": "^3.3.0",
-        "pump": "^3.0.0",
-        "rc": "^1.2.7",
-        "simple-get": "^4.0.0",
-        "tar-fs": "^2.0.0",
-        "tunnel-agent": "^0.6.0"
-      }
     },
     "prelude-ls": {
       "version": "1.2.1",
@@ -36480,45 +31020,11 @@
         "require-from-string": "^2.0.2"
       }
     },
-    "react": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
-      "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
-      }
-    },
-    "react-devtools-core": {
-      "version": "4.27.1",
-      "resolved": "https://registry.npmjs.org/react-devtools-core/-/react-devtools-core-4.27.1.tgz",
-      "integrity": "sha512-qXhcxxDWiFmFAOq48jts9YQYe1+wVoUXzJTlY4jbaATzyio6dd6CUGu3dXBhREeVgpZ+y4kg6vFJzIOZh6vY2w==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "shell-quote": "^1.6.1",
-        "ws": "^7"
-      }
-    },
     "react-is": {
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
       "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
       "dev": true
-    },
-    "react-reconciler": {
-      "version": "0.26.2",
-      "resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.26.2.tgz",
-      "integrity": "sha512-nK6kgY28HwrMNwDnMui3dvm3rCFjZrcGiuwLc5COUipBK5hWHLOxMJhSnSomirqWwjPBJKV1QcbkI0VJr7Gl1Q==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "scheduler": "^0.20.2"
-      }
     },
     "read-package-json": {
       "version": "6.0.0",
@@ -36758,22 +31264,10 @@
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "dev": true
     },
-    "require-main-filename": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
-      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
-      "dev": true
-    },
     "requires-port": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
-    },
-    "reserved-words": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/reserved-words/-/reserved-words-0.1.2.tgz",
-      "integrity": "sha512-0S5SrIUJ9LfpbVl4Yzij6VipUdafHrOTzvmfazSw/jeZrZtQK303OPZW+obtkaw7jQlTQppy0UvZWm9872PbRw==",
-      "dev": true
     },
     "resolve": {
       "version": "1.22.1",
@@ -36836,17 +31330,6 @@
           "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
           "dev": true
         }
-      }
-    },
-    "restore-cursor": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
-      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "onetime": "^5.1.0",
-        "signal-exit": "^3.0.2"
       }
     },
     "retry": {
@@ -36926,17 +31409,6 @@
         "xmlchars": "^2.2.0"
       }
     },
-    "scheduler": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
-      "integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
-      }
-    },
     "semver": {
       "version": "7.3.8",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
@@ -37013,13 +31485,6 @@
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true
     },
-    "shell-quote": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.4.tgz",
-      "integrity": "sha512-8o/QEhSSRb1a5i7TFR0iM4G16Z0vYB2OQVs4G3aAFXjn3T6yEx8AZxy1PgDF7I00LZHYA3WxaSYIf5e5sAX8Rw==",
-      "dev": true,
-      "peer": true
-    },
     "side-channel": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
@@ -37036,23 +31501,6 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
-    },
-    "simple-concat": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
-      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
-      "dev": true
-    },
-    "simple-get": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
-      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
-      "dev": true,
-      "requires": {
-        "decompress-response": "^6.0.0",
-        "once": "^1.3.1",
-        "simple-concat": "^1.0.0"
-      }
     },
     "sinon": {
       "version": "14.0.2",
@@ -37105,47 +31553,6 @@
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
       "dev": true
-    },
-    "slice-ansi": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-3.0.0.tgz",
-      "integrity": "sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "ansi-styles": "^4.0.0",
-        "astral-regex": "^2.0.0",
-        "is-fullwidth-code-point": "^3.0.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true,
-          "peer": true
-        }
-      }
     },
     "smart-buffer": {
       "version": "4.2.0",
@@ -37655,39 +32062,6 @@
         }
       }
     },
-    "tar-fs": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
-      "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
-      "dev": true,
-      "requires": {
-        "chownr": "^1.1.1",
-        "mkdirp-classic": "^0.5.2",
-        "pump": "^3.0.0",
-        "tar-stream": "^2.1.4"
-      },
-      "dependencies": {
-        "chownr": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-          "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-          "dev": true
-        }
-      }
-    },
-    "tar-stream": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
-      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
-      "dev": true,
-      "requires": {
-        "bl": "^4.0.3",
-        "end-of-stream": "^1.4.1",
-        "fs-constants": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^3.1.1"
-      }
-    },
     "terminal-link": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/terminal-link/-/terminal-link-2.1.1.tgz",
@@ -37954,15 +32328,6 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
       "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg=="
-    },
-    "tunnel-agent": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "^5.0.1"
-      }
     },
     "type-check": {
       "version": "0.4.0",
@@ -38295,12 +32660,6 @@
         "is-symbol": "^1.0.3"
       }
     },
-    "which-module": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-      "integrity": "sha512-B+enWhmw6cjfVC7kS8Pj9pCrKSc5txArRyaYGe088shv/FGWH+0Rjx/xPgtsWfsUtS27FkP697E4DDhgrgoc0Q==",
-      "dev": true
-    },
     "which-typed-array": {
       "version": "1.1.9",
       "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.9.tgz",
@@ -38324,16 +32683,6 @@
         "string-width": "^1.0.2 || 2 || 3 || 4"
       }
     },
-    "widest-line": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-3.1.0.tgz",
-      "integrity": "sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "string-width": "^4.0.0"
-      }
-    },
     "word-wrap": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
@@ -38351,43 +32700,6 @@
       "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.3.1.tgz",
       "integrity": "sha512-0x7gJm1rhpn5SPG9NENOxPtbfUZZtK/qOg6gEdSqeDBA3dTeR91RJqSPjccPRCkhNfrnnl/dWxSSj5w9CtdzNA==",
       "dev": true
-    },
-    "wrap-ansi": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-      "dev": true,
-      "requires": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true
-        }
-      }
     },
     "wrappy": {
       "version": "1.0.2",
@@ -38426,15 +32738,6 @@
       "integrity": "sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw==",
       "dev": true
     },
-    "xml-js": {
-      "version": "1.6.11",
-      "resolved": "https://registry.npmjs.org/xml-js/-/xml-js-1.6.11.tgz",
-      "integrity": "sha512-7rVi2KMfwfWFl+GpPg6m80IVMWXLRjO+PxTq7V2CDhoGak0wzYzFgUY2m4XJ47OGdXd8eLE8EmwfAmdjw7lC1g==",
-      "dev": true,
-      "requires": {
-        "sax": "^1.2.4"
-      }
-    },
     "xml-name-validator": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
@@ -38469,12 +32772,6 @@
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true
     },
-    "xstate": {
-      "version": "4.35.2",
-      "resolved": "https://registry.npmjs.org/xstate/-/xstate-4.35.2.tgz",
-      "integrity": "sha512-5X7EyJv5OHHtGQwN7DsmCAbSnDs3Mxl1cXQ4PVaLwi+7p/RRapERnd1dFyHjYin+KQoLLfuXpl1dPBThgyIGNg==",
-      "dev": true
-    },
     "xtend": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
@@ -38499,29 +32796,6 @@
       "integrity": "sha512-e0WHiYql7+9wr4cWMx3TVQrNwejKaEe7/rHNmQmqRjazfOP5W8PB6Jpebb5o6fIapbz9o9+2ipcaTM2ZwDI6lw==",
       "dev": true
     },
-    "yargs": {
-      "version": "17.6.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.6.2.tgz",
-      "integrity": "sha512-1/9UrdHjDZc0eOU0HxOHoS78C69UD3JRMvzlJ7S79S2nTaWRA/whGCTV8o9e/N/1Va9YIV7Q4sOxD8VV4pCWOw==",
-      "dev": true,
-      "requires": {
-        "cliui": "^8.0.1",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.3",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^21.1.1"
-      },
-      "dependencies": {
-        "yargs-parser": {
-          "version": "21.1.1",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-          "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-          "dev": true
-        }
-      }
-    },
     "yargs-parser": {
       "version": "20.2.9",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
@@ -38538,21 +32812,6 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-      "dev": true
-    },
-    "yoga-layout-prebuilt": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/yoga-layout-prebuilt/-/yoga-layout-prebuilt-1.10.0.tgz",
-      "integrity": "sha512-YnOmtSbv4MTf7RGJMK0FvZ+KD8OEe/J5BNnR0GHhD8J/XcG/Qvxgszm0Un6FTHWW4uHlTgP0IztiXQnGyIR45g==",
-      "dev": true,
-      "requires": {
-        "@types/yoga-layout": "1.9.2"
-      }
-    },
-    "zod": {
-      "version": "1.11.17",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-1.11.17.tgz",
-      "integrity": "sha512-UzIwO92D0dSFwIRyyqAfRXICITLjF0IP8tRbEK/un7adirMssWZx8xF/1hZNE7t61knWZ+lhEuUvxlu2MO8qqA==",
       "dev": true
     }
   }

--- a/libs/wingsdk/package.json
+++ b/libs/wingsdk/package.json
@@ -52,7 +52,6 @@
     "@winglang/wing-api-checker": "file:../../apps/wing-api-checker",
     "aws-sdk-client-mock": "^2.0.1",
     "aws-sdk-client-mock-jest": "^2.0.1",
-    "cdktf-cli": "^0.15.0",
     "eslint": "^8",
     "eslint-config-prettier": "^8.6.0",
     "eslint-import-resolver-node": "^0.3.7",

--- a/libs/wingsdk/src/core/app.ts
+++ b/libs/wingsdk/src/core/app.ts
@@ -115,7 +115,7 @@ export class CdktfApp extends Construct implements IApp {
     rmSync(this.cdktfApp.outdir, { recursive: true });
 
     // write outdir/tree.json
-    synthesizeTree(this);
+    synthesizeTree(this, this.outdir);
 
     // return a cleaned snapshot of the resulting Terraform manifest for unit testing
     const tfConfig = this.cdktfStack.toTerraform();

--- a/libs/wingsdk/src/core/app.ts
+++ b/libs/wingsdk/src/core/app.ts
@@ -1,11 +1,14 @@
+import { mkdirSync, readdirSync, renameSync, rmSync } from "fs";
 import { join } from "path";
 import * as cdktf from "cdktf";
 import { Construct, IConstruct } from "constructs";
 import { IPolyconFactory, Polycons } from "polycons";
 import stringify from "safe-stable-stringify";
-import { Files } from "./files";
+// import { Files } from "./files";
 import { synthesizeTree } from "./tree";
 import { Logger } from "../cloud/logger";
+
+const TERRAFORM_STACK_NAME = "root";
 
 /**
  * A Wing application.
@@ -63,12 +66,16 @@ export class CdktfApp extends Construct implements IApp {
 
   private readonly cdktfApp: cdktf.App;
   private readonly cdktfStack: cdktf.TerraformStack;
-  private readonly files: Files;
+  // private readonly files: Files;
 
   constructor(props: AppProps) {
     const outdir = props.outdir ?? ".";
-    const cdktfApp = new cdktf.App({ outdir: join(outdir, "cdktf.out") });
-    const cdktfStack = new cdktf.TerraformStack(cdktfApp, "root");
+    const cdktfOutdir = join(outdir, ".tmp.cdktf.out");
+
+    mkdirSync(cdktfOutdir, { recursive: true });
+
+    const cdktfApp = new cdktf.App({ outdir: cdktfOutdir });
+    const cdktfStack = new cdktf.TerraformStack(cdktfApp, TERRAFORM_STACK_NAME);
 
     if (!props.customFactory) {
       throw new Error(
@@ -83,10 +90,10 @@ export class CdktfApp extends Construct implements IApp {
     this.cdktfApp = cdktfApp;
     this.cdktfStack = cdktfStack;
 
-    this.files = new Files({
-      app: this,
-      stateFile: props.stateFile,
-    });
+    // this.files = new Files({
+    //   app: this,
+    //   stateFile: props.stateFile,
+    // });
 
     // register a logger for this app.
     Logger.register(this);
@@ -99,16 +106,53 @@ export class CdktfApp extends Construct implements IApp {
    * for unit testing.
    */
   public synth(): string {
+    // synthesize Terraform files in `outdir/.tmp.cdktf.out/stacks/root`
     this.cdktfApp.synth();
-    this.files.synth();
 
-    // write tree.json file to the outdir
+    // // clean up `main.tf.json` and `assets` from `outdir` if they exist from a previous run
+    // rmSync(join(this.outdir, "main.tf.json"));
+    // rmSync(join(this.outdir, "assets"), { recursive: true });
+
+    // move Terraform files from `outdir/.tmp.cdktf.out/stacks/root` to `outdir`
+    this.moveCdktfArtifactsToOutdir();
+
+    // rename `outdir/cdk.tf.json` to `outdir/main.tf.json`
+    renameSync(
+      join(this.outdir, "cdk.tf.json"),
+      join(this.outdir, `main.tf.json`)
+    );
+
+    // remove `outdir/.tmp.cdktf.out`
+    rmSync(this.cdktfApp.outdir, { recursive: true });
+
+    // // synthesize any other files?
+    // this.files.synth();
+
+    // write outdir/tree.json
     synthesizeTree(this);
 
+    // return a cleaned snapshot of the resulting Terraform manifest for unit testing
     const tfConfig = this.cdktfStack.toTerraform();
     const cleaned = cleanTerraformConfig(tfConfig);
 
     return stringify(cleaned, null, 2) ?? "";
+  }
+
+  /**
+   * Move files from `outdir/cdktf.out/stacks/root` to `outdir`.
+   */
+  private moveCdktfArtifactsToOutdir(): void {
+    const cdktfOutdir = this.cdktfApp.outdir;
+    const cdktfStackDir = join(cdktfOutdir, "stacks", TERRAFORM_STACK_NAME);
+
+    const files = readdirSync(cdktfStackDir, { withFileTypes: true });
+    for (const file of files) {
+      if (file.isFile()) {
+        const source = join(cdktfStackDir, file.name);
+        const destination = join(this.outdir, file.name);
+        renameSync(source, destination);
+      }
+    }
   }
 }
 

--- a/libs/wingsdk/src/core/app.ts
+++ b/libs/wingsdk/src/core/app.ts
@@ -128,7 +128,10 @@ export class CdktfApp extends Construct implements IApp {
    */
   private moveCdktfArtifactsToOutdir(): void {
     const cdktfOutdir = this.cdktfApp.outdir;
-    const cdktfStackDir = join(cdktfOutdir, "stacks", TERRAFORM_STACK_NAME);
+    const cdktfStackDir = join(
+      cdktfOutdir,
+      this.cdktfApp.manifest.stacks[TERRAFORM_STACK_NAME].workingDirectory
+    );
 
     const files = readdirSync(cdktfStackDir, { withFileTypes: true });
     for (const file of files) {

--- a/libs/wingsdk/src/core/app.ts
+++ b/libs/wingsdk/src/core/app.ts
@@ -114,7 +114,7 @@ export class CdktfApp extends Construct implements IApp {
     // delete `outdir/.tmp.cdktf.out`
     rmSync(this.cdktfApp.outdir, { recursive: true });
 
-    // write outdir/tree.json
+    // write `outdir/tree.json`
     synthesizeTree(this, this.outdir);
 
     // return a cleaned snapshot of the resulting Terraform manifest for unit testing

--- a/libs/wingsdk/src/core/app.ts
+++ b/libs/wingsdk/src/core/app.ts
@@ -4,7 +4,6 @@ import * as cdktf from "cdktf";
 import { Construct, IConstruct } from "constructs";
 import { IPolyconFactory, Polycons } from "polycons";
 import stringify from "safe-stable-stringify";
-// import { Files } from "./files";
 import { synthesizeTree } from "./tree";
 import { Logger } from "../cloud/logger";
 
@@ -66,7 +65,6 @@ export class CdktfApp extends Construct implements IApp {
 
   private readonly cdktfApp: cdktf.App;
   private readonly cdktfStack: cdktf.TerraformStack;
-  // private readonly files: Files;
 
   constructor(props: AppProps) {
     const outdir = props.outdir ?? ".";
@@ -90,11 +88,6 @@ export class CdktfApp extends Construct implements IApp {
     this.cdktfApp = cdktfApp;
     this.cdktfStack = cdktfStack;
 
-    // this.files = new Files({
-    //   app: this,
-    //   stateFile: props.stateFile,
-    // });
-
     // register a logger for this app.
     Logger.register(this);
   }
@@ -109,10 +102,6 @@ export class CdktfApp extends Construct implements IApp {
     // synthesize Terraform files in `outdir/.tmp.cdktf.out/stacks/root`
     this.cdktfApp.synth();
 
-    // // clean up `main.tf.json` and `assets` from `outdir` if they exist from a previous run
-    // rmSync(join(this.outdir, "main.tf.json"));
-    // rmSync(join(this.outdir, "assets"), { recursive: true });
-
     // move Terraform files from `outdir/.tmp.cdktf.out/stacks/root` to `outdir`
     this.moveCdktfArtifactsToOutdir();
 
@@ -122,11 +111,8 @@ export class CdktfApp extends Construct implements IApp {
       join(this.outdir, `main.tf.json`)
     );
 
-    // remove `outdir/.tmp.cdktf.out`
+    // delete `outdir/.tmp.cdktf.out`
     rmSync(this.cdktfApp.outdir, { recursive: true });
-
-    // // synthesize any other files?
-    // this.files.synth();
 
     // write outdir/tree.json
     synthesizeTree(this);
@@ -134,7 +120,6 @@ export class CdktfApp extends Construct implements IApp {
     // return a cleaned snapshot of the resulting Terraform manifest for unit testing
     const tfConfig = this.cdktfStack.toTerraform();
     const cleaned = cleanTerraformConfig(tfConfig);
-
     return stringify(cleaned, null, 2) ?? "";
   }
 

--- a/libs/wingsdk/src/core/tree.ts
+++ b/libs/wingsdk/src/core/tree.ts
@@ -116,7 +116,7 @@ function constructInfoFromConstruct(
   return undefined;
 }
 
-export function synthesizeTree(app: IApp) {
+export function synthesizeTree(app: IApp, outdir: string) {
   const visit = (construct: IConstruct): ConstructTreeNode => {
     const children = construct.node.children.map((c) => visit(c));
     const childrenMap = children
@@ -141,7 +141,7 @@ export function synthesizeTree(app: IApp) {
   };
 
   fs.writeFileSync(
-    path.join(app.outdir, TREE_FILE_PATH),
+    path.join(outdir, TREE_FILE_PATH),
     JSON.stringify(tree, undefined, 2),
     { encoding: "utf8" }
   );

--- a/libs/wingsdk/src/target-sim/app.ts
+++ b/libs/wingsdk/src/target-sim/app.ts
@@ -45,6 +45,9 @@ export class App extends Construct implements core.IApp {
     // write simulator.json file into workdir
     this.synthSimulatorFile(workdir);
 
+    // write tree.json file into workdir
+    core.synthesizeTree(this, workdir);
+
     // tar + gzip the workdir, and write it as a .wsim file to the outdir
     const filename = `${this.name}.wsim`;
     const simfile = path.join(this.outdir, filename);
@@ -57,9 +60,6 @@ export class App extends Construct implements core.IApp {
       },
       ["./"]
     );
-
-    // write tree.json file to the outdir
-    core.synthesizeTree(this);
 
     return simfile;
   }

--- a/libs/wingsdk/src/target-sim/app.ts
+++ b/libs/wingsdk/src/target-sim/app.ts
@@ -61,6 +61,10 @@ export class App extends Construct implements core.IApp {
       ["./"]
     );
 
+    // write tree.json file into the app's outdir
+    // (for backwards compatibility with older versions of the Wing console)
+    core.synthesizeTree(this, this.outdir);
+
     return simfile;
   }
 

--- a/libs/wingsdk/test/sandbox/cdktf.json
+++ b/libs/wingsdk/test/sandbox/cdktf.json
@@ -1,5 +1,0 @@
-{
-  "app": "npx tsx main.ts --tsconfig \"../../tsconfig.dev.json\"",
-  "language": "typescript",
-  "projectId": "b3c4b7ea-2fd2-4987-9bc4-6407eb466165"
-}

--- a/libs/wingsdk/test/sandbox/main.ts
+++ b/libs/wingsdk/test/sandbox/main.ts
@@ -15,14 +15,13 @@ class HelloWorld extends Construct {
 
     const bucket = new cloud.Bucket(this, "Bucket", { public: false });
     bucket.addObject("test.txt", "yoyoyo");
-
-    const handler = testing.Testing.makeHandler(this, "Handler", "code");
-    new cloud.Function(this, "Function", handler);
   }
 }
 
-const app = new tfaws.App({
-  outdir: join(__dirname, "target"),
+const app = new tfgcp.App({
+  outdir: __dirname,
+  projectId: "my-project",
+  storageLocation: "US",
 });
 new HelloWorld(app, "HelloWorld");
 app.synth();

--- a/libs/wingsdk/test/sandbox/main.ts
+++ b/libs/wingsdk/test/sandbox/main.ts
@@ -15,13 +15,14 @@ class HelloWorld extends Construct {
 
     const bucket = new cloud.Bucket(this, "Bucket", { public: false });
     bucket.addObject("test.txt", "yoyoyo");
+
+    const handler = testing.Testing.makeHandler(this, "Handler", "code");
+    new cloud.Function(this, "Function", handler);
   }
 }
 
-const app = new tfgcp.App({
-  outdir: __dirname,
-  projectId: "my-project",
-  storageLocation: "US",
+const app = new tfaws.App({
+  outdir: join(__dirname, "target"),
 });
 new HelloWorld(app, "HelloWorld");
 app.synth();

--- a/libs/wingsdk/test/sandbox/main.ts
+++ b/libs/wingsdk/test/sandbox/main.ts
@@ -19,7 +19,7 @@ class HelloWorld extends Construct {
 }
 
 const app = new tfgcp.App({
-  outdir: __dirname,
+  outdir: join(__dirname, "target"),
   projectId: "my-project",
   storageLocation: "US",
 });

--- a/libs/wingsdk/test/target-sim/__snapshots__/bucket.test.ts.snap
+++ b/libs/wingsdk/test/target-sim/__snapshots__/bucket.test.ts.snap
@@ -35,6 +35,52 @@ Object {
     ],
     "sdkVersion": "0.0.0",
   },
+  "app.wsim/tree.json": Object {
+    "tree": Object {
+      "children": Object {
+        "WingLogger": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [],
+            "wing:resource:stateful": true,
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.1.228",
+          },
+          "display": Object {
+            "description": "A cloud logging facility",
+            "hidden": true,
+            "title": "Logger",
+          },
+          "id": "WingLogger",
+          "path": "root/WingLogger",
+        },
+        "my_bucket": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [],
+            "wing:resource:stateful": true,
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.1.228",
+          },
+          "display": Object {
+            "description": "A cloud object store",
+            "title": "Bucket",
+          },
+          "id": "my_bucket",
+          "path": "root/my_bucket",
+        },
+      },
+      "constructInfo": Object {
+        "fqn": "constructs.Construct",
+        "version": "10.1.228",
+      },
+      "id": "root",
+      "path": "root",
+    },
+    "version": "tree-0.1",
+  },
   "tree.json": Object {
     "tree": Object {
       "children": Object {
@@ -115,6 +161,52 @@ Object {
       },
     ],
     "sdkVersion": "0.0.0",
+  },
+  "app.wsim/tree.json": Object {
+    "tree": Object {
+      "children": Object {
+        "WingLogger": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [],
+            "wing:resource:stateful": true,
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.1.228",
+          },
+          "display": Object {
+            "description": "A cloud logging facility",
+            "hidden": true,
+            "title": "Logger",
+          },
+          "id": "WingLogger",
+          "path": "root/WingLogger",
+        },
+        "my_bucket": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [],
+            "wing:resource:stateful": true,
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.1.228",
+          },
+          "display": Object {
+            "description": "A cloud object store",
+            "title": "Bucket",
+          },
+          "id": "my_bucket",
+          "path": "root/my_bucket",
+        },
+      },
+      "constructInfo": Object {
+        "fqn": "constructs.Construct",
+        "version": "10.1.228",
+      },
+      "id": "root",
+      "path": "root",
+    },
+    "version": "tree-0.1",
   },
   "tree.json": Object {
     "tree": Object {
@@ -197,6 +289,52 @@ Object {
       },
     ],
     "sdkVersion": "0.0.0",
+  },
+  "app.wsim/tree.json": Object {
+    "tree": Object {
+      "children": Object {
+        "WingLogger": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [],
+            "wing:resource:stateful": true,
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.1.228",
+          },
+          "display": Object {
+            "description": "A cloud logging facility",
+            "hidden": true,
+            "title": "Logger",
+          },
+          "id": "WingLogger",
+          "path": "root/WingLogger",
+        },
+        "my_bucket": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [],
+            "wing:resource:stateful": true,
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.1.228",
+          },
+          "display": Object {
+            "description": "A cloud object store",
+            "title": "Bucket",
+          },
+          "id": "my_bucket",
+          "path": "root/my_bucket",
+        },
+      },
+      "constructInfo": Object {
+        "fqn": "constructs.Construct",
+        "version": "10.1.228",
+      },
+      "id": "root",
+      "path": "root",
+    },
+    "version": "tree-0.1",
   },
   "tree.json": Object {
     "tree": Object {
@@ -282,6 +420,52 @@ Object {
     ],
     "sdkVersion": "0.0.0",
   },
+  "app.wsim/tree.json": Object {
+    "tree": Object {
+      "children": Object {
+        "WingLogger": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [],
+            "wing:resource:stateful": true,
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.1.228",
+          },
+          "display": Object {
+            "description": "A cloud logging facility",
+            "hidden": true,
+            "title": "Logger",
+          },
+          "id": "WingLogger",
+          "path": "root/WingLogger",
+        },
+        "my_bucket": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [],
+            "wing:resource:stateful": true,
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.1.228",
+          },
+          "display": Object {
+            "description": "A cloud object store",
+            "title": "Bucket",
+          },
+          "id": "my_bucket",
+          "path": "root/my_bucket",
+        },
+      },
+      "constructInfo": Object {
+        "fqn": "constructs.Construct",
+        "version": "10.1.228",
+      },
+      "id": "root",
+      "path": "root",
+    },
+    "version": "tree-0.1",
+  },
   "tree.json": Object {
     "tree": Object {
       "children": Object {
@@ -364,6 +548,52 @@ Object {
     ],
     "sdkVersion": "0.0.0",
   },
+  "app.wsim/tree.json": Object {
+    "tree": Object {
+      "children": Object {
+        "WingLogger": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [],
+            "wing:resource:stateful": true,
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.1.228",
+          },
+          "display": Object {
+            "description": "A cloud logging facility",
+            "hidden": true,
+            "title": "Logger",
+          },
+          "id": "WingLogger",
+          "path": "root/WingLogger",
+        },
+        "my_bucket": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [],
+            "wing:resource:stateful": true,
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.1.228",
+          },
+          "display": Object {
+            "description": "A cloud object store",
+            "title": "Bucket",
+          },
+          "id": "my_bucket",
+          "path": "root/my_bucket",
+        },
+      },
+      "constructInfo": Object {
+        "fqn": "constructs.Construct",
+        "version": "10.1.228",
+      },
+      "id": "root",
+      "path": "root",
+    },
+    "version": "tree-0.1",
+  },
   "tree.json": Object {
     "tree": Object {
       "children": Object {
@@ -445,6 +675,52 @@ Object {
       },
     ],
     "sdkVersion": "0.0.0",
+  },
+  "app.wsim/tree.json": Object {
+    "tree": Object {
+      "children": Object {
+        "WingLogger": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [],
+            "wing:resource:stateful": true,
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.1.228",
+          },
+          "display": Object {
+            "description": "A cloud logging facility",
+            "hidden": true,
+            "title": "Logger",
+          },
+          "id": "WingLogger",
+          "path": "root/WingLogger",
+        },
+        "my_bucket": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [],
+            "wing:resource:stateful": true,
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.1.228",
+          },
+          "display": Object {
+            "description": "A cloud object store",
+            "title": "Bucket",
+          },
+          "id": "my_bucket",
+          "path": "root/my_bucket",
+        },
+      },
+      "constructInfo": Object {
+        "fqn": "constructs.Construct",
+        "version": "10.1.228",
+      },
+      "id": "root",
+      "path": "root",
+    },
+    "version": "tree-0.1",
   },
   "tree.json": Object {
     "tree": Object {

--- a/libs/wingsdk/test/target-sim/__snapshots__/counter.test.ts.snap
+++ b/libs/wingsdk/test/target-sim/__snapshots__/counter.test.ts.snap
@@ -21,6 +21,52 @@ Object {
     ],
     "sdkVersion": "0.0.0",
   },
+  "app.wsim/tree.json": Object {
+    "tree": Object {
+      "children": Object {
+        "WingLogger": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [],
+            "wing:resource:stateful": true,
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.1.228",
+          },
+          "display": Object {
+            "description": "A cloud logging facility",
+            "hidden": true,
+            "title": "Logger",
+          },
+          "id": "WingLogger",
+          "path": "root/WingLogger",
+        },
+        "my_counter": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [],
+            "wing:resource:stateful": true,
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.1.228",
+          },
+          "display": Object {
+            "description": "A distributed atomic counter",
+            "title": "Counter",
+          },
+          "id": "my_counter",
+          "path": "root/my_counter",
+        },
+      },
+      "constructInfo": Object {
+        "fqn": "constructs.Construct",
+        "version": "10.1.228",
+      },
+      "id": "root",
+      "path": "root",
+    },
+    "version": "tree-0.1",
+  },
   "tree.json": Object {
     "tree": Object {
       "children": Object {
@@ -91,6 +137,52 @@ Object {
     ],
     "sdkVersion": "0.0.0",
   },
+  "app.wsim/tree.json": Object {
+    "tree": Object {
+      "children": Object {
+        "WingLogger": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [],
+            "wing:resource:stateful": true,
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.1.228",
+          },
+          "display": Object {
+            "description": "A cloud logging facility",
+            "hidden": true,
+            "title": "Logger",
+          },
+          "id": "WingLogger",
+          "path": "root/WingLogger",
+        },
+        "my_counter": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [],
+            "wing:resource:stateful": true,
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.1.228",
+          },
+          "display": Object {
+            "description": "A distributed atomic counter",
+            "title": "Counter",
+          },
+          "id": "my_counter",
+          "path": "root/my_counter",
+        },
+      },
+      "constructInfo": Object {
+        "fqn": "constructs.Construct",
+        "version": "10.1.228",
+      },
+      "id": "root",
+      "path": "root",
+    },
+    "version": "tree-0.1",
+  },
   "tree.json": Object {
     "tree": Object {
       "children": Object {
@@ -160,6 +252,52 @@ Object {
       },
     ],
     "sdkVersion": "0.0.0",
+  },
+  "app.wsim/tree.json": Object {
+    "tree": Object {
+      "children": Object {
+        "WingLogger": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [],
+            "wing:resource:stateful": true,
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.1.228",
+          },
+          "display": Object {
+            "description": "A cloud logging facility",
+            "hidden": true,
+            "title": "Logger",
+          },
+          "id": "WingLogger",
+          "path": "root/WingLogger",
+        },
+        "my_counter": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [],
+            "wing:resource:stateful": true,
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.1.228",
+          },
+          "display": Object {
+            "description": "A distributed atomic counter",
+            "title": "Counter",
+          },
+          "id": "my_counter",
+          "path": "root/my_counter",
+        },
+      },
+      "constructInfo": Object {
+        "fqn": "constructs.Construct",
+        "version": "10.1.228",
+      },
+      "id": "root",
+      "path": "root",
+    },
+    "version": "tree-0.1",
   },
   "tree.json": Object {
     "tree": Object {

--- a/libs/wingsdk/test/target-sim/__snapshots__/file-counter.test.ts.snap
+++ b/libs/wingsdk/test/target-sim/__snapshots__/file-counter.test.ts.snap
@@ -60,6 +60,215 @@ Object {
     ],
     "sdkVersion": "0.0.0",
   },
+  "app.wsim/tree.json": Object {
+    "tree": Object {
+      "children": Object {
+        "HelloWorld": Object {
+          "children": Object {
+            "Bucket": Object {
+              "attributes": Object {
+                "wing:resource:connections": Array [
+                  Object {
+                    "direction": "inbound",
+                    "implicit": false,
+                    "relationship": "put",
+                    "resource": "root/HelloWorld/Queue-OnMessage-401ee792",
+                  },
+                ],
+                "wing:resource:stateful": true,
+              },
+              "constructInfo": Object {
+                "fqn": "constructs.Construct",
+                "version": "10.1.228",
+              },
+              "display": Object {
+                "description": "A cloud object store",
+                "title": "Bucket",
+              },
+              "id": "Bucket",
+              "path": "root/HelloWorld/Bucket",
+            },
+            "Counter": Object {
+              "attributes": Object {
+                "wing:resource:connections": Array [
+                  Object {
+                    "direction": "inbound",
+                    "implicit": false,
+                    "relationship": "inc",
+                    "resource": "root/HelloWorld/Queue-OnMessage-401ee792",
+                  },
+                ],
+                "wing:resource:stateful": true,
+              },
+              "constructInfo": Object {
+                "fqn": "constructs.Construct",
+                "version": "10.1.228",
+              },
+              "display": Object {
+                "description": "A distributed atomic counter",
+                "title": "Counter",
+              },
+              "id": "Counter",
+              "path": "root/HelloWorld/Counter",
+            },
+            "Processor": Object {
+              "attributes": Object {
+                "wing:resource:connections": Array [
+                  Object {
+                    "direction": "inbound",
+                    "implicit": false,
+                    "relationship": "handle",
+                    "resource": "root/HelloWorld/Queue-OnMessage-401ee792",
+                  },
+                ],
+                "wing:resource:stateful": false,
+              },
+              "constructInfo": Object {
+                "fqn": "constructs.Construct",
+                "version": "10.1.228",
+              },
+              "display": Object {
+                "description": "An inflight resource",
+                "hidden": true,
+                "title": "Inflight",
+              },
+              "id": "Processor",
+              "path": "root/HelloWorld/Processor",
+            },
+            "Queue": Object {
+              "attributes": Object {
+                "wing:resource:connections": Array [
+                  Object {
+                    "direction": "outbound",
+                    "implicit": false,
+                    "relationship": "on_message",
+                    "resource": "root/HelloWorld/Queue-OnMessage-401ee792",
+                  },
+                ],
+                "wing:resource:stateful": true,
+              },
+              "constructInfo": Object {
+                "fqn": "constructs.Construct",
+                "version": "10.1.228",
+              },
+              "display": Object {
+                "description": "A distributed message queue",
+                "title": "Queue",
+              },
+              "id": "Queue",
+              "path": "root/HelloWorld/Queue",
+            },
+            "Queue-OnMessage-401ee792": Object {
+              "attributes": Object {
+                "wing:resource:connections": Array [
+                  Object {
+                    "direction": "outbound",
+                    "implicit": false,
+                    "relationship": "inc",
+                    "resource": "root/HelloWorld/Counter",
+                  },
+                  Object {
+                    "direction": "outbound",
+                    "implicit": false,
+                    "relationship": "put",
+                    "resource": "root/HelloWorld/Bucket",
+                  },
+                  Object {
+                    "direction": "outbound",
+                    "implicit": false,
+                    "relationship": "handle",
+                    "resource": "root/HelloWorld/Processor",
+                  },
+                  Object {
+                    "direction": "outbound",
+                    "implicit": true,
+                    "relationship": "print",
+                    "resource": "root/WingLogger",
+                  },
+                  Object {
+                    "direction": "inbound",
+                    "implicit": false,
+                    "relationship": "on_message",
+                    "resource": "root/HelloWorld/Queue",
+                  },
+                ],
+                "wing:resource:stateful": false,
+              },
+              "children": Object {
+                "Code": Object {
+                  "constructInfo": Object {
+                    "fqn": "constructs.Construct",
+                    "version": "10.1.228",
+                  },
+                  "id": "Code",
+                  "path": "root/HelloWorld/Queue-OnMessage-401ee792/Code",
+                },
+              },
+              "constructInfo": Object {
+                "fqn": "constructs.Construct",
+                "version": "10.1.228",
+              },
+              "display": Object {
+                "description": "A cloud function (FaaS)",
+                "title": "Function",
+              },
+              "id": "Queue-OnMessage-401ee792",
+              "path": "root/HelloWorld/Queue-OnMessage-401ee792",
+            },
+            "Queue-OnMessageHandler-401ee792": Object {
+              "attributes": Object {
+                "wing:resource:connections": Array [],
+                "wing:resource:stateful": false,
+              },
+              "constructInfo": Object {
+                "fqn": "constructs.Construct",
+                "version": "10.1.228",
+              },
+              "id": "Queue-OnMessageHandler-401ee792",
+              "path": "root/HelloWorld/Queue-OnMessageHandler-401ee792",
+            },
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.1.228",
+          },
+          "id": "HelloWorld",
+          "path": "root/HelloWorld",
+        },
+        "WingLogger": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [
+              Object {
+                "direction": "inbound",
+                "implicit": true,
+                "relationship": "print",
+                "resource": "root/HelloWorld/Queue-OnMessage-401ee792",
+              },
+            ],
+            "wing:resource:stateful": true,
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.1.228",
+          },
+          "display": Object {
+            "description": "A cloud logging facility",
+            "hidden": true,
+            "title": "Logger",
+          },
+          "id": "WingLogger",
+          "path": "root/WingLogger",
+        },
+      },
+      "constructInfo": Object {
+        "fqn": "constructs.Construct",
+        "version": "10.1.228",
+      },
+      "id": "root",
+      "path": "root",
+    },
+    "version": "tree-0.1",
+  },
   "assets/Queue-OnMessage-401ee792/index.js": "var __defProp = Object.defineProperty;
 var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
 var __getOwnPropNames = Object.getOwnPropertyNames;

--- a/libs/wingsdk/test/target-sim/__snapshots__/function.test.ts.snap
+++ b/libs/wingsdk/test/target-sim/__snapshots__/function.test.ts.snap
@@ -27,6 +27,93 @@ Object {
     ],
     "sdkVersion": "0.0.0",
   },
+  "app.wsim/tree.json": Object {
+    "tree": Object {
+      "children": Object {
+        "Handler": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [],
+            "wing:resource:stateful": false,
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.1.228",
+          },
+          "display": Object {
+            "description": "An inflight resource",
+            "hidden": true,
+            "title": "Inflight",
+          },
+          "id": "Handler",
+          "path": "root/Handler",
+        },
+        "WingLogger": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [
+              Object {
+                "direction": "inbound",
+                "implicit": true,
+                "relationship": "print",
+                "resource": "root/my_function",
+              },
+            ],
+            "wing:resource:stateful": true,
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.1.228",
+          },
+          "display": Object {
+            "description": "A cloud logging facility",
+            "hidden": true,
+            "title": "Logger",
+          },
+          "id": "WingLogger",
+          "path": "root/WingLogger",
+        },
+        "my_function": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [
+              Object {
+                "direction": "outbound",
+                "implicit": true,
+                "relationship": "print",
+                "resource": "root/WingLogger",
+              },
+            ],
+            "wing:resource:stateful": false,
+          },
+          "children": Object {
+            "Code": Object {
+              "constructInfo": Object {
+                "fqn": "constructs.Construct",
+                "version": "10.1.228",
+              },
+              "id": "Code",
+              "path": "root/my_function/Code",
+            },
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.1.228",
+          },
+          "display": Object {
+            "description": "A cloud function (FaaS)",
+            "title": "Function",
+          },
+          "id": "my_function",
+          "path": "root/my_function",
+        },
+      },
+      "constructInfo": Object {
+        "fqn": "constructs.Construct",
+        "version": "10.1.228",
+      },
+      "id": "root",
+      "path": "root",
+    },
+    "version": "tree-0.1",
+  },
   "assets/my_function/index.js": "var $logger = function(env) {
   let handle = process.env[env];
   if (!handle) {
@@ -186,6 +273,93 @@ Object {
     ],
     "sdkVersion": "0.0.0",
   },
+  "app.wsim/tree.json": Object {
+    "tree": Object {
+      "children": Object {
+        "Handler": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [],
+            "wing:resource:stateful": false,
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.1.228",
+          },
+          "display": Object {
+            "description": "An inflight resource",
+            "hidden": true,
+            "title": "Inflight",
+          },
+          "id": "Handler",
+          "path": "root/Handler",
+        },
+        "WingLogger": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [
+              Object {
+                "direction": "inbound",
+                "implicit": true,
+                "relationship": "print",
+                "resource": "root/my_function",
+              },
+            ],
+            "wing:resource:stateful": true,
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.1.228",
+          },
+          "display": Object {
+            "description": "A cloud logging facility",
+            "hidden": true,
+            "title": "Logger",
+          },
+          "id": "WingLogger",
+          "path": "root/WingLogger",
+        },
+        "my_function": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [
+              Object {
+                "direction": "outbound",
+                "implicit": true,
+                "relationship": "print",
+                "resource": "root/WingLogger",
+              },
+            ],
+            "wing:resource:stateful": false,
+          },
+          "children": Object {
+            "Code": Object {
+              "constructInfo": Object {
+                "fqn": "constructs.Construct",
+                "version": "10.1.228",
+              },
+              "id": "Code",
+              "path": "root/my_function/Code",
+            },
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.1.228",
+          },
+          "display": Object {
+            "description": "A cloud function (FaaS)",
+            "title": "Function",
+          },
+          "id": "my_function",
+          "path": "root/my_function",
+        },
+      },
+      "constructInfo": Object {
+        "fqn": "constructs.Construct",
+        "version": "10.1.228",
+      },
+      "id": "root",
+      "path": "root",
+    },
+    "version": "tree-0.1",
+  },
   "assets/my_function/index.js": "var $logger = function(env) {
   let handle = process.env[env];
   if (!handle) {
@@ -336,6 +510,93 @@ Object {
       },
     ],
     "sdkVersion": "0.0.0",
+  },
+  "app.wsim/tree.json": Object {
+    "tree": Object {
+      "children": Object {
+        "Handler": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [],
+            "wing:resource:stateful": false,
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.1.228",
+          },
+          "display": Object {
+            "description": "An inflight resource",
+            "hidden": true,
+            "title": "Inflight",
+          },
+          "id": "Handler",
+          "path": "root/Handler",
+        },
+        "WingLogger": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [
+              Object {
+                "direction": "inbound",
+                "implicit": true,
+                "relationship": "print",
+                "resource": "root/my_function",
+              },
+            ],
+            "wing:resource:stateful": true,
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.1.228",
+          },
+          "display": Object {
+            "description": "A cloud logging facility",
+            "hidden": true,
+            "title": "Logger",
+          },
+          "id": "WingLogger",
+          "path": "root/WingLogger",
+        },
+        "my_function": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [
+              Object {
+                "direction": "outbound",
+                "implicit": true,
+                "relationship": "print",
+                "resource": "root/WingLogger",
+              },
+            ],
+            "wing:resource:stateful": false,
+          },
+          "children": Object {
+            "Code": Object {
+              "constructInfo": Object {
+                "fqn": "constructs.Construct",
+                "version": "10.1.228",
+              },
+              "id": "Code",
+              "path": "root/my_function/Code",
+            },
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.1.228",
+          },
+          "display": Object {
+            "description": "A cloud function (FaaS)",
+            "title": "Function",
+          },
+          "id": "my_function",
+          "path": "root/my_function",
+        },
+      },
+      "constructInfo": Object {
+        "fqn": "constructs.Construct",
+        "version": "10.1.228",
+      },
+      "id": "root",
+      "path": "root",
+    },
+    "version": "tree-0.1",
   },
   "assets/my_function/index.js": "var $logger = function(env) {
   let handle = process.env[env];
@@ -495,6 +756,93 @@ Object {
       },
     ],
     "sdkVersion": "0.0.0",
+  },
+  "app.wsim/tree.json": Object {
+    "tree": Object {
+      "children": Object {
+        "Handler": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [],
+            "wing:resource:stateful": false,
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.1.228",
+          },
+          "display": Object {
+            "description": "An inflight resource",
+            "hidden": true,
+            "title": "Inflight",
+          },
+          "id": "Handler",
+          "path": "root/Handler",
+        },
+        "WingLogger": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [
+              Object {
+                "direction": "inbound",
+                "implicit": true,
+                "relationship": "print",
+                "resource": "root/my_function",
+              },
+            ],
+            "wing:resource:stateful": true,
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.1.228",
+          },
+          "display": Object {
+            "description": "A cloud logging facility",
+            "hidden": true,
+            "title": "Logger",
+          },
+          "id": "WingLogger",
+          "path": "root/WingLogger",
+        },
+        "my_function": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [
+              Object {
+                "direction": "outbound",
+                "implicit": true,
+                "relationship": "print",
+                "resource": "root/WingLogger",
+              },
+            ],
+            "wing:resource:stateful": false,
+          },
+          "children": Object {
+            "Code": Object {
+              "constructInfo": Object {
+                "fqn": "constructs.Construct",
+                "version": "10.1.228",
+              },
+              "id": "Code",
+              "path": "root/my_function/Code",
+            },
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.1.228",
+          },
+          "display": Object {
+            "description": "A cloud function (FaaS)",
+            "title": "Function",
+          },
+          "id": "my_function",
+          "path": "root/my_function",
+        },
+      },
+      "constructInfo": Object {
+        "fqn": "constructs.Construct",
+        "version": "10.1.228",
+      },
+      "id": "root",
+      "path": "root",
+    },
+    "version": "tree-0.1",
   },
   "assets/my_function/index.js": "var $logger = function(env) {
   let handle = process.env[env];
@@ -656,6 +1004,93 @@ Object {
     ],
     "sdkVersion": "0.0.0",
   },
+  "app.wsim/tree.json": Object {
+    "tree": Object {
+      "children": Object {
+        "Handler": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [],
+            "wing:resource:stateful": false,
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.1.228",
+          },
+          "display": Object {
+            "description": "An inflight resource",
+            "hidden": true,
+            "title": "Inflight",
+          },
+          "id": "Handler",
+          "path": "root/Handler",
+        },
+        "WingLogger": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [
+              Object {
+                "direction": "inbound",
+                "implicit": true,
+                "relationship": "print",
+                "resource": "root/my_function",
+              },
+            ],
+            "wing:resource:stateful": true,
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.1.228",
+          },
+          "display": Object {
+            "description": "A cloud logging facility",
+            "hidden": true,
+            "title": "Logger",
+          },
+          "id": "WingLogger",
+          "path": "root/WingLogger",
+        },
+        "my_function": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [
+              Object {
+                "direction": "outbound",
+                "implicit": true,
+                "relationship": "print",
+                "resource": "root/WingLogger",
+              },
+            ],
+            "wing:resource:stateful": false,
+          },
+          "children": Object {
+            "Code": Object {
+              "constructInfo": Object {
+                "fqn": "constructs.Construct",
+                "version": "10.1.228",
+              },
+              "id": "Code",
+              "path": "root/my_function/Code",
+            },
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.1.228",
+          },
+          "display": Object {
+            "description": "A cloud function (FaaS)",
+            "title": "Function",
+          },
+          "id": "my_function",
+          "path": "root/my_function",
+        },
+      },
+      "constructInfo": Object {
+        "fqn": "constructs.Construct",
+        "version": "10.1.228",
+      },
+      "id": "root",
+      "path": "root",
+    },
+    "version": "tree-0.1",
+  },
   "assets/my_function/index.js": "var $logger = function(env) {
   let handle = process.env[env];
   if (!handle) {
@@ -814,6 +1249,93 @@ Object {
       },
     ],
     "sdkVersion": "0.0.0",
+  },
+  "app.wsim/tree.json": Object {
+    "tree": Object {
+      "children": Object {
+        "Handler": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [],
+            "wing:resource:stateful": false,
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.1.228",
+          },
+          "display": Object {
+            "description": "An inflight resource",
+            "hidden": true,
+            "title": "Inflight",
+          },
+          "id": "Handler",
+          "path": "root/Handler",
+        },
+        "WingLogger": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [
+              Object {
+                "direction": "inbound",
+                "implicit": true,
+                "relationship": "print",
+                "resource": "root/my_function",
+              },
+            ],
+            "wing:resource:stateful": true,
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.1.228",
+          },
+          "display": Object {
+            "description": "A cloud logging facility",
+            "hidden": true,
+            "title": "Logger",
+          },
+          "id": "WingLogger",
+          "path": "root/WingLogger",
+        },
+        "my_function": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [
+              Object {
+                "direction": "outbound",
+                "implicit": true,
+                "relationship": "print",
+                "resource": "root/WingLogger",
+              },
+            ],
+            "wing:resource:stateful": false,
+          },
+          "children": Object {
+            "Code": Object {
+              "constructInfo": Object {
+                "fqn": "constructs.Construct",
+                "version": "10.1.228",
+              },
+              "id": "Code",
+              "path": "root/my_function/Code",
+            },
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.1.228",
+          },
+          "display": Object {
+            "description": "A cloud function (FaaS)",
+            "title": "Function",
+          },
+          "id": "my_function",
+          "path": "root/my_function",
+        },
+      },
+      "constructInfo": Object {
+        "fqn": "constructs.Construct",
+        "version": "10.1.228",
+      },
+      "id": "root",
+      "path": "root",
+    },
+    "version": "tree-0.1",
   },
   "assets/my_function/index.js": "var $logger = function(env) {
   let handle = process.env[env];

--- a/libs/wingsdk/test/target-sim/__snapshots__/immutable-capture.test.ts.snap
+++ b/libs/wingsdk/test/target-sim/__snapshots__/immutable-capture.test.ts.snap
@@ -26,6 +26,93 @@ Object {
     ],
     "sdkVersion": "0.0.0",
   },
+  "app.wsim/tree.json": Object {
+    "tree": Object {
+      "children": Object {
+        "Function": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [
+              Object {
+                "direction": "outbound",
+                "implicit": true,
+                "relationship": "print",
+                "resource": "root/WingLogger",
+              },
+            ],
+            "wing:resource:stateful": false,
+          },
+          "children": Object {
+            "Code": Object {
+              "constructInfo": Object {
+                "fqn": "constructs.Construct",
+                "version": "10.1.228",
+              },
+              "id": "Code",
+              "path": "root/Function/Code",
+            },
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.1.228",
+          },
+          "display": Object {
+            "description": "A cloud function (FaaS)",
+            "title": "Function",
+          },
+          "id": "Function",
+          "path": "root/Function",
+        },
+        "WingLogger": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [
+              Object {
+                "direction": "inbound",
+                "implicit": true,
+                "relationship": "print",
+                "resource": "root/Function",
+              },
+            ],
+            "wing:resource:stateful": true,
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.1.228",
+          },
+          "display": Object {
+            "description": "A cloud logging facility",
+            "hidden": true,
+            "title": "Logger",
+          },
+          "id": "WingLogger",
+          "path": "root/WingLogger",
+        },
+        "foo": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [],
+            "wing:resource:stateful": false,
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.1.228",
+          },
+          "display": Object {
+            "description": "An inflight resource",
+            "hidden": true,
+            "title": "Inflight",
+          },
+          "id": "foo",
+          "path": "root/foo",
+        },
+      },
+      "constructInfo": Object {
+        "fqn": "constructs.Construct",
+        "version": "10.1.228",
+      },
+      "id": "root",
+      "path": "root",
+    },
+    "version": "tree-0.1",
+  },
   "assets/Function/index.js": "var $logger = function(env) {
   let handle = process.env[env];
   if (!handle) {
@@ -194,6 +281,125 @@ Object {
       },
     ],
     "sdkVersion": "0.0.0",
+  },
+  "app.wsim/tree.json": Object {
+    "tree": Object {
+      "children": Object {
+        "B1": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [],
+            "wing:resource:stateful": true,
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.1.228",
+          },
+          "display": Object {
+            "description": "A cloud object store",
+            "title": "Bucket",
+          },
+          "id": "B1",
+          "path": "root/B1",
+        },
+        "B2": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [],
+            "wing:resource:stateful": true,
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.1.228",
+          },
+          "display": Object {
+            "description": "A cloud object store",
+            "title": "Bucket",
+          },
+          "id": "B2",
+          "path": "root/B2",
+        },
+        "Function": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [
+              Object {
+                "direction": "outbound",
+                "implicit": true,
+                "relationship": "print",
+                "resource": "root/WingLogger",
+              },
+            ],
+            "wing:resource:stateful": false,
+          },
+          "children": Object {
+            "Code": Object {
+              "constructInfo": Object {
+                "fqn": "constructs.Construct",
+                "version": "10.1.228",
+              },
+              "id": "Code",
+              "path": "root/Function/Code",
+            },
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.1.228",
+          },
+          "display": Object {
+            "description": "A cloud function (FaaS)",
+            "title": "Function",
+          },
+          "id": "Function",
+          "path": "root/Function",
+        },
+        "WingLogger": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [
+              Object {
+                "direction": "inbound",
+                "implicit": true,
+                "relationship": "print",
+                "resource": "root/Function",
+              },
+            ],
+            "wing:resource:stateful": true,
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.1.228",
+          },
+          "display": Object {
+            "description": "A cloud logging facility",
+            "hidden": true,
+            "title": "Logger",
+          },
+          "id": "WingLogger",
+          "path": "root/WingLogger",
+        },
+        "foo": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [],
+            "wing:resource:stateful": false,
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.1.228",
+          },
+          "display": Object {
+            "description": "An inflight resource",
+            "hidden": true,
+            "title": "Inflight",
+          },
+          "id": "foo",
+          "path": "root/foo",
+        },
+      },
+      "constructInfo": Object {
+        "fqn": "constructs.Construct",
+        "version": "10.1.228",
+      },
+      "id": "root",
+      "path": "root",
+    },
+    "version": "tree-0.1",
   },
   "assets/Function/index.js": "var $logger = function(env) {
   let handle = process.env[env];
@@ -391,6 +597,93 @@ Object {
     ],
     "sdkVersion": "0.0.0",
   },
+  "app.wsim/tree.json": Object {
+    "tree": Object {
+      "children": Object {
+        "Function": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [
+              Object {
+                "direction": "outbound",
+                "implicit": true,
+                "relationship": "print",
+                "resource": "root/WingLogger",
+              },
+            ],
+            "wing:resource:stateful": false,
+          },
+          "children": Object {
+            "Code": Object {
+              "constructInfo": Object {
+                "fqn": "constructs.Construct",
+                "version": "10.1.228",
+              },
+              "id": "Code",
+              "path": "root/Function/Code",
+            },
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.1.228",
+          },
+          "display": Object {
+            "description": "A cloud function (FaaS)",
+            "title": "Function",
+          },
+          "id": "Function",
+          "path": "root/Function",
+        },
+        "WingLogger": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [
+              Object {
+                "direction": "inbound",
+                "implicit": true,
+                "relationship": "print",
+                "resource": "root/Function",
+              },
+            ],
+            "wing:resource:stateful": true,
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.1.228",
+          },
+          "display": Object {
+            "description": "A cloud logging facility",
+            "hidden": true,
+            "title": "Logger",
+          },
+          "id": "WingLogger",
+          "path": "root/WingLogger",
+        },
+        "foo": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [],
+            "wing:resource:stateful": false,
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.1.228",
+          },
+          "display": Object {
+            "description": "An inflight resource",
+            "hidden": true,
+            "title": "Inflight",
+          },
+          "id": "foo",
+          "path": "root/foo",
+        },
+      },
+      "constructInfo": Object {
+        "fqn": "constructs.Construct",
+        "version": "10.1.228",
+      },
+      "id": "root",
+      "path": "root",
+    },
+    "version": "tree-0.1",
+  },
   "assets/Function/index.js": "var $logger = function(env) {
   let handle = process.env[env];
   if (!handle) {
@@ -540,6 +833,93 @@ Object {
     ],
     "sdkVersion": "0.0.0",
   },
+  "app.wsim/tree.json": Object {
+    "tree": Object {
+      "children": Object {
+        "Function": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [
+              Object {
+                "direction": "outbound",
+                "implicit": true,
+                "relationship": "print",
+                "resource": "root/WingLogger",
+              },
+            ],
+            "wing:resource:stateful": false,
+          },
+          "children": Object {
+            "Code": Object {
+              "constructInfo": Object {
+                "fqn": "constructs.Construct",
+                "version": "10.1.228",
+              },
+              "id": "Code",
+              "path": "root/Function/Code",
+            },
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.1.228",
+          },
+          "display": Object {
+            "description": "A cloud function (FaaS)",
+            "title": "Function",
+          },
+          "id": "Function",
+          "path": "root/Function",
+        },
+        "WingLogger": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [
+              Object {
+                "direction": "inbound",
+                "implicit": true,
+                "relationship": "print",
+                "resource": "root/Function",
+              },
+            ],
+            "wing:resource:stateful": true,
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.1.228",
+          },
+          "display": Object {
+            "description": "A cloud logging facility",
+            "hidden": true,
+            "title": "Logger",
+          },
+          "id": "WingLogger",
+          "path": "root/WingLogger",
+        },
+        "foo": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [],
+            "wing:resource:stateful": false,
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.1.228",
+          },
+          "display": Object {
+            "description": "An inflight resource",
+            "hidden": true,
+            "title": "Inflight",
+          },
+          "id": "foo",
+          "path": "root/foo",
+        },
+      },
+      "constructInfo": Object {
+        "fqn": "constructs.Construct",
+        "version": "10.1.228",
+      },
+      "id": "root",
+      "path": "root",
+    },
+    "version": "tree-0.1",
+  },
   "assets/Function/index.js": "var $logger = function(env) {
   let handle = process.env[env];
   if (!handle) {
@@ -686,6 +1066,93 @@ Object {
     ],
     "sdkVersion": "0.0.0",
   },
+  "app.wsim/tree.json": Object {
+    "tree": Object {
+      "children": Object {
+        "Function": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [
+              Object {
+                "direction": "outbound",
+                "implicit": true,
+                "relationship": "print",
+                "resource": "root/WingLogger",
+              },
+            ],
+            "wing:resource:stateful": false,
+          },
+          "children": Object {
+            "Code": Object {
+              "constructInfo": Object {
+                "fqn": "constructs.Construct",
+                "version": "10.1.228",
+              },
+              "id": "Code",
+              "path": "root/Function/Code",
+            },
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.1.228",
+          },
+          "display": Object {
+            "description": "A cloud function (FaaS)",
+            "title": "Function",
+          },
+          "id": "Function",
+          "path": "root/Function",
+        },
+        "WingLogger": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [
+              Object {
+                "direction": "inbound",
+                "implicit": true,
+                "relationship": "print",
+                "resource": "root/Function",
+              },
+            ],
+            "wing:resource:stateful": true,
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.1.228",
+          },
+          "display": Object {
+            "description": "A cloud logging facility",
+            "hidden": true,
+            "title": "Logger",
+          },
+          "id": "WingLogger",
+          "path": "root/WingLogger",
+        },
+        "foo": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [],
+            "wing:resource:stateful": false,
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.1.228",
+          },
+          "display": Object {
+            "description": "An inflight resource",
+            "hidden": true,
+            "title": "Inflight",
+          },
+          "id": "foo",
+          "path": "root/foo",
+        },
+      },
+      "constructInfo": Object {
+        "fqn": "constructs.Construct",
+        "version": "10.1.228",
+      },
+      "id": "root",
+      "path": "root",
+    },
+    "version": "tree-0.1",
+  },
   "assets/Function/index.js": "var $logger = function(env) {
   let handle = process.env[env];
   if (!handle) {
@@ -828,6 +1295,93 @@ Object {
       },
     ],
     "sdkVersion": "0.0.0",
+  },
+  "app.wsim/tree.json": Object {
+    "tree": Object {
+      "children": Object {
+        "Function": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [
+              Object {
+                "direction": "outbound",
+                "implicit": true,
+                "relationship": "print",
+                "resource": "root/WingLogger",
+              },
+            ],
+            "wing:resource:stateful": false,
+          },
+          "children": Object {
+            "Code": Object {
+              "constructInfo": Object {
+                "fqn": "constructs.Construct",
+                "version": "10.1.228",
+              },
+              "id": "Code",
+              "path": "root/Function/Code",
+            },
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.1.228",
+          },
+          "display": Object {
+            "description": "A cloud function (FaaS)",
+            "title": "Function",
+          },
+          "id": "Function",
+          "path": "root/Function",
+        },
+        "WingLogger": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [
+              Object {
+                "direction": "inbound",
+                "implicit": true,
+                "relationship": "print",
+                "resource": "root/Function",
+              },
+            ],
+            "wing:resource:stateful": true,
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.1.228",
+          },
+          "display": Object {
+            "description": "A cloud logging facility",
+            "hidden": true,
+            "title": "Logger",
+          },
+          "id": "WingLogger",
+          "path": "root/WingLogger",
+        },
+        "foo": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [],
+            "wing:resource:stateful": false,
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.1.228",
+          },
+          "display": Object {
+            "description": "An inflight resource",
+            "hidden": true,
+            "title": "Inflight",
+          },
+          "id": "foo",
+          "path": "root/foo",
+        },
+      },
+      "constructInfo": Object {
+        "fqn": "constructs.Construct",
+        "version": "10.1.228",
+      },
+      "id": "root",
+      "path": "root",
+    },
+    "version": "tree-0.1",
   },
   "assets/Function/index.js": "var $logger = function(env) {
   let handle = process.env[env];
@@ -977,6 +1531,93 @@ Object {
       },
     ],
     "sdkVersion": "0.0.0",
+  },
+  "app.wsim/tree.json": Object {
+    "tree": Object {
+      "children": Object {
+        "Function": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [
+              Object {
+                "direction": "outbound",
+                "implicit": true,
+                "relationship": "print",
+                "resource": "root/WingLogger",
+              },
+            ],
+            "wing:resource:stateful": false,
+          },
+          "children": Object {
+            "Code": Object {
+              "constructInfo": Object {
+                "fqn": "constructs.Construct",
+                "version": "10.1.228",
+              },
+              "id": "Code",
+              "path": "root/Function/Code",
+            },
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.1.228",
+          },
+          "display": Object {
+            "description": "A cloud function (FaaS)",
+            "title": "Function",
+          },
+          "id": "Function",
+          "path": "root/Function",
+        },
+        "WingLogger": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [
+              Object {
+                "direction": "inbound",
+                "implicit": true,
+                "relationship": "print",
+                "resource": "root/Function",
+              },
+            ],
+            "wing:resource:stateful": true,
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.1.228",
+          },
+          "display": Object {
+            "description": "A cloud logging facility",
+            "hidden": true,
+            "title": "Logger",
+          },
+          "id": "WingLogger",
+          "path": "root/WingLogger",
+        },
+        "foo": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [],
+            "wing:resource:stateful": false,
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.1.228",
+          },
+          "display": Object {
+            "description": "An inflight resource",
+            "hidden": true,
+            "title": "Inflight",
+          },
+          "id": "foo",
+          "path": "root/foo",
+        },
+      },
+      "constructInfo": Object {
+        "fqn": "constructs.Construct",
+        "version": "10.1.228",
+      },
+      "id": "root",
+      "path": "root",
+    },
+    "version": "tree-0.1",
   },
   "assets/Function/index.js": "var $logger = function(env) {
   let handle = process.env[env];
@@ -1132,6 +1773,93 @@ Object {
       },
     ],
     "sdkVersion": "0.0.0",
+  },
+  "app.wsim/tree.json": Object {
+    "tree": Object {
+      "children": Object {
+        "Function": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [
+              Object {
+                "direction": "outbound",
+                "implicit": true,
+                "relationship": "print",
+                "resource": "root/WingLogger",
+              },
+            ],
+            "wing:resource:stateful": false,
+          },
+          "children": Object {
+            "Code": Object {
+              "constructInfo": Object {
+                "fqn": "constructs.Construct",
+                "version": "10.1.228",
+              },
+              "id": "Code",
+              "path": "root/Function/Code",
+            },
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.1.228",
+          },
+          "display": Object {
+            "description": "A cloud function (FaaS)",
+            "title": "Function",
+          },
+          "id": "Function",
+          "path": "root/Function",
+        },
+        "WingLogger": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [
+              Object {
+                "direction": "inbound",
+                "implicit": true,
+                "relationship": "print",
+                "resource": "root/Function",
+              },
+            ],
+            "wing:resource:stateful": true,
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.1.228",
+          },
+          "display": Object {
+            "description": "A cloud logging facility",
+            "hidden": true,
+            "title": "Logger",
+          },
+          "id": "WingLogger",
+          "path": "root/WingLogger",
+        },
+        "foo": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [],
+            "wing:resource:stateful": false,
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.1.228",
+          },
+          "display": Object {
+            "description": "An inflight resource",
+            "hidden": true,
+            "title": "Inflight",
+          },
+          "id": "foo",
+          "path": "root/foo",
+        },
+      },
+      "constructInfo": Object {
+        "fqn": "constructs.Construct",
+        "version": "10.1.228",
+      },
+      "id": "root",
+      "path": "root",
+    },
+    "version": "tree-0.1",
   },
   "assets/Function/index.js": "var $logger = function(env) {
   let handle = process.env[env];
@@ -1293,6 +2021,93 @@ Object {
       },
     ],
     "sdkVersion": "0.0.0",
+  },
+  "app.wsim/tree.json": Object {
+    "tree": Object {
+      "children": Object {
+        "Function": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [
+              Object {
+                "direction": "outbound",
+                "implicit": true,
+                "relationship": "print",
+                "resource": "root/WingLogger",
+              },
+            ],
+            "wing:resource:stateful": false,
+          },
+          "children": Object {
+            "Code": Object {
+              "constructInfo": Object {
+                "fqn": "constructs.Construct",
+                "version": "10.1.228",
+              },
+              "id": "Code",
+              "path": "root/Function/Code",
+            },
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.1.228",
+          },
+          "display": Object {
+            "description": "A cloud function (FaaS)",
+            "title": "Function",
+          },
+          "id": "Function",
+          "path": "root/Function",
+        },
+        "WingLogger": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [
+              Object {
+                "direction": "inbound",
+                "implicit": true,
+                "relationship": "print",
+                "resource": "root/Function",
+              },
+            ],
+            "wing:resource:stateful": true,
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.1.228",
+          },
+          "display": Object {
+            "description": "A cloud logging facility",
+            "hidden": true,
+            "title": "Logger",
+          },
+          "id": "WingLogger",
+          "path": "root/WingLogger",
+        },
+        "foo": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [],
+            "wing:resource:stateful": false,
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.1.228",
+          },
+          "display": Object {
+            "description": "An inflight resource",
+            "hidden": true,
+            "title": "Inflight",
+          },
+          "id": "foo",
+          "path": "root/foo",
+        },
+      },
+      "constructInfo": Object {
+        "fqn": "constructs.Construct",
+        "version": "10.1.228",
+      },
+      "id": "root",
+      "path": "root",
+    },
+    "version": "tree-0.1",
   },
   "assets/Function/index.js": "var $logger = function(env) {
   let handle = process.env[env];
@@ -1465,6 +2280,125 @@ Object {
       },
     ],
     "sdkVersion": "0.0.0",
+  },
+  "app.wsim/tree.json": Object {
+    "tree": Object {
+      "children": Object {
+        "B1": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [],
+            "wing:resource:stateful": true,
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.1.228",
+          },
+          "display": Object {
+            "description": "A cloud object store",
+            "title": "Bucket",
+          },
+          "id": "B1",
+          "path": "root/B1",
+        },
+        "B2": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [],
+            "wing:resource:stateful": true,
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.1.228",
+          },
+          "display": Object {
+            "description": "A cloud object store",
+            "title": "Bucket",
+          },
+          "id": "B2",
+          "path": "root/B2",
+        },
+        "Function": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [
+              Object {
+                "direction": "outbound",
+                "implicit": true,
+                "relationship": "print",
+                "resource": "root/WingLogger",
+              },
+            ],
+            "wing:resource:stateful": false,
+          },
+          "children": Object {
+            "Code": Object {
+              "constructInfo": Object {
+                "fqn": "constructs.Construct",
+                "version": "10.1.228",
+              },
+              "id": "Code",
+              "path": "root/Function/Code",
+            },
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.1.228",
+          },
+          "display": Object {
+            "description": "A cloud function (FaaS)",
+            "title": "Function",
+          },
+          "id": "Function",
+          "path": "root/Function",
+        },
+        "WingLogger": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [
+              Object {
+                "direction": "inbound",
+                "implicit": true,
+                "relationship": "print",
+                "resource": "root/Function",
+              },
+            ],
+            "wing:resource:stateful": true,
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.1.228",
+          },
+          "display": Object {
+            "description": "A cloud logging facility",
+            "hidden": true,
+            "title": "Logger",
+          },
+          "id": "WingLogger",
+          "path": "root/WingLogger",
+        },
+        "foo": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [],
+            "wing:resource:stateful": false,
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.1.228",
+          },
+          "display": Object {
+            "description": "An inflight resource",
+            "hidden": true,
+            "title": "Inflight",
+          },
+          "id": "foo",
+          "path": "root/foo",
+        },
+      },
+      "constructInfo": Object {
+        "fqn": "constructs.Construct",
+        "version": "10.1.228",
+      },
+      "id": "root",
+      "path": "root",
+    },
+    "version": "tree-0.1",
   },
   "assets/Function/index.js": "var $logger = function(env) {
   let handle = process.env[env];
@@ -1655,6 +2589,93 @@ Object {
     ],
     "sdkVersion": "0.0.0",
   },
+  "app.wsim/tree.json": Object {
+    "tree": Object {
+      "children": Object {
+        "Function": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [
+              Object {
+                "direction": "outbound",
+                "implicit": true,
+                "relationship": "print",
+                "resource": "root/WingLogger",
+              },
+            ],
+            "wing:resource:stateful": false,
+          },
+          "children": Object {
+            "Code": Object {
+              "constructInfo": Object {
+                "fqn": "constructs.Construct",
+                "version": "10.1.228",
+              },
+              "id": "Code",
+              "path": "root/Function/Code",
+            },
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.1.228",
+          },
+          "display": Object {
+            "description": "A cloud function (FaaS)",
+            "title": "Function",
+          },
+          "id": "Function",
+          "path": "root/Function",
+        },
+        "WingLogger": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [
+              Object {
+                "direction": "inbound",
+                "implicit": true,
+                "relationship": "print",
+                "resource": "root/Function",
+              },
+            ],
+            "wing:resource:stateful": true,
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.1.228",
+          },
+          "display": Object {
+            "description": "A cloud logging facility",
+            "hidden": true,
+            "title": "Logger",
+          },
+          "id": "WingLogger",
+          "path": "root/WingLogger",
+        },
+        "foo": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [],
+            "wing:resource:stateful": false,
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.1.228",
+          },
+          "display": Object {
+            "description": "An inflight resource",
+            "hidden": true,
+            "title": "Inflight",
+          },
+          "id": "foo",
+          "path": "root/foo",
+        },
+      },
+      "constructInfo": Object {
+        "fqn": "constructs.Construct",
+        "version": "10.1.228",
+      },
+      "id": "root",
+      "path": "root",
+    },
+    "version": "tree-0.1",
+  },
   "assets/Function/index.js": "var $logger = function(env) {
   let handle = process.env[env];
   if (!handle) {
@@ -1797,6 +2818,93 @@ Object {
       },
     ],
     "sdkVersion": "0.0.0",
+  },
+  "app.wsim/tree.json": Object {
+    "tree": Object {
+      "children": Object {
+        "Function": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [
+              Object {
+                "direction": "outbound",
+                "implicit": true,
+                "relationship": "print",
+                "resource": "root/WingLogger",
+              },
+            ],
+            "wing:resource:stateful": false,
+          },
+          "children": Object {
+            "Code": Object {
+              "constructInfo": Object {
+                "fqn": "constructs.Construct",
+                "version": "10.1.228",
+              },
+              "id": "Code",
+              "path": "root/Function/Code",
+            },
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.1.228",
+          },
+          "display": Object {
+            "description": "A cloud function (FaaS)",
+            "title": "Function",
+          },
+          "id": "Function",
+          "path": "root/Function",
+        },
+        "WingLogger": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [
+              Object {
+                "direction": "inbound",
+                "implicit": true,
+                "relationship": "print",
+                "resource": "root/Function",
+              },
+            ],
+            "wing:resource:stateful": true,
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.1.228",
+          },
+          "display": Object {
+            "description": "A cloud logging facility",
+            "hidden": true,
+            "title": "Logger",
+          },
+          "id": "WingLogger",
+          "path": "root/WingLogger",
+        },
+        "foo": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [],
+            "wing:resource:stateful": false,
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.1.228",
+          },
+          "display": Object {
+            "description": "An inflight resource",
+            "hidden": true,
+            "title": "Inflight",
+          },
+          "id": "foo",
+          "path": "root/foo",
+        },
+      },
+      "constructInfo": Object {
+        "fqn": "constructs.Construct",
+        "version": "10.1.228",
+      },
+      "id": "root",
+      "path": "root",
+    },
+    "version": "tree-0.1",
   },
   "assets/Function/index.js": "var $logger = function(env) {
   let handle = process.env[env];
@@ -1950,6 +3058,93 @@ Object {
     ],
     "sdkVersion": "0.0.0",
   },
+  "app.wsim/tree.json": Object {
+    "tree": Object {
+      "children": Object {
+        "Function": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [
+              Object {
+                "direction": "outbound",
+                "implicit": true,
+                "relationship": "print",
+                "resource": "root/WingLogger",
+              },
+            ],
+            "wing:resource:stateful": false,
+          },
+          "children": Object {
+            "Code": Object {
+              "constructInfo": Object {
+                "fqn": "constructs.Construct",
+                "version": "10.1.228",
+              },
+              "id": "Code",
+              "path": "root/Function/Code",
+            },
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.1.228",
+          },
+          "display": Object {
+            "description": "A cloud function (FaaS)",
+            "title": "Function",
+          },
+          "id": "Function",
+          "path": "root/Function",
+        },
+        "WingLogger": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [
+              Object {
+                "direction": "inbound",
+                "implicit": true,
+                "relationship": "print",
+                "resource": "root/Function",
+              },
+            ],
+            "wing:resource:stateful": true,
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.1.228",
+          },
+          "display": Object {
+            "description": "A cloud logging facility",
+            "hidden": true,
+            "title": "Logger",
+          },
+          "id": "WingLogger",
+          "path": "root/WingLogger",
+        },
+        "foo": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [],
+            "wing:resource:stateful": false,
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.1.228",
+          },
+          "display": Object {
+            "description": "An inflight resource",
+            "hidden": true,
+            "title": "Inflight",
+          },
+          "id": "foo",
+          "path": "root/foo",
+        },
+      },
+      "constructInfo": Object {
+        "fqn": "constructs.Construct",
+        "version": "10.1.228",
+      },
+      "id": "root",
+      "path": "root",
+    },
+    "version": "tree-0.1",
+  },
   "assets/Function/index.js": "var $logger = function(env) {
   let handle = process.env[env];
   if (!handle) {
@@ -2099,6 +3294,93 @@ Object {
     ],
     "sdkVersion": "0.0.0",
   },
+  "app.wsim/tree.json": Object {
+    "tree": Object {
+      "children": Object {
+        "Function": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [
+              Object {
+                "direction": "outbound",
+                "implicit": true,
+                "relationship": "print",
+                "resource": "root/WingLogger",
+              },
+            ],
+            "wing:resource:stateful": false,
+          },
+          "children": Object {
+            "Code": Object {
+              "constructInfo": Object {
+                "fqn": "constructs.Construct",
+                "version": "10.1.228",
+              },
+              "id": "Code",
+              "path": "root/Function/Code",
+            },
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.1.228",
+          },
+          "display": Object {
+            "description": "A cloud function (FaaS)",
+            "title": "Function",
+          },
+          "id": "Function",
+          "path": "root/Function",
+        },
+        "WingLogger": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [
+              Object {
+                "direction": "inbound",
+                "implicit": true,
+                "relationship": "print",
+                "resource": "root/Function",
+              },
+            ],
+            "wing:resource:stateful": true,
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.1.228",
+          },
+          "display": Object {
+            "description": "A cloud logging facility",
+            "hidden": true,
+            "title": "Logger",
+          },
+          "id": "WingLogger",
+          "path": "root/WingLogger",
+        },
+        "foo": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [],
+            "wing:resource:stateful": false,
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.1.228",
+          },
+          "display": Object {
+            "description": "An inflight resource",
+            "hidden": true,
+            "title": "Inflight",
+          },
+          "id": "foo",
+          "path": "root/foo",
+        },
+      },
+      "constructInfo": Object {
+        "fqn": "constructs.Construct",
+        "version": "10.1.228",
+      },
+      "id": "root",
+      "path": "root",
+    },
+    "version": "tree-0.1",
+  },
   "assets/Function/index.js": "var $logger = function(env) {
   let handle = process.env[env];
   if (!handle) {
@@ -2244,6 +3526,93 @@ Object {
       },
     ],
     "sdkVersion": "0.0.0",
+  },
+  "app.wsim/tree.json": Object {
+    "tree": Object {
+      "children": Object {
+        "Function": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [
+              Object {
+                "direction": "outbound",
+                "implicit": true,
+                "relationship": "print",
+                "resource": "root/WingLogger",
+              },
+            ],
+            "wing:resource:stateful": false,
+          },
+          "children": Object {
+            "Code": Object {
+              "constructInfo": Object {
+                "fqn": "constructs.Construct",
+                "version": "10.1.228",
+              },
+              "id": "Code",
+              "path": "root/Function/Code",
+            },
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.1.228",
+          },
+          "display": Object {
+            "description": "A cloud function (FaaS)",
+            "title": "Function",
+          },
+          "id": "Function",
+          "path": "root/Function",
+        },
+        "WingLogger": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [
+              Object {
+                "direction": "inbound",
+                "implicit": true,
+                "relationship": "print",
+                "resource": "root/Function",
+              },
+            ],
+            "wing:resource:stateful": true,
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.1.228",
+          },
+          "display": Object {
+            "description": "A cloud logging facility",
+            "hidden": true,
+            "title": "Logger",
+          },
+          "id": "WingLogger",
+          "path": "root/WingLogger",
+        },
+        "foo": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [],
+            "wing:resource:stateful": false,
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.1.228",
+          },
+          "display": Object {
+            "description": "An inflight resource",
+            "hidden": true,
+            "title": "Inflight",
+          },
+          "id": "foo",
+          "path": "root/foo",
+        },
+      },
+      "constructInfo": Object {
+        "fqn": "constructs.Construct",
+        "version": "10.1.228",
+      },
+      "id": "root",
+      "path": "root",
+    },
+    "version": "tree-0.1",
   },
   "assets/Function/index.js": "var $logger = function(env) {
   let handle = process.env[env];
@@ -2396,6 +3765,93 @@ Object {
       },
     ],
     "sdkVersion": "0.0.0",
+  },
+  "app.wsim/tree.json": Object {
+    "tree": Object {
+      "children": Object {
+        "Function": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [
+              Object {
+                "direction": "outbound",
+                "implicit": true,
+                "relationship": "print",
+                "resource": "root/WingLogger",
+              },
+            ],
+            "wing:resource:stateful": false,
+          },
+          "children": Object {
+            "Code": Object {
+              "constructInfo": Object {
+                "fqn": "constructs.Construct",
+                "version": "10.1.228",
+              },
+              "id": "Code",
+              "path": "root/Function/Code",
+            },
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.1.228",
+          },
+          "display": Object {
+            "description": "A cloud function (FaaS)",
+            "title": "Function",
+          },
+          "id": "Function",
+          "path": "root/Function",
+        },
+        "WingLogger": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [
+              Object {
+                "direction": "inbound",
+                "implicit": true,
+                "relationship": "print",
+                "resource": "root/Function",
+              },
+            ],
+            "wing:resource:stateful": true,
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.1.228",
+          },
+          "display": Object {
+            "description": "A cloud logging facility",
+            "hidden": true,
+            "title": "Logger",
+          },
+          "id": "WingLogger",
+          "path": "root/WingLogger",
+        },
+        "foo": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [],
+            "wing:resource:stateful": false,
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.1.228",
+          },
+          "display": Object {
+            "description": "An inflight resource",
+            "hidden": true,
+            "title": "Inflight",
+          },
+          "id": "foo",
+          "path": "root/foo",
+        },
+      },
+      "constructInfo": Object {
+        "fqn": "constructs.Construct",
+        "version": "10.1.228",
+      },
+      "id": "root",
+      "path": "root",
+    },
+    "version": "tree-0.1",
   },
   "assets/Function/index.js": "var $logger = function(env) {
   let handle = process.env[env];
@@ -2598,6 +4054,173 @@ Object {
       },
     ],
     "sdkVersion": "0.0.0",
+  },
+  "app.wsim/tree.json": Object {
+    "tree": Object {
+      "children": Object {
+        "B1": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [],
+            "wing:resource:stateful": true,
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.1.228",
+          },
+          "display": Object {
+            "description": "A cloud object store",
+            "title": "Bucket",
+          },
+          "id": "B1",
+          "path": "root/B1",
+        },
+        "B2": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [],
+            "wing:resource:stateful": true,
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.1.228",
+          },
+          "display": Object {
+            "description": "A cloud object store",
+            "title": "Bucket",
+          },
+          "id": "B2",
+          "path": "root/B2",
+        },
+        "B3": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [],
+            "wing:resource:stateful": true,
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.1.228",
+          },
+          "display": Object {
+            "description": "A cloud object store",
+            "title": "Bucket",
+          },
+          "id": "B3",
+          "path": "root/B3",
+        },
+        "B4": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [],
+            "wing:resource:stateful": true,
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.1.228",
+          },
+          "display": Object {
+            "description": "A cloud object store",
+            "title": "Bucket",
+          },
+          "id": "B4",
+          "path": "root/B4",
+        },
+        "B5": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [],
+            "wing:resource:stateful": true,
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.1.228",
+          },
+          "display": Object {
+            "description": "A cloud object store",
+            "title": "Bucket",
+          },
+          "id": "B5",
+          "path": "root/B5",
+        },
+        "Function": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [
+              Object {
+                "direction": "outbound",
+                "implicit": true,
+                "relationship": "print",
+                "resource": "root/WingLogger",
+              },
+            ],
+            "wing:resource:stateful": false,
+          },
+          "children": Object {
+            "Code": Object {
+              "constructInfo": Object {
+                "fqn": "constructs.Construct",
+                "version": "10.1.228",
+              },
+              "id": "Code",
+              "path": "root/Function/Code",
+            },
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.1.228",
+          },
+          "display": Object {
+            "description": "A cloud function (FaaS)",
+            "title": "Function",
+          },
+          "id": "Function",
+          "path": "root/Function",
+        },
+        "WingLogger": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [
+              Object {
+                "direction": "inbound",
+                "implicit": true,
+                "relationship": "print",
+                "resource": "root/Function",
+              },
+            ],
+            "wing:resource:stateful": true,
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.1.228",
+          },
+          "display": Object {
+            "description": "A cloud logging facility",
+            "hidden": true,
+            "title": "Logger",
+          },
+          "id": "WingLogger",
+          "path": "root/WingLogger",
+        },
+        "foo": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [],
+            "wing:resource:stateful": false,
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.1.228",
+          },
+          "display": Object {
+            "description": "An inflight resource",
+            "hidden": true,
+            "title": "Inflight",
+          },
+          "id": "foo",
+          "path": "root/foo",
+        },
+      },
+      "constructInfo": Object {
+        "fqn": "constructs.Construct",
+        "version": "10.1.228",
+      },
+      "id": "root",
+      "path": "root",
+    },
+    "version": "tree-0.1",
   },
   "assets/Function/index.js": "var $logger = function(env) {
   let handle = process.env[env];

--- a/libs/wingsdk/test/target-sim/__snapshots__/logger.test.ts.snap
+++ b/libs/wingsdk/test/target-sim/__snapshots__/logger.test.ts.snap
@@ -38,6 +38,93 @@ Object {
     ],
     "sdkVersion": "0.0.0",
   },
+  "app.wsim/tree.json": Object {
+    "tree": Object {
+      "children": Object {
+        "Handler": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [],
+            "wing:resource:stateful": false,
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.1.228",
+          },
+          "display": Object {
+            "description": "An inflight resource",
+            "hidden": true,
+            "title": "Inflight",
+          },
+          "id": "Handler",
+          "path": "root/Handler",
+        },
+        "WingLogger": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [
+              Object {
+                "direction": "inbound",
+                "implicit": true,
+                "relationship": "print",
+                "resource": "root/my_function",
+              },
+            ],
+            "wing:resource:stateful": true,
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.1.228",
+          },
+          "display": Object {
+            "description": "A cloud logging facility",
+            "hidden": true,
+            "title": "Logger",
+          },
+          "id": "WingLogger",
+          "path": "root/WingLogger",
+        },
+        "my_function": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [
+              Object {
+                "direction": "outbound",
+                "implicit": true,
+                "relationship": "print",
+                "resource": "root/WingLogger",
+              },
+            ],
+            "wing:resource:stateful": false,
+          },
+          "children": Object {
+            "Code": Object {
+              "constructInfo": Object {
+                "fqn": "constructs.Construct",
+                "version": "10.1.228",
+              },
+              "id": "Code",
+              "path": "root/my_function/Code",
+            },
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.1.228",
+          },
+          "display": Object {
+            "description": "A cloud function (FaaS)",
+            "title": "Function",
+          },
+          "id": "my_function",
+          "path": "root/my_function",
+        },
+      },
+      "constructInfo": Object {
+        "fqn": "constructs.Construct",
+        "version": "10.1.228",
+      },
+      "id": "root",
+      "path": "root",
+    },
+    "version": "tree-0.1",
+  },
   "assets/my_function/index.js": "var $logger = function(env) {
   let handle = process.env[env];
   if (!handle) {

--- a/libs/wingsdk/test/target-sim/__snapshots__/queue.test.ts.snap
+++ b/libs/wingsdk/test/target-sim/__snapshots__/queue.test.ts.snap
@@ -23,6 +23,52 @@ Object {
     ],
     "sdkVersion": "0.0.0",
   },
+  "app.wsim/tree.json": Object {
+    "tree": Object {
+      "children": Object {
+        "WingLogger": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [],
+            "wing:resource:stateful": true,
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.1.228",
+          },
+          "display": Object {
+            "description": "A cloud logging facility",
+            "hidden": true,
+            "title": "Logger",
+          },
+          "id": "WingLogger",
+          "path": "root/WingLogger",
+        },
+        "my_queue": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [],
+            "wing:resource:stateful": true,
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.1.228",
+          },
+          "display": Object {
+            "description": "A distributed message queue",
+            "title": "Queue",
+          },
+          "id": "my_queue",
+          "path": "root/my_queue",
+        },
+      },
+      "constructInfo": Object {
+        "fqn": "constructs.Construct",
+        "version": "10.1.228",
+      },
+      "id": "root",
+      "path": "root",
+    },
+    "version": "tree-0.1",
+  },
   "tree.json": Object {
     "tree": Object {
       "children": Object {
@@ -130,6 +176,147 @@ Object {
       },
     ],
     "sdkVersion": "0.0.0",
+  },
+  "app.wsim/tree.json": Object {
+    "tree": Object {
+      "children": Object {
+        "Handler": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [
+              Object {
+                "direction": "inbound",
+                "implicit": false,
+                "relationship": "handle",
+                "resource": "root/my_queue-OnMessage-e645076f",
+              },
+            ],
+            "wing:resource:stateful": false,
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.1.228",
+          },
+          "display": Object {
+            "description": "An inflight resource",
+            "hidden": true,
+            "title": "Inflight",
+          },
+          "id": "Handler",
+          "path": "root/Handler",
+        },
+        "WingLogger": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [
+              Object {
+                "direction": "inbound",
+                "implicit": true,
+                "relationship": "print",
+                "resource": "root/my_queue-OnMessage-e645076f",
+              },
+            ],
+            "wing:resource:stateful": true,
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.1.228",
+          },
+          "display": Object {
+            "description": "A cloud logging facility",
+            "hidden": true,
+            "title": "Logger",
+          },
+          "id": "WingLogger",
+          "path": "root/WingLogger",
+        },
+        "my_queue": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [
+              Object {
+                "direction": "outbound",
+                "implicit": false,
+                "relationship": "on_message",
+                "resource": "root/my_queue-OnMessage-e645076f",
+              },
+            ],
+            "wing:resource:stateful": true,
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.1.228",
+          },
+          "display": Object {
+            "description": "A distributed message queue",
+            "title": "Queue",
+          },
+          "id": "my_queue",
+          "path": "root/my_queue",
+        },
+        "my_queue-OnMessage-e645076f": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [
+              Object {
+                "direction": "outbound",
+                "implicit": false,
+                "relationship": "handle",
+                "resource": "root/Handler",
+              },
+              Object {
+                "direction": "outbound",
+                "implicit": true,
+                "relationship": "print",
+                "resource": "root/WingLogger",
+              },
+              Object {
+                "direction": "inbound",
+                "implicit": false,
+                "relationship": "on_message",
+                "resource": "root/my_queue",
+              },
+            ],
+            "wing:resource:stateful": false,
+          },
+          "children": Object {
+            "Code": Object {
+              "constructInfo": Object {
+                "fqn": "constructs.Construct",
+                "version": "10.1.228",
+              },
+              "id": "Code",
+              "path": "root/my_queue-OnMessage-e645076f/Code",
+            },
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.1.228",
+          },
+          "display": Object {
+            "description": "A cloud function (FaaS)",
+            "title": "Function",
+          },
+          "id": "my_queue-OnMessage-e645076f",
+          "path": "root/my_queue-OnMessage-e645076f",
+        },
+        "my_queue-OnMessageHandler-e645076f": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [],
+            "wing:resource:stateful": false,
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.1.228",
+          },
+          "id": "my_queue-OnMessageHandler-e645076f",
+          "path": "root/my_queue-OnMessageHandler-e645076f",
+        },
+      },
+      "constructInfo": Object {
+        "fqn": "constructs.Construct",
+        "version": "10.1.228",
+      },
+      "id": "root",
+      "path": "root",
+    },
+    "version": "tree-0.1",
   },
   "assets/my_queue-OnMessage-e645076f/index.js": "var __defProp = Object.defineProperty;
 var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
@@ -382,6 +569,52 @@ Object {
     ],
     "sdkVersion": "0.0.0",
   },
+  "app.wsim/tree.json": Object {
+    "tree": Object {
+      "children": Object {
+        "WingLogger": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [],
+            "wing:resource:stateful": true,
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.1.228",
+          },
+          "display": Object {
+            "description": "A cloud logging facility",
+            "hidden": true,
+            "title": "Logger",
+          },
+          "id": "WingLogger",
+          "path": "root/WingLogger",
+        },
+        "my_queue": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [],
+            "wing:resource:stateful": true,
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.1.228",
+          },
+          "display": Object {
+            "description": "A distributed message queue",
+            "title": "Queue",
+          },
+          "id": "my_queue",
+          "path": "root/my_queue",
+        },
+      },
+      "constructInfo": Object {
+        "fqn": "constructs.Construct",
+        "version": "10.1.228",
+      },
+      "id": "root",
+      "path": "root",
+    },
+    "version": "tree-0.1",
+  },
   "tree.json": Object {
     "tree": Object {
       "children": Object {
@@ -493,6 +726,147 @@ Object {
       },
     ],
     "sdkVersion": "0.0.0",
+  },
+  "app.wsim/tree.json": Object {
+    "tree": Object {
+      "children": Object {
+        "Handler": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [
+              Object {
+                "direction": "inbound",
+                "implicit": false,
+                "relationship": "handle",
+                "resource": "root/my_queue-OnMessage-e645076f",
+              },
+            ],
+            "wing:resource:stateful": false,
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.1.228",
+          },
+          "display": Object {
+            "description": "An inflight resource",
+            "hidden": true,
+            "title": "Inflight",
+          },
+          "id": "Handler",
+          "path": "root/Handler",
+        },
+        "WingLogger": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [
+              Object {
+                "direction": "inbound",
+                "implicit": true,
+                "relationship": "print",
+                "resource": "root/my_queue-OnMessage-e645076f",
+              },
+            ],
+            "wing:resource:stateful": true,
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.1.228",
+          },
+          "display": Object {
+            "description": "A cloud logging facility",
+            "hidden": true,
+            "title": "Logger",
+          },
+          "id": "WingLogger",
+          "path": "root/WingLogger",
+        },
+        "my_queue": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [
+              Object {
+                "direction": "outbound",
+                "implicit": false,
+                "relationship": "on_message",
+                "resource": "root/my_queue-OnMessage-e645076f",
+              },
+            ],
+            "wing:resource:stateful": true,
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.1.228",
+          },
+          "display": Object {
+            "description": "A distributed message queue",
+            "title": "Queue",
+          },
+          "id": "my_queue",
+          "path": "root/my_queue",
+        },
+        "my_queue-OnMessage-e645076f": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [
+              Object {
+                "direction": "outbound",
+                "implicit": false,
+                "relationship": "handle",
+                "resource": "root/Handler",
+              },
+              Object {
+                "direction": "outbound",
+                "implicit": true,
+                "relationship": "print",
+                "resource": "root/WingLogger",
+              },
+              Object {
+                "direction": "inbound",
+                "implicit": false,
+                "relationship": "on_message",
+                "resource": "root/my_queue",
+              },
+            ],
+            "wing:resource:stateful": false,
+          },
+          "children": Object {
+            "Code": Object {
+              "constructInfo": Object {
+                "fqn": "constructs.Construct",
+                "version": "10.1.228",
+              },
+              "id": "Code",
+              "path": "root/my_queue-OnMessage-e645076f/Code",
+            },
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.1.228",
+          },
+          "display": Object {
+            "description": "A cloud function (FaaS)",
+            "title": "Function",
+          },
+          "id": "my_queue-OnMessage-e645076f",
+          "path": "root/my_queue-OnMessage-e645076f",
+        },
+        "my_queue-OnMessageHandler-e645076f": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [],
+            "wing:resource:stateful": false,
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.1.228",
+          },
+          "id": "my_queue-OnMessageHandler-e645076f",
+          "path": "root/my_queue-OnMessageHandler-e645076f",
+        },
+      },
+      "constructInfo": Object {
+        "fqn": "constructs.Construct",
+        "version": "10.1.228",
+      },
+      "id": "root",
+      "path": "root",
+    },
+    "version": "tree-0.1",
   },
   "assets/my_queue-OnMessage-e645076f/index.js": "var __defProp = Object.defineProperty;
 var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
@@ -765,6 +1139,147 @@ Object {
       },
     ],
     "sdkVersion": "0.0.0",
+  },
+  "app.wsim/tree.json": Object {
+    "tree": Object {
+      "children": Object {
+        "Handler": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [
+              Object {
+                "direction": "inbound",
+                "implicit": false,
+                "relationship": "handle",
+                "resource": "root/my_queue-OnMessage-e645076f",
+              },
+            ],
+            "wing:resource:stateful": false,
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.1.228",
+          },
+          "display": Object {
+            "description": "An inflight resource",
+            "hidden": true,
+            "title": "Inflight",
+          },
+          "id": "Handler",
+          "path": "root/Handler",
+        },
+        "WingLogger": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [
+              Object {
+                "direction": "inbound",
+                "implicit": true,
+                "relationship": "print",
+                "resource": "root/my_queue-OnMessage-e645076f",
+              },
+            ],
+            "wing:resource:stateful": true,
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.1.228",
+          },
+          "display": Object {
+            "description": "A cloud logging facility",
+            "hidden": true,
+            "title": "Logger",
+          },
+          "id": "WingLogger",
+          "path": "root/WingLogger",
+        },
+        "my_queue": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [
+              Object {
+                "direction": "outbound",
+                "implicit": false,
+                "relationship": "on_message",
+                "resource": "root/my_queue-OnMessage-e645076f",
+              },
+            ],
+            "wing:resource:stateful": true,
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.1.228",
+          },
+          "display": Object {
+            "description": "A distributed message queue",
+            "title": "Queue",
+          },
+          "id": "my_queue",
+          "path": "root/my_queue",
+        },
+        "my_queue-OnMessage-e645076f": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [
+              Object {
+                "direction": "outbound",
+                "implicit": false,
+                "relationship": "handle",
+                "resource": "root/Handler",
+              },
+              Object {
+                "direction": "outbound",
+                "implicit": true,
+                "relationship": "print",
+                "resource": "root/WingLogger",
+              },
+              Object {
+                "direction": "inbound",
+                "implicit": false,
+                "relationship": "on_message",
+                "resource": "root/my_queue",
+              },
+            ],
+            "wing:resource:stateful": false,
+          },
+          "children": Object {
+            "Code": Object {
+              "constructInfo": Object {
+                "fqn": "constructs.Construct",
+                "version": "10.1.228",
+              },
+              "id": "Code",
+              "path": "root/my_queue-OnMessage-e645076f/Code",
+            },
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.1.228",
+          },
+          "display": Object {
+            "description": "A cloud function (FaaS)",
+            "title": "Function",
+          },
+          "id": "my_queue-OnMessage-e645076f",
+          "path": "root/my_queue-OnMessage-e645076f",
+        },
+        "my_queue-OnMessageHandler-e645076f": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [],
+            "wing:resource:stateful": false,
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.1.228",
+          },
+          "id": "my_queue-OnMessageHandler-e645076f",
+          "path": "root/my_queue-OnMessageHandler-e645076f",
+        },
+      },
+      "constructInfo": Object {
+        "fqn": "constructs.Construct",
+        "version": "10.1.228",
+      },
+      "id": "root",
+      "path": "root",
+    },
+    "version": "tree-0.1",
   },
   "assets/my_queue-OnMessage-e645076f/index.js": "var __defProp = Object.defineProperty;
 var __getOwnPropDesc = Object.getOwnPropertyDescriptor;

--- a/libs/wingsdk/test/target-sim/__snapshots__/topic.test.ts.snap
+++ b/libs/wingsdk/test/target-sim/__snapshots__/topic.test.ts.snap
@@ -21,6 +21,52 @@ Object {
     ],
     "sdkVersion": "0.0.0",
   },
+  "app.wsim/tree.json": Object {
+    "tree": Object {
+      "children": Object {
+        "WingLogger": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [],
+            "wing:resource:stateful": true,
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.1.228",
+          },
+          "display": Object {
+            "description": "A cloud logging facility",
+            "hidden": true,
+            "title": "Logger",
+          },
+          "id": "WingLogger",
+          "path": "root/WingLogger",
+        },
+        "my_topic": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [],
+            "wing:resource:stateful": true,
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.1.228",
+          },
+          "display": Object {
+            "description": "A pub/sub notification topic",
+            "title": "Topic",
+          },
+          "id": "my_topic",
+          "path": "root/my_topic",
+        },
+      },
+      "constructInfo": Object {
+        "fqn": "constructs.Construct",
+        "version": "10.1.228",
+      },
+      "id": "root",
+      "path": "root",
+    },
+    "version": "tree-0.1",
+  },
   "tree.json": Object {
     "tree": Object {
       "children": Object {

--- a/tools/hangar/src/__snapshots__/cli.test.ts.snap
+++ b/tools/hangar/src/__snapshots__/cli.test.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1
 
-exports[`wing compile --target tf-aws anon_function.w > cdk.tf.json 1`] = `
+exports[`wing compile --target tf-aws anon_function.w > main.tf.json 1`] = `
 {
   "//": {
     "metadata": {
@@ -15,22 +15,6 @@ exports[`wing compile --target tf-aws anon_function.w > cdk.tf.json 1`] = `
       {},
     ],
   },
-}
-`;
-
-exports[`wing compile --target tf-aws anon_function.w > manifest.json 1`] = `
-{
-  "stacks": {
-    "root": {
-      "annotations": [],
-      "constructPath": "root",
-      "dependencies": [],
-      "name": "root",
-      "synthesizedStackPath": "stacks/root/cdk.tf.json",
-      "workingDirectory": "stacks/root",
-    },
-  },
-  "version": "0.15.2",
 }
 `;
 
@@ -76,7 +60,19 @@ constructor() {
 new MyApp().synth();"
 `;
 
-exports[`wing compile --target tf-aws asynchronous_model_implicit_await_in_functions.w > cdk.tf.json 1`] = `
+exports[`wing compile --target tf-aws asynchronous_model_implicit_await_in_functions.w > index.js 1`] = `
+"async handle(s) { const { str_to_str } = this; {
+  (await str_to_str.invoke(\\"one\\"));
+  {console.log((await str_to_str.invoke(\\"two\\")))};
+} };"
+`;
+
+exports[`wing compile --target tf-aws asynchronous_model_implicit_await_in_functions.w > index.js 2`] = `
+"async handle(s) { const {  } = this; {
+} };"
+`;
+
+exports[`wing compile --target tf-aws asynchronous_model_implicit_await_in_functions.w > main.tf.json 1`] = `
 {
   "//": {
     "metadata": {
@@ -235,34 +231,6 @@ exports[`wing compile --target tf-aws asynchronous_model_implicit_await_in_funct
 }
 `;
 
-exports[`wing compile --target tf-aws asynchronous_model_implicit_await_in_functions.w > index.js 1`] = `
-"async handle(s) { const { str_to_str } = this; {
-  (await str_to_str.invoke(\\"one\\"));
-  {console.log((await str_to_str.invoke(\\"two\\")))};
-} };"
-`;
-
-exports[`wing compile --target tf-aws asynchronous_model_implicit_await_in_functions.w > index.js 2`] = `
-"async handle(s) { const {  } = this; {
-} };"
-`;
-
-exports[`wing compile --target tf-aws asynchronous_model_implicit_await_in_functions.w > manifest.json 1`] = `
-{
-  "stacks": {
-    "root": {
-      "annotations": [],
-      "constructPath": "root",
-      "dependencies": [],
-      "name": "root",
-      "synthesizedStackPath": "stacks/root/cdk.tf.json",
-      "workingDirectory": "stacks/root",
-    },
-  },
-  "version": "0.15.2",
-}
-`;
-
 exports[`wing compile --target tf-aws asynchronous_model_implicit_await_in_functions.w > preflight.js 1`] = `
 "const $stdlib = require('@winglang/sdk');
 const $outdir = process.env.WINGSDK_SYNTH_DIR ?? \\".\\";
@@ -314,7 +282,20 @@ constructor() {
 new MyApp().synth();"
 `;
 
-exports[`wing compile --target tf-aws capture_containers.w > cdk.tf.json 1`] = `
+exports[`wing compile --target tf-aws capture_containers.w > index.js 1`] = `
+"async handle(s) { const { arr, arr_of_map, my_map, my_set } = this; {
+  {((cond) => {if (!cond) throw new Error(\`assertion failed: '((await arr.at(0)) === \\"hello\\")'\`)})(((await arr.at(0)) === \\"hello\\"))};
+  {((cond) => {if (!cond) throw new Error(\`assertion failed: '((await arr.at(1)) === \\"world\\")'\`)})(((await arr.at(1)) === \\"world\\"))};
+  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(arr.length === 2)'\`)})((arr.length === 2))};
+  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(await my_set.has(\\"my\\"))'\`)})((await my_set.has(\\"my\\")))};
+  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(my_set.size === 2)'\`)})((my_set.size === 2))};
+  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(await my_map.has(\\"world\\"))'\`)})((await my_map.has(\\"world\\")))};
+  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(my_map.size === 2)'\`)})((my_map.size === 2))};
+  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(await (await arr_of_map.at(0)).has(\\"bang\\"))'\`)})((await (await arr_of_map.at(0)).has(\\"bang\\")))};
+} };"
+`;
+
+exports[`wing compile --target tf-aws capture_containers.w > main.tf.json 1`] = `
 {
   "//": {
     "metadata": {
@@ -414,35 +395,6 @@ exports[`wing compile --target tf-aws capture_containers.w > cdk.tf.json 1`] = `
 }
 `;
 
-exports[`wing compile --target tf-aws capture_containers.w > index.js 1`] = `
-"async handle(s) { const { arr, arr_of_map, my_map, my_set } = this; {
-  {((cond) => {if (!cond) throw new Error(\`assertion failed: '((await arr.at(0)) === \\"hello\\")'\`)})(((await arr.at(0)) === \\"hello\\"))};
-  {((cond) => {if (!cond) throw new Error(\`assertion failed: '((await arr.at(1)) === \\"world\\")'\`)})(((await arr.at(1)) === \\"world\\"))};
-  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(arr.length === 2)'\`)})((arr.length === 2))};
-  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(await my_set.has(\\"my\\"))'\`)})((await my_set.has(\\"my\\")))};
-  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(my_set.size === 2)'\`)})((my_set.size === 2))};
-  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(await my_map.has(\\"world\\"))'\`)})((await my_map.has(\\"world\\")))};
-  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(my_map.size === 2)'\`)})((my_map.size === 2))};
-  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(await (await arr_of_map.at(0)).has(\\"bang\\"))'\`)})((await (await arr_of_map.at(0)).has(\\"bang\\")))};
-} };"
-`;
-
-exports[`wing compile --target tf-aws capture_containers.w > manifest.json 1`] = `
-{
-  "stacks": {
-    "root": {
-      "annotations": [],
-      "constructPath": "root",
-      "dependencies": [],
-      "name": "root",
-      "synthesizedStackPath": "stacks/root/cdk.tf.json",
-      "workingDirectory": "stacks/root",
-    },
-  },
-  "version": "0.15.2",
-}
-`;
-
 exports[`wing compile --target tf-aws capture_containers.w > preflight.js 1`] = `
 "const $stdlib = require('@winglang/sdk');
 const $outdir = process.env.WINGSDK_SYNTH_DIR ?? \\".\\";
@@ -491,7 +443,21 @@ constructor() {
 new MyApp().synth();"
 `;
 
-exports[`wing compile --target tf-aws capture_containers_of_resources.w > cdk.tf.json 1`] = `
+exports[`wing compile --target tf-aws capture_containers_of_resources.w > index.js 1`] = `
+"async handle(s) { const { arr, map, set } = this; {
+  const b1 = (await arr.at(0));
+  const b2 = (await arr.at(1));
+  const q = (await map.get(\\"my_queue\\"));
+  (await b1.put(\\"file1.txt\\",\\"boom\\"));
+  {((cond) => {if (!cond) throw new Error(\`assertion failed: '((await b2.list()).length === 0)'\`)})(((await b2.list()).length === 0))};
+  {((cond) => {if (!cond) throw new Error(\`assertion failed: '((await b1.get(\\"file1.txt\\")) === \\"boom\\")'\`)})(((await b1.get(\\"file1.txt\\")) === \\"boom\\"))};
+  (await q.push(\\"hello\\"));
+  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(await set.has(\\"foo\\"))'\`)})((await set.has(\\"foo\\")))};
+  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(set.size === 2)'\`)})((set.size === 2))};
+} };"
+`;
+
+exports[`wing compile --target tf-aws capture_containers_of_resources.w > main.tf.json 1`] = `
 {
   "//": {
     "metadata": {
@@ -674,36 +640,6 @@ exports[`wing compile --target tf-aws capture_containers_of_resources.w > cdk.tf
 }
 `;
 
-exports[`wing compile --target tf-aws capture_containers_of_resources.w > index.js 1`] = `
-"async handle(s) { const { arr, map, set } = this; {
-  const b1 = (await arr.at(0));
-  const b2 = (await arr.at(1));
-  const q = (await map.get(\\"my_queue\\"));
-  (await b1.put(\\"file1.txt\\",\\"boom\\"));
-  {((cond) => {if (!cond) throw new Error(\`assertion failed: '((await b2.list()).length === 0)'\`)})(((await b2.list()).length === 0))};
-  {((cond) => {if (!cond) throw new Error(\`assertion failed: '((await b1.get(\\"file1.txt\\")) === \\"boom\\")'\`)})(((await b1.get(\\"file1.txt\\")) === \\"boom\\"))};
-  (await q.push(\\"hello\\"));
-  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(await set.has(\\"foo\\"))'\`)})((await set.has(\\"foo\\")))};
-  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(set.size === 2)'\`)})((set.size === 2))};
-} };"
-`;
-
-exports[`wing compile --target tf-aws capture_containers_of_resources.w > manifest.json 1`] = `
-{
-  "stacks": {
-    "root": {
-      "annotations": [],
-      "constructPath": "root",
-      "dependencies": [],
-      "name": "root",
-      "synthesizedStackPath": "stacks/root/cdk.tf.json",
-      "workingDirectory": "stacks/root",
-    },
-  },
-  "version": "0.15.2",
-}
-`;
-
 exports[`wing compile --target tf-aws capture_containers_of_resources.w > preflight.js 1`] = `
 "const $stdlib = require('@winglang/sdk');
 const $outdir = process.env.WINGSDK_SYNTH_DIR ?? \\".\\";
@@ -749,7 +685,15 @@ constructor() {
 new MyApp().synth();"
 `;
 
-exports[`wing compile --target tf-aws capture_in_binary.w > cdk.tf.json 1`] = `
+exports[`wing compile --target tf-aws capture_in_binary.w > index.js 1`] = `
+"async handle(e) { const { b, x } = this; {
+  (await b.put(\\"file\\",\\"foo\\"));
+  {((cond) => {if (!cond) throw new Error(\`assertion failed: '((await b.get(\\"file\\")) === \\"foo\\")'\`)})(((await b.get(\\"file\\")) === \\"foo\\"))};
+  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(12 === x)'\`)})((12 === x))};
+} };"
+`;
+
+exports[`wing compile --target tf-aws capture_in_binary.w > main.tf.json 1`] = `
 {
   "//": {
     "metadata": {
@@ -892,30 +836,6 @@ exports[`wing compile --target tf-aws capture_in_binary.w > cdk.tf.json 1`] = `
 }
 `;
 
-exports[`wing compile --target tf-aws capture_in_binary.w > index.js 1`] = `
-"async handle(e) { const { b, x } = this; {
-  (await b.put(\\"file\\",\\"foo\\"));
-  {((cond) => {if (!cond) throw new Error(\`assertion failed: '((await b.get(\\"file\\")) === \\"foo\\")'\`)})(((await b.get(\\"file\\")) === \\"foo\\"))};
-  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(12 === x)'\`)})((12 === x))};
-} };"
-`;
-
-exports[`wing compile --target tf-aws capture_in_binary.w > manifest.json 1`] = `
-{
-  "stacks": {
-    "root": {
-      "annotations": [],
-      "constructPath": "root",
-      "dependencies": [],
-      "name": "root",
-      "synthesizedStackPath": "stacks/root/cdk.tf.json",
-      "workingDirectory": "stacks/root",
-    },
-  },
-  "version": "0.15.2",
-}
-`;
-
 exports[`wing compile --target tf-aws capture_in_binary.w > preflight.js 1`] = `
 "const $stdlib = require('@winglang/sdk');
 const $outdir = process.env.WINGSDK_SYNTH_DIR ?? \\".\\";
@@ -964,7 +884,26 @@ constructor() {
 new MyApp().synth();"
 `;
 
-exports[`wing compile --target tf-aws capture_primitives.w > cdk.tf.json 1`] = `
+exports[`wing compile --target tf-aws capture_primitives.w > index.js 1`] = `
+"async handle(s) { const { my_bool, my_dur, my_num, my_second_bool, my_str } = this; {
+  {console.log(my_str)};
+  const n = my_num;
+  {console.log(\`\${n}\`)};
+  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(my_second_bool === false)'\`)})((my_second_bool === false))};
+  if (my_bool) {
+    {console.log(\\"bool=true\\")};
+  } else {
+    {console.log(\\"bool=false\\")};
+  }
+  const min = my_dur.minutes;
+  const sec = my_dur.seconds;
+  const hr = my_dur.hours;
+  const split = (await \`min=\${min} sec=\${sec} hr=\${hr}\`.split(\\" \\"));
+  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(split.length === 3)'\`)})((split.length === 3))};
+} };"
+`;
+
+exports[`wing compile --target tf-aws capture_primitives.w > main.tf.json 1`] = `
 {
   "//": {
     "metadata": {
@@ -1064,41 +1003,6 @@ exports[`wing compile --target tf-aws capture_primitives.w > cdk.tf.json 1`] = `
 }
 `;
 
-exports[`wing compile --target tf-aws capture_primitives.w > index.js 1`] = `
-"async handle(s) { const { my_bool, my_dur, my_num, my_second_bool, my_str } = this; {
-  {console.log(my_str)};
-  const n = my_num;
-  {console.log(\`\${n}\`)};
-  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(my_second_bool === false)'\`)})((my_second_bool === false))};
-  if (my_bool) {
-    {console.log(\\"bool=true\\")};
-  } else {
-    {console.log(\\"bool=false\\")};
-  }
-  const min = my_dur.minutes;
-  const sec = my_dur.seconds;
-  const hr = my_dur.hours;
-  const split = (await \`min=\${min} sec=\${sec} hr=\${hr}\`.split(\\" \\"));
-  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(split.length === 3)'\`)})((split.length === 3))};
-} };"
-`;
-
-exports[`wing compile --target tf-aws capture_primitives.w > manifest.json 1`] = `
-{
-  "stacks": {
-    "root": {
-      "annotations": [],
-      "constructPath": "root",
-      "dependencies": [],
-      "name": "root",
-      "synthesizedStackPath": "stacks/root/cdk.tf.json",
-      "workingDirectory": "stacks/root",
-    },
-  },
-  "version": "0.15.2",
-}
-`;
-
 exports[`wing compile --target tf-aws capture_primitives.w > preflight.js 1`] = `
 "const $stdlib = require('@winglang/sdk');
 const $outdir = process.env.WINGSDK_SYNTH_DIR ?? \\".\\";
@@ -1149,7 +1053,16 @@ constructor() {
 new MyApp().synth();"
 `;
 
-exports[`wing compile --target tf-aws capture_resource_and_data.w > cdk.tf.json 1`] = `
+exports[`wing compile --target tf-aws capture_resource_and_data.w > index.js 1`] = `
+"async handle(e) { const { data, queue, res } = this; {
+  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(data.size === 3)'\`)})((data.size === 3))};
+  (await res.put(\\"file.txt\\",\\"world\\"));
+  {((cond) => {if (!cond) throw new Error(\`assertion failed: '((await res.get(\\"file.txt\\")) === \\"world\\")'\`)})(((await res.get(\\"file.txt\\")) === \\"world\\"))};
+  (await queue.push(\\"spirulina\\"));
+} };"
+`;
+
+exports[`wing compile --target tf-aws capture_resource_and_data.w > main.tf.json 1`] = `
 {
   "//": {
     "metadata": {
@@ -1293,31 +1206,6 @@ exports[`wing compile --target tf-aws capture_resource_and_data.w > cdk.tf.json 
 }
 `;
 
-exports[`wing compile --target tf-aws capture_resource_and_data.w > index.js 1`] = `
-"async handle(e) { const { data, queue, res } = this; {
-  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(data.size === 3)'\`)})((data.size === 3))};
-  (await res.put(\\"file.txt\\",\\"world\\"));
-  {((cond) => {if (!cond) throw new Error(\`assertion failed: '((await res.get(\\"file.txt\\")) === \\"world\\")'\`)})(((await res.get(\\"file.txt\\")) === \\"world\\"))};
-  (await queue.push(\\"spirulina\\"));
-} };"
-`;
-
-exports[`wing compile --target tf-aws capture_resource_and_data.w > manifest.json 1`] = `
-{
-  "stacks": {
-    "root": {
-      "annotations": [],
-      "constructPath": "root",
-      "dependencies": [],
-      "name": "root",
-      "synthesizedStackPath": "stacks/root/cdk.tf.json",
-      "workingDirectory": "stacks/root",
-    },
-  },
-  "version": "0.15.2",
-}
-`;
-
 exports[`wing compile --target tf-aws capture_resource_and_data.w > preflight.js 1`] = `
 "const $stdlib = require('@winglang/sdk');
 const $outdir = process.env.WINGSDK_SYNTH_DIR ?? \\".\\";
@@ -1371,7 +1259,19 @@ constructor() {
 new MyApp().synth();"
 `;
 
-exports[`wing compile --target tf-aws captures.w > cdk.tf.json 1`] = `
+exports[`wing compile --target tf-aws captures.w > index.js 1`] = `
+"async handle(event) { const { bucket1, bucket2, bucket3 } = this; {
+  (await bucket1.put(\\"file.txt\\",\\"data\\"));
+  (await bucket2.get(\\"file.txt\\"));
+  (await bucket2.get(\\"file2.txt\\"));
+  (await bucket3.get(\\"file3.txt\\"));
+  for (const stuff of (await bucket1.list())) {
+    {console.log(stuff)};
+  }
+} };"
+`;
+
+exports[`wing compile --target tf-aws captures.w > main.tf.json 1`] = `
 {
   "//": {
     "metadata": {
@@ -1726,34 +1626,6 @@ exports[`wing compile --target tf-aws captures.w > cdk.tf.json 1`] = `
 }
 `;
 
-exports[`wing compile --target tf-aws captures.w > index.js 1`] = `
-"async handle(event) { const { bucket1, bucket2, bucket3 } = this; {
-  (await bucket1.put(\\"file.txt\\",\\"data\\"));
-  (await bucket2.get(\\"file.txt\\"));
-  (await bucket2.get(\\"file2.txt\\"));
-  (await bucket3.get(\\"file3.txt\\"));
-  for (const stuff of (await bucket1.list())) {
-    {console.log(stuff)};
-  }
-} };"
-`;
-
-exports[`wing compile --target tf-aws captures.w > manifest.json 1`] = `
-{
-  "stacks": {
-    "root": {
-      "annotations": [],
-      "constructPath": "root",
-      "dependencies": [],
-      "name": "root",
-      "synthesizedStackPath": "stacks/root/cdk.tf.json",
-      "workingDirectory": "stacks/root",
-    },
-  },
-  "version": "0.15.2",
-}
-`;
-
 exports[`wing compile --target tf-aws captures.w > preflight.js 1`] = `
 "const $stdlib = require('@winglang/sdk');
 const $outdir = process.env.WINGSDK_SYNTH_DIR ?? \\".\\";
@@ -1815,7 +1687,7 @@ constructor() {
 new MyApp().synth();"
 `;
 
-exports[`wing compile --target tf-aws container_types.w > cdk.tf.json 1`] = `
+exports[`wing compile --target tf-aws container_types.w > main.tf.json 1`] = `
 {
   "//": {
     "metadata": {
@@ -1955,22 +1827,6 @@ exports[`wing compile --target tf-aws container_types.w > cdk.tf.json 1`] = `
 }
 `;
 
-exports[`wing compile --target tf-aws container_types.w > manifest.json 1`] = `
-{
-  "stacks": {
-    "root": {
-      "annotations": [],
-      "constructPath": "root",
-      "dependencies": [],
-      "name": "root",
-      "synthesizedStackPath": "stacks/root/cdk.tf.json",
-      "workingDirectory": "stacks/root",
-    },
-  },
-  "version": "0.15.2",
-}
-`;
-
 exports[`wing compile --target tf-aws container_types.w > preflight.js 1`] = `
 "const $stdlib = require('@winglang/sdk');
 const $outdir = process.env.WINGSDK_SYNTH_DIR ?? \\".\\";
@@ -2076,7 +1932,7 @@ constructor() {
 new MyApp().synth();"
 `;
 
-exports[`wing compile --target tf-aws enums.w > cdk.tf.json 1`] = `
+exports[`wing compile --target tf-aws enums.w > main.tf.json 1`] = `
 {
   "//": {
     "metadata": {
@@ -2091,22 +1947,6 @@ exports[`wing compile --target tf-aws enums.w > cdk.tf.json 1`] = `
       {},
     ],
   },
-}
-`;
-
-exports[`wing compile --target tf-aws enums.w > manifest.json 1`] = `
-{
-  "stacks": {
-    "root": {
-      "annotations": [],
-      "constructPath": "root",
-      "dependencies": [],
-      "name": "root",
-      "synthesizedStackPath": "stacks/root/cdk.tf.json",
-      "workingDirectory": "stacks/root",
-    },
-  },
-  "version": "0.15.2",
 }
 `;
 
@@ -2148,7 +1988,7 @@ constructor() {
 new MyApp().synth();"
 `;
 
-exports[`wing compile --target tf-aws expressions_binary_operators.w > cdk.tf.json 1`] = `
+exports[`wing compile --target tf-aws expressions_binary_operators.w > main.tf.json 1`] = `
 {
   "//": {
     "metadata": {
@@ -2163,22 +2003,6 @@ exports[`wing compile --target tf-aws expressions_binary_operators.w > cdk.tf.js
       {},
     ],
   },
-}
-`;
-
-exports[`wing compile --target tf-aws expressions_binary_operators.w > manifest.json 1`] = `
-{
-  "stacks": {
-    "root": {
-      "annotations": [],
-      "constructPath": "root",
-      "dependencies": [],
-      "name": "root",
-      "synthesizedStackPath": "stacks/root/cdk.tf.json",
-      "workingDirectory": "stacks/root",
-    },
-  },
-  "version": "0.15.2",
 }
 `;
 
@@ -2219,7 +2043,7 @@ constructor() {
 new MyApp().synth();"
 `;
 
-exports[`wing compile --target tf-aws expressions_string_interpolation.w > cdk.tf.json 1`] = `
+exports[`wing compile --target tf-aws expressions_string_interpolation.w > main.tf.json 1`] = `
 {
   "//": {
     "metadata": {
@@ -2234,22 +2058,6 @@ exports[`wing compile --target tf-aws expressions_string_interpolation.w > cdk.t
       {},
     ],
   },
-}
-`;
-
-exports[`wing compile --target tf-aws expressions_string_interpolation.w > manifest.json 1`] = `
-{
-  "stacks": {
-    "root": {
-      "annotations": [],
-      "constructPath": "root",
-      "dependencies": [],
-      "name": "root",
-      "synthesizedStackPath": "stacks/root/cdk.tf.json",
-      "workingDirectory": "stacks/root",
-    },
-  },
-  "version": "0.15.2",
 }
 `;
 
@@ -2290,7 +2098,15 @@ constructor() {
 new MyApp().synth();"
 `;
 
-exports[`wing compile --target tf-aws file_counter.w > cdk.tf.json 1`] = `
+exports[`wing compile --target tf-aws file_counter.w > index.js 1`] = `
+"async handle(body) { const { bucket, counter } = this; {
+  const next = (await counter.inc());
+  const key = \`myfile-\${\\"hi\\"}.txt\`;
+  (await bucket.put(key,body));
+} };"
+`;
+
+exports[`wing compile --target tf-aws file_counter.w > main.tf.json 1`] = `
 {
   "//": {
     "metadata": {
@@ -2466,30 +2282,6 @@ exports[`wing compile --target tf-aws file_counter.w > cdk.tf.json 1`] = `
 }
 `;
 
-exports[`wing compile --target tf-aws file_counter.w > index.js 1`] = `
-"async handle(body) { const { bucket, counter } = this; {
-  const next = (await counter.inc());
-  const key = \`myfile-\${\\"hi\\"}.txt\`;
-  (await bucket.put(key,body));
-} };"
-`;
-
-exports[`wing compile --target tf-aws file_counter.w > manifest.json 1`] = `
-{
-  "stacks": {
-    "root": {
-      "annotations": [],
-      "constructPath": "root",
-      "dependencies": [],
-      "name": "root",
-      "synthesizedStackPath": "stacks/root/cdk.tf.json",
-      "workingDirectory": "stacks/root",
-    },
-  },
-  "version": "0.15.2",
-}
-`;
-
 exports[`wing compile --target tf-aws file_counter.w > preflight.js 1`] = `
 "const $stdlib = require('@winglang/sdk');
 const $outdir = process.env.WINGSDK_SYNTH_DIR ?? \\".\\";
@@ -2541,7 +2333,7 @@ constructor() {
 new MyApp().synth();"
 `;
 
-exports[`wing compile --target tf-aws for_loop.w > cdk.tf.json 1`] = `
+exports[`wing compile --target tf-aws for_loop.w > main.tf.json 1`] = `
 {
   "//": {
     "metadata": {
@@ -2556,22 +2348,6 @@ exports[`wing compile --target tf-aws for_loop.w > cdk.tf.json 1`] = `
       {},
     ],
   },
-}
-`;
-
-exports[`wing compile --target tf-aws for_loop.w > manifest.json 1`] = `
-{
-  "stacks": {
-    "root": {
-      "annotations": [],
-      "constructPath": "root",
-      "dependencies": [],
-      "name": "root",
-      "synthesizedStackPath": "stacks/root/cdk.tf.json",
-      "workingDirectory": "stacks/root",
-    },
-  },
-  "version": "0.15.2",
 }
 `;
 
@@ -2613,7 +2389,7 @@ constructor() {
 new MyApp().synth();"
 `;
 
-exports[`wing compile --target tf-aws forward_decl.w > cdk.tf.json 1`] = `
+exports[`wing compile --target tf-aws forward_decl.w > main.tf.json 1`] = `
 {
   "//": {
     "metadata": {
@@ -2628,22 +2404,6 @@ exports[`wing compile --target tf-aws forward_decl.w > cdk.tf.json 1`] = `
       {},
     ],
   },
-}
-`;
-
-exports[`wing compile --target tf-aws forward_decl.w > manifest.json 1`] = `
-{
-  "stacks": {
-    "root": {
-      "annotations": [],
-      "constructPath": "root",
-      "dependencies": [],
-      "name": "root",
-      "synthesizedStackPath": "stacks/root/cdk.tf.json",
-      "workingDirectory": "stacks/root",
-    },
-  },
-  "version": "0.15.2",
 }
 `;
 
@@ -2695,7 +2455,14 @@ constructor() {
 new MyApp().synth();"
 `;
 
-exports[`wing compile --target tf-aws hello.w > cdk.tf.json 1`] = `
+exports[`wing compile --target tf-aws hello.w > index.js 1`] = `
+"async handle(message) { const { bucket } = this; {
+  (await bucket.put(\\"hello.txt\\",\`Hello, \${message}!\`));
+  return message;
+} };"
+`;
+
+exports[`wing compile --target tf-aws hello.w > main.tf.json 1`] = `
 {
   "//": {
     "metadata": {
@@ -2851,29 +2618,6 @@ exports[`wing compile --target tf-aws hello.w > cdk.tf.json 1`] = `
 }
 `;
 
-exports[`wing compile --target tf-aws hello.w > index.js 1`] = `
-"async handle(message) { const { bucket } = this; {
-  (await bucket.put(\\"hello.txt\\",\`Hello, \${message}!\`));
-  return message;
-} };"
-`;
-
-exports[`wing compile --target tf-aws hello.w > manifest.json 1`] = `
-{
-  "stacks": {
-    "root": {
-      "annotations": [],
-      "constructPath": "root",
-      "dependencies": [],
-      "name": "root",
-      "synthesizedStackPath": "stacks/root/cdk.tf.json",
-      "workingDirectory": "stacks/root",
-    },
-  },
-  "version": "0.15.2",
-}
-`;
-
 exports[`wing compile --target tf-aws hello.w > preflight.js 1`] = `
 "const $stdlib = require('@winglang/sdk');
 const $outdir = process.env.WINGSDK_SYNTH_DIR ?? \\".\\";
@@ -2920,7 +2664,12 @@ constructor() {
 new MyApp().synth();"
 `;
 
-exports[`wing compile --target tf-aws identical_inflights.w > cdk.tf.json 1`] = `
+exports[`wing compile --target tf-aws identical_inflights.w > index.js 1`] = `
+"async handle() { const {  } = this; {
+} };"
+`;
+
+exports[`wing compile --target tf-aws identical_inflights.w > main.tf.json 1`] = `
 {
   "//": {
     "metadata": {
@@ -2935,27 +2684,6 @@ exports[`wing compile --target tf-aws identical_inflights.w > cdk.tf.json 1`] = 
       {},
     ],
   },
-}
-`;
-
-exports[`wing compile --target tf-aws identical_inflights.w > index.js 1`] = `
-"async handle() { const {  } = this; {
-} };"
-`;
-
-exports[`wing compile --target tf-aws identical_inflights.w > manifest.json 1`] = `
-{
-  "stacks": {
-    "root": {
-      "annotations": [],
-      "constructPath": "root",
-      "dependencies": [],
-      "name": "root",
-      "synthesizedStackPath": "stacks/root/cdk.tf.json",
-      "workingDirectory": "stacks/root",
-    },
-  },
-  "version": "0.15.2",
 }
 `;
 
@@ -3003,7 +2731,7 @@ constructor() {
 new MyApp().synth();"
 `;
 
-exports[`wing compile --target tf-aws mut_container_types.w > cdk.tf.json 1`] = `
+exports[`wing compile --target tf-aws mut_container_types.w > main.tf.json 1`] = `
 {
   "//": {
     "metadata": {
@@ -3143,22 +2871,6 @@ exports[`wing compile --target tf-aws mut_container_types.w > cdk.tf.json 1`] = 
 }
 `;
 
-exports[`wing compile --target tf-aws mut_container_types.w > manifest.json 1`] = `
-{
-  "stacks": {
-    "root": {
-      "annotations": [],
-      "constructPath": "root",
-      "dependencies": [],
-      "name": "root",
-      "synthesizedStackPath": "stacks/root/cdk.tf.json",
-      "workingDirectory": "stacks/root",
-    },
-  },
-  "version": "0.15.2",
-}
-`;
-
 exports[`wing compile --target tf-aws mut_container_types.w > preflight.js 1`] = `
 "const $stdlib = require('@winglang/sdk');
 const $outdir = process.env.WINGSDK_SYNTH_DIR ?? \\".\\";
@@ -3220,7 +2932,7 @@ constructor() {
 new MyApp().synth();"
 `;
 
-exports[`wing compile --target tf-aws primitive_methods.w > cdk.tf.json 1`] = `
+exports[`wing compile --target tf-aws primitive_methods.w > main.tf.json 1`] = `
 {
   "//": {
     "metadata": {
@@ -3235,22 +2947,6 @@ exports[`wing compile --target tf-aws primitive_methods.w > cdk.tf.json 1`] = `
       {},
     ],
   },
-}
-`;
-
-exports[`wing compile --target tf-aws primitive_methods.w > manifest.json 1`] = `
-{
-  "stacks": {
-    "root": {
-      "annotations": [],
-      "constructPath": "root",
-      "dependencies": [],
-      "name": "root",
-      "synthesizedStackPath": "stacks/root/cdk.tf.json",
-      "workingDirectory": "stacks/root",
-    },
-  },
-  "version": "0.15.2",
 }
 `;
 
@@ -3290,7 +2986,13 @@ constructor() {
 new MyApp().synth();"
 `;
 
-exports[`wing compile --target tf-aws print.w > cdk.tf.json 1`] = `
+exports[`wing compile --target tf-aws print.w > index.js 1`] = `
+"async handle(event) { const {  } = this; {
+  {console.log(event)};
+} };"
+`;
+
+exports[`wing compile --target tf-aws print.w > main.tf.json 1`] = `
 {
   "//": {
     "metadata": {
@@ -3432,28 +3134,6 @@ exports[`wing compile --target tf-aws print.w > cdk.tf.json 1`] = `
 }
 `;
 
-exports[`wing compile --target tf-aws print.w > index.js 1`] = `
-"async handle(event) { const {  } = this; {
-  {console.log(event)};
-} };"
-`;
-
-exports[`wing compile --target tf-aws print.w > manifest.json 1`] = `
-{
-  "stacks": {
-    "root": {
-      "annotations": [],
-      "constructPath": "root",
-      "dependencies": [],
-      "name": "root",
-      "synthesizedStackPath": "stacks/root/cdk.tf.json",
-      "workingDirectory": "stacks/root",
-    },
-  },
-  "version": "0.15.2",
-}
-`;
-
 exports[`wing compile --target tf-aws print.w > preflight.js 1`] = `
 "const $stdlib = require('@winglang/sdk');
 const $outdir = process.env.WINGSDK_SYNTH_DIR ?? \\".\\";
@@ -3494,7 +3174,7 @@ constructor() {
 new MyApp().synth();"
 `;
 
-exports[`wing compile --target tf-aws reassignment.w > cdk.tf.json 1`] = `
+exports[`wing compile --target tf-aws reassignment.w > main.tf.json 1`] = `
 {
   "//": {
     "metadata": {
@@ -3509,22 +3189,6 @@ exports[`wing compile --target tf-aws reassignment.w > cdk.tf.json 1`] = `
       {},
     ],
   },
-}
-`;
-
-exports[`wing compile --target tf-aws reassignment.w > manifest.json 1`] = `
-{
-  "stacks": {
-    "root": {
-      "annotations": [],
-      "constructPath": "root",
-      "dependencies": [],
-      "name": "root",
-      "synthesizedStackPath": "stacks/root/cdk.tf.json",
-      "workingDirectory": "stacks/root",
-    },
-  },
-  "version": "0.15.2",
 }
 `;
 
@@ -3586,7 +3250,7 @@ constructor() {
 new MyApp().synth();"
 `;
 
-exports[`wing compile --target tf-aws resource.w > cdk.tf.json 1`] = `
+exports[`wing compile --target tf-aws resource.w > main.tf.json 1`] = `
 {
   "//": {
     "metadata": {
@@ -3601,22 +3265,6 @@ exports[`wing compile --target tf-aws resource.w > cdk.tf.json 1`] = `
       {},
     ],
   },
-}
-`;
-
-exports[`wing compile --target tf-aws resource.w > manifest.json 1`] = `
-{
-  "stacks": {
-    "root": {
-      "annotations": [],
-      "constructPath": "root",
-      "dependencies": [],
-      "name": "root",
-      "synthesizedStackPath": "stacks/root/cdk.tf.json",
-      "workingDirectory": "stacks/root",
-    },
-  },
-  "version": "0.15.2",
 }
 `;
 
@@ -3660,7 +3308,28 @@ constructor() {
 new MyApp().synth();"
 `;
 
-exports[`wing compile --target tf-aws statements_if.w > cdk.tf.json 1`] = `
+exports[`wing compile --target tf-aws statements_if.w > index.js 1`] = `
+"async handle(s) { const {  } = this; {
+  if (true) {
+    const x = 2;
+    if ((true && ((x + 2) === 4))) {
+      if ((true && ((x + 3) === 4))) {
+        {((cond) => {if (!cond) throw new Error(\`assertion failed: 'false'\`)})(false)};
+      } else if ((true && ((x + 3) === 6))) {
+        {((cond) => {if (!cond) throw new Error(\`assertion failed: 'false'\`)})(false)};
+      } else if ((false || ((x + 3) === 5))) {
+        {((cond) => {if (!cond) throw new Error(\`assertion failed: 'true'\`)})(true)};
+      } else {
+        {((cond) => {if (!cond) throw new Error(\`assertion failed: 'false'\`)})(false)};
+      }
+    } else {
+      {((cond) => {if (!cond) throw new Error(\`assertion failed: 'false'\`)})(false)};
+    }
+  }
+} };"
+`;
+
+exports[`wing compile --target tf-aws statements_if.w > main.tf.json 1`] = `
 {
   "//": {
     "metadata": {
@@ -3760,43 +3429,6 @@ exports[`wing compile --target tf-aws statements_if.w > cdk.tf.json 1`] = `
 }
 `;
 
-exports[`wing compile --target tf-aws statements_if.w > index.js 1`] = `
-"async handle(s) { const {  } = this; {
-  if (true) {
-    const x = 2;
-    if ((true && ((x + 2) === 4))) {
-      if ((true && ((x + 3) === 4))) {
-        {((cond) => {if (!cond) throw new Error(\`assertion failed: 'false'\`)})(false)};
-      } else if ((true && ((x + 3) === 6))) {
-        {((cond) => {if (!cond) throw new Error(\`assertion failed: 'false'\`)})(false)};
-      } else if ((false || ((x + 3) === 5))) {
-        {((cond) => {if (!cond) throw new Error(\`assertion failed: 'true'\`)})(true)};
-      } else {
-        {((cond) => {if (!cond) throw new Error(\`assertion failed: 'false'\`)})(false)};
-      }
-    } else {
-      {((cond) => {if (!cond) throw new Error(\`assertion failed: 'false'\`)})(false)};
-    }
-  }
-} };"
-`;
-
-exports[`wing compile --target tf-aws statements_if.w > manifest.json 1`] = `
-{
-  "stacks": {
-    "root": {
-      "annotations": [],
-      "constructPath": "root",
-      "dependencies": [],
-      "name": "root",
-      "synthesizedStackPath": "stacks/root/cdk.tf.json",
-      "workingDirectory": "stacks/root",
-    },
-  },
-  "version": "0.15.2",
-}
-`;
-
 exports[`wing compile --target tf-aws statements_if.w > preflight.js 1`] = `
 "const $stdlib = require('@winglang/sdk');
 const $outdir = process.env.WINGSDK_SYNTH_DIR ?? \\".\\";
@@ -3854,7 +3486,7 @@ constructor() {
 new MyApp().synth();"
 `;
 
-exports[`wing compile --target tf-aws statements_variable_declarations.w > cdk.tf.json 1`] = `
+exports[`wing compile --target tf-aws statements_variable_declarations.w > main.tf.json 1`] = `
 {
   "//": {
     "metadata": {
@@ -3869,22 +3501,6 @@ exports[`wing compile --target tf-aws statements_variable_declarations.w > cdk.t
       {},
     ],
   },
-}
-`;
-
-exports[`wing compile --target tf-aws statements_variable_declarations.w > manifest.json 1`] = `
-{
-  "stacks": {
-    "root": {
-      "annotations": [],
-      "constructPath": "root",
-      "dependencies": [],
-      "name": "root",
-      "synthesizedStackPath": "stacks/root/cdk.tf.json",
-      "workingDirectory": "stacks/root",
-    },
-  },
-  "version": "0.15.2",
 }
 `;
 
@@ -3920,7 +3536,14 @@ constructor() {
 new MyApp().synth();"
 `;
 
-exports[`wing compile --target tf-aws std_containers.w > cdk.tf.json 1`] = `
+exports[`wing compile --target tf-aws std_containers.w > index.js 1`] = `
+"async handle(body) { const { s_array } = this; {
+  const ss = (await s_array.at(1));
+  {console.log(\`\${s_array.length}\`)};
+} };"
+`;
+
+exports[`wing compile --target tf-aws std_containers.w > main.tf.json 1`] = `
 {
   "//": {
     "metadata": {
@@ -3935,29 +3558,6 @@ exports[`wing compile --target tf-aws std_containers.w > cdk.tf.json 1`] = `
       {},
     ],
   },
-}
-`;
-
-exports[`wing compile --target tf-aws std_containers.w > index.js 1`] = `
-"async handle(body) { const { s_array } = this; {
-  const ss = (await s_array.at(1));
-  {console.log(\`\${s_array.length}\`)};
-} };"
-`;
-
-exports[`wing compile --target tf-aws std_containers.w > manifest.json 1`] = `
-{
-  "stacks": {
-    "root": {
-      "annotations": [],
-      "constructPath": "root",
-      "dependencies": [],
-      "name": "root",
-      "synthesizedStackPath": "stacks/root/cdk.tf.json",
-      "workingDirectory": "stacks/root",
-    },
-  },
-  "version": "0.15.2",
 }
 `;
 
@@ -4002,7 +3602,22 @@ constructor() {
 new MyApp().synth();"
 `;
 
-exports[`wing compile --target tf-aws test_bucket.w > cdk.tf.json 1`] = `
+exports[`wing compile --target tf-aws test_bucket.w > index.js 1`] = `
+"async handle(_) { const { b } = this; {
+  (await b.put(\\"hello.txt\\",\\"world\\"));
+  {((cond) => {if (!cond) throw new Error(\`assertion failed: '((await b.get(\\"hello.txt\\")) === \\"world\\")'\`)})(((await b.get(\\"hello.txt\\")) === \\"world\\"))};
+} };"
+`;
+
+exports[`wing compile --target tf-aws test_bucket.w > index.js 2`] = `
+"async handle(_) { const { b } = this; {
+  {((cond) => {if (!cond) throw new Error(\`assertion failed: '((await b.list()).length === 0)'\`)})(((await b.list()).length === 0))};
+  (await b.put(\\"hello.txt\\",\\"world\\"));
+  {((cond) => {if (!cond) throw new Error(\`assertion failed: '((await b.list()).length === 1)'\`)})(((await b.list()).length === 1))};
+} };"
+`;
+
+exports[`wing compile --target tf-aws test_bucket.w > main.tf.json 1`] = `
 {
   "//": {
     "metadata": {
@@ -4204,37 +3819,6 @@ exports[`wing compile --target tf-aws test_bucket.w > cdk.tf.json 1`] = `
 }
 `;
 
-exports[`wing compile --target tf-aws test_bucket.w > index.js 1`] = `
-"async handle(_) { const { b } = this; {
-  (await b.put(\\"hello.txt\\",\\"world\\"));
-  {((cond) => {if (!cond) throw new Error(\`assertion failed: '((await b.get(\\"hello.txt\\")) === \\"world\\")'\`)})(((await b.get(\\"hello.txt\\")) === \\"world\\"))};
-} };"
-`;
-
-exports[`wing compile --target tf-aws test_bucket.w > index.js 2`] = `
-"async handle(_) { const { b } = this; {
-  {((cond) => {if (!cond) throw new Error(\`assertion failed: '((await b.list()).length === 0)'\`)})(((await b.list()).length === 0))};
-  (await b.put(\\"hello.txt\\",\\"world\\"));
-  {((cond) => {if (!cond) throw new Error(\`assertion failed: '((await b.list()).length === 1)'\`)})(((await b.list()).length === 1))};
-} };"
-`;
-
-exports[`wing compile --target tf-aws test_bucket.w > manifest.json 1`] = `
-{
-  "stacks": {
-    "root": {
-      "annotations": [],
-      "constructPath": "root",
-      "dependencies": [],
-      "name": "root",
-      "synthesizedStackPath": "stacks/root/cdk.tf.json",
-      "workingDirectory": "stacks/root",
-    },
-  },
-  "version": "0.15.2",
-}
-`;
-
 exports[`wing compile --target tf-aws test_bucket.w > preflight.js 1`] = `
 "const $stdlib = require('@winglang/sdk');
 const $outdir = process.env.WINGSDK_SYNTH_DIR ?? \\".\\";
@@ -4291,7 +3875,7 @@ constructor() {
 new MyApp().synth();"
 `;
 
-exports[`wing compile --target tf-aws while.w > cdk.tf.json 1`] = `
+exports[`wing compile --target tf-aws while.w > main.tf.json 1`] = `
 {
   "//": {
     "metadata": {
@@ -4306,22 +3890,6 @@ exports[`wing compile --target tf-aws while.w > cdk.tf.json 1`] = `
       {},
     ],
   },
-}
-`;
-
-exports[`wing compile --target tf-aws while.w > manifest.json 1`] = `
-{
-  "stacks": {
-    "root": {
-      "annotations": [],
-      "constructPath": "root",
-      "dependencies": [],
-      "name": "root",
-      "synthesizedStackPath": "stacks/root/cdk.tf.json",
-      "workingDirectory": "stacks/root",
-    },
-  },
-  "version": "0.15.2",
 }
 `;
 
@@ -4362,7 +3930,22 @@ constructor() {
 new MyApp().synth();"
 `;
 
-exports[`wing compile --target tf-aws while_loop_await.w > cdk.tf.json 1`] = `
+exports[`wing compile --target tf-aws while_loop_await.w > index.js 1`] = `
+"async handle(j) { const {  } = this; {
+  return (j + 1);
+} };"
+`;
+
+exports[`wing compile --target tf-aws while_loop_await.w > index.js 2`] = `
+"async handle(body) { const {  } = this; {
+  const i = 0;
+  while (((await iterator(i)) < 3)) {
+    {console.log(\`\${i}\`)};
+  }
+} };"
+`;
+
+exports[`wing compile --target tf-aws while_loop_await.w > main.tf.json 1`] = `
 {
   "//": {
     "metadata": {
@@ -4472,37 +4055,6 @@ exports[`wing compile --target tf-aws while_loop_await.w > cdk.tf.json 1`] = `
       },
     },
   },
-}
-`;
-
-exports[`wing compile --target tf-aws while_loop_await.w > index.js 1`] = `
-"async handle(j) { const {  } = this; {
-  return (j + 1);
-} };"
-`;
-
-exports[`wing compile --target tf-aws while_loop_await.w > index.js 2`] = `
-"async handle(body) { const {  } = this; {
-  const i = 0;
-  while (((await iterator(i)) < 3)) {
-    {console.log(\`\${i}\`)};
-  }
-} };"
-`;
-
-exports[`wing compile --target tf-aws while_loop_await.w > manifest.json 1`] = `
-{
-  "stacks": {
-    "root": {
-      "annotations": [],
-      "constructPath": "root",
-      "dependencies": [],
-      "name": "root",
-      "synthesizedStackPath": "stacks/root/cdk.tf.json",
-      "workingDirectory": "stacks/root",
-    },
-  },
-  "version": "0.15.2",
 }
 `;
 


### PR DESCRIPTION
This PR updates the CLI so that all compiler artifacts (like terraform files, simulator files, etc.) are now synthesized into target-specific directories (closes #815). For example, `wing compile -t tf-aws hello.w` will generate terraform artifacts inside `target/hello.tfaws/` while `wing compile -t tf-azure` will generate terraform artifacts inside `target/hello.tfazure/`. This avoids some problems users had where compiling to different targets would override previously compiled artifacts.

The simulator target now generates a single `.wsim` which is generated directly inside `target/`. (Under the hood, the `.wsim` file now contains the `tree.json` file that was previously generated outside).

This is a breaking change as it may require using a new version of the Wing console that understands how to read the updated .wsim file.

*By submitting this pull request, I confirm that my contribution is made under the terms of the 
[Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.
