### PR TITLE
fix: hierarchal symbol lookups in language server sometimes fail

### DIFF
--- a/libs/wingc/src/lsp/completions.rs
+++ b/libs/wingc/src/lsp/completions.rs
@@ -178,23 +178,8 @@ pub fn on_completion(params: lsp_types::CompletionParams) -> CompletionResponse 
 			completions.push(format_symbol_kind_as_completion(symbol_data.0, symbol_kind));
 		}
 
-		// The following iteration logic is needed due to a bug:
-		// The root environment is not properly accessible from .parent
-		// https://github.com/winglang/wing/issues/1644
-		// So we can't use the normal iteration logic with ancestry
-		let mut parent_env = found_env.parent;
-		while let Some(current_env) = parent_env {
-			if current_env.is_root() {
-				for symbol_data in root_env.symbol_map.iter() {
-					completions.push(format_symbol_kind_as_completion(symbol_data.0, &symbol_data.1 .1));
-				}
-				break;
-			} else {
-				for data in current_env.iter(false) {
-					completions.push(format_symbol_kind_as_completion(&data.0, &data.1));
-				}
-			}
-			parent_env = current_env.parent;
+		for data in found_env.iter(true) {
+			completions.push(format_symbol_kind_as_completion(&data.0, &data.1));
 		}
 
 		completions

--- a/libs/wingc/src/lsp/hover.rs
+++ b/libs/wingc/src/lsp/hover.rs
@@ -222,8 +222,6 @@ pub fn on_hover<'a>(params: lsp_types::HoverParams) -> Option<Hover> {
 		);
 
 		let root_scope = &parse_result.scope;
-		let root_env = root_scope.env.borrow();
-		let root_env = root_env.as_ref().expect("All scopes should have a symbol environment");
 
 		let mut hover_visitor = HoverVisitor::new(params.text_document_position_params.position);
 		hover_visitor.visit_scope(root_scope);
@@ -241,18 +239,9 @@ pub fn on_hover<'a>(params: lsp_types::HoverParams) -> Option<Hover> {
 				.expect("All symbols must be in a scope")
 				.env
 				.borrow();
+			let env = env.as_ref().expect("All scopes should have a symbol environment");
 
-			let symbol_lookup = root_env.lookup_ext(symbol, None).or_else(|_| {
-				// If the symbol is not found in the root scope, try the given scope
-
-				// NOTE: We lookup in the root scope first because failing to lookup there is much faster than failing to lookup in an inner scope.
-				// The reason for this is due to a current bug in SymbolEnv where the .parent ref gets lost when referencing the root, and becomes bad data.
-				// This bad data sometimes causes the lookup to take a long time (lots of entries), or even panic.
-				// This should not cause incorrect lookups because we do not generally have variable shadowing in Wing.
-				// https://github.com/winglang/wing/issues/1644
-				let env = env.as_ref().expect("All scopes should have a symbol environment");
-				env.lookup_ext(symbol, None)
-			});
+			let symbol_lookup = env.lookup_ext(symbol, None);
 
 			let hover_string = if let Ok(symbol_lookup) = symbol_lookup {
 				format_symbol_with_lookup(&symbol.name, symbol_lookup)

--- a/libs/wingc/src/lsp/sync.rs
+++ b/libs/wingc/src/lsp/sync.rs
@@ -20,7 +20,7 @@ pub struct FileData {
 	/// The diagnostics returned by wingc
 	pub diagnostics: Diagnostics,
 	/// The top scope of the file
-	pub scope: Scope,
+	pub scope: Box<Scope>,
 	/// The universal type collection for the scope. This is saved to ensure references live long enough.
 	pub types: Types,
 }
@@ -91,7 +91,9 @@ fn partial_compile(source_file: &str, text: &[u8]) -> FileData {
 
 	let wing_parser = Parser::new(&text[..], source_file.to_string());
 
-	let mut scope = wing_parser.wingit(&tree.root_node());
+	// Note: The scope is intentionally boxed here to force heap allocation
+	// Otherwise, the scope will be moved and we'll be left with dangling references elsewhere
+	let mut scope = Box::new(wing_parser.wingit(&tree.root_node()));
 
 	let type_diag = type_check(&mut scope, &mut types, &Path::new(source_file));
 


### PR DESCRIPTION
Full credit to @yoav-steinberg for finding the root cause/solution.

While there is a more systemic issue at play here (the unsafe pointers), I would call this change a workaround rather than a hack (which is what I was doing before).

Fixes #1644

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.