### PR TITLE
fix(sdk): spaces in function names cause problems with terraform assets

### DIFF
--- a/libs/wingsdk/src/cloud/function.ts
+++ b/libs/wingsdk/src/cloud/function.ts
@@ -108,12 +108,15 @@ export abstract class Function extends Resource implements IInflightHost {
       implicit: true,
     });
 
-    const assetName = ResourceNames.generateName(this, {
-      // Avoid characters that may cause path issues
-      disallowedRegex: /[><:"/\\|?*]/g,
-      case: CaseConventions.LOWERCASE,
-      sep: "_",
-    });
+    const assetName = join(
+      "assets",
+      ResourceNames.generateName(this, {
+        // Avoid characters that may cause path issues
+        disallowedRegex: /[><:"/\\|?* ]/g,
+        case: CaseConventions.LOWERCASE,
+        sep: "_",
+      })
+    );
 
     // write the entrypoint next to the partial inflight code emitted by the compiler, so that
     // `require` resolves naturally.

--- a/libs/wingsdk/src/cloud/function.ts
+++ b/libs/wingsdk/src/cloud/function.ts
@@ -110,7 +110,7 @@ export abstract class Function extends Resource implements IInflightHost {
 
     const assetName = ResourceNames.generateName(this, {
       // Avoid characters that may cause path issues
-      disallowedRegex: /[><:"/\\|?* ]/g,
+      disallowedRegex: /[><:"/\\|?*\s]/g,
       case: CaseConventions.LOWERCASE,
       sep: "_",
     });

--- a/libs/wingsdk/src/cloud/function.ts
+++ b/libs/wingsdk/src/cloud/function.ts
@@ -108,15 +108,12 @@ export abstract class Function extends Resource implements IInflightHost {
       implicit: true,
     });
 
-    const assetName = join(
-      "assets",
-      ResourceNames.generateName(this, {
-        // Avoid characters that may cause path issues
-        disallowedRegex: /[><:"/\\|?* ]/g,
-        case: CaseConventions.LOWERCASE,
-        sep: "_",
-      })
-    );
+    const assetName = ResourceNames.generateName(this, {
+      // Avoid characters that may cause path issues
+      disallowedRegex: /[><:"/\\|?* ]/g,
+      case: CaseConventions.LOWERCASE,
+      sep: "_",
+    });
 
     // write the entrypoint next to the partial inflight code emitted by the compiler, so that
     // `require` resolves naturally.

--- a/libs/wingsdk/test/target-tf-aws/function.test.ts
+++ b/libs/wingsdk/test/target-tf-aws/function.test.ts
@@ -129,5 +129,5 @@ test("asset path is stripped of spaces", () => {
   // WHEN
   app.synth();
   // THEN
-  expect(f.assetPath).toContain(expectedReplacement);
+  expect(f.entrypoint).toContain(expectedReplacement);
 });

--- a/libs/wingsdk/test/target-tf-aws/function.test.ts
+++ b/libs/wingsdk/test/target-tf-aws/function.test.ts
@@ -121,9 +121,9 @@ test("basic function with memory size specified", () => {
 
 test("asset path is stripped of spaces", () => {
   // GIVEN
-  const some_name = "I have a space in my name"
+  const some_name = "I have a space in my name";
   const expectedReplacement = "i_have_a_space_in_my_name";
-  const app = new tfaws.App({outdir: mkdtemp()});
+  const app = new tfaws.App({ outdir: mkdtemp() });
   const inflight = Testing.makeHandler(app, "Handler", INFLIGHT_CODE);
   const f = Function._newFunction(app, some_name, inflight);
   // WHEN

--- a/libs/wingsdk/test/target-tf-aws/function.test.ts
+++ b/libs/wingsdk/test/target-tf-aws/function.test.ts
@@ -118,3 +118,16 @@ test("basic function with memory size specified", () => {
   expect(tfSanitize(output)).toMatchSnapshot();
   expect(treeJsonOf(app.outdir)).toMatchSnapshot();
 });
+
+test("asset path is stripped of spaces", () => {
+  // GIVEN
+  const some_name = "I have a space in my name"
+  const expectedReplacement = "i_have_a_space_in_my_name";
+  const app = new tfaws.App({outdir: mkdtemp()});
+  const inflight = Testing.makeHandler(app, "Handler", INFLIGHT_CODE);
+  const f = Function._newFunction(app, some_name, inflight);
+  // WHEN
+  app.synth();
+  // THEN
+  expect(f.assetPath).toContain(expectedReplacement);
+});


### PR DESCRIPTION
Disallows spaces from asset relative directories as they cause issues when creating TerraformAssets. Fixes issue where we could not find asset zip folder when deploying terraform

Closes: https://github.com/winglang/wing/issues/1866

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.