### PR TITLE
chore(build): pull redis image in mutate workflow

### DIFF
--- a/.github/workflows/wingsdk-mutation.yml
+++ b/.github/workflows/wingsdk-mutation.yml
@@ -39,6 +39,8 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           token: ${{ secrets.MUTATION_TOKEN }}
+      - name: Pull redis docker image
+        run: docker pull redis
       # Reads versions from root package.json "volta" section
       - name: Setup Node/NPM with pinned Volta version
         uses: volta-cli/action@v4.0.0


### PR DESCRIPTION
This PR adds the redis image pull step to mutate workflow. This is being done in a separate PR from https://github.com/winglang/wing/pull/1742 so that we do not have to force merge the redis sim PR and mutate workflow can succeed running redis tests.

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.