### PR TITLE
feat(sdk): add api resource sim

### DIFF
--- a/libs/wingsdk/src/target-sim/api.onrequest.inflight.ts
+++ b/libs/wingsdk/src/target-sim/api.onrequest.inflight.ts
@@ -1,0 +1,16 @@
+import {
+  ApiRequest,
+  ApiResponse,
+  IApiEndpointHandlerClient,
+} from "../cloud/api";
+
+export class ApiOnRequestHandlerClient {
+  private readonly handler: IApiEndpointHandlerClient;
+  constructor({ handler }: { handler: IApiEndpointHandlerClient }) {
+    this.handler = handler;
+  }
+  public async handle(request: ApiRequest): Promise<ApiResponse> {
+    const apiResponse: ApiResponse = await this.handler.handle(request);
+    return apiResponse;
+  }
+}

--- a/libs/wingsdk/src/target-sim/api.ts
+++ b/libs/wingsdk/src/target-sim/api.ts
@@ -1,0 +1,178 @@
+import { join } from "path";
+import { Construct } from "constructs";
+import { ISimulatorResource } from ".";
+import { Function } from "./function";
+import { BaseResourceSchema } from "./schema";
+import { ApiSchema, API_TYPE } from "./schema-resources";
+import { bindSimulatorResource } from "./util";
+import { cloud } from "..";
+import { HttpMethod } from "../cloud";
+import { convertBetweenHandlers } from "../convert";
+import { Inflight, Code, IInflightHost, Resource } from "../core";
+
+export class Api extends cloud.Api implements ISimulatorResource {
+  constructor(
+    scope: Construct,
+    id: string,
+    props?: cloud.ApiProps | undefined
+  ) {
+    super(scope, id, props);
+  }
+
+  /**
+   * Add a inflight to handle GET requests to a route.
+   * @param route Route to add
+   * @param inflight Inflight to handle request
+   * @param props Additional props
+   */
+
+  public get(
+    route: string,
+    inflight: Inflight,
+    props?: cloud.ApiGetProps | undefined
+  ): void {
+    this._addToSpec(route, HttpMethod.GET, undefined);
+    const hash = inflight.node.addr.slice(-8);
+    const functionHandler = convertBetweenHandlers(
+      this.node.scope!, // ok since we're not a tree root
+      `${this.node.id}-OnMessageHandler-${hash}`,
+      inflight,
+      join(__dirname, "topic.onmessage.inflight.js"),
+      "TopicOnMessageHandlerClient"
+    );
+
+    const fn = Function._newFunction(
+      this.node.scope!, // ok since we're not a tree root
+      `${this.node.id}-OnMessage-${hash}`,
+      functionHandler,
+      props
+    );
+
+    this.node.addDependency(fn);
+
+    const functionHandle = `\${${fn.node.path}#attrs.handle}`;
+
+    Resource.addConnection({
+      from: this,
+      to: fn,
+      relationship: "on_message",
+    });
+  }
+
+  /**
+   * Add a inflight to handle POST requests to a route.
+   * @param route Route to add
+   * @param inflight Inflight to handle request
+   * @param props Additional props
+   */
+  public post(
+    route: string,
+    inflight: Inflight,
+    props?: cloud.ApiPostProps | undefined
+  ): void {
+    this._addToSpec(route, HttpMethod.POST, undefined);
+  }
+
+  /**
+   * Add a inflight to handle PUT requests to a route.
+   * @param route Route to add
+   * @param inflight Inflight to handle request
+   * @param props Additional props
+   */
+  public put(
+    route: string,
+    inflight: Inflight,
+    props?: cloud.ApiPutProps | undefined
+  ): void {
+    this._addToSpec(route, HttpMethod.PUT, undefined);
+  }
+
+  /**
+   * Add a inflight to handle DELETE requests to a route.
+   * @param route Route to add
+   * @param inflight Inflight to handle request
+   * @param props Additional props
+   */
+  public delete(
+    route: string,
+    inflight: Inflight,
+    props?: cloud.ApiDeleteProps | undefined
+  ): void {
+    this._addToSpec(route, HttpMethod.DELETE, undefined);
+  }
+
+  /**
+   * Add a inflight to handle PATCH requests to a route.
+   * @param route Route to add
+   * @param inflight Inflight to handle request
+   * @param props Additional props
+   */
+  public patch(
+    route: string,
+    inflight: Inflight,
+    props?: cloud.ApiPatchProps | undefined
+  ): void {
+    this._addToSpec(route, HttpMethod.PATCH, undefined);
+  }
+
+  /**
+   * Add a inflight to handle OPTIONS requests to a route.
+   * @param route Route to add
+   * @param inflight Inflight to handle request
+   * @param props Additional props
+   */
+  public options(
+    route: string,
+    inflight: Inflight,
+    props?: cloud.ApiOptionsProps | undefined
+  ): void {
+    this._addToSpec(route, HttpMethod.OPTIONS, undefined);
+  }
+
+  /**
+   * Add a inflight to handle HEAD requests to a route.
+   * @param route Route to add
+   * @param inflight Inflight to handle request
+   * @param props Additional props
+   */
+  public head(
+    route: string,
+    inflight: Inflight,
+    props?: cloud.ApiHeadProps | undefined
+  ): void {
+    this._addToSpec(route, HttpMethod.HEAD, undefined);
+  }
+
+  /**
+   * Add a inflight to handle CONNECT requests to a route.
+   * @param route Route to add
+   * @param inflight Inflight to handle request
+   * @param props Additional props
+   */
+  public connect(
+    route: string,
+    inflight: Inflight,
+    props?: cloud.ApiConnectProps | undefined
+  ): void {
+    this._addToSpec(route, HttpMethod.CONNECT, undefined);
+  }
+
+  public toSimulator(): BaseResourceSchema {
+    const schema: ApiSchema = {
+      type: API_TYPE,
+      path: this.node.path,
+      props: {},
+      attrs: {} as any,
+    };
+    return schema;
+  }
+  public _toInflight(): Code {
+    throw new Error("Method not implemented.");
+  }
+
+  /** @internal */
+  public _bind(host: IInflightHost, ops: string[]): void {
+    bindSimulatorResource("api", this, host);
+    super._bind(host, ops);
+  }
+}

--- a/libs/wingsdk/src/target-sim/index.ts
+++ b/libs/wingsdk/src/target-sim/index.ts
@@ -1,3 +1,4 @@
+export * from "./api";
 export * from "./app";
 export * from "./bucket";
 export * from "./counter";

--- a/libs/wingsdk/src/target-sim/schema-resources.ts
+++ b/libs/wingsdk/src/target-sim/schema-resources.ts
@@ -1,5 +1,6 @@
 import { BaseResourceSchema } from "./schema";
 
+export const API_TYPE = "wingsdk.cloud.Api";
 export const QUEUE_TYPE = "wingsdk.cloud.Queue";
 export const FUNCTION_TYPE = "wingsdk.cloud.Function";
 export const BUCKET_TYPE = "wingsdk.cloud.Bucket";
@@ -9,6 +10,12 @@ export const SCHEDULE_TYPE = "wingsdk.cloud.Schedule";
 export const LOGGER_TYPE = "wingsdk.cloud.Logger";
 
 export type FunctionHandle = string;
+
+/** Schema for cloud.Api */
+export interface ApiSchema extends BaseResourceSchema {
+  readonly type: typeof API_TYPE;
+  readonly props: {};
+}
 
 /** Schema for cloud.Function */
 export interface FunctionSchema extends BaseResourceSchema {

--- a/libs/wingsdk/test/target-sim/__snapshots__/api.test.ts.snap
+++ b/libs/wingsdk/test/target-sim/__snapshots__/api.test.ts.snap
@@ -1,0 +1,3 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`create api 1`] = `"foo"`;

--- a/libs/wingsdk/test/target-sim/api.test.ts
+++ b/libs/wingsdk/test/target-sim/api.test.ts
@@ -1,0 +1,22 @@
+import { expect, test } from "vitest";
+import { makeHandler } from "../../src/core/internal";
+import { Api } from "../../src/target-sim";
+import { SimApp } from "../../src/testing";
+
+test("create api", async () => {
+  // GIVEN
+  const app = new SimApp();
+  const handler = makeHandler(
+    app,
+    "Handler",
+    `async handle(message) { console.log("Received " + message); }`
+  );
+  const api = new Api(app, "my_api");
+  //   api.get("/hello", handler);
+
+  const s = await app.startSimulator();
+
+  // THEN
+  await s.stop();
+  expect("foo").toMatchSnapshot();
+});


### PR DESCRIPTION
Adds the simulator implementation if the `cloud.api` resource

closes #623

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.