### PR TITLE
fix: unavailable global property crashes simulator

### DIFF
--- a/libs/wingsdk/src/target-sim/function.inflight.ts
+++ b/libs/wingsdk/src/target-sim/function.inflight.ts
@@ -109,6 +109,7 @@ async function runInSandbox(code: string, payload: any, opts: RunCodeOptions) {
       ctx[k] = (global as any)[k];
     } catch {
       // ignore unresolvable globals
+      // see https://github.com/winglang/wing/pull/1923
     }
   }
 

--- a/libs/wingsdk/src/target-sim/function.inflight.ts
+++ b/libs/wingsdk/src/target-sim/function.inflight.ts
@@ -105,7 +105,11 @@ async function runInSandbox(code: string, payload: any, opts: RunCodeOptions) {
 
   // create a copy of all the globals from our current context.
   for (const k of Object.getOwnPropertyNames(global)) {
-    ctx[k] = (global as any)[k];
+    try {
+      ctx[k] = (global as any)[k];
+    } catch {
+      // ignore unresolvable globals
+    }
   }
 
   // append the user's context


### PR DESCRIPTION
When copying global for the new sim context, accessing `global.wasi` triggered a `require` that fails. This only seems to happens in a REPL 🤷 

In any case, a corrupted global obj probably isn't worth crashing over. I'm not even sure it's worth logging, feel free to let me know if you do.

Fixes #1912

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.