### PR TITLE
chore: update rust toolchain and several misc changes

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,4 @@
 [env]
-CC_wasm32_wasi = "/opt/wasi-sdk/bin/clang"
-AR_wasm32_wasi = "/opt/wasi-sdk/bin/ar"
+WASI_SDK = { value = ".cargo/wasi-sdk-19.0", relative = true }
+CC_wasm32_wasi = { value = ".cargo/wasi-sdk-19.0/bin/clang", relative = true }
+AR_wasm32_wasi = { value = ".cargo/wasi-sdk-19.0/bin/ar", relative = true }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ env:
   # Testing runs out of memory without this
   NODE_OPTIONS: "--max-old-space-size=4096"
   PROJEN_BUMP_VERSION: "0.0.0-dev.${{ github.run_id }}.${{ github.run_attempt }}"
-  RUST_VERSION: "1.66.0"
+  RUST_VERSION: "1.67.1"
 
 jobs:
   prepare:
@@ -107,7 +107,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           toolchain: ${{ env.RUST_VERSION }}
-          components: rustfmt
+          components: rustfmt,clippy
           override: true
 
       - name: Setup Cargo Cache

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 node_modules/
 .env
 
+# WASI SDK (insalled by "npm install")
+.cargo/wasi-sdk-*/
+
 # Generated wing output
 *.w.out/
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,9 +70,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "base16ct"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349a06037c7bf932dd7e7d1f653678b2038b9ad46a74102f1fc7bd7872678cce"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
 name = "bitflags"
@@ -494,9 +494,9 @@ dependencies = [
 
 [[package]]
 name = "lsp-types"
-version = "0.93.2"
+version = "0.94.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9be6e9c7e2d18f651974370d7aff703f9513e0df6e464fd795660edc77e6ca51"
+checksum = "0b63735a13a1f9cd4f4835223d828ed9c2e35c8c5e61837774399f558b6a1237"
 dependencies = [
  "bitflags",
  "serde",

--- a/apps/wing-playground/package-lock.json
+++ b/apps/wing-playground/package-lock.json
@@ -72,6 +72,7 @@
         "@types/tar": "^6.1.3",
         "@typescript-eslint/eslint-plugin": "^5",
         "@typescript-eslint/parser": "^5",
+        "@vitest/coverage-c8": "^0.29.2",
         "@winglang/jsii-docgen": "file:../../apps/jsii-docgen",
         "@winglang/wing-api-checker": "file:../../apps/wing-api-checker",
         "aws-sdk-client-mock": "^2.0.1",
@@ -96,7 +97,8 @@
         "ts-jest": "^27",
         "ts-node": "^10.9.1",
         "tsx": "^3.12.2",
-        "typescript": "^4.9.4"
+        "typescript": "^4.9.4",
+        "vitest": "^0.29.2"
       },
       "engines": {
         "node": ">= 16.16.0"
@@ -44592,6 +44594,7 @@
         "@types/tar": "^6.1.3",
         "@typescript-eslint/eslint-plugin": "^5",
         "@typescript-eslint/parser": "^5",
+        "@vitest/coverage-c8": "^0.29.2",
         "@winglang/jsii-docgen": "file:../../apps/jsii-docgen",
         "@winglang/wing-api-checker": "file:../../apps/wing-api-checker",
         "aws-sdk-client-mock": "^2.0.1",
@@ -44622,7 +44625,8 @@
         "ts-jest": "^27",
         "ts-node": "^10.9.1",
         "tsx": "^3.12.2",
-        "typescript": "^4.9.4"
+        "typescript": "^4.9.4",
+        "vitest": "^0.29.2"
       },
       "dependencies": {
         "@ampproject/remapping": {
@@ -71443,6 +71447,7 @@
             "@types/tar": "^6.1.3",
             "@typescript-eslint/eslint-plugin": "^5",
             "@typescript-eslint/parser": "^5",
+            "@vitest/coverage-c8": "^0.29.2",
             "@winglang/jsii-docgen": "file:../../apps/jsii-docgen",
             "@winglang/wing-api-checker": "file:../../apps/wing-api-checker",
             "aws-sdk-client-mock": "^2.0.1",
@@ -71473,7 +71478,8 @@
             "ts-jest": "^27",
             "ts-node": "^10.9.1",
             "tsx": "^3.12.2",
-            "typescript": "^4.9.4"
+            "typescript": "^4.9.4",
+            "vitest": "^0.29.2"
           },
           "dependencies": {
             "@ampproject/remapping": {

--- a/apps/wing/package-lock.json
+++ b/apps/wing/package-lock.json
@@ -96,6 +96,7 @@
         "@types/tar": "^6.1.3",
         "@typescript-eslint/eslint-plugin": "^5",
         "@typescript-eslint/parser": "^5",
+        "@vitest/coverage-c8": "^0.29.2",
         "@winglang/jsii-docgen": "file:../../apps/jsii-docgen",
         "@winglang/wing-api-checker": "file:../../apps/wing-api-checker",
         "aws-sdk-client-mock": "^2.0.1",
@@ -120,7 +121,8 @@
         "ts-jest": "^27",
         "ts-node": "^10.9.1",
         "tsx": "^3.12.2",
-        "typescript": "^4.9.4"
+        "typescript": "^4.9.4",
+        "vitest": "^0.29.2"
       },
       "engines": {
         "node": ">= 16.16.0"
@@ -43923,6 +43925,7 @@
         "@types/tar": "^6.1.3",
         "@typescript-eslint/eslint-plugin": "^5",
         "@typescript-eslint/parser": "^5",
+        "@vitest/coverage-c8": "^0.29.2",
         "@winglang/jsii-docgen": "file:../../apps/jsii-docgen",
         "@winglang/wing-api-checker": "file:../../apps/wing-api-checker",
         "aws-sdk-client-mock": "^2.0.1",
@@ -43953,7 +43956,8 @@
         "ts-jest": "^27",
         "ts-node": "^10.9.1",
         "tsx": "^3.12.2",
-        "typescript": "^4.9.4"
+        "typescript": "^4.9.4",
+        "vitest": "^0.29.2"
       },
       "dependencies": {
         "@ampproject/remapping": {

--- a/docs/06-contributors/020-development.md
+++ b/docs/06-contributors/020-development.md
@@ -105,7 +105,7 @@ separately).
 
 :::note
 
-The first time you run `npm install` you may be asked to enter your system password, this is because
+The first time you run `npm install` it may take a long time, this is because
 it's taking care of installing the [wasi-sdk](https://github.com/WebAssembly/wasi-sdk) for you.
 
 If you wish to install it manually, you may do so by running `scripts/setup_wasi.sh`

--- a/docs/06-contributors/020-development.md
+++ b/docs/06-contributors/020-development.md
@@ -105,8 +105,8 @@ separately).
 
 :::note
 
-The first time you run `npm install` it may take a long time, this is because
-it's taking care of installing the [wasi-sdk](https://github.com/WebAssembly/wasi-sdk) for you.
+The first time you run `npm install` it may take extra time to install the
+ [wasi-sdk](https://github.com/WebAssembly/wasi-sdk) for you. This is needed to compile Wing for WASM.
 
 If you wish to install it manually, you may do so by running `scripts/setup_wasi.sh`
 

--- a/libs/tree-sitter-wing/bindings/rust/build.rs
+++ b/libs/tree-sitter-wing/bindings/rust/build.rs
@@ -8,48 +8,26 @@ fn main() {
 		.expect("Generating parser");
 
 	let mut c_config = cc::Build::new();
-	c_config.include(src_dir);
 	c_config
+		.include(src_dir)
+		.flag("-Wno-unused-parameter")
+		.flag("-Wno-unused-but-set-variable")
+		.flag("-Wno-trigraphs")
+		.file(&src_dir.join("parser.c"));
+
+	if cfg!(target_arch = "wasm32") {
 		// This parser is used in a WASI context, so it needs to be compiled with
 		// the sysroot and other tools needed for WASI-compatible C
-		.flag(
+		c_config.flag(
 			format!(
 				"--sysroot={}/share/wasi-sysroot",
 				env!("WASI_SDK", "WASI_SDK env not set")
 			)
 			.as_str(),
-		)
-		.flag("-Wno-unused-parameter")
-		.flag("-Wno-unused-but-set-variable")
-		.flag("-Wno-trigraphs");
-	let parser_path = src_dir.join("parser.c");
-	c_config.file(&parser_path);
-
-	// If your language uses an external scanner written in C,
-	// then include this block of code:
-
-	/*
-	let scanner_path = src_dir.join("scanner.c");
-	c_config.file(&scanner_path);
-	println!("cargo:rerun-if-changed={}", scanner_path.to_str().unwrap());
-	*/
+		);
+	}
 
 	c_config.compile("parser");
+
 	println!("cargo:rerun-if-changed=grammar.js");
-
-	// If your language uses an external scanner written in C++,
-	// then include this block of code:
-
-	/*
-	let mut cpp_config = cc::Build::new();
-	cpp_config.cpp(true);
-	cpp_config.include(&src_dir);
-	cpp_config
-			.flag_if_supported("-Wno-unused-parameter")
-			.flag_if_supported("-Wno-unused-but-set-variable");
-	let scanner_path = src_dir.join("scanner.cc");
-	cpp_config.file(&scanner_path);
-	cpp_config.compile("scanner");
-	println!("cargo:rerun-if-changed={}", scanner_path.to_str().unwrap());
-	*/
 }

--- a/libs/tree-sitter-wing/bindings/rust/build.rs
+++ b/libs/tree-sitter-wing/bindings/rust/build.rs
@@ -7,12 +7,16 @@ fn main() {
 	generate_parser_in_directory(&PathBuf::from("."), None, tree_sitter::LANGUAGE_VERSION, false, None)
 		.expect("Generating parser");
 
+	// get WASI_SDK env
+	let wasi_sdk = std::env::var("WASI_SDK").expect("WASI_SDK env not set");
+
 	let mut c_config = cc::Build::new();
 	c_config.include(src_dir);
 	c_config
-		.flag_if_supported("-Wno-unused-parameter")
-		.flag_if_supported("-Wno-unused-but-set-variable")
-		.flag_if_supported("-Wno-trigraphs");
+		.flag(format!("--sysroot={}/share/wasi-sysroot", wasi_sdk).as_str())
+		.flag("-Wno-unused-parameter")
+		.flag("-Wno-unused-but-set-variable")
+		.flag("-Wno-trigraphs");
 	let parser_path = src_dir.join("parser.c");
 	c_config.file(&parser_path);
 

--- a/libs/tree-sitter-wing/bindings/rust/build.rs
+++ b/libs/tree-sitter-wing/bindings/rust/build.rs
@@ -7,13 +7,18 @@ fn main() {
 	generate_parser_in_directory(&PathBuf::from("."), None, tree_sitter::LANGUAGE_VERSION, false, None)
 		.expect("Generating parser");
 
-	// get WASI_SDK env
-	let wasi_sdk = std::env::var("WASI_SDK").expect("WASI_SDK env not set");
-
 	let mut c_config = cc::Build::new();
 	c_config.include(src_dir);
 	c_config
-		.flag(format!("--sysroot={}/share/wasi-sysroot", wasi_sdk).as_str())
+		// This parser is used in a WASI context, so it needs to be compiled with
+		// the sysroot and other tools needed for WASI-compatible C
+		.flag(
+			format!(
+				"--sysroot={}/share/wasi-sysroot",
+				env!("WASI_SDK", "WASI_SDK env not set")
+			)
+			.as_str(),
+		)
 		.flag("-Wno-unused-parameter")
 		.flag("-Wno-unused-but-set-variable")
 		.flag("-Wno-trigraphs");

--- a/libs/wingc/Cargo.toml
+++ b/libs/wingc/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 tree-sitter = "0.20.9"
 tree-sitter-traversal = "0.1.2"
 sha2 = "0.10.6"
-base16ct = { version = "0.1.1", features = ["alloc"] }
+base16ct = { version = "0.2.0", features = ["alloc"] }
 derivative = "2.2.0"
 tree-sitter-wing = { path = "../tree-sitter-wing" }
 wingii = { path = "../wingii" }
@@ -20,9 +20,8 @@ inflections = "1.1.1"
 phf = { version = "0.11", features = ["macros"] }
 indexmap = "1.9.1"
 aho-corasick = "0.7.20"
-lsp-types = "0.93.2"
+lsp-types = "0.94.0"
 indoc = "2.0.0"
 
 [lib]
-path = "src/lib.rs"
-crate-type = ["cdylib", "rlib"]
+crate-type = ["rlib", "cdylib"]

--- a/libs/wingc/project.json
+++ b/libs/wingc/project.json
@@ -14,8 +14,14 @@
     "lint": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "cargo clippy",
-        "cwd": "libs/wingc"
+        "commands": ["cargo clippy --no-deps --fix --allow-dirty", "cargo fmt"],
+        "cwd": "libs/wingc",
+        "parallel": false
+      },
+      "configurations": {
+        "release": {
+          "commands": ["cargo clippy --no-deps --release", "cargo fmt --check"]
+        }
       }
     },
     "build": {

--- a/libs/wingc/project.json
+++ b/libs/wingc/project.json
@@ -14,13 +14,13 @@
     "lint": {
       "executor": "nx:run-commands",
       "options": {
-        "commands": ["cargo clippy --no-deps --fix --allow-dirty", "cargo fmt"],
+        "commands": ["cargo fmt", "cargo clippy --no-deps --fix --allow-dirty"],
         "cwd": "libs/wingc",
         "parallel": false
       },
       "configurations": {
         "release": {
-          "commands": ["cargo clippy --no-deps --release", "cargo fmt --check"]
+          "commands": ["cargo fmt --check", "cargo clippy --no-deps --release"]
         }
       }
     },

--- a/libs/wingc/src/ast.rs
+++ b/libs/wingc/src/ast.rs
@@ -18,9 +18,9 @@ pub struct Symbol {
 }
 
 impl Symbol {
-	pub fn global(name: &str) -> Self {
+	pub fn global<S: Into<String>>(name: S) -> Self {
 		Self {
-			name: name.to_string(),
+			name: name.into(),
 			span: Default::default(),
 		}
 	}

--- a/libs/wingc/src/ast.rs
+++ b/libs/wingc/src/ast.rs
@@ -21,7 +21,7 @@ impl Symbol {
 	pub fn global(name: &str) -> Self {
 		Self {
 			name: name.to_string(),
-			span: WingSpan::default(),
+			span: Default::default(),
 		}
 	}
 }

--- a/libs/wingc/src/ast.rs
+++ b/libs/wingc/src/ast.rs
@@ -21,7 +21,7 @@ impl Symbol {
 	pub fn global(name: &str) -> Self {
 		Self {
 			name: name.to_string(),
-			span: WingSpan::global(),
+			span: WingSpan::default(),
 		}
 	}
 }

--- a/libs/wingc/src/diagnostic.rs
+++ b/libs/wingc/src/diagnostic.rs
@@ -63,10 +63,12 @@ impl Display for WingPoint {
 	}
 }
 
+/// A span of text in a Wing source file
 #[derive(Debug, Default, PartialEq, Eq, Hash, Clone)]
 pub struct WingSpan {
 	pub start: WingPoint,
 	pub end: WingPoint,
+	/// relative path to the file based on the working directory used to invoke the compiler
 	pub file_id: String,
 }
 

--- a/libs/wingc/src/diagnostic.rs
+++ b/libs/wingc/src/diagnostic.rs
@@ -14,7 +14,7 @@ pub type DiagnosticResult<T> = Result<T, ()>;
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct WingPoint {
 	pub line: u32,
-	pub character: u32,
+	pub col: u32,
 }
 
 /// tree-sitter-based Point => WingPoint
@@ -22,7 +22,7 @@ impl From<Point> for WingPoint {
 	fn from(point: Point) -> Self {
 		Self {
 			line: point.row as u32,
-			character: point.column as u32,
+			col: point.column as u32,
 		}
 	}
 }
@@ -32,7 +32,7 @@ impl From<Position> for WingPoint {
 	fn from(position: Position) -> Self {
 		Self {
 			line: position.line,
-			character: position.character,
+			col: position.character,
 		}
 	}
 }
@@ -42,7 +42,7 @@ impl Into<Point> for WingPoint {
 	fn into(self) -> Point {
 		Point {
 			row: self.line as usize,
-			column: self.character as usize,
+			column: self.col as usize,
 		}
 	}
 }
@@ -52,14 +52,14 @@ impl Into<Position> for WingPoint {
 	fn into(self) -> Position {
 		Position {
 			line: self.line,
-			character: self.character,
+			character: self.col,
 		}
 	}
 }
 
 impl Display for WingPoint {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-		write!(f, "{}:{}", self.line, self.character)
+		write!(f, "{}:{}", self.line, self.col)
 	}
 }
 
@@ -97,11 +97,11 @@ impl WingSpan {
 
 		if pos_line >= start.line && pos_line <= end.line {
 			if start.line == end.line && pos_line == start.line {
-				pos_char >= start.character && pos_char <= end.character
+				pos_char >= start.col && pos_char <= end.col
 			} else if pos_line == start.line {
-				pos_char >= start.character
+				pos_char >= start.col
 			} else if pos_line == end.line {
-				pos_char <= end.character
+				pos_char <= end.col
 			} else {
 				true
 			}
@@ -113,13 +113,7 @@ impl WingSpan {
 
 impl std::fmt::Display for WingSpan {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-		write!(
-			f,
-			"{}:{}:{}",
-			self.file_id,
-			self.start.line + 1,
-			self.start.character + 1
-		)
+		write!(f, "{}:{}:{}", self.file_id, self.start.line + 1, self.start.col + 1)
 	}
 }
 

--- a/libs/wingc/src/diagnostic.rs
+++ b/libs/wingc/src/diagnostic.rs
@@ -207,3 +207,51 @@ impl std::fmt::Display for TypeError {
 		write!(f, "{} at {}", self.message, self.span)
 	}
 }
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn wingspan_contains() {
+		let span = WingSpan {
+			start: WingLocation { line: 0, col: 0 },
+			end: WingLocation { line: 1, col: 10 },
+			file_id: "test".to_string(),
+		};
+
+		let in_position = Position { line: 0, character: 5 };
+		let out_position = Position { line: 2, character: 5 };
+
+		assert!(span.contains(&in_position));
+		assert!(!span.contains(&out_position));
+	}
+
+	#[test]
+	fn wingspan_comparisons() {
+		let span1 = WingSpan {
+			start: WingLocation { line: 1, col: 5 },
+			end: WingLocation { line: 1, col: 10 },
+			file_id: "test".to_string(),
+		};
+
+		let like_span1 = span1.clone();
+
+		let sooner = WingSpan {
+			start: WingLocation { line: 0, col: 0 },
+			end: WingLocation { line: 1, col: 1 },
+			file_id: "test".to_string(),
+		};
+		let later = WingSpan {
+			start: WingLocation { line: 2, col: 0 },
+			end: WingLocation { line: 2, col: 5 },
+			file_id: "test".to_string(),
+		};
+
+		assert!(span1 == like_span1);
+		assert!(span1 < later);
+		assert!(!(span1 > later));
+		assert!(span1 > sooner);
+		assert!(!(span1 < sooner));
+	}
+}

--- a/libs/wingc/src/diagnostic.rs
+++ b/libs/wingc/src/diagnostic.rs
@@ -12,13 +12,13 @@ pub type DiagnosticResult<T> = Result<T, ()>;
 
 /// Line and character location in a UTF8 Wing source file
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub struct WingPoint {
+pub struct WingLocation {
 	pub line: u32,
 	pub col: u32,
 }
 
-/// tree-sitter-based Point => WingPoint
-impl From<Point> for WingPoint {
+/// tree-sitter-based Point => WingLocation
+impl From<Point> for WingLocation {
 	fn from(point: Point) -> Self {
 		Self {
 			line: point.row as u32,
@@ -27,8 +27,8 @@ impl From<Point> for WingPoint {
 	}
 }
 
-/// LSP-based Position => WingPoint
-impl From<Position> for WingPoint {
+/// LSP-based Position => WingLocation
+impl From<Position> for WingLocation {
 	fn from(position: Position) -> Self {
 		Self {
 			line: position.line,
@@ -37,8 +37,8 @@ impl From<Position> for WingPoint {
 	}
 }
 
-/// WingPoint => tree-sitter-based Point
-impl Into<Point> for WingPoint {
+/// WingLocation => tree-sitter-based Point
+impl Into<Point> for WingLocation {
 	fn into(self) -> Point {
 		Point {
 			row: self.line as usize,
@@ -47,8 +47,8 @@ impl Into<Point> for WingPoint {
 	}
 }
 
-/// WingPoint => LSP-based Position
-impl Into<Position> for WingPoint {
+/// WingLocation => LSP-based Position
+impl Into<Position> for WingLocation {
 	fn into(self) -> Position {
 		Position {
 			line: self.line,
@@ -57,7 +57,7 @@ impl Into<Position> for WingPoint {
 	}
 }
 
-impl Display for WingPoint {
+impl Display for WingLocation {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		write!(f, "{}:{}", self.line, self.col)
 	}
@@ -66,8 +66,8 @@ impl Display for WingPoint {
 /// A span of text in a Wing source file
 #[derive(Debug, Default, PartialEq, Eq, Hash, Clone)]
 pub struct WingSpan {
-	pub start: WingPoint,
-	pub end: WingPoint,
+	pub start: WingLocation,
+	pub end: WingLocation,
 	/// Relative path to the file based on the working directory used to invoke the compiler
 	pub file_id: String,
 }

--- a/libs/wingc/src/diagnostic.rs
+++ b/libs/wingc/src/diagnostic.rs
@@ -68,7 +68,7 @@ impl Display for WingPoint {
 pub struct WingSpan {
 	pub start: WingPoint,
 	pub end: WingPoint,
-	/// relative path to the file based on the working directory used to invoke the compiler
+	/// Relative path to the file based on the working directory used to invoke the compiler
 	pub file_id: String,
 }
 

--- a/libs/wingc/src/lsp/completions.rs
+++ b/libs/wingc/src/lsp/completions.rs
@@ -118,7 +118,6 @@ pub fn on_completion(params: lsp_types::CompletionParams) -> CompletionResponse 
 					let text = item.text.as_str();
 					CompletionItem {
 						label: text.to_string(),
-						insert_text: None,
 						kind: Some(item.kind),
 						detail: item.detail.clone(),
 						preselect: Some(true),

--- a/libs/wingc/src/lsp/document_symbols.rs
+++ b/libs/wingc/src/lsp/document_symbols.rs
@@ -2,8 +2,7 @@ use crate::ast::*;
 use crate::lsp::sync::FILES;
 use crate::visit::Visit;
 use crate::wasm_util::{ptr_to_string, string_to_combined_ptr, WASM_RETURN_ERROR};
-use lsp_types::DocumentSymbol;
-use lsp_types::SymbolKind;
+use lsp_types::{DocumentSymbol, SymbolKind};
 
 pub struct DocumentSymbolVisitor {
 	pub document_symbols: Vec<DocumentSymbol>,
@@ -25,123 +24,46 @@ impl Visit<'_> for DocumentSymbolVisitor {
 				identifier,
 			} => {
 				let mod_symbol = module_name;
-				let mod_symbol_range = mod_symbol.span.range();
-				self.document_symbols.push(
-					#[allow(deprecated)]
-					DocumentSymbol {
-						name: mod_symbol.name.clone(),
-						detail: None,
-						kind: SymbolKind::NAMESPACE,
-						range: mod_symbol_range,
-						selection_range: mod_symbol_range,
-						children: None,
-						tags: None,
-						deprecated: None,
-					},
-				);
+				self
+					.document_symbols
+					.push(create_document_symbol(mod_symbol, SymbolKind::MODULE));
 
 				if let Some(identifier) = identifier {
 					let symbol = identifier;
-					let symbol_range = symbol.span.range();
-					self.document_symbols.push(
-						#[allow(deprecated)]
-						DocumentSymbol {
-							name: symbol.name.clone(),
-							detail: None,
-							kind: SymbolKind::VARIABLE,
-							range: symbol_range,
-							selection_range: symbol_range,
-							children: None,
-							tags: None,
-							deprecated: None,
-						},
-					);
+					self
+						.document_symbols
+						.push(create_document_symbol(symbol, SymbolKind::VARIABLE));
 				}
 			}
 			StmtKind::VariableDef { var_name, .. } => {
 				let symbol = var_name;
-				let symbol_range = symbol.span.range();
-				self.document_symbols.push(
-					#[allow(deprecated)]
-					DocumentSymbol {
-						name: symbol.name.clone(),
-						detail: None,
-						kind: SymbolKind::VARIABLE,
-						range: symbol_range,
-						selection_range: symbol_range,
-						children: None,
-						tags: None,
-						deprecated: None,
-					},
-				);
+				self
+					.document_symbols
+					.push(create_document_symbol(symbol, SymbolKind::VARIABLE));
 			}
 			StmtKind::ForLoop { iterator, .. } => {
 				let symbol = iterator;
-				let symbol_range = symbol.span.range();
-				self.document_symbols.push(
-					#[allow(deprecated)]
-					DocumentSymbol {
-						name: symbol.name.clone(),
-						detail: None,
-						kind: SymbolKind::VARIABLE,
-						range: symbol_range,
-						selection_range: symbol_range,
-						children: None,
-						tags: None,
-						deprecated: None,
-					},
-				);
+				self
+					.document_symbols
+					.push(create_document_symbol(symbol, SymbolKind::VARIABLE));
 			}
 			StmtKind::Class(c) => {
 				let symbol = &c.name;
-				let symbol_range = symbol.span.range();
-				self.document_symbols.push(
-					#[allow(deprecated)]
-					DocumentSymbol {
-						name: symbol.name.clone(),
-						detail: None,
-						kind: SymbolKind::CLASS,
-						range: symbol_range,
-						selection_range: symbol_range,
-						children: None,
-						tags: None,
-						deprecated: None,
-					},
-				);
+				self
+					.document_symbols
+					.push(create_document_symbol(symbol, SymbolKind::CLASS));
 			}
 			StmtKind::Struct { name, .. } => {
 				let symbol = name;
-				let symbol_range = symbol.span.range();
-				self.document_symbols.push(
-					#[allow(deprecated)]
-					DocumentSymbol {
-						name: symbol.name.clone(),
-						detail: None,
-						kind: SymbolKind::STRUCT,
-						range: symbol_range,
-						selection_range: symbol_range,
-						children: None,
-						tags: None,
-						deprecated: None,
-					},
-				);
+				self
+					.document_symbols
+					.push(create_document_symbol(symbol, SymbolKind::STRUCT));
 			}
 			StmtKind::Enum { name, .. } => {
 				let symbol = name;
-				let symbol_range = symbol.span.range();
-				self.document_symbols.push(
-					#[allow(deprecated)]
-					DocumentSymbol {
-						name: symbol.name.clone(),
-						detail: None,
-						kind: SymbolKind::ENUM,
-						range: symbol_range,
-						selection_range: symbol_range,
-						children: None,
-						tags: None,
-						deprecated: None,
-					},
-				);
+				self
+					.document_symbols
+					.push(create_document_symbol(symbol, SymbolKind::ENUM));
 			}
 			_ => {}
 		};
@@ -174,4 +96,19 @@ pub fn on_document_symbols<'a>(params: lsp_types::DocumentSymbolParams) -> Vec<D
 
 		visitor.document_symbols
 	})
+}
+
+fn create_document_symbol(symbol: &Symbol, kind: SymbolKind) -> DocumentSymbol {
+	let span = &symbol.span;
+	#[allow(deprecated)]
+	DocumentSymbol {
+		name: symbol.name.clone(),
+		detail: None,
+		kind,
+		range: span.into(),
+		selection_range: span.into(),
+		children: None,
+		tags: None,
+		deprecated: None,
+	}
 }

--- a/libs/wingc/src/lsp/hover.rs
+++ b/libs/wingc/src/lsp/hover.rs
@@ -258,7 +258,7 @@ pub fn on_hover<'a>(params: lsp_types::HoverParams) -> Option<Hover> {
 					kind: MarkupKind::Markdown,
 					value: hover_string,
 				}),
-				range: Some(symbol.span.range()),
+				range: Some((&symbol.span).into()),
 			});
 		}
 
@@ -315,6 +315,6 @@ fn build_nested_identifier_hover(property: &Symbol, expr: &Expr) -> Option<Hover
 		}),
 		// When hovering over a reference, we want to highlight the entire relevant expression
 		// e.g. Hovering over `b` in `a.b.c` will highlight `a.b`
-		range: Some(expr.span.range()),
+		range: Some((&expr.span).into()),
 	});
 }

--- a/libs/wingc/src/lsp/notifications.rs
+++ b/libs/wingc/src/lsp/notifications.rs
@@ -1,5 +1,5 @@
 use itertools::Itertools;
-use lsp_types::{Position, Range, Url};
+use lsp_types::{Range, Url};
 
 use crate::diagnostic::{DiagnosticLevel, Diagnostics};
 
@@ -46,14 +46,8 @@ pub fn send_diagnostics(uri: &Url, diagnostics: &Diagnostics) {
 		.filter(|item| matches!(item.level, DiagnosticLevel::Error) && item.span.is_some())
 		.map(|item| {
 			let span = item.span.as_ref().unwrap();
-			let start_position = Position {
-				line: span.start.row as u32,
-				character: span.start.column as u32,
-			};
-			let end_position = Position {
-				line: span.end.row as u32,
-				character: span.end.column as u32,
-			};
+			let start_position = span.start.into();
+			let end_position = span.end.into();
 			lsp_types::Diagnostic::new_simple(Range::new(start_position, end_position), item.message.clone())
 		})
 		.collect_vec();

--- a/libs/wingc/src/parser.rs
+++ b/libs/wingc/src/parser.rs
@@ -140,11 +140,10 @@ impl Parser<'_> {
 	}
 
 	fn node_span(&self, node: &Node) -> WingSpan {
+		let node_range = node.range();
 		WingSpan {
-			start: node.range().start_point,
-			end: node.range().end_point,
-			start_byte: node.byte_range().start,
-			end_byte: node.byte_range().end,
+			start: node_range.start_point.into(),
+			end: node_range.end_point.into(),
 			// TODO: Implement multi-file support
 			file_id: self.source_name.to_string(),
 		}

--- a/libs/wingc/src/type_check.rs
+++ b/libs/wingc/src/type_check.rs
@@ -762,10 +762,7 @@ impl<'a> TypeChecker<'a> {
 			scope.env.borrow_mut().as_mut().unwrap(),
 			WINGSDK_ASSEMBLY_NAME.to_string(),
 			vec![WINGSDK_STD_MODULE.to_string()],
-			&Symbol {
-				name: WINGSDK_STD_MODULE.to_string(),
-				span: Default::default(),
-			},
+			&Symbol::global(WINGSDK_STD_MODULE),
 			None,
 		);
 	}
@@ -2249,10 +2246,7 @@ impl<'a> TypeChecker<'a> {
 
 							match new_type_class.env.define(
 								// TODO: Original symbol is not available. SymbolKind::Variable should probably expose it
-								&Symbol {
-									name: name.clone(),
-									span: Default::default(),
-								},
+								&Symbol::global(name),
 								if *is_static {
 									SymbolKind::make_variable(self.types.add_type(Type::Function(new_sig)), *reassignable, *flight)
 								} else {
@@ -2283,10 +2277,7 @@ impl<'a> TypeChecker<'a> {
 							};
 							match new_type_class.env.define(
 								// TODO: Original symbol is not available. SymbolKind::Variable should probably expose it
-								&Symbol {
-									name: name.clone(),
-									span: Default::default(),
-								},
+								&Symbol::global(name),
 								if *is_static {
 									SymbolKind::make_variable(new_var_type, reassignable, flight)
 								} else {

--- a/libs/wingc/src/type_check.rs
+++ b/libs/wingc/src/type_check.rs
@@ -4,7 +4,7 @@ use crate::ast::{
 	Class as AstClass, Expr, ExprKind, InterpolatedStringPart, Literal, Phase, Reference, Scope, Stmt, StmtKind, Symbol,
 	TypeAnnotation, UnaryOperator, UserDefinedType,
 };
-use crate::diagnostic::{Diagnostic, DiagnosticLevel, Diagnostics, TypeError, WingSpan};
+use crate::diagnostic::{Diagnostic, DiagnosticLevel, Diagnostics, TypeError};
 use crate::{
 	debug, WINGSDK_ARRAY, WINGSDK_ASSEMBLY_NAME, WINGSDK_CLOUD_MODULE, WINGSDK_DURATION, WINGSDK_FS_MODULE, WINGSDK_JSON,
 	WINGSDK_MAP, WINGSDK_MUT_ARRAY, WINGSDK_MUT_JSON, WINGSDK_MUT_MAP, WINGSDK_MUT_SET, WINGSDK_SET, WINGSDK_STD_MODULE,
@@ -764,7 +764,7 @@ impl<'a> TypeChecker<'a> {
 			vec![WINGSDK_STD_MODULE.to_string()],
 			&Symbol {
 				name: WINGSDK_STD_MODULE.to_string(),
-				span: WingSpan::default(),
+				span: Default::default(),
 			},
 			None,
 		);
@@ -2066,7 +2066,7 @@ impl<'a> TypeChecker<'a> {
 				Err(type_error) => {
 					self.type_error(TypeError {
 						message: format!("Cannot locate Wing standard library (checking \"{}\"", manifest_root),
-						span: stmt.map(|s| s.span.clone()).unwrap_or(WingSpan::default()),
+						span: stmt.map(|s| s.span.clone()).unwrap_or_default(),
 					});
 					debug!("{:?}", type_error);
 					return;
@@ -2082,7 +2082,7 @@ impl<'a> TypeChecker<'a> {
 				Err(type_error) => {
 					self.type_error(TypeError {
 						message: format!("Cannot find module \"{}\" in source directory", library_name),
-						span: stmt.map(|s| s.span.clone()).unwrap_or(WingSpan::default()),
+						span: stmt.map(|s| s.span.clone()).unwrap_or_default(),
 					});
 					debug!("{:?}", type_error);
 					return;
@@ -2251,7 +2251,7 @@ impl<'a> TypeChecker<'a> {
 								// TODO: Original symbol is not available. SymbolKind::Variable should probably expose it
 								&Symbol {
 									name: name.clone(),
-									span: WingSpan::default(),
+									span: Default::default(),
 								},
 								if *is_static {
 									SymbolKind::make_variable(self.types.add_type(Type::Function(new_sig)), *reassignable, *flight)
@@ -2285,7 +2285,7 @@ impl<'a> TypeChecker<'a> {
 								// TODO: Original symbol is not available. SymbolKind::Variable should probably expose it
 								&Symbol {
 									name: name.clone(),
-									span: WingSpan::default(),
+									span: Default::default(),
 								},
 								if *is_static {
 									SymbolKind::make_variable(new_var_type, reassignable, flight)

--- a/libs/wingc/src/type_check.rs
+++ b/libs/wingc/src/type_check.rs
@@ -764,7 +764,7 @@ impl<'a> TypeChecker<'a> {
 			vec![WINGSDK_STD_MODULE.to_string()],
 			&Symbol {
 				name: WINGSDK_STD_MODULE.to_string(),
-				span: WingSpan::global(),
+				span: WingSpan::default(),
 			},
 			None,
 		);
@@ -2066,7 +2066,7 @@ impl<'a> TypeChecker<'a> {
 				Err(type_error) => {
 					self.type_error(TypeError {
 						message: format!("Cannot locate Wing standard library (checking \"{}\"", manifest_root),
-						span: stmt.map(|s| s.span.clone()).unwrap_or(WingSpan::global()),
+						span: stmt.map(|s| s.span.clone()).unwrap_or(WingSpan::default()),
 					});
 					debug!("{:?}", type_error);
 					return;
@@ -2082,7 +2082,7 @@ impl<'a> TypeChecker<'a> {
 				Err(type_error) => {
 					self.type_error(TypeError {
 						message: format!("Cannot find module \"{}\" in source directory", library_name),
-						span: stmt.map(|s| s.span.clone()).unwrap_or(WingSpan::global()),
+						span: stmt.map(|s| s.span.clone()).unwrap_or(WingSpan::default()),
 					});
 					debug!("{:?}", type_error);
 					return;
@@ -2251,7 +2251,7 @@ impl<'a> TypeChecker<'a> {
 								// TODO: Original symbol is not available. SymbolKind::Variable should probably expose it
 								&Symbol {
 									name: name.clone(),
-									span: WingSpan::global(),
+									span: WingSpan::default(),
 								},
 								if *is_static {
 									SymbolKind::make_variable(self.types.add_type(Type::Function(new_sig)), *reassignable, *flight)
@@ -2285,7 +2285,7 @@ impl<'a> TypeChecker<'a> {
 								// TODO: Original symbol is not available. SymbolKind::Variable should probably expose it
 								&Symbol {
 									name: name.clone(),
-									span: WingSpan::global(),
+									span: WingSpan::default(),
 								},
 								if *is_static {
 									SymbolKind::make_variable(new_var_type, reassignable, flight)

--- a/libs/wingc/src/type_check/jsii_importer.rs
+++ b/libs/wingc/src/type_check/jsii_importer.rs
@@ -276,7 +276,7 @@ impl<'a> JsiiImporter<'a> {
 					.define(
 						&Symbol {
 							name: namespace_name.to_string(),
-							span: WingSpan::default(),
+							span: Default::default(),
 						},
 						SymbolKind::Namespace(ns),
 						StatementIdx::Top,
@@ -547,7 +547,7 @@ impl<'a> JsiiImporter<'a> {
 				file_id: (&jsii_source_location.filename).into(),
 			}
 		} else {
-			WingSpan::default()
+			Default::default()
 		};
 		Symbol {
 			name: name.to_string(),

--- a/libs/wingc/src/type_check/jsii_importer.rs
+++ b/libs/wingc/src/type_check/jsii_importer.rs
@@ -274,10 +274,7 @@ impl<'a> JsiiImporter<'a> {
 				parent_ns
 					.env
 					.define(
-						&Symbol {
-							name: namespace_name.to_string(),
-							span: Default::default(),
-						},
+						&Symbol::global(namespace_name),
 						SymbolKind::Namespace(ns),
 						StatementIdx::Top,
 					)
@@ -538,11 +535,11 @@ impl<'a> JsiiImporter<'a> {
 			WingSpan {
 				start: WingPoint {
 					line: (jsii_source_location.line - 1.0) as u32,
-					character: 0,
+					col: 0,
 				},
 				end: WingPoint {
 					line: (jsii_source_location.line - 1.0) as u32,
-					character: 0,
+					col: 0,
 				},
 				file_id: (&jsii_source_location.filename).into(),
 			}

--- a/libs/wingc/src/type_check/jsii_importer.rs
+++ b/libs/wingc/src/type_check/jsii_importer.rs
@@ -1,7 +1,7 @@
 use crate::{
 	ast::{Phase, Symbol},
 	debug,
-	diagnostic::{WingPoint, WingSpan},
+	diagnostic::{WingLocation, WingSpan},
 	type_check::{
 		self, symbol_env::StatementIdx, Class, FunctionSignature, Struct, SymbolKind, Type, TypeRef, Types,
 		WING_CONSTRUCTOR_NAME,
@@ -533,11 +533,11 @@ impl<'a> JsiiImporter<'a> {
 	fn jsii_name_to_symbol(name: &str, jsii_source_location: &Option<jsii::SourceLocation>) -> Symbol {
 		let span = if let Some(jsii_source_location) = jsii_source_location {
 			WingSpan {
-				start: WingPoint {
+				start: WingLocation {
 					line: (jsii_source_location.line - 1.0) as u32,
 					col: 0,
 				},
-				end: WingPoint {
+				end: WingLocation {
 					line: (jsii_source_location.line - 1.0) as u32,
 					col: 0,
 				},

--- a/libs/wingc/src/type_check/jsii_importer.rs
+++ b/libs/wingc/src/type_check/jsii_importer.rs
@@ -1,7 +1,7 @@
 use crate::{
 	ast::{Phase, Symbol},
 	debug,
-	diagnostic::{CharacterLocation, WingSpan},
+	diagnostic::{WingPoint, WingSpan},
 	type_check::{
 		self, symbol_env::StatementIdx, Class, FunctionSignature, Struct, SymbolKind, Type, TypeRef, Types,
 		WING_CONSTRUCTOR_NAME,
@@ -276,7 +276,7 @@ impl<'a> JsiiImporter<'a> {
 					.define(
 						&Symbol {
 							name: namespace_name.to_string(),
-							span: WingSpan::global(),
+							span: WingSpan::default(),
 						},
 						SymbolKind::Namespace(ns),
 						StatementIdx::Top,
@@ -536,20 +536,18 @@ impl<'a> JsiiImporter<'a> {
 	fn jsii_name_to_symbol(name: &str, jsii_source_location: &Option<jsii::SourceLocation>) -> Symbol {
 		let span = if let Some(jsii_source_location) = jsii_source_location {
 			WingSpan {
-				start: CharacterLocation {
-					row: (jsii_source_location.line - 1.0) as usize,
-					column: 0,
+				start: WingPoint {
+					line: (jsii_source_location.line - 1.0) as u32,
+					character: 0,
 				},
-				end: CharacterLocation {
-					row: (jsii_source_location.line - 1.0) as usize,
-					column: 0,
+				end: WingPoint {
+					line: (jsii_source_location.line - 1.0) as u32,
+					character: 0,
 				},
-				start_byte: 0,
-				end_byte: 0,
 				file_id: (&jsii_source_location.filename).into(),
 			}
 		} else {
-			WingSpan::global()
+			WingSpan::default()
 		};
 		Symbol {
 			name: name.to_string(),

--- a/libs/wingii/project.json
+++ b/libs/wingii/project.json
@@ -14,8 +14,8 @@
       "executor": "nx:run-commands",
       "options": {
         "commands": [
-          "cargo clippy --fix --no-deps --target wasm32-wasi --release",
-          "cargo fmt"
+          "cargo fmt",
+          "cargo clippy --fix --no-deps --target wasm32-wasi --release"
         ],
         "cwd": "libs/wingii",
         "parallel": false
@@ -23,8 +23,8 @@
       "configurations": {
         "release": {
           "commands": [
-            "cargo clippy --no-deps --target wasm32-wasi --release",
-            "cargo fmt --check"
+            "cargo fmt --check",
+            "cargo clippy --no-deps --target wasm32-wasi --release"
           ]
         }
       }

--- a/libs/wingii/project.json
+++ b/libs/wingii/project.json
@@ -13,8 +13,20 @@
     "lint": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "cargo clippy",
-        "cwd": "libs/wingii"
+        "commands": [
+          "cargo clippy --fix --no-deps --target wasm32-wasi --release",
+          "cargo fmt"
+        ],
+        "cwd": "libs/wingii",
+        "parallel": false
+      },
+      "configurations": {
+        "release": {
+          "commands": [
+            "cargo clippy --no-deps --target wasm32-wasi --release",
+            "cargo fmt --check"
+          ]
+        }
       }
     },
     "build": {

--- a/nx.json
+++ b/nx.json
@@ -40,6 +40,7 @@
           "build",
           "copy",
           "test",
+          "lint",
           "package"
         ]
       }
@@ -66,6 +67,14 @@
         "src",
         "test",
         "examples-tests"
+      ]
+    },
+    "lint": {
+      "inputs": [
+        "project-files",
+        "workspace-files",
+        "src",
+        "test"
       ]
     }
   }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 profile = "default"
-channel = "1.66.0"
+channel = "1.67.1"

--- a/scripts/setup_wasi.sh
+++ b/scripts/setup_wasi.sh
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
 set -eo pipefail
 
-WASI_VERSION="16"
+WASI_VERSION="19"
+WASI_VERSION_FULL="$WASI_VERSION.0"
+WASI_INSTALL_PARENT_DIR="./.cargo"
+WASI_INSTALL_DIR="$WASI_INSTALL_PARENT_DIR/wasi-sdk-$WASI_VERSION_FULL"
 
 # Check if mac or linux
 if [[ "$OSTYPE" == "linux-gnu"* ]]; then
@@ -18,10 +21,9 @@ if ! command -v cargo-wasi &> /dev/null; then
     cargo install cargo-wasi
 fi
 
-if [ ! -d "/opt/wasi-sdk" ]; then
-    echo "Installing WASI SDK $WASI_VERSION to /opt/wasi-sdk..."
-    wasi_sdk_url="https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-$WASI_VERSION/wasi-sdk-$WASI_VERSION.0-$WASI_OS.tar.gz"
-    curl --retry 2 -L $wasi_sdk_url | tar zxf - -C /tmp
-    sudo mv /tmp/wasi-sdk-$WASI_VERSION.0 /opt/wasi-sdk
+if [ ! -d $WASI_INSTALL_DIR ]; then
+    WASI_INSTALL_URL="https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-$WASI_VERSION/wasi-sdk-$WASI_VERSION_FULL-$WASI_OS.tar.gz"
+    echo "Installing WASI SDK $WASI_VERSION_FULL to $WASI_INSTALL_DIR..."
+    curl --retry 2 -L $WASI_INSTALL_URL | tar zxf - -C $WASI_INSTALL_PARENT_DIR
 fi
 

--- a/tools/hangar/src/invalid.test.ts
+++ b/tools/hangar/src/invalid.test.ts
@@ -19,7 +19,7 @@ describe.each(invalidWingFiles)("%s", (wingFile) => {
 
       const out = await runWingCommand(testDir, relativeWingFile, args, false);
 
-      const stderr = out.all ?? out.stderr;
+      const stderr = out.stderr;
 
       const stderrSanitized = stderr
         // Remove absolute paths

--- a/tools/hangar/src/test.test.ts
+++ b/tools/hangar/src/test.test.ts
@@ -19,7 +19,7 @@ describe.each(validWingFiles)("%s", (wingFile) => {
         true
       );
 
-      expect(out.all).toMatchSnapshot("stdout");
+      expect(out.stdout).toMatchSnapshot("stdout");
 
       // TODO snapshot .wsim contents
     },

--- a/tools/hangar/src/utils.ts
+++ b/tools/hangar/src/utils.ts
@@ -14,16 +14,15 @@ export async function runWingCommand(
     cwd,
     reject: false,
     stdin: "ignore",
-    all: true,
     env: env,
   });
   if (shouldSucceed) {
     if (out.exitCode !== 0) {
-      throw out.all;
+      expect.fail(out.stderr);
     }
   } else {
     expect(out.exitCode).not.toBe(0);
-    expect(out.all).not.toBe("");
+    expect(out.stderr).not.toBe("");
   }
   return out;
 }


### PR DESCRIPTION
Misc changes while working on other stuff

- Update rust to 1.67.1 and made change to .cargo/config.toml to get it to work
- Changed hangar so that it stops spitting out `undefined` when the cli errors
- Updated wasi-sdk to the latest version, and changed the install scripts that it installs a tool within the repo itself (gitignored)
  - This avoids using sudo in the install
  - It is also now a versioned dir, this should make it easier to make sure everyone stays in sync whenever it changes
- Added WingPoint, and made better use of `Into`, `From`, and `Default` so that and WingSpan for some hopefully more idiomatic rust experiences
- Added "lint" as a cached nx operation. This should be okay since it relies on changes to src files
- Made sure clippy runs with release and a couple of other flags when needed, to avoid unnecessary compilations in CI
- Run rustfmt in "lint"
- Add "--fix" arg to clippy

Fixes #813

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.