### PR TITLE
chore(repo): revert to default number of columns for the contributors section

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ We are also actively tracking planned features in our roadmap:
 ## Contributors
 
 <a href="https://github.com/winglang/wing/graphs/contributors">
-  <img src="https://contrib.rocks/image?repo=winglang/wing&columns=7" />
+  <img src="https://contrib.rocks/image?repo=winglang/wing" />
 </a>
 
 ## License


### PR DESCRIPTION
Hey there, after committing I realised that contributor avatars didn't increase in size when the column number was decreased, leaving a huge gap on the right hand size (as seen in the screenshot below). I've reverted to the default number of columns (12) which will fill up the readme file from left to right. 

![Screenshot 2023-03-11 at 11 40 42](https://user-images.githubusercontent.com/38757612/224482548-19f11d62-019b-4447-8e7e-89a7b6132633.png)

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.

