### PR TITLE
chore(compiler): clean up how parameters are modeled

### DIFF
--- a/libs/wingc/src/ast.rs
+++ b/libs/wingc/src/ast.rs
@@ -189,13 +189,6 @@ impl Display for FunctionTypeAnnotation {
 	}
 }
 
-impl Display for FunctionParameter {
-	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-		let reassignable_str = if self.reassignable { "var " } else { "" };
-		write!(f, "{}{}: {}", reassignable_str, self.name, self.type_annotation)
-	}
-}
-
 #[derive(Debug, Clone)]
 pub struct FunctionSignature {
 	pub parameters: Vec<FunctionParameter>,

--- a/libs/wingc/src/ast.rs
+++ b/libs/wingc/src/ast.rs
@@ -113,8 +113,17 @@ pub enum TypeAnnotation {
 	MutMap(Box<TypeAnnotation>),
 	Set(Box<TypeAnnotation>),
 	MutSet(Box<TypeAnnotation>),
-	FunctionSignature(FunctionSignature),
+	Function(FunctionTypeAnnotation),
 	UserDefined(UserDefinedType),
+}
+
+/// Unlike a FunctionSignature, a FunctionTypeAnnotation doesn't include the names
+/// of parameters or whether they are reassignable.
+#[derive(Debug, Clone)]
+pub struct FunctionTypeAnnotation {
+	pub param_types: Vec<TypeAnnotation>,
+	pub return_type: Option<Box<TypeAnnotation>>,
+	pub phase: Phase,
 }
 
 // In the future this may be an enum for type-alias, class, etc. For now its just a nested name.
@@ -152,13 +161,13 @@ impl Display for TypeAnnotation {
 			TypeAnnotation::MutMap(t) => write!(f, "MutMap<{}>", t),
 			TypeAnnotation::Set(t) => write!(f, "Set<{}>", t),
 			TypeAnnotation::MutSet(t) => write!(f, "MutSet<{}>", t),
-			TypeAnnotation::FunctionSignature(sig) => write!(f, "{}", sig),
+			TypeAnnotation::Function(t) => write!(f, "{}", t),
 			TypeAnnotation::UserDefined(user_defined_type) => write!(f, "{}", user_defined_type),
 		}
 	}
 }
 
-impl Display for FunctionSignature {
+impl Display for FunctionTypeAnnotation {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		let phase_str = match self.phase {
 			Phase::Inflight => "inflight ",
@@ -166,7 +175,7 @@ impl Display for FunctionSignature {
 			Phase::Independent => "",
 		};
 		let params_str = self
-			.parameters
+			.param_types
 			.iter()
 			.map(|a| format!("{}", a))
 			.collect::<Vec<String>>()
@@ -180,11 +189,35 @@ impl Display for FunctionSignature {
 	}
 }
 
+impl Display for FunctionParameter {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		let reassignable_str = if self.reassignable { "var " } else { "" };
+		write!(f, "{}{}: {}", reassignable_str, self.name, self.type_annotation)
+	}
+}
+
 #[derive(Debug, Clone)]
 pub struct FunctionSignature {
-	pub parameters: Vec<TypeAnnotation>,
+	pub parameters: Vec<FunctionParameter>,
 	pub return_type: Option<Box<TypeAnnotation>>,
 	pub phase: Phase,
+}
+
+impl FunctionSignature {
+	pub fn to_type_annotation(&self) -> TypeAnnotation {
+		TypeAnnotation::Function(FunctionTypeAnnotation {
+			param_types: self.parameters.iter().map(|p| p.type_annotation.clone()).collect(),
+			return_type: self.return_type.clone(),
+			phase: self.phase.clone(),
+		})
+	}
+}
+
+#[derive(Debug, Clone)]
+pub struct FunctionParameter {
+	pub name: Symbol,
+	pub type_annotation: TypeAnnotation,
+	pub reassignable: bool,
 }
 
 #[derive(Debug)]
@@ -197,7 +230,7 @@ pub enum FunctionBody {
 
 pub trait MethodLike {
 	fn statements(&self) -> Option<&Scope>;
-	fn parameters(&self) -> &Vec<(Symbol, bool)>;
+	fn parameters(&self) -> &Vec<FunctionParameter>;
 	fn signature(&self) -> &FunctionSignature;
 	fn is_static(&self) -> bool;
 }
@@ -205,8 +238,6 @@ pub trait MethodLike {
 #[derive(Derivative)]
 #[derivative(Debug)]
 pub struct FunctionDefinition {
-	/// List of names of function parameters and whether they are reassignable (`var`) or not.
-	pub parameters: Vec<(Symbol, bool)>, // TODO: move into FunctionSignature and make optional
 	/// The function implementation.
 	pub body: FunctionBody,
 	/// The function signature, including the return type.
@@ -228,8 +259,8 @@ impl MethodLike for FunctionDefinition {
 		}
 	}
 
-	fn parameters(&self) -> &Vec<(Symbol, bool)> {
-		&self.parameters
+	fn parameters(&self) -> &Vec<FunctionParameter> {
+		&self.signature.parameters
 	}
 
 	fn signature(&self) -> &FunctionSignature {
@@ -243,11 +274,8 @@ impl MethodLike for FunctionDefinition {
 
 #[derive(Debug)]
 pub struct Constructor {
-	/// List of names of constructor parameters and whether they are reassignable (`var`) or not.
-	pub parameters: Vec<(Symbol, bool)>,
-
-	pub statements: Scope,
 	pub signature: FunctionSignature,
+	pub statements: Scope,
 }
 
 impl MethodLike for Constructor {
@@ -255,8 +283,8 @@ impl MethodLike for Constructor {
 		Some(&self.statements)
 	}
 
-	fn parameters(&self) -> &Vec<(Symbol, bool)> {
-		&self.parameters
+	fn parameters(&self) -> &Vec<FunctionParameter> {
+		&self.signature.parameters
 	}
 
 	fn signature(&self) -> &FunctionSignature {

--- a/libs/wingc/src/jsify.rs
+++ b/libs/wingc/src/jsify.rs
@@ -812,7 +812,7 @@ impl<'a> JSifier<'a> {
 	fn jsify_constructor(&mut self, name: Option<&str>, func_def: &Constructor, context: &JSifyContext) -> String {
 		let mut parameter_list = vec![];
 
-		for p in func_def.parameters().iter() {
+		for p in func_def.parameters() {
 			parameter_list.push(self.jsify_symbol(&p.name));
 		}
 
@@ -835,7 +835,7 @@ impl<'a> JSifier<'a> {
 	fn jsify_function(&mut self, name: Option<&str>, func_def: &FunctionDefinition, context: &JSifyContext) -> String {
 		let mut parameter_list = vec![];
 
-		for p in func_def.parameters().iter() {
+		for p in func_def.parameters() {
 			parameter_list.push(self.jsify_symbol(&p.name));
 		}
 

--- a/libs/wingc/src/lsp/hover.rs
+++ b/libs/wingc/src/lsp/hover.rs
@@ -124,15 +124,12 @@ impl<'a> Visit<'a> for HoverVisitor<'a> {
 
 		if let FunctionBody::Statements(scope) = &node.body {
 			self.with_scope(scope, |v| {
-				for param in &node.parameters {
-					v.visit_symbol(&param.0);
+				for param in &node.signature.parameters {
+					v.visit_function_parameter(&param);
 				}
 			});
 		}
 
-		for param_type in &node.signature.parameters {
-			self.visit_type_annotation(param_type);
-		}
 		if let Some(return_type) = &node.signature.return_type {
 			self.visit_type_annotation(return_type);
 		}
@@ -168,16 +165,13 @@ impl<'a> Visit<'a> for HoverVisitor<'a> {
 			return;
 		}
 
-		for param_type in &node.signature.parameters {
-			self.visit_type_annotation(param_type);
-		}
 		if let Some(return_type) = &node.signature.return_type {
 			self.visit_type_annotation(return_type);
 		}
 
 		self.with_scope(&node.statements, |v| {
-			for param in &node.parameters {
-				v.visit_symbol(&param.0);
+			for param in &node.signature.parameters {
+				v.visit_function_parameter(&param);
 			}
 		});
 

--- a/libs/wingc/src/parser.rs
+++ b/libs/wingc/src/parser.rs
@@ -8,8 +8,9 @@ use tree_sitter_traversal::{traverse, Order};
 
 use crate::ast::{
 	ArgList, BinaryOperator, CatchBlock, Class, ClassField, Constructor, ElifBlock, Expr, ExprKind, FunctionBody,
-	FunctionDefinition, FunctionSignature, Interface, InterpolatedString, InterpolatedStringPart, Literal, Phase,
-	Reference, Scope, Stmt, StmtKind, Symbol, TypeAnnotation, UnaryOperator, UserDefinedType,
+	FunctionDefinition, FunctionParameter, FunctionSignature, FunctionTypeAnnotation, Interface, InterpolatedString,
+	InterpolatedStringPart, Literal, Phase, Reference, Scope, Stmt, StmtKind, Symbol, TypeAnnotation, UnaryOperator,
+	UserDefinedType,
 };
 use crate::diagnostic::{Diagnostic, DiagnosticLevel, DiagnosticResult, Diagnostics, WingSpan};
 use crate::WINGSDK_STD_MODULE;
@@ -492,10 +493,9 @@ impl<'s> Parser<'s> {
 					}
 					let parameters = self.build_parameter_list(&class_element.child_by_field_name("parameter_list").unwrap())?;
 					constructor = Some(Constructor {
-						parameters: parameters.iter().map(|p| (p.0.clone(), p.2)).collect(),
 						statements: self.build_scope(&class_element.child_by_field_name("block").unwrap()),
 						signature: FunctionSignature {
-							parameters: parameters.iter().map(|p| p.1.clone()).collect(),
+							parameters,
 							return_type: Some(Box::new(TypeAnnotation::UserDefined(UserDefinedType {
 								root: name.clone(),
 								fields: vec![],
@@ -650,13 +650,14 @@ impl<'s> Parser<'s> {
 
 	fn build_function_signature(&self, func_sig_node: &Node, phase: Phase) -> DiagnosticResult<FunctionSignature> {
 		let parameters = self.build_parameter_list(&func_sig_node.child_by_field_name("parameter_list").unwrap())?;
+		let return_type = if let Some(rt) = func_sig_node.child_by_field_name("type") {
+			Some(Box::new(self.build_type_annotation(&rt)?))
+		} else {
+			None
+		};
 		Ok(FunctionSignature {
-			parameters: parameters.iter().map(|p| p.1.clone()).collect(),
-			return_type: if let Some(rt) = func_sig_node.child_by_field_name("type") {
-				Some(Box::new(self.build_type_annotation(&rt)?))
-			} else {
-				None
-			},
+			parameters,
+			return_type,
 			phase,
 		})
 	}
@@ -677,10 +678,10 @@ impl<'s> Parser<'s> {
 		};
 
 		Ok(FunctionDefinition {
-			parameters: parameters.iter().map(|p| (p.0.clone(), p.2)).collect(),
 			body: statements,
+			// TODO: duplicated?
 			signature: FunctionSignature {
-				parameters: parameters.iter().map(|p| p.1.clone()).collect(),
+				parameters,
 				return_type: if let Some(rt) = func_def_node.child_by_field_name("type") {
 					Some(Box::new(self.build_type_annotation(&rt)?))
 				} else {
@@ -699,7 +700,7 @@ impl<'s> Parser<'s> {
 	/// # Returns
 	/// A vector of tuples for each parameter in the list. The tuples are the name, type and a bool letting
 	/// us know whether the parameter is reassignable or not respectively.
-	fn build_parameter_list(&self, parameter_list_node: &Node) -> DiagnosticResult<Vec<(Symbol, TypeAnnotation, bool)>> {
+	fn build_parameter_list(&self, parameter_list_node: &Node) -> DiagnosticResult<Vec<FunctionParameter>> {
 		let mut res = vec![];
 		let mut cursor = parameter_list_node.walk();
 		for parameter_definition_node in parameter_list_node.named_children(&mut cursor) {
@@ -707,11 +708,11 @@ impl<'s> Parser<'s> {
 				continue;
 			}
 
-			res.push((
-				self.node_symbol(&parameter_definition_node.child_by_field_name("name").unwrap())?,
-				self.build_type_annotation(&parameter_definition_node.child_by_field_name("type").unwrap())?,
-				parameter_definition_node.child_by_field_name("reassignable").is_some(),
-			))
+			res.push(FunctionParameter {
+				name: self.node_symbol(&parameter_definition_node.child_by_field_name("name").unwrap())?,
+				type_annotation: self.build_type_annotation(&parameter_definition_node.child_by_field_name("type").unwrap())?,
+				reassignable: parameter_definition_node.child_by_field_name("reassignable").is_some(),
+			});
 		}
 
 		Ok(res)
@@ -735,15 +736,15 @@ impl<'s> Parser<'s> {
 			"function_type" => {
 				let param_type_list_node = type_node.child_by_field_name("parameter_types").unwrap();
 				let mut cursor = param_type_list_node.walk();
-				let parameters = param_type_list_node
+				let param_types = param_type_list_node
 					.named_children(&mut cursor)
 					.filter_map(|param_type| self.build_type_annotation(&param_type).ok())
 					.collect::<Vec<TypeAnnotation>>();
 				let return_type = type_node
 					.child_by_field_name("return_type")
 					.map(|n| Box::new(self.build_type_annotation(&n).unwrap()));
-				Ok(TypeAnnotation::FunctionSignature(FunctionSignature {
-					parameters,
+				Ok(TypeAnnotation::Function(FunctionTypeAnnotation {
+					param_types,
 					return_type,
 					phase: if type_node.child_by_field_name("inflight").is_some() {
 						Phase::Inflight

--- a/libs/wingc/src/parser.rs
+++ b/libs/wingc/src/parser.rs
@@ -667,8 +667,7 @@ impl<'s> Parser<'s> {
 	}
 
 	fn build_function_definition(&self, func_def_node: &Node, phase: Phase) -> DiagnosticResult<FunctionDefinition> {
-		let parameters = self.build_parameter_list(&func_def_node.child_by_field_name("parameter_list").unwrap())?;
-
+		let signature = self.build_function_signature(func_def_node, phase)?;
 		let statements = if let Some(external) = func_def_node.child_by_field_name("extern_modifier") {
 			let node_text = self.node_text(&external.named_child(0).unwrap());
 			let node_text = &node_text[1..node_text.len() - 1];
@@ -679,16 +678,7 @@ impl<'s> Parser<'s> {
 
 		Ok(FunctionDefinition {
 			body: statements,
-			// TODO: duplicated?
-			signature: FunctionSignature {
-				parameters,
-				return_type: if let Some(rt) = func_def_node.child_by_field_name("type") {
-					Some(Box::new(self.build_type_annotation(&rt)?))
-				} else {
-					None
-				},
-				phase,
-			},
+			signature,
 			is_static: func_def_node.child_by_field_name("static").is_some(),
 			captures: RefCell::new(None),
 			span: self.node_span(func_def_node),

--- a/libs/wingc/src/type_check.rs
+++ b/libs/wingc/src/type_check.rs
@@ -1,9 +1,10 @@
 pub(crate) mod jsii_importer;
 pub mod symbol_env;
+use crate::ast;
 use crate::ast::{
-	ArgList, BinaryOperator, Class as AstClass, Expr, ExprKind, FunctionBody, Interface as AstInterface,
-	InterpolatedStringPart, Literal, MethodLike, Phase, Reference, Scope, Stmt, StmtKind, Symbol, ToSpan, TypeAnnotation,
-	UnaryOperator, UserDefinedType,
+	ArgList, BinaryOperator, Class as AstClass, Expr, ExprKind, FunctionBody, FunctionParameter,
+	Interface as AstInterface, InterpolatedStringPart, Literal, MethodLike, Phase, Reference, Scope, Stmt, StmtKind,
+	Symbol, ToSpan, TypeAnnotation, UnaryOperator, UserDefinedType,
 };
 use crate::diagnostic::{Diagnostic, DiagnosticLevel, Diagnostics, TypeError};
 use crate::{
@@ -1547,11 +1548,10 @@ impl<'a> TypeChecker<'a> {
 		}
 	}
 
-	fn type_check_closure(&mut self, func_def: &crate::ast::FunctionDefinition, env: &SymbolEnv) -> UnsafeRef<Type> {
+	fn type_check_closure(&mut self, func_def: &ast::FunctionDefinition, env: &SymbolEnv) -> UnsafeRef<Type> {
 		// TODO: make sure this function returns on all control paths when there's a return type (can be done by recursively traversing the statements and making sure there's a "return" statements in all control paths)
 		// Create a type_checker function signature from the AST function definition
-		let function_type =
-			self.resolve_type_annotation(&TypeAnnotation::FunctionSignature(func_def.signature.clone()), env);
+		let function_type = self.resolve_type_annotation(&func_def.signature.to_type_annotation(), env);
 		let sig = function_type.as_function_sig().unwrap();
 
 		// Create an environment for the function
@@ -1562,7 +1562,7 @@ impl<'a> TypeChecker<'a> {
 			func_def.signature.phase,
 			self.statement_idx,
 		);
-		self.add_arguments_to_env(&func_def.parameters, &sig, &mut function_env);
+		self.add_arguments_to_env(&func_def.signature.parameters, &sig, &mut function_env);
 
 		// Type check the function body
 		if let FunctionBody::Statements(scope) = &func_def.body {
@@ -1722,9 +1722,9 @@ impl<'a> TypeChecker<'a> {
 				let value_type = self.resolve_type_annotation(v, env);
 				self.types.add_type(Type::Optional(value_type))
 			}
-			TypeAnnotation::FunctionSignature(ast_sig) => {
+			TypeAnnotation::Function(ast_sig) => {
 				let mut args = vec![];
-				for arg in ast_sig.parameters.iter() {
+				for arg in ast_sig.param_types.iter() {
 					args.push(self.resolve_type_annotation(arg, env));
 				}
 				let sig = FunctionSignature {
@@ -2256,7 +2256,7 @@ impl<'a> TypeChecker<'a> {
 
 				// Add methods to the interface env
 				for (method_name, sig) in methods.iter() {
-					let mut method_type = self.resolve_type_annotation(&TypeAnnotation::FunctionSignature(sig.clone()), env);
+					let mut method_type = self.resolve_type_annotation(&sig.to_type_annotation(), env);
 					// use the interface type as the function's "this" type
 					if let Type::Function(ref mut f) = *method_type {
 						f.this_type = Some(interface_type.clone());
@@ -2462,13 +2462,13 @@ impl<'a> TypeChecker<'a> {
 
 	fn add_method_to_class_env(
 		&mut self,
-		method_sig: &crate::ast::FunctionSignature,
+		method_sig: &ast::FunctionSignature,
 		env: &mut SymbolEnv,
 		instance_type: Option<TypeRef>,
 		class_env: &mut SymbolEnv,
 		method_name: &Symbol,
 	) {
-		let mut method_type = self.resolve_type_annotation(&TypeAnnotation::FunctionSignature(method_sig.clone()), env);
+		let mut method_type = self.resolve_type_annotation(&method_sig.to_type_annotation(), env);
 		// use the class type as the function's "this" type (or None if static)
 		method_type
 			.as_mut_function_sig()
@@ -2581,12 +2581,12 @@ impl<'a> TypeChecker<'a> {
 	/// * `sig` - The function signature (used to figure out the type of each argument).
 	/// * `env` - The function's environment to prime with the args.
 	///
-	fn add_arguments_to_env(&mut self, args: &Vec<(Symbol, bool)>, sig: &FunctionSignature, env: &mut SymbolEnv) {
+	fn add_arguments_to_env(&mut self, args: &Vec<FunctionParameter>, sig: &FunctionSignature, env: &mut SymbolEnv) {
 		assert!(args.len() == sig.parameters.len());
 		for (arg, arg_type) in args.iter().zip(sig.parameters.iter()) {
 			match env.define(
-				&arg.0,
-				SymbolKind::make_variable(*arg_type, arg.1, true, env.phase),
+				&arg.name,
+				SymbolKind::make_variable(*arg_type, arg.reassignable, true, env.phase),
 				StatementIdx::Top,
 			) {
 				Err(type_error) => {

--- a/libs/wingc/src/visit.rs
+++ b/libs/wingc/src/visit.rs
@@ -1,6 +1,6 @@
 use crate::ast::{
-	ArgList, Class, Constructor, Expr, ExprKind, FunctionBody, FunctionDefinition, FunctionSignature, Interface,
-	InterpolatedStringPart, Literal, Reference, Scope, Stmt, StmtKind, Symbol, TypeAnnotation,
+	ArgList, Class, Constructor, Expr, ExprKind, FunctionBody, FunctionDefinition, FunctionParameter, FunctionSignature,
+	Interface, InterpolatedStringPart, Literal, Reference, Scope, Stmt, StmtKind, Symbol, TypeAnnotation,
 };
 
 /// Visitor pattern inspired by implementation from https://docs.rs/syn/latest/syn/visit/index.html
@@ -58,6 +58,9 @@ pub trait Visit<'ast> {
 	}
 	fn visit_function_signature(&mut self, node: &'ast FunctionSignature) {
 		visit_function_signature(self, node);
+	}
+	fn visit_function_parameter(&mut self, node: &'ast FunctionParameter) {
+		visit_function_parameter(self, node);
 	}
 	fn visit_args(&mut self, node: &'ast ArgList) {
 		visit_args(self, node);
@@ -228,16 +231,7 @@ pub fn visit_constructor<'ast, V>(v: &mut V, node: &'ast Constructor)
 where
 	V: Visit<'ast> + ?Sized,
 {
-	for param in &node.parameters {
-		v.visit_symbol(&param.0);
-	}
-	for param_type in &node.signature.parameters {
-		v.visit_type_annotation(param_type);
-	}
-	if let Some(return_type) = &node.signature.return_type {
-		v.visit_type_annotation(return_type);
-	}
-
+	v.visit_function_signature(&node.signature);
 	v.visit_scope(&node.statements);
 }
 
@@ -360,9 +354,6 @@ where
 	V: Visit<'ast> + ?Sized,
 {
 	v.visit_function_signature(&node.signature);
-	for param in &node.parameters {
-		v.visit_symbol(&param.0);
-	}
 	if let FunctionBody::Statements(scope) = &node.body {
 		v.visit_scope(scope);
 	};
@@ -372,12 +363,20 @@ pub fn visit_function_signature<'ast, V>(v: &mut V, node: &'ast FunctionSignatur
 where
 	V: Visit<'ast> + ?Sized,
 {
-	for param_type in &node.parameters {
-		v.visit_type_annotation(param_type);
+	for param in &node.parameters {
+		v.visit_function_parameter(param);
 	}
 	if let Some(return_type) = &node.return_type {
 		v.visit_type_annotation(return_type);
 	}
+}
+
+pub fn visit_function_parameter<'ast, V>(v: &mut V, node: &'ast FunctionParameter)
+where
+	V: Visit<'ast> + ?Sized,
+{
+	v.visit_symbol(&node.name);
+	v.visit_type_annotation(&node.type_annotation);
 }
 
 pub fn visit_args<'ast, V>(v: &mut V, node: &'ast ArgList)
@@ -411,9 +410,9 @@ where
 		TypeAnnotation::MutMap(t) => v.visit_type_annotation(t),
 		TypeAnnotation::Set(t) => v.visit_type_annotation(t),
 		TypeAnnotation::MutSet(t) => v.visit_type_annotation(t),
-		TypeAnnotation::FunctionSignature(f) => {
-			for arg_type in &f.parameters {
-				v.visit_type_annotation(&arg_type);
+		TypeAnnotation::Function(f) => {
+			for param in &f.param_types {
+				v.visit_type_annotation(&param);
 			}
 			if let Some(return_type) = &f.return_type {
 				v.visit_type_annotation(return_type);


### PR DESCRIPTION
Inside the AST nodes for `FunctionDefinition` and `Constructor`, we were storing the function signature in one field (which contains a list of parameter types) and a vector of parameter metadata (their names and whether they're reassignable) in another field. To keep all parameter information together, this PR refactors the data model so all parameter-related information is in a `FunctionParameter` struct and store that in `FunctionSignature`.

Since function type annotations don't have all this information (a function type annotation like `inflight (num): str` doesn't track reassignable-ness or parameter names), I've moved that information into a dedicated `FunctionTypeAnnotation` struct.

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.