### PR TITLE
fix: compiling cloud function mangles terminal output

### DIFF
--- a/libs/wingc/src/jsify.rs
+++ b/libs/wingc/src/jsify.rs
@@ -325,15 +325,14 @@ impl<'a> JSifier<'a> {
 					None
 				};
 
-				if !is_resource || fqn.is_none() {
-					format!("new {}({})", ctor, args)
-				} else {
-					let fqn = fqn.expect("expecting fqn to be defined");
+				if let (true, Some(fqn)) = (is_resource, fqn) {
 					if is_abstract {
 						format!("this.node.root.newAbstract(\"{}\",{})", fqn, args)
 					} else {
 						format!("this.node.root.new(\"{}\",{},{})", fqn, ctor, args)
 					}
+				} else {
+					format!("new {}({})", ctor, args)
 				}
 			}
 			ExprKind::Literal(lit) => match lit {

--- a/libs/wingsdk/src/cloud/function.ts
+++ b/libs/wingsdk/src/cloud/function.ts
@@ -114,8 +114,10 @@ export abstract class Function extends Resource implements IInflightHost {
     const outfile = join(tempdir, "index.js");
     writeFileSync(infile, lines.join("\n"));
 
-    // Run esbuild in a child process to bundle the handler code.
-    // A workaround for https://github.com/evanw/esbuild/issues/2927
+    // We would invoke esbuild directly here, but there is a bug where esbuild
+    // mangles the stdout/stderr of the process that invokes it.
+    // https://github.com/evanw/esbuild/issues/2927
+    // To workaround the issue, spawn a new process and invoke esbuild inside it.
     try {
       let esbuildScript = [
         `const esbuild = require("${require.resolve("esbuild-wasm")}");`,

--- a/libs/wingsdk/src/core/app.ts
+++ b/libs/wingsdk/src/core/app.ts
@@ -1,11 +1,4 @@
-import {
-  mkdirSync,
-  readdirSync,
-  renameSync,
-  rmSync,
-  rmdirSync,
-  existsSync,
-} from "fs";
+import { mkdirSync, readdirSync, renameSync, rmSync, existsSync } from "fs";
 import { join } from "path";
 import * as cdktf from "cdktf";
 import { Construct } from "constructs";
@@ -272,7 +265,7 @@ export abstract class CdktfApp extends App {
         // If the file is a directory we need to delete contents of previous synthesis
         // or rename will fail
         if (existsSync(destination)) {
-          rmdirSync(destination, { recursive: true });
+          rmSync(destination, { recursive: true });
         }
 
         renameSync(source, destination);

--- a/libs/wingsdk/test/sandbox/main.ts
+++ b/libs/wingsdk/test/sandbox/main.ts
@@ -13,15 +13,19 @@ class HelloWorld extends Construct {
   constructor(scope: Construct, id: string) {
     super(scope, id);
 
-    const bucket = new cloud.Bucket(this, "Bucket", { public: false });
-    bucket.addObject("test.txt", "yoyoyo");
+    const handler = testing.Testing.makeHandler(
+      this,
+      "Handler",
+      `async handle() { console.log("Hello, world!"); }`
+    );
+    // cloud.Function._newFunction(this, "Function", handler);
+    const queue = cloud.Queue._newQueue(this, "Queue");
+    queue.onMessage(handler);
   }
 }
 
-const app = new tfgcp.App({
+const app = new tfaws.App({
   outdir: join(__dirname, "target"),
-  projectId: "my-project",
-  storageLocation: "US",
 });
 new HelloWorld(app, "HelloWorld");
 app.synth();

--- a/libs/wingsdk/test/target-sim/__snapshots__/file-counter.test.ts.snap
+++ b/libs/wingsdk/test/target-sim/__snapshots__/file-counter.test.ts.snap
@@ -296,7 +296,7 @@ __export(queue_onmessage_inflight_exports, {
 });
 var QueueOnMessageHandlerClient;
 var init_queue_onmessage_inflight = __esm({
-  \\"[REDACTED]/wingsdk/src/target-sim/queue.onmessage.inflight.ts\\"() {
+  \\"src/target-sim/queue.onmessage.inflight.ts\\"() {
     \\"use strict\\";
     QueueOnMessageHandlerClient = class {
       constructor({ handler }) {

--- a/libs/wingsdk/test/target-sim/__snapshots__/queue.test.ts.snap
+++ b/libs/wingsdk/test/target-sim/__snapshots__/queue.test.ts.snap
@@ -345,7 +345,7 @@ __export(queue_onmessage_inflight_exports, {
 });
 var QueueOnMessageHandlerClient;
 var init_queue_onmessage_inflight = __esm({
-  \\"[REDACTED]/wingsdk/src/target-sim/queue.onmessage.inflight.ts\\"() {
+  \\"src/target-sim/queue.onmessage.inflight.ts\\"() {
     \\"use strict\\";
     QueueOnMessageHandlerClient = class {
       constructor({ handler }) {
@@ -895,7 +895,7 @@ __export(queue_onmessage_inflight_exports, {
 });
 var QueueOnMessageHandlerClient;
 var init_queue_onmessage_inflight = __esm({
-  \\"[REDACTED]/wingsdk/src/target-sim/queue.onmessage.inflight.ts\\"() {
+  \\"src/target-sim/queue.onmessage.inflight.ts\\"() {
     \\"use strict\\";
     QueueOnMessageHandlerClient = class {
       constructor({ handler }) {
@@ -1308,7 +1308,7 @@ __export(queue_onmessage_inflight_exports, {
 });
 var QueueOnMessageHandlerClient;
 var init_queue_onmessage_inflight = __esm({
-  \\"[REDACTED]/wingsdk/src/target-sim/queue.onmessage.inflight.ts\\"() {
+  \\"src/target-sim/queue.onmessage.inflight.ts\\"() {
     \\"use strict\\";
     QueueOnMessageHandlerClient = class {
       constructor({ handler }) {


### PR DESCRIPTION
Adds a workaround for an issue where compiling cloud functions (which calls esbuild) results in mangled terminal output.

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.