### PR TITLE
feat!: rename queue on_message to add_consumer

### DIFF
--- a/docs/01-welcome.md
+++ b/docs/01-welcome.md
@@ -50,7 +50,7 @@ let queue = new cloud.Queue(timeout: 2m);
 let bucket = new cloud.Bucket();
 let counter = new cloud.Counter(initial: 100);
 
-queue.on_message(inflight (body: str): str => {
+queue.add_consumer(inflight (body: str): str => {
   let next = counter.inc();
   let key = "myfile-${next}.txt";
   bucket.put(key, body);

--- a/docs/02-getting-started/03-hello.md
+++ b/docs/02-getting-started/03-hello.md
@@ -26,7 +26,7 @@ bring cloud;
 let bucket = new cloud.Bucket();
 let queue = new cloud.Queue();
 
-queue.on_message(inflight (message: str) => {
+queue.add_consumer(inflight (message: str) => {
   bucket.put("wing.txt", "Hello, ${message}");
 });
 ```

--- a/docs/03-concepts/01-resources.md
+++ b/docs/03-concepts/01-resources.md
@@ -31,7 +31,7 @@ resource SafeQueue extends cloud.Queue {
   init() {
     let dlq = new cloud.Queue();
 
-    dlq.on_message(inflight (m: str) => {
+    dlq.add_consumer(inflight (m: str) => {
       log.error("dead-letter: ${m}");
     });
 

--- a/docs/04-reference/wingsdk-api.md
+++ b/docs/04-reference/wingsdk-api.md
@@ -901,25 +901,25 @@ new cloud.Queue(props?: QueueProps)
 
 | **Name** | **Description** |
 | --- | --- |
-| <code><a href="#@winglang/sdk.cloud.Queue.onMessage">on_message</a></code> | Create a function to consume messages from this queue. |
+| <code><a href="#@winglang/sdk.cloud.Queue.addConsumer">add_consumer</a></code> | Create a function to consume messages from this queue. |
 
 ---
 
-##### `on_message` <a name="on_message" id="@winglang/sdk.cloud.Queue.onMessage"></a>
+##### `add_consumer` <a name="add_consumer" id="@winglang/sdk.cloud.Queue.addConsumer"></a>
 
 ```wing
-on_message(handler: IQueueOnMessageHandler, props?: QueueOnMessageProps): Function
+add_consumer(handler: IQueueOnMessageHandler, props?: QueueOnMessageProps): Function
 ```
 
 Create a function to consume messages from this queue.
 
-###### `handler`<sup>Required</sup> <a name="handler" id="@winglang/sdk.cloud.Queue.onMessage.parameter.handler"></a>
+###### `handler`<sup>Required</sup> <a name="handler" id="@winglang/sdk.cloud.Queue.addConsumer.parameter.handler"></a>
 
 - *Type:* <a href="#@winglang/sdk.cloud.IQueueOnMessageHandler">IQueueOnMessageHandler</a>
 
 ---
 
-###### `props`<sup>Optional</sup> <a name="props" id="@winglang/sdk.cloud.Queue.onMessage.parameter.props"></a>
+###### `props`<sup>Optional</sup> <a name="props" id="@winglang/sdk.cloud.Queue.addConsumer.parameter.props"></a>
 
 - *Type:* <a href="#@winglang/sdk.cloud.QueueOnMessageProps">QueueOnMessageProps</a>
 
@@ -1965,7 +1965,7 @@ The maximum amount of time the function can run.
 
 ### QueueOnMessageProps <a name="QueueOnMessageProps" id="@winglang/sdk.cloud.QueueOnMessageProps"></a>
 
-Options for Queue.onMessage.
+Options for Queue.addConsumer.
 
 #### Initializer <a name="Initializer" id="@winglang/sdk.cloud.QueueOnMessageProps.Initializer"></a>
 
@@ -4774,7 +4774,7 @@ Payload to send to the queue.
 
 **Inflight client:** [@winglang/sdk.cloud.IQueueOnMessageHandlerClient](#@winglang/sdk.cloud.IQueueOnMessageHandlerClient)
 
-Represents a resource with an inflight "handle" method that can be passed to `Queue.on_message`.
+Represents a resource with an inflight "handle" method that can be passed to `Queue.add_consumer`.
 
 
 #### Properties <a name="Properties" id="Properties"></a>

--- a/docs/04-reference/wingsdk-spec.md
+++ b/docs/04-reference/wingsdk-spec.md
@@ -184,7 +184,7 @@ resource CounterWithThreshold extends cloud.Counter {
 
   // or: on_threshold(handler: EventHandler<ThresholdReachedEvent>)
   on_threshold(handler: inflight (event: ThresholdReachedEvent) => void) {
-    return this._topic.on_message(handler);
+    return this._topic.add_consumer(handler);
   }
 }
 
@@ -709,7 +709,7 @@ resource Topic {
   /**
    * Run an inflight whenever a message is published to the topic.
    */
-  on_message(fn: inflight (message: Json) => void, opts: TopicOnPublishProps?): void;
+  add_consumer(fn: inflight (message: Json) => void, opts: TopicOnPublishProps?): void;
 
   /**
    * Publish a message to the topic.

--- a/docs/06-contributors/999-rfcs/000-stories/story-04.md
+++ b/docs/06-contributors/999-rfcs/000-stories/story-04.md
@@ -110,7 +110,7 @@ bring cloud;
 
 let queue = new cloud.Queue();
 
-queue.on_message(inflight (message) => {
+queue.add_consumer(inflight (message) => {
   log("Hello, ${message}!");
 });
 ```

--- a/examples/plugins/app.w
+++ b/examples/plugins/app.w
@@ -3,6 +3,6 @@ bring cloud;
 let b = new cloud.Bucket();
 let q = new cloud.Queue();
 
-q.on_message(inflight (msg: str) => {
+q.add_consumer(inflight (msg: str) => {
   b.put("file.txt", msg);
 });

--- a/examples/proposed/counting-semaphore.w
+++ b/examples/proposed/counting-semaphore.w
@@ -55,7 +55,7 @@ let queue = new cloud.Queue();
 /**
  * An example handler to work with two shared resources.
  */
-queue.on_message(inflight (message: str) => {
+queue.add_consumer(inflight (message: str) => {
   let is_resource_1_acquired = resource_1.try_acquire();
   if !is_resource_1_acquired {
     // brutally error out to re-enqueue

--- a/examples/proposed/replayable-queue.w
+++ b/examples/proposed/replayable-queue.w
@@ -14,8 +14,8 @@ resource ReplayableQueue {
     this.counter = new cloud.Counter();
   }
 
-  on_message(fn: inflight (str): str){
-    this.queue.on_message(fn);
+  add_consumer(fn: inflight (str): str){
+    this.queue.add_consumer(fn);
   }
   
   inflight push(m: str) {
@@ -35,10 +35,10 @@ resource ReplayableQueue {
 resource RemoteControl { 
   init(q: ReplayableQueue){
     let f = inflight (m: str): str => {
-      log("on_message got triggered with ${m}");
+      log("add_consumer got triggered with ${m}");
     };
       
-    q.on_message(f);
+    q.add_consumer(f);
     
     new cloud.Function(inflight (m: str) => {
       q.push(m);

--- a/examples/tests/invalid/cloud_function_expects_inflight.w
+++ b/examples/tests/invalid/cloud_function_expects_inflight.w
@@ -6,7 +6,7 @@ new cloud.Function((name: str): str => {
 // ^ Expected type to be "inflight (any): any", but got "preflight (str): str" instead
 
 let q = new cloud.Queue();
-q.on_message(inflight (x: num) => {
+q.add_consumer(inflight (x: num) => {
                     // ^ "num" doesn't match the expected type "str"
     return;
 });

--- a/examples/tests/invalid/missing_semicolon.w
+++ b/examples/tests/invalid/missing_semicolon.w
@@ -4,11 +4,11 @@ let b = new cloud.Bucket() as "Eyal Keren";
 let q1 = new cloud.Queue() as "q1";
 let q2 = new cloud.Queue() as "q2";
 
-q1.on_message(inflight (m:str): str => {
+q1.add_consumer(inflight (m:str): str => {
   b.put("1.txt", "Hello, ${m}"); 
 })
 
-q2.on_message(inflight (m:str): str => {
+q2.add_consumer(inflight (m:str): str => {
   b.put("2.txt", "Hello, ${m}"); 
 });
 

--- a/examples/tests/valid/captures.w
+++ b/examples/tests/valid/captures.w
@@ -26,7 +26,7 @@ let handler = inflight (event: str): str => {
   }
 };
 
-queue.on_message(handler, batch_size: 5);
+queue.add_consumer(handler, batch_size: 5);
 
 new cloud.Function(
   handler, 

--- a/examples/tests/valid/file_counter.w
+++ b/examples/tests/valid/file_counter.w
@@ -10,4 +10,4 @@ let handler = inflight (body: str /* string arg */): str => {
   bucket.put(key, body);
 };
 
-queue.on_message(handler);
+queue.add_consumer(handler);

--- a/examples/tests/valid/hello.w
+++ b/examples/tests/valid/hello.w
@@ -3,6 +3,6 @@ bring cloud;
 let bucket = new cloud.Bucket();
 let queue = new cloud.Queue();
 
-queue.on_message(inflight (message: str) => {
+queue.add_consumer(inflight (message: str) => {
   bucket.put("wing.txt", "Hello, ${message}");
 });

--- a/examples/tests/valid/while_loop_await.w
+++ b/examples/tests/valid/while_loop_await.w
@@ -13,4 +13,4 @@ let handler = inflight (body: str): str => {
     }
 };
 
-queue.on_message(handler);
+queue.add_consumer(handler);

--- a/libs/wingsdk/API.md
+++ b/libs/wingsdk/API.md
@@ -894,25 +894,25 @@ new cloud.Queue(props?: QueueProps)
 
 | **Name** | **Description** |
 | --- | --- |
-| <code><a href="#@winglang/sdk.cloud.Queue.onMessage">on_message</a></code> | Create a function to consume messages from this queue. |
+| <code><a href="#@winglang/sdk.cloud.Queue.addConsumer">add_consumer</a></code> | Create a function to consume messages from this queue. |
 
 ---
 
-##### `on_message` <a name="on_message" id="@winglang/sdk.cloud.Queue.onMessage"></a>
+##### `add_consumer` <a name="add_consumer" id="@winglang/sdk.cloud.Queue.addConsumer"></a>
 
 ```wing
-on_message(handler: IQueueOnMessageHandler, props?: QueueOnMessageProps): Function
+add_consumer(handler: IQueueOnMessageHandler, props?: QueueOnMessageProps): Function
 ```
 
 Create a function to consume messages from this queue.
 
-###### `handler`<sup>Required</sup> <a name="handler" id="@winglang/sdk.cloud.Queue.onMessage.parameter.handler"></a>
+###### `handler`<sup>Required</sup> <a name="handler" id="@winglang/sdk.cloud.Queue.addConsumer.parameter.handler"></a>
 
 - *Type:* <a href="#@winglang/sdk.cloud.IQueueOnMessageHandler">IQueueOnMessageHandler</a>
 
 ---
 
-###### `props`<sup>Optional</sup> <a name="props" id="@winglang/sdk.cloud.Queue.onMessage.parameter.props"></a>
+###### `props`<sup>Optional</sup> <a name="props" id="@winglang/sdk.cloud.Queue.addConsumer.parameter.props"></a>
 
 - *Type:* <a href="#@winglang/sdk.cloud.QueueOnMessageProps">QueueOnMessageProps</a>
 
@@ -1958,7 +1958,7 @@ The maximum amount of time the function can run.
 
 ### QueueOnMessageProps <a name="QueueOnMessageProps" id="@winglang/sdk.cloud.QueueOnMessageProps"></a>
 
-Options for Queue.onMessage.
+Options for Queue.addConsumer.
 
 #### Initializer <a name="Initializer" id="@winglang/sdk.cloud.QueueOnMessageProps.Initializer"></a>
 
@@ -4767,7 +4767,7 @@ Payload to send to the queue.
 
 **Inflight client:** [@winglang/sdk.cloud.IQueueOnMessageHandlerClient](#@winglang/sdk.cloud.IQueueOnMessageHandlerClient)
 
-Represents a resource with an inflight "handle" method that can be passed to `Queue.on_message`.
+Represents a resource with an inflight "handle" method that can be passed to `Queue.add_consumer`.
 
 
 #### Properties <a name="Properties" id="Properties"></a>

--- a/libs/wingsdk/README.md
+++ b/libs/wingsdk/README.md
@@ -28,7 +28,7 @@ bring cloud;
 
 let queue = new cloud.Queue();
 
-queue.on_message(inflight (message) => {
+queue.add_consumer(inflight (message) => {
   log("Hello, ${message}!");
 });
 ```

--- a/libs/wingsdk/src/cloud/queue.ts
+++ b/libs/wingsdk/src/cloud/queue.ts
@@ -57,14 +57,14 @@ export abstract class Queue extends Resource {
   /**
    * Create a function to consume messages from this queue.
    */
-  public abstract onMessage(
+  public abstract addConsumer(
     handler: IQueueOnMessageHandler,
     props?: QueueOnMessageProps
   ): Function;
 }
 
 /**
- * Options for Queue.onMessage.
+ * Options for Queue.addConsumer.
  */
 export interface QueueOnMessageProps extends FunctionProps {
   /**
@@ -100,7 +100,7 @@ export interface IQueueClient {
 
 /**
  * Represents a resource with an inflight "handle" method that can be passed to
- * `Queue.on_message`.
+ * `Queue.add_consumer`.
  *
  * @inflight `@winglang/sdk.cloud.IQueueOnMessageHandlerClient`
  */

--- a/libs/wingsdk/src/target-sim/queue.ts
+++ b/libs/wingsdk/src/target-sim/queue.ts
@@ -28,7 +28,7 @@ export class Queue extends cloud.Queue implements ISimulatorResource {
     this.initialMessages.push(...(props.initialMessages ?? []));
   }
 
-  public onMessage(
+  public addConsumer(
     inflight: cloud.IQueueOnMessageHandler,
     props: cloud.QueueOnMessageProps = {}
   ): cloud.Function {
@@ -83,7 +83,7 @@ export class Queue extends cloud.Queue implements ISimulatorResource {
     core.Resource.addConnection({
       from: this,
       to: fn,
-      relationship: "on_message",
+      relationship: "add_consumer",
     });
 
     return fn;

--- a/libs/wingsdk/src/target-tf-aws/queue.ts
+++ b/libs/wingsdk/src/target-tf-aws/queue.ts
@@ -40,7 +40,7 @@ export class Queue extends cloud.Queue {
     }
   }
 
-  public onMessage(
+  public addConsumer(
     inflight: cloud.IQueueOnMessageHandler,
     props: cloud.QueueOnMessageProps = {}
   ): cloud.Function {
@@ -91,7 +91,7 @@ export class Queue extends cloud.Queue {
     core.Resource.addConnection({
       from: this,
       to: fn,
-      relationship: "on_message",
+      relationship: "add_consumer",
     });
 
     return fn;

--- a/libs/wingsdk/src/target-tf-aws/topic.ts
+++ b/libs/wingsdk/src/target-tf-aws/topic.ts
@@ -89,7 +89,7 @@ export class Topic extends cloud.Topic {
     core.Resource.addConnection({
       from: this,
       to: fn,
-      relationship: "on_message",
+      relationship: "add_consumer",
     });
 
     return fn;

--- a/libs/wingsdk/test/sandbox/main.ts
+++ b/libs/wingsdk/test/sandbox/main.ts
@@ -20,7 +20,7 @@ class HelloWorld extends Construct {
     );
     // cloud.Function._newFunction(this, "Function", handler);
     const queue = cloud.Queue._newQueue(this, "Queue");
-    queue.onMessage(handler);
+    queue.addConsumer(handler);
   }
 }
 

--- a/libs/wingsdk/test/target-sim/__snapshots__/file-counter.test.ts.snap
+++ b/libs/wingsdk/test/target-sim/__snapshots__/file-counter.test.ts.snap
@@ -189,7 +189,7 @@ bucket: (function(env) {
                   {
                     "direction": "outbound",
                     "implicit": false,
-                    "relationship": "on_message",
+                    "relationship": "add_consumer",
                     "resource": "root/HelloWorld/Queue-OnMessage-401ee792",
                   },
                 ],
@@ -236,7 +236,7 @@ bucket: (function(env) {
                   {
                     "direction": "inbound",
                     "implicit": false,
-                    "relationship": "on_message",
+                    "relationship": "add_consumer",
                     "resource": "root/HelloWorld/Queue",
                   },
                 ],

--- a/libs/wingsdk/test/target-sim/__snapshots__/queue.test.ts.snap
+++ b/libs/wingsdk/test/target-sim/__snapshots__/queue.test.ts.snap
@@ -267,7 +267,7 @@ async handle(message) {
               {
                 "direction": "outbound",
                 "implicit": false,
-                "relationship": "on_message",
+                "relationship": "add_consumer",
                 "resource": "root/my_queue-OnMessage-e645076f",
               },
             ],
@@ -302,7 +302,7 @@ async handle(message) {
               {
                 "direction": "inbound",
                 "implicit": false,
-                "relationship": "on_message",
+                "relationship": "add_consumer",
                 "resource": "root/my_queue",
               },
             ],
@@ -634,7 +634,7 @@ async handle(message) {
               {
                 "direction": "outbound",
                 "implicit": false,
-                "relationship": "on_message",
+                "relationship": "add_consumer",
                 "resource": "root/my_queue-OnMessage-e645076f",
               },
             ],
@@ -669,7 +669,7 @@ async handle(message) {
               {
                 "direction": "inbound",
                 "implicit": false,
-                "relationship": "on_message",
+                "relationship": "add_consumer",
                 "resource": "root/my_queue",
               },
             ],
@@ -883,7 +883,7 @@ async handle(message) {
               {
                 "direction": "outbound",
                 "implicit": false,
-                "relationship": "on_message",
+                "relationship": "add_consumer",
                 "resource": "root/my_queue-OnMessage-e645076f",
               },
             ],
@@ -918,7 +918,7 @@ async handle(message) {
               {
                 "direction": "inbound",
                 "implicit": false,
-                "relationship": "on_message",
+                "relationship": "add_consumer",
                 "resource": "root/my_queue",
               },
             ],

--- a/libs/wingsdk/test/target-sim/file-counter.test.ts
+++ b/libs/wingsdk/test/target-sim/file-counter.test.ts
@@ -35,7 +35,7 @@ test("can create sequential files in a bucket", async () => {
           },
         }
       );
-      queue.onMessage(processor);
+      queue.addConsumer(processor);
     }
   }
 

--- a/libs/wingsdk/test/target-sim/queue-consumer.test.ts
+++ b/libs/wingsdk/test/target-sim/queue-consumer.test.ts
@@ -35,7 +35,7 @@ test("pushing messages through a queue", async () => {
           console.log("Received " + event);
         }`
       );
-      queue.onMessage(processor);
+      queue.addConsumer(processor);
     }
   }
 

--- a/libs/wingsdk/test/target-sim/queue.test.ts
+++ b/libs/wingsdk/test/target-sim/queue.test.ts
@@ -41,7 +41,7 @@ test("queue with one subscriber, default batch size of 1", async () => {
   const app = new SimApp();
   const handler = Testing.makeHandler(app, "Handler", INFLIGHT_CODE);
   const queue = cloud.Queue._newQueue(app, "my_queue");
-  queue.onMessage(handler);
+  queue.addConsumer(handler);
   const s = await app.startSimulator();
 
   const queueClient = s.getResource("/my_queue") as cloud.IQueueClient;
@@ -97,7 +97,7 @@ test("queue with one subscriber, batch size of 5", async () => {
   const queue = cloud.Queue._newQueue(app, "my_queue", {
     initialMessages: ["A", "B", "C", "D", "E", "F"],
   });
-  queue.onMessage(handler, { batchSize: 5 });
+  queue.addConsumer(handler, { batchSize: 5 });
   const s = await app.startSimulator();
 
   // WHEN
@@ -115,7 +115,7 @@ test("messages are requeued if the function fails", async () => {
   const app = new SimApp();
   const handler = Testing.makeHandler(app, "Handler", INFLIGHT_CODE);
   const queue = cloud.Queue._newQueue(app, "my_queue");
-  queue.onMessage(handler);
+  queue.addConsumer(handler);
   const s = await app.startSimulator();
 
   // WHEN

--- a/libs/wingsdk/test/target-tf-aws/__snapshots__/bucket.test.ts.snap
+++ b/libs/wingsdk/test/target-tf-aws/__snapshots__/bucket.test.ts.snap
@@ -802,7 +802,7 @@ exports[`bucket with onCreate method 2`] = `
                         {
                           "direction": "outbound",
                           "implicit": false,
-                          "relationship": "on_message",
+                          "relationship": "add_consumer",
                           "resource": "root/Default/my_bucket/my_bucket-on_create-OnMessage-2c90a36b",
                         },
                       ],
@@ -869,7 +869,7 @@ exports[`bucket with onCreate method 2`] = `
                         {
                           "direction": "inbound",
                           "implicit": false,
-                          "relationship": "on_message",
+                          "relationship": "add_consumer",
                           "resource": "root/Default/my_bucket/my_bucket-on_create",
                         },
                       ],
@@ -1311,7 +1311,7 @@ exports[`bucket with onDelete method 2`] = `
                         {
                           "direction": "outbound",
                           "implicit": false,
-                          "relationship": "on_message",
+                          "relationship": "add_consumer",
                           "resource": "root/Default/my_bucket/my_bucket-on_delete-OnMessage-f22c8a47",
                         },
                       ],
@@ -1378,7 +1378,7 @@ exports[`bucket with onDelete method 2`] = `
                         {
                           "direction": "inbound",
                           "implicit": false,
-                          "relationship": "on_message",
+                          "relationship": "add_consumer",
                           "resource": "root/Default/my_bucket/my_bucket-on_delete",
                         },
                       ],
@@ -2012,7 +2012,7 @@ exports[`bucket with onEvent method 2`] = `
                         {
                           "direction": "outbound",
                           "implicit": false,
-                          "relationship": "on_message",
+                          "relationship": "add_consumer",
                           "resource": "root/Default/my_bucket/my_bucket-on_create-OnMessage-2c90a36b",
                         },
                       ],
@@ -2079,7 +2079,7 @@ exports[`bucket with onEvent method 2`] = `
                         {
                           "direction": "inbound",
                           "implicit": false,
-                          "relationship": "on_message",
+                          "relationship": "add_consumer",
                           "resource": "root/Default/my_bucket/my_bucket-on_create",
                         },
                       ],
@@ -2189,7 +2189,7 @@ exports[`bucket with onEvent method 2`] = `
                         {
                           "direction": "outbound",
                           "implicit": false,
-                          "relationship": "on_message",
+                          "relationship": "add_consumer",
                           "resource": "root/Default/my_bucket/my_bucket-on_delete-OnMessage-f22c8a47",
                         },
                       ],
@@ -2256,7 +2256,7 @@ exports[`bucket with onEvent method 2`] = `
                         {
                           "direction": "inbound",
                           "implicit": false,
-                          "relationship": "on_message",
+                          "relationship": "add_consumer",
                           "resource": "root/Default/my_bucket/my_bucket-on_delete",
                         },
                       ],
@@ -2366,7 +2366,7 @@ exports[`bucket with onEvent method 2`] = `
                         {
                           "direction": "outbound",
                           "implicit": false,
-                          "relationship": "on_message",
+                          "relationship": "add_consumer",
                           "resource": "root/Default/my_bucket/my_bucket-on_update-OnMessage-32b7a290",
                         },
                       ],
@@ -2433,7 +2433,7 @@ exports[`bucket with onEvent method 2`] = `
                         {
                           "direction": "inbound",
                           "implicit": false,
-                          "relationship": "on_message",
+                          "relationship": "add_consumer",
                           "resource": "root/Default/my_bucket/my_bucket-on_update",
                         },
                       ],
@@ -2919,7 +2919,7 @@ exports[`bucket with onUpdate method 2`] = `
                         {
                           "direction": "outbound",
                           "implicit": false,
-                          "relationship": "on_message",
+                          "relationship": "add_consumer",
                           "resource": "root/Default/my_bucket/my_bucket-on_update-OnMessage-32b7a290",
                         },
                       ],
@@ -2986,7 +2986,7 @@ exports[`bucket with onUpdate method 2`] = `
                         {
                           "direction": "inbound",
                           "implicit": false,
-                          "relationship": "on_message",
+                          "relationship": "add_consumer",
                           "resource": "root/Default/my_bucket/my_bucket-on_update",
                         },
                       ],

--- a/libs/wingsdk/test/target-tf-aws/__snapshots__/queue.test.ts.snap
+++ b/libs/wingsdk/test/target-tf-aws/__snapshots__/queue.test.ts.snap
@@ -393,7 +393,7 @@ exports[`queue with a consumer function 3`] = `
                     {
                       "direction": "outbound",
                       "implicit": false,
-                      "relationship": "on_message",
+                      "relationship": "add_consumer",
                       "resource": "root/Default/Queue-OnMessage-c5395e41",
                     },
                   ],
@@ -446,7 +446,7 @@ exports[`queue with a consumer function 3`] = `
                     {
                       "direction": "inbound",
                       "implicit": false,
-                      "relationship": "on_message",
+                      "relationship": "add_consumer",
                       "resource": "root/Default/Queue",
                     },
                   ],

--- a/libs/wingsdk/test/target-tf-aws/__snapshots__/topic.test.ts.snap
+++ b/libs/wingsdk/test/target-tf-aws/__snapshots__/topic.test.ts.snap
@@ -552,7 +552,7 @@ exports[`topic with subscriber function 3`] = `
                     {
                       "direction": "outbound",
                       "implicit": false,
-                      "relationship": "on_message",
+                      "relationship": "add_consumer",
                       "resource": "root/Default/Topic-OnMessage-c5395e41",
                     },
                   ],
@@ -605,7 +605,7 @@ exports[`topic with subscriber function 3`] = `
                     {
                       "direction": "inbound",
                       "implicit": false,
-                      "relationship": "on_message",
+                      "relationship": "add_consumer",
                       "resource": "root/Default/Topic",
                     },
                   ],

--- a/libs/wingsdk/test/target-tf-aws/captures.test.ts
+++ b/libs/wingsdk/test/target-tf-aws/captures.test.ts
@@ -203,7 +203,7 @@ test("function with a queue binding", () => {
     "Processor",
     `async handle(event) { console.log("Received" + event); }`
   );
-  queue.onMessage(processor);
+  queue.addConsumer(processor);
   const output = app.synth();
 
   // THEN

--- a/libs/wingsdk/test/target-tf-aws/queue.test.ts
+++ b/libs/wingsdk/test/target-tf-aws/queue.test.ts
@@ -47,7 +47,7 @@ async handle(event) {
   console.log("Received " + event.name);
 }`
   );
-  const processorFn = queue.onMessage(processor);
+  const processorFn = queue.addConsumer(processor);
   const output = app.synth();
 
   // THEN

--- a/tools/hangar/__snapshots__/invalid.ts.snap
+++ b/tools/hangar/__snapshots__/invalid.ts.snap
@@ -149,10 +149,10 @@ exports[`cloud_function_expects_inflight.w > stderr 1`] = `
 
 
 error: Expected type to be \\"IQueueOnMessageHandler (inflight (str): void)\\", but got \\"inflight (num): void\\" instead
-   --> ../../../examples/tests/invalid/cloud_function_expects_inflight.w:9:14
+   --> ../../../examples/tests/invalid/cloud_function_expects_inflight.w:9:16
    |  
- 9 |   q.on_message(inflight (x: num) => {
-   | /--------------^
+ 9 |   q.add_consumer(inflight (x: num) => {
+   | /----------------^
 10 | |                     // ^ \\"num\\" doesn't match the expected type \\"str\\"
 11 | |     return;
 12 | | });
@@ -535,18 +535,18 @@ exports[`missing_semicolon.w > stderr 1`] = `
 "error: Syntax error
    --> ../../../examples/tests/invalid/missing_semicolon.w:7:1
    |  
- 7 | / q1.on_message(inflight (m:str): str => {
+ 7 | / q1.add_consumer(inflight (m:str): str => {
  8 | |   b.put(\\"1.txt\\", \\"Hello, \${m}\\"); 
  9 | | })
 10 | | 
-11 | | q2.on_message(inflight (m:str): str => {
-   | \\\\-------------^ Syntax error
+11 | | q2.add_consumer(inflight (m:str): str => {
+   | \\\\---------------^ Syntax error
 
 
 error: Unexpected 'identifier'.
    --> ../../../examples/tests/invalid/missing_semicolon.w:11:1
    |
-11 | q2.on_message(inflight (m:str): str => {
+11 | q2.add_consumer(inflight (m:str): str => {
    | ^^ Unexpected 'identifier'.
 
 

--- a/tools/hangar/__snapshots__/test_corpus/valid/captures.w.ts.snap
+++ b/tools/hangar/__snapshots__/test_corpus/valid/captures.w.ts.snap
@@ -480,7 +480,7 @@ class $Root extends $stdlib.core.Resource {
     },
   }
 });
-    (queue.onMessage(handler,{ batchSize: 5 }));
+    (queue.addConsumer(handler,{ batchSize: 5 }));
     this.node.root.newAbstract(\\"@winglang/sdk.cloud.Function\\",this,\\"cloud.Function\\",handler,{ env: Object.freeze({}) });
     const empty_env = Object.freeze({});
     this.node.root.newAbstract(\\"@winglang/sdk.cloud.Function\\",this,\\"AnotherFunction\\",handler,{ env: empty_env });

--- a/tools/hangar/__snapshots__/test_corpus/valid/file_counter.w.ts.snap
+++ b/tools/hangar/__snapshots__/test_corpus/valid/file_counter.w.ts.snap
@@ -253,7 +253,7 @@ class $Root extends $stdlib.core.Resource {
     },
   }
 });
-    (queue.onMessage(handler));
+    (queue.addConsumer(handler));
   }
 }
 

--- a/tools/hangar/__snapshots__/test_corpus/valid/hello.w.ts.snap
+++ b/tools/hangar/__snapshots__/test_corpus/valid/hello.w.ts.snap
@@ -218,7 +218,7 @@ class $Root extends $stdlib.core.Resource {
     super(scope, id);
     const bucket = this.node.root.newAbstract(\\"@winglang/sdk.cloud.Bucket\\",this,\\"cloud.Bucket\\");
     const queue = this.node.root.newAbstract(\\"@winglang/sdk.cloud.Queue\\",this,\\"cloud.Queue\\");
-    (queue.onMessage(new $stdlib.core.Inflight(this, \\"$Inflight1\\", {
+    (queue.addConsumer(new $stdlib.core.Inflight(this, \\"$Inflight1\\", {
   code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.211d46e8ec3b5ce3e93872fcb29755356fb3566f5016eae5fcd6ec0f670ab580/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
   bindings: {
     bucket: {

--- a/tools/hangar/__snapshots__/test_corpus/valid/while_loop_await.w.ts.snap
+++ b/tools/hangar/__snapshots__/test_corpus/valid/while_loop_await.w.ts.snap
@@ -182,7 +182,7 @@ class $Root extends $stdlib.core.Resource {
   bindings: {
   }
 });
-    (queue.onMessage(handler));
+    (queue.addConsumer(handler));
   }
 }
 


### PR DESCRIPTION
Implemented https://github.com/winglang/wing/issues/1384.

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.