### PR TITLE
chore: fix broken `main` due to #1618

### DIFF
--- a/apps/jsii-docgen/test/__snapshots__/cli.test.ts.snap
+++ b/apps/jsii-docgen/test/__snapshots__/cli.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`construct-library 1`] = `
 "# API Reference <a name=\\"API Reference\\" id=\\"api-reference\\"></a>
 
-## Constructs <a name=\\"Constructs\\" id=\\"Constructs\\"></a>
+## Resources <a name=\\"Resources\\" id=\\"Resources\\"></a>
 
 ### GoodbyeBucket <a name=\\"GoodbyeBucket\\" id=\\"construct-library.submod1.GoodbyeBucket\\"></a>
 
@@ -45,7 +45,6 @@ new submod1.GoodbyeBucket(scope: Construct, id: string, props?: BucketProps)
 
 | **Name** | **Description** |
 | --- | --- |
-| <code><a href=\\"#construct-library.submod1.GoodbyeBucket.toString\\">toString</a></code> | Returns a string representation of this construct. |
 | <code><a href=\\"#construct-library.submod1.GoodbyeBucket.applyRemovalPolicy\\">applyRemovalPolicy</a></code> | Apply the given removal policy to this resource. |
 | <code><a href=\\"#construct-library.submod1.GoodbyeBucket.addEventNotification\\">addEventNotification</a></code> | Adds a bucket notification event destination. |
 | <code><a href=\\"#construct-library.submod1.GoodbyeBucket.addObjectCreatedNotification\\">addObjectCreatedNotification</a></code> | Subscribes a destination to receive notifications when an object is created in the bucket. |
@@ -73,14 +72,6 @@ new submod1.GoodbyeBucket(scope: Construct, id: string, props?: BucketProps)
 | <code><a href=\\"#construct-library.submod1.GoodbyeBucket.goodbye\\">goodbye</a></code> | *No description.* |
 
 ---
-
-##### \`toString\` <a name=\\"toString\\" id=\\"construct-library.submod1.GoodbyeBucket.toString\\"></a>
-
-\`\`\`typescript
-public toString(): string
-\`\`\`
-
-Returns a string representation of this construct.
 
 ##### \`applyRemovalPolicy\` <a name=\\"applyRemovalPolicy\\" id=\\"construct-library.submod1.GoodbyeBucket.applyRemovalPolicy\\"></a>
 
@@ -732,28 +723,11 @@ public goodbye(): void
 
 | **Name** | **Description** |
 | --- | --- |
-| <code><a href=\\"#construct-library.submod1.GoodbyeBucket.isConstruct\\">isConstruct</a></code> | Return whether the given object is a Construct. |
 | <code><a href=\\"#construct-library.submod1.GoodbyeBucket.isResource\\">isResource</a></code> | Check whether the given construct is a Resource. |
 | <code><a href=\\"#construct-library.submod1.GoodbyeBucket.fromBucketArn\\">fromBucketArn</a></code> | *No description.* |
 | <code><a href=\\"#construct-library.submod1.GoodbyeBucket.fromBucketAttributes\\">fromBucketAttributes</a></code> | Creates a Bucket construct that represents an external bucket. |
 | <code><a href=\\"#construct-library.submod1.GoodbyeBucket.fromBucketName\\">fromBucketName</a></code> | *No description.* |
 | <code><a href=\\"#construct-library.submod1.GoodbyeBucket.validateBucketName\\">validateBucketName</a></code> | Thrown an exception if the given bucket name is not valid. |
-
----
-
-##### \`isConstruct\` <a name=\\"isConstruct\\" id=\\"construct-library.submod1.GoodbyeBucket.isConstruct\\"></a>
-
-\`\`\`typescript
-import { submod1 } from 'construct-library'
-
-submod1.GoodbyeBucket.isConstruct(x: any)
-\`\`\`
-
-Return whether the given object is a Construct.
-
-###### \`x\`<sup>Required</sup> <a name=\\"x\\" id=\\"construct-library.submod1.GoodbyeBucket.isConstruct.parameter.x\\"></a>
-
-- *Type:* any
 
 ---
 
@@ -1107,7 +1081,6 @@ new GreeterBucket(scope: Construct, id: string, props?: BucketProps)
 
 | **Name** | **Description** |
 | --- | --- |
-| <code><a href=\\"#construct-library.GreeterBucket.toString\\">toString</a></code> | Returns a string representation of this construct. |
 | <code><a href=\\"#construct-library.GreeterBucket.applyRemovalPolicy\\">applyRemovalPolicy</a></code> | Apply the given removal policy to this resource. |
 | <code><a href=\\"#construct-library.GreeterBucket.addEventNotification\\">addEventNotification</a></code> | Adds a bucket notification event destination. |
 | <code><a href=\\"#construct-library.GreeterBucket.addObjectCreatedNotification\\">addObjectCreatedNotification</a></code> | Subscribes a destination to receive notifications when an object is created in the bucket. |
@@ -1135,14 +1108,6 @@ new GreeterBucket(scope: Construct, id: string, props?: BucketProps)
 | <code><a href=\\"#construct-library.GreeterBucket.greet\\">greet</a></code> | *No description.* |
 
 ---
-
-##### \`toString\` <a name=\\"toString\\" id=\\"construct-library.GreeterBucket.toString\\"></a>
-
-\`\`\`typescript
-public toString(): string
-\`\`\`
-
-Returns a string representation of this construct.
 
 ##### \`applyRemovalPolicy\` <a name=\\"applyRemovalPolicy\\" id=\\"construct-library.GreeterBucket.applyRemovalPolicy\\"></a>
 
@@ -1794,28 +1759,11 @@ public greet(): void
 
 | **Name** | **Description** |
 | --- | --- |
-| <code><a href=\\"#construct-library.GreeterBucket.isConstruct\\">isConstruct</a></code> | Return whether the given object is a Construct. |
 | <code><a href=\\"#construct-library.GreeterBucket.isResource\\">isResource</a></code> | Check whether the given construct is a Resource. |
 | <code><a href=\\"#construct-library.GreeterBucket.fromBucketArn\\">fromBucketArn</a></code> | *No description.* |
 | <code><a href=\\"#construct-library.GreeterBucket.fromBucketAttributes\\">fromBucketAttributes</a></code> | Creates a Bucket construct that represents an external bucket. |
 | <code><a href=\\"#construct-library.GreeterBucket.fromBucketName\\">fromBucketName</a></code> | *No description.* |
 | <code><a href=\\"#construct-library.GreeterBucket.validateBucketName\\">validateBucketName</a></code> | Thrown an exception if the given bucket name is not valid. |
-
----
-
-##### \`isConstruct\` <a name=\\"isConstruct\\" id=\\"construct-library.GreeterBucket.isConstruct\\"></a>
-
-\`\`\`typescript
-import { GreeterBucket } from 'construct-library'
-
-GreeterBucket.isConstruct(x: any)
-\`\`\`
-
-Return whether the given object is a Construct.
-
-###### \`x\`<sup>Required</sup> <a name=\\"x\\" id=\\"construct-library.GreeterBucket.isConstruct.parameter.x\\"></a>
-
-- *Type:* any
 
 ---
 
@@ -2138,7 +2086,7 @@ first call to addToResourcePolicy(s).
 exports[`specify language 1`] = `
 "# API Reference <a name=\\"API Reference\\" id=\\"api-reference\\"></a>
 
-## Constructs <a name=\\"Constructs\\" id=\\"Constructs\\"></a>
+## Resources <a name=\\"Resources\\" id=\\"Resources\\"></a>
 
 ### GoodbyeBucket <a name=\\"GoodbyeBucket\\" id=\\"construct-library.submod1.GoodbyeBucket\\"></a>
 
@@ -2500,7 +2448,6 @@ Rules that define when a redirect is applied and the redirect behavior.
 
 | **Name** | **Description** |
 | --- | --- |
-| <code><a href=\\"#construct-library.submod1.GoodbyeBucket.toString\\">to_string</a></code> | Returns a string representation of this construct. |
 | <code><a href=\\"#construct-library.submod1.GoodbyeBucket.applyRemovalPolicy\\">apply_removal_policy</a></code> | Apply the given removal policy to this resource. |
 | <code><a href=\\"#construct-library.submod1.GoodbyeBucket.addEventNotification\\">add_event_notification</a></code> | Adds a bucket notification event destination. |
 | <code><a href=\\"#construct-library.submod1.GoodbyeBucket.addObjectCreatedNotification\\">add_object_created_notification</a></code> | Subscribes a destination to receive notifications when an object is created in the bucket. |
@@ -2528,14 +2475,6 @@ Rules that define when a redirect is applied and the redirect behavior.
 | <code><a href=\\"#construct-library.submod1.GoodbyeBucket.goodbye\\">goodbye</a></code> | *No description.* |
 
 ---
-
-##### \`to_string\` <a name=\\"to_string\\" id=\\"construct-library.submod1.GoodbyeBucket.toString\\"></a>
-
-\`\`\`python
-def to_string() -> str
-\`\`\`
-
-Returns a string representation of this construct.
 
 ##### \`apply_removal_policy\` <a name=\\"apply_removal_policy\\" id=\\"construct-library.submod1.GoodbyeBucket.applyRemovalPolicy\\"></a>
 
@@ -3723,30 +3662,11 @@ def goodbye() -> None
 
 | **Name** | **Description** |
 | --- | --- |
-| <code><a href=\\"#construct-library.submod1.GoodbyeBucket.isConstruct\\">is_construct</a></code> | Return whether the given object is a Construct. |
 | <code><a href=\\"#construct-library.submod1.GoodbyeBucket.isResource\\">is_resource</a></code> | Check whether the given construct is a Resource. |
 | <code><a href=\\"#construct-library.submod1.GoodbyeBucket.fromBucketArn\\">from_bucket_arn</a></code> | *No description.* |
 | <code><a href=\\"#construct-library.submod1.GoodbyeBucket.fromBucketAttributes\\">from_bucket_attributes</a></code> | Creates a Bucket construct that represents an external bucket. |
 | <code><a href=\\"#construct-library.submod1.GoodbyeBucket.fromBucketName\\">from_bucket_name</a></code> | *No description.* |
 | <code><a href=\\"#construct-library.submod1.GoodbyeBucket.validateBucketName\\">validate_bucket_name</a></code> | Thrown an exception if the given bucket name is not valid. |
-
----
-
-##### \`is_construct\` <a name=\\"is_construct\\" id=\\"construct-library.submod1.GoodbyeBucket.isConstruct\\"></a>
-
-\`\`\`python
-from construct_library import submod1
-
-submod1.GoodbyeBucket.is_construct(
-  x: typing.Any
-)
-\`\`\`
-
-Return whether the given object is a Construct.
-
-###### \`x\`<sup>Required</sup> <a name=\\"x\\" id=\\"construct-library.submod1.GoodbyeBucket.isConstruct.parameter.x\\"></a>
-
-- *Type:* typing.Any
 
 ---
 
@@ -4548,7 +4468,6 @@ Rules that define when a redirect is applied and the redirect behavior.
 
 | **Name** | **Description** |
 | --- | --- |
-| <code><a href=\\"#construct-library.GreeterBucket.toString\\">to_string</a></code> | Returns a string representation of this construct. |
 | <code><a href=\\"#construct-library.GreeterBucket.applyRemovalPolicy\\">apply_removal_policy</a></code> | Apply the given removal policy to this resource. |
 | <code><a href=\\"#construct-library.GreeterBucket.addEventNotification\\">add_event_notification</a></code> | Adds a bucket notification event destination. |
 | <code><a href=\\"#construct-library.GreeterBucket.addObjectCreatedNotification\\">add_object_created_notification</a></code> | Subscribes a destination to receive notifications when an object is created in the bucket. |
@@ -4576,14 +4495,6 @@ Rules that define when a redirect is applied and the redirect behavior.
 | <code><a href=\\"#construct-library.GreeterBucket.greet\\">greet</a></code> | *No description.* |
 
 ---
-
-##### \`to_string\` <a name=\\"to_string\\" id=\\"construct-library.GreeterBucket.toString\\"></a>
-
-\`\`\`python
-def to_string() -> str
-\`\`\`
-
-Returns a string representation of this construct.
 
 ##### \`apply_removal_policy\` <a name=\\"apply_removal_policy\\" id=\\"construct-library.GreeterBucket.applyRemovalPolicy\\"></a>
 
@@ -5771,30 +5682,11 @@ def greet() -> None
 
 | **Name** | **Description** |
 | --- | --- |
-| <code><a href=\\"#construct-library.GreeterBucket.isConstruct\\">is_construct</a></code> | Return whether the given object is a Construct. |
 | <code><a href=\\"#construct-library.GreeterBucket.isResource\\">is_resource</a></code> | Check whether the given construct is a Resource. |
 | <code><a href=\\"#construct-library.GreeterBucket.fromBucketArn\\">from_bucket_arn</a></code> | *No description.* |
 | <code><a href=\\"#construct-library.GreeterBucket.fromBucketAttributes\\">from_bucket_attributes</a></code> | Creates a Bucket construct that represents an external bucket. |
 | <code><a href=\\"#construct-library.GreeterBucket.fromBucketName\\">from_bucket_name</a></code> | *No description.* |
 | <code><a href=\\"#construct-library.GreeterBucket.validateBucketName\\">validate_bucket_name</a></code> | Thrown an exception if the given bucket name is not valid. |
-
----
-
-##### \`is_construct\` <a name=\\"is_construct\\" id=\\"construct-library.GreeterBucket.isConstruct\\"></a>
-
-\`\`\`python
-import construct_library
-
-construct_library.GreeterBucket.is_construct(
-  x: typing.Any
-)
-\`\`\`
-
-Return whether the given object is a Construct.
-
-###### \`x\`<sup>Required</sup> <a name=\\"x\\" id=\\"construct-library.GreeterBucket.isConstruct.parameter.x\\"></a>
-
-- *Type:* typing.Any
 
 ---
 
@@ -6245,7 +6137,7 @@ first call to addToResourcePolicy(s).
 exports[`specify root submodule 1`] = `
 "# API Reference <a name=\\"API Reference\\" id=\\"api-reference\\"></a>
 
-## Constructs <a name=\\"Constructs\\" id=\\"Constructs\\"></a>
+## Resources <a name=\\"Resources\\" id=\\"Resources\\"></a>
 
 ### GreeterBucket <a name=\\"GreeterBucket\\" id=\\"construct-library.GreeterBucket\\"></a>
 
@@ -6287,7 +6179,6 @@ new GreeterBucket(scope: Construct, id: string, props?: BucketProps)
 
 | **Name** | **Description** |
 | --- | --- |
-| <code><a href=\\"#construct-library.GreeterBucket.toString\\">toString</a></code> | Returns a string representation of this construct. |
 | <code><a href=\\"#construct-library.GreeterBucket.applyRemovalPolicy\\">applyRemovalPolicy</a></code> | Apply the given removal policy to this resource. |
 | <code><a href=\\"#construct-library.GreeterBucket.addEventNotification\\">addEventNotification</a></code> | Adds a bucket notification event destination. |
 | <code><a href=\\"#construct-library.GreeterBucket.addObjectCreatedNotification\\">addObjectCreatedNotification</a></code> | Subscribes a destination to receive notifications when an object is created in the bucket. |
@@ -6315,14 +6206,6 @@ new GreeterBucket(scope: Construct, id: string, props?: BucketProps)
 | <code><a href=\\"#construct-library.GreeterBucket.greet\\">greet</a></code> | *No description.* |
 
 ---
-
-##### \`toString\` <a name=\\"toString\\" id=\\"construct-library.GreeterBucket.toString\\"></a>
-
-\`\`\`typescript
-public toString(): string
-\`\`\`
-
-Returns a string representation of this construct.
 
 ##### \`applyRemovalPolicy\` <a name=\\"applyRemovalPolicy\\" id=\\"construct-library.GreeterBucket.applyRemovalPolicy\\"></a>
 
@@ -6974,28 +6857,11 @@ public greet(): void
 
 | **Name** | **Description** |
 | --- | --- |
-| <code><a href=\\"#construct-library.GreeterBucket.isConstruct\\">isConstruct</a></code> | Return whether the given object is a Construct. |
 | <code><a href=\\"#construct-library.GreeterBucket.isResource\\">isResource</a></code> | Check whether the given construct is a Resource. |
 | <code><a href=\\"#construct-library.GreeterBucket.fromBucketArn\\">fromBucketArn</a></code> | *No description.* |
 | <code><a href=\\"#construct-library.GreeterBucket.fromBucketAttributes\\">fromBucketAttributes</a></code> | Creates a Bucket construct that represents an external bucket. |
 | <code><a href=\\"#construct-library.GreeterBucket.fromBucketName\\">fromBucketName</a></code> | *No description.* |
 | <code><a href=\\"#construct-library.GreeterBucket.validateBucketName\\">validateBucketName</a></code> | Thrown an exception if the given bucket name is not valid. |
-
----
-
-##### \`isConstruct\` <a name=\\"isConstruct\\" id=\\"construct-library.GreeterBucket.isConstruct\\"></a>
-
-\`\`\`typescript
-import { GreeterBucket } from 'construct-library'
-
-GreeterBucket.isConstruct(x: any)
-\`\`\`
-
-Return whether the given object is a Construct.
-
-###### \`x\`<sup>Required</sup> <a name=\\"x\\" id=\\"construct-library.GreeterBucket.isConstruct.parameter.x\\"></a>
-
-- *Type:* any
 
 ---
 
@@ -7318,7 +7184,7 @@ first call to addToResourcePolicy(s).
 exports[`specify submodule 1`] = `
 "# API Reference <a name=\\"API Reference\\" id=\\"api-reference\\"></a>
 
-## Constructs <a name=\\"Constructs\\" id=\\"Constructs\\"></a>
+## Resources <a name=\\"Resources\\" id=\\"Resources\\"></a>
 
 ### GoodbyeBucket <a name=\\"GoodbyeBucket\\" id=\\"construct-library.submod1.GoodbyeBucket\\"></a>
 
@@ -7360,7 +7226,6 @@ new submod1.GoodbyeBucket(scope: Construct, id: string, props?: BucketProps)
 
 | **Name** | **Description** |
 | --- | --- |
-| <code><a href=\\"#construct-library.submod1.GoodbyeBucket.toString\\">toString</a></code> | Returns a string representation of this construct. |
 | <code><a href=\\"#construct-library.submod1.GoodbyeBucket.applyRemovalPolicy\\">applyRemovalPolicy</a></code> | Apply the given removal policy to this resource. |
 | <code><a href=\\"#construct-library.submod1.GoodbyeBucket.addEventNotification\\">addEventNotification</a></code> | Adds a bucket notification event destination. |
 | <code><a href=\\"#construct-library.submod1.GoodbyeBucket.addObjectCreatedNotification\\">addObjectCreatedNotification</a></code> | Subscribes a destination to receive notifications when an object is created in the bucket. |
@@ -7388,14 +7253,6 @@ new submod1.GoodbyeBucket(scope: Construct, id: string, props?: BucketProps)
 | <code><a href=\\"#construct-library.submod1.GoodbyeBucket.goodbye\\">goodbye</a></code> | *No description.* |
 
 ---
-
-##### \`toString\` <a name=\\"toString\\" id=\\"construct-library.submod1.GoodbyeBucket.toString\\"></a>
-
-\`\`\`typescript
-public toString(): string
-\`\`\`
-
-Returns a string representation of this construct.
 
 ##### \`applyRemovalPolicy\` <a name=\\"applyRemovalPolicy\\" id=\\"construct-library.submod1.GoodbyeBucket.applyRemovalPolicy\\"></a>
 
@@ -8047,28 +7904,11 @@ public goodbye(): void
 
 | **Name** | **Description** |
 | --- | --- |
-| <code><a href=\\"#construct-library.submod1.GoodbyeBucket.isConstruct\\">isConstruct</a></code> | Return whether the given object is a Construct. |
 | <code><a href=\\"#construct-library.submod1.GoodbyeBucket.isResource\\">isResource</a></code> | Check whether the given construct is a Resource. |
 | <code><a href=\\"#construct-library.submod1.GoodbyeBucket.fromBucketArn\\">fromBucketArn</a></code> | *No description.* |
 | <code><a href=\\"#construct-library.submod1.GoodbyeBucket.fromBucketAttributes\\">fromBucketAttributes</a></code> | Creates a Bucket construct that represents an external bucket. |
 | <code><a href=\\"#construct-library.submod1.GoodbyeBucket.fromBucketName\\">fromBucketName</a></code> | *No description.* |
 | <code><a href=\\"#construct-library.submod1.GoodbyeBucket.validateBucketName\\">validateBucketName</a></code> | Thrown an exception if the given bucket name is not valid. |
-
----
-
-##### \`isConstruct\` <a name=\\"isConstruct\\" id=\\"construct-library.submod1.GoodbyeBucket.isConstruct\\"></a>
-
-\`\`\`typescript
-import { submod1 } from 'construct-library'
-
-submod1.GoodbyeBucket.isConstruct(x: any)
-\`\`\`
-
-Return whether the given object is a Construct.
-
-###### \`x\`<sup>Required</sup> <a name=\\"x\\" id=\\"construct-library.submod1.GoodbyeBucket.isConstruct.parameter.x\\"></a>
-
-- *Type:* any
 
 ---
 

--- a/apps/jsii-docgen/test/docgen/view/__snapshots__/documentation.test.ts.snap
+++ b/apps/jsii-docgen/test/docgen/view/__snapshots__/documentation.test.ts.snap
@@ -43,16 +43,6 @@ new GreeterBucket(props?: BucketProps)",
         },
         "instanceMethods": Array [
           Object {
-            "displayName": "to_string",
-            "docs": Object {
-              "summary": "Returns a string representation of this construct.",
-            },
-            "fqn": "construct-library.GreeterBucket.to_string",
-            "id": "construct-library.GreeterBucket.toString",
-            "parameters": Array [],
-            "usage": "to_string(): str",
-          },
-          Object {
             "displayName": "apply_removal_policy",
             "docs": Object {
               "remarks": "The Removal Policy controls what happens to this resource when it stops
@@ -1361,30 +1351,6 @@ first call to addToResourcePolicy(s).",
         ],
         "staticMethods": Array [
           Object {
-            "displayName": "is_construct",
-            "docs": Object {
-              "summary": "Return whether the given object is a Construct.",
-            },
-            "fqn": "construct-library.GreeterBucket.is_construct",
-            "id": "construct-library.GreeterBucket.isConstruct",
-            "parameters": Array [
-              Object {
-                "default": undefined,
-                "displayName": "x",
-                "docs": Object {},
-                "fqn": "construct-library.GreeterBucket.is_construct.parameter.x",
-                "id": "construct-library.GreeterBucket.isConstruct.parameter.x",
-                "optional": undefined,
-                "type": Object {
-                  "formattingPattern": "any",
-                },
-              },
-            ],
-            "usage": "bring { GreeterBucket } from \\"construct-library\\"
-
-GreeterBucket.is_construct(x: any)",
-          },
-          Object {
             "displayName": "is_resource",
             "docs": Object {
               "summary": "Check whether the given construct is a Resource.",
@@ -1552,7 +1518,7 @@ This is a test project to make sure the \`jsii-docgen\` cli property renders API
 for construct libraries.
 # API Reference <a name=\\"API Reference\\" id=\\"api-reference\\"></a>
 
-## Constructs <a name=\\"Constructs\\" id=\\"Constructs\\"></a>
+## Resources <a name=\\"Resources\\" id=\\"Resources\\"></a>
 
 ### GreeterBucket <a name=\\"GreeterBucket\\" id=\\"construct-library.GreeterBucket\\"></a>
 
@@ -1580,7 +1546,6 @@ new GreeterBucket(props?: BucketProps)
 
 | **Name** | **Description** |
 | --- | --- |
-| <code><a href=\\"#construct-library.GreeterBucket.toString\\">to_string</a></code> | Returns a string representation of this construct. |
 | <code><a href=\\"#construct-library.GreeterBucket.applyRemovalPolicy\\">apply_removal_policy</a></code> | Apply the given removal policy to this resource. |
 | <code><a href=\\"#construct-library.GreeterBucket.addEventNotification\\">add_event_notification</a></code> | Adds a bucket notification event destination. |
 | <code><a href=\\"#construct-library.GreeterBucket.addObjectCreatedNotification\\">add_object_created_notification</a></code> | Subscribes a destination to receive notifications when an object is created in the bucket. |
@@ -1608,14 +1573,6 @@ new GreeterBucket(props?: BucketProps)
 | <code><a href=\\"#construct-library.GreeterBucket.greet\\">greet</a></code> | *No description.* |
 
 ---
-
-##### \`to_string\` <a name=\\"to_string\\" id=\\"construct-library.GreeterBucket.toString\\"></a>
-
-\`\`\`wing
-to_string(): str
-\`\`\`
-
-Returns a string representation of this construct.
 
 ##### \`apply_removal_policy\` <a name=\\"apply_removal_policy\\" id=\\"construct-library.GreeterBucket.applyRemovalPolicy\\"></a>
 
@@ -2243,28 +2200,11 @@ greet(): void
 
 | **Name** | **Description** |
 | --- | --- |
-| <code><a href=\\"#construct-library.GreeterBucket.isConstruct\\">is_construct</a></code> | Return whether the given object is a Construct. |
 | <code><a href=\\"#construct-library.GreeterBucket.isResource\\">is_resource</a></code> | Check whether the given construct is a Resource. |
 | <code><a href=\\"#construct-library.GreeterBucket.fromBucketArn\\">from_bucket_arn</a></code> | *No description.* |
 | <code><a href=\\"#construct-library.GreeterBucket.fromBucketAttributes\\">from_bucket_attributes</a></code> | Creates a Bucket construct that represents an external bucket. |
 | <code><a href=\\"#construct-library.GreeterBucket.fromBucketName\\">from_bucket_name</a></code> | *No description.* |
 | <code><a href=\\"#construct-library.GreeterBucket.validateBucketName\\">validate_bucket_name</a></code> | Thrown an exception if the given bucket name is not valid. |
-
----
-
-##### \`is_construct\` <a name=\\"is_construct\\" id=\\"construct-library.GreeterBucket.isConstruct\\"></a>
-
-\`\`\`wing
-bring { GreeterBucket } from \\"construct-library\\"
-
-GreeterBucket.is_construct(x: any)
-\`\`\`
-
-Return whether the given object is a Construct.
-
-###### \`x\`<sup>Required</sup> <a name=\\"x\\" id=\\"construct-library.GreeterBucket.isConstruct.parameter.x\\"></a>
-
-- *Type:* any
 
 ---
 

--- a/apps/jsii-docgen/test/docgen/view/__snapshots__/markdown.test.ts.snap
+++ b/apps/jsii-docgen/test/docgen/view/__snapshots__/markdown.test.ts.snap
@@ -7,7 +7,7 @@ This is a test project to make sure the \`jsii-docgen\` cli property renders API
 for construct libraries.
 # API Reference <a name=\\"API Reference\\" id=\\"api-reference\\"></a>
 
-## Constructs <a name=\\"Constructs\\" id=\\"Constructs\\"></a>
+## Resources <a name=\\"Resources\\" id=\\"Resources\\"></a>
 
 ### GreeterBucket <a name=\\"GreeterBucket\\" id=\\"GreeterBucket\\"></a>
 
@@ -35,7 +35,6 @@ new GreeterBucket(props?: BucketProps)
 
 | **Name** | **Description** |
 | --- | --- |
-| <code><a href=\\"/packages/construct-library/v/0.0.0/api/GreeterBucket.toString?lang=python\\">to_string</a></code> | Returns a string representation of this construct. |
 | <code><a href=\\"/packages/construct-library/v/0.0.0/api/GreeterBucket.applyRemovalPolicy?lang=python\\">apply_removal_policy</a></code> | Apply the given removal policy to this resource. |
 | <code><a href=\\"/packages/construct-library/v/0.0.0/api/GreeterBucket.addEventNotification?lang=python\\">add_event_notification</a></code> | Adds a bucket notification event destination. |
 | <code><a href=\\"/packages/construct-library/v/0.0.0/api/GreeterBucket.addObjectCreatedNotification?lang=python\\">add_object_created_notification</a></code> | Subscribes a destination to receive notifications when an object is created in the bucket. |
@@ -63,14 +62,6 @@ new GreeterBucket(props?: BucketProps)
 | <code><a href=\\"/packages/construct-library/v/0.0.0/api/GreeterBucket.greet?lang=python\\">greet</a></code> | *No description.* |
 
 ---
-
-##### \`to_string\` <a name=\\"to_string\\" id=\\"GreeterBucket.toString\\"></a>
-
-\`\`\`wing
-to_string(): str
-\`\`\`
-
-Returns a string representation of this construct.
 
 ##### \`apply_removal_policy\` <a name=\\"apply_removal_policy\\" id=\\"GreeterBucket.applyRemovalPolicy\\"></a>
 
@@ -698,28 +689,11 @@ greet(): void
 
 | **Name** | **Description** |
 | --- | --- |
-| <code><a href=\\"/packages/construct-library/v/0.0.0/api/GreeterBucket.isConstruct?lang=python\\">is_construct</a></code> | Return whether the given object is a Construct. |
 | <code><a href=\\"/packages/construct-library/v/0.0.0/api/GreeterBucket.isResource?lang=python\\">is_resource</a></code> | Check whether the given construct is a Resource. |
 | <code><a href=\\"/packages/construct-library/v/0.0.0/api/GreeterBucket.fromBucketArn?lang=python\\">from_bucket_arn</a></code> | *No description.* |
 | <code><a href=\\"/packages/construct-library/v/0.0.0/api/GreeterBucket.fromBucketAttributes?lang=python\\">from_bucket_attributes</a></code> | Creates a Bucket construct that represents an external bucket. |
 | <code><a href=\\"/packages/construct-library/v/0.0.0/api/GreeterBucket.fromBucketName?lang=python\\">from_bucket_name</a></code> | *No description.* |
 | <code><a href=\\"/packages/construct-library/v/0.0.0/api/GreeterBucket.validateBucketName?lang=python\\">validate_bucket_name</a></code> | Thrown an exception if the given bucket name is not valid. |
-
----
-
-##### \`is_construct\` <a name=\\"is_construct\\" id=\\"GreeterBucket.isConstruct\\"></a>
-
-\`\`\`wing
-bring { GreeterBucket } from \\"construct-library\\"
-
-GreeterBucket.is_construct(x: any)
-\`\`\`
-
-Return whether the given object is a Construct.
-
-###### \`x\`<sup>Required</sup> <a name=\\"x\\" id=\\"GreeterBucket.isConstruct.parameter.x\\"></a>
-
-- *Type:* any
 
 ---
 
@@ -1006,7 +980,7 @@ This is a test project to make sure the \`jsii-docgen\` cli property renders API
 for construct libraries.
 # API Reference <a name=\\"API Reference\\" id=\\"api-reference\\"></a>
 
-## Constructs <a name=\\"Constructs\\" id=\\"Constructs\\"></a>
+## Resources <a name=\\"Resources\\" id=\\"Resources\\"></a>
 
 ### GreeterBucket <a name=\\"GreeterBucket\\" id=\\"construct-library.GreeterBucket\\"></a>
 
@@ -1034,7 +1008,6 @@ new GreeterBucket(props?: BucketProps)
 
 | **Name** | **Description** |
 | --- | --- |
-| <code><a href=\\"#custom-construct-library.GreeterBucket.toString\\">to_string</a></code> | Returns a string representation of this construct. |
 | <code><a href=\\"#custom-construct-library.GreeterBucket.applyRemovalPolicy\\">apply_removal_policy</a></code> | Apply the given removal policy to this resource. |
 | <code><a href=\\"#custom-construct-library.GreeterBucket.addEventNotification\\">add_event_notification</a></code> | Adds a bucket notification event destination. |
 | <code><a href=\\"#custom-construct-library.GreeterBucket.addObjectCreatedNotification\\">add_object_created_notification</a></code> | Subscribes a destination to receive notifications when an object is created in the bucket. |
@@ -1062,14 +1035,6 @@ new GreeterBucket(props?: BucketProps)
 | <code><a href=\\"#custom-construct-library.GreeterBucket.greet\\">greet</a></code> | *No description.* |
 
 ---
-
-##### \`to_string\` <a name=\\"to_string\\" id=\\"construct-library.GreeterBucket.toString\\"></a>
-
-\`\`\`wing
-to_string(): str
-\`\`\`
-
-Returns a string representation of this construct.
 
 ##### \`apply_removal_policy\` <a name=\\"apply_removal_policy\\" id=\\"construct-library.GreeterBucket.applyRemovalPolicy\\"></a>
 
@@ -1697,28 +1662,11 @@ greet(): void
 
 | **Name** | **Description** |
 | --- | --- |
-| <code><a href=\\"#custom-construct-library.GreeterBucket.isConstruct\\">is_construct</a></code> | Return whether the given object is a Construct. |
 | <code><a href=\\"#custom-construct-library.GreeterBucket.isResource\\">is_resource</a></code> | Check whether the given construct is a Resource. |
 | <code><a href=\\"#custom-construct-library.GreeterBucket.fromBucketArn\\">from_bucket_arn</a></code> | *No description.* |
 | <code><a href=\\"#custom-construct-library.GreeterBucket.fromBucketAttributes\\">from_bucket_attributes</a></code> | Creates a Bucket construct that represents an external bucket. |
 | <code><a href=\\"#custom-construct-library.GreeterBucket.fromBucketName\\">from_bucket_name</a></code> | *No description.* |
 | <code><a href=\\"#custom-construct-library.GreeterBucket.validateBucketName\\">validate_bucket_name</a></code> | Thrown an exception if the given bucket name is not valid. |
-
----
-
-##### \`is_construct\` <a name=\\"is_construct\\" id=\\"construct-library.GreeterBucket.isConstruct\\"></a>
-
-\`\`\`wing
-bring { GreeterBucket } from \\"construct-library\\"
-
-GreeterBucket.is_construct(x: any)
-\`\`\`
-
-Return whether the given object is a Construct.
-
-###### \`x\`<sup>Required</sup> <a name=\\"x\\" id=\\"construct-library.GreeterBucket.isConstruct.parameter.x\\"></a>
-
-- *Type:* any
 
 ---
 

--- a/apps/wing-playground/package-lock.json
+++ b/apps/wing-playground/package-lock.json
@@ -60,7 +60,6 @@
         "constructs": "~10.1.228",
         "debug": "^4.3.4",
         "esbuild-wasm": "^0.17.4",
-        "polycons": "^0.1.8",
         "safe-stable-stringify": "*",
         "tar": "^6.1.13"
       },
@@ -108,8 +107,7 @@
         "@cdktf/provider-google": "^5.0.2",
         "@cdktf/provider-random": "^5.0.0",
         "cdktf": "0.15.2",
-        "constructs": "~10.1.228",
-        "polycons": "^0.1.1"
+        "constructs": "~10.1.228"
       }
     },
     "../../libs/wingsdk/node_modules/@ampproject/remapping": {
@@ -13362,13 +13360,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "../../libs/wingsdk/node_modules/polycons": {
-      "version": "0.1.8",
-      "license": "MIT",
-      "peerDependencies": {
-        "constructs": "^10.0.25"
       }
     },
     "../../libs/wingsdk/node_modules/prelude-ls": {
@@ -44623,7 +44614,6 @@
         "jsii-pacmak": "^1.73.0",
         "npm-check-updates": "^16",
         "patch-package": "^6.5.1",
-        "polycons": "^0.1.8",
         "prettier": "^2.8.3",
         "projen": "^0.67.11",
         "safe-stable-stringify": "*",
@@ -67706,10 +67696,6 @@
             }
           }
         },
-        "polycons": {
-          "version": "0.1.8",
-          "requires": {}
-        },
         "prelude-ls": {
           "version": "1.2.1",
           "dev": true
@@ -71479,7 +71465,6 @@
             "jsii-pacmak": "^1.73.0",
             "npm-check-updates": "^16",
             "patch-package": "^6.5.1",
-            "polycons": "^0.1.8",
             "prettier": "^2.8.3",
             "projen": "^0.67.11",
             "safe-stable-stringify": "*",
@@ -94561,10 +94546,6 @@
                   }
                 }
               }
-            },
-            "polycons": {
-              "version": "0.1.8",
-              "requires": {}
             },
             "prelude-ls": {
               "version": "1.2.1",

--- a/apps/wing/package-lock.json
+++ b/apps/wing/package-lock.json
@@ -84,7 +84,6 @@
         "constructs": "~10.1.228",
         "debug": "^4.3.4",
         "esbuild-wasm": "^0.17.4",
-        "polycons": "^0.1.8",
         "safe-stable-stringify": "*",
         "tar": "^6.1.13"
       },
@@ -132,8 +131,7 @@
         "@cdktf/provider-google": "^5.0.2",
         "@cdktf/provider-random": "^5.0.0",
         "cdktf": "0.15.2",
-        "constructs": "~10.1.228",
-        "polycons": "^0.1.1"
+        "constructs": "~10.1.228"
       }
     },
     "../../libs/wingsdk/node_modules/@ampproject/remapping": {
@@ -13386,13 +13384,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "../../libs/wingsdk/node_modules/polycons": {
-      "version": "0.1.8",
-      "license": "MIT",
-      "peerDependencies": {
-        "constructs": "^10.0.25"
       }
     },
     "../../libs/wingsdk/node_modules/prelude-ls": {
@@ -43954,7 +43945,6 @@
         "jsii-pacmak": "^1.73.0",
         "npm-check-updates": "^16",
         "patch-package": "^6.5.1",
-        "polycons": "^0.1.8",
         "prettier": "^2.8.3",
         "projen": "^0.67.11",
         "safe-stable-stringify": "*",
@@ -67036,10 +67026,6 @@
               }
             }
           }
-        },
-        "polycons": {
-          "version": "0.1.8",
-          "requires": {}
         },
         "prelude-ls": {
           "version": "1.2.1",

--- a/docs/06-contributors/020-development.md
+++ b/docs/06-contributors/020-development.md
@@ -54,6 +54,17 @@ npx nx <target> <project> -- <args>
 [Docker]: https://docs.docker.com/get-docker/
 [emscripten]: https://emscripten.org/docs/getting_started/downloads.html
 
+## Full build
+
+If you wish to perform a full build (similar to the one CI is running), just run this from the root:
+
+```sh
+npm run build
+```
+
+It will run the `build`, `test` and `package` targets on all modules.
+
+
 ## 🏠 What's the recommended development workflow?
 
 The `npx nx wing` command can be executed from the root of the repository in order to build and run the

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "nx": "15.6.3"
   },
   "scripts": {
-    "build": "nx build winglang",
+    "build": "nx run-many --all --targets build,test,package",
     "contributors:add": "all-contributors add",
     "contributors:check": "all-contributors check",
     "contributors:update": "all-contributors check | grep \"Missing contributors\" -A 1 | tail -n1 | sed -e \"s/,//g\" | xargs -n1 | grep -v \"\\[bot\\]\" | xargs -n1 -I{} all-contributors add {} code",

--- a/tools/hangar/src/__snapshots__/compile.test.ts.snap
+++ b/tools/hangar/src/__snapshots__/compile.test.ts.snap
@@ -263,13 +263,13 @@ class MyApp extends $App {
 constructor() {
   super({ outdir: $outdir, name: \\"asynchronous_model_implicit_await_in_functions\\", plugins: $plugins });
   
-  const q = this.node.root.new(\\"@winglang/sdk.cloud.Queue\\",undefined,this,\\"cloud.Queue\\");
-  const str_to_str = this.node.root.new(\\"@winglang/sdk.cloud.Function\\",undefined,this,\\"str_to_str\\",new $stdlib.core.Inflight(this, \\"$Inflight1\\", {
+  const q = this.node.root.newAbstract(\\"@winglang/sdk.cloud.Queue\\",this,\\"cloud.Queue\\");
+  const str_to_str = this.node.root.newAbstract(\\"@winglang/sdk.cloud.Function\\",this,\\"str_to_str\\",new $stdlib.core.Inflight(this, \\"$Inflight1\\", {
     code: $stdlib.core.NodeJsCode.fromFile(require('path').resolve(__dirname, \\"proc.8eb95bcbc154530931e15fc418c8b1fe991095671409552099ea1aa596999ede/index.js\\").replace(/\\\\\\\\/g, \\"/\\")),
     bindings: {
     }
   }));
-  const func = this.node.root.new(\\"@winglang/sdk.cloud.Function\\",undefined,this,\\"func\\",new $stdlib.core.Inflight(this, \\"$Inflight2\\", {
+  const func = this.node.root.newAbstract(\\"@winglang/sdk.cloud.Function\\",this,\\"func\\",new $stdlib.core.Inflight(this, \\"$Inflight2\\", {
     code: $stdlib.core.NodeJsCode.fromFile(require('path').resolve(__dirname, \\"proc.2241fd974faa47c8b8d27f5a3e172f473ca36c6b44cb328a58655fd2d0aac7d7/index.js\\").replace(/\\\\\\\\/g, \\"/\\")),
     bindings: {
       str_to_str: {
@@ -443,7 +443,7 @@ class MyApp extends $App {
 constructor() {
   super({ outdir: $outdir, name: \\"bring_fs\\", plugins: $plugins });
   
-  this.node.root.new(\\"@winglang/sdk.cloud.Bucket\\",undefined,this,\\"cloud.Bucket\\");
+  this.node.root.newAbstract(\\"@winglang/sdk.cloud.Bucket\\",this,\\"cloud.Bucket\\");
   this.node.root.new(\\"@winglang/sdk.fs.TextFile\\",fs.TextFile,this,\\"fs.TextFile\\",\\"/tmp/test.txt\\");
 }
 }
@@ -586,7 +586,7 @@ constructor() {
   
   const hello = new stuff.HelloWorld();
   const greeting = (hello.sayHello(\\"wingnuts\\"));
-  this.node.root.new(\\"@winglang/sdk.cloud.Function\\",undefined,this,\\"test:say_hello\\",new $stdlib.core.Inflight(this, \\"$Inflight1\\", {
+  this.node.root.newAbstract(\\"@winglang/sdk.cloud.Function\\",this,\\"test:say_hello\\",new $stdlib.core.Inflight(this, \\"$Inflight1\\", {
     code: $stdlib.core.NodeJsCode.fromFile(require('path').resolve(__dirname, \\"proc.5d209e0c3acca40c825662cab73c204803d9dd9f7903de90d0da6dc99ea7fa35/index.js\\").replace(/\\\\\\\\/g, \\"/\\")),
     bindings: {
       greeting: {
@@ -736,7 +736,7 @@ constructor() {
   
   const hello = new jsii_code_samples.HelloWorld();
   const greeting = (hello.sayHello(\\"wingnuts\\"));
-  this.node.root.new(\\"@winglang/sdk.cloud.Function\\",undefined,this,\\"test:say_hello\\",new $stdlib.core.Inflight(this, \\"$Inflight1\\", {
+  this.node.root.newAbstract(\\"@winglang/sdk.cloud.Function\\",this,\\"test:say_hello\\",new $stdlib.core.Inflight(this, \\"$Inflight1\\", {
     code: $stdlib.core.NodeJsCode.fromFile(require('path').resolve(__dirname, \\"proc.5d209e0c3acca40c825662cab73c204803d9dd9f7903de90d0da6dc99ea7fa35/index.js\\").replace(/\\\\\\\\/g, \\"/\\")),
     bindings: {
       greeting: {
@@ -965,7 +965,7 @@ constructor() {
       },
     }
   });
-  this.node.root.new(\\"@winglang/sdk.cloud.Function\\",undefined,this,\\"test\\",handler);
+  this.node.root.newAbstract(\\"@winglang/sdk.cloud.Function\\",this,\\"test\\",handler);
 }
 }
 new MyApp().synth();"
@@ -1195,10 +1195,10 @@ class MyApp extends $App {
 constructor() {
   super({ outdir: $outdir, name: \\"capture_containers_of_resources\\", plugins: $plugins });
   
-  const arr = Object.freeze([this.node.root.new(\\"@winglang/sdk.cloud.Bucket\\",undefined,this,\\"b1\\"), this.node.root.new(\\"@winglang/sdk.cloud.Bucket\\",undefined,this,\\"b2\\")]);
-  const map = Object.freeze({\\"my_queue\\":this.node.root.new(\\"@winglang/sdk.cloud.Queue\\",undefined,this,\\"cloud.Queue\\")});
+  const arr = Object.freeze([this.node.root.newAbstract(\\"@winglang/sdk.cloud.Bucket\\",this,\\"b1\\"), this.node.root.newAbstract(\\"@winglang/sdk.cloud.Bucket\\",this,\\"b2\\")]);
+  const map = Object.freeze({\\"my_queue\\":this.node.root.newAbstract(\\"@winglang/sdk.cloud.Queue\\",this,\\"cloud.Queue\\")});
   const set = Object.freeze(new Set([\\"foo\\", \\"foo\\", \\"bar\\"]));
-  this.node.root.new(\\"@winglang/sdk.cloud.Function\\",undefined,this,\\"test\\",new $stdlib.core.Inflight(this, \\"$Inflight1\\", {
+  this.node.root.newAbstract(\\"@winglang/sdk.cloud.Function\\",this,\\"test\\",new $stdlib.core.Inflight(this, \\"$Inflight1\\", {
     code: $stdlib.core.NodeJsCode.fromFile(require('path').resolve(__dirname, \\"proc.e204fa6fba10aa68396c0fe4d920796b1ec739609b648739fe4ae94d0621db6d/index.js\\").replace(/\\\\\\\\/g, \\"/\\")),
     bindings: {
       arr: {
@@ -1398,7 +1398,7 @@ class MyApp extends $App {
 constructor() {
   super({ outdir: $outdir, name: \\"capture_in_binary\\", plugins: $plugins });
   
-  const b = this.node.root.new(\\"@winglang/sdk.cloud.Bucket\\",undefined,this,\\"cloud.Bucket\\");
+  const b = this.node.root.newAbstract(\\"@winglang/sdk.cloud.Bucket\\",this,\\"cloud.Bucket\\");
   const x = 12;
   const handler2 = new $stdlib.core.Inflight(this, \\"$Inflight1\\", {
     code: $stdlib.core.NodeJsCode.fromFile(require('path').resolve(__dirname, \\"proc.d3cc1deae5ea8972097ff15c11d688f395bd17117453789488a005b829eea245/index.js\\").replace(/\\\\\\\\/g, \\"/\\")),
@@ -1413,7 +1413,7 @@ constructor() {
       },
     }
   });
-  this.node.root.new(\\"@winglang/sdk.cloud.Function\\",undefined,this,\\"test\\",handler2);
+  this.node.root.newAbstract(\\"@winglang/sdk.cloud.Function\\",this,\\"test\\",handler2);
 }
 }
 new MyApp().synth();"
@@ -1595,7 +1595,7 @@ constructor() {
       },
     }
   });
-  this.node.root.new(\\"@winglang/sdk.cloud.Function\\",undefined,this,\\"cloud.Function\\",handler);
+  this.node.root.newAbstract(\\"@winglang/sdk.cloud.Function\\",this,\\"cloud.Function\\",handler);
 }
 }
 new MyApp().synth();"
@@ -1782,8 +1782,8 @@ constructor() {
   super({ outdir: $outdir, name: \\"capture_resource_and_data\\", plugins: $plugins });
   
   const data = Object.freeze(new Set([1, 2, 3]));
-  const res = this.node.root.new(\\"@winglang/sdk.cloud.Bucket\\",undefined,this,\\"cloud.Bucket\\");
-  const queue = this.node.root.new(\\"@winglang/sdk.cloud.Queue\\",undefined,this,\\"cloud.Queue\\");
+  const res = this.node.root.newAbstract(\\"@winglang/sdk.cloud.Bucket\\",this,\\"cloud.Bucket\\");
+  const queue = this.node.root.newAbstract(\\"@winglang/sdk.cloud.Queue\\",this,\\"cloud.Queue\\");
   const handler = new $stdlib.core.Inflight(this, \\"$Inflight1\\", {
     code: $stdlib.core.NodeJsCode.fromFile(require('path').resolve(__dirname, \\"proc.10149a479ee5940e90f4621a2bca78dda7429636b1f235fcd785b3e33c131537/index.js\\").replace(/\\\\\\\\/g, \\"/\\")),
     bindings: {
@@ -1801,7 +1801,7 @@ constructor() {
       },
     }
   });
-  this.node.root.new(\\"@winglang/sdk.cloud.Function\\",undefined,this,\\"test\\",handler);
+  this.node.root.newAbstract(\\"@winglang/sdk.cloud.Function\\",this,\\"test\\",handler);
 }
 }
 new MyApp().synth();"
@@ -1965,7 +1965,7 @@ constructor() {
   }
   
   const a = new A(this,\\"A\\");
-  this.node.root.new(\\"@winglang/sdk.cloud.Function\\",undefined,this,\\"test\\",new $stdlib.core.Inflight(this, \\"$Inflight1\\", {
+  this.node.root.newAbstract(\\"@winglang/sdk.cloud.Function\\",this,\\"test\\",new $stdlib.core.Inflight(this, \\"$Inflight1\\", {
     code: $stdlib.core.NodeJsCode.fromFile(require('path').resolve(__dirname, \\"proc.b771192b636450edefdc8f4b596a6372d5b2520efa1fcdb75c51589c12a10c59/index.js\\").replace(/\\\\\\\\/g, \\"/\\")),
     bindings: {
       a: {
@@ -2375,12 +2375,12 @@ class MyApp extends $App {
 constructor() {
   super({ outdir: $outdir, name: \\"captures\\", plugins: $plugins });
   
-  const bucket1 = this.node.root.new(\\"@winglang/sdk.cloud.Bucket\\",undefined,this,\\"cloud.Bucket\\");
-  const bucket2 = this.node.root.new(\\"@winglang/sdk.cloud.Bucket\\",undefined,this,\\"PublicBucket\\",{
+  const bucket1 = this.node.root.newAbstract(\\"@winglang/sdk.cloud.Bucket\\",this,\\"cloud.Bucket\\");
+  const bucket2 = this.node.root.newAbstract(\\"@winglang/sdk.cloud.Bucket\\",this,\\"PublicBucket\\",{
   \\"public\\": true,}
   );
-  const bucket3 = this.node.root.new(\\"@winglang/sdk.cloud.Bucket\\",undefined,this,\\"PrivateBucket\\",{ public: false });
-  const queue = this.node.root.new(\\"@winglang/sdk.cloud.Queue\\",undefined,this,\\"cloud.Queue\\");
+  const bucket3 = this.node.root.newAbstract(\\"@winglang/sdk.cloud.Bucket\\",this,\\"PrivateBucket\\",{ public: false });
+  const queue = this.node.root.newAbstract(\\"@winglang/sdk.cloud.Queue\\",this,\\"cloud.Queue\\");
   const handler = new $stdlib.core.Inflight(this, \\"$Inflight1\\", {
     code: $stdlib.core.NodeJsCode.fromFile(require('path').resolve(__dirname, \\"proc.5f0e4e25898a72c973f063e92444f7572d58a18cdd38b3fb3a575af6adf7440f/index.js\\").replace(/\\\\\\\\/g, \\"/\\")),
     bindings: {
@@ -2399,9 +2399,9 @@ constructor() {
     }
   });
   (queue.onMessage(handler,{ batchSize: 5 }));
-  this.node.root.new(\\"@winglang/sdk.cloud.Function\\",undefined,this,\\"cloud.Function\\",handler,{ env: Object.freeze({}) });
+  this.node.root.newAbstract(\\"@winglang/sdk.cloud.Function\\",this,\\"cloud.Function\\",handler,{ env: Object.freeze({}) });
   const empty_env = Object.freeze({});
-  this.node.root.new(\\"@winglang/sdk.cloud.Function\\",undefined,this,\\"AnotherFunction\\",handler,{ env: empty_env });
+  this.node.root.newAbstract(\\"@winglang/sdk.cloud.Function\\",this,\\"AnotherFunction\\",handler,{ env: empty_env });
 }
 }
 new MyApp().synth();"
@@ -2573,9 +2573,9 @@ class MyApp extends $App {
 constructor() {
   super({ outdir: $outdir, name: \\"container_types\\", plugins: $plugins });
   
-  const bucket1 = this.node.root.new(\\"@winglang/sdk.cloud.Bucket\\",undefined,this,\\"bucket1\\");
-  const bucket2 = this.node.root.new(\\"@winglang/sdk.cloud.Bucket\\",undefined,this,\\"bucket2\\");
-  const bucket3 = this.node.root.new(\\"@winglang/sdk.cloud.Bucket\\",undefined,this,\\"bucket3\\");
+  const bucket1 = this.node.root.newAbstract(\\"@winglang/sdk.cloud.Bucket\\",this,\\"bucket1\\");
+  const bucket2 = this.node.root.newAbstract(\\"@winglang/sdk.cloud.Bucket\\",this,\\"bucket2\\");
+  const bucket3 = this.node.root.newAbstract(\\"@winglang/sdk.cloud.Bucket\\",this,\\"bucket3\\");
   const empty_array = Object.freeze([]);
   {((cond) => {if (!cond) throw new Error(\`assertion failed: '(empty_array.length === 0)'\`)})((empty_array.length === 0))};
   const empty_array2 = [];
@@ -3039,9 +3039,9 @@ class MyApp extends $App {
 constructor() {
   super({ outdir: $outdir, name: \\"file_counter\\", plugins: $plugins });
   
-  const bucket = this.node.root.new(\\"@winglang/sdk.cloud.Bucket\\",undefined,this,\\"cloud.Bucket\\");
-  const counter = this.node.root.new(\\"@winglang/sdk.cloud.Counter\\",undefined,this,\\"cloud.Counter\\",{ initial: 100 });
-  const queue = this.node.root.new(\\"@winglang/sdk.cloud.Queue\\",undefined,this,\\"cloud.Queue\\",{ timeout: $stdlib.std.Duration.fromSeconds(10) });
+  const bucket = this.node.root.newAbstract(\\"@winglang/sdk.cloud.Bucket\\",this,\\"cloud.Bucket\\");
+  const counter = this.node.root.newAbstract(\\"@winglang/sdk.cloud.Counter\\",this,\\"cloud.Counter\\",{ initial: 100 });
+  const queue = this.node.root.newAbstract(\\"@winglang/sdk.cloud.Queue\\",this,\\"cloud.Queue\\",{ timeout: $stdlib.std.Duration.fromSeconds(10) });
   const handler = new $stdlib.core.Inflight(this, \\"$Inflight1\\", {
     code: $stdlib.core.NodeJsCode.fromFile(require('path').resolve(__dirname, \\"proc.1ece6a476239c44d64d8b687b9e4389715198c49564defb8766e8b85b0f54620/index.js\\").replace(/\\\\\\\\/g, \\"/\\")),
     bindings: {
@@ -3392,8 +3392,8 @@ class MyApp extends $App {
 constructor() {
   super({ outdir: $outdir, name: \\"hello\\", plugins: $plugins });
   
-  const bucket = this.node.root.new(\\"@winglang/sdk.cloud.Bucket\\",undefined,this,\\"cloud.Bucket\\");
-  const queue = this.node.root.new(\\"@winglang/sdk.cloud.Queue\\",undefined,this,\\"cloud.Queue\\");
+  const bucket = this.node.root.newAbstract(\\"@winglang/sdk.cloud.Bucket\\",this,\\"cloud.Bucket\\");
+  const queue = this.node.root.newAbstract(\\"@winglang/sdk.cloud.Queue\\",this,\\"cloud.Queue\\");
   (queue.onMessage(new $stdlib.core.Inflight(this, \\"$Inflight1\\", {
     code: $stdlib.core.NodeJsCode.fromFile(require('path').resolve(__dirname, \\"proc.211d46e8ec3b5ce3e93872fcb29755356fb3566f5016eae5fcd6ec0f670ab580/index.js\\").replace(/\\\\\\\\/g, \\"/\\")),
     bindings: {
@@ -3637,9 +3637,9 @@ class MyApp extends $App {
 constructor() {
   super({ outdir: $outdir, name: \\"mut_container_types\\", plugins: $plugins });
   
-  const bucket1 = this.node.root.new(\\"@winglang/sdk.cloud.Bucket\\",undefined,this,\\"bucket1\\");
-  const bucket2 = this.node.root.new(\\"@winglang/sdk.cloud.Bucket\\",undefined,this,\\"bucket2\\");
-  const bucket3 = this.node.root.new(\\"@winglang/sdk.cloud.Bucket\\",undefined,this,\\"bucket3\\");
+  const bucket1 = this.node.root.newAbstract(\\"@winglang/sdk.cloud.Bucket\\",this,\\"bucket1\\");
+  const bucket2 = this.node.root.newAbstract(\\"@winglang/sdk.cloud.Bucket\\",this,\\"bucket2\\");
+  const bucket3 = this.node.root.newAbstract(\\"@winglang/sdk.cloud.Bucket\\",this,\\"bucket3\\");
   const arr1 = [\\"a\\", \\"b\\", \\"c\\"];
   const arr2 = [1, 2, 3];
   const arr3 = [bucket1, bucket2];
@@ -3941,12 +3941,12 @@ constructor() {
   super({ outdir: $outdir, name: \\"print\\", plugins: $plugins });
   
   {console.log(\\"preflight print\\")};
-  this.node.root.new(\\"@winglang/sdk.cloud.Function\\",undefined,this,\\"test:print1\\",new $stdlib.core.Inflight(this, \\"$Inflight1\\", {
+  this.node.root.newAbstract(\\"@winglang/sdk.cloud.Function\\",this,\\"test:print1\\",new $stdlib.core.Inflight(this, \\"$Inflight1\\", {
     code: $stdlib.core.NodeJsCode.fromFile(require('path').resolve(__dirname, \\"proc.5d5065e7d4d5abb68575b6b618fc014e76b4159c3240fef327354a5900bb9fa6/index.js\\").replace(/\\\\\\\\/g, \\"/\\")),
     bindings: {
     }
   }));
-  this.node.root.new(\\"@winglang/sdk.cloud.Function\\",undefined,this,\\"test:print2\\",new $stdlib.core.Inflight(this, \\"$Inflight2\\", {
+  this.node.root.newAbstract(\\"@winglang/sdk.cloud.Function\\",this,\\"test:print2\\",new $stdlib.core.Inflight(this, \\"$Inflight2\\", {
     code: $stdlib.core.NodeJsCode.fromFile(require('path').resolve(__dirname, \\"proc.44e74a6db41cb5fd5b35696592c6a747e9831b228b4d1ce62b6e65f43dee835d/index.js\\").replace(/\\\\\\\\/g, \\"/\\")),
     bindings: {
     }
@@ -4288,7 +4288,7 @@ constructor() {
   	constructor(scope, id, ) {
   	super(scope, id);
   {
-    this.c = this.node.root.new(\\"@winglang/sdk.cloud.Counter\\",undefined,this,\\"cloud.Counter\\");
+    this.c = this.node.root.newAbstract(\\"@winglang/sdk.cloud.Counter\\",this,\\"cloud.Counter\\");
   }
   }
   	
@@ -4319,9 +4319,9 @@ constructor() {
   }
   }
   Bar._annotateInflight(\\"my_method\\", {\\"this.b\\": { ops: [\\"delete\\", \\"get\\", \\"list\\", \\"put\\"]}, \\"this.foo\\": { ops: [\\"foo_get\\", \\"foo_inc\\"]}, \\"this.name\\": { ops: []}});
-  const bucket = this.node.root.new(\\"@winglang/sdk.cloud.Bucket\\",undefined,this,\\"cloud.Bucket\\");
+  const bucket = this.node.root.newAbstract(\\"@winglang/sdk.cloud.Bucket\\",this,\\"cloud.Bucket\\");
   const res = new Bar(this,\\"Bar\\",\\"Arr\\",bucket);
-  this.node.root.new(\\"@winglang/sdk.cloud.Function\\",undefined,this,\\"test\\",new $stdlib.core.Inflight(this, \\"$Inflight1\\", {
+  this.node.root.newAbstract(\\"@winglang/sdk.cloud.Function\\",this,\\"test\\",new $stdlib.core.Inflight(this, \\"$Inflight1\\", {
     code: $stdlib.core.NodeJsCode.fromFile(require('path').resolve(__dirname, \\"proc.e50bc85b13df379286b4aa72aa88788422e26d9146adbc9bba989a8a59253a73/index.js\\").replace(/\\\\\\\\/g, \\"/\\")),
     bindings: {
       bucket: {
@@ -4506,7 +4506,7 @@ constructor() {
       {((cond) => {if (!cond) throw new Error(\`assertion failed: 'false'\`)})(false)};
     }
   }
-  this.node.root.new(\\"@winglang/sdk.cloud.Function\\",undefined,this,\\"test\\",new $stdlib.core.Inflight(this, \\"$Inflight1\\", {
+  this.node.root.newAbstract(\\"@winglang/sdk.cloud.Function\\",this,\\"test\\",new $stdlib.core.Inflight(this, \\"$Inflight1\\", {
     code: $stdlib.core.NodeJsCode.fromFile(require('path').resolve(__dirname, \\"proc.09c5e24751d9ba1246f91518f2f7f5c5d1102a09d0b1acff479ae27ad134090f/index.js\\").replace(/\\\\\\\\/g, \\"/\\")),
     bindings: {
     }
@@ -4754,7 +4754,7 @@ constructor() {
   const foo = new Foo(this,\\"Foo\\");
   {((cond) => {if (!cond) throw new Error(\`assertion failed: '(foo.instance_field === 100)'\`)})((foo.instance_field === 100))};
   {((cond) => {if (!cond) throw new Error(\`assertion failed: '((Foo.m()) === 99)'\`)})(((Foo.m()) === 99))};
-  new cloud.Function(this,\\"test\\",new $stdlib.core.Inflight(this, \\"$Inflight1\\", {
+  this.node.root.newAbstract(\\"@winglang/sdk.cloud.Function\\",this,\\"test\\",new $stdlib.core.Inflight(this, \\"$Inflight1\\", {
     code: $stdlib.core.NodeJsCode.fromFile(require('path').resolve(__dirname, \\"proc.8b58045c72709175549d51937a233ff65ac5e5aa12e83837daf5ea7baf9f224b/index.js\\").replace(/\\\\\\\\/g, \\"/\\")),
     bindings: {
     }
@@ -4988,7 +4988,7 @@ constructor() {
   {((cond) => {if (!cond) throw new Error(\`assertion failed: '((s1.substring(5,7)) === \\"st\\")'\`)})(((s1.substring(5,7)) === \\"st\\"))};
   {((cond) => {if (!cond) throw new Error(\`assertion failed: '((\\"   some string   \\".trim()) === \\"some string\\")'\`)})(((\\"   some string   \\".trim()) === \\"some string\\"))};
   {((cond) => {if (!cond) throw new Error(\`assertion failed: '(\\"Some String\\".toLocaleUpperCase() === \\"SOME STRING\\")'\`)})((\\"Some String\\".toLocaleUpperCase() === \\"SOME STRING\\"))};
-  this.node.root.new(\\"@winglang/sdk.cloud.Function\\",undefined,this,\\"test:string\\",new $stdlib.core.Inflight(this, \\"$Inflight1\\", {
+  this.node.root.newAbstract(\\"@winglang/sdk.cloud.Function\\",this,\\"test:string\\",new $stdlib.core.Inflight(this, \\"$Inflight1\\", {
     code: $stdlib.core.NodeJsCode.fromFile(require('path').resolve(__dirname, \\"proc.0fb01e81c63b003d77d6245e36ba84561e3e2d3268e69a7c975f81cfe7565fac/index.js\\").replace(/\\\\\\\\/g, \\"/\\")),
     bindings: {
       s1: {
@@ -5251,8 +5251,8 @@ class MyApp extends $App {
 constructor() {
   super({ outdir: $outdir, name: \\"test_bucket\\", plugins: $plugins });
   
-  const b = this.node.root.new(\\"@winglang/sdk.cloud.Bucket\\",undefined,this,\\"cloud.Bucket\\");
-  this.node.root.new(\\"@winglang/sdk.cloud.Function\\",undefined,this,\\"test:put\\",new $stdlib.core.Inflight(this, \\"$Inflight1\\", {
+  const b = this.node.root.newAbstract(\\"@winglang/sdk.cloud.Bucket\\",this,\\"cloud.Bucket\\");
+  this.node.root.newAbstract(\\"@winglang/sdk.cloud.Function\\",this,\\"test:put\\",new $stdlib.core.Inflight(this, \\"$Inflight1\\", {
     code: $stdlib.core.NodeJsCode.fromFile(require('path').resolve(__dirname, \\"proc.9f10a129b90bc1328dcb1e6194e3902931d1011d95e46825362ef5b06ec17380/index.js\\").replace(/\\\\\\\\/g, \\"/\\")),
     bindings: {
       b: {
@@ -5261,7 +5261,7 @@ constructor() {
       },
     }
   }));
-  this.node.root.new(\\"@winglang/sdk.cloud.Function\\",undefined,this,\\"test:get\\",new $stdlib.core.Inflight(this, \\"$Inflight2\\", {
+  this.node.root.newAbstract(\\"@winglang/sdk.cloud.Function\\",this,\\"test:get\\",new $stdlib.core.Inflight(this, \\"$Inflight2\\", {
     code: $stdlib.core.NodeJsCode.fromFile(require('path').resolve(__dirname, \\"proc.1b9abefaef8ce4230db863000273d2c12bacb97e33ac10e6c8b50341e415fdac/index.js\\").replace(/\\\\\\\\/g, \\"/\\")),
     bindings: {
       b: {
@@ -6049,14 +6049,14 @@ constructor() {
   	constructor(scope, id, ) {
   	super(scope, id);
   {
-    this.my_resource = this.node.root.new(\\"@winglang/sdk.cloud.Bucket\\",undefined,this,\\"cloud.Bucket\\");
+    this.my_resource = this.node.root.newAbstract(\\"@winglang/sdk.cloud.Bucket\\",this,\\"cloud.Bucket\\");
     this.my_str = \\"my_string\\";
     this.my_num = 42;
     this.my_bool = true;
     this.array_of_str = Object.freeze([\\"s1\\", \\"s2\\"]);
     this.map_of_num = Object.freeze({\\"k1\\":11,\\"k2\\":22});
     this.set_of_str = Object.freeze(new Set([\\"s1\\", \\"s2\\", \\"s1\\"]));
-    this.array_of_queues = Object.freeze([this.node.root.new(\\"@winglang/sdk.cloud.Queue\\",undefined,this,\\"q1\\"), this.node.root.new(\\"@winglang/sdk.cloud.Queue\\",undefined,this,\\"q2\\")]);
+    this.array_of_queues = Object.freeze([this.node.root.newAbstract(\\"@winglang/sdk.cloud.Queue\\",this,\\"q1\\"), this.node.root.newAbstract(\\"@winglang/sdk.cloud.Queue\\",this,\\"q2\\")]);
   }
   }
   	
@@ -6080,7 +6080,7 @@ constructor() {
   MyResource._annotateInflight(\\"capture_set\\", {\\"this.array_of_queues\\": { ops: []}, \\"this.array_of_str\\": { ops: []}, \\"this.map_of_num\\": { ops: []}, \\"this.my_bool\\": { ops: []}, \\"this.my_num\\": { ops: []}, \\"this.my_resource\\": { ops: [\\"delete\\", \\"get\\", \\"list\\", \\"put\\"]}, \\"this.my_str\\": { ops: []}, \\"this.set_of_str\\": { ops: []}});
   MyResource._annotateInflight(\\"capture_array_of_queues\\", {\\"this.array_of_queues\\": { ops: []}, \\"this.array_of_str\\": { ops: []}, \\"this.map_of_num\\": { ops: []}, \\"this.my_bool\\": { ops: []}, \\"this.my_num\\": { ops: []}, \\"this.my_resource\\": { ops: [\\"delete\\", \\"get\\", \\"list\\", \\"put\\"]}, \\"this.my_str\\": { ops: []}, \\"this.set_of_str\\": { ops: []}});
   const r = new MyResource(this,\\"MyResource\\");
-  this.node.root.new(\\"@winglang/sdk.cloud.Function\\",undefined,this,\\"test:capture_resource\\",new $stdlib.core.Inflight(this, \\"$Inflight1\\", {
+  this.node.root.newAbstract(\\"@winglang/sdk.cloud.Function\\",this,\\"test:capture_resource\\",new $stdlib.core.Inflight(this, \\"$Inflight1\\", {
     code: $stdlib.core.NodeJsCode.fromFile(require('path').resolve(__dirname, \\"proc.b5e7bd6cc9f6c741c4f0afa8adc0208ccee08e6297495b1fbe29db8afb6ee789/index.js\\").replace(/\\\\\\\\/g, \\"/\\")),
     bindings: {
       r: {
@@ -6089,7 +6089,7 @@ constructor() {
       },
     }
   }));
-  this.node.root.new(\\"@winglang/sdk.cloud.Function\\",undefined,this,\\"test:capture_primitives\\",new $stdlib.core.Inflight(this, \\"$Inflight2\\", {
+  this.node.root.newAbstract(\\"@winglang/sdk.cloud.Function\\",this,\\"test:capture_primitives\\",new $stdlib.core.Inflight(this, \\"$Inflight2\\", {
     code: $stdlib.core.NodeJsCode.fromFile(require('path').resolve(__dirname, \\"proc.1814d20e284e4a33aff014ce4391d7da7998b0cd7db8ebee477a5400763bbe7b/index.js\\").replace(/\\\\\\\\/g, \\"/\\")),
     bindings: {
       r: {
@@ -6098,7 +6098,7 @@ constructor() {
       },
     }
   }));
-  this.node.root.new(\\"@winglang/sdk.cloud.Function\\",undefined,this,\\"test:capture_array\\",new $stdlib.core.Inflight(this, \\"$Inflight3\\", {
+  this.node.root.newAbstract(\\"@winglang/sdk.cloud.Function\\",this,\\"test:capture_array\\",new $stdlib.core.Inflight(this, \\"$Inflight3\\", {
     code: $stdlib.core.NodeJsCode.fromFile(require('path').resolve(__dirname, \\"proc.c341832069b7b13603626bc26227d936f0a7d7b7da45751e3666d6f4e7fa599a/index.js\\").replace(/\\\\\\\\/g, \\"/\\")),
     bindings: {
       r: {
@@ -6107,7 +6107,7 @@ constructor() {
       },
     }
   }));
-  this.node.root.new(\\"@winglang/sdk.cloud.Function\\",undefined,this,\\"test:capture_map\\",new $stdlib.core.Inflight(this, \\"$Inflight4\\", {
+  this.node.root.newAbstract(\\"@winglang/sdk.cloud.Function\\",this,\\"test:capture_map\\",new $stdlib.core.Inflight(this, \\"$Inflight4\\", {
     code: $stdlib.core.NodeJsCode.fromFile(require('path').resolve(__dirname, \\"proc.7235e8fbf10f106318ff9c22489e4e955483c8de6b39df0dbf143fdfa4691109/index.js\\").replace(/\\\\\\\\/g, \\"/\\")),
     bindings: {
       r: {
@@ -6116,7 +6116,7 @@ constructor() {
       },
     }
   }));
-  this.node.root.new(\\"@winglang/sdk.cloud.Function\\",undefined,this,\\"test:capture_set\\",new $stdlib.core.Inflight(this, \\"$Inflight5\\", {
+  this.node.root.newAbstract(\\"@winglang/sdk.cloud.Function\\",this,\\"test:capture_set\\",new $stdlib.core.Inflight(this, \\"$Inflight5\\", {
     code: $stdlib.core.NodeJsCode.fromFile(require('path').resolve(__dirname, \\"proc.b7df534fba155b498841a75f4610f6bb576ee00e2fbe6869317adf3718597864/index.js\\").replace(/\\\\\\\\/g, \\"/\\")),
     bindings: {
       r: {
@@ -6125,7 +6125,7 @@ constructor() {
       },
     }
   }));
-  this.node.root.new(\\"@winglang/sdk.cloud.Function\\",undefined,this,\\"test:capture_array_of_queues\\",new $stdlib.core.Inflight(this, \\"$Inflight6\\", {
+  this.node.root.newAbstract(\\"@winglang/sdk.cloud.Function\\",this,\\"test:capture_array_of_queues\\",new $stdlib.core.Inflight(this, \\"$Inflight6\\", {
     code: $stdlib.core.NodeJsCode.fromFile(require('path').resolve(__dirname, \\"proc.179eef1ca19aa2bf908a3113209c3d8b96c23bac7bc35f1d6381c0f5cd2ec603/index.js\\").replace(/\\\\\\\\/g, \\"/\\")),
     bindings: {
       r: {
@@ -6349,7 +6349,7 @@ class MyApp extends $App {
 constructor() {
   super({ outdir: $outdir, name: \\"while_loop_await\\", plugins: $plugins });
   
-  const queue = this.node.root.new(\\"@winglang/sdk.cloud.Queue\\",undefined,this,\\"cloud.Queue\\");
+  const queue = this.node.root.newAbstract(\\"@winglang/sdk.cloud.Queue\\",this,\\"cloud.Queue\\");
   const iterator = new $stdlib.core.Inflight(this, \\"$Inflight1\\", {
     code: $stdlib.core.NodeJsCode.fromFile(require('path').resolve(__dirname, \\"proc.82d0059fdbaebaab6d1be68f497052f9d5b8662f4333952a6e9ad55f564e0c97/index.js\\").replace(/\\\\\\\\/g, \\"/\\")),
     bindings: {


### PR DESCRIPTION
Somehow #1681 got merged with some stale snapshots and other generated artifacts. This PR fixes that.

Misc: changed the root `build` npm script to mimick what we run in CI because basically there's no easy way to run a full build on the system.



*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.