### PR TITLE
feat(compiler): display preflight prints

### DIFF
--- a/apps/wing/src/commands/compile.ts
+++ b/apps/wing/src/commands/compile.ts
@@ -137,6 +137,7 @@ export async function compile(entrypoint: string, options: ICompileOptions) {
         WING_TARGET: options.target,
       },
     },
+    console,
     __dirname: workDir,
     __filename: artifactPath,
     $plugins: resolvePluginPaths(options.plugins ?? []),

--- a/tools/hangar/src/__snapshots__/test.test.ts.snap
+++ b/tools/hangar/src/__snapshots__/test.test.ts.snap
@@ -1,6 +1,11 @@
 // Vitest Snapshot v1
 
-exports[`anon_function.w > wing test --target sim > stdout 1`] = `"<green>pass</color> <gray>─</color> anon_function.w <gray>(no tests)</color>"`;
+exports[`anon_function.w > wing test --target sim > stdout 1`] = `
+"1
+2
+3
+<green>pass</color> <gray>─</color> anon_function.w <gray>(no tests)</color>"
+`;
 
 exports[`asynchronous_model_implicit_await_in_functions.w > wing test --target sim > stdout 1`] = `"<green>pass</color> <gray>─</color> asynchronous_model_implicit_await_in_functions.w <gray>(no tests)</color>"`;
 
@@ -38,9 +43,23 @@ exports[`expressions_string_interpolation.w > wing test --target sim > stdout 1`
 
 exports[`file_counter.w > wing test --target sim > stdout 1`] = `"<green>pass</color> <gray>─</color> file_counter.w <gray>(no tests)</color>"`;
 
-exports[`for_loop.w > wing test --target sim > stdout 1`] = `"<green>pass</color> <gray>─</color> for_loop.w <gray>(no tests)</color>"`;
+exports[`for_loop.w > wing test --target sim > stdout 1`] = `
+"wing: 1
+wing: 2
+wing: 3
+lang: 1
+lang: 2
+lang: 3
+dang: 1
+dang: 2
+dang: 3
+<green>pass</color> <gray>─</color> for_loop.w <gray>(no tests)</color>"
+`;
 
-exports[`forward_decl.w > wing test --target sim > stdout 1`] = `"<green>pass</color> <gray>─</color> forward_decl.w <gray>(no tests)</color>"`;
+exports[`forward_decl.w > wing test --target sim > stdout 1`] = `
+"hi
+<green>pass</color> <gray>─</color> forward_decl.w <gray>(no tests)</color>"
+`;
 
 exports[`hello.w > wing test --target sim > stdout 1`] = `"<green>pass</color> <gray>─</color> hello.w <gray>(no tests)</color>"`;
 
@@ -50,10 +69,14 @@ exports[`json.w > wing test --target sim > stdout 1`] = `"<green>pass</color> <g
 
 exports[`mut_container_types.w > wing test --target sim > stdout 1`] = `"<green>pass</color> <gray>─</color> mut_container_types.w <gray>(no tests)</color>"`;
 
-exports[`primitive_methods.w > wing test --target sim > stdout 1`] = `"<green>pass</color> <gray>─</color> primitive_methods.w <gray>(no tests)</color>"`;
+exports[`primitive_methods.w > wing test --target sim > stdout 1`] = `
+"1:60
+<green>pass</color> <gray>─</color> primitive_methods.w <gray>(no tests)</color>"
+`;
 
 exports[`print.w > wing test --target sim > stdout 1`] = `
-"<green>pass</color> <gray>┌</color> print.w <gray>»</color> <brightWhite>root/test:print1</color>
+"preflight print
+<green>pass</color> <gray>┌</color> print.w <gray>»</color> <brightWhite>root/test:print1</color>
     <gray> │ </color><gray>inflight print 1.1</color>
     <gray> └ </color><gray>inflight print 1.2</color>
 <green>pass</color> <gray>┌</color> print.w <gray>»</color> <brightWhite>root/test:print2</color>


### PR DESCRIPTION
Shares the console with preflight vm allowing us to display preflight print statements

Closes: #1538 

Screenshot of the hotness:
<img width="410" alt="image" src="https://user-images.githubusercontent.com/45375125/222264945-85763a8a-eca0-473b-8bbd-ed5f4aa69460.png">

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.