### PR TITLE
fix(compiler): handle json type mapping in jsii importer

### DIFF
--- a/libs/wingc/src/type_check/jsii_importer.rs
+++ b/libs/wingc/src/type_check/jsii_importer.rs
@@ -7,7 +7,8 @@ use crate::{
 		WING_CONSTRUCTOR_NAME,
 	},
 	utilities::camel_case_to_snake_case,
-	CONSTRUCT_BASE, WINGSDK_ASSEMBLY_NAME, WINGSDK_DURATION, WINGSDK_INFLIGHT, WINGSDK_RESOURCE,
+	CONSTRUCT_BASE, WINGSDK_ASSEMBLY_NAME, WINGSDK_DURATION, WINGSDK_INFLIGHT, WINGSDK_JSON, WINGSDK_MUT_JSON,
+	WINGSDK_RESOURCE,
 };
 use colored::Colorize;
 use serde_json::Value;
@@ -108,6 +109,10 @@ impl<'a> JsiiImporter<'a> {
 					}))
 				} else if type_fqn == &format!("{}.{}", WINGSDK_ASSEMBLY_NAME, WINGSDK_DURATION) {
 					self.wing_types.duration()
+				} else if type_fqn == &format!("{}.{}", WINGSDK_ASSEMBLY_NAME, WINGSDK_JSON) {
+					self.wing_types.json()
+				} else if type_fqn == &format!("{}.{}", WINGSDK_ASSEMBLY_NAME, WINGSDK_MUT_JSON) {
+					self.wing_types.mut_json()
 				} else if type_fqn == "constructs.IConstruct" || type_fqn == "constructs.Construct" {
 					// TODO: this should be a special type that represents "any resource" https://github.com/winglang/wing/issues/261
 					self.wing_types.anything()


### PR DESCRIPTION
**self inflicted goof**
removed logic in typechecker where it would try and map Json from stdlib to Json in compiler. I have since learned that the jsii_importer is a much more holistic solution. 😅 

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.