### PR TITLE
chore: use pull_request instead of pull_request_target for builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,9 +32,6 @@ jobs:
       - name: Checkout
         if: github.event_name == 'push' && github.repository == 'winglang/wing'
         uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.pull_request.head.ref || github.ref }}
-          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
 
       - name: Get tags
         id: tags
@@ -102,9 +99,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.pull_request.head.ref || github.ref }}
-          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
 
       - name: Setup Node
         uses: actions/setup-node@v3
@@ -205,9 +199,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.pull_request.head.ref || github.ref }}
-          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
 
       - name: Setup Node
         uses: actions/setup-node@v3
@@ -268,9 +259,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.pull_request.head.ref || github.ref }}
-          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
 
       - name: Download Build Artifacts
         uses: actions/download-artifact@v2
@@ -307,9 +295,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.pull_request.head.ref || github.ref }}
-          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
 
       - name: Download Build Artifacts
         uses: actions/download-artifact@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -276,7 +276,8 @@ jobs:
 
       - name: Run E2E Tests
         env:
-          NPM_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # publishes to a dummy NPM registry, requires a non-empty token
+          NPM_TOKEN: "dummy-token"
         run: |
           export HANGAR_WING_TGZ="$(pwd)/$(find wing/*.tgz)"
           export HANGAR_WINGSDK_TGZ="$(pwd)/$(find wingsdk/*.tgz)"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,7 @@
 name: Build
 
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - synchronize


### PR DESCRIPTION
We switched to pull_request_target a while back while making sure fork workflows would work. This made sense for the self-mutation workflow, but this isn't necessary for the build workflow. 
If triggered from a PR, the workflow does not use any secrets or attempt to write anything so it doesn't need those permissions. The only time secrets are read is on `push` to main.

The primary benefit of this change is that now we can easily test workflow changes in PRs. It's also just the generally recommended way for doing these workflows.


The explicit `ref` and `repository` settings were removed because pull_request_target didn't set it in the expected way. No longer needed, PRs will checkout the merge commit now.

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.