### PR TITLE
chore(build): disable windows tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -174,7 +174,7 @@ jobs:
       matrix:
         runner:
           - ubuntu-latest
-          - windows-latest
+          # - windows-latest
           - macos-latest
         node: [18, 19]
     runs-on: ${{ matrix.runner }}


### PR DESCRIPTION
We have decided to temporarily disable windows tests as it was blocking publishing new releases.
*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.