### PR TITLE
fix(compiler): applying camel case to the keys of a struct

### DIFF
--- a/libs/wingc/src/jsify.rs
+++ b/libs/wingc/src/jsify.rs
@@ -418,13 +418,7 @@ impl<'a> JSifier<'a> {
 			ExprKind::MapLiteral { fields, .. } => {
 				let f = fields
 					.iter()
-					.map(|(key, expr)| {
-						format!(
-							"\"{}\":{}",
-							snake_case_to_camel_case(key),
-							self.jsify_expression(expr, phase)
-						)
-					})
+					.map(|(key, expr)| format!("\"{}\":{}", key, self.jsify_expression(expr, phase)))
 					.collect::<Vec<String>>()
 					.join(",");
 

--- a/libs/wingc/src/jsify.rs
+++ b/libs/wingc/src/jsify.rs
@@ -406,7 +406,11 @@ impl<'a> JSifier<'a> {
 					"{{\n{}}}\n",
 					fields
 						.iter()
-						.map(|(name, expr)| format!("\"{}\": {},", name.name, self.jsify_expression(expr, phase)))
+						.map(|(name, expr)| format!(
+							"\"{}\": {},",
+							snake_case_to_camel_case(&name.name),
+							self.jsify_expression(expr, phase)
+						))
 						.collect::<Vec<String>>()
 						.join("\n")
 				)
@@ -414,7 +418,13 @@ impl<'a> JSifier<'a> {
 			ExprKind::MapLiteral { fields, .. } => {
 				let f = fields
 					.iter()
-					.map(|(key, expr)| format!("\"{}\":{}", key, self.jsify_expression(expr, phase)))
+					.map(|(key, expr)| {
+						format!(
+							"\"{}\":{}",
+							snake_case_to_camel_case(key),
+							self.jsify_expression(expr, phase)
+						)
+					})
 					.collect::<Vec<String>>()
 					.join(",");
 

--- a/tools/hangar/src/__snapshots__/compile.test.ts.snap
+++ b/tools/hangar/src/__snapshots__/compile.test.ts.snap
@@ -306,6 +306,7 @@ exports[`bring_cdktf.w > wing compile --target tf-aws > main.tf.json 1`] = `
         "bucket_prefix": "hello",
         "versioning": {
           "enabled": true,
+          "mfa_delete": true,
         },
       },
     },
@@ -341,7 +342,7 @@ constructor() {
   
   new aws.s3Bucket.S3Bucket(this,\\"Bucket\\",{ bucketPrefix: \\"hello\\", versioning: {
   \\"enabled\\": true,
-  \\"mfa_delete\\": true,}
+  \\"mfaDelete\\": true,}
    });
 }
 }


### PR DESCRIPTION
Applying camel case to the keys of a struct

Closes #1632 

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.