### PR TITLE
feat(cli): ask politely for bug reports when panic occurs

### DIFF
--- a/apps/wing/src/commands/compile.ts
+++ b/apps/wing/src/commands/compile.ts
@@ -100,7 +100,7 @@ export async function compile(entrypoint: string, options: ICompileOptions) {
   } catch (e) {
     // This is a bug in Wing, not the user's code.
     console.error(e);
-    console.log("  " + chalk.bold.red("error:") + " An internal error occurred while Wing was compiling. Please report this bug by creating an issue on GitHub (github.com/winglang/wing) with your Wing code.");
+    console.log("\n\n" + chalk.bold.red("Internal error:") + " An internal compiler error occurred. Please report this bug by creating an issue on GitHub (github.com/winglang/wing/issues) with your code and this trace.");
     process.exit(1);
   }
   if (compileResult !== 0) {


### PR DESCRIPTION
Closes #912

Panic error messages should look something like this now
<img width="688" alt="Screenshot 2023-02-23 at 12 07 30 PM" src="https://user-images.githubusercontent.com/5008987/220979100-c3a4e5bf-4183-4144-9105-00f9a2a2f118.png">

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.