### PR TITLE
chore: add test for compiling with missing source file

### DIFF
--- a/apps/wing/src/commands/compile.test.ts
+++ b/apps/wing/src/commands/compile.test.ts
@@ -48,6 +48,12 @@ describe("compile command tests", () => {
     expect(files).toContain("captures.wsim");
     expect(files).toContain("tree.json");
   });
+
+  it("should error if a nonexistent file is compiled", async () => {
+    const outDir = mkdtemp();
+    return expect(compile("non-existent-file.w", { outDir, target: Target.SIM }))
+      .rejects.toThrowError(/Source file cannot be found/);
+  });
 });
 
 function mkdtemp() {

--- a/apps/wing/src/commands/compile.ts
+++ b/apps/wing/src/commands/compile.ts
@@ -6,7 +6,6 @@ import { basename, dirname, join, resolve } from "path";
 import * as chalk from "chalk";
 import debug from "debug";
 import * as wingCompiler from "../wingc";
-import { exit } from "process";
 import { normalPath } from "../util";
 
 const log = debug("wing:compile");
@@ -57,7 +56,7 @@ function resolveSynthDir(outDir: string, entrypoint: string, target: Target) {
 }
 
 /**
- * Compiles a Wing program.
+ * Compiles a Wing program. Throws an error if compilation fails.
  * @param entrypoint The program .w entrypoint.
  * @param options Compile options.
  */
@@ -99,8 +98,7 @@ export async function compile(entrypoint: string, options: ICompileOptions) {
   log(`invoking %s with: "%s"`, WINGC_COMPILE, arg);
   const compileResult = wingCompiler.invoke(wingc, WINGC_COMPILE, arg);
   if (compileResult !== 0) {
-    console.error(compileResult);
-    exit(1);
+    throw new Error(compileResult.toString());
   }
 
   const artifactPath = resolve(workDir, WINGC_PREFLIGHT);

--- a/apps/wing/src/index.ts
+++ b/apps/wing/src/index.ts
@@ -16,6 +16,13 @@ if (!SUPPORTED_NODE_VERSION) {
 }
 const log = debug("wing:cli");
 
+function actionErrorHandler(fn: (...args: any[]) => Promise<any>) {
+  return (...args: any[]) => fn(...args).catch((err: Error) => {
+    console.error(err.message);
+    process.exit(1);
+  });
+}
+
 async function main() {
   checkNodeVersion()
 
@@ -59,7 +66,7 @@ async function main() {
       "-p, --plugins [plugin...]",
       "Compiler plugins"
     )
-    .action(compile);
+    .action(actionErrorHandler(compile));
 
   program
     .command("test")

--- a/apps/wing/src/index.ts
+++ b/apps/wing/src/index.ts
@@ -72,7 +72,7 @@ async function main() {
     .command("test")
     .description("Compiles a Wing program and runs all functions with the word 'test' or start with 'test:' in their resource identifiers")
     .argument("<entrypoint...>", "all entrypoints to test")
-    .action(test);
+    .action(actionErrorHandler(test));
 
   program
     .command("docs")


### PR DESCRIPTION
https://github.com/winglang/wing/pull/1533#discussion_r1106810918

I did some minor refactoring so that the `compile` function can be unit tested more easily (it now throws an error instead of printing and exiting immediately).

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.