### PR TITLE
chore(docs): missing `json` type initializer

### DIFF
--- a/docs/04-reference/winglang-spec.md
+++ b/docs/04-reference/winglang-spec.md
@@ -252,7 +252,7 @@ To obtain an array of all the keys within a JSON object use the `Json.keys(o)` m
 
 
 ```js
-let j = { hello: 123, world: [ 1, 2, 3 ] };
+let j = Json { hello: 123, world: [ 1, 2, 3 ] };
 assert(Json.keys(j) == ["hello", "world"]);
 ```
 


### PR DESCRIPTION

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.