### PR TITLE
chore: add plugins scope to pr lint

### DIFF
--- a/.github/workflows/pull-request-lint.yml
+++ b/.github/workflows/pull-request-lint.yml
@@ -29,6 +29,7 @@ jobs:
             repo
             playground
             vscode
+            plugins
           types: |-
             feat
             fix

--- a/docs/06-contributors/030-pull-requests.md
+++ b/docs/06-contributors/030-pull-requests.md
@@ -47,6 +47,7 @@ changelog. To that end, pull request titles must follow this convention:
   * `examples`
   * `playground`
   * `vscode`
+  * `plugins`
   * `build` - change related to development environment, build system, build tools, etc.
   * `repo` - change related to repository behavior (e.g. pull request templates, issue templates,
     etc).


### PR DESCRIPTION
Just tying up a loose end - adding `plugins` scope to PR linter and to our documentation at: https://docs.winglang.io/contributors/pull_requests#how-are-pull-request-titles-formatted to indicate PRs related to the Wing Plugin System
*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.