### PR TITLE
chore: publish workflow and versioning issues

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -232,7 +232,7 @@ jobs:
       - name: Rename Docs
         run: mv docs "docs-${{ needs.build.outputs.version }}.tgz"
 
-      - name: Write File
+      - name: Write Changelog
         uses: DamianReeves/write-file-action@v1.2
         with:
           path: "CHANGELOG.md"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -232,6 +232,13 @@ jobs:
       - name: Rename Docs
         run: mv docs "docs-${{ needs.build.outputs.version }}.tgz"
 
+      - name: Write File
+        uses: DamianReeves/write-file-action@v1.2
+        with:
+          path: "CHANGELOG.md"
+          contents: ${{ needs.build.outputs.changelog }}
+          write-mode: overwrite
+
       - name: Compute Checksums
         run: |
           mkdir dist
@@ -240,7 +247,6 @@ jobs:
           mv ./*/*.wasm ./dist
           cd dist
 
-          echo '${{ needs.build.outputs.changelog }}' > ../CHANGELOG.md
           echo '### SHA-1 Checksums' >> ../CHANGELOG.md
           echo '```' >> ../CHANGELOG.md
           sha1sum --binary * >> ../CHANGELOG.md


### PR DESCRIPTION
- changelogen does not handle multiple tags on a commit very well. Put some mitigation code in.
- If the release notes contained any characters that need escaping in bash, it broke the publish step

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.