### PR TITLE
fix(sdk): add missing api functions

### DIFF
--- a/libs/wingsdk/API.md
+++ b/libs/wingsdk/API.md
@@ -30,7 +30,78 @@ new cloud.Api(props?: ApiProps)
 
 | **Name** | **Description** |
 | --- | --- |
+| <code><a href="#@winglang/sdk.cloud.Api.connect">connect</a></code> | Add a inflight handler to the api for CONNECT requests on the given route. |
+| <code><a href="#@winglang/sdk.cloud.Api.delete">delete</a></code> | Add a inflight handler to the api for DELETE requests on the given route. |
 | <code><a href="#@winglang/sdk.cloud.Api.get">get</a></code> | Add a inflight handler to the api for GET requests on the given route. |
+| <code><a href="#@winglang/sdk.cloud.Api.head">head</a></code> | Add a inflight handler to the api for HEAD requests on the given route. |
+| <code><a href="#@winglang/sdk.cloud.Api.options">options</a></code> | Add a inflight handler to the api for OPTIONS requests on the given route. |
+| <code><a href="#@winglang/sdk.cloud.Api.patch">patch</a></code> | Add a inflight handler to the api for PATCH requests on the given route. |
+| <code><a href="#@winglang/sdk.cloud.Api.post">post</a></code> | Add a inflight handler to the api for POST requests on the given route. |
+| <code><a href="#@winglang/sdk.cloud.Api.put">put</a></code> | Add a inflight handler to the api for PUT requests on the given route. |
+
+---
+
+##### `connect` <a name="connect" id="@winglang/sdk.cloud.Api.connect"></a>
+
+```wing
+connect(route: str, inflight: ~Inflight, props?: ApiConnectProps): void
+```
+
+Add a inflight handler to the api for CONNECT requests on the given route.
+
+###### `route`<sup>Required</sup> <a name="route" id="@winglang/sdk.cloud.Api.connect.parameter.route"></a>
+
+- *Type:* str
+
+The route to handle CONNECT requests for.
+
+---
+
+###### `inflight`<sup>Required</sup> <a name="inflight" id="@winglang/sdk.cloud.Api.connect.parameter.inflight"></a>
+
+- *Type:* <a href="#@winglang/sdk.core.Inflight">Inflight</a>
+
+The function to handle the request.
+
+---
+
+###### `props`<sup>Optional</sup> <a name="props" id="@winglang/sdk.cloud.Api.connect.parameter.props"></a>
+
+- *Type:* <a href="#@winglang/sdk.cloud.ApiConnectProps">ApiConnectProps</a>
+
+Options for the route.
+
+---
+
+##### `delete` <a name="delete" id="@winglang/sdk.cloud.Api.delete"></a>
+
+```wing
+delete(route: str, inflight: ~Inflight, props?: ApiDeleteProps): void
+```
+
+Add a inflight handler to the api for DELETE requests on the given route.
+
+###### `route`<sup>Required</sup> <a name="route" id="@winglang/sdk.cloud.Api.delete.parameter.route"></a>
+
+- *Type:* str
+
+The route to handle DELETE requests for.
+
+---
+
+###### `inflight`<sup>Required</sup> <a name="inflight" id="@winglang/sdk.cloud.Api.delete.parameter.inflight"></a>
+
+- *Type:* <a href="#@winglang/sdk.core.Inflight">Inflight</a>
+
+The function to handle the request.
+
+---
+
+###### `props`<sup>Optional</sup> <a name="props" id="@winglang/sdk.cloud.Api.delete.parameter.props"></a>
+
+- *Type:* <a href="#@winglang/sdk.cloud.ApiDeleteProps">ApiDeleteProps</a>
+
+Options for the route.
 
 ---
 
@@ -61,6 +132,166 @@ The function to handle the request.
 ###### `props`<sup>Optional</sup> <a name="props" id="@winglang/sdk.cloud.Api.get.parameter.props"></a>
 
 - *Type:* <a href="#@winglang/sdk.cloud.ApiGetProps">ApiGetProps</a>
+
+Options for the route.
+
+---
+
+##### `head` <a name="head" id="@winglang/sdk.cloud.Api.head"></a>
+
+```wing
+head(route: str, inflight: ~Inflight, props?: ApiHeadProps): void
+```
+
+Add a inflight handler to the api for HEAD requests on the given route.
+
+###### `route`<sup>Required</sup> <a name="route" id="@winglang/sdk.cloud.Api.head.parameter.route"></a>
+
+- *Type:* str
+
+The route to handle HEAD requests for.
+
+---
+
+###### `inflight`<sup>Required</sup> <a name="inflight" id="@winglang/sdk.cloud.Api.head.parameter.inflight"></a>
+
+- *Type:* <a href="#@winglang/sdk.core.Inflight">Inflight</a>
+
+The function to handle the request.
+
+---
+
+###### `props`<sup>Optional</sup> <a name="props" id="@winglang/sdk.cloud.Api.head.parameter.props"></a>
+
+- *Type:* <a href="#@winglang/sdk.cloud.ApiHeadProps">ApiHeadProps</a>
+
+Options for the route.
+
+---
+
+##### `options` <a name="options" id="@winglang/sdk.cloud.Api.options"></a>
+
+```wing
+options(route: str, inflight: ~Inflight, props?: ApiOptionsProps): void
+```
+
+Add a inflight handler to the api for OPTIONS requests on the given route.
+
+###### `route`<sup>Required</sup> <a name="route" id="@winglang/sdk.cloud.Api.options.parameter.route"></a>
+
+- *Type:* str
+
+The route to handle OPTIONS requests for.
+
+---
+
+###### `inflight`<sup>Required</sup> <a name="inflight" id="@winglang/sdk.cloud.Api.options.parameter.inflight"></a>
+
+- *Type:* <a href="#@winglang/sdk.core.Inflight">Inflight</a>
+
+The function to handle the request.
+
+---
+
+###### `props`<sup>Optional</sup> <a name="props" id="@winglang/sdk.cloud.Api.options.parameter.props"></a>
+
+- *Type:* <a href="#@winglang/sdk.cloud.ApiOptionsProps">ApiOptionsProps</a>
+
+Options for the route.
+
+---
+
+##### `patch` <a name="patch" id="@winglang/sdk.cloud.Api.patch"></a>
+
+```wing
+patch(route: str, inflight: ~Inflight, props?: ApiPatchProps): void
+```
+
+Add a inflight handler to the api for PATCH requests on the given route.
+
+###### `route`<sup>Required</sup> <a name="route" id="@winglang/sdk.cloud.Api.patch.parameter.route"></a>
+
+- *Type:* str
+
+The route to handle PATCH requests for.
+
+---
+
+###### `inflight`<sup>Required</sup> <a name="inflight" id="@winglang/sdk.cloud.Api.patch.parameter.inflight"></a>
+
+- *Type:* <a href="#@winglang/sdk.core.Inflight">Inflight</a>
+
+The function to handle the request.
+
+---
+
+###### `props`<sup>Optional</sup> <a name="props" id="@winglang/sdk.cloud.Api.patch.parameter.props"></a>
+
+- *Type:* <a href="#@winglang/sdk.cloud.ApiPatchProps">ApiPatchProps</a>
+
+Options for the route.
+
+---
+
+##### `post` <a name="post" id="@winglang/sdk.cloud.Api.post"></a>
+
+```wing
+post(route: str, inflight: ~Inflight, props?: ApiPostProps): void
+```
+
+Add a inflight handler to the api for POST requests on the given route.
+
+###### `route`<sup>Required</sup> <a name="route" id="@winglang/sdk.cloud.Api.post.parameter.route"></a>
+
+- *Type:* str
+
+The route to handle POST requests for.
+
+---
+
+###### `inflight`<sup>Required</sup> <a name="inflight" id="@winglang/sdk.cloud.Api.post.parameter.inflight"></a>
+
+- *Type:* <a href="#@winglang/sdk.core.Inflight">Inflight</a>
+
+The function to handle the request.
+
+---
+
+###### `props`<sup>Optional</sup> <a name="props" id="@winglang/sdk.cloud.Api.post.parameter.props"></a>
+
+- *Type:* <a href="#@winglang/sdk.cloud.ApiPostProps">ApiPostProps</a>
+
+Options for the route.
+
+---
+
+##### `put` <a name="put" id="@winglang/sdk.cloud.Api.put"></a>
+
+```wing
+put(route: str, inflight: ~Inflight, props?: ApiPutProps): void
+```
+
+Add a inflight handler to the api for PUT requests on the given route.
+
+###### `route`<sup>Required</sup> <a name="route" id="@winglang/sdk.cloud.Api.put.parameter.route"></a>
+
+- *Type:* str
+
+The route to handle PUT requests for.
+
+---
+
+###### `inflight`<sup>Required</sup> <a name="inflight" id="@winglang/sdk.cloud.Api.put.parameter.inflight"></a>
+
+- *Type:* <a href="#@winglang/sdk.core.Inflight">Inflight</a>
+
+The function to handle the request.
+
+---
+
+###### `props`<sup>Optional</sup> <a name="props" id="@winglang/sdk.cloud.Api.put.parameter.props"></a>
+
+- *Type:* <a href="#@winglang/sdk.cloud.ApiPutProps">ApiPutProps</a>
 
 Options for the route.
 

--- a/libs/wingsdk/src/cloud/api.ts
+++ b/libs/wingsdk/src/cloud/api.ts
@@ -69,6 +69,90 @@ export abstract class Api extends Resource {
   ): void;
 
   /**
+   * Add a inflight handler to the api for POST requests on the given route.
+   * @param route The route to handle POST requests for.
+   * @param inflight The function to handle the request.
+   * @param props Options for the route.
+   */
+  public abstract post(
+    route: string,
+    inflight: Inflight,
+    props?: ApiPostProps
+  ): void;
+
+  /**
+   * Add a inflight handler to the api for PUT requests on the given route.
+   * @param route The route to handle PUT requests for.
+   * @param inflight The function to handle the request.
+   * @param props Options for the route.
+   */
+  public abstract put(
+    route: string,
+    inflight: Inflight,
+    props?: ApiPutProps
+  ): void;
+
+  /**
+   * Add a inflight handler to the api for DELETE requests on the given route.
+   * @param route The route to handle DELETE requests for.
+   * @param inflight The function to handle the request.
+   * @param props Options for the route.
+   */
+  public abstract delete(
+    route: string,
+    inflight: Inflight,
+    props?: ApiDeleteProps
+  ): void;
+
+  /**
+   * Add a inflight handler to the api for PATCH requests on the given route.
+   * @param route The route to handle PATCH requests for.
+   * @param inflight The function to handle the request.
+   * @param props Options for the route.
+   */
+  public abstract patch(
+    route: string,
+    inflight: Inflight,
+    props?: ApiPatchProps
+  ): void;
+
+  /**
+   * Add a inflight handler to the api for OPTIONS requests on the given route.
+   * @param route The route to handle OPTIONS requests for.
+   * @param inflight The function to handle the request.
+   * @param props Options for the route.
+   */
+  public abstract options(
+    route: string,
+    inflight: Inflight,
+    props?: ApiOptionsProps
+  ): void;
+
+  /**
+   * Add a inflight handler to the api for HEAD requests on the given route.
+   * @param route The route to handle HEAD requests for.
+   * @param inflight The function to handle the request.
+   * @param props Options for the route.
+   */
+  public abstract head(
+    route: string,
+    inflight: Inflight,
+    props?: ApiHeadProps
+  ): void;
+
+  /**
+   * Add a inflight handler to the api for CONNECT requests on the given route.
+   * @param route The route to handle CONNECT requests for.
+   * @param inflight The function to handle the request.
+   * @param props Options for the route.
+   */
+  public abstract connect(
+    route: string,
+    inflight: Inflight,
+    props?: ApiConnectProps
+  ): void;
+
+  /**
    * Add a route to the api spec.
    * @param route The route to add.
    * @param method The method to add.


### PR DESCRIPTION
Add the missing functions to the cloud api class.

On the initial implementation https://github.com/winglang/wing/pull/1285 only the get function was part of the abstract cloud class. 


*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.