### PR TITLE
fix(vscode): wrong completion label for interfaces and aliased namespaces

### DIFF
--- a/apps/vscode-wing/syntaxes/wing.tmLanguage.json
+++ b/apps/vscode-wing/syntaxes/wing.tmLanguage.json
@@ -121,15 +121,15 @@
         },
         {
           "name": "storage.modifier.wing",
-          "match": "\\b(inflight|preflight|var|let|protected|internal|static|extends|extern)\\b"
+          "match": "\\b(inflight|preflight|var|let|protected|internal|static|extends|impl|extern)\\b"
         },
         {
           "name": "storage.type.wing",
-          "match": "\\b(class|resource|struct|enum)\\b"
+          "match": "\\b(class|resource|struct|enum|interface)\\b"
         },
         {
           "name": "support.function.wing",
-          "match": "\\b(print|assert|throw|panic)\\b"
+          "match": "\\b(log|assert|throw|panic)\\b"
         }
       ]
     },

--- a/libs/wingc/src/lsp/completions.rs
+++ b/libs/wingc/src/lsp/completions.rs
@@ -300,17 +300,14 @@ fn get_completions_from_class(
 			} else {
 				Some(CompletionItemKind::FIELD)
 			};
+			let insert_text = if kind == Some(CompletionItemKind::METHOD) {
+				Some(format!("{}($0)", symbol_data.0))
+			} else {
+				Some(symbol_data.0.to_string())
+			};
 
 			Some(CompletionItem {
-				insert_text: Some(format!(
-					"{}{}",
-					symbol_data.0,
-					if kind == Some(CompletionItemKind::METHOD) {
-						"($0)"
-					} else {
-						""
-					}
-				)),
+				insert_text,
 				label: symbol_data.0.clone(),
 				detail: Some(variable.type_.to_string()),
 				kind,
@@ -358,9 +355,16 @@ fn format_symbol_kind_as_completion(name: &str, symbol_kind: &SymbolKind) -> Com
 			} else {
 				Some(CompletionItemKind::VARIABLE)
 			};
+			let insert_text = if kind == Some(CompletionItemKind::FUNCTION) {
+				Some(format!("{}($0)", name))
+			} else {
+				Some(name.to_string())
+			};
 			CompletionItem {
 				label: name.to_string(),
+				insert_text,
 				detail: Some(v.type_.to_string()),
+				insert_text_format: Some(InsertTextFormat::SNIPPET),
 				kind,
 				..Default::default()
 			}


### PR DESCRIPTION
Fixes #1887
Fixes #1983

Additionally:
- Added/fixed some missing highlights
- Slipped in a fun feature where completing a function/method includes `()` and sets the cursor inside them.
  - There is a smidge of duplication with this feature, but expect lots more handling of interesting snippets like this, so I think we can leave that sort of cleanup for a less special-case PR.

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.