### PR TITLE
docs: add counter.reset api

### DIFF
--- a/docs/04-reference/wingsdk-spec.md
+++ b/docs/04-reference/wingsdk-spec.md
@@ -612,6 +612,12 @@ resource Counter {
    * @default - key: "default"
    */
   inflight peek(key: string?): number;
+
+  /**
+   * Reset a counter to a given value.
+   * @default - key: "default"
+   */
+  inflight reset(value: num, key: string?): void;
 }
 ```
 


### PR DESCRIPTION
Proposal to add an API to `cloud.Counter` for `counter.reset(value)`. I was trying to build some Wing applications and I noticed it was sometimes awkward to use `cloud.Counter` in unit tests without a mechanism to set the counter back to an initial value.

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.