### PR TITLE
chore: remove intra-test concurrency in hangar

### DIFF
--- a/tools/hangar/src/error.test.ts
+++ b/tools/hangar/src/error.test.ts
@@ -4,7 +4,7 @@ import { errorTestDir, errorWingFiles, tmpDir } from "./paths";
 import { runWingCommand } from "./utils";
 
 errorWingFiles.forEach((wingFile) => {
-  test.concurrent(wingFile, async ({ expect }) => {
+  test(wingFile, async ({ expect }) => {
     const args = ["test"];
 
     const relativeWingFile = path.relative(

--- a/tools/hangar/src/generate_tests.ts
+++ b/tools/hangar/src/generate_tests.ts
@@ -19,11 +19,11 @@ for (const fileInfo of readdirSync(validTestDir, { withFileTypes: true })) {
 import { test } from "vitest";
 import { compileTest, testTest } from "../../generated_test_targets";
 
-test${skipText}.concurrent("wing compile -t tf-aws", async ({ expect }) => {
+test${skipText}("wing compile -t tf-aws", async ({ expect }) => {
   await compileTest(expect, "${filename}");
 });
 
-test${skipText}.concurrent("wing test", async ({ expect }) => {
+test${skipText}("wing test", async ({ expect }) => {
   await testTest(expect, "${filename}");
 });`;
 

--- a/tools/hangar/src/invalid.test.ts
+++ b/tools/hangar/src/invalid.test.ts
@@ -4,7 +4,7 @@ import { invalidTestDir, invalidWingFiles, tmpDir } from "./paths";
 import { runWingCommand } from "./utils";
 
 invalidWingFiles.forEach((wingFile) => {
-  test.concurrent(wingFile, async ({ expect }) => {
+  test(wingFile, async ({ expect }) => {
     const args = ["test"];
 
     const relativeWingFile = path.relative(

--- a/tools/hangar/src/test_corpus/valid/anon_function.w.test.ts
+++ b/tools/hangar/src/test_corpus/valid/anon_function.w.test.ts
@@ -3,10 +3,10 @@
 import { test } from "vitest";
 import { compileTest, testTest } from "../../generated_test_targets";
 
-test.concurrent("wing compile -t tf-aws", async ({ expect }) => {
+test("wing compile -t tf-aws", async ({ expect }) => {
   await compileTest(expect, "anon_function.w");
 });
 
-test.concurrent("wing test", async ({ expect }) => {
+test("wing test", async ({ expect }) => {
   await testTest(expect, "anon_function.w");
 });

--- a/tools/hangar/src/test_corpus/valid/api.skip.w.test.ts
+++ b/tools/hangar/src/test_corpus/valid/api.skip.w.test.ts
@@ -3,10 +3,10 @@
 import { test } from "vitest";
 import { compileTest, testTest } from "../../generated_test_targets";
 
-test.skip.concurrent("wing compile -t tf-aws", async ({ expect }) => {
+test.skip("wing compile -t tf-aws", async ({ expect }) => {
   await compileTest(expect, "api.skip.w");
 });
 
-test.skip.concurrent("wing test", async ({ expect }) => {
+test.skip("wing test", async ({ expect }) => {
   await testTest(expect, "api.skip.w");
 });

--- a/tools/hangar/src/test_corpus/valid/asynchronous_model_implicit_await_in_functions.w.test.ts
+++ b/tools/hangar/src/test_corpus/valid/asynchronous_model_implicit_await_in_functions.w.test.ts
@@ -3,10 +3,10 @@
 import { test } from "vitest";
 import { compileTest, testTest } from "../../generated_test_targets";
 
-test.concurrent("wing compile -t tf-aws", async ({ expect }) => {
+test("wing compile -t tf-aws", async ({ expect }) => {
   await compileTest(expect, "asynchronous_model_implicit_await_in_functions.w");
 });
 
-test.concurrent("wing test", async ({ expect }) => {
+test("wing test", async ({ expect }) => {
   await testTest(expect, "asynchronous_model_implicit_await_in_functions.w");
 });

--- a/tools/hangar/src/test_corpus/valid/bring_cdktf.w.test.ts
+++ b/tools/hangar/src/test_corpus/valid/bring_cdktf.w.test.ts
@@ -3,10 +3,10 @@
 import { test } from "vitest";
 import { compileTest, testTest } from "../../generated_test_targets";
 
-test.concurrent("wing compile -t tf-aws", async ({ expect }) => {
+test("wing compile -t tf-aws", async ({ expect }) => {
   await compileTest(expect, "bring_cdktf.w");
 });
 
-test.concurrent("wing test", async ({ expect }) => {
+test("wing test", async ({ expect }) => {
   await testTest(expect, "bring_cdktf.w");
 });

--- a/tools/hangar/src/test_corpus/valid/bring_jsii.w.test.ts
+++ b/tools/hangar/src/test_corpus/valid/bring_jsii.w.test.ts
@@ -3,10 +3,10 @@
 import { test } from "vitest";
 import { compileTest, testTest } from "../../generated_test_targets";
 
-test.concurrent("wing compile -t tf-aws", async ({ expect }) => {
+test("wing compile -t tf-aws", async ({ expect }) => {
   await compileTest(expect, "bring_jsii.w");
 });
 
-test.concurrent("wing test", async ({ expect }) => {
+test("wing test", async ({ expect }) => {
   await testTest(expect, "bring_jsii.w");
 });

--- a/tools/hangar/src/test_corpus/valid/bring_jsii_path.w.test.ts
+++ b/tools/hangar/src/test_corpus/valid/bring_jsii_path.w.test.ts
@@ -3,10 +3,10 @@
 import { test } from "vitest";
 import { compileTest, testTest } from "../../generated_test_targets";
 
-test.concurrent("wing compile -t tf-aws", async ({ expect }) => {
+test("wing compile -t tf-aws", async ({ expect }) => {
   await compileTest(expect, "bring_jsii_path.w");
 });
 
-test.concurrent("wing test", async ({ expect }) => {
+test("wing test", async ({ expect }) => {
   await testTest(expect, "bring_jsii_path.w");
 });

--- a/tools/hangar/src/test_corpus/valid/bring_projen.w.test.ts
+++ b/tools/hangar/src/test_corpus/valid/bring_projen.w.test.ts
@@ -3,10 +3,10 @@
 import { test } from "vitest";
 import { compileTest, testTest } from "../../generated_test_targets";
 
-test.concurrent("wing compile -t tf-aws", async ({ expect }) => {
+test("wing compile -t tf-aws", async ({ expect }) => {
   await compileTest(expect, "bring_projen.w");
 });
 
-test.concurrent("wing test", async ({ expect }) => {
+test("wing test", async ({ expect }) => {
   await testTest(expect, "bring_projen.w");
 });

--- a/tools/hangar/src/test_corpus/valid/bucket_keys.w.test.ts
+++ b/tools/hangar/src/test_corpus/valid/bucket_keys.w.test.ts
@@ -3,10 +3,10 @@
 import { test } from "vitest";
 import { compileTest, testTest } from "../../generated_test_targets";
 
-test.concurrent("wing compile -t tf-aws", async ({ expect }) => {
+test("wing compile -t tf-aws", async ({ expect }) => {
   await compileTest(expect, "bucket_keys.w");
 });
 
-test.concurrent("wing test", async ({ expect }) => {
+test("wing test", async ({ expect }) => {
   await testTest(expect, "bucket_keys.w");
 });

--- a/tools/hangar/src/test_corpus/valid/capture_containers.w.test.ts
+++ b/tools/hangar/src/test_corpus/valid/capture_containers.w.test.ts
@@ -3,10 +3,10 @@
 import { test } from "vitest";
 import { compileTest, testTest } from "../../generated_test_targets";
 
-test.concurrent("wing compile -t tf-aws", async ({ expect }) => {
+test("wing compile -t tf-aws", async ({ expect }) => {
   await compileTest(expect, "capture_containers.w");
 });
 
-test.concurrent("wing test", async ({ expect }) => {
+test("wing test", async ({ expect }) => {
   await testTest(expect, "capture_containers.w");
 });

--- a/tools/hangar/src/test_corpus/valid/capture_containers_of_resources.w.test.ts
+++ b/tools/hangar/src/test_corpus/valid/capture_containers_of_resources.w.test.ts
@@ -3,10 +3,10 @@
 import { test } from "vitest";
 import { compileTest, testTest } from "../../generated_test_targets";
 
-test.concurrent("wing compile -t tf-aws", async ({ expect }) => {
+test("wing compile -t tf-aws", async ({ expect }) => {
   await compileTest(expect, "capture_containers_of_resources.w");
 });
 
-test.concurrent("wing test", async ({ expect }) => {
+test("wing test", async ({ expect }) => {
   await testTest(expect, "capture_containers_of_resources.w");
 });

--- a/tools/hangar/src/test_corpus/valid/capture_in_binary.w.test.ts
+++ b/tools/hangar/src/test_corpus/valid/capture_in_binary.w.test.ts
@@ -3,10 +3,10 @@
 import { test } from "vitest";
 import { compileTest, testTest } from "../../generated_test_targets";
 
-test.concurrent("wing compile -t tf-aws", async ({ expect }) => {
+test("wing compile -t tf-aws", async ({ expect }) => {
   await compileTest(expect, "capture_in_binary.w");
 });
 
-test.concurrent("wing test", async ({ expect }) => {
+test("wing test", async ({ expect }) => {
   await testTest(expect, "capture_in_binary.w");
 });

--- a/tools/hangar/src/test_corpus/valid/capture_primitives.w.test.ts
+++ b/tools/hangar/src/test_corpus/valid/capture_primitives.w.test.ts
@@ -3,10 +3,10 @@
 import { test } from "vitest";
 import { compileTest, testTest } from "../../generated_test_targets";
 
-test.concurrent("wing compile -t tf-aws", async ({ expect }) => {
+test("wing compile -t tf-aws", async ({ expect }) => {
   await compileTest(expect, "capture_primitives.w");
 });
 
-test.concurrent("wing test", async ({ expect }) => {
+test("wing test", async ({ expect }) => {
   await testTest(expect, "capture_primitives.w");
 });

--- a/tools/hangar/src/test_corpus/valid/capture_resource_and_data.w.test.ts
+++ b/tools/hangar/src/test_corpus/valid/capture_resource_and_data.w.test.ts
@@ -3,10 +3,10 @@
 import { test } from "vitest";
 import { compileTest, testTest } from "../../generated_test_targets";
 
-test.concurrent("wing compile -t tf-aws", async ({ expect }) => {
+test("wing compile -t tf-aws", async ({ expect }) => {
   await compileTest(expect, "capture_resource_and_data.w");
 });
 
-test.concurrent("wing test", async ({ expect }) => {
+test("wing test", async ({ expect }) => {
   await testTest(expect, "capture_resource_and_data.w");
 });

--- a/tools/hangar/src/test_corpus/valid/capture_resource_with_no_inflight.w.test.ts
+++ b/tools/hangar/src/test_corpus/valid/capture_resource_with_no_inflight.w.test.ts
@@ -3,10 +3,10 @@
 import { test } from "vitest";
 import { compileTest, testTest } from "../../generated_test_targets";
 
-test.concurrent("wing compile -t tf-aws", async ({ expect }) => {
+test("wing compile -t tf-aws", async ({ expect }) => {
   await compileTest(expect, "capture_resource_with_no_inflight.w");
 });
 
-test.concurrent("wing test", async ({ expect }) => {
+test("wing test", async ({ expect }) => {
   await testTest(expect, "capture_resource_with_no_inflight.w");
 });

--- a/tools/hangar/src/test_corpus/valid/captures.w.test.ts
+++ b/tools/hangar/src/test_corpus/valid/captures.w.test.ts
@@ -3,10 +3,10 @@
 import { test } from "vitest";
 import { compileTest, testTest } from "../../generated_test_targets";
 
-test.concurrent("wing compile -t tf-aws", async ({ expect }) => {
+test("wing compile -t tf-aws", async ({ expect }) => {
   await compileTest(expect, "captures.w");
 });
 
-test.concurrent("wing test", async ({ expect }) => {
+test("wing test", async ({ expect }) => {
   await testTest(expect, "captures.w");
 });

--- a/tools/hangar/src/test_corpus/valid/container_types.w.test.ts
+++ b/tools/hangar/src/test_corpus/valid/container_types.w.test.ts
@@ -3,10 +3,10 @@
 import { test } from "vitest";
 import { compileTest, testTest } from "../../generated_test_targets";
 
-test.concurrent("wing compile -t tf-aws", async ({ expect }) => {
+test("wing compile -t tf-aws", async ({ expect }) => {
   await compileTest(expect, "container_types.w");
 });
 
-test.concurrent("wing test", async ({ expect }) => {
+test("wing test", async ({ expect }) => {
   await testTest(expect, "container_types.w");
 });

--- a/tools/hangar/src/test_corpus/valid/enums.w.test.ts
+++ b/tools/hangar/src/test_corpus/valid/enums.w.test.ts
@@ -3,10 +3,10 @@
 import { test } from "vitest";
 import { compileTest, testTest } from "../../generated_test_targets";
 
-test.concurrent("wing compile -t tf-aws", async ({ expect }) => {
+test("wing compile -t tf-aws", async ({ expect }) => {
   await compileTest(expect, "enums.w");
 });
 
-test.concurrent("wing test", async ({ expect }) => {
+test("wing test", async ({ expect }) => {
   await testTest(expect, "enums.w");
 });

--- a/tools/hangar/src/test_corpus/valid/expressions_binary_operators.w.test.ts
+++ b/tools/hangar/src/test_corpus/valid/expressions_binary_operators.w.test.ts
@@ -3,10 +3,10 @@
 import { test } from "vitest";
 import { compileTest, testTest } from "../../generated_test_targets";
 
-test.concurrent("wing compile -t tf-aws", async ({ expect }) => {
+test("wing compile -t tf-aws", async ({ expect }) => {
   await compileTest(expect, "expressions_binary_operators.w");
 });
 
-test.concurrent("wing test", async ({ expect }) => {
+test("wing test", async ({ expect }) => {
   await testTest(expect, "expressions_binary_operators.w");
 });

--- a/tools/hangar/src/test_corpus/valid/expressions_string_interpolation.w.test.ts
+++ b/tools/hangar/src/test_corpus/valid/expressions_string_interpolation.w.test.ts
@@ -3,10 +3,10 @@
 import { test } from "vitest";
 import { compileTest, testTest } from "../../generated_test_targets";
 
-test.concurrent("wing compile -t tf-aws", async ({ expect }) => {
+test("wing compile -t tf-aws", async ({ expect }) => {
   await compileTest(expect, "expressions_string_interpolation.w");
 });
 
-test.concurrent("wing test", async ({ expect }) => {
+test("wing test", async ({ expect }) => {
   await testTest(expect, "expressions_string_interpolation.w");
 });

--- a/tools/hangar/src/test_corpus/valid/file_counter.w.test.ts
+++ b/tools/hangar/src/test_corpus/valid/file_counter.w.test.ts
@@ -3,10 +3,10 @@
 import { test } from "vitest";
 import { compileTest, testTest } from "../../generated_test_targets";
 
-test.concurrent("wing compile -t tf-aws", async ({ expect }) => {
+test("wing compile -t tf-aws", async ({ expect }) => {
   await compileTest(expect, "file_counter.w");
 });
 
-test.concurrent("wing test", async ({ expect }) => {
+test("wing test", async ({ expect }) => {
   await testTest(expect, "file_counter.w");
 });

--- a/tools/hangar/src/test_corpus/valid/for_loop.w.test.ts
+++ b/tools/hangar/src/test_corpus/valid/for_loop.w.test.ts
@@ -3,10 +3,10 @@
 import { test } from "vitest";
 import { compileTest, testTest } from "../../generated_test_targets";
 
-test.concurrent("wing compile -t tf-aws", async ({ expect }) => {
+test("wing compile -t tf-aws", async ({ expect }) => {
   await compileTest(expect, "for_loop.w");
 });
 
-test.concurrent("wing test", async ({ expect }) => {
+test("wing test", async ({ expect }) => {
   await testTest(expect, "for_loop.w");
 });

--- a/tools/hangar/src/test_corpus/valid/forward_decl.w.test.ts
+++ b/tools/hangar/src/test_corpus/valid/forward_decl.w.test.ts
@@ -3,10 +3,10 @@
 import { test } from "vitest";
 import { compileTest, testTest } from "../../generated_test_targets";
 
-test.concurrent("wing compile -t tf-aws", async ({ expect }) => {
+test("wing compile -t tf-aws", async ({ expect }) => {
   await compileTest(expect, "forward_decl.w");
 });
 
-test.concurrent("wing test", async ({ expect }) => {
+test("wing test", async ({ expect }) => {
   await testTest(expect, "forward_decl.w");
 });

--- a/tools/hangar/src/test_corpus/valid/hello.w.test.ts
+++ b/tools/hangar/src/test_corpus/valid/hello.w.test.ts
@@ -3,10 +3,10 @@
 import { test } from "vitest";
 import { compileTest, testTest } from "../../generated_test_targets";
 
-test.concurrent("wing compile -t tf-aws", async ({ expect }) => {
+test("wing compile -t tf-aws", async ({ expect }) => {
   await compileTest(expect, "hello.w");
 });
 
-test.concurrent("wing test", async ({ expect }) => {
+test("wing test", async ({ expect }) => {
   await testTest(expect, "hello.w");
 });

--- a/tools/hangar/src/test_corpus/valid/identical_inflights.w.test.ts
+++ b/tools/hangar/src/test_corpus/valid/identical_inflights.w.test.ts
@@ -3,10 +3,10 @@
 import { test } from "vitest";
 import { compileTest, testTest } from "../../generated_test_targets";
 
-test.concurrent("wing compile -t tf-aws", async ({ expect }) => {
+test("wing compile -t tf-aws", async ({ expect }) => {
   await compileTest(expect, "identical_inflights.w");
 });
 
-test.concurrent("wing test", async ({ expect }) => {
+test("wing test", async ({ expect }) => {
   await testTest(expect, "identical_inflights.w");
 });

--- a/tools/hangar/src/test_corpus/valid/impl_interface.w.test.ts
+++ b/tools/hangar/src/test_corpus/valid/impl_interface.w.test.ts
@@ -3,10 +3,10 @@
 import { test } from "vitest";
 import { compileTest, testTest } from "../../generated_test_targets";
 
-test.concurrent("wing compile -t tf-aws", async ({ expect }) => {
+test("wing compile -t tf-aws", async ({ expect }) => {
   await compileTest(expect, "impl_interface.w");
 });
 
-test.concurrent("wing test", async ({ expect }) => {
+test("wing test", async ({ expect }) => {
   await testTest(expect, "impl_interface.w");
 });

--- a/tools/hangar/src/test_corpus/valid/inflight_ref_external.w.test.ts
+++ b/tools/hangar/src/test_corpus/valid/inflight_ref_external.w.test.ts
@@ -3,10 +3,10 @@
 import { test } from "vitest";
 import { compileTest, testTest } from "../../generated_test_targets";
 
-test.concurrent("wing compile -t tf-aws", async ({ expect }) => {
+test("wing compile -t tf-aws", async ({ expect }) => {
   await compileTest(expect, "inflight_ref_external.w");
 });
 
-test.concurrent("wing test", async ({ expect }) => {
+test("wing test", async ({ expect }) => {
   await testTest(expect, "inflight_ref_external.w");
 });

--- a/tools/hangar/src/test_corpus/valid/inflight_ref_inflight_field.w.test.ts
+++ b/tools/hangar/src/test_corpus/valid/inflight_ref_inflight_field.w.test.ts
@@ -3,10 +3,10 @@
 import { test } from "vitest";
 import { compileTest, testTest } from "../../generated_test_targets";
 
-test.concurrent("wing compile -t tf-aws", async ({ expect }) => {
+test("wing compile -t tf-aws", async ({ expect }) => {
   await compileTest(expect, "inflight_ref_inflight_field.w");
 });
 
-test.concurrent("wing test", async ({ expect }) => {
+test("wing test", async ({ expect }) => {
   await testTest(expect, "inflight_ref_inflight_field.w");
 });

--- a/tools/hangar/src/test_corpus/valid/inflight_ref_primitive.w.test.ts
+++ b/tools/hangar/src/test_corpus/valid/inflight_ref_primitive.w.test.ts
@@ -3,10 +3,10 @@
 import { test } from "vitest";
 import { compileTest, testTest } from "../../generated_test_targets";
 
-test.concurrent("wing compile -t tf-aws", async ({ expect }) => {
+test("wing compile -t tf-aws", async ({ expect }) => {
   await compileTest(expect, "inflight_ref_primitive.w");
 });
 
-test.concurrent("wing test", async ({ expect }) => {
+test("wing test", async ({ expect }) => {
   await testTest(expect, "inflight_ref_primitive.w");
 });

--- a/tools/hangar/src/test_corpus/valid/inflight_ref_resource.w.test.ts
+++ b/tools/hangar/src/test_corpus/valid/inflight_ref_resource.w.test.ts
@@ -3,10 +3,10 @@
 import { test } from "vitest";
 import { compileTest, testTest } from "../../generated_test_targets";
 
-test.concurrent("wing compile -t tf-aws", async ({ expect }) => {
+test("wing compile -t tf-aws", async ({ expect }) => {
   await compileTest(expect, "inflight_ref_resource.w");
 });
 
-test.concurrent("wing test", async ({ expect }) => {
+test("wing test", async ({ expect }) => {
   await testTest(expect, "inflight_ref_resource.w");
 });

--- a/tools/hangar/src/test_corpus/valid/inflight_ref_resource_collection.w.test.ts
+++ b/tools/hangar/src/test_corpus/valid/inflight_ref_resource_collection.w.test.ts
@@ -3,10 +3,10 @@
 import { test } from "vitest";
 import { compileTest, testTest } from "../../generated_test_targets";
 
-test.concurrent("wing compile -t tf-aws", async ({ expect }) => {
+test("wing compile -t tf-aws", async ({ expect }) => {
   await compileTest(expect, "inflight_ref_resource_collection.w");
 });
 
-test.concurrent("wing test", async ({ expect }) => {
+test("wing test", async ({ expect }) => {
   await testTest(expect, "inflight_ref_resource_collection.w");
 });

--- a/tools/hangar/src/test_corpus/valid/inflight_ref_resource_field.w.test.ts
+++ b/tools/hangar/src/test_corpus/valid/inflight_ref_resource_field.w.test.ts
@@ -3,10 +3,10 @@
 import { test } from "vitest";
 import { compileTest, testTest } from "../../generated_test_targets";
 
-test.concurrent("wing compile -t tf-aws", async ({ expect }) => {
+test("wing compile -t tf-aws", async ({ expect }) => {
   await compileTest(expect, "inflight_ref_resource_field.w");
 });
 
-test.concurrent("wing test", async ({ expect }) => {
+test("wing test", async ({ expect }) => {
   await testTest(expect, "inflight_ref_resource_field.w");
 });

--- a/tools/hangar/src/test_corpus/valid/inflight_ref_resource_sub_method.w.test.ts
+++ b/tools/hangar/src/test_corpus/valid/inflight_ref_resource_sub_method.w.test.ts
@@ -3,10 +3,10 @@
 import { test } from "vitest";
 import { compileTest, testTest } from "../../generated_test_targets";
 
-test.concurrent("wing compile -t tf-aws", async ({ expect }) => {
+test("wing compile -t tf-aws", async ({ expect }) => {
   await compileTest(expect, "inflight_ref_resource_sub_method.w");
 });
 
-test.concurrent("wing test", async ({ expect }) => {
+test("wing test", async ({ expect }) => {
   await testTest(expect, "inflight_ref_resource_sub_method.w");
 });

--- a/tools/hangar/src/test_corpus/valid/inflight_ref_resource_userdefined.w.test.ts
+++ b/tools/hangar/src/test_corpus/valid/inflight_ref_resource_userdefined.w.test.ts
@@ -3,10 +3,10 @@
 import { test } from "vitest";
 import { compileTest, testTest } from "../../generated_test_targets";
 
-test.concurrent("wing compile -t tf-aws", async ({ expect }) => {
+test("wing compile -t tf-aws", async ({ expect }) => {
   await compileTest(expect, "inflight_ref_resource_userdefined.w");
 });
 
-test.concurrent("wing test", async ({ expect }) => {
+test("wing test", async ({ expect }) => {
   await testTest(expect, "inflight_ref_resource_userdefined.w");
 });

--- a/tools/hangar/src/test_corpus/valid/inflight_ref_unknown_op.w.test.ts
+++ b/tools/hangar/src/test_corpus/valid/inflight_ref_unknown_op.w.test.ts
@@ -3,10 +3,10 @@
 import { test } from "vitest";
 import { compileTest, testTest } from "../../generated_test_targets";
 
-test.concurrent("wing compile -t tf-aws", async ({ expect }) => {
+test("wing compile -t tf-aws", async ({ expect }) => {
   await compileTest(expect, "inflight_ref_unknown_op.w");
 });
 
-test.concurrent("wing test", async ({ expect }) => {
+test("wing test", async ({ expect }) => {
   await testTest(expect, "inflight_ref_unknown_op.w");
 });

--- a/tools/hangar/src/test_corpus/valid/json.w.test.ts
+++ b/tools/hangar/src/test_corpus/valid/json.w.test.ts
@@ -3,10 +3,10 @@
 import { test } from "vitest";
 import { compileTest, testTest } from "../../generated_test_targets";
 
-test.concurrent("wing compile -t tf-aws", async ({ expect }) => {
+test("wing compile -t tf-aws", async ({ expect }) => {
   await compileTest(expect, "json.w");
 });
 
-test.concurrent("wing test", async ({ expect }) => {
+test("wing test", async ({ expect }) => {
   await testTest(expect, "json.w");
 });

--- a/tools/hangar/src/test_corpus/valid/json_bucket.w.test.ts
+++ b/tools/hangar/src/test_corpus/valid/json_bucket.w.test.ts
@@ -3,10 +3,10 @@
 import { test } from "vitest";
 import { compileTest, testTest } from "../../generated_test_targets";
 
-test.concurrent("wing compile -t tf-aws", async ({ expect }) => {
+test("wing compile -t tf-aws", async ({ expect }) => {
   await compileTest(expect, "json_bucket.w");
 });
 
-test.concurrent("wing test", async ({ expect }) => {
+test("wing test", async ({ expect }) => {
   await testTest(expect, "json_bucket.w");
 });

--- a/tools/hangar/src/test_corpus/valid/json_static.w.test.ts
+++ b/tools/hangar/src/test_corpus/valid/json_static.w.test.ts
@@ -3,10 +3,10 @@
 import { test } from "vitest";
 import { compileTest, testTest } from "../../generated_test_targets";
 
-test.concurrent("wing compile -t tf-aws", async ({ expect }) => {
+test("wing compile -t tf-aws", async ({ expect }) => {
   await compileTest(expect, "json_static.w");
 });
 
-test.concurrent("wing test", async ({ expect }) => {
+test("wing test", async ({ expect }) => {
   await testTest(expect, "json_static.w");
 });

--- a/tools/hangar/src/test_corpus/valid/mut_container_types.w.test.ts
+++ b/tools/hangar/src/test_corpus/valid/mut_container_types.w.test.ts
@@ -3,10 +3,10 @@
 import { test } from "vitest";
 import { compileTest, testTest } from "../../generated_test_targets";
 
-test.concurrent("wing compile -t tf-aws", async ({ expect }) => {
+test("wing compile -t tf-aws", async ({ expect }) => {
   await compileTest(expect, "mut_container_types.w");
 });
 
-test.concurrent("wing test", async ({ expect }) => {
+test("wing test", async ({ expect }) => {
   await testTest(expect, "mut_container_types.w");
 });

--- a/tools/hangar/src/test_corpus/valid/primitive_methods.w.test.ts
+++ b/tools/hangar/src/test_corpus/valid/primitive_methods.w.test.ts
@@ -3,10 +3,10 @@
 import { test } from "vitest";
 import { compileTest, testTest } from "../../generated_test_targets";
 
-test.concurrent("wing compile -t tf-aws", async ({ expect }) => {
+test("wing compile -t tf-aws", async ({ expect }) => {
   await compileTest(expect, "primitive_methods.w");
 });
 
-test.concurrent("wing test", async ({ expect }) => {
+test("wing test", async ({ expect }) => {
   await testTest(expect, "primitive_methods.w");
 });

--- a/tools/hangar/src/test_corpus/valid/print.w.test.ts
+++ b/tools/hangar/src/test_corpus/valid/print.w.test.ts
@@ -3,10 +3,10 @@
 import { test } from "vitest";
 import { compileTest, testTest } from "../../generated_test_targets";
 
-test.concurrent("wing compile -t tf-aws", async ({ expect }) => {
+test("wing compile -t tf-aws", async ({ expect }) => {
   await compileTest(expect, "print.w");
 });
 
-test.concurrent("wing test", async ({ expect }) => {
+test("wing test", async ({ expect }) => {
   await testTest(expect, "print.w");
 });

--- a/tools/hangar/src/test_corpus/valid/reassignment.w.test.ts
+++ b/tools/hangar/src/test_corpus/valid/reassignment.w.test.ts
@@ -3,10 +3,10 @@
 import { test } from "vitest";
 import { compileTest, testTest } from "../../generated_test_targets";
 
-test.concurrent("wing compile -t tf-aws", async ({ expect }) => {
+test("wing compile -t tf-aws", async ({ expect }) => {
   await compileTest(expect, "reassignment.w");
 });
 
-test.concurrent("wing test", async ({ expect }) => {
+test("wing test", async ({ expect }) => {
   await testTest(expect, "reassignment.w");
 });

--- a/tools/hangar/src/test_corpus/valid/resource.w.test.ts
+++ b/tools/hangar/src/test_corpus/valid/resource.w.test.ts
@@ -3,10 +3,10 @@
 import { test } from "vitest";
 import { compileTest, testTest } from "../../generated_test_targets";
 
-test.concurrent("wing compile -t tf-aws", async ({ expect }) => {
+test("wing compile -t tf-aws", async ({ expect }) => {
   await compileTest(expect, "resource.w");
 });
 
-test.concurrent("wing test", async ({ expect }) => {
+test("wing test", async ({ expect }) => {
   await testTest(expect, "resource.w");
 });

--- a/tools/hangar/src/test_corpus/valid/statements_if.w.test.ts
+++ b/tools/hangar/src/test_corpus/valid/statements_if.w.test.ts
@@ -3,10 +3,10 @@
 import { test } from "vitest";
 import { compileTest, testTest } from "../../generated_test_targets";
 
-test.concurrent("wing compile -t tf-aws", async ({ expect }) => {
+test("wing compile -t tf-aws", async ({ expect }) => {
   await compileTest(expect, "statements_if.w");
 });
 
-test.concurrent("wing test", async ({ expect }) => {
+test("wing test", async ({ expect }) => {
   await testTest(expect, "statements_if.w");
 });

--- a/tools/hangar/src/test_corpus/valid/statements_variable_declarations.w.test.ts
+++ b/tools/hangar/src/test_corpus/valid/statements_variable_declarations.w.test.ts
@@ -3,10 +3,10 @@
 import { test } from "vitest";
 import { compileTest, testTest } from "../../generated_test_targets";
 
-test.concurrent("wing compile -t tf-aws", async ({ expect }) => {
+test("wing compile -t tf-aws", async ({ expect }) => {
   await compileTest(expect, "statements_variable_declarations.w");
 });
 
-test.concurrent("wing test", async ({ expect }) => {
+test("wing test", async ({ expect }) => {
   await testTest(expect, "statements_variable_declarations.w");
 });

--- a/tools/hangar/src/test_corpus/valid/static_members.w.test.ts
+++ b/tools/hangar/src/test_corpus/valid/static_members.w.test.ts
@@ -3,10 +3,10 @@
 import { test } from "vitest";
 import { compileTest, testTest } from "../../generated_test_targets";
 
-test.concurrent("wing compile -t tf-aws", async ({ expect }) => {
+test("wing compile -t tf-aws", async ({ expect }) => {
   await compileTest(expect, "static_members.w");
 });
 
-test.concurrent("wing test", async ({ expect }) => {
+test("wing test", async ({ expect }) => {
   await testTest(expect, "static_members.w");
 });

--- a/tools/hangar/src/test_corpus/valid/std_containers.w.test.ts
+++ b/tools/hangar/src/test_corpus/valid/std_containers.w.test.ts
@@ -3,10 +3,10 @@
 import { test } from "vitest";
 import { compileTest, testTest } from "../../generated_test_targets";
 
-test.concurrent("wing compile -t tf-aws", async ({ expect }) => {
+test("wing compile -t tf-aws", async ({ expect }) => {
   await compileTest(expect, "std_containers.w");
 });
 
-test.concurrent("wing test", async ({ expect }) => {
+test("wing test", async ({ expect }) => {
   await testTest(expect, "std_containers.w");
 });

--- a/tools/hangar/src/test_corpus/valid/std_string.w.test.ts
+++ b/tools/hangar/src/test_corpus/valid/std_string.w.test.ts
@@ -3,10 +3,10 @@
 import { test } from "vitest";
 import { compileTest, testTest } from "../../generated_test_targets";
 
-test.concurrent("wing compile -t tf-aws", async ({ expect }) => {
+test("wing compile -t tf-aws", async ({ expect }) => {
   await compileTest(expect, "std_string.w");
 });
 
-test.concurrent("wing test", async ({ expect }) => {
+test("wing test", async ({ expect }) => {
   await testTest(expect, "std_string.w");
 });

--- a/tools/hangar/src/test_corpus/valid/test_bucket.w.test.ts
+++ b/tools/hangar/src/test_corpus/valid/test_bucket.w.test.ts
@@ -3,10 +3,10 @@
 import { test } from "vitest";
 import { compileTest, testTest } from "../../generated_test_targets";
 
-test.concurrent("wing compile -t tf-aws", async ({ expect }) => {
+test("wing compile -t tf-aws", async ({ expect }) => {
   await compileTest(expect, "test_bucket.w");
 });
 
-test.concurrent("wing test", async ({ expect }) => {
+test("wing test", async ({ expect }) => {
   await testTest(expect, "test_bucket.w");
 });

--- a/tools/hangar/src/test_corpus/valid/try_catch.w.test.ts
+++ b/tools/hangar/src/test_corpus/valid/try_catch.w.test.ts
@@ -3,10 +3,10 @@
 import { test } from "vitest";
 import { compileTest, testTest } from "../../generated_test_targets";
 
-test.concurrent("wing compile -t tf-aws", async ({ expect }) => {
+test("wing compile -t tf-aws", async ({ expect }) => {
   await compileTest(expect, "try_catch.w");
 });
 
-test.concurrent("wing test", async ({ expect }) => {
+test("wing test", async ({ expect }) => {
   await testTest(expect, "try_catch.w");
 });

--- a/tools/hangar/src/test_corpus/valid/user-defined-resources-captures.w.test.ts
+++ b/tools/hangar/src/test_corpus/valid/user-defined-resources-captures.w.test.ts
@@ -3,10 +3,10 @@
 import { test } from "vitest";
 import { compileTest, testTest } from "../../generated_test_targets";
 
-test.concurrent("wing compile -t tf-aws", async ({ expect }) => {
+test("wing compile -t tf-aws", async ({ expect }) => {
   await compileTest(expect, "user-defined-resources-captures.w");
 });
 
-test.concurrent("wing test", async ({ expect }) => {
+test("wing test", async ({ expect }) => {
   await testTest(expect, "user-defined-resources-captures.w");
 });

--- a/tools/hangar/src/test_corpus/valid/while.w.test.ts
+++ b/tools/hangar/src/test_corpus/valid/while.w.test.ts
@@ -3,10 +3,10 @@
 import { test } from "vitest";
 import { compileTest, testTest } from "../../generated_test_targets";
 
-test.concurrent("wing compile -t tf-aws", async ({ expect }) => {
+test("wing compile -t tf-aws", async ({ expect }) => {
   await compileTest(expect, "while.w");
 });
 
-test.concurrent("wing test", async ({ expect }) => {
+test("wing test", async ({ expect }) => {
   await testTest(expect, "while.w");
 });

--- a/tools/hangar/src/test_corpus/valid/while_loop_await.w.test.ts
+++ b/tools/hangar/src/test_corpus/valid/while_loop_await.w.test.ts
@@ -3,10 +3,10 @@
 import { test } from "vitest";
 import { compileTest, testTest } from "../../generated_test_targets";
 
-test.concurrent("wing compile -t tf-aws", async ({ expect }) => {
+test("wing compile -t tf-aws", async ({ expect }) => {
   await compileTest(expect, "while_loop_await.w");
 });
 
-test.concurrent("wing test", async ({ expect }) => {
+test("wing test", async ({ expect }) => {
   await testTest(expect, "while_loop_await.w");
 });


### PR DESCRIPTION
After splitting hangar tests into many files, we get test-suite level parallelism improved. This is great, but running tests concurrently within those files was probably a step too far. 

~Will verify that the speed of tests is similar in CI here before merging.~ 
Speeds look good, about the same as before

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.