### PR TITLE
fix(sdk): correct redis container name in case of resource nesting (fix #1959)

### DIFF
--- a/libs/wingsdk/src/target-sim/redis.inflight.ts
+++ b/libs/wingsdk/src/target-sim/redis.inflight.ts
@@ -24,7 +24,7 @@ export class Redis implements IRedisClient, ISimulatorResourceInstance {
   public constructor(_props: RedisSchema["props"], context: ISimulatorContext) {
     this.context = context;
     this.container_name = `wing-sim-redis-${this.context.resourcePath.replace(
-      "/",
+      /\//g,
       "."
     )}-${uuidv4()}`;
   }


### PR DESCRIPTION
See #1959

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.