### PR TITLE
fix: windows absolute paths break cli

### DIFF
--- a/apps/wing/src/commands/compile.ts
+++ b/apps/wing/src/commands/compile.ts
@@ -74,7 +74,7 @@ export async function compile(entrypoint: string, options: ICompileOptions) {
   log("wing file: %s", wingFile);
   const wingDir = dirname(wingFile);
   log("wing dir: %s", wingDir);
-  const synthDir = resolveSynthDir(options.outDir, wingFile, options.target);
+  const synthDir = resolveSynthDir(normalPath(options.outDir), wingFile, options.target);
   log("synth dir: %s", synthDir);
   const workDir = resolve(synthDir, ".wing");
   log("work dir: %s", workDir);

--- a/apps/wing/src/util.ts
+++ b/apps/wing/src/util.ts
@@ -2,6 +2,10 @@
  * Normalizes paths from windows to posix.
  */
 export function normalPath(path: string) {
-  return path.replace(/\\/g, "/");
+  if (process.platform === "win32") {
+    return path.replace(/\\/g, "/").replace(/^[a-zA-Z]:/, "");
+  } else {
+    return path;
+  }
 }
 

--- a/apps/wing/src/util.ts
+++ b/apps/wing/src/util.ts
@@ -3,7 +3,12 @@
  */
 export function normalPath(path: string) {
   if (process.platform === "win32") {
-    return path.replace(/\\/g, "/").replace(/^[a-zA-Z]:/, "");
+    return path
+    // Replace backslashes with forward slashes
+    .replace(/\\/g, "/")
+    // Remove drive letter
+    // Note: This uses the assumption that starting a path with `/` in windows resolves to the default drive
+    .replace(/^[a-zA-Z]:/, "");
   } else {
     return path;
   }


### PR DESCRIPTION
Followup to https://github.com/winglang/wing/pull/1454

My iteration cycle on fixes for Windows is a bit slow. Also added an if check to do the normalization cause it would be wasted cycles outside of windows.

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.