### PR TITLE
feat!: improved performance for sim compilation

### DIFF
--- a/apps/wing/src/cli.ts
+++ b/apps/wing/src/cli.ts
@@ -2,7 +2,6 @@
 /// <reference lib="dom" />
 
 import { compile, docs, test, upgrade, run } from "./commands";
-import { join } from "path";
 import { satisfies } from "compare-versions";
 
 import { Command, Option } from "commander";
@@ -51,11 +50,6 @@ async function main() {
     .command("compile")
     .description("Compiles a Wing program")
     .argument("<entrypoint>", "program .w entrypoint")
-    .option(
-      "-o, --out-dir <out-dir>",
-      "Output directory - where to place all generated artifacts",
-      join(process.cwd(), "target")
-    )
     .addOption(
       new Option("-t, --target <target>", "Target platform")
         .choices(["tf-aws", "tf-azure", "tf-gcp", "sim"])

--- a/apps/wing/src/commands/compile.test.ts
+++ b/apps/wing/src/commands/compile.test.ts
@@ -1,9 +1,7 @@
 import { Target, compile } from "./compile";
 import { readdir, stat } from "fs/promises";
 
-import { join, resolve } from "path";
-import { mkdtempSync } from "fs";
-import { tmpdir } from "os";
+import { resolve } from "path";
 
 jest.setTimeout(1000 * 60 * 5);
 
@@ -14,14 +12,9 @@ describe("compile command tests", () => {
   );
 
   it("should be able to compile the SDK capture test to tf-aws", async () => {
-    const outDir = mkdtemp();
-    await compile(exampleWingFile, {
-      outDir,
+    const artifactDir = await compile(exampleWingFile, {
       target: Target.TF_AWS,
     });
-
-    // expect files to be generated in outDir/captures.tfaws
-    const artifactDir = join(outDir, "captures.tfaws");
 
     const stats = await stat(artifactDir);
     expect(stats.isDirectory()).toBeTruthy();
@@ -32,9 +25,7 @@ describe("compile command tests", () => {
   });
 
   it("should be able to compile the SDK capture test to sim", async () => {
-    const outDir = mkdtemp();
-    await compile(exampleWingFile, {
-      outDir: outDir,
+    const outDir = await compile(exampleWingFile, {
       target: Target.SIM,
     });
 
@@ -49,12 +40,8 @@ describe("compile command tests", () => {
   });
 
   it("should error if a nonexistent file is compiled", async () => {
-    const outDir = mkdtemp();
-    return expect(compile("non-existent-file.w", { outDir, target: Target.SIM }))
+    return expect(compile("non-existent-file.w", { target: Target.SIM }))
       .rejects.toThrowError(/Source file cannot be found/);
   });
 });
 
-function mkdtemp() {
-  return mkdtempSync(join(tmpdir(), "wingcli-tests."));
-}

--- a/apps/wing/src/commands/compile.ts
+++ b/apps/wing/src/commands/compile.ts
@@ -1,6 +1,6 @@
 import * as vm from "vm";
 
-import { mkdir, readFile } from "fs/promises";
+import { mkdir, readFile, rm} from "fs/promises";
 import { basename, dirname, join, resolve } from "path";
 
 import * as chalk from "chalk";
@@ -8,7 +8,6 @@ import debug from "debug";
 import * as wingCompiler from "../wingc";
 import { normalPath } from "../util";
 import { CHARS_ASCII, emitDiagnostic, Severity, File, Label } from "codespan-wasm";
-import { readFileSync } from "fs";
 
 // increase the stack trace limit to 50, useful for debugging Rust panics
 // (not setting the limit too high in case of infinite recursion)
@@ -33,7 +32,7 @@ const DEFAULT_SYNTH_DIR_SUFFIX: Record<Target, string | undefined> = {
   [Target.TF_AWS]: "tfaws",
   [Target.TF_AZURE]: "tfazure",
   [Target.TF_GCP]: "tfgcp",
-  [Target.SIM]: undefined,
+  [Target.SIM]: "wsim",
 };
 
 /**
@@ -41,7 +40,6 @@ const DEFAULT_SYNTH_DIR_SUFFIX: Record<Target, string | undefined> = {
  * This is passed from Commander to the `compile` function.
  */
 export interface ICompileOptions {
-  readonly outDir: string;
   readonly target: Target;
   readonly plugins?: string[];
 }
@@ -53,9 +51,8 @@ export interface ICompileOptions {
  */
 function resolveSynthDir(outDir: string, entrypoint: string, target: Target) {
   const targetDirSuffix = DEFAULT_SYNTH_DIR_SUFFIX[target];
-  if (targetDirSuffix === undefined) {
-    // this target produces a single artifact, so we don't need a subdirectory
-    return outDir;
+  if (!targetDirSuffix) {
+    throw new Error(`unsupported target ${target}`);
   }
   const entrypointName = basename(entrypoint, ".w");
   return join(outDir, `${entrypointName}.${targetDirSuffix}`);
@@ -65,16 +62,21 @@ function resolveSynthDir(outDir: string, entrypoint: string, target: Target) {
  * Compiles a Wing program. Throws an error if compilation fails.
  * @param entrypoint The program .w entrypoint.
  * @param options Compile options.
+ * @returns the output directory
  */
-export async function compile(entrypoint: string, options: ICompileOptions) {
+export async function compile(entrypoint: string, options: ICompileOptions): Promise<string> {
+  const targetdir = join(dirname(entrypoint), "target");
   const wingFile = entrypoint;
   log("wing file: %s", wingFile);
   const wingDir = dirname(wingFile);
   log("wing dir: %s", wingDir);
-  const synthDir = resolveSynthDir(options.outDir, wingFile, options.target);
+  const synthDir = resolveSynthDir(targetdir, wingFile, options.target);
   log("synth dir: %s", synthDir);
   const workDir = resolve(synthDir, ".wing");
   log("work dir: %s", workDir);
+
+  // clean up before
+  await rm(synthDir, { recursive: true, force: true });
 
   process.env["WING_SYNTH_DIR"] = synthDir;
   process.env["WING_NODE_MODULES"] = resolve(join(wingDir, "node_modules") );
@@ -123,7 +125,7 @@ export async function compile(entrypoint: string, options: ICompileOptions) {
 
       if (span !== null) {
         // `span` should only be null if source file couldn't be read etc.
-        const source = readFileSync(span.file_id, "utf8");
+        const source = await readFile(span.file_id, "utf8");
         const start = offsetFromLineAndColumn(source, span.start.line, span.start.col);
         const end = offsetFromLineAndColumn(source, span.end.line, span.end.col);
         files.push({
@@ -156,14 +158,13 @@ export async function compile(entrypoint: string, options: ICompileOptions) {
   const artifact = await readFile(artifactPath, "utf-8");
   log("artifact: %s", artifact);
 
-  const preflightRequire = (path: string) => {
-    // Try looking for dependencies not only in the current directory (wherever
-    // the wing CLI was installed to), but also in the source code directory.
-    // This is necessary because the Wing app may have installed dependencies in
-    // the project directory.
-    const requirePath = require.resolve(path, { paths: [__dirname, wingDir] });
-    return require(requirePath);
-  };
+  // Try looking for dependencies not only in the current directory (wherever
+  // the wing CLI was installed to), but also in the source code directory.
+  // This is necessary because the Wing app may have installed dependencies in
+  // the project directory.
+  const requireResolve = (path: string) => require.resolve(path, { paths: [workDir, __dirname, wingDir] }); 
+  const preflightRequire = (path: string) => require(requireResolve(path));
+  preflightRequire.resolve = requireResolve;
 
   // If you're wondering how the execution of the preflight works, despite it
   // being in a different directory: it works because at the top of the file
@@ -244,8 +245,10 @@ export async function compile(entrypoint: string, options: ICompileOptions) {
       );
     }
 
-    process.exitCode = 1;
+    return process.exit(1);
   }
+
+  return synthDir;
 }
 
 /**

--- a/apps/wing/src/commands/test.ts
+++ b/apps/wing/src/commands/test.ts
@@ -1,6 +1,4 @@
-import { mkdtemp, readdir } from "fs/promises";
-import { tmpdir } from "os";
-import { basename, extname, join } from "path";
+import { basename } from "path";
 import { compile, Target } from "./compile";
 import * as chalk from "chalk";
 import * as sdk from "@winglang/sdk";
@@ -12,15 +10,9 @@ export async function test(entrypoints: string[]) {
 }
 
 async function testOne(entrypoint: string) {
-  const workdir = await mkdtemp(join(tmpdir(), "wing-test-"));
-  await compile(entrypoint, { outDir: workdir, target: Target.SIM });
-  const wsim = (await readdir(workdir)).find((f) => extname(f) === ".wsim");
-  if (!wsim) {
-    throw new Error("no .wsim file found in output directory");
-  }
-
-  const simfile = join(workdir, wsim);
-  const s = new sdk.testing.Simulator({ simfile });
+  const simdir = await compile(entrypoint, { target: Target.SIM });
+  
+  const s = new sdk.testing.Simulator({ simdir });
   await s.start();
   const results = await s.runAllTests();
   await s.stop();

--- a/libs/wingsdk/src/cloud/function.ts
+++ b/libs/wingsdk/src/cloud/function.ts
@@ -1,12 +1,10 @@
-import { spawnSync } from "child_process";
-import { mkdirSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { writeFileSync } from "fs";
 import { join } from "path";
 import { Construct } from "constructs";
 import { Logger } from "./logger";
 import { fqnForType } from "../constants";
-import { IInflightHost, IResource, Inflight, Resource, App } from "../core";
+import { IInflightHost, IResource, Resource, App, Inflight } from "../core";
 import { Duration } from "../std";
-import { normalPath } from "../util";
 import { CaseConventions, ResourceNames } from "../utils/resource-names";
 
 /**
@@ -63,9 +61,9 @@ export abstract class Function extends Resource implements IInflightHost {
   public readonly stateful = false;
 
   /**
-   * The path to the file asset that contains the handler code.
+   * The path to the entrypoint source code of the function.
    */
-  protected readonly assetPath: string;
+  protected readonly entrypoint: string;
 
   constructor(
     scope: Construct,
@@ -110,63 +108,19 @@ export abstract class Function extends Resource implements IInflightHost {
       implicit: true,
     });
 
-    const assetRelativeDir = join(
-      "assets",
-      ResourceNames.generateName(this, {
-        // Avoid characters that may cause path issues
-        disallowedRegex: /[><:"/\\|?*]/g,
-        case: CaseConventions.LOWERCASE,
-        sep: "_",
-      })
-    );
+    const assetName = ResourceNames.generateName(this, {
+      // Avoid characters that may cause path issues
+      disallowedRegex: /[><:"/\\|?*]/g,
+      case: CaseConventions.LOWERCASE,
+      sep: "_",
+    });
 
-    const assetDir = join(App.of(this).workdir, assetRelativeDir);
-    mkdirSync(assetDir, { recursive: true });
+    // write the entrypoint next to the partial inflight code emitted by the compiler, so that
+    // `require` resolves naturally.
 
-    const infile = join(assetDir, "prebundle.js");
-    const outfile = join(assetDir, "index.js");
-    writeFileSync(infile, lines.join("\n"));
-
-    // if the user has specified a node_modules directory to resolve from
-    const nodePathString = process.env.WING_NODE_MODULES
-      ? `nodePaths: [\"${normalPath(
-          process.env.WING_NODE_MODULES as string
-        )}\"],`
-      : "";
-
-    // We would invoke esbuild directly here, but there is a bug where esbuild
-    // mangles the stdout/stderr of the process that invokes it.
-    // https://github.com/evanw/esbuild/issues/2927
-    // To workaround the issue, spawn a new process and invoke esbuild inside it.
-
-    let esbuildScript = [
-      `const esbuild = require("${normalPath(
-        require.resolve("esbuild-wasm")
-      )}");`,
-      `esbuild.buildSync({ bundle: true, entryPoints: ["${normalPath(
-        infile
-      )}"], outfile: "${normalPath(outfile)}", ${nodePathString}
-      minify: false, platform: "node", target: "node16", external: ["aws-sdk"],
-     });`,
-    ].join("\n");
-    let result = spawnSync(process.argv[0], ["-e", esbuildScript]);
-    if (result.status !== 0) {
-      throw new Error(
-        `Failed to bundle function: ${result.stderr.toString("utf-8")}`
-      );
-    }
-
-    // the bundled contains line comments with file paths, which are not useful for us, especially
-    // since they may contain system-specific paths. sadly, esbuild doesn't have a way to disable
-    // this, so we simply filter those out from the bundle.
-    const outlines = readFileSync(outfile, "utf-8").split("\n");
-    const isNotLineComment = (line: string) => !line.startsWith("//");
-    writeFileSync(outfile, outlines.filter(isNotLineComment).join("\n"));
-
-    // remove input file
-    rmSync(infile);
-
-    this.assetPath = outfile;
+    const entrypoint = join(App.of(this).workdir, `${assetName}.js`);
+    writeFileSync(entrypoint, lines.join("\n"));
+    this.entrypoint = entrypoint;
   }
 
   /**

--- a/libs/wingsdk/src/core/app.ts
+++ b/libs/wingsdk/src/core/app.ts
@@ -62,9 +62,18 @@ export abstract class App extends Construct {
   }
 
   /**
-   * Directory where artifacts are synthesized to.
+   * The output directory.
    */
-  public abstract readonly workdir: string;
+  public abstract readonly outdir: string;
+
+  /**
+   * The ".wing" directory, which is where the compiler emits its output. We are taking an implicit
+   * assumption here that it is always set to be `$outdir/.wing` which is currently hard coded into
+   * the `cli/compile.ts` file.
+   */
+  public get workdir() {
+    return `${this.outdir}/.wing`;
+  }
 
   /**
    * Synthesize the app into an artifact.
@@ -146,18 +155,14 @@ export abstract class App extends Construct {
  */
 export abstract class CdktfApp extends App {
   /**
-   * Directory where artifacts are synthesized to.
-   */
-  public readonly workdir: string;
-  /**
    * Path to the Terraform manifest file.
    */
   public readonly terraformManifestPath: string;
+  public readonly outdir: string;
 
   private readonly cdktfApp: cdktf.App;
   private readonly cdktfStack: cdktf.TerraformStack;
   private readonly pluginManager: PluginManager;
-  private readonly outdir: string;
 
   private synthed: boolean;
   private synthedOutput: string | undefined;
@@ -174,6 +179,8 @@ export abstract class CdktfApp extends App {
     const cdktfStack = new cdktf.TerraformStack(cdktfApp, TERRAFORM_STACK_NAME);
 
     super(cdktfStack, "Default");
+
+    this.outdir = outdir;
 
     // HACK: monkey patch the `new` method on the cdktf app (which is the root of the tree) so that
     // we can intercept the creation of resources and replace them with our own.
@@ -195,7 +202,6 @@ export abstract class CdktfApp extends App {
     this.pluginManager = new PluginManager(props.plugins ?? []);
 
     this.outdir = outdir;
-    this.workdir = cdktfOutdir;
     this.cdktfApp = cdktfApp;
     this.cdktfStack = cdktfStack;
     this.terraformManifestPath = join(this.outdir, "main.tf.json");
@@ -267,6 +273,9 @@ export abstract class CdktfApp extends App {
 
     this.synthed = true;
     this.synthedOutput = stringify(cleaned, null, 2) ?? "";
+
+    // clean up working directory
+    rmSync(this.workdir, { recursive: true });
 
     return this.synthedOutput;
   }

--- a/libs/wingsdk/src/target-sim/app.ts
+++ b/libs/wingsdk/src/target-sim/app.ts
@@ -1,7 +1,6 @@
 import * as fs from "fs";
 import * as path from "path";
 import { Construct } from "constructs";
-import * as tar from "tar";
 import { Bucket } from "./bucket";
 import { Counter } from "./counter";
 import { Function } from "./function";
@@ -21,7 +20,7 @@ import {
 import { SDK_VERSION } from "../constants";
 import * as core from "../core";
 import { preSynthesizeAllConstructs } from "../core/app";
-import { mkdtemp, SIMULATOR_FILE_PATH } from "../util";
+import { SIMULATOR_FILE_PATH } from "../util";
 
 /**
  * A construct that knows how to synthesize simulator resources into a
@@ -29,27 +28,17 @@ import { mkdtemp, SIMULATOR_FILE_PATH } from "../util";
  */
 export class App extends core.App {
   /**
-   * Directory where artifacts are synthesized to.
-   */
-  public readonly workdir: string;
-
-  /**
    * The output directory of this app.
    */
-  protected readonly outdir: string;
+  public readonly outdir: string;
 
-  private readonly name: string;
-  private readonly simfile: string;
   private synthed = false;
 
   constructor(props: core.AppProps) {
     super(undefined as any, "root");
-    this.name = props.name ?? "app";
     this.outdir = props.outdir ?? ".";
-    this.workdir = mkdtemp();
 
     Logger.register(this);
-    this.simfile = path.join(this.outdir, `${this.name}.wsim`);
   }
 
   protected tryNew(
@@ -90,32 +79,21 @@ export class App extends core.App {
    */
   public synth(): string {
     if (this.synthed) {
-      return this.simfile;
+      return this.outdir;
     }
 
     // call preSynthesize() on every construct in the tree
     preSynthesizeAllConstructs(this);
 
     // write simulator.json file into workdir
-    this.synthSimulatorFile(this.workdir);
+    this.synthSimulatorFile(this.outdir);
 
     // write tree.json file into workdir
-    core.synthesizeTree(this, this.workdir);
-
-    // tar + gzip the workdir, and write it as a .wsim file to the simfile
-    tar.create(
-      {
-        gzip: true,
-        cwd: this.workdir,
-        sync: true,
-        file: this.simfile,
-      },
-      ["./"]
-    );
+    core.synthesizeTree(this, this.outdir);
 
     this.synthed = true;
 
-    return this.simfile;
+    return this.outdir;
   }
 
   private synthSimulatorFile(outdir: string) {

--- a/libs/wingsdk/src/target-sim/function.ts
+++ b/libs/wingsdk/src/target-sim/function.ts
@@ -20,7 +20,6 @@ export const ENV_WING_SIM_INFLIGHT_RESOURCE_TYPE =
  * @inflight `@winglang/sdk.cloud.IFunctionClient`
  */
 export class Function extends cloud.Function implements ISimulatorResource {
-  private readonly code: core.Code;
   private readonly timeout: Duration;
   constructor(
     scope: Construct,
@@ -32,16 +31,15 @@ export class Function extends cloud.Function implements ISimulatorResource {
 
     // props.memory is unused since we are not simulating it
     this.timeout = props.timeout ?? Duration.fromMinutes(1);
-    this.code = core.NodeJsCode.fromFile(this.assetPath);
   }
 
   public toSimulator(): BaseResourceSchema {
-    const workdir = App.of(this).workdir;
+    const outdir = App.of(this).outdir;
     const schema: FunctionSchema = {
       type: FUNCTION_TYPE,
       path: this.node.path,
       props: {
-        sourceCodeFile: relative(workdir, this.code.path),
+        sourceCodeFile: relative(outdir, this.entrypoint),
         sourceCodeLanguage: "javascript",
         environmentVariables: this.env,
         timeout: this.timeout.seconds * 1000,

--- a/libs/wingsdk/src/testing/sim-app.ts
+++ b/libs/wingsdk/src/testing/sim-app.ts
@@ -23,7 +23,7 @@ export class SimApp extends sim.App {
   public async startSimulator(): Promise<Simulator> {
     this.synthIfNeeded();
     const simfile = this.synth();
-    const s = new Simulator({ simfile });
+    const s = new Simulator({ simdir: simfile });
     await s.start();
     return s;
   }

--- a/libs/wingsdk/src/testing/simulator.ts
+++ b/libs/wingsdk/src/testing/simulator.ts
@@ -1,6 +1,5 @@
 import { existsSync } from "fs";
 import { join } from "path";
-import * as tar from "tar";
 import { Tree } from "./tree";
 import { SDK_VERSION } from "../constants";
 import { ConstructTree } from "../core";
@@ -10,16 +9,16 @@ import { DefaultSimulatorFactory } from "../target-sim/factory.inflight";
 // eslint-disable-next-line import/no-restricted-paths
 import { Function } from "../target-sim/function.inflight";
 import { BaseResourceSchema, WingSimulatorSchema } from "../target-sim/schema";
-import { mkdtemp, readJsonSync } from "../util";
+import { readJsonSync } from "../util";
 
 /**
  * Props for `Simulator`.
  */
 export interface SimulatorProps {
   /**
-   * Path to a Wing simulator file (.wsim).
+   * Path to a Wing simulator output directory (.wsim).
    */
-  readonly simfile: string;
+  readonly simdir: string;
 
   /**
    * The factory that produces resource simulations.
@@ -114,10 +113,9 @@ export enum TraceType {
  */
 export interface ISimulatorContext {
   /**
-   * The directory where all assets extracted from `.wsim` file are stored
-   * during the simulation run.
+   * This directory where the compilation output is
    */
-  readonly assetsDir: string;
+  readonly simdir: string;
 
   /**
    * The path of the resource that is being simulated.
@@ -160,8 +158,7 @@ export class Simulator {
   // fields that are same between simulation runs / reloads
   private readonly _factory: ISimulatorFactory;
   private _config: WingSimulatorSchema;
-  private readonly _simfile: string;
-  private _assetsDir: string;
+  private readonly simdir: string;
 
   // fields that change between simulation runs / reloads
   private _running: boolean;
@@ -171,10 +168,9 @@ export class Simulator {
   private _tree: Tree;
 
   constructor(props: SimulatorProps) {
-    this._simfile = props.simfile;
-    const { assetsDir, config, treeData } = this._loadApp(props.simfile);
+    this.simdir = props.simdir;
+    const { config, treeData } = this._loadApp(props.simdir);
     this._config = config;
-    this._assetsDir = assetsDir;
     this._tree = new Tree(treeData);
 
     this._running = false;
@@ -184,23 +180,14 @@ export class Simulator {
     this._traceSubscribers = new Array();
   }
 
-  private _loadApp(simfile: string): {
-    assetsDir: string;
+  private _loadApp(simdir: string): {
     config: any;
     treeData: ConstructTree;
   } {
-    // create a temporary directory to store extracted files
-    const workdir = mkdtemp();
-    tar.extract({
-      cwd: workdir,
-      sync: true,
-      file: simfile,
-    });
-
-    const simJson = join(workdir, "simulator.json");
+    const simJson = join(this.simdir, "simulator.json");
     if (!existsSync(simJson)) {
       throw new Error(
-        `Invalid Wing app (${simfile}) - simulator.json not found.`
+        `Invalid Wing app (${simdir}) - simulator.json not found.`
       );
     }
 
@@ -210,22 +197,22 @@ export class Simulator {
     const expectedVersion = SDK_VERSION;
     if (foundVersion !== expectedVersion) {
       console.error(
-        `WARNING: The simulator file (${simfile}) was generated with Wing SDK v${foundVersion} but it is being simulated with Wing SDK v${expectedVersion}.`
+        `WARNING: The simulator directory (${simdir}) was generated with Wing SDK v${foundVersion} but it is being simulated with Wing SDK v${expectedVersion}.`
       );
     }
     if (config.resources === undefined) {
       throw new Error(
-        `Incompatible .wsim file. The simulator file (${simfile}) was generated with Wing SDK v${foundVersion} but it is being simulated with Wing SDK v${expectedVersion}.`
+        `Incompatible .wsim file. The simulator directory (${simdir}) was generated with Wing SDK v${foundVersion} but it is being simulated with Wing SDK v${expectedVersion}.`
       );
     }
 
-    const treeJson = join(workdir, "tree.json");
+    const treeJson = join(this.simdir, "tree.json");
     if (!existsSync(treeJson)) {
-      throw new Error(`Invalid Wing app (${simfile}) - tree.json not found.`);
+      throw new Error(`Invalid Wing app (${simdir}) - tree.json not found.`);
     }
     const treeData = readJsonSync(treeJson);
 
-    return { assetsDir: workdir, config, treeData };
+    return { config, treeData };
   }
 
   /**
@@ -242,7 +229,7 @@ export class Simulator {
 
     for (const resourceConfig of this._config.resources) {
       const context: ISimulatorContext = {
-        assetsDir: this._assetsDir,
+        simdir: this.simdir,
         resourcePath: resourceConfig.path,
         findInstance: (handle: string) => {
           return this._handles.find(handle);
@@ -347,9 +334,8 @@ export class Simulator {
   public async reload(): Promise<void> {
     await this.stop();
 
-    const { assetsDir, config, treeData } = this._loadApp(this._simfile);
+    const { config, treeData } = this._loadApp(this.simdir);
     this._config = config;
-    this._assetsDir = assetsDir;
     this._tree = new Tree(treeData);
 
     await this.start();
@@ -460,7 +446,7 @@ export class Simulator {
    */
   public async runTest(path: string): Promise<TestResult> {
     // create a new simulator instance to run this test in isolation
-    const isolated = new Simulator({ simfile: this._simfile });
+    const isolated = new Simulator({ simdir: this.simdir });
     await isolated.start();
 
     // find the test function and verify it exists and indeed is a function

--- a/libs/wingsdk/src/utils/bundling.ts
+++ b/libs/wingsdk/src/utils/bundling.ts
@@ -1,0 +1,61 @@
+import { spawnSync } from "child_process";
+import * as crypto from "crypto";
+import { mkdirSync, readFileSync, writeFileSync } from "fs";
+import { join } from "path";
+import { normalPath } from "../util";
+
+export interface Bundle {
+  entrypointPath: string;
+  directory: string;
+  hash: string;
+}
+
+export function createBundle(entrypoint: string): Bundle {
+  const outdir = entrypoint + ".bundle";
+  mkdirSync(outdir, { recursive: true });
+  const outfile = join(outdir, "index.js");
+
+  // if the user has specified a node_modules directory to resolve from
+  const nodePathString = process.env.WING_NODE_MODULES
+    ? `nodePaths: [\"${normalPath(process.env.WING_NODE_MODULES as string)}\"],`
+    : "";
+
+  // We would invoke esbuild directly here, but there is a bug where esbuild
+  // mangles the stdout/stderr of the process that invokes it.
+  // https://github.com/evanw/esbuild/issues/2927
+  // To workaround the issue, spawn a new process and invoke esbuild inside it.
+
+  let esbuildScript = [
+    `const esbuild = require("${normalPath(
+      require.resolve("esbuild-wasm")
+    )}");`,
+    `esbuild.buildSync({ bundle: true, entryPoints: ["${normalPath(
+      entrypoint
+    )}"], outfile: "${normalPath(outfile)}", ${nodePathString}
+    minify: false, platform: "node", target: "node16", external: ["aws-sdk"],
+   });`,
+  ].join("\n");
+  let result = spawnSync(process.argv[0], ["-e", esbuildScript]);
+  if (result.status !== 0) {
+    throw new Error(
+      `Failed to bundle function: ${result.stderr.toString("utf-8")}`
+    );
+  }
+
+  // the bundled contains line comments with file paths, which are not useful for us, especially
+  // since they may contain system-specific paths. sadly, esbuild doesn't have a way to disable
+  // this, so we simply filter those out from the bundle.
+  const outlines = readFileSync(outfile, "utf-8").split("\n");
+  const isNotLineComment = (line: string) => !line.startsWith("//");
+  const final = outlines.filter(isNotLineComment).join("\n");
+  writeFileSync(outfile, final);
+
+  // calculate a md5 hash of the contents of asset.path
+  const codeHash = crypto.createHash("md5").update(final).digest("hex");
+
+  return {
+    entrypointPath: outfile,
+    directory: outdir,
+    hash: codeHash,
+  };
+}

--- a/tools/hangar/src/generated_test_targets.ts
+++ b/tools/hangar/src/generated_test_targets.ts
@@ -6,17 +6,14 @@ import { runWingCommand, sanitize_json_paths } from "./utils";
 export async function compileTest(expect: Vi.ExpectStatic, wingFile: string) {
   const wingBasename = basename(wingFile);
   const args = ["compile", "--target", "tf-aws"];
-  const testDir = join(tmpDir, `${wingBasename}_cdktf`);
   const targetDir = join(
-    testDir,
+    validTestDir,
     "target",
     `${wingBasename.replace(".w", "")}.tfaws`
   );
   const tf_json = join(targetDir, "main.tf.json");
 
-  await mkdir(testDir);
-
-  await runWingCommand(testDir, join(validTestDir, wingBasename), args, true);
+  await runWingCommand(validTestDir, join(validTestDir, wingBasename), args, true);
 
   const npx_tfJson = sanitize_json_paths(tf_json);
 


### PR DESCRIPTION
Improve performance from *O(inflight)* to *O(1)* when compiling and testing on the `sim` target by skipping cloud function bundling. As a benchmark, compiling a program with a single cloud function took 6s and now takes 1s. A program with 5 cloud functions took 24s and now also takes 1s.

The `.wsim` format has changed. It is now a directory instead of a tarball and includes the generated javascript files without bundling any dependencies. The output directory is now fixed to be `target/xxx.wsim` relative to the location of the Wing entrypoint file. This allows any `require()` statements to resolve against the correct `node_modules`. In the future we will consider some kind of self-contained bundle format, but for now, we optimize for the local iteration case.

To avoid mistakes, we removed support for specifying the output directory `--out` in the compiler. We can introduce later when we implement bundling for the simulator (or forbid only for the simulator).

- **Compiler**: Changed `js_resolve_path` to produce relative paths instead of absolute paths.
- **SDK**: Moved the bundling logic into a utility function under `bundling.ts`

BREAKING CHANGE: **cli**: The `--outdir` switch has been removed and the default location has been changed so that compilation artifacts are always placed under `target/xxx.ttt` (where `xxx` is the base name of the entrypoint and `ttt` is the target - for example, `target/hello.tfaws`, `target/hello.wsim`).
* **sim**: The `.wsim` output is now a directory and not a file (tarball), and must reside in a location where node module resolution can find any external dependencies.



*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.