### PR TITLE
chore: snapshot updates not failing ci

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -240,7 +240,7 @@ jobs:
     name: Publish
     if: ${{ github.event_name == 'push' && github.repository == 'winglang/wing' }}
     needs:
-      - e2e
+      - quality-gate
       - prepare
     runs-on: ubuntu-latest
     steps:

--- a/libs/wingsdk/src/std/string.ts
+++ b/libs/wingsdk/src/std/string.ts
@@ -66,6 +66,8 @@ export class String {
   /**
    * Does this string end with the given searchString?
    *
+   * @macro $self$.endsWith($args$)
+   * 
    * @param searchString substring to search for.
    * @returns true if string ends with searchString.
    */
@@ -111,7 +113,9 @@ export class String {
 
   /**
    * Does this string start with the given searchString?
-   *
+   * 
+   * @macro $self$.startsWith($args$)
+   * 
    * @param searchString substring to search for.
    * @returns true if string starts with searchString.
    */

--- a/libs/wingsdk/src/std/string.ts
+++ b/libs/wingsdk/src/std/string.ts
@@ -67,7 +67,7 @@ export class String {
    * Does this string end with the given searchString?
    *
    * @macro $self$.endsWith($args$)
-   * 
+   *
    * @param searchString substring to search for.
    * @returns true if string ends with searchString.
    */
@@ -113,9 +113,9 @@ export class String {
 
   /**
    * Does this string start with the given searchString?
-   * 
+   *
    * @macro $self$.startsWith($args$)
-   * 
+   *
    * @param searchString substring to search for.
    * @returns true if string starts with searchString.
    */

--- a/tools/hangar/__snapshots__/plugins.ts.snap
+++ b/tools/hangar/__snapshots__/plugins.ts.snap
@@ -152,13 +152,8 @@ exports[`Plugin examples > AWS target plugins > permission-boundary.js 1`] = `
           },
         },
         "bucket": "\${aws_s3_bucket.root_cloudQueueOnMessagee46e5cb7_Code_A7B6C6A0.bucket}",
-<<<<<<< HEAD
         "key": "<ASSET_KEY>",
         "source": "<ASSET_SOURCE>",
-=======
-        "key": "asset.c86cd0c0c9dc1b0298aaebb2fb4561ba65c36c4795.319552e364ce69b821ac32800fe52fd7.zip",
-        "source": "assets/root_cloudQueueOnMessagee46e5cb7_Asset_1C1D632C/319552E364CE69B821AC32800FE52FD7/archive.zip",
->>>>>>> 241cf37ae8515b057e313746edf429e21648c17f
       },
     },
     "aws_sqs_queue": {
@@ -173,22 +168,6 @@ exports[`Plugin examples > AWS target plugins > permission-boundary.js 1`] = `
       },
     },
   },
-<<<<<<< HEAD
-=======
-  "terraform": {
-    "backend": {
-      "local": {
-        "path": "/Users/chrisr/dev/wing3/tools/hangar/tmp/terraform.root.tfstate",
-      },
-    },
-    "required_providers": {
-      "aws": {
-        "source": "aws",
-        "version": "4.52.0",
-      },
-    },
-  },
->>>>>>> 241cf37ae8515b057e313746edf429e21648c17f
 }
 `;
 
@@ -531,13 +510,8 @@ exports[`Plugin examples > AWS target plugins > replicate-s3.js 1`] = `
           },
         },
         "bucket": "\${aws_s3_bucket.root_cloudQueueOnMessagee46e5cb7_Code_A7B6C6A0.bucket}",
-<<<<<<< HEAD
         "key": "<ASSET_KEY>",
         "source": "<ASSET_SOURCE>",
-=======
-        "key": "asset.c86cd0c0c9dc1b0298aaebb2fb4561ba65c36c4795.319552e364ce69b821ac32800fe52fd7.zip",
-        "source": "assets/root_cloudQueueOnMessagee46e5cb7_Asset_1C1D632C/319552E364CE69B821AC32800FE52FD7/archive.zip",
->>>>>>> 241cf37ae8515b057e313746edf429e21648c17f
       },
     },
     "aws_sqs_queue": {
@@ -552,22 +526,6 @@ exports[`Plugin examples > AWS target plugins > replicate-s3.js 1`] = `
       },
     },
   },
-<<<<<<< HEAD
-=======
-  "terraform": {
-    "backend": {
-      "local": {
-        "path": "/Users/chrisr/dev/wing3/tools/hangar/tmp/terraform.root.tfstate",
-      },
-    },
-    "required_providers": {
-      "aws": {
-        "source": "aws",
-        "version": "4.52.0",
-      },
-    },
-  },
->>>>>>> 241cf37ae8515b057e313746edf429e21648c17f
 }
 `;
 

--- a/tools/hangar/__snapshots__/plugins.ts.snap
+++ b/tools/hangar/__snapshots__/plugins.ts.snap
@@ -680,8 +680,8 @@ exports[`Plugin examples > AWS target plugins > tf-s3-backend.js 1`] = `
           },
         },
         "bucket": "\${aws_s3_bucket.root_cloudQueueOnMessagee46e5cb7_Code_A7B6C6A0.bucket}",
-        "key": "asset.c86cd0c0c9dc1b0298aaebb2fb4561ba65c36c4795.319552e364ce69b821ac32800fe52fd7.zip",
-        "source": "assets/root_cloudQueueOnMessagee46e5cb7_Asset_1C1D632C/319552E364CE69B821AC32800FE52FD7/archive.zip",
+        "key": "<ASSET_KEY>",
+        "source": "<ASSET_SOURCE>",
       },
     },
     "aws_sqs_queue": {
@@ -693,21 +693,6 @@ exports[`Plugin examples > AWS target plugins > tf-s3-backend.js 1`] = `
           },
         },
         "name": "cloud-Queue-c86e03d8",
-      },
-    },
-  },
-  "terraform": {
-    "backend": {
-      "s3": {
-        "bucket": "my-wing-bucket",
-        "key": "some-state-file.tfstate",
-        "region": "us-east-1",
-      },
-    },
-    "required_providers": {
-      "aws": {
-        "source": "aws",
-        "version": "4.52.0",
       },
     },
   },

--- a/tools/hangar/__snapshots__/plugins.ts.snap
+++ b/tools/hangar/__snapshots__/plugins.ts.snap
@@ -152,8 +152,8 @@ exports[`Plugin examples > AWS target plugins > permission-boundary.js 1`] = `
           },
         },
         "bucket": "\${aws_s3_bucket.root_cloudQueueOnMessagee46e5cb7_Code_A7B6C6A0.bucket}",
-        "key": "asset.c86cd0c0c9dc1b0298aaebb2fb4561ba65c36c4795.438fc38ad238079f941f7530172ce962.zip",
-        "source": "assets/root_cloudQueueOnMessagee46e5cb7_Asset_1C1D632C/438FC38AD238079F941F7530172CE962/archive.zip",
+        "key": "<ASSET_KEY>",
+        "source": "<ASSET_SOURCE>",
       },
     },
     "aws_sqs_queue": {
@@ -165,19 +165,6 @@ exports[`Plugin examples > AWS target plugins > permission-boundary.js 1`] = `
           },
         },
         "name": "cloud-Queue-c86e03d8",
-      },
-    },
-  },
-  "terraform": {
-    "backend": {
-      "local": {
-        "path": "/Users/hasan/repos/monada/wing/tools/hangar/tmp/terraform.root.tfstate",
-      },
-    },
-    "required_providers": {
-      "aws": {
-        "source": "aws",
-        "version": "4.52.0",
       },
     },
   },
@@ -523,8 +510,8 @@ exports[`Plugin examples > AWS target plugins > replicate-s3.js 1`] = `
           },
         },
         "bucket": "\${aws_s3_bucket.root_cloudQueueOnMessagee46e5cb7_Code_A7B6C6A0.bucket}",
-        "key": "asset.c86cd0c0c9dc1b0298aaebb2fb4561ba65c36c4795.438fc38ad238079f941f7530172ce962.zip",
-        "source": "assets/root_cloudQueueOnMessagee46e5cb7_Asset_1C1D632C/438FC38AD238079F941F7530172CE962/archive.zip",
+        "key": "<ASSET_KEY>",
+        "source": "<ASSET_SOURCE>",
       },
     },
     "aws_sqs_queue": {
@@ -536,19 +523,6 @@ exports[`Plugin examples > AWS target plugins > replicate-s3.js 1`] = `
           },
         },
         "name": "cloud-Queue-c86e03d8",
-      },
-    },
-  },
-  "terraform": {
-    "backend": {
-      "local": {
-        "path": "/Users/hasan/repos/monada/wing/tools/hangar/tmp/terraform.root.tfstate",
-      },
-    },
-    "required_providers": {
-      "aws": {
-        "source": "aws",
-        "version": "4.52.0",
       },
     },
   },

--- a/tools/hangar/__snapshots__/test_corpus/valid/api.w.ts.snap
+++ b/tools/hangar/__snapshots__/test_corpus/valid/api.w.ts.snap
@@ -184,6 +184,7 @@ exports[`wing compile -t tf-aws > main.tf.json 1`] = `
         },
         "bucket": "\${aws_s3_bucket.root_cloudApi_cloudApiOnRequeste46e5cb7_Code_42BF847C.bucket}",
         "key": "<ASSET_KEY>",
+        "source": "<ASSET_SOURCE>",
       },
     },
   },

--- a/tools/hangar/__snapshots__/test_corpus/valid/asynchronous_model_implicit_await_in_functions.w.ts.snap
+++ b/tools/hangar/__snapshots__/test_corpus/valid/asynchronous_model_implicit_await_in_functions.w.ts.snap
@@ -155,6 +155,29 @@ exports[`wing compile -t tf-aws > main.tf.json 1`] = `
         },
         "bucket": "\${aws_s3_bucket.root_func_Code_58BA0E0E.bucket}",
         "key": "<ASSET_KEY>",
+        "source": "<ASSET_SOURCE>",
+      },
+      "root_strtostr_S3Object_C6E06A09": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/str_to_str/S3Object",
+            "uniqueId": "root_strtostr_S3Object_C6E06A09",
+          },
+        },
+        "bucket": "\${aws_s3_bucket.root_strtostr_Code_5BA38746.bucket}",
+        "key": "<ASSET_KEY>",
+        "source": "<ASSET_SOURCE>",
+      },
+    },
+    "aws_sqs_queue": {
+      "root_cloudQueue_E3597F7A": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/cloud.Queue/Default",
+            "uniqueId": "root_cloudQueue_E3597F7A",
+          },
+        },
+        "name": "cloud-Queue-c86e03d8",
       },
     },
   },

--- a/tools/hangar/__snapshots__/test_corpus/valid/bring_jsii.w.ts.snap
+++ b/tools/hangar/__snapshots__/test_corpus/valid/bring_jsii.w.ts.snap
@@ -95,6 +95,7 @@ exports[`wing compile -t tf-aws > main.tf.json 1`] = `
         },
         "bucket": "\${aws_s3_bucket.root_testsayhello_Code_D4453363.bucket}",
         "key": "<ASSET_KEY>",
+        "source": "<ASSET_SOURCE>",
       },
     },
   },

--- a/tools/hangar/__snapshots__/test_corpus/valid/bring_jsii_path.w.ts.snap
+++ b/tools/hangar/__snapshots__/test_corpus/valid/bring_jsii_path.w.ts.snap
@@ -95,6 +95,7 @@ exports[`wing compile -t tf-aws > main.tf.json 1`] = `
         },
         "bucket": "\${aws_s3_bucket.root_testsayhello_Code_D4453363.bucket}",
         "key": "<ASSET_KEY>",
+        "source": "<ASSET_SOURCE>",
       },
     },
   },

--- a/tools/hangar/__snapshots__/test_corpus/valid/bucket_keys.w.ts.snap
+++ b/tools/hangar/__snapshots__/test_corpus/valid/bucket_keys.w.ts.snap
@@ -139,6 +139,7 @@ exports[`wing compile -t tf-aws > main.tf.json 1`] = `
         },
         "bucket": "\${aws_s3_bucket.root_test_Code_2D131EC2.bucket}",
         "key": "<ASSET_KEY>",
+        "source": "<ASSET_SOURCE>",
       },
     },
   },

--- a/tools/hangar/__snapshots__/test_corpus/valid/capture_containers.w.ts.snap
+++ b/tools/hangar/__snapshots__/test_corpus/valid/capture_containers.w.ts.snap
@@ -95,6 +95,7 @@ exports[`wing compile -t tf-aws > main.tf.json 1`] = `
         },
         "bucket": "\${aws_s3_bucket.root_test_Code_2D131EC2.bucket}",
         "key": "<ASSET_KEY>",
+        "source": "<ASSET_SOURCE>",
       },
     },
   },

--- a/tools/hangar/__snapshots__/test_corpus/valid/capture_containers_of_resources.w.ts.snap
+++ b/tools/hangar/__snapshots__/test_corpus/valid/capture_containers_of_resources.w.ts.snap
@@ -180,6 +180,18 @@ exports[`wing compile -t tf-aws > main.tf.json 1`] = `
         },
         "bucket": "\${aws_s3_bucket.root_test_Code_2D131EC2.bucket}",
         "key": "<ASSET_KEY>",
+        "source": "<ASSET_SOURCE>",
+      },
+    },
+    "aws_sqs_queue": {
+      "root_cloudQueue_E3597F7A": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/cloud.Queue/Default",
+            "uniqueId": "root_cloudQueue_E3597F7A",
+          },
+        },
+        "name": "cloud-Queue-c86e03d8",
       },
     },
   },

--- a/tools/hangar/__snapshots__/test_corpus/valid/capture_in_binary.w.ts.snap
+++ b/tools/hangar/__snapshots__/test_corpus/valid/capture_in_binary.w.ts.snap
@@ -139,6 +139,7 @@ exports[`wing compile -t tf-aws > main.tf.json 1`] = `
         },
         "bucket": "\${aws_s3_bucket.root_test_Code_2D131EC2.bucket}",
         "key": "<ASSET_KEY>",
+        "source": "<ASSET_SOURCE>",
       },
     },
   },

--- a/tools/hangar/__snapshots__/test_corpus/valid/capture_primitives.w.ts.snap
+++ b/tools/hangar/__snapshots__/test_corpus/valid/capture_primitives.w.ts.snap
@@ -95,6 +95,7 @@ exports[`wing compile -t tf-aws > main.tf.json 1`] = `
         },
         "bucket": "\${aws_s3_bucket.root_cloudFunction_Code_2F6A7948.bucket}",
         "key": "<ASSET_KEY>",
+        "source": "<ASSET_SOURCE>",
       },
     },
   },

--- a/tools/hangar/__snapshots__/test_corpus/valid/capture_resource_and_data.w.ts.snap
+++ b/tools/hangar/__snapshots__/test_corpus/valid/capture_resource_and_data.w.ts.snap
@@ -140,6 +140,18 @@ exports[`wing compile -t tf-aws > main.tf.json 1`] = `
         },
         "bucket": "\${aws_s3_bucket.root_test_Code_2D131EC2.bucket}",
         "key": "<ASSET_KEY>",
+        "source": "<ASSET_SOURCE>",
+      },
+    },
+    "aws_sqs_queue": {
+      "root_cloudQueue_E3597F7A": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/cloud.Queue/Default",
+            "uniqueId": "root_cloudQueue_E3597F7A",
+          },
+        },
+        "name": "cloud-Queue-c86e03d8",
       },
     },
   },

--- a/tools/hangar/__snapshots__/test_corpus/valid/capture_resource_with_no_inflight.w.ts.snap
+++ b/tools/hangar/__snapshots__/test_corpus/valid/capture_resource_with_no_inflight.w.ts.snap
@@ -105,6 +105,7 @@ exports[`wing compile -t tf-aws > main.tf.json 1`] = `
         },
         "bucket": "\${aws_s3_bucket.root_test_Code_2D131EC2.bucket}",
         "key": "<ASSET_KEY>",
+        "source": "<ASSET_SOURCE>",
       },
     },
   },

--- a/tools/hangar/__snapshots__/test_corpus/valid/captures.w.ts.snap
+++ b/tools/hangar/__snapshots__/test_corpus/valid/captures.w.ts.snap
@@ -361,6 +361,40 @@ exports[`wing compile -t tf-aws > main.tf.json 1`] = `
         },
         "bucket": "\${aws_s3_bucket.root_AnotherFunction_Code_B0183137.bucket}",
         "key": "<ASSET_KEY>",
+        "source": "<ASSET_SOURCE>",
+      },
+      "root_cloudFunction_S3Object_C8435368": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/cloud.Function/S3Object",
+            "uniqueId": "root_cloudFunction_S3Object_C8435368",
+          },
+        },
+        "bucket": "\${aws_s3_bucket.root_cloudFunction_Code_2F6A7948.bucket}",
+        "key": "<ASSET_KEY>",
+        "source": "<ASSET_SOURCE>",
+      },
+      "root_cloudQueueOnMessagee46e5cb7_S3Object_E583CB6B": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/cloud.Queue-OnMessage-e46e5cb7/S3Object",
+            "uniqueId": "root_cloudQueueOnMessagee46e5cb7_S3Object_E583CB6B",
+          },
+        },
+        "bucket": "\${aws_s3_bucket.root_cloudQueueOnMessagee46e5cb7_Code_A7B6C6A0.bucket}",
+        "key": "<ASSET_KEY>",
+        "source": "<ASSET_SOURCE>",
+      },
+    },
+    "aws_sqs_queue": {
+      "root_cloudQueue_E3597F7A": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/cloud.Queue/Default",
+            "uniqueId": "root_cloudQueue_E3597F7A",
+          },
+        },
+        "name": "cloud-Queue-c86e03d8",
       },
     },
   },

--- a/tools/hangar/__snapshots__/test_corpus/valid/extern_implementation.w.ts.snap
+++ b/tools/hangar/__snapshots__/test_corpus/valid/extern_implementation.w.ts.snap
@@ -133,6 +133,7 @@ exports[`wing compile -t tf-aws > main.tf.json 1`] = `
         },
         "bucket": "\${aws_s3_bucket.root_testcall_Code_A13B9FEB.bucket}",
         "key": "<ASSET_KEY>",
+        "source": "<ASSET_SOURCE>",
       },
     },
   },

--- a/tools/hangar/__snapshots__/test_corpus/valid/file_counter.w.ts.snap
+++ b/tools/hangar/__snapshots__/test_corpus/valid/file_counter.w.ts.snap
@@ -172,6 +172,19 @@ exports[`wing compile -t tf-aws > main.tf.json 1`] = `
         },
         "bucket": "\${aws_s3_bucket.root_cloudQueueOnMessagee46e5cb7_Code_A7B6C6A0.bucket}",
         "key": "<ASSET_KEY>",
+        "source": "<ASSET_SOURCE>",
+      },
+    },
+    "aws_sqs_queue": {
+      "root_cloudQueue_E3597F7A": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/cloud.Queue/Default",
+            "uniqueId": "root_cloudQueue_E3597F7A",
+          },
+        },
+        "name": "cloud-Queue-c86e03d8",
+        "visibility_timeout_seconds": 10,
       },
     },
   },

--- a/tools/hangar/__snapshots__/test_corpus/valid/hello.w.ts.snap
+++ b/tools/hangar/__snapshots__/test_corpus/valid/hello.w.ts.snap
@@ -152,6 +152,18 @@ exports[`wing compile -t tf-aws > main.tf.json 1`] = `
         },
         "bucket": "\${aws_s3_bucket.root_cloudQueueOnMessagee46e5cb7_Code_A7B6C6A0.bucket}",
         "key": "<ASSET_KEY>",
+        "source": "<ASSET_SOURCE>",
+      },
+    },
+    "aws_sqs_queue": {
+      "root_cloudQueue_E3597F7A": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/cloud.Queue/Default",
+            "uniqueId": "root_cloudQueue_E3597F7A",
+          },
+        },
+        "name": "cloud-Queue-c86e03d8",
       },
     },
   },

--- a/tools/hangar/__snapshots__/test_corpus/valid/json_bucket.w.ts.snap
+++ b/tools/hangar/__snapshots__/test_corpus/valid/json_bucket.w.ts.snap
@@ -201,6 +201,18 @@ exports[`wing compile -t tf-aws > main.tf.json 1`] = `
         },
         "bucket": "\${aws_s3_bucket.root_cloudFunction_Code_2F6A7948.bucket}",
         "key": "<ASSET_KEY>",
+        "source": "<ASSET_SOURCE>",
+      },
+      "root_testput_S3Object_30BF1DDD": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/test:put/S3Object",
+            "uniqueId": "root_testput_S3Object_30BF1DDD",
+          },
+        },
+        "bucket": "\${aws_s3_bucket.root_testput_Code_DE7653AD.bucket}",
+        "key": "<ASSET_KEY>",
+        "source": "<ASSET_SOURCE>",
       },
     },
   },

--- a/tools/hangar/__snapshots__/test_corpus/valid/print.w.ts.snap
+++ b/tools/hangar/__snapshots__/test_corpus/valid/print.w.ts.snap
@@ -156,14 +156,14 @@ exports[`wing compile -t tf-aws > main.tf.json 1`] = `
         "key": "<ASSET_KEY>",
         "source": "<ASSET_SOURCE>",
       },
-      "root_testprint2_S3Object_22A6E03D": {
+      "root_testlog2_S3Object_93F5CD8E": {
         "//": {
           "metadata": {
-            "path": "root/Default/test:print2/S3Object",
-            "uniqueId": "root_testprint2_S3Object_22A6E03D",
+            "path": "root/Default/test:log2/S3Object",
+            "uniqueId": "root_testlog2_S3Object_93F5CD8E",
           },
         },
-        "bucket": "\${aws_s3_bucket.root_testprint2_Code_0F714597.bucket}",
+        "bucket": "\${aws_s3_bucket.root_testlog2_Code_F54FF962.bucket}",
         "key": "<ASSET_KEY>",
         "source": "<ASSET_SOURCE>",
       },

--- a/tools/hangar/__snapshots__/test_corpus/valid/print.w.ts.snap
+++ b/tools/hangar/__snapshots__/test_corpus/valid/print.w.ts.snap
@@ -154,6 +154,18 @@ exports[`wing compile -t tf-aws > main.tf.json 1`] = `
         },
         "bucket": "\${aws_s3_bucket.root_testprint1_Code_EF1D7786.bucket}",
         "key": "<ASSET_KEY>",
+        "source": "<ASSET_SOURCE>",
+      },
+      "root_testprint2_S3Object_22A6E03D": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/test:print2/S3Object",
+            "uniqueId": "root_testprint2_S3Object_22A6E03D",
+          },
+        },
+        "bucket": "\${aws_s3_bucket.root_testprint2_Code_0F714597.bucket}",
+        "key": "<ASSET_KEY>",
+        "source": "<ASSET_SOURCE>",
       },
     },
   },

--- a/tools/hangar/__snapshots__/test_corpus/valid/resource.w.ts.snap
+++ b/tools/hangar/__snapshots__/test_corpus/valid/resource.w.ts.snap
@@ -196,6 +196,7 @@ exports[`wing compile -t tf-aws > main.tf.json 1`] = `
         },
         "bucket": "\${aws_s3_bucket.root_test_Code_2D131EC2.bucket}",
         "key": "<ASSET_KEY>",
+        "source": "<ASSET_SOURCE>",
       },
     },
   },

--- a/tools/hangar/__snapshots__/test_corpus/valid/resource_as_inflight_literal.w.ts.snap
+++ b/tools/hangar/__snapshots__/test_corpus/valid/resource_as_inflight_literal.w.ts.snap
@@ -169,6 +169,18 @@ exports[`wing compile -t tf-aws > main.tf.json 1`] = `
         },
         "bucket": "\${aws_s3_bucket.root_cloudFunction_Code_2F6A7948.bucket}",
         "key": "<ASSET_KEY>",
+        "source": "<ASSET_SOURCE>",
+      },
+      "root_test_S3Object_A16CD789": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/test/S3Object",
+            "uniqueId": "root_test_S3Object_A16CD789",
+          },
+        },
+        "bucket": "\${aws_s3_bucket.root_test_Code_2D131EC2.bucket}",
+        "key": "<ASSET_KEY>",
+        "source": "<ASSET_SOURCE>",
       },
     },
   },

--- a/tools/hangar/__snapshots__/test_corpus/valid/resource_captures.w.ts.snap
+++ b/tools/hangar/__snapshots__/test_corpus/valid/resource_captures.w.ts.snap
@@ -338,6 +338,18 @@ exports[`wing compile -t tf-aws > main.tf.json 1`] = `
         },
         "bucket": "\${aws_s3_bucket.root_test_Code_2D131EC2.bucket}",
         "key": "<ASSET_KEY>",
+        "source": "<ASSET_SOURCE>",
+      },
+    },
+    "aws_sqs_queue": {
+      "root_MyResource_cloudQueue_156CFA11": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/MyResource/cloud.Queue/Default",
+            "uniqueId": "root_MyResource_cloudQueue_156CFA11",
+          },
+        },
+        "name": "cloud-Queue-c8185458",
       },
     },
   },

--- a/tools/hangar/__snapshots__/test_corpus/valid/statements_if.w.ts.snap
+++ b/tools/hangar/__snapshots__/test_corpus/valid/statements_if.w.ts.snap
@@ -95,6 +95,7 @@ exports[`wing compile -t tf-aws > main.tf.json 1`] = `
         },
         "bucket": "\${aws_s3_bucket.root_test_Code_2D131EC2.bucket}",
         "key": "<ASSET_KEY>",
+        "source": "<ASSET_SOURCE>",
       },
     },
   },

--- a/tools/hangar/__snapshots__/test_corpus/valid/static_members.w.ts.snap
+++ b/tools/hangar/__snapshots__/test_corpus/valid/static_members.w.ts.snap
@@ -109,6 +109,7 @@ exports[`wing compile -t tf-aws > main.tf.json 1`] = `
         },
         "bucket": "\${aws_s3_bucket.root_test_Code_2D131EC2.bucket}",
         "key": "<ASSET_KEY>",
+        "source": "<ASSET_SOURCE>",
       },
     },
   },

--- a/tools/hangar/__snapshots__/test_corpus/valid/std_string.w.ts.snap
+++ b/tools/hangar/__snapshots__/test_corpus/valid/std_string.w.ts.snap
@@ -95,6 +95,7 @@ exports[`wing compile -t tf-aws > main.tf.json 1`] = `
         },
         "bucket": "\${aws_s3_bucket.root_teststring_Code_042172E8.bucket}",
         "key": "<ASSET_KEY>",
+        "source": "<ASSET_SOURCE>",
       },
     },
   },

--- a/tools/hangar/__snapshots__/test_corpus/valid/symbol_shadow.w.ts.snap
+++ b/tools/hangar/__snapshots__/test_corpus/valid/symbol_shadow.w.ts.snap
@@ -282,6 +282,40 @@ exports[`wing compile -t tf-aws > main.tf.json 1`] = `
         },
         "bucket": "\${aws_s3_bucket.root_A_testinflightinresourceshouldcapturetherightscopedvar_Code_470A0E83.bucket}",
         "key": "<ASSET_KEY>",
+        "source": "<ASSET_SOURCE>",
+      },
+      "root_testinflightnestedshouldnotcapturetheshadowedvar_S3Object_C99A3326": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/test:inflight nested should not capture the shadowed var/S3Object",
+            "uniqueId": "root_testinflightnestedshouldnotcapturetheshadowedvar_S3Object_C99A3326",
+          },
+        },
+        "bucket": "\${aws_s3_bucket.root_testinflightnestedshouldnotcapturetheshadowedvar_Code_56F93BD5.bucket}",
+        "key": "<ASSET_KEY>",
+        "source": "<ASSET_SOURCE>",
+      },
+      "root_testinflightontopshouldcapturetop_S3Object_75B26800": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/test:inflight on top should capture top/S3Object",
+            "uniqueId": "root_testinflightontopshouldcapturetop_S3Object_75B26800",
+          },
+        },
+        "bucket": "\${aws_s3_bucket.root_testinflightontopshouldcapturetop_Code_F50B9894.bucket}",
+        "key": "<ASSET_KEY>",
+        "source": "<ASSET_SOURCE>",
+      },
+      "root_testinsideinflightshouldcapturetherightscope_S3Object_33BC24EC": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/test:inside_inflight should capture the right scope/S3Object",
+            "uniqueId": "root_testinsideinflightshouldcapturetherightscope_S3Object_33BC24EC",
+          },
+        },
+        "bucket": "\${aws_s3_bucket.root_testinsideinflightshouldcapturetherightscope_Code_0FC24998.bucket}",
+        "key": "<ASSET_KEY>",
+        "source": "<ASSET_SOURCE>",
       },
     },
   },

--- a/tools/hangar/__snapshots__/test_corpus/valid/test_bucket.w.ts.snap
+++ b/tools/hangar/__snapshots__/test_corpus/valid/test_bucket.w.ts.snap
@@ -200,6 +200,18 @@ exports[`wing compile -t tf-aws > main.tf.json 1`] = `
         },
         "bucket": "\${aws_s3_bucket.root_testget_Code_EC989716.bucket}",
         "key": "<ASSET_KEY>",
+        "source": "<ASSET_SOURCE>",
+      },
+      "root_testput_S3Object_30BF1DDD": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/test:put/S3Object",
+            "uniqueId": "root_testput_S3Object_30BF1DDD",
+          },
+        },
+        "bucket": "\${aws_s3_bucket.root_testput_Code_DE7653AD.bucket}",
+        "key": "<ASSET_KEY>",
+        "source": "<ASSET_SOURCE>",
       },
     },
   },

--- a/tools/hangar/__snapshots__/test_corpus/valid/while_loop_await.w.ts.snap
+++ b/tools/hangar/__snapshots__/test_corpus/valid/while_loop_await.w.ts.snap
@@ -108,6 +108,18 @@ exports[`wing compile -t tf-aws > main.tf.json 1`] = `
         },
         "bucket": "\${aws_s3_bucket.root_cloudQueueOnMessageb3f3d188_Code_4D451A84.bucket}",
         "key": "<ASSET_KEY>",
+        "source": "<ASSET_SOURCE>",
+      },
+    },
+    "aws_sqs_queue": {
+      "root_cloudQueue_E3597F7A": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/cloud.Queue/Default",
+            "uniqueId": "root_cloudQueue_E3597F7A",
+          },
+        },
+        "name": "cloud-Queue-c86e03d8",
       },
     },
   },

--- a/tools/hangar/src/plugins.test.ts
+++ b/tools/hangar/src/plugins.test.ts
@@ -100,13 +100,12 @@ describe("Plugin examples", () => {
         plugins: [plugin],
       });
 
-      const terraformOutput = fs.readJsonSync(
-        path.join(targetDir, "main.tf.json"),
-        "utf-8"
-      );
+      const tfPath = path.join(targetDir, "main.tf.json");
+      const terraformOutput = sanitize_json_paths(tfPath);
+      const unsanitizedTerraformOutput = fs.readJsonSync(tfPath);
 
       expect(terraformOutput).toMatchSnapshot();
-      expect(terraformOutput.terraform.backend).toEqual({
+      expect(unsanitizedTerraformOutput.terraform.backend).toEqual({
         s3: {
           bucket: tfBackendBucket,
           region: tfBackendBucketRegion,

--- a/tools/hangar/src/plugins.test.ts
+++ b/tools/hangar/src/plugins.test.ts
@@ -1,8 +1,12 @@
-import {describe, expect, test} from "vitest"
+import { describe, expect, test } from "vitest";
 import * as path from "path";
 import fs from "fs-extra";
 import { pluginsDir, tmpDir } from "./paths";
-import { runWingCommand, tfResourcesOfCount } from "./utils";
+import {
+  runWingCommand,
+  sanitize_json_paths,
+  tfResourcesOfCount,
+} from "./utils";
 import * as cdktf from "cdktf";
 
 describe("Plugin examples", () => {
@@ -15,10 +19,10 @@ describe("Plugin examples", () => {
 
     test("permission-boundary.js", async () => {
       const plugin = path.join(pluginsDir, "permission-boundary.js");
-      
+
       const expectedPermissionBoundaryArn = "some:fake:arn:SUPERADMIN";
       process.env.PERMISSION_BOUNDARY_ARN = expectedPermissionBoundaryArn;
-      
+
       await runWingCommand({
         cwd: tmpDir,
         wingFile: appFile,
@@ -26,17 +30,24 @@ describe("Plugin examples", () => {
         shouldSucceed: true,
         plugins: [plugin],
       });
-  
-      const terraformOutput = fs.readFileSync(path.join(targetDir, "main.tf.json"), "utf-8");
-  
-      expect(JSON.parse(terraformOutput)).toMatchSnapshot();
+
+      const terraformOutput = sanitize_json_paths(
+        path.join(targetDir, "main.tf.json")
+      );
+      const terraformOutputString = JSON.stringify(terraformOutput);
+
+      expect(terraformOutput).toMatchSnapshot();
       expect(
-        cdktf.Testing.toHaveResourceWithProperties(terraformOutput, "aws_iam_role", {
-          permissions_boundary: expectedPermissionBoundaryArn,
-        })
+        cdktf.Testing.toHaveResourceWithProperties(
+          terraformOutputString,
+          "aws_iam_role",
+          {
+            permissions_boundary: expectedPermissionBoundaryArn,
+          }
+        )
       ).toEqual(true);
     });
-  
+
     test("replicate-s3.js", async () => {
       const plugin = path.join(pluginsDir, "replicate-s3.js");
       const replicaPrefix = "some-prefix";
@@ -52,13 +63,23 @@ describe("Plugin examples", () => {
         plugins: [plugin],
       });
 
-      const terraformOutput = fs.readFileSync(path.join(targetDir, "main.tf.json"), "utf-8");
-  
-      expect(JSON.parse(terraformOutput)).toMatchSnapshot();
-      expect(tfResourcesOfCount(terraformOutput, "aws_s3_bucket")).toEqual(4); // 2 buckets + 2 replicas
-      expect(tfResourcesOfCount(terraformOutput, "aws_s3_bucket_versioning")).toEqual(4); // 2 buckets + 2 replicas
+      const terraformOutput = sanitize_json_paths(
+        path.join(targetDir, "main.tf.json")
+      );
+      const terraformOutputString = JSON.stringify(terraformOutput);
+
+      expect(terraformOutput).toMatchSnapshot();
       expect(
-        tfResourcesOfCount(terraformOutput, "aws_s3_bucket_replication_configuration")
+        tfResourcesOfCount(terraformOutputString, "aws_s3_bucket")
+      ).toEqual(4); // 2 buckets + 2 replicas
+      expect(
+        tfResourcesOfCount(terraformOutputString, "aws_s3_bucket_versioning")
+      ).toEqual(4); // 2 buckets + 2 replicas
+      expect(
+        tfResourcesOfCount(
+          terraformOutputString,
+          "aws_s3_bucket_replication_configuration"
+        )
       ).toEqual(2); // 2 replica rules
     });
 
@@ -78,8 +99,11 @@ describe("Plugin examples", () => {
         shouldSucceed: true,
         plugins: [plugin],
       });
-      
-      const terraformOutput = fs.readJsonSync(path.join(targetDir, "main.tf.json"), "utf-8");
+
+      const terraformOutput = fs.readJsonSync(
+        path.join(targetDir, "main.tf.json"),
+        "utf-8"
+      );
 
       expect(terraformOutput).toMatchSnapshot();
       expect(terraformOutput.terraform.backend).toEqual({
@@ -91,5 +115,4 @@ describe("Plugin examples", () => {
       });
     });
   });
-  
 });

--- a/tools/hangar/src/utils.ts
+++ b/tools/hangar/src/utils.ts
@@ -21,7 +21,7 @@ export async function runWingCommand(options: RunWingCommandOptions) {
     env: options.env,
   });
   if (options.shouldSucceed) {
-    if (out.exitCode !== 0) {
+    if (out.exitCode !== 0 || out.stderr !== "") {
       expect.fail(out.stderr);
     }
   } else {

--- a/tools/hangar/src/utils.ts
+++ b/tools/hangar/src/utils.ts
@@ -32,8 +32,8 @@ export async function runWingCommand(options: RunWingCommandOptions) {
 }
 
 export function sanitize_json_paths(path: string) {
-  const assetKeyRegex = /"asset\..+"/g;
-  const assetSourceRegex = /"assets\/.+"/g;
+  const assetKeyRegex = /"asset\..+?"/g;
+  const assetSourceRegex = /"assets\/.+?"/g;
   const json = fs.readJsonSync(path);
 
   const jsonText = JSON.stringify(json);

--- a/tools/hangar/vitest.config.ts
+++ b/tools/hangar/vitest.config.ts
@@ -5,7 +5,6 @@ export default defineConfig({
   test: {
     testTimeout: 200_000,
     globalSetup: "src/package.setup.ts",
-    update: true,
     resolveSnapshotPath(path, extension) {
       const baseSnapshotPath = join(__dirname, "__snapshots__");
       const srcPath = join(__dirname, "src");


### PR DESCRIPTION
Several whoopsies at once:

- Vitest config accidentally had `update: true`, so snapshots always updated instead of failing
- The recent starts_with and ends_with change didn't work, but this was considered a snapshot change so it was unnoticed. Added additional code to hangar to always fail if there's stderr when unexpected
- Snapshots had an unsanitized path for the new plugin tests, causing constant change
- Snapshots we're actually being overly-sanitized in many cases, causing chunks to be deleted from the terraform output
- During `main` builds, things were being published before e2e tests were run


*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.