### PR TITLE
chore(compiler): additional struct tests and minor refactors

### DIFF
--- a/examples/tests/invalid/structs.w
+++ b/examples/tests/invalid/structs.w
@@ -29,3 +29,15 @@ let a = A {
 };
 log(a.bad_field);
 //      ^^^^^^ Unknown symbol "bad_field"
+
+// two inherits with same field name and type
+struct Razzle {
+  a: str;
+}
+
+struct Dazzle {
+  a: num;
+}
+
+struct Showtime extends Razzle, Dazzle {}
+//     ^^^^^^^^ struct "Showtime" extends "Dazzle" but has a conflicting member "a"

--- a/examples/tests/invalid/structs.w
+++ b/examples/tests/invalid/structs.w
@@ -30,7 +30,7 @@ let a = A {
 log(a.bad_field);
 //      ^^^^^^ Unknown symbol "bad_field"
 
-// two inherits with same field name and type
+// two inherits with same field name but different type
 struct Razzle {
   a: str;
 }

--- a/examples/tests/valid/structs.w
+++ b/examples/tests/valid/structs.w
@@ -48,3 +48,18 @@ struct lots_of_types {
   g: str?;
   h: Array<Map<num>>;
 }
+
+// two inherits with same field name and type
+struct Razzle {
+  a: str;
+}
+
+struct Dazzle {
+  a: str;
+}
+
+struct Showtime extends Razzle, Dazzle {}
+
+let s = Showtime {
+  a: "Boom baby"
+};

--- a/libs/tree-sitter-wing/test/corpus/statements/statements.txt
+++ b/libs/tree-sitter-wing/test/corpus/statements/statements.txt
@@ -219,7 +219,11 @@ inflight (callback: (num,num):bool) => {};
 Struct definition
 ================================================================================
 
-struct Test {
+struct Foo {
+    a: num;
+}
+
+struct Test extends Foo {
     cool: num;
     hip: str?;
 }
@@ -228,13 +232,20 @@ struct Test {
 
 (source
   (struct_definition
-    (identifier)
-    (struct_field
-      (identifier)
-      (builtin_type))
-    (struct_field
-      (identifier)
-      (optional
+    name: (identifier)
+    field: (struct_field
+      name: (identifier)
+      type: (builtin_type)))
+  (struct_definition
+    name: (identifier)
+    extends: (custom_type
+      object: (identifier))
+    field: (struct_field
+      name: (identifier)
+      type: (builtin_type))
+    field: (struct_field
+      name: (identifier)
+      type: (optional
         (builtin_type)))))
 
 ================================================================================

--- a/libs/wingc/src/ast.rs
+++ b/libs/wingc/src/ast.rs
@@ -380,7 +380,7 @@ pub enum StmtKind {
 	Struct {
 		name: Symbol,
 		extends: Vec<UserDefinedType>,
-		fields: Vec<ClassField>,
+		fields: Vec<StructField>,
 	},
 	Enum {
 		name: Symbol,
@@ -406,6 +406,12 @@ pub struct ClassField {
 	pub reassignable: bool,
 	pub phase: Phase,
 	pub is_static: bool,
+}
+
+#[derive(Debug)]
+pub struct StructField {
+	pub name: Symbol,
+	pub member_type: TypeAnnotation,
 }
 
 #[derive(Debug)]

--- a/libs/wingc/src/parser.rs
+++ b/libs/wingc/src/parser.rs
@@ -9,8 +9,8 @@ use tree_sitter_traversal::{traverse, Order};
 use crate::ast::{
 	ArgList, BinaryOperator, CatchBlock, Class, ClassField, Constructor, ElifBlock, Expr, ExprKind, FunctionBody,
 	FunctionDefinition, FunctionParameter, FunctionSignature, FunctionTypeAnnotation, Interface, InterpolatedString,
-	InterpolatedStringPart, Literal, Phase, Reference, Scope, Stmt, StmtKind, Symbol, TypeAnnotation, UnaryOperator,
-	UserDefinedType,
+	InterpolatedStringPart, Literal, Phase, Reference, Scope, Stmt, StmtKind, StructField, Symbol, TypeAnnotation,
+	UnaryOperator, UserDefinedType,
 };
 use crate::diagnostic::{Diagnostic, DiagnosticLevel, DiagnosticResult, Diagnostics, WingSpan};
 use crate::WINGSDK_STD_MODULE;
@@ -342,12 +342,9 @@ impl<'s> Parser<'s> {
 		for field_node in statement_node.children_by_field_name("field", &mut cursor) {
 			let identifier = self.node_symbol(&self.get_child_field(&field_node, "name")?)?;
 			let type_ = &self.get_child_field(&field_node, "type")?;
-			let f = ClassField {
+			let f = StructField {
 				name: identifier,
 				member_type: self.build_type_annotation(&type_)?,
-				reassignable: false,
-				phase: Phase::Independent,
-				is_static: false,
 			};
 			members.push(f);
 		}

--- a/libs/wingc/src/type_check.rs
+++ b/libs/wingc/src/type_check.rs
@@ -2322,7 +2322,7 @@ impl<'a> TypeChecker<'a> {
 					}
 					match struct_env.define(
 						&field.name,
-						SymbolKind::make_variable(field_type, false, false, field.phase),
+						SymbolKind::make_variable(field_type, false, false, Phase::Independent),
 						StatementIdx::Top,
 					) {
 						Err(type_error) => {

--- a/libs/wingc/src/type_check.rs
+++ b/libs/wingc/src/type_check.rs
@@ -821,16 +821,16 @@ impl TypeRef {
 	}
 
 	// returns true if mutable type or if immutable container type contains a mutable type
-	pub fn is_deep_mutable(&self) -> bool {
+	pub fn is_mutable(&self) -> bool {
 		match &**self {
 			Type::MutArray(_) => true,
 			Type::MutMap(_) => true,
 			Type::MutSet(_) => true,
 			Type::MutJson => true,
-			Type::Array(v) => v.is_deep_mutable(),
-			Type::Map(v) => v.is_deep_mutable(),
-			Type::Set(v) => v.is_deep_mutable(),
-			Type::Optional(v) => v.is_deep_mutable(),
+			Type::Array(v) => v.is_mutable(),
+			Type::Map(v) => v.is_mutable(),
+			Type::Set(v) => v.is_mutable(),
+			Type::Optional(v) => v.is_mutable(),
 			_ => false,
 		}
 	}
@@ -2314,7 +2314,7 @@ impl<'a> TypeChecker<'a> {
 				// Add fields to the struct env
 				for field in fields.iter() {
 					let field_type = self.resolve_type_annotation(&field.member_type, env);
-					if field_type.is_deep_mutable() {
+					if field_type.is_mutable() {
 						self.type_error(TypeError {
 							message: format!("struct fields must be immutable got: {}", field_type),
 							span: field.name.span.clone(),

--- a/tools/hangar/__snapshots__/invalid.ts.snap
+++ b/tools/hangar/__snapshots__/invalid.ts.snap
@@ -1035,6 +1035,13 @@ error: Unknown symbol \\"bad_field\\"
 30 | log(a.bad_field);
    |       ^^^^^^^^^ Unknown symbol \\"bad_field\\"
 
+
+error: Struct \\"Showtime (at ../../../examples/tests/invalid/structs.w:42:8)\\" extends \\"Dazzle\\" but has a conflicting member \\"a\\" (num != num)
+   --> ../../../examples/tests/invalid/structs.w:42:8
+   |
+42 | struct Showtime extends Razzle, Dazzle {}
+   |        ^^^^^^^^ Struct \\"Showtime (at ../../../examples/tests/invalid/structs.w:42:8)\\" extends \\"Dazzle\\" but has a conflicting member \\"a\\" (num != num)
+
 "
 `;
 

--- a/tools/hangar/__snapshots__/test_corpus/valid/structs.w.ts.snap
+++ b/tools/hangar/__snapshots__/test_corpus/valid/structs.w.ts.snap
@@ -102,6 +102,9 @@ Foo._annotateInflight(\\"$init\\", {\\"this.data\\": { ops: [] }});
     {((cond) => {if (!cond) throw new Error(\`assertion failed: '(x.field0 === \\"Sup\\")'\`)})((x.field0 === \\"Sup\\"))};
     {((cond) => {if (!cond) throw new Error(\`assertion failed: '(y.field1 === 1)'\`)})((y.field1 === 1))};
     {((cond) => {if (!cond) throw new Error(\`assertion failed: '(y.field3.field0 === \\"foo\\")'\`)})((y.field3.field0 === \\"foo\\"))};
+    const s = {
+\\"a\\": \\"Boom baby\\",}
+;
   }
 }
 


### PR DESCRIPTION
This PR addresses some of the simple struct left overs from the struct declaration PR. 

Primarily:

1. Adds more tests
2. Fixes grammar tests to use field names
3. Creates a `StructField` rather than use existing `ClassField`
4. Some misc renames

Closes: https://github.com/winglang/wing/issues/1909

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.