### PR TITLE
chore(compiler): dedup interface/class method/field iterator helpers

### DIFF
--- a/libs/wingc/src/capture.rs
+++ b/libs/wingc/src/capture.rs
@@ -12,8 +12,7 @@ use crate::{
 		Scope, StmtKind, Symbol,
 	},
 	diagnostic::{Diagnostic, DiagnosticLevel, Diagnostics},
-	type_check::symbol_env::SymbolEnv,
-	type_check::Type,
+	type_check::{symbol_env::SymbolEnv, ClassLike, Type},
 	visit::Visit,
 };
 use std::collections::{BTreeMap, BTreeSet};

--- a/libs/wingc/src/jsify.rs
+++ b/libs/wingc/src/jsify.rs
@@ -11,7 +11,7 @@ use crate::{
 		InterpolatedStringPart, Literal, Phase, Reference, Scope, Stmt, StmtKind, Symbol, TypeAnnotation, UnaryOperator,
 		UserDefinedType,
 	},
-	type_check::{resolve_user_defined_type, symbol_env::SymbolEnv, Type, TypeRef},
+	type_check::{resolve_user_defined_type, symbol_env::SymbolEnv, ClassLike, Type, TypeRef},
 	utilities::snake_case_to_camel_case,
 	MACRO_REPLACE_ARGS, MACRO_REPLACE_SELF, WINGSDK_ASSEMBLY_NAME, WINGSDK_RESOURCE,
 };


### PR DESCRIPTION
done by creating a `ClassLike` trait that can be useful for other things like a `get_method` api.

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.