### PR TITLE
fix(build): allow window install hooks for dockerode

### DIFF
--- a/tools/hangar/src/package.setup.ts
+++ b/tools/hangar/src/package.setup.ts
@@ -57,7 +57,8 @@ export default async function () {
     /> cpu-features@.* install/,
     /> ssh2@.* install/,
     /> node install\.js/,
-    /> node buildcheck\.js/
+    /> node buildcheck\.js/,
+    /> .*sshcrypto.node/
   ];
 
   const installHooks = installResult.stdout.match(/>.*/g)?.filter((hook) => {


### PR DESCRIPTION
Need to allow install scripts for dockerode in windows.

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.