### PR TITLE
fix: windows path delimiters break cli

### DIFF
--- a/apps/wing/src/commands/compile.ts
+++ b/apps/wing/src/commands/compile.ts
@@ -9,6 +9,7 @@ import { mkdir, readFile } from "fs/promises";
 import { WASI } from "wasi";
 import debug from "debug";
 import * as chalk from "chalk";
+import { normalPath } from "src/util";
 
 const log = debug("wing:compile");
 const WINGC_COMPILE = "wingc_compile";
@@ -46,13 +47,6 @@ const DEFAULT_SYNTH_DIR_SUFFIX: Record<Target, string | undefined> = {
 export interface ICompileOptions {
   readonly outDir: string;
   readonly target: Target;
-}
-
-/**
- * Normalizes paths from windows to posix.
- */
-function normalPath(path: string) {
-  return path.replace(/\\/g, "/");
 }
 
 /**

--- a/apps/wing/src/commands/compile.ts
+++ b/apps/wing/src/commands/compile.ts
@@ -3,7 +3,7 @@
 
 import * as vm from "vm";
 
-import { basename, dirname, join, resolve } from "path";
+import { basename, dirname, join, resolve } from "path/posix";
 import { mkdir, readFile } from "fs/promises";
 
 import { WASI } from "wasi";
@@ -13,9 +13,9 @@ import * as chalk from "chalk";
 const log = debug("wing:compile");
 const WINGC_COMPILE = "wingc_compile";
 
-const WINGC_WASM_PATH = resolve(__dirname, "../../wingc.wasm");
+const WINGC_WASM_PATH = normalPath(resolve(__dirname, "../../wingc.wasm"));
 log("wasm path: %s", WINGC_WASM_PATH);
-const WINGSDK_RESOLVED_PATH = require.resolve("@winglang/sdk");
+const WINGSDK_RESOLVED_PATH = normalPath(require.resolve("@winglang/sdk"));
 log("wingsdk module path: %s", WINGSDK_RESOLVED_PATH);
 const WINGSDK_MANIFEST_ROOT = resolve(WINGSDK_RESOLVED_PATH, "../..");
 log("wingsdk manifest path: %s", WINGSDK_MANIFEST_ROOT);
@@ -49,6 +49,13 @@ export interface ICompileOptions {
 }
 
 /**
+ * Normalizes paths from windows to posix.
+ */
+function normalPath(path: string) {
+  return path.replace(/\\/g, "/");
+}
+
+/**
  * Determines the synth directory for a given target. This is the directory
  * within the output directory where the SDK app will synthesize its artifacts
  * for the given target.
@@ -69,11 +76,11 @@ function resolveSynthDir(outDir: string, entrypoint: string, target: Target) {
  * @param options Compile options.
  */
 export async function compile(entrypoint: string, options: ICompileOptions) {
-  const wingFile = entrypoint;
+  const wingFile = normalPath(entrypoint);
   log("wing file: %s", wingFile);
   const wingDir = dirname(wingFile);
   log("wing dir: %s", wingDir);
-  const synthDir = resolveSynthDir(options.outDir, entrypoint, options.target);
+  const synthDir = resolveSynthDir(options.outDir, wingFile, options.target);
   log("synth dir: %s", synthDir);
   const workDir = resolve(synthDir, ".wing");
   log("work dir: %s", workDir);

--- a/apps/wing/src/commands/compile.ts
+++ b/apps/wing/src/commands/compile.ts
@@ -9,7 +9,7 @@ import { mkdir, readFile } from "fs/promises";
 import { WASI } from "wasi";
 import debug from "debug";
 import * as chalk from "chalk";
-import { normalPath } from "src/util";
+import { normalPath } from "../util";
 
 const log = debug("wing:compile");
 const WINGC_COMPILE = "wingc_compile";

--- a/apps/wing/src/commands/run.ts
+++ b/apps/wing/src/commands/run.ts
@@ -2,7 +2,7 @@ import { readdirSync  } from "fs";
 import { debug } from "debug";
 import { resolve } from "path";
 import open = require("open");
-import { normalPath } from "src/util";
+import { normalPath } from "../util";
 
 export async function run(simfile?: string) {
     const wingFiles = readdirSync('.').filter(item => item.endsWith('.w'));

--- a/apps/wing/src/commands/run.ts
+++ b/apps/wing/src/commands/run.ts
@@ -14,7 +14,7 @@ export async function run(simfile?: string) {
         throw new Error(simfile + " doesn't exist");
     }
 
-    simfile = resolve(simfile);
+    simfile = resolve(simfile).replace(/\\/g, "/");
     debug("calling wing console protocol with:" + simfile);
     open("wing-console://" + simfile);
 }

--- a/apps/wing/src/commands/run.ts
+++ b/apps/wing/src/commands/run.ts
@@ -2,6 +2,7 @@ import { readdirSync  } from "fs";
 import { debug } from "debug";
 import { resolve } from "path";
 import open = require("open");
+import { normalPath } from "src/util";
 
 export async function run(simfile?: string) {
     const wingFiles = readdirSync('.').filter(item => item.endsWith('.w'));
@@ -14,7 +15,7 @@ export async function run(simfile?: string) {
         throw new Error(simfile + " doesn't exist");
     }
 
-    simfile = resolve(simfile).replace(/\\/g, "/");
+    simfile = normalPath(resolve(simfile));
     debug("calling wing console protocol with:" + simfile);
     open("wing-console://" + simfile);
 }

--- a/apps/wing/src/commands/test.ts
+++ b/apps/wing/src/commands/test.ts
@@ -4,7 +4,7 @@ import { basename, extname, join } from "path/posix";
 import { compile, Target } from "./compile";
 import * as chalk from "chalk";
 import * as sdk from "@winglang/sdk";
-import { normalPath } from "src/util";
+import { normalPath } from "../util";
 
 export async function test(entrypoints: string[]) {
   for (const entrypoint of entrypoints) {

--- a/apps/wing/src/commands/test.ts
+++ b/apps/wing/src/commands/test.ts
@@ -4,6 +4,7 @@ import { basename, extname, join } from "path/posix";
 import { compile, Target } from "./compile";
 import * as chalk from "chalk";
 import * as sdk from "@winglang/sdk";
+import { normalPath } from "src/util";
 
 export async function test(entrypoints: string[]) {
   for (const entrypoint of entrypoints) {
@@ -12,7 +13,7 @@ export async function test(entrypoints: string[]) {
 }
 
 async function testOne(entrypoint: string) {
-  const workdir = (await mkdtemp(join(tmpdir(), "wing-test-"))).replace(/\\/g, "/");
+  const workdir = normalPath(await mkdtemp(join(tmpdir(), "wing-test-")));
   await compile(entrypoint, { outDir: workdir, target: Target.SIM });
   const wsim = (await readdir(workdir)).find(f => extname(f) === ".wsim");
   if (!wsim) {

--- a/apps/wing/src/commands/test.ts
+++ b/apps/wing/src/commands/test.ts
@@ -1,6 +1,6 @@
 import { mkdtemp, readdir } from "fs/promises";
 import { tmpdir } from "os";
-import { basename, extname, join } from "path";
+import { basename, extname, join } from "path/posix";
 import { compile, Target } from "./compile";
 import * as chalk from "chalk";
 import * as sdk from "@winglang/sdk";
@@ -12,7 +12,7 @@ export async function test(entrypoints: string[]) {
 }
 
 async function testOne(entrypoint: string) {
-  const workdir = await mkdtemp(join(tmpdir(), "wing-test-"));
+  const workdir = (await mkdtemp(join(tmpdir(), "wing-test-"))).replace(/\\/g, "/");
   await compile(entrypoint, { outDir: workdir, target: Target.SIM });
   const wsim = (await readdir(workdir)).find(f => extname(f) === ".wsim");
   if (!wsim) {

--- a/apps/wing/src/util.ts
+++ b/apps/wing/src/util.ts
@@ -1,0 +1,7 @@
+/**
+ * Normalizes paths from windows to posix.
+ */
+export function normalPath(path: string) {
+  return path.replace(/\\/g, "/");
+}
+


### PR DESCRIPTION
The first of many additions of `replace(/\\/g, "/")` :)

While the CLI does work on windows, if the user provides any `\`s in the path it breaks the wasm preopens.

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.