### PR TITLE
chore(repo): update rust dependencies, add rust linting

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ env:
   # Testing runs out of memory without this
   NODE_OPTIONS: "--max-old-space-size=4096"
   PROJEN_BUMP_VERSION: "0.0.0-dev.${{ github.run_id }}.${{ github.run_attempt }}"
-  RUST_VERSION: "1.67.1"
+  RUST_VERSION: "1.66.0"
 
 jobs:
   prepare:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ env:
   # Testing runs out of memory without this
   NODE_OPTIONS: "--max-old-space-size=4096"
   PROJEN_BUMP_VERSION: "0.0.0-dev.${{ github.run_id }}.${{ github.run_attempt }}"
-  RUST_VERSION: "1.66.0"
+  RUST_VERSION: "1.67.1"
 
 jobs:
   prepare:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,9 +41,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.68"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cb2f989d18dd141ab8ae82f64d1a8cdd37e0840f73a406896cf5e99502fab61"
+checksum = "224afbd727c3d6e4b90103ece64b8d1b67fbb1973b1046c2281eed3f3803f800"
 
 [[package]]
 name = "ascii"
@@ -91,9 +91,9 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.1.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b45ea9b00a7b3f2988e9a65ad3917e62123c38dba709b666506207be96d1790b"
+checksum = "5ffdb39cb703212f3c11973452c2861b972f757b021158f3516ba10f2fa8b2c1"
 dependencies = [
  "memchr",
  "serde",
@@ -198,9 +198,9 @@ dependencies = [
 
 [[package]]
 name = "cxx"
-version = "1.0.87"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b61a7545f753a88bcbe0a70de1fcc0221e10bfc752f576754fa91e663db1622e"
+checksum = "86d3488e7665a7a483b57e25bdd90d0aeb2bc7608c8d0346acf2ad3f1caf1d62"
 dependencies = [
  "cc",
  "cxxbridge-flags",
@@ -210,9 +210,9 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.87"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f464457d494b5ed6905c63b0c4704842aba319084a0a3561cdc1359536b53200"
+checksum = "48fcaf066a053a41a81dfb14d57d99738b767febb8b735c3016e469fac5da690"
 dependencies = [
  "cc",
  "codespan-reporting",
@@ -225,15 +225,15 @@ dependencies = [
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.87"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c7119ce3a3701ed81aca8410b9acf6fc399d2629d057b87e2efa4e63a3aaea"
+checksum = "a2ef98b8b717a829ca5603af80e1f9e2e48013ab227b68ef37872ef84ee479bf"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.87"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65e07508b90551e610910fa648a1878991d367064997a596135b86df30daf07e"
+checksum = "086c685979a698443656e5cf7856c95c642295a38599f12fb1ff76fb28d19892"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -289,9 +289,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
+checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 
 [[package]]
 name = "fnv"
@@ -439,15 +439,15 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
+checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
 
 [[package]]
 name = "js-sys"
-version = "0.3.60"
+version = "0.3.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49409df3e3bf0856b916e2ceaca09ee28e6871cf7d9ce97a692cacfdb2a25a47"
+checksum = "445dde2150c55e483f3d8416706b97ec8e8237c307e5b7b4b8dd15e6af2a0730"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -532,9 +532,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.17.0"
+version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
+checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
 name = "percent-encoding"
@@ -592,9 +592,9 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.50"
+version = "1.0.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ef7d57beacfaf2d8aee5937dab7b7f28de3cb8b1828479bb5de2a7106f2bae2"
+checksum = "5d727cae5b39d21da60fa540906919ad737832fe0b1c165da3a34d6548c849d6"
 dependencies = [
  "unicode-ident",
 ]
@@ -683,9 +683,9 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "ryu"
-version = "1.0.12"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b4b9743ed687d4b4bcedf9ff5eaa7398495ae14e61cba0a295704edbc7decde"
+checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
 
 [[package]]
 name = "same-file"
@@ -725,9 +725,9 @@ dependencies = [
 
 [[package]]
 name = "scratch"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddccb15bcce173023b3fedd9436f882a0739b8dfb45e4f6b6002bee5929f61b2"
+checksum = "5d5e082f6ea090deaf0e6dd04b68360fd5cddb152af6ce8927c9d25db299f98c"
 
 [[package]]
 name = "semver"
@@ -757,9 +757,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.91"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877c235533714907a8c2464236f5c4b2a17262ef1bd71f38f35ea592c8da6883"
+checksum = "cad406b69c91885b5107daf2c29572f6c8cdb3c66826821e286c533490c0bc76"
 dependencies = [
  "indexmap",
  "itoa",
@@ -809,9 +809,9 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "syn"
-version = "1.0.107"
+version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -880,9 +880,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec_macros"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "toml"
@@ -1025,9 +1025,9 @@ checksum = "d54675592c1dbefd78cbd98db9bacd89886e1ca50692a0692baefffdeb92dd58"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
+checksum = "775c11906edafc97bc378816b94585fbd9a054eabaf86fdd0ced94af449efab7"
 
 [[package]]
 name = "unicode-normalization"
@@ -1103,9 +1103,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaf9f5aceeec8be17c128b2e93e031fb8a4d469bb9c4ae2d7dc1888b26887268"
+checksum = "31f8dcbc21f30d9b8f2ea926ecb58f6b91192c17e9d33594b3df58b2007ca53b"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -1113,9 +1113,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c8ffb332579b0557b52d268b91feab8df3615f265d5270fec2a8c95b17c1142"
+checksum = "95ce90fd5bcc06af55a641a86428ee4229e44e07033963a2290a8e241607ccb9"
 dependencies = [
  "bumpalo",
  "log",
@@ -1128,9 +1128,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "052be0f94026e6cbc75cdefc9bae13fd6052cdcaf532fa6c45e7ae33a1e6c810"
+checksum = "4c21f77c0bedc37fd5dc21f897894a5ca01e7bb159884559461862ae90c0b4c5"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1138,9 +1138,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c"
+checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1151,15 +1151,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
+checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
 
 [[package]]
 name = "web-sys"
-version = "0.3.60"
+version = "0.3.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcda906d8be16e728fd5adc5b729afad4e444e106ab28cd1c7256e54fa61510f"
+checksum = "e33b99f4b23ba3eec1a53ac264e35a755f00e966e0065077d6027c0f575b0b97"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/apps/vscode-wing/project.json
+++ b/apps/vscode-wing/project.json
@@ -10,6 +10,14 @@
         "command": "npm run build"
       }
     },
+    "package": {
+      "executor": "nx:run-commands",
+      "dependsOn": ["^build", "build"],
+      "options": {
+        "cwd": "apps/vscode-wing",
+        "command": "npm run package"
+      }
+    },
     "dev": {
       "executor": "nx:run-commands",
       "dependsOn": ["^build", "build"],

--- a/docs/06-contributors/020-development.md
+++ b/docs/06-contributors/020-development.md
@@ -138,7 +138,16 @@ The following command runs `wingc` on a file. This performs all the compilation 
 npx nx wing -- compile <path to a .w file (full path, or relative to the location of the apps/wing folder)>
 ```
 
-You can find the compilation artifacts in the apps/wing/targets folder
+You can find the compilation artifacts in the apps/wing/targets folder.
+
+To check that your code passes all the lints, run:
+
+```sh
+npx nx lint wingc
+```
+
+If you are using VS Code, you can show clippy errors in your IDE by installing the rust-analyzer extension and setting the option "Rust-analyzer › Check: Command" to "clippy" instead of "check".
+
 
 ## How do I make changes to the Wing grammar?
 

--- a/libs/tree-sitter-wing/bindings/rust/build.rs
+++ b/libs/tree-sitter-wing/bindings/rust/build.rs
@@ -1,5 +1,4 @@
 use std::path::PathBuf;
-use tree_sitter;
 use tree_sitter_cli::generate::generate_parser_in_directory;
 
 fn main() {
@@ -9,7 +8,7 @@ fn main() {
 		.expect("Generating parser");
 
 	let mut c_config = cc::Build::new();
-	c_config.include(&src_dir);
+	c_config.include(src_dir);
 	c_config
 		.flag_if_supported("-Wno-unused-parameter")
 		.flag_if_supported("-Wno-unused-but-set-variable")
@@ -27,7 +26,7 @@ fn main() {
 	*/
 
 	c_config.compile("parser");
-	println!("cargo:rerun-if-changed={}", "grammar.js");
+	println!("cargo:rerun-if-changed=grammar.js");
 
 	// If your language uses an external scanner written in C++,
 	// then include this block of code:

--- a/libs/tree-sitter-wing/bindings/rust/lib.rs
+++ b/libs/tree-sitter-wing/bindings/rust/lib.rs
@@ -1,6 +1,3 @@
-#![allow(clippy::all)]
-#![deny(clippy::correctness)]
-
 //! This crate provides wing language support for the [tree-sitter][] parsing library.
 //!
 //! Typically, you will use the [language][language func] function to add this language to a
@@ -34,11 +31,11 @@ pub fn language() -> Language {
 /// The content of the [`node-types.json`][] file for this grammar.
 ///
 /// [`node-types.json`]: https://tree-sitter.github.io/tree-sitter/using-parsers#static-node-types
-pub const NODE_TYPES: &'static str = include_str!("../../src/node-types.json");
+pub const NODE_TYPES: &str = include_str!("../../src/node-types.json");
 
 // Uncomment these to include any queries that this grammar contains
 
-pub const HIGHLIGHTS_QUERY: &'static str = include_str!("../../queries/highlights.scm");
+pub const HIGHLIGHTS_QUERY: &str = include_str!("../../queries/highlights.scm");
 // pub const INJECTIONS_QUERY: &'static str = include_str!("../../queries/injections.scm");
-pub const LOCALS_QUERY: &'static str = include_str!("../../queries/locals.scm");
+pub const LOCALS_QUERY: &str = include_str!("../../queries/locals.scm");
 // pub const TAGS_QUERY: &'static str = include_str!("../../queries/tags.scm");

--- a/libs/tree-sitter-wing/bindings/rust/lib.rs
+++ b/libs/tree-sitter-wing/bindings/rust/lib.rs
@@ -1,3 +1,6 @@
+#![allow(clippy::all)]
+#![deny(clippy::correctness)]
+
 //! This crate provides wing language support for the [tree-sitter][] parsing library.
 //!
 //! Typically, you will use the [language][language func] function to add this language to a

--- a/libs/wingc/examples/compile.rs
+++ b/libs/wingc/examples/compile.rs
@@ -16,7 +16,7 @@ pub fn main() {
 	let results = compile(Path::new(source_path), None);
 	if let Err(mut err) = results {
 		// Sort error messages by line number (ascending)
-		err.sort_by(|a, b| a.cmp(&b));
+		err.sort();
 		eprintln!(
 			"Compilation failed with {} errors\n{}",
 			err.len(),

--- a/libs/wingc/project.json
+++ b/libs/wingc/project.json
@@ -4,9 +4,17 @@
   "implicitDependencies": ["sdk", "wingii", "tree-sitter-wing"],
   "targets": {
     "test": {
+      "dependsOn": ["lint"],
       "executor": "nx:run-commands",
       "options": {
         "command": "cargo test",
+        "cwd": "libs/wingc"
+      }
+    },
+    "lint": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "cargo clippy",
         "cwd": "libs/wingc"
       }
     },

--- a/libs/wingc/src/lib.rs
+++ b/libs/wingc/src/lib.rs
@@ -1,3 +1,6 @@
+#![allow(clippy::all)]
+#![deny(clippy::correctness)]
+
 #[macro_use]
 extern crate lazy_static;
 

--- a/libs/wingii/project.json
+++ b/libs/wingii/project.json
@@ -3,9 +3,17 @@
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "targets": {
     "test": {
+      "dependsOn": ["lint"],
       "executor": "nx:run-commands",
       "options": {
         "command": "cargo test",
+        "cwd": "libs/wingii"
+      }
+    },
+    "lint": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "cargo clippy",
         "cwd": "libs/wingii"
       }
     },

--- a/libs/wingii/src/lib.rs
+++ b/libs/wingii/src/lib.rs
@@ -1,3 +1,6 @@
+#![allow(clippy::all)]
+#![deny(clippy::correctness)]
+
 use std::error::Error;
 
 extern crate serde;
@@ -161,7 +164,7 @@ pub mod type_system {
 		}
 
 		fn load_assembly(&mut self, path: &str) -> Result<Assembly> {
-			Ok(spec::load_assembly_from_file(path)?)
+			spec::load_assembly_from_file(path)
 		}
 
 		fn add_root(&mut self, assembly: &Assembly) -> Result<()> {

--- a/libs/wingii/src/node_resolve.rs
+++ b/libs/wingii/src/node_resolve.rs
@@ -72,12 +72,10 @@ pub fn resolve_from(target: &str, basedir: &Path) -> Result<PathBuf, Box<dyn Err
 	// 3. If X begins with './' or '../' or '/'
 	if is_path_dependency(target) {
 		let path = basedir.join(target);
-		return resolve_as_file(&path)
-			.or_else(|_| resolve_as_directory(&path))
-			.and_then(|p| Ok(p));
+		return resolve_as_file(&path).or_else(|_| resolve_as_directory(&path));
 	}
 
-	resolve_node_modules(target, basedir).and_then(|p| Ok(p))
+	resolve_node_modules(target, basedir)
 }
 
 /// Resolve a path as a file. If `path` refers to a file, it is returned;

--- a/libs/wingii/src/util.rs
+++ b/libs/wingii/src/util.rs
@@ -68,7 +68,7 @@ pub mod package_json {
 				}
 				let package_json = fs::read_to_string(&package_json).unwrap();
 				let package_json: serde_json::Value = serde_json::from_str(&package_json).unwrap();
-				package_json.get("name").map(|x| x.as_str()).flatten() == Some(package_name)
+				package_json.get("name").and_then(|x| x.as_str()) == Some(package_name)
 			} else {
 				false
 			}

--- a/nx.json
+++ b/nx.json
@@ -39,7 +39,6 @@
         "cacheableOperations": [
           "build",
           "copy",
-          "lint",
           "test",
           "package"
         ]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 profile = "default"
-channel = "1.66.0"
+channel = "1.67.1"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 profile = "default"
-channel = "1.67.1"
+channel = "1.66.0"


### PR DESCRIPTION
- Update Rust dependencies
- Fix an issue where the vscode-wing package task could be executed before the vscode-wing build task
- Add rust linting with the built-in `clippy` tool to our build process (automatically runs as part of `nx run test wingc` and `nx run test wingii`)

For linting, clippy has over 600 different lints that are grouped into categories. To start, I've just enabled the "correctness" set of lints in this PR. But over time we can add more lints by simply adding directives into the source code.

Contributors using VS Code can install the `rust-analyzer` extension and set "Rust-analyzer › Check: Command" to "clippy" to start seeing the full set of lint errors/warnings in their editor.

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.