### PR TITLE
feat: bring cdktf

### DIFF
--- a/examples/tests/valid/bring_cdktf.w
+++ b/examples/tests/valid/bring_cdktf.w
@@ -1,0 +1,9 @@
+bring "@cdktf/provider-aws" as aws;
+
+new aws.s3Bucket.S3Bucket(
+  bucket_prefix: "hello",
+  versioning: aws.s3Bucket.S3BucketVersioning {
+    enabled: true,
+    mfa_delete: true,
+  },
+) as "Bucket";

--- a/examples/tests/valid/package-lock.json
+++ b/examples/tests/valid/package-lock.json
@@ -5,7 +5,624 @@
   "packages": {
     "": {
       "dependencies": {
+        "@cdktf/provider-aws": "12.0.5",
         "jsii-code-samples": "1.7.0"
+      }
+    },
+    "node_modules/@cdktf/provider-aws": {
+      "version": "12.0.5",
+      "resolved": "https://registry.npmjs.org/@cdktf/provider-aws/-/provider-aws-12.0.5.tgz",
+      "integrity": "sha512-voDpYyXn1DomBA3HqezV0DquWwlNcCijJJ7M2YaOA31LtQ9emHNXf/jN2qmHwl59RsIH7NQKcq/+zcdqUusfEA==",
+      "engines": {
+        "node": ">= 14.17.0"
+      },
+      "peerDependencies": {
+        "cdktf": "^0.15.0",
+        "constructs": "^10.0.0"
+      }
+    },
+    "node_modules/cdktf": {
+      "version": "0.15.5",
+      "resolved": "https://registry.npmjs.org/cdktf/-/cdktf-0.15.5.tgz",
+      "integrity": "sha512-fcamLs7SKz+kTbQFf+fOXDGvmwT5bH4bHwp+jkVKjGTRsu6C8z5oFVAjKYm+aP1tC7sSWG967+ihSx6+uPNAGw==",
+      "bundleDependencies": [
+        "archiver",
+        "json-stable-stringify",
+        "semver"
+      ],
+      "peer": true,
+      "dependencies": {
+        "archiver": "5.3.1",
+        "json-stable-stringify": "^1.0.2",
+        "semver": "^7.3.8"
+      },
+      "peerDependencies": {
+        "constructs": "^10.0.25"
+      }
+    },
+    "node_modules/cdktf/node_modules/archiver": {
+      "version": "5.3.1",
+      "inBundle": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "archiver-utils": "^2.1.0",
+        "async": "^3.2.3",
+        "buffer-crc32": "^0.2.1",
+        "readable-stream": "^3.6.0",
+        "readdir-glob": "^1.0.0",
+        "tar-stream": "^2.2.0",
+        "zip-stream": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/cdktf/node_modules/archiver-utils": {
+      "version": "2.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "glob": "^7.1.4",
+        "graceful-fs": "^4.2.0",
+        "lazystream": "^1.0.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.difference": "^4.5.0",
+        "lodash.flatten": "^4.4.0",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.union": "^4.6.0",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/cdktf/node_modules/archiver-utils/node_modules/readable-stream": {
+      "version": "2.3.7",
+      "inBundle": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/cdktf/node_modules/archiver-utils/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "inBundle": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/cdktf/node_modules/async": {
+      "version": "3.2.4",
+      "inBundle": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/cdktf/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "inBundle": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/cdktf/node_modules/base64-js": {
+      "version": "1.5.1",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "inBundle": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/cdktf/node_modules/bl": {
+      "version": "4.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/cdktf/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/cdktf/node_modules/buffer": {
+      "version": "5.7.1",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "inBundle": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/cdktf/node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "inBundle": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/cdktf/node_modules/compress-commons": {
+      "version": "4.1.1",
+      "inBundle": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "buffer-crc32": "^0.2.13",
+        "crc32-stream": "^4.0.2",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/cdktf/node_modules/concat-map": {
+      "version": "0.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/cdktf/node_modules/core-util-is": {
+      "version": "1.0.3",
+      "inBundle": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/cdktf/node_modules/crc-32": {
+      "version": "1.2.2",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/cdktf/node_modules/crc32-stream": {
+      "version": "4.0.2",
+      "inBundle": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "crc-32": "^1.2.0",
+        "readable-stream": "^3.4.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/cdktf/node_modules/end-of-stream": {
+      "version": "1.4.4",
+      "inBundle": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/cdktf/node_modules/fs-constants": {
+      "version": "1.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/cdktf/node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "inBundle": true,
+      "license": "ISC",
+      "peer": true
+    },
+    "node_modules/cdktf/node_modules/glob": {
+      "version": "7.2.3",
+      "inBundle": true,
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/cdktf/node_modules/glob/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "inBundle": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/cdktf/node_modules/glob/node_modules/minimatch": {
+      "version": "3.1.2",
+      "inBundle": true,
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/cdktf/node_modules/graceful-fs": {
+      "version": "4.2.10",
+      "inBundle": true,
+      "license": "ISC",
+      "peer": true
+    },
+    "node_modules/cdktf/node_modules/ieee754": {
+      "version": "1.2.1",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "inBundle": true,
+      "license": "BSD-3-Clause",
+      "peer": true
+    },
+    "node_modules/cdktf/node_modules/inflight": {
+      "version": "1.0.6",
+      "inBundle": true,
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/cdktf/node_modules/inherits": {
+      "version": "2.0.4",
+      "inBundle": true,
+      "license": "ISC",
+      "peer": true
+    },
+    "node_modules/cdktf/node_modules/isarray": {
+      "version": "1.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/cdktf/node_modules/json-stable-stringify": {
+      "version": "1.0.2",
+      "inBundle": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "jsonify": "^0.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/cdktf/node_modules/jsonify": {
+      "version": "0.0.1",
+      "inBundle": true,
+      "license": "Public Domain",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/cdktf/node_modules/lazystream": {
+      "version": "1.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "readable-stream": "^2.0.5"
+      },
+      "engines": {
+        "node": ">= 0.6.3"
+      }
+    },
+    "node_modules/cdktf/node_modules/lazystream/node_modules/readable-stream": {
+      "version": "2.3.7",
+      "inBundle": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/cdktf/node_modules/lazystream/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "inBundle": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/cdktf/node_modules/lodash.defaults": {
+      "version": "4.2.0",
+      "inBundle": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/cdktf/node_modules/lodash.difference": {
+      "version": "4.5.0",
+      "inBundle": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/cdktf/node_modules/lodash.flatten": {
+      "version": "4.4.0",
+      "inBundle": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/cdktf/node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "inBundle": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/cdktf/node_modules/lodash.union": {
+      "version": "4.6.0",
+      "inBundle": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/cdktf/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "inBundle": true,
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/cdktf/node_modules/minimatch": {
+      "version": "5.1.0",
+      "inBundle": true,
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/cdktf/node_modules/normalize-path": {
+      "version": "3.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/cdktf/node_modules/once": {
+      "version": "1.4.0",
+      "inBundle": true,
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/cdktf/node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/cdktf/node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/cdktf/node_modules/readable-stream": {
+      "version": "3.6.0",
+      "inBundle": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/cdktf/node_modules/readdir-glob": {
+      "version": "1.1.2",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "minimatch": "^5.1.0"
+      }
+    },
+    "node_modules/cdktf/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "inBundle": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/cdktf/node_modules/semver": {
+      "version": "7.3.8",
+      "inBundle": true,
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/cdktf/node_modules/string_decoder": {
+      "version": "1.3.0",
+      "inBundle": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/cdktf/node_modules/string_decoder/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "inBundle": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/cdktf/node_modules/tar-stream": {
+      "version": "2.2.0",
+      "inBundle": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/cdktf/node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "inBundle": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/cdktf/node_modules/wrappy": {
+      "version": "1.0.2",
+      "inBundle": true,
+      "license": "ISC",
+      "peer": true
+    },
+    "node_modules/cdktf/node_modules/yallist": {
+      "version": "4.0.0",
+      "inBundle": true,
+      "license": "ISC",
+      "peer": true
+    },
+    "node_modules/cdktf/node_modules/zip-stream": {
+      "version": "4.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "archiver-utils": "^2.1.0",
+        "compress-commons": "^4.1.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/constructs": {
+      "version": "10.1.257",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.1.257.tgz",
+      "integrity": "sha512-Wyg17gM+YE/2TsuPMmS+QyWVZ39fTW77AD+87kSs3M94A+0hIrakPH58kif3Q0FlAVyoUDCZIy/qtTBh2AC+jA==",
+      "peer": true,
+      "engines": {
+        "node": ">= 14.17.0"
       }
     },
     "node_modules/jsii-code-samples": {
@@ -15,6 +632,439 @@
     }
   },
   "dependencies": {
+    "@cdktf/provider-aws": {
+      "version": "12.0.5",
+      "resolved": "https://registry.npmjs.org/@cdktf/provider-aws/-/provider-aws-12.0.5.tgz",
+      "integrity": "sha512-voDpYyXn1DomBA3HqezV0DquWwlNcCijJJ7M2YaOA31LtQ9emHNXf/jN2qmHwl59RsIH7NQKcq/+zcdqUusfEA==",
+      "requires": {}
+    },
+    "cdktf": {
+      "version": "0.15.5",
+      "resolved": "https://registry.npmjs.org/cdktf/-/cdktf-0.15.5.tgz",
+      "integrity": "sha512-fcamLs7SKz+kTbQFf+fOXDGvmwT5bH4bHwp+jkVKjGTRsu6C8z5oFVAjKYm+aP1tC7sSWG967+ihSx6+uPNAGw==",
+      "peer": true,
+      "requires": {
+        "archiver": "5.3.1",
+        "json-stable-stringify": "^1.0.2",
+        "semver": "^7.3.8"
+      },
+      "dependencies": {
+        "archiver": {
+          "version": "5.3.1",
+          "bundled": true,
+          "peer": true,
+          "requires": {
+            "archiver-utils": "^2.1.0",
+            "async": "^3.2.3",
+            "buffer-crc32": "^0.2.1",
+            "readable-stream": "^3.6.0",
+            "readdir-glob": "^1.0.0",
+            "tar-stream": "^2.2.0",
+            "zip-stream": "^4.1.0"
+          }
+        },
+        "archiver-utils": {
+          "version": "2.1.0",
+          "bundled": true,
+          "peer": true,
+          "requires": {
+            "glob": "^7.1.4",
+            "graceful-fs": "^4.2.0",
+            "lazystream": "^1.0.0",
+            "lodash.defaults": "^4.2.0",
+            "lodash.difference": "^4.5.0",
+            "lodash.flatten": "^4.4.0",
+            "lodash.isplainobject": "^4.0.6",
+            "lodash.union": "^4.6.0",
+            "normalize-path": "^3.0.0",
+            "readable-stream": "^2.0.0"
+          },
+          "dependencies": {
+            "readable-stream": {
+              "version": "2.3.7",
+              "bundled": true,
+              "peer": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+              }
+            },
+            "string_decoder": {
+              "version": "1.1.1",
+              "bundled": true,
+              "peer": true,
+              "requires": {
+                "safe-buffer": "~5.1.0"
+              }
+            }
+          }
+        },
+        "async": {
+          "version": "3.2.4",
+          "bundled": true,
+          "peer": true
+        },
+        "balanced-match": {
+          "version": "1.0.2",
+          "bundled": true,
+          "peer": true
+        },
+        "base64-js": {
+          "version": "1.5.1",
+          "bundled": true,
+          "peer": true
+        },
+        "bl": {
+          "version": "4.1.0",
+          "bundled": true,
+          "peer": true,
+          "requires": {
+            "buffer": "^5.5.0",
+            "inherits": "^2.0.4",
+            "readable-stream": "^3.4.0"
+          }
+        },
+        "brace-expansion": {
+          "version": "2.0.1",
+          "bundled": true,
+          "peer": true,
+          "requires": {
+            "balanced-match": "^1.0.0"
+          }
+        },
+        "buffer": {
+          "version": "5.7.1",
+          "bundled": true,
+          "peer": true,
+          "requires": {
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.1.13"
+          }
+        },
+        "buffer-crc32": {
+          "version": "0.2.13",
+          "bundled": true,
+          "peer": true
+        },
+        "compress-commons": {
+          "version": "4.1.1",
+          "bundled": true,
+          "peer": true,
+          "requires": {
+            "buffer-crc32": "^0.2.13",
+            "crc32-stream": "^4.0.2",
+            "normalize-path": "^3.0.0",
+            "readable-stream": "^3.6.0"
+          }
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true,
+          "peer": true
+        },
+        "core-util-is": {
+          "version": "1.0.3",
+          "bundled": true,
+          "peer": true
+        },
+        "crc-32": {
+          "version": "1.2.2",
+          "bundled": true,
+          "peer": true
+        },
+        "crc32-stream": {
+          "version": "4.0.2",
+          "bundled": true,
+          "peer": true,
+          "requires": {
+            "crc-32": "^1.2.0",
+            "readable-stream": "^3.4.0"
+          }
+        },
+        "end-of-stream": {
+          "version": "1.4.4",
+          "bundled": true,
+          "peer": true,
+          "requires": {
+            "once": "^1.4.0"
+          }
+        },
+        "fs-constants": {
+          "version": "1.0.0",
+          "bundled": true,
+          "peer": true
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "bundled": true,
+          "peer": true
+        },
+        "glob": {
+          "version": "7.2.3",
+          "bundled": true,
+          "peer": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.1.1",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          },
+          "dependencies": {
+            "brace-expansion": {
+              "version": "1.1.11",
+              "bundled": true,
+              "peer": true,
+              "requires": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+              }
+            },
+            "minimatch": {
+              "version": "3.1.2",
+              "bundled": true,
+              "peer": true,
+              "requires": {
+                "brace-expansion": "^1.1.7"
+              }
+            }
+          }
+        },
+        "graceful-fs": {
+          "version": "4.2.10",
+          "bundled": true,
+          "peer": true
+        },
+        "ieee754": {
+          "version": "1.2.1",
+          "bundled": true,
+          "peer": true
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "bundled": true,
+          "peer": true,
+          "requires": {
+            "once": "^1.3.0",
+            "wrappy": "1"
+          }
+        },
+        "inherits": {
+          "version": "2.0.4",
+          "bundled": true,
+          "peer": true
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "bundled": true,
+          "peer": true
+        },
+        "json-stable-stringify": {
+          "version": "1.0.2",
+          "bundled": true,
+          "peer": true,
+          "requires": {
+            "jsonify": "^0.0.1"
+          }
+        },
+        "jsonify": {
+          "version": "0.0.1",
+          "bundled": true,
+          "peer": true
+        },
+        "lazystream": {
+          "version": "1.0.1",
+          "bundled": true,
+          "peer": true,
+          "requires": {
+            "readable-stream": "^2.0.5"
+          },
+          "dependencies": {
+            "readable-stream": {
+              "version": "2.3.7",
+              "bundled": true,
+              "peer": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+              }
+            },
+            "string_decoder": {
+              "version": "1.1.1",
+              "bundled": true,
+              "peer": true,
+              "requires": {
+                "safe-buffer": "~5.1.0"
+              }
+            }
+          }
+        },
+        "lodash.defaults": {
+          "version": "4.2.0",
+          "bundled": true,
+          "peer": true
+        },
+        "lodash.difference": {
+          "version": "4.5.0",
+          "bundled": true,
+          "peer": true
+        },
+        "lodash.flatten": {
+          "version": "4.4.0",
+          "bundled": true,
+          "peer": true
+        },
+        "lodash.isplainobject": {
+          "version": "4.0.6",
+          "bundled": true,
+          "peer": true
+        },
+        "lodash.union": {
+          "version": "4.6.0",
+          "bundled": true,
+          "peer": true
+        },
+        "lru-cache": {
+          "version": "6.0.0",
+          "bundled": true,
+          "peer": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "minimatch": {
+          "version": "5.1.0",
+          "bundled": true,
+          "peer": true,
+          "requires": {
+            "brace-expansion": "^2.0.1"
+          }
+        },
+        "normalize-path": {
+          "version": "3.0.0",
+          "bundled": true,
+          "peer": true
+        },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true,
+          "peer": true,
+          "requires": {
+            "wrappy": "1"
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "bundled": true,
+          "peer": true
+        },
+        "process-nextick-args": {
+          "version": "2.0.1",
+          "bundled": true,
+          "peer": true
+        },
+        "readable-stream": {
+          "version": "3.6.0",
+          "bundled": true,
+          "peer": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "readdir-glob": {
+          "version": "1.1.2",
+          "bundled": true,
+          "peer": true,
+          "requires": {
+            "minimatch": "^5.1.0"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "bundled": true,
+          "peer": true
+        },
+        "semver": {
+          "version": "7.3.8",
+          "bundled": true,
+          "peer": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "string_decoder": {
+          "version": "1.3.0",
+          "bundled": true,
+          "peer": true,
+          "requires": {
+            "safe-buffer": "~5.2.0"
+          },
+          "dependencies": {
+            "safe-buffer": {
+              "version": "5.2.1",
+              "bundled": true,
+              "peer": true
+            }
+          }
+        },
+        "tar-stream": {
+          "version": "2.2.0",
+          "bundled": true,
+          "peer": true,
+          "requires": {
+            "bl": "^4.0.3",
+            "end-of-stream": "^1.4.1",
+            "fs-constants": "^1.0.0",
+            "inherits": "^2.0.3",
+            "readable-stream": "^3.1.1"
+          }
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "bundled": true,
+          "peer": true
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true,
+          "peer": true
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "bundled": true,
+          "peer": true
+        },
+        "zip-stream": {
+          "version": "4.1.0",
+          "bundled": true,
+          "peer": true,
+          "requires": {
+            "archiver-utils": "^2.1.0",
+            "compress-commons": "^4.1.0",
+            "readable-stream": "^3.6.0"
+          }
+        }
+      }
+    },
+    "constructs": {
+      "version": "10.1.257",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.1.257.tgz",
+      "integrity": "sha512-Wyg17gM+YE/2TsuPMmS+QyWVZ39fTW77AD+87kSs3M94A+0hIrakPH58kif3Q0FlAVyoUDCZIy/qtTBh2AC+jA==",
+      "peer": true
+    },
     "jsii-code-samples": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/jsii-code-samples/-/jsii-code-samples-1.7.0.tgz",

--- a/examples/tests/valid/package.json
+++ b/examples/tests/valid/package.json
@@ -1,6 +1,7 @@
 {
   "dependencies": {
-    "jsii-code-samples": "1.7.0"
+    "jsii-code-samples": "1.7.0",
+    "@cdktf/provider-aws": "12.0.5"
   },
   "volta": {
     "node": "18.12.1",

--- a/libs/wingc/src/type_check/fqn.rs
+++ b/libs/wingc/src/type_check/fqn.rs
@@ -38,7 +38,6 @@ impl<'a> FQN<'a> {
 
 	/// Returns the "assembly" part of the FQN. This is the name of the
 	/// JSII library or Wing library the type is defined in.
-	#[allow(dead_code)]
 	pub fn assembly(&self) -> &str {
 		self.0.split('.').next().unwrap()
 	}

--- a/tools/hangar/src/__snapshots__/compile.test.ts.snap
+++ b/tools/hangar/src/__snapshots__/compile.test.ts.snap
@@ -286,6 +286,75 @@ constructor() {
 new MyApp().synth();"
 `;
 
+exports[`bring_cdktf.w > wing compile --target tf-aws > main.tf.json 1`] = `
+{
+  "//": {
+    "metadata": {
+      "backend": "local",
+      "stackName": "root",
+      "version": "0.15.2",
+    },
+    "outputs": {},
+  },
+  "provider": {
+    "aws": [
+      {},
+    ],
+  },
+  "resource": {
+    "aws_s3_bucket": {
+      "root_Bucket_966015A6": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/Bucket",
+            "uniqueId": "root_Bucket_966015A6",
+          },
+        },
+        "bucket_prefix": "hello",
+        "versioning": {
+          "enabled": true,
+        },
+      },
+    },
+  },
+}
+`;
+
+exports[`bring_cdktf.w > wing compile --target tf-aws > preflight.js 1`] = `
+"const $stdlib = require('@winglang/sdk');
+const $outdir = process.env.WINGSDK_SYNTH_DIR ?? \\".\\";
+
+function __app(target) {
+	switch (target) {
+		case \\"sim\\":
+			return $stdlib.sim.App;
+		case \\"tfaws\\":
+		case \\"tf-aws\\":
+			return $stdlib.tfaws.App;
+		case \\"tf-gcp\\":
+			return $stdlib.tfgcp.App;
+		case \\"tf-azure\\":
+			return $stdlib.tfazure.App;
+		default:
+			throw new Error(\`Unknown WING_TARGET value: \\"\${process.env.WING_TARGET ?? \\"\\"}\\"\`);
+	}
+}
+const $App = __app(process.env.WING_TARGET);
+
+const aws = require(\\"@cdktf/provider-aws\\");
+class MyApp extends $App {
+constructor() {
+  super({ outdir: $outdir, name: \\"bring_cdktf\\", plugins: $plugins });
+  
+  new aws.s3Bucket.S3Bucket(this,\\"Bucket\\",{ versioning: {
+  \\"enabled\\": true,
+  \\"mfa_delete\\": true,}
+  , bucketPrefix: \\"hello\\" });
+}
+}
+new MyApp().synth();"
+`;
+
 exports[`bring_fs.w > wing compile --target tf-aws > main.tf.json 1`] = `
 {
   "//": {

--- a/tools/hangar/src/__snapshots__/test.test.ts.snap
+++ b/tools/hangar/src/__snapshots__/test.test.ts.snap
@@ -4,6 +4,8 @@ exports[`anon_function.w > wing test --target sim > stdout 1`] = `"<green>pass</
 
 exports[`asynchronous_model_implicit_await_in_functions.w > wing test --target sim > stdout 1`] = `"<green>pass</color> <gray>─</color> asynchronous_model_implicit_await_in_functions.w <gray>(no tests)</color>"`;
 
+exports[`bring_cdktf.w > wing test --target sim > stdout 1`] = `"<green>pass</color> <gray>─</color> bring_cdktf.w <gray>(no tests)</color>"`;
+
 exports[`bring_fs.w > wing test --target sim > stdout 1`] = `"<green>pass</color> <gray>─</color> bring_fs.w <gray>(no tests)</color>"`;
 
 exports[`bring_jsii.w > wing test --target sim > stdout 1`] = `"<green>pass</color> <gray>─</color> bring_jsii.w <gray>»</color> <brightWhite>root/test:say_hello</color>"`;


### PR DESCRIPTION
Fixes some limitations with the compiler's jsii importer so that it's now possible to import types from most CDKTF libraries (tested with `@cdktf/provider-aws`).

Notes:
- There were some issues with the jsii importer not unhiding namespaces correctly -- the plan is still to just remove this namespace-hiding logic (see #1487), but to avoid mixing concerns I just fixed the issues I found in this PR.
- Since the compiler doesn't support interfaces yet, I imported these types as `anything`. It's not possible skip importing them because many other resource methods reference interfaces in their parameters (e.g. "cdktf.IResolvable") and our jsii importer doesn't support gracefully failing in these kinds of situations.
- Fixed an issue with symbol shadowing (copied from #1610)

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.