### PR TITLE
chore: revert env usage in github `if` expressions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,8 +19,6 @@ env:
   NODE_OPTIONS: "--max-old-space-size=4096"
   PROJEN_BUMP_VERSION: "0.0.0-dev.${{ github.run_id }}.${{ github.run_attempt }}"
   RUST_VERSION: "1.66.0"
-  WORKFLOW_FULL_E2E: "${{ github.event_name == 'push' }}"
-  WORKFLOW_PUBLISH: "${{ github.event_name == 'push' && github.repository == 'winglang/wing' }}"
 
 jobs:
   prepare:
@@ -31,25 +29,25 @@ jobs:
       version: ${{ steps.info.outputs.version || steps.pr_info.outputs.version }}
     steps:
       - name: Checkout
-        if: ${{ env.WORKFLOW_PUBLISH == 'true' }}
+        if: ${{ github.event_name == 'push' && github.repository == 'winglang/wing' }}
         uses: actions/checkout@v3
 
       - name: Get tags
         id: tags
-        if: ${{ env.WORKFLOW_PUBLISH == 'true' }}
+        if: ${{ github.event_name == 'push' && github.repository == 'winglang/wing' }}
         run: |
           git fetch --unshallow --tags
           LAST_VERSION="$(git describe --tags `git rev-list --tags --max-count=1`)"
           echo "last-version=${LAST_VERSION#?}" >> $GITHUB_OUTPUT
 
       - name: Install Dependencies
-        if: ${{ env.WORKFLOW_PUBLISH == 'true' }}
+        if: ${{ github.event_name == 'push' && github.repository == 'winglang/wing' }}
         uses: bahmutov/npm-install@v1
         with:
           install-command: npm ci --ignore-scripts
 
       - name: Get Version Info
-        if: ${{ env.WORKFLOW_PUBLISH == 'true' }}
+        if: ${{ github.event_name == 'push' && github.repository == 'winglang/wing' }}
         id: info
         env:
           # Needed for `auto` cli
@@ -62,7 +60,7 @@ jobs:
 
       # newlines are easier to handle in single-line yaml
       - run: "echo '\n' >> CHANGELOG.md"
-        if: ${{ env.WORKFLOW_PUBLISH == 'true' }}
+        if: ${{ github.event_name == 'push' && github.repository == 'winglang/wing' }}
 
       - name: PR Version Info
         id: pr_info
@@ -80,11 +78,11 @@ jobs:
           path: CHANGELOG.md
 
       - name: Compress Docs
-        if: ${{ env.WORKFLOW_PUBLISH == 'true' }}
+        if: ${{ github.event_name == 'push' && github.repository == 'winglang/wing' }}
         run: tar -czvf docs.tgz docs/*
 
       - name: Upload Docs
-        if: ${{ env.WORKFLOW_PUBLISH == 'true' }}
+        if: ${{ github.event_name == 'push' && github.repository == 'winglang/wing' }}
         uses: actions/upload-artifact@v2
         with:
           name: docs
@@ -127,7 +125,7 @@ jobs:
           targets: "build,test,package"
           all: true
           # If pushing, exclude hangar because we're going to run it in a separate job
-          args: "${{ env.WORKFLOW_FULL_E2E == 'true' && '--exclude=hangar ' || '' }}--configuration=release --output-style=stream --verbose"
+          args: "${{ github.event_name == 'push' && '--exclude=hangar ' || '' }}--configuration=release --output-style=stream --verbose"
 
       - name: Upload Wing CLI
         uses: actions/upload-artifact@v2
@@ -154,7 +152,7 @@ jobs:
           path: apps/vscode-wing/vscode-wing.vsix
 
       - name: "Publish Wing Playground"
-        if: ${{ env.WORKFLOW_PUBLISH == 'true' }}
+        if: ${{ github.event_name == 'push' && github.repository == 'winglang/wing' }}
         uses: amondnet/vercel-action@v25.1.0
         with:
           github-token: ${{ secrets.PROJEN_GITHUB_TOKEN }}
@@ -219,7 +217,7 @@ jobs:
 
   publish:
     name: Publish
-    if: ${{ env.WORKFLOW_PUBLISH == 'true' }}
+    if: ${{ github.event_name == 'push' && github.repository == 'winglang/wing' }}
     needs:
       - e2e
       - prepare


### PR DESCRIPTION
WORKFLOW_FULL_E2E and WORKFLOW_PUBLISH were a well-meaning change, but I can't get it to resolve correctly (`github.env` and `env` worked on `act`, but not on github).

Will need to revisit.

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.