### PR TITLE
chore(docs): you must use the primary key to delete a row from a table

### DIFF
--- a/docs/04-reference/wingsdk-spec.md
+++ b/docs/04-reference/wingsdk-spec.md
@@ -1262,9 +1262,9 @@ resource Table {
   inflight update(row: Map<str, Json>): void;
 
   /**
-   * Delete a row from the table.
+   * Delete a row from the table, by primary key.
    */
-  inflight delete(row: Map<str, Json>): void;
+  inflight delete(key: str): void;
 
   /**
    * Get a row from the table, by primary key.


### PR DESCRIPTION
You must use the primary key to delete a row from a table


*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.