### PR TITLE
chore(repo): move "community note" to the end of issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -101,5 +101,6 @@ body:
     label: Community Note
     value: |
       <!-- Please keep this note for the community -->
-      > Please vote by adding a 👍 reaction to the issue to help us prioritize.
-      > If you are interested to work on this issue, please leave a comment.
+      ---
+      * Please vote by adding a 👍 reaction to the issue to help us prioritize.
+      * If you are interested to work on this issue, please leave a comment.

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -13,7 +13,7 @@ body:
 - type: textarea
   id: i-tried-this
   attributes:
-    label: "I tried this:"
+    label: "I tried this"
     placeholder: "What did you try to do? A code snippet or exact command line is ideal."
   validations:
     required: true
@@ -27,7 +27,7 @@ body:
 - type: textarea
   id: instead-what-happened
   attributes:
-    label: "Instead, this happened:"
+    label: "Instead, this happened"
     placeholder: "What happend instead of what you've expected?"
   validations:
     required: true
@@ -39,7 +39,7 @@ body:
 - type: dropdown
   id: Component
   attributes:
-    label: "Component:"
+    label: "Component"
     description: "Which component(s) in the toolchain is this related to?"
     multiple: true
     options:
@@ -61,20 +61,29 @@ body:
   attributes:
     value: |
        ## Environment
+
 - type: input
   id: version
   attributes:
-    label: "Wing Version:"
+    label: "Wing Version"
     placeholder: "wing --version"
+
+- type: input
+  id: version
+  attributes:
+    label: "Wing Console Version"
+    placeholder: "Wing Console > About Wing Console (if relevant)"
+
 - type: input
   id: node
   attributes:
-    label: "Node.js Version:"
+    label: "Node.js Version"
     placeholder: "node --version"
+
 - type: dropdown
   id: platform
   attributes:
-    label: "Platform(s):"
+    label: "Platform(s)"
     multiple: true
     options:
       - MacOS
@@ -98,7 +107,7 @@ body:
 
 - type: textarea
   attributes:
-    label: Community Note
+    label: Community Notes
     value: |
       <!-- Please keep this note for the community -->
       * Please vote by adding a 👍 reaction to the issue to help us prioritize.

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -101,6 +101,5 @@ body:
     label: Community Note
     value: |
       <!-- Please keep this note for the community -->
-      ---
       * Please vote by adding a 👍 reaction to the issue to help us prioritize.
       * If you are interested to work on this issue, please leave a comment.

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -6,13 +6,6 @@ body:
   attributes:
     value: |
        :pray: Thanks for taking the time to fill out this bug report! Feel free to ping us on [Wing Slack](https://t.winglang.io/slack) if you have any questions or need help.
-- type: textarea
-  attributes:
-    label: Community Note
-    value: |
-      <!-- Please keep this note for the community -->
-      > Please vote by adding a 👍 reaction to the issue to help us prioritize.
-      > If you are interested to work on this issue, please leave a comment.
 - type: markdown
   attributes:
     value: |
@@ -102,3 +95,11 @@ body:
       Tip: You can attach images or log files by dragging files in.
   validations:
     required: false
+
+- type: textarea
+  attributes:
+    label: Community Note
+    value: |
+      <!-- Please keep this note for the community -->
+      > Please vote by adding a 👍 reaction to the issue to help us prioritize.
+      > If you are interested to work on this issue, please leave a comment.

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -6,13 +6,6 @@ body:
   attributes:
     value: |
        :pray: Thanks for taking the time to fill out this enhancement request! Feel free to ping us on [Wing Slack](https://t.winglang.io/slack) if you have any questions or need help.
-- type: textarea
-  attributes:
-    label: Community Note
-    description: "Please keep this note for the community:"
-    value: |
-      > Please vote by adding a 👍 reaction to the issue to help us prioritize.
-      > If you are interested to work on this issue, please leave a comment.
 - type: markdown
   attributes:
     value: |
@@ -61,3 +54,10 @@ body:
     - Other
   validations:
     required: false
+- type: textarea
+  attributes:
+    label: Community Note
+    description: "Please keep this note for the community:"
+    value: |
+      > Please vote by adding a 👍 reaction to the issue to help us prioritize.
+      > If you are interested to work on this issue, please leave a comment.

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -54,10 +54,13 @@ body:
     - Other
   validations:
     required: false
+
+
 - type: textarea
   attributes:
     label: Community Note
-    description: "Please keep this note for the community:"
     value: |
-      > Please vote by adding a 👍 reaction to the issue to help us prioritize.
-      > If you are interested to work on this issue, please leave a comment.
+      <!-- Please keep this note for the community -->
+      ---
+      * Please vote by adding a 👍 reaction to the issue to help us prioritize.
+      * If you are interested to work on this issue, please leave a comment.

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -61,6 +61,5 @@ body:
     label: Community Note
     value: |
       <!-- Please keep this note for the community -->
-      ---
       * Please vote by adding a 👍 reaction to the issue to help us prioritize.
       * If you are interested to work on this issue, please leave a comment.

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -58,7 +58,7 @@ body:
 
 - type: textarea
   attributes:
-    label: Community Note
+    label: Community Notes
     value: |
       <!-- Please keep this note for the community -->
       * Please vote by adding a 👍 reaction to the issue to help us prioritize.


### PR DESCRIPTION
The community note is currently at the top of the issue templates, which means that all of our issue description begin with the same text, making it hard to identify the content in short notifications, etc.



*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.