### PR TITLE
chore: publish wingsdk before wing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -211,15 +211,6 @@ jobs:
       - name: Login to NPM registry
         run: npm set //registry.npmjs.org/:_authToken ${{ secrets.NPM_PUBLISH_TOKEN }}
 
-      - name: Check published Wing version
-        id: wing-version
-        run: echo "version=$(npm view winglang version)" >> $GITHUB_OUTPUT
-
-      - name: Publish Wing
-        if: ${{ steps.wing-version.outputs.version != needs.build.outputs.version }}
-        working-directory: wing
-        run: npm publish *.tgz --access public
-
       - name: Check published WingSDK version
         id: wingsdk-version
         run: echo "version=$(npm view @winglang/sdk version)" >> $GITHUB_OUTPUT
@@ -227,6 +218,15 @@ jobs:
       - name: Publish Wing SDK
         if: ${{ steps.wingsdk-version.outputs.version != needs.build.outputs.version }}
         working-directory: wingsdk
+        run: npm publish *.tgz --access public
+
+      - name: Check published Wing version
+        id: wing-version
+        run: echo "version=$(npm view winglang version)" >> $GITHUB_OUTPUT
+
+      - name: Publish Wing
+        if: ${{ steps.wing-version.outputs.version != needs.build.outputs.version }}
+        working-directory: wing
         run: npm publish *.tgz --access public
 
       - name: Rename Docs


### PR DESCRIPTION
`winglang` depends on `@winglang/sdk`, so publishing `winglang` first doesn't make sense and can lead to a scenario where `winglang` is published where no matching sdk version is available.

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.