### PR TITLE
chore: improve error message when dependency not found

### DIFF
--- a/libs/wingii/src/lib.rs
+++ b/libs/wingii/src/lib.rs
@@ -232,7 +232,10 @@ pub mod type_system {
 			if opts.deps {
 				for dep in deps {
 					if !bundled.contains(&dep) {
-						let dep_dir = package_json::find_dependency_directory(&dep, &module_directory).unwrap();
+						let dep_dir = package_json::find_dependency_directory(&dep, &module_directory).ok_or(format!(
+							"Unable to load \"{}\": Module not found from \"{}\"",
+							dep, module_directory
+						))?;
 						self.load_module(&dep_dir, opts)?;
 					}
 				}


### PR DESCRIPTION
Instead of `unwrap`-ing it should be ok to just error here

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.