### PR TITLE
feat: include js path in preflight error message

### DIFF
--- a/apps/wing/src/commands/compile.ts
+++ b/apps/wing/src/commands/compile.ts
@@ -172,7 +172,7 @@ export async function compile(entrypoint: string, options: ICompileOptions) {
         "  " +
           chalk.bold.white("note:") +
           " " +
-          chalk.white("intermediate javascript code:")
+          chalk.white(`intermediate javascript code (${artifactPath}):`)
       );
       const lineNumber =
         Number.parseInt(


### PR DESCRIPTION
Adds the path to the referenced JS file in preflight error messages. This information is handy when you are trying to dive into debug why an error occurred, especially for people unfamiliar with where Wing compile artifacts are generated.

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.