### PR TITLE
fix(compiler): can't call `return` in `try`/`catch`/`finally`, no error when missing `catch`/`finally`

### DIFF
--- a/docs/04-reference/winglang-spec.md
+++ b/docs/04-reference/winglang-spec.md
@@ -946,7 +946,7 @@ type is inferred iff a default value is provided.
 Exceptions and `try/catch/finally` is the error mechanism. Mechanics directly
 translate to JavaScript. You can create a new exception with a `throw` call.
 
-In the presence of `try`, both `catch` and `finally` are optional.
+In the presence of `try`, both `catch` and `finally` are optional but at least one of them must be present.
 In the presence of `catch` the variable holding the exception (`e` in the example below) is optional.
 
 `panic` is meant to be fatal error handling.  

--- a/examples/tests/invalid/try_no_catch_or_finally.w
+++ b/examples/tests/invalid/try_no_catch_or_finally.w
@@ -1,0 +1,3 @@
+try {
+  print("Hello World");
+}

--- a/examples/tests/valid/try_catch.w
+++ b/examples/tests/valid/try_catch.w
@@ -38,3 +38,10 @@ try {
   x = "finally with no catch and no exception";
 }
 assert(x == "finally with no catch and no exception");
+
+// Verify we can return from a closure in a finally block.
+assert((():num => { try {} finally {return 1;}})() == 1);
+// Verify we can return from a closure in a catch block.
+assert((():num => { try {throw("");} catch {return 2;}})() == 2);
+// Verify we can return from a closure in a try block.
+assert((():num => { try {return 3;} finally {}})() == 3);

--- a/libs/wingc/src/type_check.rs
+++ b/libs/wingc/src/type_check.rs
@@ -1852,27 +1852,13 @@ impl<'a> TypeChecker<'a> {
 				finally_statements,
 			} => {
 				// Create a new environment for the try block
-				let try_env = SymbolEnv::new(
-					Some(env.get_ref()),
-					self.types.void(),
-					false,
-					false,
-					env.flight,
-					stmt.idx,
-				);
+				let try_env = SymbolEnv::new(Some(env.get_ref()), env.return_type, false, false, env.flight, stmt.idx);
 				try_statements.set_env(try_env);
 				self.inner_scopes.push(try_statements);
 
 				// Create a new environment for the catch block
 				if let Some(catch_block) = catch_block {
-					let mut catch_env = SymbolEnv::new(
-						Some(env.get_ref()),
-						self.types.void(),
-						false,
-						false,
-						env.flight,
-						stmt.idx,
-					);
+					let mut catch_env = SymbolEnv::new(Some(env.get_ref()), env.return_type, false, false, env.flight, stmt.idx);
 
 					// Add the exception variable to the catch block
 					if let Some(exception_var) = &catch_block.exception_var {
@@ -1893,14 +1879,7 @@ impl<'a> TypeChecker<'a> {
 
 				// Create a new environment for the finally block
 				if let Some(finally_statements) = finally_statements {
-					let finally_env = SymbolEnv::new(
-						Some(env.get_ref()),
-						self.types.void(),
-						false,
-						false,
-						env.flight,
-						stmt.idx,
-					);
+					let finally_env = SymbolEnv::new(Some(env.get_ref()), env.return_type, false, false, env.flight, stmt.idx);
 					finally_statements.set_env(finally_env);
 					self.inner_scopes.push(finally_statements);
 				}

--- a/tools/hangar/src/__snapshots__/compile.test.ts.snap
+++ b/tools/hangar/src/__snapshots__/compile.test.ts.snap
@@ -4501,6 +4501,83 @@ constructor() {
   };
   }
   {((cond) => {if (!cond) throw new Error(\`assertion failed: '(x === \\"finally with no catch and no exception\\")'\`)})((x === \\"finally with no catch and no exception\\"))};
+  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(((() => {
+    try {
+    	{
+    }
+    } catch  {
+    	
+    	
+    } finally {
+    	{
+      return 1;
+    };
+    }
+  })()) === 1)'\`)})((((() => {
+    try {
+    	{
+    }
+    } catch  {
+    	
+    	
+    } finally {
+    	{
+      return 1;
+    };
+    }
+  })()) === 1))};
+  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(((() => {
+    try {
+    	{
+      {((msg) => {throw new Error(msg)})(\\"\\")};
+    }
+    } catch  {
+    	
+    	{
+      return 2;
+    }
+    } finally {
+    	
+    }
+  })()) === 2)'\`)})((((() => {
+    try {
+    	{
+      {((msg) => {throw new Error(msg)})(\\"\\")};
+    }
+    } catch  {
+    	
+    	{
+      return 2;
+    }
+    } finally {
+    	
+    }
+  })()) === 2))};
+  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(((() => {
+    try {
+    	{
+      return 3;
+    }
+    } catch  {
+    	
+    	
+    } finally {
+    	{
+    };
+    }
+  })()) === 3)'\`)})((((() => {
+    try {
+    	{
+      return 3;
+    }
+    } catch  {
+    	
+    	
+    } finally {
+    	{
+    };
+    }
+  })()) === 3))};
 }
 }
 new MyApp().synth();"

--- a/tools/hangar/src/__snapshots__/invalid.test.ts.snap
+++ b/tools/hangar/src/__snapshots__/invalid.test.ts.snap
@@ -163,6 +163,11 @@ Error at struct_expansion.w:7:15 | Unknown parser error.
 Error at struct_expansion.w:11:3 | Unknown symbol \\"handler\\""
 `;
 
+exports[`try_no_catch_or_finally.w > wing test (--target sim) - invalid > stderr 1`] = `
+"Compilation failed with 1 error(s)
+Error at try_no_catch_or_finally.w:1:1 | Missing \`catch\` or \`finally\` blocks for this try statement"
+`;
+
 exports[`types_string_interpolation.w > wing test (--target sim) - invalid > stderr 1`] = `
 "Compilation failed with 2 error(s)
 Error at types_string_interpolation.w:3:12 | Expected type to be one of \\"str,num\\", but got \\"bool\\" instead


### PR DESCRIPTION
 * Support `return` in `try`/`catch`.
 * Error if both `catch` and `finally` are missing.



*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.