### PR TITLE
chore(docs): rename json.format() to json.to_str()

### DIFF
--- a/docs/04-reference/winglang-spec.md
+++ b/docs/04-reference/winglang-spec.md
@@ -477,13 +477,13 @@ j1.hello = a1;
 
 ##### 1.1.4.9 Serialization
 
-The `Json.format(j: Json): str` static method can be used to serialize a `Json` as a string
+The `Json.to_str(j: Json): str` static method can be used to serialize a `Json` as a string
 ([JSON.stringify](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify)):
 
 ```js
-assert(Json.format(json_string) == "\"hello\"");
-assert(Json.format(json_obj) == "{\"boom\":123}");
-assert(Json.format(json_mut_obj, indent: 2) == "{\n\"hello\": 123,\n"  \"world\": [\n    1,\n    2,\n    3\n  ],\n  \"boom\": {\n    \"hello\": 1233\n  }\n}");
+assert(Json.to_str(json_string) == "\"hello\"");
+assert(Json.to_str(json_obj) == "{\"boom\":123}");
+assert(Json.to_str(json_mut_obj, indent: 2) == "{\n\"hello\": 123,\n"  \"world\": [\n    1,\n    2,\n    3\n  ],\n  \"boom\": {\n    \"hello\": 1233\n  }\n}");
 ```
 
 The `Json.parse(s: str): Json` static method can be used to parse a string into a `Json`:
@@ -541,7 +541,7 @@ A `Json` value can be printed using `print()`, in which case it will be pretty-f
 ```js
 print("my object is: ${json_obj}");
 // is equivalent to
-print("my object is: ${Json.format(json_obj, indent: 2)}");
+print("my object is: ${Json.to_str(json_obj, indent: 2)}");
 ```
 
 This will output:


### PR DESCRIPTION
Following [a discussion](https://github.com/winglang/wing/pull/1665#discussion_r1120271792) - we decided to update `Json.format()` to `Json.to_str()`.
Updated the spec and also issue #1053.
*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.