### PR TITLE
chore: exclude windows from pr build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -184,6 +184,8 @@ jobs:
         exclude:
           - runner: macos
             full_run: false
+          - runner: windows
+            full_run: false
           - runner: ubuntu
             node: 19
             full_run: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -218,6 +218,13 @@ jobs:
         working-directory: tools/hangar
         run: npm run test -- --shard=${{ matrix.shard }}
 
+  quality-gate:
+    name: Quality Gate
+    runs-on: ubuntu-latest
+    needs: 
+     - prepare
+     - e2e
+
   publish:
     name: Publish
     if: ${{ github.event_name == 'push' && github.repository == 'winglang/wing' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -222,8 +222,11 @@ jobs:
     name: Quality Gate
     runs-on: ubuntu-latest
     needs: 
-     - prepare
+     - build
      - e2e
+    steps:
+      - name: All good
+        run: echo "Builds and tests passed! 🎉🎉🎉"
 
   publish:
     name: Publish

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -2,7 +2,7 @@
 queue_rules:
   - name: default
     conditions:
-      - status-success=Build
+      - status-success=Quality Gate
       - status-success=Validate PR title
 
 pull_request_rules:
@@ -25,5 +25,5 @@ pull_request_rules:
       - "#changes-requested-reviews-by=0"
       - "#review-threads-unresolved=0"
       - -approved-reviews-by~=author
-      - check-success=Build
+      - check-success=Quality Gate
       - check-success=Validate PR title


### PR DESCRIPTION
Also fix mergify config, which started ignoring the E2E test requirement due to a regression from my last PR.

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.