### PR TITLE
fix: panic while analyzing captures in unknown calls/news

### DIFF
--- a/examples/tests/invalid/construction.w
+++ b/examples/tests/invalid/construction.w
@@ -1,0 +1,4 @@
+bring cloud;
+
+let x = new cloud.BucketProps(1);
+          //^ Cannot instantiate type "BucketProps" because it is not a class or resource

--- a/examples/tests/invalid/unknown_symbol.w
+++ b/examples/tests/invalid/unknown_symbol.w
@@ -14,6 +14,9 @@ resource SomeResource {
   }
 
   inflight get_task(id: str): str {
+    this._bucket.assert(2 + "2");
+               //^ Unknown symbol
+                          //^ Expected type to be "num", but got "str" instead
     return this._bucket.method_which_is_not_part_of_bucket_api(id);
                       //^ Unknown symbol
   }

--- a/examples/tests/invalid/unknown_symbol.w
+++ b/examples/tests/invalid/unknown_symbol.w
@@ -3,6 +3,9 @@ bring cloud;
 let bucket = new clod.Bucket();
                //^ Unknown symbol
 
+let funky = new cloudy.Funktion(inflight () => { });
+              //^ Unknown symbol
+
 let x = 2 + y;
           //^ Unknown symbol
 

--- a/libs/wingc/src/type_check.rs
+++ b/libs/wingc/src/type_check.rs
@@ -1201,6 +1201,13 @@ impl<'a> TypeChecker<'a> {
 
 				// TODO: hack to support methods of stdlib object we don't know their types yet (basically stuff like cloud.Bucket().upload())
 				if matches!(*func_type, Type::Anything) {
+					// Even if we don't know the type of the function, we can still type check the arguments
+					for arg in arg_list.pos_args.iter() {
+						self.type_check_exp(arg, env, statement_idx, context);
+					}
+					for arg in arg_list.named_args.values() {
+						self.type_check_exp(arg, env, statement_idx, context);
+					}
 					return self.types.anything();
 				}
 

--- a/libs/wingc/src/type_check.rs
+++ b/libs/wingc/src/type_check.rs
@@ -1114,7 +1114,7 @@ impl<'a> TypeChecker<'a> {
 							return self.types.anything();
 						} else {
 							return self.general_type_error(format!(
-								"Cannot create an instance of the type \"{}\"",
+								"Cannot instantiate type \"{}\" because it is not a class or resource",
 								type_.to_string()
 							));
 						}

--- a/tools/hangar/__snapshots__/invalid.ts.snap
+++ b/tools/hangar/__snapshots__/invalid.ts.snap
@@ -899,31 +899,38 @@ exports[`unknown_symbol.w > stderr 1`] = `
   |                  ^^^^ Unknown symbol \\"clod\\"
 
 
-error: Unknown symbol \\"y\\"
-  --> ../../../examples/tests/invalid/unknown_symbol.w:6:13
+error: Unknown symbol \\"cloudy\\"
+  --> ../../../examples/tests/invalid/unknown_symbol.w:6:17
   |
-6 | let x = 2 + y;
+6 | let funky = new cloudy.Funktion(inflight () => { });
+  |                 ^^^^^^ Unknown symbol \\"cloudy\\"
+
+
+error: Unknown symbol \\"y\\"
+  --> ../../../examples/tests/invalid/unknown_symbol.w:9:13
+  |
+9 | let x = 2 + y;
   |             ^ Unknown symbol \\"y\\"
 
 
 error: Unknown symbol \\"assert\\"
-   --> ../../../examples/tests/invalid/unknown_symbol.w:17:18
+   --> ../../../examples/tests/invalid/unknown_symbol.w:20:18
    |
-17 |     this._bucket.assert(2 + \\"2\\");
+20 |     this._bucket.assert(2 + \\"2\\");
    |                  ^^^^^^ Unknown symbol \\"assert\\"
 
 
 error: Expected type to be \\"num\\", but got \\"str\\" instead
-   --> ../../../examples/tests/invalid/unknown_symbol.w:17:29
+   --> ../../../examples/tests/invalid/unknown_symbol.w:20:29
    |
-17 |     this._bucket.assert(2 + \\"2\\");
+20 |     this._bucket.assert(2 + \\"2\\");
    |                             ^^^ Expected type to be \\"num\\", but got \\"str\\" instead
 
 
 error: Unknown symbol \\"method_which_is_not_part_of_bucket_api\\"
-   --> ../../../examples/tests/invalid/unknown_symbol.w:20:25
+   --> ../../../examples/tests/invalid/unknown_symbol.w:23:25
    |
-20 |     return this._bucket.method_which_is_not_part_of_bucket_api(id);
+23 |     return this._bucket.method_which_is_not_part_of_bucket_api(id);
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Unknown symbol \\"method_which_is_not_part_of_bucket_api\\"
 
 "

--- a/tools/hangar/__snapshots__/invalid.ts.snap
+++ b/tools/hangar/__snapshots__/invalid.ts.snap
@@ -906,10 +906,24 @@ error: Unknown symbol \\"y\\"
   |             ^ Unknown symbol \\"y\\"
 
 
-error: Unknown symbol \\"method_which_is_not_part_of_bucket_api\\"
-   --> ../../../examples/tests/invalid/unknown_symbol.w:17:25
+error: Unknown symbol \\"assert\\"
+   --> ../../../examples/tests/invalid/unknown_symbol.w:17:18
    |
-17 |     return this._bucket.method_which_is_not_part_of_bucket_api(id);
+17 |     this._bucket.assert(2 + \\"2\\");
+   |                  ^^^^^^ Unknown symbol \\"assert\\"
+
+
+error: Expected type to be \\"num\\", but got \\"str\\" instead
+   --> ../../../examples/tests/invalid/unknown_symbol.w:17:29
+   |
+17 |     this._bucket.assert(2 + \\"2\\");
+   |                             ^^^ Expected type to be \\"num\\", but got \\"str\\" instead
+
+
+error: Unknown symbol \\"method_which_is_not_part_of_bucket_api\\"
+   --> ../../../examples/tests/invalid/unknown_symbol.w:20:25
+   |
+20 |     return this._bucket.method_which_is_not_part_of_bucket_api(id);
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Unknown symbol \\"method_which_is_not_part_of_bucket_api\\"
 
 "

--- a/tools/hangar/__snapshots__/invalid.ts.snap
+++ b/tools/hangar/__snapshots__/invalid.ts.snap
@@ -150,6 +150,12 @@ exports[`cloud_function_expects_inflight.w > stderr 1`] = `
 "
 `;
 
+exports[`construction.w > stderr 1`] = `
+"error: Cannot instantiate type \\"BucketProps\\" because it is not a class or resource
+
+"
+`;
+
 exports[`container_types.w > stderr 1`] = `
 "error: Unknown parser error.
    --> ../../../examples/tests/invalid/container_types.w:10:24


### PR DESCRIPTION
When type checking and coming across a bad (_read_: typed as `any`) call/new reference, we did not traverse the arguments. That means we never gave them type info. 
The capturing process (and lsp) assumes all expressions in the AST have a type, so it panics.

Also re-enabled vscode's capture diagnostics, because this bug is why I removed them in the first place.

Fixes #1747
Fixes #1647
Fixes #1802

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.