### PR TITLE
chore: feats should only increment patch version by default

### DIFF
--- a/scripts/changelog.mjs
+++ b/scripts/changelog.mjs
@@ -36,6 +36,10 @@ async function getData() {
         title: "🚀 Features",
         semver: "patch",
       },
+      revert: {
+        title: "⏪ Reverts",
+        semver: "patch",
+      },
     },
   });
 

--- a/scripts/changelog.mjs
+++ b/scripts/changelog.mjs
@@ -32,6 +32,10 @@ async function getData() {
         title: "👓 RFC",
         semver: "patch",
       },
+      feat: {
+        title: "🚀 Features",
+        semver: "patch",
+      },
     },
   });
 


### PR DESCRIPTION
Regression from https://github.com/winglang/wing/pull/1902 (thanks @Chriscbr)

If it's a breaking change, then it'll increment minor

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.