### PR TITLE
chore(repo): remove newline in pr template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,3 @@
 
 
-*By submitting this pull request, I confirm that my contribution is made under the terms of the 
-[Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.
+*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.


### PR DESCRIPTION
In PR description GitHub actually respects newlines in markdown (yes, an awful mistake)


*By submitting this pull request, I confirm that my contribution is made under the terms of the 
[Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.
