### PR TITLE
feat: save local terraform state per app

### DIFF
--- a/libs/wingsdk/src/core/app.ts
+++ b/libs/wingsdk/src/core/app.ts
@@ -189,6 +189,7 @@ export abstract class CdktfApp extends App {
     super(cdktfStack, "Default");
 
     // TODO: allow the user to specify custom backends
+    // https://github.com/winglang/wing/issues/2003
     new cdktf.LocalBackend(cdktfStack, {
       path: "./terraform.tfstate",
     });

--- a/libs/wingsdk/src/core/app.ts
+++ b/libs/wingsdk/src/core/app.ts
@@ -188,6 +188,11 @@ export abstract class CdktfApp extends App {
 
     super(cdktfStack, "Default");
 
+    // TODO: allow the user to specify custom backends
+    new cdktf.LocalBackend(cdktfStack, {
+      path: "./terraform.tfstate",
+    });
+
     this.outdir = outdir;
     this.isTestEnvironment = props.isTestEnvironment ?? false;
 


### PR DESCRIPTION
Today, if you try compiling your app to `tf-aws` and check the terraform JSON file that is created inside `target/`, you will find the value `terraform.backend.local.path` is set to a location at the root of your project directory (like `/path/to/my-project/terraform.root.tfstate`). This path specifies where `terraform apply` will create a local terraform state file to track what resources have already been created etc.

That works fine if you are working with a single Wing program. However, if you want to deploy or test multiple Wing apps in the cloud, they will all try to store their state in the same file, which means resources may get destroyed unexpectedly.

This PR fixes that so that the terraform state is saved in the per-target directory (for example, if you compiled `main.w` to AWS, your terraform state will be saved at `target/main.tfaws/terraform.tfstate`). This also applies to `wing test` (for example, `wing test -t tf-aws main.w` will save any terraform state to `target/test/main.tfaws/terraform.tfstate`).

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.