### PR TITLE
fix(compiler): allow unused sim resources

### DIFF
--- a/examples/tests/valid/resource_captures.w
+++ b/examples/tests/valid/resource_captures.w
@@ -36,9 +36,11 @@ resource MyResource {
   set_of_str: Set<str>;
   another: Another;
   my_queue: cloud.Queue;
+  unused_resource: cloud.Counter;
 
   ext_bucket: cloud.Bucket;
   ext_num: num;
+
 
   // Needs to be var since we don't support inflight inits yet.
   inflight var inflight_field: num;
@@ -59,6 +61,7 @@ resource MyResource {
     this.my_queue = new cloud.Queue();
     this.ext_bucket = external_bucket;
     this.ext_num = external_num;
+    this.unused_resource = new cloud.Counter();
   }
 
   inflight test_no_capture() {

--- a/libs/wingc/src/jsify.rs
+++ b/libs/wingc/src/jsify.rs
@@ -1218,17 +1218,17 @@ impl<'a> JSifier<'a> {
 			self.diagnostics.extend(find_diags);
 
 			// Add no-ops for fields that are not referenced
-			resource_class
+			let resource_fields = resource_class
 				.fields
 				.iter()
-        .filter(|f| f.phase == Phase::Preflight)
-				.map(|f| format!("this.{}", f.name.name))
-				.filter(|f| !refs.contains_key(f.as_str()))
-				.collect::<Vec<String>>()
-				.iter()
-				.for_each(|f| {
-					refs.insert(String::from(f.clone()), BTreeSet::new());
-				});
+				.filter(|f| f.phase == Phase::Preflight)
+				.map(|f| format!("this.{}", f.name.name));
+
+			for f in resource_fields {
+				if !refs.contains_key(f.as_str()) {
+					refs.insert(f, BTreeSet::new());
+				}
+			}
 
 			// add the references to the result
 			result.push((method_name.name.clone(), refs));

--- a/libs/wingc/src/jsify.rs
+++ b/libs/wingc/src/jsify.rs
@@ -959,7 +959,6 @@ impl<'a> JSifier<'a> {
 
 		// Get all references between inflight methods and preflight fields
 		let refs = self.find_inflight_references(class);
-
 		// Get fields to be captured by resource's client
 		let captured_fields = self.get_captures(resource_type);
 
@@ -1058,14 +1057,10 @@ impl<'a> JSifier<'a> {
 		)
 	}
 
-	fn jsify_toinflight_method(
-		&mut self,
-		resource_name: &Symbol,
-		captured_fields: &[(String, TypeRef, Vec<String>)],
-	) -> String {
+	fn jsify_toinflight_method(&mut self, resource_name: &Symbol, captured_fields: &[String]) -> String {
 		let inner_clients = captured_fields
 			.iter()
-			.map(|(inner_member_name, _, _)| {
+			.map(|inner_member_name| {
 				format!(
 					"const {}_client = this._lift(this.{});",
 					inner_member_name, inner_member_name,
@@ -1077,7 +1072,7 @@ impl<'a> JSifier<'a> {
 		let client_path = Self::js_resolve_path(&format!("{}/{}.inflight.js", INFLIGHT_CLIENTS_DIR, resource_name.name));
 		let captured_fields = captured_fields
 			.iter()
-			.map(|(inner_member_name, _, _)| format!("{}: ${{{}_client}}", inner_member_name, inner_member_name))
+			.map(|inner_member_name| format!("{}: ${{{}_client}}", inner_member_name, inner_member_name))
 			.join(", ");
 		formatdoc!("
 			_toInflight() {{
@@ -1094,7 +1089,7 @@ impl<'a> JSifier<'a> {
 		&mut self,
 		env: &SymbolEnv,
 		name: &Symbol,
-		captured_fields: &[(String, TypeRef, Vec<String>)],
+		captured_fields: &[String],
 		inflight_methods: &[&(Symbol, FunctionDefinition)],
 		parent: &Option<UserDefinedType>,
 		context: &JSifyContext,
@@ -1109,17 +1104,13 @@ impl<'a> JSifier<'a> {
 		// Get the fields that are captured by this resource but not by its parent, they will be initialized in the generated constructor
 		let my_captures = captured_fields
 			.iter()
-			.filter(|(name, _, _)| !parent_captures.iter().any(|(n, _, _)| n == name))
+			.filter(|name| !parent_captures.iter().any(|n| n == *name))
 			.collect_vec();
 
 		let super_call = if parent.is_some() {
 			format!(
 				"  super({});",
-				parent_captures
-					.iter()
-					.map(|(name, _, _)| name.clone())
-					.collect_vec()
-					.join(", ")
+				parent_captures.iter().map(|name| name.clone()).collect_vec().join(", ")
 			)
 		} else {
 			"".to_string()
@@ -1131,13 +1122,13 @@ impl<'a> JSifier<'a> {
 			"constructor({{ {} }}) {{\n{}\n{}\n}}",
 			captured_fields
 				.iter()
-				.map(|(name, _, _)| { name.clone() })
+				.map(|name| { name.clone() })
 				.collect_vec()
 				.join(", "),
 			super_call,
 			my_captures
 				.iter()
-				.map(|(name, _, _)| { format!("  this.{} = {};", name, name) })
+				.map(|name| { format!("  this.{} = {};", name, name) })
 				.collect_vec()
 				.join("\n")
 		);
@@ -1222,9 +1213,22 @@ impl<'a> JSifier<'a> {
 		for (method_name, function_def) in inflight_methods {
 			// visit statements of method and find all references to fields ("this.xxx")
 			let visitor = FieldReferenceVisitor::new(&function_def);
-			let (refs, find_diags) = visitor.find_refs();
+			let (mut refs, find_diags) = visitor.find_refs();
 
 			self.diagnostics.extend(find_diags);
+
+			// Add no-ops for fields that are not referenced
+			resource_class
+				.fields
+				.iter()
+        .filter(|f| f.phase == Phase::Preflight)
+				.map(|f| format!("this.{}", f.name.name))
+				.filter(|f| !refs.contains_key(f.as_str()))
+				.collect::<Vec<String>>()
+				.iter()
+				.for_each(|f| {
+					refs.insert(String::from(f.clone()), BTreeSet::new());
+				});
 
 			// add the references to the result
 			result.push((method_name.name.clone(), refs));
@@ -1234,7 +1238,7 @@ impl<'a> JSifier<'a> {
 	}
 
 	// Get the type and capture info for fields that are captured in the client of the given resource
-	fn get_captures(&self, resource_type: TypeRef) -> Vec<(String, TypeRef, Vec<String>)> {
+	fn get_captures(&self, resource_type: TypeRef) -> Vec<String> {
 		resource_type
 			.as_resource()
 			.unwrap()
@@ -1245,29 +1249,7 @@ impl<'a> JSifier<'a> {
 				// We capture preflight non-reassignable fields
 				var.phase != Phase::Inflight && !var.reassignable && var.type_.is_capturable()
 			})
-			.map(|(name, kind, _)| {
-				let _type = kind.as_variable().unwrap().type_;
-				// TODO: For now we collect all the inflight methods in the resource (in the future we
-				// we'll need to analyze each inflight method to see what it does with the captured resource)
-				let methods = if _type.as_resource().is_some() {
-					_type
-						.as_resource()
-						.unwrap()
-						.methods(true)
-						.filter_map(|(name, sig)| {
-							if sig.as_function_sig().unwrap().phase == Phase::Inflight {
-								Some(name)
-							} else {
-								None
-							}
-						})
-						.collect_vec()
-				} else {
-					vec![]
-				};
-
-				(name, _type, methods)
-			})
+			.map(|(name, ..)| name)
 			.collect_vec()
 	}
 }

--- a/tools/hangar/__snapshots__/test_corpus/valid/resource.w.ts.snap
+++ b/tools/hangar/__snapshots__/test_corpus/valid/resource.w.ts.snap
@@ -279,7 +279,7 @@ const name_client = this._lift(this.name);
 	return $stdlib.core.NodeJsCode.fromInline(\`(new (require(\\"\${self_client_path}\\")).Bar({b: \${b_client}, foo: \${foo_client}, name: \${name_client}}))\`);
 }
 }
-Bar._annotateInflight(\\"my_method\\", {\\"this.b\\": { ops: [\\"get\\",\\"put\\"] },\\"this.foo\\": { ops: [\\"foo_get\\",\\"foo_inc\\"] }});
+Bar._annotateInflight(\\"my_method\\", {\\"this.b\\": { ops: [\\"get\\",\\"put\\"] },\\"this.foo\\": { ops: [\\"foo_get\\",\\"foo_inc\\"] },\\"this.name\\": { ops: [] }});
     const bucket = this.node.root.newAbstract(\\"@winglang/sdk.cloud.Bucket\\",this,\\"cloud.Bucket\\");
     const res = new Bar(this,\\"Bar\\",\\"Arr\\",bucket);
     this.node.root.newAbstract(\\"@winglang/sdk.cloud.Function\\",this,\\"test\\",new $stdlib.core.Inflight(this, \\"$Inflight1\\", {

--- a/tools/hangar/__snapshots__/test_corpus/valid/resource_captures.w.ts.snap
+++ b/tools/hangar/__snapshots__/test_corpus/valid/resource_captures.w.ts.snap
@@ -32,7 +32,7 @@ exports.First = First;"
 
 exports[`wing compile -t tf-aws > clients/MyResource.inflight.js 1`] = `
 "class MyResource  {
-constructor({ another, array_of_str, ext_bucket, ext_num, map_of_num, my_bool, my_num, my_queue, my_resource, my_str, set_of_str }) {
+constructor({ another, array_of_str, ext_bucket, ext_num, map_of_num, my_bool, my_num, my_queue, my_resource, my_str, set_of_str, unused_resource }) {
 
   this.another = another;
   this.array_of_str = array_of_str;
@@ -45,6 +45,7 @@ constructor({ another, array_of_str, ext_bucket, ext_num, map_of_num, my_bool, m
   this.my_resource = my_resource;
   this.my_str = my_str;
   this.set_of_str = set_of_str;
+  this.unused_resource = unused_resource;
 }
 async test_no_capture()  {
 	{
@@ -147,6 +148,25 @@ exports[`wing compile -t tf-aws > main.tf.json 1`] = `
     ],
   },
   "resource": {
+    "aws_dynamodb_table": {
+      "root_MyResource_cloudCounter_B6FF7B6A": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/MyResource/cloud.Counter/Default",
+            "uniqueId": "root_MyResource_cloudCounter_B6FF7B6A",
+          },
+        },
+        "attribute": [
+          {
+            "name": "id",
+            "type": "S",
+          },
+        ],
+        "billing_mode": "PAY_PER_REQUEST",
+        "hash_key": "id",
+        "name": "wing-counter-cloud.Counter-c87187fa",
+      },
+    },
     "aws_iam_role": {
       "root_test_IamRole_6CDC2D16": {
         "//": {
@@ -198,6 +218,7 @@ exports[`wing compile -t tf-aws > main.tf.json 1`] = `
             "BUCKET_NAME_830bf023_IS_PUBLIC": "false",
             "BUCKET_NAME_d755b447": "\${aws_s3_bucket.root_cloudBucket_4F3C4F53.bucket}",
             "BUCKET_NAME_d755b447_IS_PUBLIC": "false",
+            "DYNAMODB_TABLE_NAME_5afed199": "\${aws_dynamodb_table.root_MyResource_cloudCounter_B6FF7B6A.name}",
             "QUEUE_URL_ea9f63d6": "\${aws_sqs_queue.root_MyResource_cloudQueue_156CFA11.url}",
             "WING_FUNCTION_NAME": "test-c8b6eece",
           },

--- a/tools/hangar/__snapshots__/test_corpus/valid/resource_captures.w.ts.snap
+++ b/tools/hangar/__snapshots__/test_corpus/valid/resource_captures.w.ts.snap
@@ -152,7 +152,7 @@ exports[`wing compile -t tf-aws > main.tf.json 1`] = `
       "root_MyResource_cloudCounter_B6FF7B6A": {
         "//": {
           "metadata": {
-            "path": "root/Default/MyResource/cloud.Counter/Default",
+            "path": "root/Default/Default/MyResource/cloud.Counter/Default",
             "uniqueId": "root_MyResource_cloudCounter_B6FF7B6A",
           },
         },
@@ -452,8 +452,8 @@ const my_field_client = this._lift(this.my_field);
 	return $stdlib.core.NodeJsCode.fromInline(\`(new (require(\\"\${self_client_path}\\")).Another({first: \${first_client}, my_field: \${my_field_client}}))\`);
 }
 }
-Another._annotateInflight(\\"meaning_of_life\\", {});
-Another._annotateInflight(\\"another_func\\", {});
+Another._annotateInflight(\\"meaning_of_life\\", {\\"this.first\\": { ops: [] },\\"this.my_field\\": { ops: [] }});
+Another._annotateInflight(\\"another_func\\", {\\"this.first\\": { ops: [] },\\"this.my_field\\": { ops: [] }});
     class MyResource extends $stdlib.core.Resource {
 	constructor(scope, id, external_bucket, external_num) {
 	super(scope, id);
@@ -469,6 +469,7 @@ Another._annotateInflight(\\"another_func\\", {});
   this.my_queue = this.node.root.newAbstract(\\"@winglang/sdk.cloud.Queue\\",this,\\"cloud.Queue\\");
   this.ext_bucket = external_bucket;
   this.ext_num = external_num;
+  this.unused_resource = this.node.root.newAbstract(\\"@winglang/sdk.cloud.Counter\\",this,\\"cloud.Counter\\");
 }
 }
 	 hello_preflight()  {
@@ -488,20 +489,21 @@ const my_queue_client = this._lift(this.my_queue);
 const my_resource_client = this._lift(this.my_resource);
 const my_str_client = this._lift(this.my_str);
 const set_of_str_client = this._lift(this.set_of_str);
+const unused_resource_client = this._lift(this.unused_resource);
 	const self_client_path = \\"./clients/MyResource.inflight.js\\".replace(/\\\\\\\\/g, \\"/\\");
-	return $stdlib.core.NodeJsCode.fromInline(\`(new (require(\\"\${self_client_path}\\")).MyResource({another: \${another_client}, array_of_str: \${array_of_str_client}, ext_bucket: \${ext_bucket_client}, ext_num: \${ext_num_client}, map_of_num: \${map_of_num_client}, my_bool: \${my_bool_client}, my_num: \${my_num_client}, my_queue: \${my_queue_client}, my_resource: \${my_resource_client}, my_str: \${my_str_client}, set_of_str: \${set_of_str_client}}))\`);
+	return $stdlib.core.NodeJsCode.fromInline(\`(new (require(\\"\${self_client_path}\\")).MyResource({another: \${another_client}, array_of_str: \${array_of_str_client}, ext_bucket: \${ext_bucket_client}, ext_num: \${ext_num_client}, map_of_num: \${map_of_num_client}, my_bool: \${my_bool_client}, my_num: \${my_num_client}, my_queue: \${my_queue_client}, my_resource: \${my_resource_client}, my_str: \${my_str_client}, set_of_str: \${set_of_str_client}, unused_resource: \${unused_resource_client}}))\`);
 }
 }
-MyResource._annotateInflight(\\"test_no_capture\\", {});
-MyResource._annotateInflight(\\"test_capture_collections_of_data\\", {\\"this.array_of_str\\": { ops: [\\"at\\",\\"length\\"] },\\"this.map_of_num\\": { ops: [\\"get\\"] },\\"this.set_of_str\\": { ops: [\\"has\\"] }});
-MyResource._annotateInflight(\\"test_capture_primitives\\", {\\"this.my_bool\\": { ops: [] },\\"this.my_num\\": { ops: [] },\\"this.my_str\\": { ops: [] }});
-MyResource._annotateInflight(\\"test_capture_resource\\", {\\"this.my_resource\\": { ops: [\\"get\\",\\"list\\",\\"put\\"] }});
-MyResource._annotateInflight(\\"test_nested_preflight_field\\", {\\"this.another.my_field\\": { ops: [] }});
-MyResource._annotateInflight(\\"test_nested_resource\\", {\\"this.another.first.my_resource\\": { ops: [\\"get\\",\\"list\\",\\"put\\"] },\\"this.my_str\\": { ops: [] }});
-MyResource._annotateInflight(\\"test_expression_recursive\\", {\\"this.my_queue\\": { ops: [\\"push\\"] },\\"this.my_str\\": { ops: [] }});
-MyResource._annotateInflight(\\"test_external\\", {\\"this.ext_bucket\\": { ops: [\\"list\\"] },\\"this.ext_num\\": { ops: [] }});
-MyResource._annotateInflight(\\"test_user_defined_resource\\", {\\"this.another\\": { ops: [\\"another_func\\",\\"meaning_of_life\\"] }});
-MyResource._annotateInflight(\\"test_inflight_field\\", {});
+MyResource._annotateInflight(\\"test_no_capture\\", {\\"this.another\\": { ops: [] },\\"this.array_of_str\\": { ops: [] },\\"this.ext_bucket\\": { ops: [] },\\"this.ext_num\\": { ops: [] },\\"this.map_of_num\\": { ops: [] },\\"this.my_bool\\": { ops: [] },\\"this.my_num\\": { ops: [] },\\"this.my_queue\\": { ops: [] },\\"this.my_resource\\": { ops: [] },\\"this.my_str\\": { ops: [] },\\"this.set_of_str\\": { ops: [] },\\"this.unused_resource\\": { ops: [] }});
+MyResource._annotateInflight(\\"test_capture_collections_of_data\\", {\\"this.another\\": { ops: [] },\\"this.array_of_str\\": { ops: [\\"at\\",\\"length\\"] },\\"this.ext_bucket\\": { ops: [] },\\"this.ext_num\\": { ops: [] },\\"this.map_of_num\\": { ops: [\\"get\\"] },\\"this.my_bool\\": { ops: [] },\\"this.my_num\\": { ops: [] },\\"this.my_queue\\": { ops: [] },\\"this.my_resource\\": { ops: [] },\\"this.my_str\\": { ops: [] },\\"this.set_of_str\\": { ops: [\\"has\\"] },\\"this.unused_resource\\": { ops: [] }});
+MyResource._annotateInflight(\\"test_capture_primitives\\", {\\"this.another\\": { ops: [] },\\"this.array_of_str\\": { ops: [] },\\"this.ext_bucket\\": { ops: [] },\\"this.ext_num\\": { ops: [] },\\"this.map_of_num\\": { ops: [] },\\"this.my_bool\\": { ops: [] },\\"this.my_num\\": { ops: [] },\\"this.my_queue\\": { ops: [] },\\"this.my_resource\\": { ops: [] },\\"this.my_str\\": { ops: [] },\\"this.set_of_str\\": { ops: [] },\\"this.unused_resource\\": { ops: [] }});
+MyResource._annotateInflight(\\"test_capture_resource\\", {\\"this.another\\": { ops: [] },\\"this.array_of_str\\": { ops: [] },\\"this.ext_bucket\\": { ops: [] },\\"this.ext_num\\": { ops: [] },\\"this.map_of_num\\": { ops: [] },\\"this.my_bool\\": { ops: [] },\\"this.my_num\\": { ops: [] },\\"this.my_queue\\": { ops: [] },\\"this.my_resource\\": { ops: [\\"get\\",\\"list\\",\\"put\\"] },\\"this.my_str\\": { ops: [] },\\"this.set_of_str\\": { ops: [] },\\"this.unused_resource\\": { ops: [] }});
+MyResource._annotateInflight(\\"test_nested_preflight_field\\", {\\"this.another\\": { ops: [] },\\"this.another.my_field\\": { ops: [] },\\"this.array_of_str\\": { ops: [] },\\"this.ext_bucket\\": { ops: [] },\\"this.ext_num\\": { ops: [] },\\"this.map_of_num\\": { ops: [] },\\"this.my_bool\\": { ops: [] },\\"this.my_num\\": { ops: [] },\\"this.my_queue\\": { ops: [] },\\"this.my_resource\\": { ops: [] },\\"this.my_str\\": { ops: [] },\\"this.set_of_str\\": { ops: [] },\\"this.unused_resource\\": { ops: [] }});
+MyResource._annotateInflight(\\"test_nested_resource\\", {\\"this.another\\": { ops: [] },\\"this.another.first.my_resource\\": { ops: [\\"get\\",\\"list\\",\\"put\\"] },\\"this.array_of_str\\": { ops: [] },\\"this.ext_bucket\\": { ops: [] },\\"this.ext_num\\": { ops: [] },\\"this.map_of_num\\": { ops: [] },\\"this.my_bool\\": { ops: [] },\\"this.my_num\\": { ops: [] },\\"this.my_queue\\": { ops: [] },\\"this.my_resource\\": { ops: [] },\\"this.my_str\\": { ops: [] },\\"this.set_of_str\\": { ops: [] },\\"this.unused_resource\\": { ops: [] }});
+MyResource._annotateInflight(\\"test_expression_recursive\\", {\\"this.another\\": { ops: [] },\\"this.array_of_str\\": { ops: [] },\\"this.ext_bucket\\": { ops: [] },\\"this.ext_num\\": { ops: [] },\\"this.map_of_num\\": { ops: [] },\\"this.my_bool\\": { ops: [] },\\"this.my_num\\": { ops: [] },\\"this.my_queue\\": { ops: [\\"push\\"] },\\"this.my_resource\\": { ops: [] },\\"this.my_str\\": { ops: [] },\\"this.set_of_str\\": { ops: [] },\\"this.unused_resource\\": { ops: [] }});
+MyResource._annotateInflight(\\"test_external\\", {\\"this.another\\": { ops: [] },\\"this.array_of_str\\": { ops: [] },\\"this.ext_bucket\\": { ops: [\\"list\\"] },\\"this.ext_num\\": { ops: [] },\\"this.map_of_num\\": { ops: [] },\\"this.my_bool\\": { ops: [] },\\"this.my_num\\": { ops: [] },\\"this.my_queue\\": { ops: [] },\\"this.my_resource\\": { ops: [] },\\"this.my_str\\": { ops: [] },\\"this.set_of_str\\": { ops: [] },\\"this.unused_resource\\": { ops: [] }});
+MyResource._annotateInflight(\\"test_user_defined_resource\\", {\\"this.another\\": { ops: [\\"another_func\\",\\"meaning_of_life\\"] },\\"this.array_of_str\\": { ops: [] },\\"this.ext_bucket\\": { ops: [] },\\"this.ext_num\\": { ops: [] },\\"this.map_of_num\\": { ops: [] },\\"this.my_bool\\": { ops: [] },\\"this.my_num\\": { ops: [] },\\"this.my_queue\\": { ops: [] },\\"this.my_resource\\": { ops: [] },\\"this.my_str\\": { ops: [] },\\"this.set_of_str\\": { ops: [] },\\"this.unused_resource\\": { ops: [] }});
+MyResource._annotateInflight(\\"test_inflight_field\\", {\\"this.another\\": { ops: [] },\\"this.array_of_str\\": { ops: [] },\\"this.ext_bucket\\": { ops: [] },\\"this.ext_num\\": { ops: [] },\\"this.map_of_num\\": { ops: [] },\\"this.my_bool\\": { ops: [] },\\"this.my_num\\": { ops: [] },\\"this.my_queue\\": { ops: [] },\\"this.my_resource\\": { ops: [] },\\"this.my_str\\": { ops: [] },\\"this.set_of_str\\": { ops: [] },\\"this.unused_resource\\": { ops: [] }});
     const b = this.node.root.newAbstract(\\"@winglang/sdk.cloud.Bucket\\",this,\\"cloud.Bucket\\");
     const r = new MyResource(this,\\"MyResource\\",b,12);
     this.node.root.newAbstract(\\"@winglang/sdk.cloud.Function\\",this,\\"test\\",new $stdlib.core.Inflight(this, \\"$Inflight1\\", {

--- a/tools/hangar/__snapshots__/test_corpus/valid/static_members.w.ts.snap
+++ b/tools/hangar/__snapshots__/test_corpus/valid/static_members.w.ts.snap
@@ -175,7 +175,7 @@ class $Root extends $stdlib.core.Resource {
 	return $stdlib.core.NodeJsCode.fromInline(\`(new (require(\\"\${self_client_path}\\")).Foo({instance_field: \${instance_field_client}}))\`);
 }
 }
-Foo._annotateInflight(\\"get_123\\", {});
+Foo._annotateInflight(\\"get_123\\", {\\"this.instance_field\\": { ops: [] }});
     const foo = new Foo(this,\\"Foo\\");
     {((cond) => {if (!cond) throw new Error(\`assertion failed: '(foo.instance_field === 100)'\`)})((foo.instance_field === 100))};
     {((cond) => {if (!cond) throw new Error(\`assertion failed: '((Foo.m()) === 99)'\`)})(((Foo.m()) === 99))};

--- a/tools/hangar/__snapshots__/test_corpus/valid/structs.w.ts.snap
+++ b/tools/hangar/__snapshots__/test_corpus/valid/structs.w.ts.snap
@@ -86,7 +86,7 @@ class $Root extends $stdlib.core.Resource {
 	return $stdlib.core.NodeJsCode.fromInline(\`(new (require(\\"\${self_client_path}\\")).Foo({data: \${data_client}}))\`);
 }
 }
-Foo._annotateInflight(\\"get_stuff\\", {\\"this.data.field0\\": { ops: [] }});
+Foo._annotateInflight(\\"get_stuff\\", {\\"this.data\\": { ops: [] },\\"this.data.field0\\": { ops: [] }});
     const x = {
 \\"field0\\": \\"Sup\\",}
 ;


### PR DESCRIPTION
Added no-ops bindings for unused fields in resources.

Thanks @Chriscbr and @yoav-steinberg for the pow-wows on this.

Closes: https://github.com/winglang/wing/issues/1872

**Misc**
- Cleaned up unneeded code in `get_captures()` where we no longer needed to return vec of tuples and can just use vec of string

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.