### PR TITLE
chore: duplicate id in `bug` issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -63,13 +63,13 @@ body:
        ## Environment
 
 - type: input
-  id: version
+  id: wing-version
   attributes:
     label: "Wing Version"
     placeholder: "wing --version"
 
 - type: input
-  id: version
+  id: console-version
   attributes:
     label: "Wing Console Version"
     placeholder: "Wing Console > About Wing Console (if relevant)"


### PR DESCRIPTION
Duplicate id was preventing the bug template from being usable

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.