### PR TITLE
fix(docs): refers to inflight by incorrect name

### DIFF
--- a/docs/03-concepts/02-inflight.md
+++ b/docs/03-concepts/02-inflight.md
@@ -12,8 +12,8 @@ platforms in the cloud (such as containers, CI/CD pipelines or FaaS).
 Inflights can seamlessly interact with resources through the resource's inflight
 API.
 
-The following example shows how `my_inflight` is hosted inside a cloud function
-and puts an object inside a bucket:
+The following example shows an inflight which puts an object inside a bucket,
+hosted in a cloud function:
 
 ```js
 bring cloud;


### PR DESCRIPTION
The doc text was referring to an inflight by name, but the inflight no longer has a name after https://github.com/winglang/wing/commit/62b13c6c9e6760ef9423506da366b702c686a62e



*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.