### PR TITLE
chore: allow `pr/e2e-full` label to be added or removed after build starts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,6 +96,8 @@ jobs:
     needs: prepare
     env:
       PROJEN_BUMP_VERSION: ${{ needs.prepare.outputs.version }}
+    outputs:
+      labels: ${{ steps.pr-labels.outputs.labels }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -167,6 +169,10 @@ jobs:
           github-comment: false
           vercel-args: "--prod "
 
+      - name: Get PR labels
+        id: pr-labels
+        uses: joerick/pr-labels-action@v1.0.7
+
   e2e:
     name: "E2E / ${{ matrix.runner }} + Node${{ matrix.node }} [${{ matrix.shard }}]"
     needs:
@@ -181,8 +187,8 @@ jobs:
         node: ["18", "19.7.0"]
         shard: ["1/2", "2/2"]
         full_run:
-          # Do a full run on push or when the PR is labeled "full-run"
-          - ${{ github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'pr/e2e-full') }}
+          # Do a full run on push or when the PR is labeled "pr/e2e-full"
+          - ${{ github.event_name == 'push' || contains(needs.build.labels, 'pr/e2e-full') }}
         exclude:
           - runner: macos
             full_run: false


### PR DESCRIPTION
The label still has to be added during the actual build run (won't retrigger anything), but this was an easy change and it's better than nothing.

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.