### PR TITLE
chore(compiler): cleanups in type checker

### DIFF
--- a/examples/tests/valid/json.w
+++ b/examples/tests/valid/json.w
@@ -76,3 +76,9 @@ let arr = Json [1, 2, b, "my", "shoe", 3, 4, [ "shut", "the", "door"]];
 assert(arr.get_at(0) == 1);
 assert(arr.get_at(2) == b);
 assert(arr.get_at(7).get_at(0) == "shut");
+
+// Nested Json with mixed Json and non-json literals
+Json {
+  a: Json [1, 2, "world"],
+  b: [1, 2, "world"], // Verify the type-checker knows we're still in a Json after handling `a` above
+};

--- a/libs/wingc/src/ast.rs
+++ b/libs/wingc/src/ast.rs
@@ -273,8 +273,6 @@ pub struct Stmt {
 	pub kind: StmtKind,
 	pub span: WingSpan,
 	pub idx: usize,
-	// #[derivative(Debug = "ignore")]
-	// pub generated_resources: RefCell<Option<Vec<TypeRef>>>,
 }
 
 #[derive(Debug)]

--- a/libs/wingc/src/ast.rs
+++ b/libs/wingc/src/ast.rs
@@ -195,6 +195,13 @@ pub enum FunctionBody {
 	External(String),
 }
 
+pub trait MethodLike {
+	fn statements(&self) -> Option<&Scope>;
+	fn parameters(&self) -> &Vec<(Symbol, bool)>;
+	fn signature(&self) -> &FunctionSignature;
+	fn is_static(&self) -> bool;
+}
+
 #[derive(Derivative)]
 #[derivative(Debug)]
 pub struct FunctionDefinition {
@@ -213,6 +220,27 @@ pub struct FunctionDefinition {
 	pub captures: RefCell<Option<Captures>>,
 }
 
+impl MethodLike for FunctionDefinition {
+	fn statements(&self) -> Option<&Scope> {
+		match &self.body {
+			FunctionBody::Statements(statements) => Some(statements),
+			FunctionBody::External(_) => None,
+		}
+	}
+
+	fn parameters(&self) -> &Vec<(Symbol, bool)> {
+		&self.parameters
+	}
+
+	fn signature(&self) -> &FunctionSignature {
+		&self.signature
+	}
+
+	fn is_static(&self) -> bool {
+		self.is_static
+	}
+}
+
 #[derive(Debug)]
 pub struct Constructor {
 	/// List of names of constructor parameters and whether they are reassignable (`var`) or not.
@@ -222,11 +250,31 @@ pub struct Constructor {
 	pub signature: FunctionSignature,
 }
 
-#[derive(Debug)]
+impl MethodLike for Constructor {
+	fn statements(&self) -> Option<&Scope> {
+		Some(&self.statements)
+	}
+
+	fn parameters(&self) -> &Vec<(Symbol, bool)> {
+		&self.parameters
+	}
+
+	fn signature(&self) -> &FunctionSignature {
+		&self.signature
+	}
+
+	fn is_static(&self) -> bool {
+		true
+	}
+}
+
+#[derive(Derivative, Debug)]
 pub struct Stmt {
 	pub kind: StmtKind,
 	pub span: WingSpan,
 	pub idx: usize,
+	// #[derivative(Debug = "ignore")]
+	// pub generated_resources: RefCell<Option<Vec<TypeRef>>>,
 }
 
 #[derive(Debug)]

--- a/libs/wingc/src/type_check.rs
+++ b/libs/wingc/src/type_check.rs
@@ -1,8 +1,9 @@
 mod jsii_importer;
 pub mod symbol_env;
 use crate::ast::{
-	ArgList, BinaryOperator, Class as AstClass, Expr, ExprKind, FunctionBody, InterpolatedStringPart, Literal,
-	MethodLike, Phase, Reference, Scope, Stmt, StmtKind, Symbol, ToSpan, TypeAnnotation, UnaryOperator, UserDefinedType,
+	ArgList, BinaryOperator, Class as AstClass, Expr, ExprKind, FunctionBody, Interface as AstInterface,
+	InterpolatedStringPart, Literal, MethodLike, Phase, Reference, Scope, Stmt, StmtKind, Symbol, ToSpan, TypeAnnotation,
+	UnaryOperator, UserDefinedType,
 };
 use crate::diagnostic::{Diagnostic, DiagnosticLevel, Diagnostics, TypeError};
 use crate::{
@@ -1611,7 +1612,6 @@ impl<'a> TypeChecker<'a> {
 			Some(env.get_ref()),
 			sig.return_type,
 			false,
-			false,
 			func_def.signature.phase,
 			self.statement_idx,
 		);
@@ -2299,8 +2299,7 @@ impl<'a> TypeChecker<'a> {
 
 				// Add methods to the interface env
 				for (method_name, sig) in methods.iter() {
-					let mut method_type =
-						self.resolve_type_annotation(&TypeAnnotation::FunctionSignature(sig.clone()), env, stmt.idx);
+					let mut method_type = self.resolve_type_annotation(&TypeAnnotation::FunctionSignature(sig.clone()), env);
 					// use the interface type as the function's "this" type
 					if let Type::Function(ref mut f) = *method_type {
 						f.this_type = Some(interface_type.clone());
@@ -2478,7 +2477,6 @@ impl<'a> TypeChecker<'a> {
 		let mut method_env = SymbolEnv::new(
 			Some(env.get_ref()),
 			method_sig.return_type,
-			false,
 			is_init,
 			method_sig.phase,
 			statement_idx,

--- a/libs/wingc/src/type_check.rs
+++ b/libs/wingc/src/type_check.rs
@@ -1794,7 +1794,11 @@ impl<'a> TypeChecker<'a> {
 	}
 
 	fn type_check_statement(&mut self, stmt: &Stmt, env: &mut SymbolEnv) {
+		// Set the current statement index for symbol lookup checks. We can safely assume we're
+		// not overwriting the current statement index because `type_check_statement` is never
+		// recursively called (we use a breadth-first traversal of the AST statements).
 		self.statement_idx = stmt.idx;
+
 		match &stmt.kind {
 			StmtKind::VariableDef {
 				reassignable,

--- a/libs/wingc/src/type_check.rs
+++ b/libs/wingc/src/type_check.rs
@@ -998,7 +998,6 @@ pub struct TypeChecker<'a> {
 
 	in_json: bool,
 	statement_idx: usize,
-	// generated_resource_counter: usize,
 }
 
 impl<'a> TypeChecker<'a> {
@@ -1528,15 +1527,7 @@ impl<'a> TypeChecker<'a> {
 				container_type
 			}
 			ExprKind::FunctionClosure(func_def) => {
-				// TODO: make sure this function returns on all control paths when there's a return type (can be done by recursively traversing the statements and making sure there's a "return" statements in all control paths)
-
-				// When defining an inflight closure in and preflight env we need to generate a custom resource with a `handle` method for the closure's content
-				// and evaluate this expression to and instance of that custom resource.
-				/*				if func_def.signature.phase == Phase::Inflight && env.phase == Phase::Preflight {
-					self.type_check_inflight_closure(func_def, env, statement_idx)
-				} else {*/
 				self.type_check_closure(func_def, env)
-				//				}
 			}
 			ExprKind::OptionalTest { optional } => {
 				let t = self.type_check_exp(optional, env);
@@ -1548,60 +1539,8 @@ impl<'a> TypeChecker<'a> {
 		}
 	}
 
-	// fn type_check_inflight_closure(
-	// 	&mut self,
-	// 	func_def: &crate::ast::FunctionDefinition,
-	// 	env: &SymbolEnv,
-	// 	statement_idx: usize,
-	// ) {
-	// 	// Validate we're in preflight
-	// 	assert!(env.phase == Phase::Preflight);
-	// 	// Create a a name for the generated resource
-	// 	self.generated_resource_counter += 1;
-	// 	let generated_resoruce_symb = Symbol {
-	// 		name: format!("_$GeneratedResource{}", self.generated_resource_counter),
-	// 		span: func_def.span,
-	// 	};
-	// 	// Create environment for the generated resource
-	// 	let generated_resource_env = SymbolEnv::new(None, self.types.void(), true, false, Phase::Preflight, statement_idx);
-	// 	// Add a single `handle` method to the env
-	// 	let handle_method_symb = Symbol {
-	// 		name: "handle".to_string(),
-	// 		span: func_def.span,
-	// 	};
-	// 	generated_resource_env.define(
-	// 		&handle_method_symb,
-	// 		SymbolKind::Variable(VariableInfo {
-	// 			type_: self.type_check_closure(func_def, env, statement_idx),
-	// 			reassignable: false,
-	// 			phase: Phase::Inflight,
-	// 			is_static: false,
-	// 		}),
-	// 		StatementIdx::Index(1),
-	// 	);
-	// 	// Create a resource type for the inflight closure
-	// 	let closure_resource_type = self.types.add_type(Type::Resource(Class {
-	// 		name: generated_resoruce_symb,
-	// 		parent: None,
-	// 		implements: vec![],
-	// 		env: generated_resource_env,
-	// 		should_case_convert_jsii: false,
-	// 		fqn: None,
-	// 		is_abstract: false,
-	// 		type_parameters: None,
-	// 	}));
-	// 	// Type check the `handle` method body
-	// 	self.type_check_method(
-	// 		&generated_resource_env,
-	// 		&handle_method_symb,
-	// 		env,
-	// 		statement_idx,
-	// 		func_def,
-	// 		closure_resource_type,
-	// 	)
-	// }
-
 	fn type_check_closure(&mut self, func_def: &crate::ast::FunctionDefinition, env: &SymbolEnv) -> UnsafeRef<Type> {
+		// TODO: make sure this function returns on all control paths when there's a return type (can be done by recursively traversing the statements and making sure there's a "return" statements in all control paths)
 		// Create a type_checker function signature from the AST function definition
 		let function_type =
 			self.resolve_type_annotation(&TypeAnnotation::FunctionSignature(func_def.signature.clone()), env);
@@ -2460,6 +2399,7 @@ impl<'a> TypeChecker<'a> {
 	) where
 		T: MethodLike,
 	{
+		// TODO: make sure this function returns on all control paths when there's a return type (can be done by recursively traversing the statements and making sure there's a "return" statements in all control paths)
 		// Lookup the method in the class_env
 		let method_type = class_env
 			.lookup(method_name, None)

--- a/libs/wingc/src/type_check.rs
+++ b/libs/wingc/src/type_check.rs
@@ -1526,9 +1526,7 @@ impl<'a> TypeChecker<'a> {
 
 				container_type
 			}
-			ExprKind::FunctionClosure(func_def) => {
-				self.type_check_closure(func_def, env)
-			}
+			ExprKind::FunctionClosure(func_def) => self.type_check_closure(func_def, env),
 			ExprKind::OptionalTest { optional } => {
 				let t = self.type_check_exp(optional, env);
 				if !t.is_option() {


### PR DESCRIPTION
* don't pass statement index all around the type checker, instead store it in the TypeChecker sate.
* Store `in_json` in the type checker state instead of adding the extra context struct.
* removed duplicate code for method/init type checking 

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.