### PR TITLE
chore(docs): update story 13 - convert json to string

### DIFF
--- a/docs/06-contributors/999-rfcs/000-stories/story-13.md
+++ b/docs/06-contributors/999-rfcs/000-stories/story-13.md
@@ -92,7 +92,7 @@ resource TaskList {
     let output = MutArray<str>[];
     for id in task_ids {
       let j = this.get_task(id); 
-      let title = Json.to_str(j.get("title"));
+      let title = str.from_json(j.get("title"));
       if title.contains(term) { 
         print("found task ${id} with title \"${title}\" with term \"${term}\"");
         output.push(id);
@@ -114,7 +114,7 @@ new cloud.Function(inflight (s: str): str => {
   let result = tasks.find_tasks_with("clean the dishes");
   assert(result.length == 1);
   let t = tasks.get_task(result.at(0));
-  assert("clean the dishes" == Json.to_str(t.get("title")));
+  assert("clean the dishes" == str.from_json(t.get("title")));
 }) as "test:add, get and find task";
 
 new cloud.Function(inflight (s: str): str => {


### PR DESCRIPTION
Updating story 13 to use the correct way to convert json to string (`str.from_json()` instead of `Json.to_str()`).

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.