### PR TITLE
fix(sdk): some bucket keys are invalid

### DIFF
--- a/examples/tests/valid/bucket_keys.w
+++ b/examples/tests/valid/bucket_keys.w
@@ -1,0 +1,17 @@
+bring cloud;
+
+let b = new cloud.Bucket();
+
+new cloud.Function(inflight () => {
+  b.put("foo", "text");
+  b.put("foo/", "text");
+  b.put("foo/bar", "text");
+  b.put("foo/bar/", "text");
+  b.put("foo/bar/baz", "text");
+  let objs = b.list();
+  assert(objs.at(0) == "foo");
+  assert(objs.at(1) == "foo/");
+  assert(objs.at(2) == "foo/bar");
+  assert(objs.at(3) == "foo/bar/");
+  assert(objs.at(4) == "foo/bar/baz");
+}) as "test";

--- a/libs/wingsdk/src/target-sim/bucket.inflight.ts
+++ b/libs/wingsdk/src/target-sim/bucket.inflight.ts
@@ -1,17 +1,20 @@
+import * as crypto from "crypto";
 import * as fs from "fs";
 import * as os from "os";
 import { dirname, join } from "path";
 import { ISimulatorResourceInstance } from "./resource";
 import { BucketSchema } from "./schema-resources";
-import { exists } from "./util";
 import { BucketDeleteOptions, IBucketClient } from "../cloud";
 import { ISimulatorContext } from "../testing/simulator";
 
 export class Bucket implements IBucketClient, ISimulatorResourceInstance {
+  private readonly objectKeys: Set<string>;
   private readonly fileDir: string;
   private readonly context: ISimulatorContext;
   private readonly initialObjects: Record<string, string>;
+
   public constructor(props: BucketSchema["props"], context: ISimulatorContext) {
+    this.objectKeys = new Set();
     this.fileDir = fs.mkdtempSync(join(os.tmpdir(), "wing-sim-"));
     this.context = context;
     this.initialObjects = props.initialObjects ?? {};
@@ -22,8 +25,7 @@ export class Bucket implements IBucketClient, ISimulatorResourceInstance {
       await this.context.withTrace({
         message: `Adding object from preflight (key=${key}).`,
         activity: async () => {
-          const filename = join(this.fileDir, key);
-          await fs.promises.writeFile(filename, value);
+          return this.addFile(key, value);
         },
       });
     }
@@ -37,10 +39,7 @@ export class Bucket implements IBucketClient, ISimulatorResourceInstance {
     return this.context.withTrace({
       message: `Put (key=${key}).`,
       activity: async () => {
-        const filename = join(this.fileDir, key);
-        const dirName = dirname(filename);
-        await fs.promises.mkdir(dirName, { recursive: true });
-        await fs.promises.writeFile(filename, value);
+        return this.addFile(key, value);
       },
     });
   }
@@ -49,7 +48,8 @@ export class Bucket implements IBucketClient, ISimulatorResourceInstance {
     return this.context.withTrace({
       message: `Get (key=${key}).`,
       activity: async () => {
-        const filename = join(this.fileDir, key);
+        const hash = this.hashKey(key);
+        const filename = join(this.fileDir, hash);
         return fs.promises.readFile(filename, "utf8");
       },
     });
@@ -59,7 +59,13 @@ export class Bucket implements IBucketClient, ISimulatorResourceInstance {
     return this.context.withTrace({
       message: `List (prefix=${prefix ?? "null"}).`,
       activity: async () => {
-        return fs.promises.readdir(`${this.fileDir}/${prefix ?? ""}`);
+        return Array.from(this.objectKeys.values()).filter((key) => {
+          if (prefix) {
+            return key.startsWith(prefix);
+          } else {
+            return true;
+          }
+        });
       },
     });
   }
@@ -69,21 +75,33 @@ export class Bucket implements IBucketClient, ISimulatorResourceInstance {
       message: `Delete (key=${key}).`,
       activity: async () => {
         const mustExist = opts?.mustExist ?? false;
-        const filePath = join(this.fileDir, key);
 
-        if (!mustExist) {
-          // check if the file exists
-          const fileExists = await exists(filePath);
-
-          if (!fileExists) {
-            // nothing to delete, return without throwing
+        if (!this.objectKeys.has(key)) {
+          if (mustExist) {
+            throw new Error(`Object does not exist (key=${key}).`);
+          } else {
             return;
           }
         }
 
-        // unlink file from the filesystem
-        return fs.promises.unlink(filePath);
+        const hash = this.hashKey(key);
+        const filename = join(this.fileDir, hash);
+        await fs.promises.unlink(filename);
+        this.objectKeys.delete(key);
       },
     });
+  }
+
+  private async addFile(key: string, value: string): Promise<void> {
+    const hash = this.hashKey(key);
+    const filename = join(this.fileDir, hash);
+    const dirName = dirname(filename);
+    await fs.promises.mkdir(dirName, { recursive: true });
+    await fs.promises.writeFile(filename, value);
+    this.objectKeys.add(key);
+  }
+
+  private hashKey(key: string): string {
+    return crypto.createHash("sha512").update(key).digest("hex");
   }
 }

--- a/libs/wingsdk/src/target-sim/bucket.inflight.ts
+++ b/libs/wingsdk/src/target-sim/bucket.inflight.ts
@@ -97,12 +97,12 @@ export class Bucket implements IBucketClient, ISimulatorResourceInstance {
       activity: async () => {
         const mustExist = opts?.mustExist ?? false;
 
+        if (!this.objectKeys.has(key) && mustExist) {
+          throw new Error(`Object does not exist (key=${key}).`);
+        }
+
         if (!this.objectKeys.has(key)) {
-          if (mustExist) {
-            throw new Error(`Object does not exist (key=${key}).`);
-          } else {
-            return;
-          }
+          return;
         }
 
         const hash = this.hashKey(key);

--- a/libs/wingsdk/test/target-sim/__snapshots__/bucket.test.ts.snap
+++ b/libs/wingsdk/test/target-sim/__snapshots__/bucket.test.ts.snap
@@ -13,6 +13,125 @@ Array [
 ]
 `;
 
+exports[`can add object in preflight 2`] = `
+Object {
+  "app.wsim/simulator.json": Object {
+    "resources": Array [
+      Object {
+        "attrs": Object {},
+        "path": "root/WingLogger",
+        "props": Object {},
+        "type": "wingsdk.cloud.Logger",
+      },
+      Object {
+        "attrs": Object {},
+        "path": "root/my_bucket",
+        "props": Object {
+          "initialObjects": Object {
+            "greeting.txt": "Hello world!",
+          },
+          "public": false,
+        },
+        "type": "wingsdk.cloud.Bucket",
+      },
+    ],
+    "sdkVersion": "0.0.0",
+  },
+  "app.wsim/tree.json": Object {
+    "tree": Object {
+      "children": Object {
+        "WingLogger": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [],
+            "wing:resource:stateful": true,
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.1.245",
+          },
+          "display": Object {
+            "description": "A cloud logging facility",
+            "hidden": true,
+            "title": "Logger",
+          },
+          "id": "WingLogger",
+          "path": "root/WingLogger",
+        },
+        "my_bucket": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [],
+            "wing:resource:stateful": true,
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.1.245",
+          },
+          "display": Object {
+            "description": "A cloud object store",
+            "title": "Bucket",
+          },
+          "id": "my_bucket",
+          "path": "root/my_bucket",
+        },
+      },
+      "constructInfo": Object {
+        "fqn": "constructs.Construct",
+        "version": "10.1.245",
+      },
+      "id": "root",
+      "path": "root",
+    },
+    "version": "tree-0.1",
+  },
+  "tree.json": Object {
+    "tree": Object {
+      "children": Object {
+        "WingLogger": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [],
+            "wing:resource:stateful": true,
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.1.245",
+          },
+          "display": Object {
+            "description": "A cloud logging facility",
+            "hidden": true,
+            "title": "Logger",
+          },
+          "id": "WingLogger",
+          "path": "root/WingLogger",
+        },
+        "my_bucket": Object {
+          "attributes": Object {
+            "wing:resource:connections": Array [],
+            "wing:resource:stateful": true,
+          },
+          "constructInfo": Object {
+            "fqn": "constructs.Construct",
+            "version": "10.1.245",
+          },
+          "display": Object {
+            "description": "A cloud object store",
+            "title": "Bucket",
+          },
+          "id": "my_bucket",
+          "path": "root/my_bucket",
+        },
+      },
+      "constructInfo": Object {
+        "fqn": "constructs.Construct",
+        "version": "10.1.245",
+      },
+      "id": "root",
+      "path": "root",
+    },
+    "version": "tree-0.1",
+  },
+}
+`;
+
 exports[`create a bucket 1`] = `
 Object {
   "app.wsim/simulator.json": Object {
@@ -257,6 +376,41 @@ Object {
 }
 `;
 
+exports[`list respects prefixes 1`] = `
+Array [
+  "wingsdk.cloud.Logger created.",
+  "wingsdk.cloud.Bucket created.",
+  "Put (key=path/dir1/file1.txt).",
+  "Put (key=path/dir2/file2.txt).",
+  "List (prefix=null).",
+  "List (prefix=path).",
+  "List (prefix=path/dir1).",
+  "List (prefix=path/dir2).",
+  "wingsdk.cloud.Bucket deleted.",
+  "wingsdk.cloud.Logger deleted.",
+]
+`;
+
+exports[`objects can have keys that look like directories 1`] = `
+Array [
+  "wingsdk.cloud.Logger created.",
+  "wingsdk.cloud.Bucket created.",
+  "Put (key=foo).",
+  "Put (key=foo/).",
+  "Put (key=foo/bar).",
+  "Put (key=foo/bar/).",
+  "Put (key=foo/bar/baz).",
+  "List (prefix=null).",
+  "List (prefix=foo).",
+  "List (prefix=foo/).",
+  "List (prefix=foo/bar).",
+  "List (prefix=foo/bar/).",
+  "List (prefix=foo/bar/baz).",
+  "wingsdk.cloud.Bucket deleted.",
+  "wingsdk.cloud.Logger deleted.",
+]
+`;
+
 exports[`put and get objects from bucket 1`] = `
 Array [
   "wingsdk.cloud.Logger created.",
@@ -266,123 +420,6 @@ Array [
   "wingsdk.cloud.Bucket deleted.",
   "wingsdk.cloud.Logger deleted.",
 ]
-`;
-
-exports[`put and get objects from bucket 2`] = `
-Object {
-  "app.wsim/simulator.json": Object {
-    "resources": Array [
-      Object {
-        "attrs": Object {},
-        "path": "root/WingLogger",
-        "props": Object {},
-        "type": "wingsdk.cloud.Logger",
-      },
-      Object {
-        "attrs": Object {},
-        "path": "root/my_bucket",
-        "props": Object {
-          "initialObjects": Object {},
-          "public": false,
-        },
-        "type": "wingsdk.cloud.Bucket",
-      },
-    ],
-    "sdkVersion": "0.0.0",
-  },
-  "app.wsim/tree.json": Object {
-    "tree": Object {
-      "children": Object {
-        "WingLogger": Object {
-          "attributes": Object {
-            "wing:resource:connections": Array [],
-            "wing:resource:stateful": true,
-          },
-          "constructInfo": Object {
-            "fqn": "constructs.Construct",
-            "version": "10.1.245",
-          },
-          "display": Object {
-            "description": "A cloud logging facility",
-            "hidden": true,
-            "title": "Logger",
-          },
-          "id": "WingLogger",
-          "path": "root/WingLogger",
-        },
-        "my_bucket": Object {
-          "attributes": Object {
-            "wing:resource:connections": Array [],
-            "wing:resource:stateful": true,
-          },
-          "constructInfo": Object {
-            "fqn": "constructs.Construct",
-            "version": "10.1.245",
-          },
-          "display": Object {
-            "description": "A cloud object store",
-            "title": "Bucket",
-          },
-          "id": "my_bucket",
-          "path": "root/my_bucket",
-        },
-      },
-      "constructInfo": Object {
-        "fqn": "constructs.Construct",
-        "version": "10.1.245",
-      },
-      "id": "root",
-      "path": "root",
-    },
-    "version": "tree-0.1",
-  },
-  "tree.json": Object {
-    "tree": Object {
-      "children": Object {
-        "WingLogger": Object {
-          "attributes": Object {
-            "wing:resource:connections": Array [],
-            "wing:resource:stateful": true,
-          },
-          "constructInfo": Object {
-            "fqn": "constructs.Construct",
-            "version": "10.1.245",
-          },
-          "display": Object {
-            "description": "A cloud logging facility",
-            "hidden": true,
-            "title": "Logger",
-          },
-          "id": "WingLogger",
-          "path": "root/WingLogger",
-        },
-        "my_bucket": Object {
-          "attributes": Object {
-            "wing:resource:connections": Array [],
-            "wing:resource:stateful": true,
-          },
-          "constructInfo": Object {
-            "fqn": "constructs.Construct",
-            "version": "10.1.245",
-          },
-          "display": Object {
-            "description": "A cloud object store",
-            "title": "Bucket",
-          },
-          "id": "my_bucket",
-          "path": "root/my_bucket",
-        },
-      },
-      "constructInfo": Object {
-        "fqn": "constructs.Construct",
-        "version": "10.1.245",
-      },
-      "id": "root",
-      "path": "root",
-    },
-    "version": "tree-0.1",
-  },
-}
 `;
 
 exports[`put multiple objects and list all from bucket 1`] = `
@@ -398,255 +435,6 @@ Array [
 ]
 `;
 
-exports[`put multiple objects and list all from bucket 2`] = `
-Object {
-  "app.wsim/simulator.json": Object {
-    "resources": Array [
-      Object {
-        "attrs": Object {},
-        "path": "root/WingLogger",
-        "props": Object {},
-        "type": "wingsdk.cloud.Logger",
-      },
-      Object {
-        "attrs": Object {},
-        "path": "root/my_bucket",
-        "props": Object {
-          "initialObjects": Object {},
-          "public": false,
-        },
-        "type": "wingsdk.cloud.Bucket",
-      },
-    ],
-    "sdkVersion": "0.0.0",
-  },
-  "app.wsim/tree.json": Object {
-    "tree": Object {
-      "children": Object {
-        "WingLogger": Object {
-          "attributes": Object {
-            "wing:resource:connections": Array [],
-            "wing:resource:stateful": true,
-          },
-          "constructInfo": Object {
-            "fqn": "constructs.Construct",
-            "version": "10.1.245",
-          },
-          "display": Object {
-            "description": "A cloud logging facility",
-            "hidden": true,
-            "title": "Logger",
-          },
-          "id": "WingLogger",
-          "path": "root/WingLogger",
-        },
-        "my_bucket": Object {
-          "attributes": Object {
-            "wing:resource:connections": Array [],
-            "wing:resource:stateful": true,
-          },
-          "constructInfo": Object {
-            "fqn": "constructs.Construct",
-            "version": "10.1.245",
-          },
-          "display": Object {
-            "description": "A cloud object store",
-            "title": "Bucket",
-          },
-          "id": "my_bucket",
-          "path": "root/my_bucket",
-        },
-      },
-      "constructInfo": Object {
-        "fqn": "constructs.Construct",
-        "version": "10.1.245",
-      },
-      "id": "root",
-      "path": "root",
-    },
-    "version": "tree-0.1",
-  },
-  "tree.json": Object {
-    "tree": Object {
-      "children": Object {
-        "WingLogger": Object {
-          "attributes": Object {
-            "wing:resource:connections": Array [],
-            "wing:resource:stateful": true,
-          },
-          "constructInfo": Object {
-            "fqn": "constructs.Construct",
-            "version": "10.1.245",
-          },
-          "display": Object {
-            "description": "A cloud logging facility",
-            "hidden": true,
-            "title": "Logger",
-          },
-          "id": "WingLogger",
-          "path": "root/WingLogger",
-        },
-        "my_bucket": Object {
-          "attributes": Object {
-            "wing:resource:connections": Array [],
-            "wing:resource:stateful": true,
-          },
-          "constructInfo": Object {
-            "fqn": "constructs.Construct",
-            "version": "10.1.245",
-          },
-          "display": Object {
-            "description": "A cloud object store",
-            "title": "Bucket",
-          },
-          "id": "my_bucket",
-          "path": "root/my_bucket",
-        },
-      },
-      "constructInfo": Object {
-        "fqn": "constructs.Construct",
-        "version": "10.1.245",
-      },
-      "id": "root",
-      "path": "root",
-    },
-    "version": "tree-0.1",
-  },
-}
-`;
-
-exports[`put when directory does not exist 1`] = `
-Array [
-  "wingsdk.cloud.Logger created.",
-  "wingsdk.cloud.Bucket created.",
-  "Put (key=path/dir1/file1.txt).",
-  "Put (key=path/dir2/file2.txt).",
-  "List (prefix=null).",
-  "List (prefix=path).",
-  "List (prefix=path/dir1).",
-  "List (prefix=path/dir2).",
-  "wingsdk.cloud.Bucket deleted.",
-  "wingsdk.cloud.Logger deleted.",
-]
-`;
-
-exports[`put when directory does not exist 2`] = `
-Object {
-  "app.wsim/simulator.json": Object {
-    "resources": Array [
-      Object {
-        "attrs": Object {},
-        "path": "root/WingLogger",
-        "props": Object {},
-        "type": "wingsdk.cloud.Logger",
-      },
-      Object {
-        "attrs": Object {},
-        "path": "root/my_bucket",
-        "props": Object {
-          "initialObjects": Object {},
-          "public": false,
-        },
-        "type": "wingsdk.cloud.Bucket",
-      },
-    ],
-    "sdkVersion": "0.0.0",
-  },
-  "app.wsim/tree.json": Object {
-    "tree": Object {
-      "children": Object {
-        "WingLogger": Object {
-          "attributes": Object {
-            "wing:resource:connections": Array [],
-            "wing:resource:stateful": true,
-          },
-          "constructInfo": Object {
-            "fqn": "constructs.Construct",
-            "version": "10.1.245",
-          },
-          "display": Object {
-            "description": "A cloud logging facility",
-            "hidden": true,
-            "title": "Logger",
-          },
-          "id": "WingLogger",
-          "path": "root/WingLogger",
-        },
-        "my_bucket": Object {
-          "attributes": Object {
-            "wing:resource:connections": Array [],
-            "wing:resource:stateful": true,
-          },
-          "constructInfo": Object {
-            "fqn": "constructs.Construct",
-            "version": "10.1.245",
-          },
-          "display": Object {
-            "description": "A cloud object store",
-            "title": "Bucket",
-          },
-          "id": "my_bucket",
-          "path": "root/my_bucket",
-        },
-      },
-      "constructInfo": Object {
-        "fqn": "constructs.Construct",
-        "version": "10.1.245",
-      },
-      "id": "root",
-      "path": "root",
-    },
-    "version": "tree-0.1",
-  },
-  "tree.json": Object {
-    "tree": Object {
-      "children": Object {
-        "WingLogger": Object {
-          "attributes": Object {
-            "wing:resource:connections": Array [],
-            "wing:resource:stateful": true,
-          },
-          "constructInfo": Object {
-            "fqn": "constructs.Construct",
-            "version": "10.1.245",
-          },
-          "display": Object {
-            "description": "A cloud logging facility",
-            "hidden": true,
-            "title": "Logger",
-          },
-          "id": "WingLogger",
-          "path": "root/WingLogger",
-        },
-        "my_bucket": Object {
-          "attributes": Object {
-            "wing:resource:connections": Array [],
-            "wing:resource:stateful": true,
-          },
-          "constructInfo": Object {
-            "fqn": "constructs.Construct",
-            "version": "10.1.245",
-          },
-          "display": Object {
-            "description": "A cloud object store",
-            "title": "Bucket",
-          },
-          "id": "my_bucket",
-          "path": "root/my_bucket",
-        },
-      },
-      "constructInfo": Object {
-        "fqn": "constructs.Construct",
-        "version": "10.1.245",
-      },
-      "id": "root",
-      "path": "root",
-    },
-    "version": "tree-0.1",
-  },
-}
-`;
-
 exports[`remove object from a bucket 1`] = `
 Array [
   "wingsdk.cloud.Logger created.",
@@ -658,123 +446,6 @@ Array [
 ]
 `;
 
-exports[`remove object from a bucket 2`] = `
-Object {
-  "app.wsim/simulator.json": Object {
-    "resources": Array [
-      Object {
-        "attrs": Object {},
-        "path": "root/WingLogger",
-        "props": Object {},
-        "type": "wingsdk.cloud.Logger",
-      },
-      Object {
-        "attrs": Object {},
-        "path": "root/my_bucket",
-        "props": Object {
-          "initialObjects": Object {},
-          "public": false,
-        },
-        "type": "wingsdk.cloud.Bucket",
-      },
-    ],
-    "sdkVersion": "0.0.0",
-  },
-  "app.wsim/tree.json": Object {
-    "tree": Object {
-      "children": Object {
-        "WingLogger": Object {
-          "attributes": Object {
-            "wing:resource:connections": Array [],
-            "wing:resource:stateful": true,
-          },
-          "constructInfo": Object {
-            "fqn": "constructs.Construct",
-            "version": "10.1.245",
-          },
-          "display": Object {
-            "description": "A cloud logging facility",
-            "hidden": true,
-            "title": "Logger",
-          },
-          "id": "WingLogger",
-          "path": "root/WingLogger",
-        },
-        "my_bucket": Object {
-          "attributes": Object {
-            "wing:resource:connections": Array [],
-            "wing:resource:stateful": true,
-          },
-          "constructInfo": Object {
-            "fqn": "constructs.Construct",
-            "version": "10.1.245",
-          },
-          "display": Object {
-            "description": "A cloud object store",
-            "title": "Bucket",
-          },
-          "id": "my_bucket",
-          "path": "root/my_bucket",
-        },
-      },
-      "constructInfo": Object {
-        "fqn": "constructs.Construct",
-        "version": "10.1.245",
-      },
-      "id": "root",
-      "path": "root",
-    },
-    "version": "tree-0.1",
-  },
-  "tree.json": Object {
-    "tree": Object {
-      "children": Object {
-        "WingLogger": Object {
-          "attributes": Object {
-            "wing:resource:connections": Array [],
-            "wing:resource:stateful": true,
-          },
-          "constructInfo": Object {
-            "fqn": "constructs.Construct",
-            "version": "10.1.245",
-          },
-          "display": Object {
-            "description": "A cloud logging facility",
-            "hidden": true,
-            "title": "Logger",
-          },
-          "id": "WingLogger",
-          "path": "root/WingLogger",
-        },
-        "my_bucket": Object {
-          "attributes": Object {
-            "wing:resource:connections": Array [],
-            "wing:resource:stateful": true,
-          },
-          "constructInfo": Object {
-            "fqn": "constructs.Construct",
-            "version": "10.1.245",
-          },
-          "display": Object {
-            "description": "A cloud object store",
-            "title": "Bucket",
-          },
-          "id": "my_bucket",
-          "path": "root/my_bucket",
-        },
-      },
-      "constructInfo": Object {
-        "fqn": "constructs.Construct",
-        "version": "10.1.245",
-      },
-      "id": "root",
-      "path": "root",
-    },
-    "version": "tree-0.1",
-  },
-}
-`;
-
 exports[`remove object from a bucket with mustExist as option 1`] = `
 Array [
   "wingsdk.cloud.Logger created.",
@@ -784,121 +455,4 @@ Array [
   "wingsdk.cloud.Bucket deleted.",
   "wingsdk.cloud.Logger deleted.",
 ]
-`;
-
-exports[`remove object from a bucket with mustExist as option 2`] = `
-Object {
-  "app.wsim/simulator.json": Object {
-    "resources": Array [
-      Object {
-        "attrs": Object {},
-        "path": "root/WingLogger",
-        "props": Object {},
-        "type": "wingsdk.cloud.Logger",
-      },
-      Object {
-        "attrs": Object {},
-        "path": "root/my_bucket",
-        "props": Object {
-          "initialObjects": Object {},
-          "public": false,
-        },
-        "type": "wingsdk.cloud.Bucket",
-      },
-    ],
-    "sdkVersion": "0.0.0",
-  },
-  "app.wsim/tree.json": Object {
-    "tree": Object {
-      "children": Object {
-        "WingLogger": Object {
-          "attributes": Object {
-            "wing:resource:connections": Array [],
-            "wing:resource:stateful": true,
-          },
-          "constructInfo": Object {
-            "fqn": "constructs.Construct",
-            "version": "10.1.245",
-          },
-          "display": Object {
-            "description": "A cloud logging facility",
-            "hidden": true,
-            "title": "Logger",
-          },
-          "id": "WingLogger",
-          "path": "root/WingLogger",
-        },
-        "my_bucket": Object {
-          "attributes": Object {
-            "wing:resource:connections": Array [],
-            "wing:resource:stateful": true,
-          },
-          "constructInfo": Object {
-            "fqn": "constructs.Construct",
-            "version": "10.1.245",
-          },
-          "display": Object {
-            "description": "A cloud object store",
-            "title": "Bucket",
-          },
-          "id": "my_bucket",
-          "path": "root/my_bucket",
-        },
-      },
-      "constructInfo": Object {
-        "fqn": "constructs.Construct",
-        "version": "10.1.245",
-      },
-      "id": "root",
-      "path": "root",
-    },
-    "version": "tree-0.1",
-  },
-  "tree.json": Object {
-    "tree": Object {
-      "children": Object {
-        "WingLogger": Object {
-          "attributes": Object {
-            "wing:resource:connections": Array [],
-            "wing:resource:stateful": true,
-          },
-          "constructInfo": Object {
-            "fqn": "constructs.Construct",
-            "version": "10.1.245",
-          },
-          "display": Object {
-            "description": "A cloud logging facility",
-            "hidden": true,
-            "title": "Logger",
-          },
-          "id": "WingLogger",
-          "path": "root/WingLogger",
-        },
-        "my_bucket": Object {
-          "attributes": Object {
-            "wing:resource:connections": Array [],
-            "wing:resource:stateful": true,
-          },
-          "constructInfo": Object {
-            "fqn": "constructs.Construct",
-            "version": "10.1.245",
-          },
-          "display": Object {
-            "description": "A cloud object store",
-            "title": "Bucket",
-          },
-          "id": "my_bucket",
-          "path": "root/my_bucket",
-        },
-      },
-      "constructInfo": Object {
-        "fqn": "constructs.Construct",
-        "version": "10.1.245",
-      },
-      "id": "root",
-      "path": "root",
-    },
-    "version": "tree-0.1",
-  },
-}
 `;

--- a/libs/wingsdk/test/target-sim/bucket.test.ts
+++ b/libs/wingsdk/test/target-sim/bucket.test.ts
@@ -45,7 +45,6 @@ test("put and get objects from bucket", async () => {
 
   expect(response).toEqual(VALUE);
   expect(listMessages(s)).toMatchSnapshot();
-  expect(app.snapshot()).toMatchSnapshot();
 });
 
 test("put multiple objects and list all from bucket", async () => {
@@ -74,10 +73,9 @@ test("put multiple objects and list all from bucket", async () => {
 
   expect(response).toEqual([KEY1, KEY2, KEY3]);
   expect(listMessages(s)).toMatchSnapshot();
-  expect(app.snapshot()).toMatchSnapshot();
 });
 
-test("put when directory does not exist", async () => {
+test("list respects prefixes", async () => {
   // GIVEN
   const app = new SimApp();
   cloud.Bucket._newBucket(app, "my_bucket");
@@ -106,12 +104,49 @@ test("put when directory does not exist", async () => {
   // THEN
   await s.stop();
 
-  expect(responseRoot).toEqual([ROOT_DIR]);
-  expect(responsePath).toEqual([DIR1, DIR2]);
-  expect(responseDir1).toEqual([filename1]);
-  expect(responseDir2).toEqual([filename2]);
+  expect(responseRoot).toEqual([KEY1, KEY2]);
+  expect(responsePath).toEqual([KEY1, KEY2]);
+  expect(responseDir1).toEqual([KEY1]);
+  expect(responseDir2).toEqual([KEY2]);
   expect(listMessages(s)).toMatchSnapshot();
-  expect(app.snapshot()).toMatchSnapshot();
+});
+
+test("objects can have keys that look like directories", async () => {
+  // GIVEN
+  const app = new SimApp();
+  cloud.Bucket._newBucket(app, "my_bucket");
+
+  const s = await app.startSimulator();
+  const client = s.getResource("/my_bucket") as cloud.IBucketClient;
+
+  // WHEN
+  const KEY1 = "foo";
+  const KEY2 = "foo/";
+  const KEY3 = "foo/bar";
+  const KEY4 = "foo/bar/";
+  const KEY5 = "foo/bar/baz";
+  await client.put(KEY1, "text");
+  await client.put(KEY2, "text");
+  await client.put(KEY3, "text");
+  await client.put(KEY4, "text");
+  await client.put(KEY5, "text");
+  const response = await client.list();
+  const responseFoo = await client.list(KEY1);
+  const responseFooSlash = await client.list(KEY2);
+  const responseFooBar = await client.list(KEY3);
+  const responseFooBarSlash = await client.list(KEY4);
+  const responseFooBarBaz = await client.list(KEY5);
+
+  // THEN
+  await s.stop();
+
+  expect(response).toEqual([KEY1, KEY2, KEY3, KEY4, KEY5]);
+  expect(responseFoo).toEqual([KEY1, KEY2, KEY3, KEY4, KEY5]);
+  expect(responseFooSlash).toEqual([KEY2, KEY3, KEY4, KEY5]);
+  expect(responseFooBar).toEqual([KEY3, KEY4, KEY5]);
+  expect(responseFooBarSlash).toEqual([KEY4, KEY5]);
+  expect(responseFooBarBaz).toEqual([KEY5]);
+  expect(listMessages(s)).toMatchSnapshot();
 });
 
 test("get invalid object throws an error", async () => {
@@ -156,7 +191,6 @@ test("remove object from a bucket with mustExist as option", async () => {
 
   expect(response).toEqual(undefined);
   expect(listMessages(s)).toMatchSnapshot();
-  expect(app.snapshot()).toMatchSnapshot();
 });
 
 test("remove object from a bucket", async () => {
@@ -183,7 +217,6 @@ test("remove object from a bucket", async () => {
 
   expect(response).toEqual(undefined);
   expect(listMessages(s)).toMatchSnapshot();
-  expect(app.snapshot()).toMatchSnapshot();
 });
 
 test("remove non-existent object from a bucket", async () => {
@@ -290,4 +323,5 @@ test("can add object in preflight", async () => {
   expect(getResponse).toEqual(VALUE);
   expect(listResponse).toEqual([KEY]);
   expect(listMessages(s)).toMatchSnapshot();
+  expect(app.snapshot()).toMatchSnapshot();
 });

--- a/tools/hangar/src/__snapshots__/compile.test.ts.snap
+++ b/tools/hangar/src/__snapshots__/compile.test.ts.snap
@@ -800,6 +800,207 @@ constructor() {
 new MyApp().synth();"
 `;
 
+exports[`bucket_keys.w > wing compile --target tf-aws > index.js 1`] = `
+"async handle() { const { b } = this; {
+  (await b.put(\\"foo\\",\\"text\\"));
+  (await b.put(\\"foo/\\",\\"text\\"));
+  (await b.put(\\"foo/bar\\",\\"text\\"));
+  (await b.put(\\"foo/bar/\\",\\"text\\"));
+  (await b.put(\\"foo/bar/baz\\",\\"text\\"));
+  const objs = (await b.list());
+  {((cond) => {if (!cond) throw new Error(\`assertion failed: '((await objs.at(0)) === \\"foo\\")'\`)})(((await objs.at(0)) === \\"foo\\"))};
+  {((cond) => {if (!cond) throw new Error(\`assertion failed: '((await objs.at(1)) === \\"foo/\\")'\`)})(((await objs.at(1)) === \\"foo/\\"))};
+  {((cond) => {if (!cond) throw new Error(\`assertion failed: '((await objs.at(2)) === \\"foo/bar\\")'\`)})(((await objs.at(2)) === \\"foo/bar\\"))};
+  {((cond) => {if (!cond) throw new Error(\`assertion failed: '((await objs.at(3)) === \\"foo/bar/\\")'\`)})(((await objs.at(3)) === \\"foo/bar/\\"))};
+  {((cond) => {if (!cond) throw new Error(\`assertion failed: '((await objs.at(4)) === \\"foo/bar/baz\\")'\`)})(((await objs.at(4)) === \\"foo/bar/baz\\"))};
+} };"
+`;
+
+exports[`bucket_keys.w > wing compile --target tf-aws > main.tf.json 1`] = `
+{
+  "//": {
+    "metadata": {
+      "backend": "local",
+      "stackName": "root",
+      "version": "0.15.2",
+    },
+    "outputs": {},
+  },
+  "provider": {
+    "aws": [
+      {},
+    ],
+  },
+  "resource": {
+    "aws_iam_role": {
+      "root_test_IamRole_6CDC2D16": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/test/IamRole",
+            "uniqueId": "root_test_IamRole_6CDC2D16",
+          },
+        },
+        "assume_role_policy": "{\\"Version\\":\\"2012-10-17\\",\\"Statement\\":[{\\"Action\\":\\"sts:AssumeRole\\",\\"Principal\\":{\\"Service\\":\\"lambda.amazonaws.com\\"},\\"Effect\\":\\"Allow\\"}]}",
+      },
+    },
+    "aws_iam_role_policy": {
+      "root_test_IamRolePolicy_474A6820": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/test/IamRolePolicy",
+            "uniqueId": "root_test_IamRolePolicy_474A6820",
+          },
+        },
+        "policy": "{\\"Version\\":\\"2012-10-17\\",\\"Statement\\":[{\\"Action\\":[\\"s3:PutObject*\\",\\"s3:Abort*\\"],\\"Resource\\":[\\"\${aws_s3_bucket.root_cloudBucket_4F3C4F53.arn}\\",\\"\${aws_s3_bucket.root_cloudBucket_4F3C4F53.arn}/*\\"],\\"Effect\\":\\"Allow\\"},{\\"Action\\":[\\"s3:GetObject*\\",\\"s3:GetBucket*\\",\\"s3:List*\\"],\\"Resource\\":[\\"\${aws_s3_bucket.root_cloudBucket_4F3C4F53.arn}\\",\\"\${aws_s3_bucket.root_cloudBucket_4F3C4F53.arn}/*\\"],\\"Effect\\":\\"Allow\\"},{\\"Action\\":[\\"s3:GetObject*\\",\\"s3:GetBucket*\\",\\"s3:List*\\"],\\"Resource\\":[\\"\${aws_s3_bucket.root_cloudBucket_4F3C4F53.arn}\\",\\"\${aws_s3_bucket.root_cloudBucket_4F3C4F53.arn}/*\\"],\\"Effect\\":\\"Allow\\"},{\\"Action\\":[\\"s3:DeleteObject*\\",\\"s3:DeleteObjectVersion*\\",\\"s3:PutLifecycleConfiguration*\\"],\\"Resource\\":[\\"\${aws_s3_bucket.root_cloudBucket_4F3C4F53.arn}\\",\\"\${aws_s3_bucket.root_cloudBucket_4F3C4F53.arn}/*\\"],\\"Effect\\":\\"Allow\\"}]}",
+        "role": "\${aws_iam_role.root_test_IamRole_6CDC2D16.name}",
+      },
+    },
+    "aws_iam_role_policy_attachment": {
+      "root_test_IamRolePolicyAttachment_1102A28A": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/test/IamRolePolicyAttachment",
+            "uniqueId": "root_test_IamRolePolicyAttachment_1102A28A",
+          },
+        },
+        "policy_arn": "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+        "role": "\${aws_iam_role.root_test_IamRole_6CDC2D16.name}",
+      },
+    },
+    "aws_lambda_function": {
+      "root_test_AAE85061": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/test/Default",
+            "uniqueId": "root_test_AAE85061",
+          },
+        },
+        "environment": {
+          "variables": {
+            "BUCKET_NAME_d755b447": "\${aws_s3_bucket.root_cloudBucket_4F3C4F53.bucket}",
+            "WING_FUNCTION_NAME": "test-c8b6eece",
+          },
+        },
+        "function_name": "test-c8b6eece",
+        "handler": "index.handler",
+        "publish": true,
+        "role": "\${aws_iam_role.root_test_IamRole_6CDC2D16.arn}",
+        "runtime": "nodejs16.x",
+        "s3_bucket": "\${aws_s3_bucket.root_test_Code_2D131EC2.bucket}",
+        "s3_key": "\${aws_s3_object.root_test_S3Object_A16CD789.key}",
+        "timeout": 30,
+      },
+    },
+    "aws_s3_bucket": {
+      "root_cloudBucket_4F3C4F53": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/cloud.Bucket/Default",
+            "uniqueId": "root_cloudBucket_4F3C4F53",
+          },
+        },
+        "bucket_prefix": "cloud-bucket-c87175e7-",
+      },
+      "root_test_Code_2D131EC2": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/test/Code",
+            "uniqueId": "root_test_Code_2D131EC2",
+          },
+        },
+        "bucket_prefix": "code-c883c33b-",
+      },
+    },
+    "aws_s3_bucket_public_access_block": {
+      "root_cloudBucket_PublicAccessBlock_319C1C2E": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/cloud.Bucket/PublicAccessBlock",
+            "uniqueId": "root_cloudBucket_PublicAccessBlock_319C1C2E",
+          },
+        },
+        "block_public_acls": true,
+        "block_public_policy": true,
+        "bucket": "\${aws_s3_bucket.root_cloudBucket_4F3C4F53.bucket}",
+        "ignore_public_acls": true,
+        "restrict_public_buckets": true,
+      },
+    },
+    "aws_s3_bucket_server_side_encryption_configuration": {
+      "root_cloudBucket_Encryption_8ED0CD9C": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/cloud.Bucket/Encryption",
+            "uniqueId": "root_cloudBucket_Encryption_8ED0CD9C",
+          },
+        },
+        "bucket": "\${aws_s3_bucket.root_cloudBucket_4F3C4F53.bucket}",
+        "rule": [
+          {
+            "apply_server_side_encryption_by_default": {
+              "sse_algorithm": "AES256",
+            },
+          },
+        ],
+      },
+    },
+    "aws_s3_object": {
+      "root_test_S3Object_A16CD789": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/test/S3Object",
+            "uniqueId": "root_test_S3Object_A16CD789",
+          },
+        },
+        "bucket": "\${aws_s3_bucket.root_test_Code_2D131EC2.bucket}",
+        "key": "<ASSET_KEY>",
+      },
+    },
+  },
+}
+`;
+
+exports[`bucket_keys.w > wing compile --target tf-aws > preflight.js 1`] = `
+"const $stdlib = require('@winglang/sdk');
+const $outdir = process.env.WINGSDK_SYNTH_DIR ?? \\".\\";
+
+function __app(target) {
+	switch (target) {
+		case \\"sim\\":
+			return $stdlib.sim.App;
+		case \\"tfaws\\":
+		case \\"tf-aws\\":
+			return $stdlib.tfaws.App;
+		case \\"tf-gcp\\":
+			return $stdlib.tfgcp.App;
+		case \\"tf-azure\\":
+			return $stdlib.tfazure.App;
+		default:
+			throw new Error(\`Unknown WING_TARGET value: \\"\${process.env.WING_TARGET ?? \\"\\"}\\"\`);
+	}
+}
+const $App = __app(process.env.WING_TARGET);
+
+const cloud = require('@winglang/sdk').cloud;
+class MyApp extends $App {
+constructor() {
+  super({ outdir: $outdir, name: \\"bucket_keys\\", plugins: $plugins });
+  
+  const b = this.node.root.newAbstract(\\"@winglang/sdk.cloud.Bucket\\",this,\\"cloud.Bucket\\");
+  this.node.root.newAbstract(\\"@winglang/sdk.cloud.Function\\",this,\\"test\\",new $stdlib.core.Inflight(this, \\"$Inflight1\\", {
+    code: $stdlib.core.NodeJsCode.fromFile(require('path').resolve(__dirname, \\"proc.6228e26a5981501feaae450d2628c682bfebb15974f5cc021606bb6e273636e0/index.js\\").replace(/\\\\\\\\/g, \\"/\\")),
+    bindings: {
+      b: {
+        obj: b,
+        ops: [\\"delete\\",\\"get\\",\\"list\\",\\"put\\"]
+      },
+    }
+  }));
+}
+}
+new MyApp().synth();"
+`;
+
 exports[`capture_containers.w > wing compile --target tf-aws > index.js 1`] = `
 "async handle(s) { const { arr, arr_of_map, j, my_map, my_set } = this; {
   {((cond) => {if (!cond) throw new Error(\`assertion failed: '((await arr.at(0)) === \\"hello\\")'\`)})(((await arr.at(0)) === \\"hello\\"))};

--- a/tools/hangar/src/__snapshots__/test.test.ts.snap
+++ b/tools/hangar/src/__snapshots__/test.test.ts.snap
@@ -19,6 +19,8 @@ exports[`bring_jsii_path.w > wing test --target sim > stdout 1`] = `"<green>pass
 
 exports[`bring_projen.w > wing test --target sim > stdout 1`] = `"<green>pass</color> <gray>─</color> bring_projen.w <gray>(no tests)</color>"`;
 
+exports[`bucket_keys.w > wing test --target sim > stdout 1`] = `"<green>pass</color> <gray>─</color> bucket_keys.w <gray>»</color> <brightWhite>root/test</color>"`;
+
 exports[`capture_containers.w > wing test --target sim > stdout 1`] = `"<green>pass</color> <gray>─</color> capture_containers.w <gray>»</color> <brightWhite>root/test</color>"`;
 
 exports[`capture_containers_of_resources.w > wing test --target sim > stdout 1`] = `"<green>pass</color> <gray>─</color> capture_containers_of_resources.w <gray>»</color> <brightWhite>root/test</color>"`;


### PR DESCRIPTION
Previously, many kinds of keys could not be used for objects in `cloud.Bucket`. This would result in runtime errors in the Wing simulator (even these keys are valid in AWS and other cloud providers).

Fixed the issue by storing objects in the file system according to a hashed version of their key, and storing the set of keys in-memory.

Related to #1676

Misc: cleaned up some redundant test snapshots

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.