### PR TITLE
fix(compiler): indentation in javascript output is a mess

### DIFF
--- a/examples/tests/valid/try_catch.w
+++ b/examples/tests/valid/try_catch.w
@@ -26,11 +26,15 @@ assert(x == "finally");
 
 // Verify that finally is executed even if there's no catch block.
 try {
-  throw("hello");
-} finally {
-  x = "finally with no catch";
+  try {
+    throw("hello");
+  } finally {
+    x = "finally with no catch";
+  }
+  assert(x == "finally with no catch");
+} catch {
+  // no op (we just dont want the inner exception to stop the test)
 }
-assert(x == "finally with no catch");
 
 // Verify that finally is executed even if there's no catch block and no exception.
 try {

--- a/libs/wingc/src/jsify.rs
+++ b/libs/wingc/src/jsify.rs
@@ -2,7 +2,6 @@ mod codemaker;
 
 use aho_corasick::AhoCorasick;
 use const_format::formatcp;
-use indoc::formatdoc;
 use itertools::Itertools;
 
 use std::{
@@ -98,25 +97,25 @@ impl<'a> JSifier<'a> {
 		format!("\"./{}\".replace(/\\\\/g, \"/\")", path_name)
 	}
 
-	fn render_block(statements: impl IntoIterator<Item = impl core::fmt::Display>) -> String {
-		let mut lines = vec![];
-		lines.push("{".to_string());
+	// fn render_block(statements: impl IntoIterator<Item = impl core::fmt::Display>) -> String {
+	// 	let mut lines = vec![];
+	// 	lines.push("{".to_string());
 
-		for statement in statements {
-			let statement_str = format!("{}", statement);
-			let result = statement_str.split("\n");
-			for l in result {
-				lines.push(format!("  {}", l));
-			}
-		}
+	// 	for statement in statements {
+	// 		let statement_str = format!("{}", statement);
+	// 		let result = statement_str.split("\n");
+	// 		for l in result {
+	// 			lines.push(format!("  {}", l));
+	// 		}
+	// 	}
 
-		lines.push("}".to_string());
-		lines.join("\n")
-	}
+	// 	lines.push("}".to_string());
+	// 	lines.join("\n")
+	// }
 
 	pub fn jsify(&mut self, scope: &Scope) -> String {
-		let mut js = vec![];
-		let mut imports = vec![];
+		let mut js = CodeMaker::default();
+		let mut imports = CodeMaker::default();
 
 		for statement in scope.statements.iter().sorted_by(|a, b| match (&a.kind, &b.kind) {
 			// Put type definitions first so JS won't complain of unknown types
@@ -129,41 +128,38 @@ impl<'a> JSifier<'a> {
 				in_json: false,
 				phase: Phase::Preflight,
 			};
-			let line = self.jsify_statement(scope.env.borrow().as_ref().unwrap(), statement, &jsify_context); // top level statements are always preflight
-			if line.is_empty() {
-				continue;
-			}
+			let s = self.jsify_statement(scope.env.borrow().as_ref().unwrap(), statement, &jsify_context); // top level statements are always preflight
 			if let StmtKind::Bring {
 				identifier: _,
 				module_name: _,
 			} = statement.kind
 			{
-				imports.push(line);
+				imports.add_code(s);
 			} else {
-				js.push(line);
+				js.add_code(s);
 			}
 		}
 
-		let mut output = vec![];
+		let mut output = CodeMaker::default();
 
 		if self.shim {
-			output.push(format!("const {} = require('{}');", STDLIB, STDLIB_MODULE));
-			output.push(format!("const {} = process.env.WING_SYNTH_DIR ?? \".\";", OUTDIR_VAR));
-			output.push(format!(
+			output.line(format!("const {} = require('{}');", STDLIB, STDLIB_MODULE));
+			output.line(format!("const {} = process.env.WING_SYNTH_DIR ?? \".\";", OUTDIR_VAR));
+			output.line(format!(
 				"const {} = process.env.WING_IS_TEST === \"true\";",
 				ENV_WING_IS_TEST
 			));
-			output.push(TARGET_CODE.to_owned());
+			output.line(TARGET_CODE.to_owned());
 		}
 
-		output.append(&mut imports);
+		output.add_code(imports);
 
 		if self.shim {
 			let mut root_class = CodeMaker::default();
 			root_class.open(format!("class {} extends {} {{", ROOT_CLASS, STDLIB_CORE_RESOURCE));
 			root_class.open("constructor(scope, id) {");
 			root_class.line(format!("super(scope, id);"));
-			root_class.add_lines(js);
+			root_class.add_code(js);
 			root_class.close("}");
 			root_class.close("}");
 
@@ -188,31 +184,30 @@ impl<'a> JSifier<'a> {
 			app_wrapper.close("}");
 			app_wrapper.close("}");
 
-			output.push(root_class.to_string());
-			output.push(app_wrapper.to_string());
+			output.add_code(root_class);
+			output.add_code(app_wrapper);
 
-			output.push(format!("new {}().synth();", APP_CLASS));
+			output.line(format!("new {}().synth();", APP_CLASS));
 		} else {
-			output.append(&mut js);
+			output.add_code(js);
 		}
 
-		output.join("\n")
+		output.to_string()
 	}
 
-	fn jsify_scope(&mut self, scope: &Scope, context: &JSifyContext) -> String {
-		let mut lines = vec![];
-		lines.push("{".to_string());
+	fn jsify_scope_inner(&mut self, scope: &Scope, context: &JSifyContext) -> CodeMaker {
+		let mut code = CodeMaker::default();
+
+		// code.open("{");
 
 		for statement in scope.statements.iter() {
-			let statement_str = self.jsify_statement(scope.env.borrow().as_ref().unwrap(), statement, context);
-			let result = statement_str.split("\n");
-			for l in result {
-				lines.push(format!("  {}", l));
-			}
+			let statement_code = self.jsify_statement(scope.env.borrow().as_ref().unwrap(), statement, context);
+			code.add_code(statement_code);
 		}
 
-		lines.push("}".to_string());
-		lines.join("\n")
+		// code.close("}");
+
+		code
 	}
 
 	fn jsify_reference(&mut self, reference: &Reference, case_convert: Option<bool>, context: &JSifyContext) -> String {
@@ -596,20 +591,20 @@ impl<'a> JSifier<'a> {
 				}
 			}
 			ExprKind::FunctionClosure(func_def) => match func_def.signature.phase {
-				Phase::Inflight => self.jsify_inflight_function(func_def, context),
+				Phase::Inflight => self.jsify_inflight_function(func_def, context).to_string(),
 				Phase::Independent => unimplemented!(),
-				Phase::Preflight => self.jsify_function(None, func_def, context),
+				Phase::Preflight => self.jsify_function(None, func_def, context).to_string(),
 			},
 		}
 	}
 
-	fn jsify_statement(&mut self, env: &SymbolEnv, statement: &Stmt, context: &JSifyContext) -> String {
+	fn jsify_statement(&mut self, env: &SymbolEnv, statement: &Stmt, context: &JSifyContext) -> CodeMaker {
 		match &statement.kind {
 			StmtKind::Bring {
 				module_name,
 				identifier,
 			} => {
-				format!(
+				CodeMaker::one_line(format!(
 					"const {} = {};",
 					self.jsify_symbol(if let Some(identifier) = identifier {
 						// use alias
@@ -626,7 +621,7 @@ impl<'a> JSifier<'a> {
 					} else {
 						format!("require('{}').{}", STDLIB_MODULE, module_name.name)
 					}
-				)
+				))
 			}
 			StmtKind::VariableDef {
 				reassignable,
@@ -636,143 +631,152 @@ impl<'a> JSifier<'a> {
 			} => {
 				let initial_value = self.jsify_expression(initial_value, context);
 				return if *reassignable {
-					format!("let {} = {};", self.jsify_symbol(var_name), initial_value)
+					CodeMaker::one_line(format!("let {} = {};", self.jsify_symbol(var_name), initial_value))
 				} else {
-					format!("const {} = {};", self.jsify_symbol(var_name), initial_value)
+					CodeMaker::one_line(format!("const {} = {};", self.jsify_symbol(var_name), initial_value))
 				};
 			}
 			StmtKind::ForLoop {
 				iterator,
 				iterable,
 				statements,
-			} => format!(
-				"for (const {} of {}) {}",
-				self.jsify_symbol(iterator),
-				self.jsify_expression(iterable, context),
-				self.jsify_scope(statements, context)
-			),
-			StmtKind::While { condition, statements } => {
-				format!(
-					"while ({}) {}",
-					self.jsify_expression(condition, context),
-					self.jsify_scope(statements, context),
-				)
+			} => {
+				let mut code = CodeMaker::default();
+				code.open(format!(
+					"for (const {} of {}) {{",
+					self.jsify_symbol(iterator),
+					self.jsify_expression(iterable, context)
+				));
+				code.add_code(self.jsify_scope_inner(statements, context));
+				code.close("}");
+				code
 			}
-			StmtKind::Break => "break;".into(),
-			StmtKind::Continue => "continue;".into(),
+			StmtKind::While { condition, statements } => {
+				let mut code = CodeMaker::default();
+				code.open(format!("while ({}) {{", self.jsify_expression(condition, context)));
+				code.add_code(self.jsify_scope_inner(statements, context));
+				code.close("}");
+				code
+			}
+			StmtKind::Break => CodeMaker::one_line("break;"),
+			StmtKind::Continue => CodeMaker::one_line("continue;"),
 			StmtKind::If {
 				condition,
 				statements,
 				elif_statements,
 				else_statements,
 			} => {
-				let mut if_statement = format!(
-					"if ({}) {}",
-					self.jsify_expression(condition, context),
-					self.jsify_scope(statements, context),
-				);
+				let mut code = CodeMaker::default();
+
+				code.open(format!("if ({}) {{", self.jsify_expression(condition, context)));
+				code.add_code(self.jsify_scope_inner(statements, context));
+				code.close("}");
 
 				for elif_block in elif_statements {
-					let elif_statement = format!(
-						" else if ({}) {}",
-						self.jsify_expression(&elif_block.condition, context),
-						self.jsify_scope(&elif_block.statements, context),
-					);
-					if_statement.push_str(&elif_statement);
+					let condition = self.jsify_expression(&elif_block.condition, context);
+					// TODO: this puts the "else if" in a separate line from the closing block but
+					// technically that shouldn't be a problem, its just ugly
+					code.open(format!("else if ({}) {{", condition));
+					code.add_code(self.jsify_scope_inner(&elif_block.statements, context));
+					code.close("}");
 				}
 
 				if let Some(else_scope) = else_statements {
-					let else_statement = format!(" else {}", self.jsify_scope(else_scope, context));
-					if_statement.push_str(&else_statement);
+					code.open("else {");
+					code.add_code(self.jsify_scope_inner(else_scope, context));
+					code.close("}");
 				}
 
-				if_statement
+				code
 			}
-			StmtKind::Expression(e) => format!("{};", self.jsify_expression(e, context)),
-			StmtKind::Assignment { variable, value } => {
-				format!(
-					"{} = {};",
-					self.jsify_reference(&variable, None, context),
-					self.jsify_expression(value, context)
-				)
+			StmtKind::Expression(e) => CodeMaker::one_line(format!("{};", self.jsify_expression(e, context))),
+			StmtKind::Assignment { variable, value } => CodeMaker::one_line(format!(
+				"{} = {};",
+				self.jsify_reference(&variable, None, context),
+				self.jsify_expression(value, context)
+			)),
+			StmtKind::Scope(scope) => {
+				let mut code = CodeMaker::default();
+				code.open("{");
+				code.add_code(self.jsify_scope_inner(scope, context));
+				code.close("}");
+				code
 			}
-			StmtKind::Scope(scope) => self.jsify_scope(scope, context),
 			StmtKind::Return(exp) => {
 				if let Some(exp) = exp {
-					format!("return {};", self.jsify_expression(exp, context))
+					CodeMaker::one_line(format!("return {};", self.jsify_expression(exp, context)))
 				} else {
-					"return;".into()
+					CodeMaker::one_line("return;")
 				}
 			}
 			StmtKind::Class(class) => self.jsify_class(env, class, context),
 			StmtKind::Interface { .. } => {
 				// This is a no-op in JS
-				format!("")
+				CodeMaker::default()
 			}
 			StmtKind::Struct { .. } => {
 				// This is a no-op in JS
-				format!("")
+				CodeMaker::default()
 			}
 			StmtKind::Enum { name, values } => {
+				let mut code = CodeMaker::default();
 				let name = self.jsify_symbol(name);
 				let mut value_index = 0;
-				format!(
-					"const {} = Object.freeze((function ({}) {{\n{}\n  return {};\n}})({{}}));",
-					name,
-					name,
-					values
-						.iter()
-						.map(|value| {
-							let text = format!(
-								"  {}[{}[\"{}\"] = {}] = \"{}\";",
-								name, name, value.name, value_index, value.name
-							);
-							value_index = value_index + 1;
-							text
-						})
-						.collect::<Vec<String>>()
-						.join("\n"),
-					name,
-				)
+
+				code.open(format!("const {} = Object.freeze((function ({}) {{", name, name));
+
+				for value in values {
+					code.line(format!(
+						"{}[{}[\"{}\"] = {}] = \"{}\";",
+						name, name, value.name, value_index, value.name
+					));
+
+					value_index = value_index + 1;
+				}
+
+				code.line(format!("return {};", name));
+
+				code.close(format!("}})({{}}));"));
+				code
 			}
 			StmtKind::TryCatch {
 				try_statements,
 				catch_block,
 				finally_statements,
 			} => {
-				let try_block = self.jsify_scope(try_statements, context);
-				let mut catch_statements = "".to_string();
-				let mut js_exception_var = "".to_string();
-				let mut exception_var_conversion = "".to_string();
+				let mut code = CodeMaker::default();
+
+				code.open("try {");
+				code.add_code(self.jsify_scope_inner(try_statements, context));
+				code.close("}");
+
 				if let Some(catch_block) = catch_block {
-					catch_statements = self.jsify_scope(&catch_block.statements, context);
 					if let Some(exception_var_symbol) = &catch_block.exception_var {
 						let exception_var_str = self.jsify_symbol(exception_var_symbol);
-						js_exception_var = format!("($error_{exception_var_str})");
-						exception_var_conversion = format!("const {exception_var_str} = $error_{exception_var_str}.message;");
+						code.open(format!("catch ($error_{exception_var_str}) {{"));
+						code.line(format!(
+							"const {exception_var_str} = $error_{exception_var_str}.message;"
+						));
+					} else {
+						code.open("catch {");
 					}
+
+					code.add_code(self.jsify_scope_inner(&catch_block.statements, context));
+					code.close("}");
 				}
-				let finally_block = if let Some(finally_statements) = finally_statements {
-					format!("{};", self.jsify_scope(finally_statements, context))
-				} else {
-					"".to_string()
-				};
-				formatdoc!(
-					"
-					try {{
-						{try_block}
-					}} catch {js_exception_var} {{
-						{exception_var_conversion}
-						{catch_statements}
-					}} finally {{
-						{finally_block}
-					}}"
-				)
+
+				if let Some(finally_statements) = finally_statements {
+					code.open("finally {");
+					code.add_code(self.jsify_scope_inner(finally_statements, context));
+					code.close("}");
+				}
+
+				code
 			}
 		}
 	}
 
-	fn jsify_inflight_function(&mut self, func_def: &FunctionDefinition, context: &JSifyContext) -> String {
+	fn jsify_inflight_function(&mut self, func_def: &FunctionDefinition, context: &JSifyContext) -> CodeMaker {
 		let parameters = func_def
 			.parameters()
 			.iter()
@@ -780,61 +784,86 @@ impl<'a> JSifier<'a> {
 			.join(", ");
 
 		let block = match &func_def.body {
-			FunctionBody::Statements(scope) => self.jsify_scope(
-				scope,
-				&JSifyContext {
-					in_json: context.in_json.clone(),
-					phase: Phase::Inflight,
-				},
-			),
-			FunctionBody::External(_) => format!("{{ throw new Error(\"extern with closures is not supported\") }}"),
+			FunctionBody::Statements(scope) => {
+				let mut code = CodeMaker::default();
+				code.open("{");
+				code.add_code(self.jsify_scope_inner(
+					scope,
+					&JSifyContext {
+						in_json: context.in_json.clone(),
+						phase: Phase::Inflight,
+					},
+				));
+				code.close("}");
+				code
+			}
+			FunctionBody::External(_) => {
+				let mut code = CodeMaker::default();
+				code.open("{");
+				code.line("throw new Error(\"extern with closures is not supported\");");
+				code.close("}");
+				code
+			}
 		};
 
-		let procid = base16ct::lower::encode_string(&Sha256::new().chain_update(&block).finalize());
+		let procid = base16ct::lower::encode_string(&Sha256::new().chain_update(&block.to_string()).finalize());
 		let mut bindings = vec![];
 		let mut capture_names = vec![];
 
 		for capture in func_def.captures.borrow().as_ref().unwrap().iter() {
 			capture_names.push(capture.symbol.name.clone());
 
-			bindings.push(format!(
-				"{}: {},",
-				capture.symbol.name,
-				Self::render_block([
-					format!("obj: {},", capture.symbol.name),
-					format!(
-						"ops: [{}]",
-						capture.ops.iter().map(|x| format!("\"{}\"", x.member)).join(",")
-					)
-				])
+			let mut binding = CodeMaker::default();
+			binding.open(format!("{}: {{", capture.symbol.name));
+			binding.line(format!("obj: {},", capture.symbol.name));
+			binding.line(format!(
+				"ops: [{}]",
+				capture.ops.iter().map(|x| format!("\"{}\"", x.member)).join(",")
 			));
+			binding.close("},");
+			bindings.push(binding);
 		}
-		let mut proc_source = vec![];
-		let body = format!("{{ const {{ {} }} = this; {} }}", capture_names.join(", "), block);
-		proc_source.push(format!("async handle({parameters}) {body};"));
+
+		let mut proc_source = CodeMaker::default();
+		proc_source.open(format!("async handle({parameters}) {{"));
+		proc_source.line(format!("const {{ {} }} = this;", capture_names.join(", ")));
+		proc_source.add_code(block);
+		proc_source.close("};");
+
 		let proc_dir = format!("{}/proc.{}", self.out_dir.to_string_lossy(), procid);
 		fs::create_dir_all(&proc_dir).expect("Creating inflight proc dir");
 		let file_path = format!("{}/index.js", proc_dir);
 		let relative_file_path = format!("proc.{}/index.js", procid);
-		fs::write(&file_path, proc_source.join("\n")).expect("Writing inflight proc source");
-		let props_block = Self::render_block([
-			format!(
-				"code: {}.core.NodeJsCode.fromFile(require.resolve({})),",
-				STDLIB,
-				Self::js_resolve_path(&relative_file_path)
-			),
-			format!("bindings: {}", Self::render_block(&bindings)),
-		]);
+		fs::write(&file_path, proc_source.to_string()).expect("Writing inflight proc source");
+
+		let mut props_block = CodeMaker::default();
+		props_block.line(format!(
+			"code: {}.core.NodeJsCode.fromFile(require.resolve({})),",
+			STDLIB,
+			Self::js_resolve_path(&relative_file_path)
+		));
+		props_block.open("bindings: {");
+		for binding in bindings {
+			props_block.add_code(binding);
+		}
+		props_block.close("}");
+
 		let mut inflight_counter = self.inflight_counter.borrow_mut();
 		*inflight_counter += 1;
 		let inflight_obj_id = format!("{}{}", INFLIGHT_OBJ_PREFIX, inflight_counter);
-		format!(
-			"new {}.core.Inflight(this, \"{}\", {})",
-			STDLIB, inflight_obj_id, props_block
-		)
+
+		let mut code = CodeMaker::default();
+		code.open(format!(
+			"new {}.core.Inflight(this, \"{}\", {{",
+			STDLIB, inflight_obj_id
+		));
+		code.add_code(props_block);
+		code.close("})");
+
+		code
 	}
 
-	fn jsify_constructor(&mut self, name: Option<&str>, func_def: &Constructor, context: &JSifyContext) -> String {
+	fn jsify_constructor(&mut self, name: Option<&str>, func_def: &Constructor, context: &JSifyContext) -> CodeMaker {
 		let mut parameter_list = vec![];
 
 		for p in func_def.parameters() {
@@ -847,17 +876,16 @@ impl<'a> JSifier<'a> {
 		};
 
 		let parameters = parameter_list.iter().map(|x| x.as_str()).collect::<Vec<_>>().join(", ");
-		let body = self.jsify_scope(&func_def.statements, context);
 
-		formatdoc!(
-			"
-		{name}({parameters}) {arrow} {{
-			{body}
-		}}"
-		)
+		let mut code = CodeMaker::default();
+		code.open(format!("{name}({parameters}) {arrow} {{"));
+		code.add_code(self.jsify_scope_inner(&func_def.statements, context));
+		code.close("}");
+
+		code
 	}
 
-	fn jsify_function(&mut self, name: Option<&str>, func_def: &FunctionDefinition, context: &JSifyContext) -> String {
+	fn jsify_function(&mut self, name: Option<&str>, func_def: &FunctionDefinition, context: &JSifyContext) -> CodeMaker {
 		let mut parameter_list = vec![];
 
 		for p in func_def.parameters() {
@@ -872,8 +900,15 @@ impl<'a> JSifier<'a> {
 		let parameters = parameter_list.iter().map(|x| x.as_str()).collect::<Vec<_>>().join(", ");
 
 		let body = match &func_def.body {
-			FunctionBody::Statements(scope) => self.jsify_scope(scope, context),
-			FunctionBody::External(external_spec) => format!("return (require(require.resolve(\"{external_spec}\", {{paths: [process.env.WING_PROJECT_DIR]}}))[\"{name}\"])({parameters})")
+			FunctionBody::Statements(scope) => {
+				let mut code = CodeMaker::default();
+				code.open("{");
+				code.add_code(self.jsify_scope_inner(scope, context));
+				code.close("}");
+				code
+			}
+			FunctionBody::External(external_spec) =>
+				CodeMaker::one_line(format!("return (require(require.resolve(\"{external_spec}\", {{paths: [process.env.WING_PROJECT_DIR]}}))[\"{name}\"])({parameters})"))
 		};
 		let mut modifiers = vec![];
 		if func_def.is_static {
@@ -884,16 +919,16 @@ impl<'a> JSifier<'a> {
 		}
 		let modifiers = modifiers.join(" ");
 
-		formatdoc!(
-			"
-			{modifiers} {name}({parameters}) {arrow} {{
-				{body}
-			}}"
-		)
+		let mut code = CodeMaker::default();
+		code.open(format!("{modifiers} {name}({parameters}) {arrow} {{"));
+		code.add_code(body);
+		code.close("}");
+
+		code
 	}
 
-	fn jsify_class_member(&mut self, member: &ClassField) -> String {
-		format!("{};", self.jsify_symbol(&member.name))
+	fn jsify_class_member(&mut self, member: &ClassField) -> CodeMaker {
+		CodeMaker::one_line(format!("{};", self.jsify_symbol(&member.name)))
 	}
 
 	/// Jsify a resource
@@ -947,7 +982,7 @@ impl<'a> JSifier<'a> {
 	///   }
 	/// }
 	/// ```
-	fn jsify_resource(&mut self, env: &SymbolEnv, class: &AstClass, context: &JSifyContext) -> String {
+	fn jsify_resource(&mut self, env: &SymbolEnv, class: &AstClass, context: &JSifyContext) -> CodeMaker {
 		assert!(context.phase == Phase::Preflight);
 
 		// Lookup the resource type
@@ -985,34 +1020,28 @@ impl<'a> JSifier<'a> {
 			.filter(|(_, m)| m.signature.phase != Phase::Inflight)
 			.collect::<Vec<_>>();
 
-		let toinflight_method = self.jsify_toinflight_method(&class.name, &captured_fields);
+		let mut code = CodeMaker::default();
 
-		// Jsify class
-		let resource_class = formatdoc!(
-			"
-			class {}{} {{
-				{}
-				{}
-				{toinflight_method}
-			}}",
-			self.jsify_symbol(&class.name),
-			if let Some(parent) = &class.parent {
-				format!(" extends {}", self.jsify_user_defined_type(parent))
-			} else {
-				format!(" extends {}", STDLIB_CORE_RESOURCE)
-			},
-			self.jsify_resource_constructor(&class.constructor, class.parent.is_none(), context),
-			preflight_methods
-				.iter()
-				.map(|(n, m)| self.jsify_function(Some(&n.name), &m, context))
-				.collect::<Vec<String>>()
-				.join("\n"),
-		);
+		let extends = if let Some(parent) = &class.parent {
+			format!(" extends {}", self.jsify_user_defined_type(parent))
+		} else {
+			format!(" extends {}", STDLIB_CORE_RESOURCE)
+		};
+
+		code.open(format!("class {}{} {{", self.jsify_symbol(&class.name), extends));
+		code.add_code(self.jsify_resource_constructor(&class.constructor, class.parent.is_none(), context));
+
+		for (n, m) in preflight_methods {
+			code.add_code(self.jsify_function(Some(&n.name), &m, context));
+		}
+
+		code.add_code(self.jsify_toinflight_method(&class.name, &captured_fields));
+
+		code.close("}");
 
 		// go over all bindings and produce inflight annotations
-		let mut inflight_annotations = vec![];
 		for (method_name, refs) in refs {
-			inflight_annotations.push(format!(
+			code.line(format!(
 				"{}._annotateInflight(\"{}\", {{{}}});",
 				self.jsify_symbol(&class.name),
 				method_name,
@@ -1028,7 +1057,7 @@ impl<'a> JSifier<'a> {
 		}
 
 		// Return the preflight resource class
-		return format!("{}\n{}", resource_class, inflight_annotations.join("\n"));
+		code
 	}
 
 	fn jsify_resource_constructor(
@@ -1036,53 +1065,67 @@ impl<'a> JSifier<'a> {
 		constructor: &Constructor,
 		no_parent: bool,
 		context: &JSifyContext,
-	) -> String {
-		format!(
-			"constructor(scope, id, {}) {{\n{}\n{}\n}}",
+	) -> CodeMaker {
+		let mut code = CodeMaker::default();
+		code.open(format!(
+			"constructor(scope, id, {}) {{",
 			constructor
 				.parameters()
 				.iter()
 				.map(|p| self.jsify_symbol(&p.name))
 				.collect::<Vec<_>>()
 				.join(", "),
-			// If there's no parent then this resource is derived from the base resource class (core.Resource) and we need
-			// to manually call its super
-			if no_parent { "	super(scope, id);" } else { "" },
-			self.jsify_scope(
-				&constructor.statements,
-				&JSifyContext {
-					in_json: context.in_json.clone(),
-					phase: Phase::Preflight,
-				}
-			)
-		)
+		));
+
+		if no_parent {
+			code.line("super(scope, id);");
+		}
+
+		code.add_code(self.jsify_scope_inner(
+			&constructor.statements,
+			&JSifyContext {
+				in_json: context.in_json.clone(),
+				phase: Phase::Preflight,
+			},
+		));
+
+		code.close("}");
+		code
 	}
 
-	fn jsify_toinflight_method(&mut self, resource_name: &Symbol, captured_fields: &[String]) -> String {
-		let inner_clients = captured_fields
-			.iter()
-			.map(|inner_member_name| {
-				format!(
-					"const {}_client = this._lift(this.{});",
-					inner_member_name, inner_member_name,
-				)
-			})
-			.collect_vec()
-			.join("\n");
-
+	fn jsify_toinflight_method(&mut self, resource_name: &Symbol, captured_fields: &[String]) -> CodeMaker {
 		let client_path = Self::js_resolve_path(&format!("{}/{}.inflight.js", INFLIGHT_CLIENTS_DIR, resource_name.name));
-		let captured_fields = captured_fields
-			.iter()
-			.map(|inner_member_name| format!("{}: ${{{}_client}}", inner_member_name, inner_member_name))
-			.join(", ");
-		formatdoc!("
-			_toInflight() {{
-				{inner_clients}
-				const self_client_path = {client_path};
-				return {STDLIB}.core.NodeJsCode.fromInline(`(new (require(\"${{self_client_path}}\")).{resource_name}({{{captured_fields}}}))`);
-			}}",
-			resource_name = resource_name.name,
-		)
+
+		let mut code = CodeMaker::default();
+
+		code.open("_toInflight() {");
+
+		for inner_member_name in captured_fields {
+			code.line(format!(
+				"const {}_client = this._lift(this.{});",
+				inner_member_name, inner_member_name,
+			));
+		}
+
+		code.line(format!("const self_client_path = {client_path};"));
+
+		code.open(format!("return {STDLIB}.core.NodeJsCode.fromInline(`"));
+
+		code.open(format!(
+			"(new (require(\"${{self_client_path}}\")).{}({{",
+			resource_name.name
+		));
+
+		for inner_member_name in captured_fields {
+			code.line(format!("{}: ${{{}_client}},", inner_member_name, inner_member_name));
+		}
+
+		code.close("}))");
+
+		code.close("`);");
+
+		code.close("}");
+		code
 	}
 
 	// Write a client class for a file for the given resource
@@ -1108,94 +1151,92 @@ impl<'a> JSifier<'a> {
 			.filter(|name| !parent_captures.iter().any(|n| n == *name))
 			.collect_vec();
 
-		let super_call = if parent.is_some() {
-			format!(
-				"  super({});",
-				parent_captures.iter().map(|name| name.clone()).collect_vec().join(", ")
-			)
-		} else {
-			"".to_string()
-		};
-
 		// TODO jsify inflight fields: https://github.com/winglang/wing/issues/864
+		let mut code = CodeMaker::default();
 
-		let client_constructor = format!(
-			"constructor({{ {} }}) {{\n{}\n{}\n}}",
-			captured_fields
-				.iter()
-				.map(|name| { name.clone() })
-				.collect_vec()
-				.join(", "),
-			super_call,
-			my_captures
-				.iter()
-				.map(|name| { format!("  this.{} = {};", name, name) })
-				.collect_vec()
-				.join("\n")
-		);
-
-		let client_methods = inflight_methods
-			.iter()
-			.map(|(name, def)| {
-				self.jsify_function(
-					Some(&name.name),
-					&def,
-					&JSifyContext {
-						in_json: context.in_json.clone(),
-						phase: def.signature.phase,
-					},
-				)
-			})
-			.collect_vec();
-
-		let client_source = format!(
-			"class {} {} {{\n{}\n{}}}\nexports.{} = {};",
+		code.open(format!(
+			"class {} {} {{",
 			name.name,
 			if let Some(parent) = parent {
 				format!("extends {}", self.jsify_user_defined_type(parent))
 			} else {
 				"".to_string()
-			},
-			client_constructor,
-			client_methods.join("\n"),
-			name.name,
-			name.name
-		);
+			}
+		));
+
+		code.open(format!(
+			"constructor({{ {} }}) {{",
+			captured_fields
+				.iter()
+				.map(|name| { name.clone() })
+				.collect_vec()
+				.join(", ")
+		));
+
+		if parent.is_some() {
+			code.line(format!(
+				"super({});",
+				parent_captures.iter().map(|name| name.clone()).collect_vec().join(", ")
+			));
+		}
+
+		for name in &my_captures {
+			code.line(format!("this.{} = {};", name, name));
+		}
+
+		code.close("}");
+
+		for (name, def) in inflight_methods {
+			code.add_code(self.jsify_function(
+				Some(&name.name),
+				&def,
+				&JSifyContext {
+					in_json: context.in_json.clone(),
+					phase: def.signature.phase,
+				},
+			));
+		}
+
+		code.close("}");
+
+		// export all classes from this file
+		code.line(format!("exports.{} = {};", name.name, name.name));
 
 		let clients_dir = format!("{}/clients", self.out_dir.to_string_lossy());
 		fs::create_dir_all(&clients_dir).expect("Creating inflight clients");
 		let client_file_name = format!("{}.inflight.js", name.name);
 		let relative_file_path = format!("{}/{}", clients_dir, client_file_name);
-		fs::write(&relative_file_path, client_source).expect("Writing client inflight source");
+		fs::write(&relative_file_path, code.to_string()).expect("Writing client inflight source");
 	}
 
-	fn jsify_class(&mut self, env: &SymbolEnv, class: &AstClass, context: &JSifyContext) -> String {
+	fn jsify_class(&mut self, env: &SymbolEnv, class: &AstClass, context: &JSifyContext) -> CodeMaker {
 		if class.is_resource {
 			return self.jsify_resource(env, class, context);
 		}
 
-		format!(
-			"class {}{}\n{{\n{}\n{}\n{}\n}}",
+		let mut code = CodeMaker::default();
+		code.open(format!(
+			"class {}{}\n{{",
 			self.jsify_symbol(&class.name),
 			if let Some(parent) = &class.parent {
 				format!(" extends {}", self.jsify_user_defined_type(parent))
 			} else {
 				"".to_string()
 			},
-			self.jsify_constructor(Some("constructor"), &class.constructor, context),
-			class
-				.fields
-				.iter()
-				.map(|m| self.jsify_class_member(m))
-				.collect::<Vec<String>>()
-				.join("\n"),
-			class
-				.methods
-				.iter()
-				.map(|(n, m)| self.jsify_function(Some(&n.name), &m, context))
-				.collect::<Vec<String>>()
-				.join("\n")
-		)
+		));
+
+		code.add_code(self.jsify_constructor(Some("constructor"), &class.constructor, context));
+
+		for m in class.fields.iter() {
+			code.add_code(self.jsify_class_member(&m));
+		}
+
+		for (n, m) in class.methods.iter() {
+			code.add_code(self.jsify_function(Some(&n.name), &m, context));
+		}
+
+		code.close("}");
+		code
 	}
 
 	/// Get the type and capture info for fields that are captured in the client of the given resource

--- a/libs/wingc/src/jsify.rs
+++ b/libs/wingc/src/jsify.rs
@@ -97,22 +97,6 @@ impl<'a> JSifier<'a> {
 		format!("\"./{}\".replace(/\\\\/g, \"/\")", path_name)
 	}
 
-	// fn render_block(statements: impl IntoIterator<Item = impl core::fmt::Display>) -> String {
-	// 	let mut lines = vec![];
-	// 	lines.push("{".to_string());
-
-	// 	for statement in statements {
-	// 		let statement_str = format!("{}", statement);
-	// 		let result = statement_str.split("\n");
-	// 		for l in result {
-	// 			lines.push(format!("  {}", l));
-	// 		}
-	// 	}
-
-	// 	lines.push("}".to_string());
-	// 	lines.join("\n")
-	// }
-
 	pub fn jsify(&mut self, scope: &Scope) -> String {
 		let mut js = CodeMaker::default();
 		let mut imports = CodeMaker::default();
@@ -195,17 +179,13 @@ impl<'a> JSifier<'a> {
 		output.to_string()
 	}
 
-	fn jsify_scope_inner(&mut self, scope: &Scope, context: &JSifyContext) -> CodeMaker {
+	fn jsify_scope_statements(&mut self, scope: &Scope, context: &JSifyContext) -> CodeMaker {
 		let mut code = CodeMaker::default();
-
-		// code.open("{");
 
 		for statement in scope.statements.iter() {
 			let statement_code = self.jsify_statement(scope.env.borrow().as_ref().unwrap(), statement, context);
 			code.add_code(statement_code);
 		}
-
-		// code.close("}");
 
 		code
 	}
@@ -647,14 +627,14 @@ impl<'a> JSifier<'a> {
 					self.jsify_symbol(iterator),
 					self.jsify_expression(iterable, context)
 				));
-				code.add_code(self.jsify_scope_inner(statements, context));
+				code.add_code(self.jsify_scope_statements(statements, context));
 				code.close("}");
 				code
 			}
 			StmtKind::While { condition, statements } => {
 				let mut code = CodeMaker::default();
 				code.open(format!("while ({}) {{", self.jsify_expression(condition, context)));
-				code.add_code(self.jsify_scope_inner(statements, context));
+				code.add_code(self.jsify_scope_statements(statements, context));
 				code.close("}");
 				code
 			}
@@ -669,7 +649,7 @@ impl<'a> JSifier<'a> {
 				let mut code = CodeMaker::default();
 
 				code.open(format!("if ({}) {{", self.jsify_expression(condition, context)));
-				code.add_code(self.jsify_scope_inner(statements, context));
+				code.add_code(self.jsify_scope_statements(statements, context));
 				code.close("}");
 
 				for elif_block in elif_statements {
@@ -677,13 +657,13 @@ impl<'a> JSifier<'a> {
 					// TODO: this puts the "else if" in a separate line from the closing block but
 					// technically that shouldn't be a problem, its just ugly
 					code.open(format!("else if ({}) {{", condition));
-					code.add_code(self.jsify_scope_inner(&elif_block.statements, context));
+					code.add_code(self.jsify_scope_statements(&elif_block.statements, context));
 					code.close("}");
 				}
 
 				if let Some(else_scope) = else_statements {
 					code.open("else {");
-					code.add_code(self.jsify_scope_inner(else_scope, context));
+					code.add_code(self.jsify_scope_statements(else_scope, context));
 					code.close("}");
 				}
 
@@ -698,7 +678,7 @@ impl<'a> JSifier<'a> {
 			StmtKind::Scope(scope) => {
 				let mut code = CodeMaker::default();
 				code.open("{");
-				code.add_code(self.jsify_scope_inner(scope, context));
+				code.add_code(self.jsify_scope_statements(scope, context));
 				code.close("}");
 				code
 			}
@@ -747,7 +727,7 @@ impl<'a> JSifier<'a> {
 				let mut code = CodeMaker::default();
 
 				code.open("try {");
-				code.add_code(self.jsify_scope_inner(try_statements, context));
+				code.add_code(self.jsify_scope_statements(try_statements, context));
 				code.close("}");
 
 				if let Some(catch_block) = catch_block {
@@ -761,13 +741,13 @@ impl<'a> JSifier<'a> {
 						code.open("catch {");
 					}
 
-					code.add_code(self.jsify_scope_inner(&catch_block.statements, context));
+					code.add_code(self.jsify_scope_statements(&catch_block.statements, context));
 					code.close("}");
 				}
 
 				if let Some(finally_statements) = finally_statements {
 					code.open("finally {");
-					code.add_code(self.jsify_scope_inner(finally_statements, context));
+					code.add_code(self.jsify_scope_statements(finally_statements, context));
 					code.close("}");
 				}
 
@@ -787,7 +767,7 @@ impl<'a> JSifier<'a> {
 			FunctionBody::Statements(scope) => {
 				let mut code = CodeMaker::default();
 				code.open("{");
-				code.add_code(self.jsify_scope_inner(
+				code.add_code(self.jsify_scope_statements(
 					scope,
 					&JSifyContext {
 						in_json: context.in_json.clone(),
@@ -879,7 +859,7 @@ impl<'a> JSifier<'a> {
 
 		let mut code = CodeMaker::default();
 		code.open(format!("{name}({parameters}) {arrow} {{"));
-		code.add_code(self.jsify_scope_inner(&func_def.statements, context));
+		code.add_code(self.jsify_scope_statements(&func_def.statements, context));
 		code.close("}");
 
 		code
@@ -903,7 +883,7 @@ impl<'a> JSifier<'a> {
 			FunctionBody::Statements(scope) => {
 				let mut code = CodeMaker::default();
 				code.open("{");
-				code.add_code(self.jsify_scope_inner(scope, context));
+				code.add_code(self.jsify_scope_statements(scope, context));
 				code.close("}");
 				code
 			}
@@ -1081,7 +1061,7 @@ impl<'a> JSifier<'a> {
 			code.line("super(scope, id);");
 		}
 
-		code.add_code(self.jsify_scope_inner(
+		code.add_code(self.jsify_scope_statements(
 			&constructor.statements,
 			&JSifyContext {
 				in_json: context.in_json.clone(),

--- a/libs/wingc/src/jsify.rs
+++ b/libs/wingc/src/jsify.rs
@@ -1216,7 +1216,7 @@ impl<'a> JSifier<'a> {
 
 		let mut code = CodeMaker::default();
 		code.open(format!(
-			"class {}{}\n{{",
+			"class {}{} {{",
 			self.jsify_symbol(&class.name),
 			if let Some(parent) = &class.parent {
 				format!(" extends {}", self.jsify_user_defined_type(parent))

--- a/libs/wingc/src/jsify/codemaker.rs
+++ b/libs/wingc/src/jsify/codemaker.rs
@@ -1,5 +1,3 @@
-use indoc::indoc;
-
 /// A helper for generating code snippets with indentation.
 ///
 /// TODO: add `open_block` or `close_block` methods that automatically add
@@ -32,7 +30,6 @@ impl CodeMaker {
 	}
 
 	/// Emits multiple lines of code starting with the current indent.
-	#[allow(dead_code)]
 	pub fn add_code(&mut self, code: CodeMaker) {
 		assert_eq!(code.indent, 0, "Cannot add code with indent");
 		for (indent, line) in code.lines {
@@ -101,6 +98,7 @@ mod tests {
 			"#}
 		);
 	}
+
 	#[test]
 	fn codemaker_add_code() {
 		let mut code1 = CodeMaker::default();
@@ -120,21 +118,21 @@ mod tests {
 		"#}
 		);
 	}
-}
 
-#[test]
-fn codemaker_line_with_newlines() {
-	let mut code = CodeMaker::default();
-	code.open("<");
-	code.line("hello\nworld");
-	code.close(">");
-	assert_eq!(
-		code.to_string(),
-		indoc! {r#"
-			<
-			  hello
-			  world
-			>
-		"#}
-	);
+	#[test]
+	fn codemaker_line_with_newlines() {
+		let mut code = CodeMaker::default();
+		code.open("<");
+		code.line("hello\nworld");
+		code.close(">");
+		assert_eq!(
+			code.to_string(),
+			indoc! {r#"
+				<
+				  hello
+				  world
+				>
+			"#}
+		);
+	}
 }

--- a/libs/wingc/src/jsify/codemaker.rs
+++ b/libs/wingc/src/jsify/codemaker.rs
@@ -1,3 +1,5 @@
+use indoc::indoc;
+
 /// A helper for generating code snippets with indentation.
 ///
 /// TODO: add `open_block` or `close_block` methods that automatically add
@@ -23,13 +25,9 @@ impl CodeMaker {
 
 	/// Emits a line of code with the current indent.
 	pub fn line<S: Into<String>>(&mut self, line: S) {
-		self.lines.push((self.indent, line.into()));
-	}
-
-	/// Emits multiple lines of code starting with the current indent.
-	pub fn add_lines<S: Into<String>>(&mut self, lines: Vec<S>) {
-		for line in lines {
-			self.line(line);
+		// if the line has newlines in it, consider each line separately
+		for subline in line.into().split('\n') {
+			self.lines.push((self.indent, subline.into()));
 		}
 	}
 
@@ -51,6 +49,12 @@ impl CodeMaker {
 	/// Increases the current indent by one.
 	pub fn indent(&mut self) {
 		self.indent += 1;
+	}
+
+	pub fn one_line<S: Into<String>>(s: S) -> CodeMaker {
+		let mut code = CodeMaker::default();
+		code.line(s);
+		code
 	}
 }
 
@@ -97,24 +101,6 @@ mod tests {
 			"#}
 		);
 	}
-
-	#[test]
-	fn codemaker_add_lines() {
-		let mut code = CodeMaker::default();
-		code.open("{");
-		code.add_lines(vec!["let a = 1;", "let b = 2;"]);
-		code.close("}");
-		assert_eq!(
-			code.to_string(),
-			indoc! {r#"
-			{
-			  let a = 1;
-			  let b = 2;
-			}
-		"#}
-		);
-	}
-
 	#[test]
 	fn codemaker_add_code() {
 		let mut code1 = CodeMaker::default();
@@ -134,4 +120,21 @@ mod tests {
 		"#}
 		);
 	}
+}
+
+#[test]
+fn codemaker_line_with_newlines() {
+	let mut code = CodeMaker::default();
+	code.open("<");
+	code.line("hello\nworld");
+	code.close(">");
+	assert_eq!(
+		code.to_string(),
+		indoc! {r#"
+			<
+			  hello
+			  world
+			>
+		"#}
+	);
 }

--- a/tools/hangar/__snapshots__/test_corpus/valid/anon_function.w.ts.snap
+++ b/tools/hangar/__snapshots__/test_corpus/valid/anon_function.w.ts.snap
@@ -59,24 +59,25 @@ class $Root extends $stdlib.core.Resource {
   constructor(scope, id) {
     super(scope, id);
     const myfunc =  (x) =>  {
-	{
-  {console.log(\`\${x}\`)};
-  x = (x + 1);
-  if ((x > 3.14)) {
-    return;
-  }
-  (myfunc(x));
-}
-};
+      {
+        {console.log(\`\${x}\`)};
+        x = (x + 1);
+        if ((x > 3.14)) {
+          return;
+        }
+        (myfunc(x));
+      }
+    }
+    ;
     (myfunc(1));
     (( (x) =>  {
-	{
-  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(x === 1)'\`)})((x === 1))};
-}
-})(1));
+      {
+        {((cond) => {if (!cond) throw new Error(\`assertion failed: '(x === 1)'\`)})((x === 1))};
+      }
+    }
+    )(1));
   }
 }
-
 class $App extends $AppBase {
   constructor() {
     super({ outdir: $outdir, name: \\"anon_function\\", plugins: $plugins, isTestEnvironment: $wing_is_test });
@@ -92,8 +93,8 @@ class $App extends $AppBase {
     }
   }
 }
-
-new $App().synth();"
+new $App().synth();
+"
 `;
 
 exports[`wing test -t sim > stdout 1`] = `

--- a/tools/hangar/__snapshots__/test_corpus/valid/api.w.ts.snap
+++ b/tools/hangar/__snapshots__/test_corpus/valid/api.w.ts.snap
@@ -239,18 +239,18 @@ class $Root extends $stdlib.core.Resource {
     const api = this.node.root.newAbstract(\\"@winglang/sdk.cloud.Api\\",this,\\"cloud.Api\\");
     const counter = this.node.root.newAbstract(\\"@winglang/sdk.cloud.Counter\\",this,\\"cloud.Counter\\");
     const handler = new $stdlib.core.Inflight(this, \\"$Inflight1\\", {
-  code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.c83263b121750e827ffc19b09e3c0813a9accb33e17a19eae0dbc2680135a09e/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
-  bindings: {
-    counter: {
-      obj: counter,
-      ops: [\\"dec\\",\\"inc\\",\\"peek\\",\\"reset\\"]
-    },
-  }
-});
+      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.c26051a89f405d2468faad55f0be7a1f255e07ed6068d1ead8ce15a0421e1c55/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
+      bindings: {
+        counter: {
+          obj: counter,
+          ops: [\\"dec\\",\\"inc\\",\\"peek\\",\\"reset\\"]
+        },
+      }
+    })
+    ;
     (api.get(\\"/hello/world\\",handler));
   }
 }
-
 class $App extends $AppBase {
   constructor() {
     super({ outdir: $outdir, name: \\"api\\", plugins: $plugins, isTestEnvironment: $wing_is_test });
@@ -266,20 +266,24 @@ class $App extends $AppBase {
     }
   }
 }
-
-new $App().synth();"
+new $App().synth();
+"
 `;
 
-exports[`wing compile -t tf-aws > proc.c83263b121750e827ffc19b09e3c0813a9accb33e17a19eae0dbc2680135a09e/index.js 1`] = `
-"async handle(request) { const { counter } = this; {
-  const count = (await counter.inc());
-  const bodyResponse = Object.freeze({\\"count\\":count});
-  const resp = {
-  \\"body\\": bodyResponse,
-  \\"status\\": 200,}
-  ;
-  return resp;
-} };"
+exports[`wing compile -t tf-aws > proc.c26051a89f405d2468faad55f0be7a1f255e07ed6068d1ead8ce15a0421e1c55/index.js 1`] = `
+"async handle(request) {
+  const { counter } = this;
+  {
+    const count = (await counter.inc());
+    const bodyResponse = Object.freeze({\\"count\\":count});
+    const resp = {
+    \\"body\\": bodyResponse,
+    \\"status\\": 200,}
+    ;
+    return resp;
+  }
+};
+"
 `;
 
 exports[`wing test -t sim > stdout 1`] = `

--- a/tools/hangar/__snapshots__/test_corpus/valid/api.w.ts.snap
+++ b/tools/hangar/__snapshots__/test_corpus/valid/api.w.ts.snap
@@ -239,7 +239,7 @@ class $Root extends $stdlib.core.Resource {
     const api = this.node.root.newAbstract(\\"@winglang/sdk.cloud.Api\\",this,\\"cloud.Api\\");
     const counter = this.node.root.newAbstract(\\"@winglang/sdk.cloud.Counter\\",this,\\"cloud.Counter\\");
     const handler = new $stdlib.core.Inflight(this, \\"$Inflight1\\", {
-      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.c26051a89f405d2468faad55f0be7a1f255e07ed6068d1ead8ce15a0421e1c55/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
+      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.4ea11c0c20cac55e9e28b889e8e770331d2ed4a5baf0d566c4402cfa2b200882/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
       bindings: {
         counter: {
           obj: counter,
@@ -270,19 +270,17 @@ new $App().synth();
 "
 `;
 
-exports[`wing compile -t tf-aws > proc.c26051a89f405d2468faad55f0be7a1f255e07ed6068d1ead8ce15a0421e1c55/index.js 1`] = `
+exports[`wing compile -t tf-aws > proc.4ea11c0c20cac55e9e28b889e8e770331d2ed4a5baf0d566c4402cfa2b200882/index.js 1`] = `
 "async handle(request) {
   const { counter } = this;
-  {
-    const count = (await counter.inc());
-    const bodyResponse = Object.freeze({\\"count\\":count});
-    const resp = {
-    \\"body\\": bodyResponse,
-    \\"status\\": 200,}
-    ;
-    return resp;
-  }
-};
+  const count = (await counter.inc());
+  const bodyResponse = Object.freeze({\\"count\\":count});
+  const resp = {
+  \\"body\\": bodyResponse,
+  \\"status\\": 200,}
+  ;
+  return resp;
+}
 "
 `;
 

--- a/tools/hangar/__snapshots__/test_corpus/valid/asynchronous_model_implicit_await_in_functions.w.ts.snap
+++ b/tools/hangar/__snapshots__/test_corpus/valid/asynchronous_model_implicit_await_in_functions.w.ts.snap
@@ -235,13 +235,13 @@ class $Root extends $stdlib.core.Resource {
     super(scope, id);
     const q = this.node.root.newAbstract(\\"@winglang/sdk.cloud.Queue\\",this,\\"cloud.Queue\\");
     const str_to_str = this.node.root.newAbstract(\\"@winglang/sdk.cloud.Function\\",this,\\"str_to_str\\",new $stdlib.core.Inflight(this, \\"$Inflight1\\", {
-      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.d914176fd50bd7f565700006a31aa97b79d3ad17cee20c8e5ff2061d5cb74817/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
+      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
       bindings: {
       }
     })
     );
     const func = this.node.root.newAbstract(\\"@winglang/sdk.cloud.Function\\",this,\\"func\\",new $stdlib.core.Inflight(this, \\"$Inflight2\\", {
-      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.13b2cb30eb584e849d9aa55004deb4898450673323e185775bfb0f54d98feaee/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
+      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.e60080e02327d620984af1e0f736391d5699cae59be5733b234340cc59c07e66/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
       bindings: {
         str_to_str: {
           obj: str_to_str,
@@ -271,23 +271,19 @@ new $App().synth();
 "
 `;
 
-exports[`wing compile -t tf-aws > proc.13b2cb30eb584e849d9aa55004deb4898450673323e185775bfb0f54d98feaee/index.js 1`] = `
+exports[`wing compile -t tf-aws > proc.e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/index.js 1`] = `
 "async handle(s) {
-  const { str_to_str } = this;
-  {
-    (await str_to_str.invoke(\\"one\\"));
-    {console.log((await str_to_str.invoke(\\"two\\")))};
-  }
-};
+  const {  } = this;
+}
 "
 `;
 
-exports[`wing compile -t tf-aws > proc.d914176fd50bd7f565700006a31aa97b79d3ad17cee20c8e5ff2061d5cb74817/index.js 1`] = `
+exports[`wing compile -t tf-aws > proc.e60080e02327d620984af1e0f736391d5699cae59be5733b234340cc59c07e66/index.js 1`] = `
 "async handle(s) {
-  const {  } = this;
-  {
-  }
-};
+  const { str_to_str } = this;
+  (await str_to_str.invoke(\\"one\\"));
+  {console.log((await str_to_str.invoke(\\"two\\")))};
+}
 "
 `;
 

--- a/tools/hangar/__snapshots__/test_corpus/valid/asynchronous_model_implicit_await_in_functions.w.ts.snap
+++ b/tools/hangar/__snapshots__/test_corpus/valid/asynchronous_model_implicit_await_in_functions.w.ts.snap
@@ -235,22 +235,23 @@ class $Root extends $stdlib.core.Resource {
     super(scope, id);
     const q = this.node.root.newAbstract(\\"@winglang/sdk.cloud.Queue\\",this,\\"cloud.Queue\\");
     const str_to_str = this.node.root.newAbstract(\\"@winglang/sdk.cloud.Function\\",this,\\"str_to_str\\",new $stdlib.core.Inflight(this, \\"$Inflight1\\", {
-  code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.8eb95bcbc154530931e15fc418c8b1fe991095671409552099ea1aa596999ede/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
-  bindings: {
-  }
-}));
+      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.d914176fd50bd7f565700006a31aa97b79d3ad17cee20c8e5ff2061d5cb74817/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
+      bindings: {
+      }
+    })
+    );
     const func = this.node.root.newAbstract(\\"@winglang/sdk.cloud.Function\\",this,\\"func\\",new $stdlib.core.Inflight(this, \\"$Inflight2\\", {
-  code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.2241fd974faa47c8b8d27f5a3e172f473ca36c6b44cb328a58655fd2d0aac7d7/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
-  bindings: {
-    str_to_str: {
-      obj: str_to_str,
-      ops: [\\"invoke\\"]
-    },
-  }
-}));
+      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.13b2cb30eb584e849d9aa55004deb4898450673323e185775bfb0f54d98feaee/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
+      bindings: {
+        str_to_str: {
+          obj: str_to_str,
+          ops: [\\"invoke\\"]
+        },
+      }
+    })
+    );
   }
 }
-
 class $App extends $AppBase {
   constructor() {
     super({ outdir: $outdir, name: \\"asynchronous_model_implicit_await_in_functions\\", plugins: $plugins, isTestEnvironment: $wing_is_test });
@@ -266,20 +267,28 @@ class $App extends $AppBase {
     }
   }
 }
-
-new $App().synth();"
+new $App().synth();
+"
 `;
 
-exports[`wing compile -t tf-aws > proc.8eb95bcbc154530931e15fc418c8b1fe991095671409552099ea1aa596999ede/index.js 1`] = `
-"async handle(s) { const {  } = this; {
-} };"
+exports[`wing compile -t tf-aws > proc.13b2cb30eb584e849d9aa55004deb4898450673323e185775bfb0f54d98feaee/index.js 1`] = `
+"async handle(s) {
+  const { str_to_str } = this;
+  {
+    (await str_to_str.invoke(\\"one\\"));
+    {console.log((await str_to_str.invoke(\\"two\\")))};
+  }
+};
+"
 `;
 
-exports[`wing compile -t tf-aws > proc.2241fd974faa47c8b8d27f5a3e172f473ca36c6b44cb328a58655fd2d0aac7d7/index.js 1`] = `
-"async handle(s) { const { str_to_str } = this; {
-  (await str_to_str.invoke(\\"one\\"));
-  {console.log((await str_to_str.invoke(\\"two\\")))};
-} };"
+exports[`wing compile -t tf-aws > proc.d914176fd50bd7f565700006a31aa97b79d3ad17cee20c8e5ff2061d5cb74817/index.js 1`] = `
+"async handle(s) {
+  const {  } = this;
+  {
+  }
+};
+"
 `;
 
 exports[`wing test -t sim > stdout 1`] = `

--- a/tools/hangar/__snapshots__/test_corpus/valid/bring_cdktf.w.ts.snap
+++ b/tools/hangar/__snapshots__/test_corpus/valid/bring_cdktf.w.ts.snap
@@ -77,12 +77,11 @@ class $Root extends $stdlib.core.Resource {
   constructor(scope, id) {
     super(scope, id);
     this.node.root.new(\\"@cdktf/provider-aws.s3Bucket.S3Bucket\\",aws.s3Bucket.S3Bucket,this,\\"Bucket\\",{ bucketPrefix: \\"hello\\", versioning: {
-\\"enabled\\": true,
-\\"mfaDelete\\": true,}
- });
+    \\"enabled\\": true,
+    \\"mfaDelete\\": true,}
+     });
   }
 }
-
 class $App extends $AppBase {
   constructor() {
     super({ outdir: $outdir, name: \\"bring_cdktf\\", plugins: $plugins, isTestEnvironment: $wing_is_test });
@@ -98,8 +97,8 @@ class $App extends $AppBase {
     }
   }
 }
-
-new $App().synth();"
+new $App().synth();
+"
 `;
 
 exports[`wing test -t sim > stdout 1`] = `

--- a/tools/hangar/__snapshots__/test_corpus/valid/bring_jsii.w.ts.snap
+++ b/tools/hangar/__snapshots__/test_corpus/valid/bring_jsii.w.ts.snap
@@ -151,17 +151,17 @@ class $Root extends $stdlib.core.Resource {
     const hello = new stuff.HelloWorld();
     const greeting = (hello.sayHello(\\"wingnuts\\"));
     this.node.root.newAbstract(\\"@winglang/sdk.cloud.Function\\",this,\\"test:say_hello\\",new $stdlib.core.Inflight(this, \\"$Inflight1\\", {
-  code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.5d209e0c3acca40c825662cab73c204803d9dd9f7903de90d0da6dc99ea7fa35/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
-  bindings: {
-    greeting: {
-      obj: greeting,
-      ops: []
-    },
-  }
-}));
+      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.f9fd45e979c44914dac14967e8ad3a3b4c5beb85154a204a119e273326d0f3c0/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
+      bindings: {
+        greeting: {
+          obj: greeting,
+          ops: []
+        },
+      }
+    })
+    );
   }
 }
-
 class $App extends $AppBase {
   constructor() {
     super({ outdir: $outdir, name: \\"bring_jsii\\", plugins: $plugins, isTestEnvironment: $wing_is_test });
@@ -177,14 +177,18 @@ class $App extends $AppBase {
     }
   }
 }
-
-new $App().synth();"
+new $App().synth();
+"
 `;
 
-exports[`wing compile -t tf-aws > proc.5d209e0c3acca40c825662cab73c204803d9dd9f7903de90d0da6dc99ea7fa35/index.js 1`] = `
-"async handle(m) { const { greeting } = this; {
-  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(greeting === \\"Hello, wingnuts\\")'\`)})((greeting === \\"Hello, wingnuts\\"))};
-} };"
+exports[`wing compile -t tf-aws > proc.f9fd45e979c44914dac14967e8ad3a3b4c5beb85154a204a119e273326d0f3c0/index.js 1`] = `
+"async handle(m) {
+  const { greeting } = this;
+  {
+    {((cond) => {if (!cond) throw new Error(\`assertion failed: '(greeting === \\"Hello, wingnuts\\")'\`)})((greeting === \\"Hello, wingnuts\\"))};
+  }
+};
+"
 `;
 
 exports[`wing test -t sim > stdout 1`] = `

--- a/tools/hangar/__snapshots__/test_corpus/valid/bring_jsii.w.ts.snap
+++ b/tools/hangar/__snapshots__/test_corpus/valid/bring_jsii.w.ts.snap
@@ -151,7 +151,7 @@ class $Root extends $stdlib.core.Resource {
     const hello = new stuff.HelloWorld();
     const greeting = (hello.sayHello(\\"wingnuts\\"));
     this.node.root.newAbstract(\\"@winglang/sdk.cloud.Function\\",this,\\"test:say_hello\\",new $stdlib.core.Inflight(this, \\"$Inflight1\\", {
-      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.f9fd45e979c44914dac14967e8ad3a3b4c5beb85154a204a119e273326d0f3c0/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
+      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.0971d6c6098fbbfe02ff3f99e46b6e89243dbbb93903848c1d100f29b265d40c/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
       bindings: {
         greeting: {
           obj: greeting,
@@ -181,13 +181,11 @@ new $App().synth();
 "
 `;
 
-exports[`wing compile -t tf-aws > proc.f9fd45e979c44914dac14967e8ad3a3b4c5beb85154a204a119e273326d0f3c0/index.js 1`] = `
+exports[`wing compile -t tf-aws > proc.0971d6c6098fbbfe02ff3f99e46b6e89243dbbb93903848c1d100f29b265d40c/index.js 1`] = `
 "async handle(m) {
   const { greeting } = this;
-  {
-    {((cond) => {if (!cond) throw new Error(\`assertion failed: '(greeting === \\"Hello, wingnuts\\")'\`)})((greeting === \\"Hello, wingnuts\\"))};
-  }
-};
+  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(greeting === \\"Hello, wingnuts\\")'\`)})((greeting === \\"Hello, wingnuts\\"))};
+}
 "
 `;
 

--- a/tools/hangar/__snapshots__/test_corpus/valid/bring_jsii_path.w.ts.snap
+++ b/tools/hangar/__snapshots__/test_corpus/valid/bring_jsii_path.w.ts.snap
@@ -151,7 +151,7 @@ class $Root extends $stdlib.core.Resource {
     const hello = new jsii_code_samples.HelloWorld();
     const greeting = (hello.sayHello(\\"wingnuts\\"));
     this.node.root.newAbstract(\\"@winglang/sdk.cloud.Function\\",this,\\"test:say_hello\\",new $stdlib.core.Inflight(this, \\"$Inflight1\\", {
-      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.f9fd45e979c44914dac14967e8ad3a3b4c5beb85154a204a119e273326d0f3c0/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
+      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.0971d6c6098fbbfe02ff3f99e46b6e89243dbbb93903848c1d100f29b265d40c/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
       bindings: {
         greeting: {
           obj: greeting,
@@ -181,13 +181,11 @@ new $App().synth();
 "
 `;
 
-exports[`wing compile -t tf-aws > proc.f9fd45e979c44914dac14967e8ad3a3b4c5beb85154a204a119e273326d0f3c0/index.js 1`] = `
+exports[`wing compile -t tf-aws > proc.0971d6c6098fbbfe02ff3f99e46b6e89243dbbb93903848c1d100f29b265d40c/index.js 1`] = `
 "async handle(m) {
   const { greeting } = this;
-  {
-    {((cond) => {if (!cond) throw new Error(\`assertion failed: '(greeting === \\"Hello, wingnuts\\")'\`)})((greeting === \\"Hello, wingnuts\\"))};
-  }
-};
+  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(greeting === \\"Hello, wingnuts\\")'\`)})((greeting === \\"Hello, wingnuts\\"))};
+}
 "
 `;
 

--- a/tools/hangar/__snapshots__/test_corpus/valid/bring_jsii_path.w.ts.snap
+++ b/tools/hangar/__snapshots__/test_corpus/valid/bring_jsii_path.w.ts.snap
@@ -151,17 +151,17 @@ class $Root extends $stdlib.core.Resource {
     const hello = new jsii_code_samples.HelloWorld();
     const greeting = (hello.sayHello(\\"wingnuts\\"));
     this.node.root.newAbstract(\\"@winglang/sdk.cloud.Function\\",this,\\"test:say_hello\\",new $stdlib.core.Inflight(this, \\"$Inflight1\\", {
-  code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.5d209e0c3acca40c825662cab73c204803d9dd9f7903de90d0da6dc99ea7fa35/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
-  bindings: {
-    greeting: {
-      obj: greeting,
-      ops: []
-    },
-  }
-}));
+      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.f9fd45e979c44914dac14967e8ad3a3b4c5beb85154a204a119e273326d0f3c0/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
+      bindings: {
+        greeting: {
+          obj: greeting,
+          ops: []
+        },
+      }
+    })
+    );
   }
 }
-
 class $App extends $AppBase {
   constructor() {
     super({ outdir: $outdir, name: \\"bring_jsii_path\\", plugins: $plugins, isTestEnvironment: $wing_is_test });
@@ -177,14 +177,18 @@ class $App extends $AppBase {
     }
   }
 }
-
-new $App().synth();"
+new $App().synth();
+"
 `;
 
-exports[`wing compile -t tf-aws > proc.5d209e0c3acca40c825662cab73c204803d9dd9f7903de90d0da6dc99ea7fa35/index.js 1`] = `
-"async handle(m) { const { greeting } = this; {
-  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(greeting === \\"Hello, wingnuts\\")'\`)})((greeting === \\"Hello, wingnuts\\"))};
-} };"
+exports[`wing compile -t tf-aws > proc.f9fd45e979c44914dac14967e8ad3a3b4c5beb85154a204a119e273326d0f3c0/index.js 1`] = `
+"async handle(m) {
+  const { greeting } = this;
+  {
+    {((cond) => {if (!cond) throw new Error(\`assertion failed: '(greeting === \\"Hello, wingnuts\\")'\`)})((greeting === \\"Hello, wingnuts\\"))};
+  }
+};
+"
 `;
 
 exports[`wing test -t sim > stdout 1`] = `

--- a/tools/hangar/__snapshots__/test_corpus/valid/bring_projen.w.ts.snap
+++ b/tools/hangar/__snapshots__/test_corpus/valid/bring_projen.w.ts.snap
@@ -62,7 +62,6 @@ class $Root extends $stdlib.core.Resource {
     {((cond) => {if (!cond) throw new Error(\`assertion failed: '(projen.LogLevel.OFF !== projen.LogLevel.VERBOSE)'\`)})((projen.LogLevel.OFF !== projen.LogLevel.VERBOSE))};
   }
 }
-
 class $App extends $AppBase {
   constructor() {
     super({ outdir: $outdir, name: \\"bring_projen\\", plugins: $plugins, isTestEnvironment: $wing_is_test });
@@ -78,8 +77,8 @@ class $App extends $AppBase {
     }
   }
 }
-
-new $App().synth();"
+new $App().synth();
+"
 `;
 
 exports[`wing test -t sim > stdout 1`] = `

--- a/tools/hangar/__snapshots__/test_corpus/valid/bucket_events.w.ts.snap
+++ b/tools/hangar/__snapshots__/test_corpus/valid/bucket_events.w.ts.snap
@@ -1357,25 +1357,25 @@ class $Root extends $stdlib.core.Resource {
     const other = this.node.root.newAbstract(\\"@winglang/sdk.cloud.Bucket\\",this,\\"other\\");
     const b = this.node.root.newAbstract(\\"@winglang/sdk.cloud.Bucket\\",this,\\"b\\");
     (b.onDelete(new $stdlib.core.Inflight(this, \\"$Inflight1\\", {
-      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.aa03e1387ba38982c1ca4d1fe5e602011fd3d7a5182eebad2c4fa5e0cb175af7/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
+      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.09dcc4ff0890e102805bbc51ef3934c08d91e5bf84395afde5497f34df87a7d8/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
       bindings: {
       }
     })
     ));
     (b.onUpdate(new $stdlib.core.Inflight(this, \\"$Inflight2\\", {
-      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.0ba99251b8fd432899fb87dae36226eda07bc83069e2aa613e10f3429f2682db/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
+      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.cdae347b8886baf52a55404c418d32d00e90df41124134b320bfa397a5f74c25/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
       bindings: {
       }
     })
     ));
     (b.onCreate(new $stdlib.core.Inflight(this, \\"$Inflight3\\", {
-      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.56bd1fa6dd091a59cf7072611019dac875177c7c9d02471388a1c7cba3bc4706/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
+      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.cf448bce60320955625b8e5174094d9799f236443e940587740acf6da94eed75/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
       bindings: {
       }
     })
     ));
     (b.onEvent(new $stdlib.core.Inflight(this, \\"$Inflight4\\", {
-      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.0b6500d3229de22066b0d8ef0d85b80986dabd1f05d4adce56d1a2f16b46a58e/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
+      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.a726467156eb8c271f9225b3e17be8de6d6c17a49aaa65da842e2f7d6bdaf896/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
       bindings: {
         other: {
           obj: other,
@@ -1385,13 +1385,13 @@ class $Root extends $stdlib.core.Resource {
     })
     ));
     (other.onEvent(new $stdlib.core.Inflight(this, \\"$Inflight5\\", {
-      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.6a4706d466dd93dafb41d081acadbf6ec4349eac14bfc1f627408643fa8d3990/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
+      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.fca059c479747295eb7f36bfd8dcd61c2e15d4b53e0aca4acb4cdea062e4b3a3/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
       bindings: {
       }
     })
     ));
     this.node.root.newAbstract(\\"@winglang/sdk.cloud.Function\\",this,\\"test\\",new $stdlib.core.Inflight(this, \\"$Inflight6\\", {
-      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.f1c0388f6fd41adcaf4c6e046d9a31b8b804936dd202daeb8a6387abcfc32334/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
+      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.44ffe304e2ab76a8326d652a552eab6dfaadac1194df65fecf28d7c384a8cc13/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
       bindings: {
         b: {
           obj: b,
@@ -1421,68 +1421,56 @@ new $App().synth();
 "
 `;
 
-exports[`wing compile -t tf-aws > proc.0b6500d3229de22066b0d8ef0d85b80986dabd1f05d4adce56d1a2f16b46a58e/index.js 1`] = `
-"async handle(key) {
-  const { other } = this;
-  {
-    {console.log(\`last key \${key}\`)};
-    (await other.put(\\"last_operation_key\\",((args) => { return JSON.stringify(args[0], null, args[1]) })([key])));
-  }
-};
-"
-`;
-
-exports[`wing compile -t tf-aws > proc.0ba99251b8fd432899fb87dae36226eda07bc83069e2aa613e10f3429f2682db/index.js 1`] = `
+exports[`wing compile -t tf-aws > proc.09dcc4ff0890e102805bbc51ef3934c08d91e5bf84395afde5497f34df87a7d8/index.js 1`] = `
 "async handle(key) {
   const {  } = this;
-  {
-    {console.log(\`updated \${key}\`)};
-  }
-};
+  {console.log(\`deleted \${key}\`)};
+}
 "
 `;
 
-exports[`wing compile -t tf-aws > proc.6a4706d466dd93dafb41d081acadbf6ec4349eac14bfc1f627408643fa8d3990/index.js 1`] = `
-"async handle(key) {
-  const {  } = this;
-  {
-    {console.log(\\"other bucket event called!\\")};
-  }
-};
-"
-`;
-
-exports[`wing compile -t tf-aws > proc.56bd1fa6dd091a59cf7072611019dac875177c7c9d02471388a1c7cba3bc4706/index.js 1`] = `
-"async handle(key) {
-  const {  } = this;
-  {
-    {console.log(\`created \${key}\`)};
-  }
-};
-"
-`;
-
-exports[`wing compile -t tf-aws > proc.aa03e1387ba38982c1ca4d1fe5e602011fd3d7a5182eebad2c4fa5e0cb175af7/index.js 1`] = `
-"async handle(key) {
-  const {  } = this;
-  {
-    {console.log(\`deleted \${key}\`)};
-  }
-};
-"
-`;
-
-exports[`wing compile -t tf-aws > proc.f1c0388f6fd41adcaf4c6e046d9a31b8b804936dd202daeb8a6387abcfc32334/index.js 1`] = `
+exports[`wing compile -t tf-aws > proc.44ffe304e2ab76a8326d652a552eab6dfaadac1194df65fecf28d7c384a8cc13/index.js 1`] = `
 "async handle() {
   const { b } = this;
-  {
-    (await b.put(\\"a\\",\\"1\\"));
-    (await b.put(\\"b\\",\\"1\\"));
-    (await b.put(\\"b\\",\\"100\\"));
-    (await b.put(\\"c\\",\\"1\\"));
-    (await b.delete(\\"c\\"));
-  }
-};
+  (await b.put(\\"a\\",\\"1\\"));
+  (await b.put(\\"b\\",\\"1\\"));
+  (await b.put(\\"b\\",\\"100\\"));
+  (await b.put(\\"c\\",\\"1\\"));
+  (await b.delete(\\"c\\"));
+}
+"
+`;
+
+exports[`wing compile -t tf-aws > proc.a726467156eb8c271f9225b3e17be8de6d6c17a49aaa65da842e2f7d6bdaf896/index.js 1`] = `
+"async handle(key) {
+  const { other } = this;
+  {console.log(\`last key \${key}\`)};
+  (await other.put(\\"last_operation_key\\",((args) => { return JSON.stringify(args[0], null, args[1]) })([key])));
+}
+"
+`;
+
+exports[`wing compile -t tf-aws > proc.cdae347b8886baf52a55404c418d32d00e90df41124134b320bfa397a5f74c25/index.js 1`] = `
+"async handle(key) {
+  const {  } = this;
+  {console.log(\`updated \${key}\`)};
+}
+"
+`;
+
+exports[`wing compile -t tf-aws > proc.cf448bce60320955625b8e5174094d9799f236443e940587740acf6da94eed75/index.js 1`] = `
+"async handle(key) {
+  const {  } = this;
+  {console.log(\`created \${key}\`)};
+}
+"
+`;
+
+exports[`wing compile -t tf-aws > proc.fca059c479747295eb7f36bfd8dcd61c2e15d4b53e0aca4acb4cdea062e4b3a3/index.js 1`] = `
+"async handle(key) {
+  const {  } = this;
+  {console.log(\\"other bucket event called!\\")};
+}
 "
 `;
 

--- a/tools/hangar/__snapshots__/test_corpus/valid/bucket_events.w.ts.snap
+++ b/tools/hangar/__snapshots__/test_corpus/valid/bucket_events.w.ts.snap
@@ -1357,46 +1357,51 @@ class $Root extends $stdlib.core.Resource {
     const other = this.node.root.newAbstract(\\"@winglang/sdk.cloud.Bucket\\",this,\\"other\\");
     const b = this.node.root.newAbstract(\\"@winglang/sdk.cloud.Bucket\\",this,\\"b\\");
     (b.onDelete(new $stdlib.core.Inflight(this, \\"$Inflight1\\", {
-  code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.e0895e35017839af19c4cdf5e5752ce00b8bee3a6425933fc1349d037cf9ed23/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
-  bindings: {
-  }
-})));
+      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.aa03e1387ba38982c1ca4d1fe5e602011fd3d7a5182eebad2c4fa5e0cb175af7/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
+      bindings: {
+      }
+    })
+    ));
     (b.onUpdate(new $stdlib.core.Inflight(this, \\"$Inflight2\\", {
-  code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.4c20a426ba35d2bc9530ee9673d6111365502af4b9943b5993189fef4c9cbb24/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
-  bindings: {
-  }
-})));
+      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.0ba99251b8fd432899fb87dae36226eda07bc83069e2aa613e10f3429f2682db/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
+      bindings: {
+      }
+    })
+    ));
     (b.onCreate(new $stdlib.core.Inflight(this, \\"$Inflight3\\", {
-  code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.fea0ccbdf726c314d7bdccef2e9a3af2667b14bbf90b08535bc3b8531676a5f7/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
-  bindings: {
-  }
-})));
+      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.56bd1fa6dd091a59cf7072611019dac875177c7c9d02471388a1c7cba3bc4706/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
+      bindings: {
+      }
+    })
+    ));
     (b.onEvent(new $stdlib.core.Inflight(this, \\"$Inflight4\\", {
-  code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.dbe235d917909459004bd5b4ee5f5c116451dd314d6afb668f81aca7412c951c/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
-  bindings: {
-    other: {
-      obj: other,
-      ops: [\\"delete\\",\\"get\\",\\"get_json\\",\\"list\\",\\"public_url\\",\\"put\\",\\"put_json\\"]
-    },
-  }
-})));
+      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.0b6500d3229de22066b0d8ef0d85b80986dabd1f05d4adce56d1a2f16b46a58e/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
+      bindings: {
+        other: {
+          obj: other,
+          ops: [\\"delete\\",\\"get\\",\\"get_json\\",\\"list\\",\\"public_url\\",\\"put\\",\\"put_json\\"]
+        },
+      }
+    })
+    ));
     (other.onEvent(new $stdlib.core.Inflight(this, \\"$Inflight5\\", {
-  code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.1077abc4fd9d2c1dcaf67fa6bfcd127520e9da3f7cb638866ee99e8ac058bb04/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
-  bindings: {
-  }
-})));
+      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.6a4706d466dd93dafb41d081acadbf6ec4349eac14bfc1f627408643fa8d3990/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
+      bindings: {
+      }
+    })
+    ));
     this.node.root.newAbstract(\\"@winglang/sdk.cloud.Function\\",this,\\"test\\",new $stdlib.core.Inflight(this, \\"$Inflight6\\", {
-  code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.bd899ae09cdb75ce681c2be5132db5f8fbc54bd45d0a438077f48809708c05a6/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
-  bindings: {
-    b: {
-      obj: b,
-      ops: [\\"delete\\",\\"get\\",\\"get_json\\",\\"list\\",\\"public_url\\",\\"put\\",\\"put_json\\"]
-    },
-  }
-}));
+      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.f1c0388f6fd41adcaf4c6e046d9a31b8b804936dd202daeb8a6387abcfc32334/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
+      bindings: {
+        b: {
+          obj: b,
+          ops: [\\"delete\\",\\"get\\",\\"get_json\\",\\"list\\",\\"public_url\\",\\"put\\",\\"put_json\\"]
+        },
+      }
+    })
+    );
   }
 }
-
 class $App extends $AppBase {
   constructor() {
     super({ outdir: $outdir, name: \\"bucket_events\\", plugins: $plugins, isTestEnvironment: $wing_is_test });
@@ -1412,49 +1417,73 @@ class $App extends $AppBase {
     }
   }
 }
-
-new $App().synth();"
+new $App().synth();
+"
 `;
 
-exports[`wing compile -t tf-aws > proc.4c20a426ba35d2bc9530ee9673d6111365502af4b9943b5993189fef4c9cbb24/index.js 1`] = `
-"async handle(key) { const {  } = this; {
-  {console.log(\`updated \${key}\`)};
-} };"
+exports[`wing compile -t tf-aws > proc.0b6500d3229de22066b0d8ef0d85b80986dabd1f05d4adce56d1a2f16b46a58e/index.js 1`] = `
+"async handle(key) {
+  const { other } = this;
+  {
+    {console.log(\`last key \${key}\`)};
+    (await other.put(\\"last_operation_key\\",((args) => { return JSON.stringify(args[0], null, args[1]) })([key])));
+  }
+};
+"
 `;
 
-exports[`wing compile -t tf-aws > proc.1077abc4fd9d2c1dcaf67fa6bfcd127520e9da3f7cb638866ee99e8ac058bb04/index.js 1`] = `
-"async handle(key) { const {  } = this; {
-  {console.log(\\"other bucket event called!\\")};
-} };"
+exports[`wing compile -t tf-aws > proc.0ba99251b8fd432899fb87dae36226eda07bc83069e2aa613e10f3429f2682db/index.js 1`] = `
+"async handle(key) {
+  const {  } = this;
+  {
+    {console.log(\`updated \${key}\`)};
+  }
+};
+"
 `;
 
-exports[`wing compile -t tf-aws > proc.bd899ae09cdb75ce681c2be5132db5f8fbc54bd45d0a438077f48809708c05a6/index.js 1`] = `
-"async handle() { const { b } = this; {
-  (await b.put(\\"a\\",\\"1\\"));
-  (await b.put(\\"b\\",\\"1\\"));
-  (await b.put(\\"b\\",\\"100\\"));
-  (await b.put(\\"c\\",\\"1\\"));
-  (await b.delete(\\"c\\"));
-} };"
+exports[`wing compile -t tf-aws > proc.6a4706d466dd93dafb41d081acadbf6ec4349eac14bfc1f627408643fa8d3990/index.js 1`] = `
+"async handle(key) {
+  const {  } = this;
+  {
+    {console.log(\\"other bucket event called!\\")};
+  }
+};
+"
 `;
 
-exports[`wing compile -t tf-aws > proc.dbe235d917909459004bd5b4ee5f5c116451dd314d6afb668f81aca7412c951c/index.js 1`] = `
-"async handle(key) { const { other } = this; {
-  {console.log(\`last key \${key}\`)};
-  (await other.put(\\"last_operation_key\\",((args) => { return JSON.stringify(args[0], null, args[1]) })([key])));
-} };"
+exports[`wing compile -t tf-aws > proc.56bd1fa6dd091a59cf7072611019dac875177c7c9d02471388a1c7cba3bc4706/index.js 1`] = `
+"async handle(key) {
+  const {  } = this;
+  {
+    {console.log(\`created \${key}\`)};
+  }
+};
+"
 `;
 
-exports[`wing compile -t tf-aws > proc.e0895e35017839af19c4cdf5e5752ce00b8bee3a6425933fc1349d037cf9ed23/index.js 1`] = `
-"async handle(key) { const {  } = this; {
-  {console.log(\`deleted \${key}\`)};
-} };"
+exports[`wing compile -t tf-aws > proc.aa03e1387ba38982c1ca4d1fe5e602011fd3d7a5182eebad2c4fa5e0cb175af7/index.js 1`] = `
+"async handle(key) {
+  const {  } = this;
+  {
+    {console.log(\`deleted \${key}\`)};
+  }
+};
+"
 `;
 
-exports[`wing compile -t tf-aws > proc.fea0ccbdf726c314d7bdccef2e9a3af2667b14bbf90b08535bc3b8531676a5f7/index.js 1`] = `
-"async handle(key) { const {  } = this; {
-  {console.log(\`created \${key}\`)};
-} };"
+exports[`wing compile -t tf-aws > proc.f1c0388f6fd41adcaf4c6e046d9a31b8b804936dd202daeb8a6387abcfc32334/index.js 1`] = `
+"async handle() {
+  const { b } = this;
+  {
+    (await b.put(\\"a\\",\\"1\\"));
+    (await b.put(\\"b\\",\\"1\\"));
+    (await b.put(\\"b\\",\\"100\\"));
+    (await b.put(\\"c\\",\\"1\\"));
+    (await b.delete(\\"c\\"));
+  }
+};
+"
 `;
 
 exports[`wing test -t sim > stdout 1`] = `

--- a/tools/hangar/__snapshots__/test_corpus/valid/bucket_keys.w.ts.snap
+++ b/tools/hangar/__snapshots__/test_corpus/valid/bucket_keys.w.ts.snap
@@ -194,7 +194,7 @@ class $Root extends $stdlib.core.Resource {
     super(scope, id);
     const b = this.node.root.newAbstract(\\"@winglang/sdk.cloud.Bucket\\",this,\\"cloud.Bucket\\");
     this.node.root.newAbstract(\\"@winglang/sdk.cloud.Function\\",this,\\"test\\",new $stdlib.core.Inflight(this, \\"$Inflight1\\", {
-      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.b57118b048bea26e55aac570fcc0ae1038d26e67690efaefaa6b76713025b3ff/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
+      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.e985a655d1d19405f1798377278c6205fc276c76ea8815eb157a120ca44fdbcc/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
       bindings: {
         b: {
           obj: b,
@@ -224,23 +224,21 @@ new $App().synth();
 "
 `;
 
-exports[`wing compile -t tf-aws > proc.b57118b048bea26e55aac570fcc0ae1038d26e67690efaefaa6b76713025b3ff/index.js 1`] = `
+exports[`wing compile -t tf-aws > proc.e985a655d1d19405f1798377278c6205fc276c76ea8815eb157a120ca44fdbcc/index.js 1`] = `
 "async handle() {
   const { b } = this;
-  {
-    (await b.put(\\"foo\\",\\"text\\"));
-    (await b.put(\\"foo/\\",\\"text\\"));
-    (await b.put(\\"foo/bar\\",\\"text\\"));
-    (await b.put(\\"foo/bar/\\",\\"text\\"));
-    (await b.put(\\"foo/bar/baz\\",\\"text\\"));
-    const objs = (await b.list());
-    {((cond) => {if (!cond) throw new Error(\`assertion failed: '((await objs.at(0)) === \\"foo\\")'\`)})(((await objs.at(0)) === \\"foo\\"))};
-    {((cond) => {if (!cond) throw new Error(\`assertion failed: '((await objs.at(1)) === \\"foo/\\")'\`)})(((await objs.at(1)) === \\"foo/\\"))};
-    {((cond) => {if (!cond) throw new Error(\`assertion failed: '((await objs.at(2)) === \\"foo/bar\\")'\`)})(((await objs.at(2)) === \\"foo/bar\\"))};
-    {((cond) => {if (!cond) throw new Error(\`assertion failed: '((await objs.at(3)) === \\"foo/bar/\\")'\`)})(((await objs.at(3)) === \\"foo/bar/\\"))};
-    {((cond) => {if (!cond) throw new Error(\`assertion failed: '((await objs.at(4)) === \\"foo/bar/baz\\")'\`)})(((await objs.at(4)) === \\"foo/bar/baz\\"))};
-  }
-};
+  (await b.put(\\"foo\\",\\"text\\"));
+  (await b.put(\\"foo/\\",\\"text\\"));
+  (await b.put(\\"foo/bar\\",\\"text\\"));
+  (await b.put(\\"foo/bar/\\",\\"text\\"));
+  (await b.put(\\"foo/bar/baz\\",\\"text\\"));
+  const objs = (await b.list());
+  {((cond) => {if (!cond) throw new Error(\`assertion failed: '((await objs.at(0)) === \\"foo\\")'\`)})(((await objs.at(0)) === \\"foo\\"))};
+  {((cond) => {if (!cond) throw new Error(\`assertion failed: '((await objs.at(1)) === \\"foo/\\")'\`)})(((await objs.at(1)) === \\"foo/\\"))};
+  {((cond) => {if (!cond) throw new Error(\`assertion failed: '((await objs.at(2)) === \\"foo/bar\\")'\`)})(((await objs.at(2)) === \\"foo/bar\\"))};
+  {((cond) => {if (!cond) throw new Error(\`assertion failed: '((await objs.at(3)) === \\"foo/bar/\\")'\`)})(((await objs.at(3)) === \\"foo/bar/\\"))};
+  {((cond) => {if (!cond) throw new Error(\`assertion failed: '((await objs.at(4)) === \\"foo/bar/baz\\")'\`)})(((await objs.at(4)) === \\"foo/bar/baz\\"))};
+}
 "
 `;
 

--- a/tools/hangar/__snapshots__/test_corpus/valid/bucket_keys.w.ts.snap
+++ b/tools/hangar/__snapshots__/test_corpus/valid/bucket_keys.w.ts.snap
@@ -194,17 +194,17 @@ class $Root extends $stdlib.core.Resource {
     super(scope, id);
     const b = this.node.root.newAbstract(\\"@winglang/sdk.cloud.Bucket\\",this,\\"cloud.Bucket\\");
     this.node.root.newAbstract(\\"@winglang/sdk.cloud.Function\\",this,\\"test\\",new $stdlib.core.Inflight(this, \\"$Inflight1\\", {
-  code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.6228e26a5981501feaae450d2628c682bfebb15974f5cc021606bb6e273636e0/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
-  bindings: {
-    b: {
-      obj: b,
-      ops: [\\"delete\\",\\"get\\",\\"get_json\\",\\"list\\",\\"public_url\\",\\"put\\",\\"put_json\\"]
-    },
-  }
-}));
+      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.b57118b048bea26e55aac570fcc0ae1038d26e67690efaefaa6b76713025b3ff/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
+      bindings: {
+        b: {
+          obj: b,
+          ops: [\\"delete\\",\\"get\\",\\"get_json\\",\\"list\\",\\"public_url\\",\\"put\\",\\"put_json\\"]
+        },
+      }
+    })
+    );
   }
 }
-
 class $App extends $AppBase {
   constructor() {
     super({ outdir: $outdir, name: \\"bucket_keys\\", plugins: $plugins, isTestEnvironment: $wing_is_test });
@@ -220,24 +220,28 @@ class $App extends $AppBase {
     }
   }
 }
-
-new $App().synth();"
+new $App().synth();
+"
 `;
 
-exports[`wing compile -t tf-aws > proc.6228e26a5981501feaae450d2628c682bfebb15974f5cc021606bb6e273636e0/index.js 1`] = `
-"async handle() { const { b } = this; {
-  (await b.put(\\"foo\\",\\"text\\"));
-  (await b.put(\\"foo/\\",\\"text\\"));
-  (await b.put(\\"foo/bar\\",\\"text\\"));
-  (await b.put(\\"foo/bar/\\",\\"text\\"));
-  (await b.put(\\"foo/bar/baz\\",\\"text\\"));
-  const objs = (await b.list());
-  {((cond) => {if (!cond) throw new Error(\`assertion failed: '((await objs.at(0)) === \\"foo\\")'\`)})(((await objs.at(0)) === \\"foo\\"))};
-  {((cond) => {if (!cond) throw new Error(\`assertion failed: '((await objs.at(1)) === \\"foo/\\")'\`)})(((await objs.at(1)) === \\"foo/\\"))};
-  {((cond) => {if (!cond) throw new Error(\`assertion failed: '((await objs.at(2)) === \\"foo/bar\\")'\`)})(((await objs.at(2)) === \\"foo/bar\\"))};
-  {((cond) => {if (!cond) throw new Error(\`assertion failed: '((await objs.at(3)) === \\"foo/bar/\\")'\`)})(((await objs.at(3)) === \\"foo/bar/\\"))};
-  {((cond) => {if (!cond) throw new Error(\`assertion failed: '((await objs.at(4)) === \\"foo/bar/baz\\")'\`)})(((await objs.at(4)) === \\"foo/bar/baz\\"))};
-} };"
+exports[`wing compile -t tf-aws > proc.b57118b048bea26e55aac570fcc0ae1038d26e67690efaefaa6b76713025b3ff/index.js 1`] = `
+"async handle() {
+  const { b } = this;
+  {
+    (await b.put(\\"foo\\",\\"text\\"));
+    (await b.put(\\"foo/\\",\\"text\\"));
+    (await b.put(\\"foo/bar\\",\\"text\\"));
+    (await b.put(\\"foo/bar/\\",\\"text\\"));
+    (await b.put(\\"foo/bar/baz\\",\\"text\\"));
+    const objs = (await b.list());
+    {((cond) => {if (!cond) throw new Error(\`assertion failed: '((await objs.at(0)) === \\"foo\\")'\`)})(((await objs.at(0)) === \\"foo\\"))};
+    {((cond) => {if (!cond) throw new Error(\`assertion failed: '((await objs.at(1)) === \\"foo/\\")'\`)})(((await objs.at(1)) === \\"foo/\\"))};
+    {((cond) => {if (!cond) throw new Error(\`assertion failed: '((await objs.at(2)) === \\"foo/bar\\")'\`)})(((await objs.at(2)) === \\"foo/bar\\"))};
+    {((cond) => {if (!cond) throw new Error(\`assertion failed: '((await objs.at(3)) === \\"foo/bar/\\")'\`)})(((await objs.at(3)) === \\"foo/bar/\\"))};
+    {((cond) => {if (!cond) throw new Error(\`assertion failed: '((await objs.at(4)) === \\"foo/bar/baz\\")'\`)})(((await objs.at(4)) === \\"foo/bar/baz\\"))};
+  }
+};
+"
 `;
 
 exports[`wing test -t sim > stdout 1`] = `

--- a/tools/hangar/__snapshots__/test_corpus/valid/capture_containers.w.ts.snap
+++ b/tools/hangar/__snapshots__/test_corpus/valid/capture_containers.w.ts.snap
@@ -153,7 +153,7 @@ class $Root extends $stdlib.core.Resource {
     const arr_of_map = Object.freeze([Object.freeze({\\"bang\\":123})]);
     const j = Object.freeze({\\"a\\":\\"hello\\",\\"b\\":\\"world\\"});
     const handler = new $stdlib.core.Inflight(this, \\"$Inflight1\\", {
-      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.517641749e3cd3e3a9f11738f8bf0e3bfc5d6cae362e926ee33e7877e15905db/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
+      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.8737b7ddfddfd5b0f34d5d28d474901ed7c1f4bd7c3028e87d902df663b0f9ca/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
       bindings: {
         arr: {
           obj: arr,
@@ -200,21 +200,19 @@ new $App().synth();
 "
 `;
 
-exports[`wing compile -t tf-aws > proc.517641749e3cd3e3a9f11738f8bf0e3bfc5d6cae362e926ee33e7877e15905db/index.js 1`] = `
+exports[`wing compile -t tf-aws > proc.8737b7ddfddfd5b0f34d5d28d474901ed7c1f4bd7c3028e87d902df663b0f9ca/index.js 1`] = `
 "async handle(s) {
   const { arr, arr_of_map, j, my_map, my_set } = this;
-  {
-    {((cond) => {if (!cond) throw new Error(\`assertion failed: '((await arr.at(0)) === \\"hello\\")'\`)})(((await arr.at(0)) === \\"hello\\"))};
-    {((cond) => {if (!cond) throw new Error(\`assertion failed: '((await arr.at(1)) === \\"world\\")'\`)})(((await arr.at(1)) === \\"world\\"))};
-    {((cond) => {if (!cond) throw new Error(\`assertion failed: '(arr.length === 2)'\`)})((arr.length === 2))};
-    {((cond) => {if (!cond) throw new Error(\`assertion failed: '(await my_set.has(\\"my\\"))'\`)})((await my_set.has(\\"my\\")))};
-    {((cond) => {if (!cond) throw new Error(\`assertion failed: '(my_set.size === 2)'\`)})((my_set.size === 2))};
-    {((cond) => {if (!cond) throw new Error(\`assertion failed: '(\\"world\\" in (my_map))'\`)})((\\"world\\" in (my_map)))};
-    {((cond) => {if (!cond) throw new Error(\`assertion failed: '(Object.keys(my_map).length === 2)'\`)})((Object.keys(my_map).length === 2))};
-    {((cond) => {if (!cond) throw new Error(\`assertion failed: '(\\"bang\\" in ((await arr_of_map.at(0))))'\`)})((\\"bang\\" in ((await arr_of_map.at(0)))))};
-    {((cond) => {if (!cond) throw new Error(\`assertion failed: '((j)[\\"b\\"] === \\"world\\")'\`)})(((j)[\\"b\\"] === \\"world\\"))};
-  }
-};
+  {((cond) => {if (!cond) throw new Error(\`assertion failed: '((await arr.at(0)) === \\"hello\\")'\`)})(((await arr.at(0)) === \\"hello\\"))};
+  {((cond) => {if (!cond) throw new Error(\`assertion failed: '((await arr.at(1)) === \\"world\\")'\`)})(((await arr.at(1)) === \\"world\\"))};
+  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(arr.length === 2)'\`)})((arr.length === 2))};
+  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(await my_set.has(\\"my\\"))'\`)})((await my_set.has(\\"my\\")))};
+  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(my_set.size === 2)'\`)})((my_set.size === 2))};
+  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(\\"world\\" in (my_map))'\`)})((\\"world\\" in (my_map)))};
+  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(Object.keys(my_map).length === 2)'\`)})((Object.keys(my_map).length === 2))};
+  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(\\"bang\\" in ((await arr_of_map.at(0))))'\`)})((\\"bang\\" in ((await arr_of_map.at(0)))))};
+  {((cond) => {if (!cond) throw new Error(\`assertion failed: '((j)[\\"b\\"] === \\"world\\")'\`)})(((j)[\\"b\\"] === \\"world\\"))};
+}
 "
 `;
 

--- a/tools/hangar/__snapshots__/test_corpus/valid/capture_containers.w.ts.snap
+++ b/tools/hangar/__snapshots__/test_corpus/valid/capture_containers.w.ts.snap
@@ -153,34 +153,34 @@ class $Root extends $stdlib.core.Resource {
     const arr_of_map = Object.freeze([Object.freeze({\\"bang\\":123})]);
     const j = Object.freeze({\\"a\\":\\"hello\\",\\"b\\":\\"world\\"});
     const handler = new $stdlib.core.Inflight(this, \\"$Inflight1\\", {
-  code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.dc7e5dc23da309970778fe7db4c795e3a6ae63c0d0ddc5e1780d4e2daadf67e1/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
-  bindings: {
-    arr: {
-      obj: arr,
-      ops: []
-    },
-    arr_of_map: {
-      obj: arr_of_map,
-      ops: []
-    },
-    j: {
-      obj: j,
-      ops: []
-    },
-    my_map: {
-      obj: my_map,
-      ops: []
-    },
-    my_set: {
-      obj: my_set,
-      ops: []
-    },
-  }
-});
+      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.517641749e3cd3e3a9f11738f8bf0e3bfc5d6cae362e926ee33e7877e15905db/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
+      bindings: {
+        arr: {
+          obj: arr,
+          ops: []
+        },
+        arr_of_map: {
+          obj: arr_of_map,
+          ops: []
+        },
+        j: {
+          obj: j,
+          ops: []
+        },
+        my_map: {
+          obj: my_map,
+          ops: []
+        },
+        my_set: {
+          obj: my_set,
+          ops: []
+        },
+      }
+    })
+    ;
     this.node.root.newAbstract(\\"@winglang/sdk.cloud.Function\\",this,\\"test\\",handler);
   }
 }
-
 class $App extends $AppBase {
   constructor() {
     super({ outdir: $outdir, name: \\"capture_containers\\", plugins: $plugins, isTestEnvironment: $wing_is_test });
@@ -196,22 +196,26 @@ class $App extends $AppBase {
     }
   }
 }
-
-new $App().synth();"
+new $App().synth();
+"
 `;
 
-exports[`wing compile -t tf-aws > proc.dc7e5dc23da309970778fe7db4c795e3a6ae63c0d0ddc5e1780d4e2daadf67e1/index.js 1`] = `
-"async handle(s) { const { arr, arr_of_map, j, my_map, my_set } = this; {
-  {((cond) => {if (!cond) throw new Error(\`assertion failed: '((await arr.at(0)) === \\"hello\\")'\`)})(((await arr.at(0)) === \\"hello\\"))};
-  {((cond) => {if (!cond) throw new Error(\`assertion failed: '((await arr.at(1)) === \\"world\\")'\`)})(((await arr.at(1)) === \\"world\\"))};
-  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(arr.length === 2)'\`)})((arr.length === 2))};
-  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(await my_set.has(\\"my\\"))'\`)})((await my_set.has(\\"my\\")))};
-  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(my_set.size === 2)'\`)})((my_set.size === 2))};
-  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(\\"world\\" in (my_map))'\`)})((\\"world\\" in (my_map)))};
-  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(Object.keys(my_map).length === 2)'\`)})((Object.keys(my_map).length === 2))};
-  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(\\"bang\\" in ((await arr_of_map.at(0))))'\`)})((\\"bang\\" in ((await arr_of_map.at(0)))))};
-  {((cond) => {if (!cond) throw new Error(\`assertion failed: '((j)[\\"b\\"] === \\"world\\")'\`)})(((j)[\\"b\\"] === \\"world\\"))};
-} };"
+exports[`wing compile -t tf-aws > proc.517641749e3cd3e3a9f11738f8bf0e3bfc5d6cae362e926ee33e7877e15905db/index.js 1`] = `
+"async handle(s) {
+  const { arr, arr_of_map, j, my_map, my_set } = this;
+  {
+    {((cond) => {if (!cond) throw new Error(\`assertion failed: '((await arr.at(0)) === \\"hello\\")'\`)})(((await arr.at(0)) === \\"hello\\"))};
+    {((cond) => {if (!cond) throw new Error(\`assertion failed: '((await arr.at(1)) === \\"world\\")'\`)})(((await arr.at(1)) === \\"world\\"))};
+    {((cond) => {if (!cond) throw new Error(\`assertion failed: '(arr.length === 2)'\`)})((arr.length === 2))};
+    {((cond) => {if (!cond) throw new Error(\`assertion failed: '(await my_set.has(\\"my\\"))'\`)})((await my_set.has(\\"my\\")))};
+    {((cond) => {if (!cond) throw new Error(\`assertion failed: '(my_set.size === 2)'\`)})((my_set.size === 2))};
+    {((cond) => {if (!cond) throw new Error(\`assertion failed: '(\\"world\\" in (my_map))'\`)})((\\"world\\" in (my_map)))};
+    {((cond) => {if (!cond) throw new Error(\`assertion failed: '(Object.keys(my_map).length === 2)'\`)})((Object.keys(my_map).length === 2))};
+    {((cond) => {if (!cond) throw new Error(\`assertion failed: '(\\"bang\\" in ((await arr_of_map.at(0))))'\`)})((\\"bang\\" in ((await arr_of_map.at(0)))))};
+    {((cond) => {if (!cond) throw new Error(\`assertion failed: '((j)[\\"b\\"] === \\"world\\")'\`)})(((j)[\\"b\\"] === \\"world\\"))};
+  }
+};
+"
 `;
 
 exports[`wing test -t sim > stdout 1`] = `

--- a/tools/hangar/__snapshots__/test_corpus/valid/capture_containers_of_resources.w.ts.snap
+++ b/tools/hangar/__snapshots__/test_corpus/valid/capture_containers_of_resources.w.ts.snap
@@ -249,25 +249,25 @@ class $Root extends $stdlib.core.Resource {
     const map = Object.freeze({\\"my_queue\\":this.node.root.newAbstract(\\"@winglang/sdk.cloud.Queue\\",this,\\"cloud.Queue\\")});
     const set = Object.freeze(new Set([\\"foo\\", \\"foo\\", \\"bar\\"]));
     this.node.root.newAbstract(\\"@winglang/sdk.cloud.Function\\",this,\\"test\\",new $stdlib.core.Inflight(this, \\"$Inflight1\\", {
-  code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.e204fa6fba10aa68396c0fe4d920796b1ec739609b648739fe4ae94d0621db6d/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
-  bindings: {
-    arr: {
-      obj: arr,
-      ops: []
-    },
-    map: {
-      obj: map,
-      ops: []
-    },
-    set: {
-      obj: set,
-      ops: []
-    },
-  }
-}));
+      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.7d6cc5eb3bb5bd7def1556ea81e3aecded299610f67dfd97a86a12c68e07c9ac/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
+      bindings: {
+        arr: {
+          obj: arr,
+          ops: []
+        },
+        map: {
+          obj: map,
+          ops: []
+        },
+        set: {
+          obj: set,
+          ops: []
+        },
+      }
+    })
+    );
   }
 }
-
 class $App extends $AppBase {
   constructor() {
     super({ outdir: $outdir, name: \\"capture_containers_of_resources\\", plugins: $plugins, isTestEnvironment: $wing_is_test });
@@ -283,22 +283,26 @@ class $App extends $AppBase {
     }
   }
 }
-
-new $App().synth();"
+new $App().synth();
+"
 `;
 
-exports[`wing compile -t tf-aws > proc.e204fa6fba10aa68396c0fe4d920796b1ec739609b648739fe4ae94d0621db6d/index.js 1`] = `
-"async handle(s) { const { arr, map, set } = this; {
-  const b1 = (await arr.at(0));
-  const b2 = (await arr.at(1));
-  const q = (map)[\\"my_queue\\"];
-  (await b1.put(\\"file1.txt\\",\\"boom\\"));
-  {((cond) => {if (!cond) throw new Error(\`assertion failed: '((await b2.list()).length === 0)'\`)})(((await b2.list()).length === 0))};
-  {((cond) => {if (!cond) throw new Error(\`assertion failed: '((await b1.get(\\"file1.txt\\")) === \\"boom\\")'\`)})(((await b1.get(\\"file1.txt\\")) === \\"boom\\"))};
-  (await q.push(\\"hello\\"));
-  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(await set.has(\\"foo\\"))'\`)})((await set.has(\\"foo\\")))};
-  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(set.size === 2)'\`)})((set.size === 2))};
-} };"
+exports[`wing compile -t tf-aws > proc.7d6cc5eb3bb5bd7def1556ea81e3aecded299610f67dfd97a86a12c68e07c9ac/index.js 1`] = `
+"async handle(s) {
+  const { arr, map, set } = this;
+  {
+    const b1 = (await arr.at(0));
+    const b2 = (await arr.at(1));
+    const q = (map)[\\"my_queue\\"];
+    (await b1.put(\\"file1.txt\\",\\"boom\\"));
+    {((cond) => {if (!cond) throw new Error(\`assertion failed: '((await b2.list()).length === 0)'\`)})(((await b2.list()).length === 0))};
+    {((cond) => {if (!cond) throw new Error(\`assertion failed: '((await b1.get(\\"file1.txt\\")) === \\"boom\\")'\`)})(((await b1.get(\\"file1.txt\\")) === \\"boom\\"))};
+    (await q.push(\\"hello\\"));
+    {((cond) => {if (!cond) throw new Error(\`assertion failed: '(await set.has(\\"foo\\"))'\`)})((await set.has(\\"foo\\")))};
+    {((cond) => {if (!cond) throw new Error(\`assertion failed: '(set.size === 2)'\`)})((set.size === 2))};
+  }
+};
+"
 `;
 
 exports[`wing test -t sim > stdout 1`] = `

--- a/tools/hangar/__snapshots__/test_corpus/valid/capture_containers_of_resources.w.ts.snap
+++ b/tools/hangar/__snapshots__/test_corpus/valid/capture_containers_of_resources.w.ts.snap
@@ -249,7 +249,7 @@ class $Root extends $stdlib.core.Resource {
     const map = Object.freeze({\\"my_queue\\":this.node.root.newAbstract(\\"@winglang/sdk.cloud.Queue\\",this,\\"cloud.Queue\\")});
     const set = Object.freeze(new Set([\\"foo\\", \\"foo\\", \\"bar\\"]));
     this.node.root.newAbstract(\\"@winglang/sdk.cloud.Function\\",this,\\"test\\",new $stdlib.core.Inflight(this, \\"$Inflight1\\", {
-      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.7d6cc5eb3bb5bd7def1556ea81e3aecded299610f67dfd97a86a12c68e07c9ac/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
+      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.ea0323e98cac08dd11d819f738e933ff5bf537dbe04472f29a655f50c5d7a70b/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
       bindings: {
         arr: {
           obj: arr,
@@ -287,21 +287,19 @@ new $App().synth();
 "
 `;
 
-exports[`wing compile -t tf-aws > proc.7d6cc5eb3bb5bd7def1556ea81e3aecded299610f67dfd97a86a12c68e07c9ac/index.js 1`] = `
+exports[`wing compile -t tf-aws > proc.ea0323e98cac08dd11d819f738e933ff5bf537dbe04472f29a655f50c5d7a70b/index.js 1`] = `
 "async handle(s) {
   const { arr, map, set } = this;
-  {
-    const b1 = (await arr.at(0));
-    const b2 = (await arr.at(1));
-    const q = (map)[\\"my_queue\\"];
-    (await b1.put(\\"file1.txt\\",\\"boom\\"));
-    {((cond) => {if (!cond) throw new Error(\`assertion failed: '((await b2.list()).length === 0)'\`)})(((await b2.list()).length === 0))};
-    {((cond) => {if (!cond) throw new Error(\`assertion failed: '((await b1.get(\\"file1.txt\\")) === \\"boom\\")'\`)})(((await b1.get(\\"file1.txt\\")) === \\"boom\\"))};
-    (await q.push(\\"hello\\"));
-    {((cond) => {if (!cond) throw new Error(\`assertion failed: '(await set.has(\\"foo\\"))'\`)})((await set.has(\\"foo\\")))};
-    {((cond) => {if (!cond) throw new Error(\`assertion failed: '(set.size === 2)'\`)})((set.size === 2))};
-  }
-};
+  const b1 = (await arr.at(0));
+  const b2 = (await arr.at(1));
+  const q = (map)[\\"my_queue\\"];
+  (await b1.put(\\"file1.txt\\",\\"boom\\"));
+  {((cond) => {if (!cond) throw new Error(\`assertion failed: '((await b2.list()).length === 0)'\`)})(((await b2.list()).length === 0))};
+  {((cond) => {if (!cond) throw new Error(\`assertion failed: '((await b1.get(\\"file1.txt\\")) === \\"boom\\")'\`)})(((await b1.get(\\"file1.txt\\")) === \\"boom\\"))};
+  (await q.push(\\"hello\\"));
+  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(await set.has(\\"foo\\"))'\`)})((await set.has(\\"foo\\")))};
+  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(set.size === 2)'\`)})((set.size === 2))};
+}
 "
 `;
 

--- a/tools/hangar/__snapshots__/test_corpus/valid/capture_in_binary.w.ts.snap
+++ b/tools/hangar/__snapshots__/test_corpus/valid/capture_in_binary.w.ts.snap
@@ -195,7 +195,7 @@ class $Root extends $stdlib.core.Resource {
     const b = this.node.root.newAbstract(\\"@winglang/sdk.cloud.Bucket\\",this,\\"cloud.Bucket\\");
     const x = 12;
     const handler2 = new $stdlib.core.Inflight(this, \\"$Inflight1\\", {
-      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.bcb8690cc463a83ae3c7eb76972f6ff9ee57451673027a90d396043e531b9f6e/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
+      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.e77b2aeb97c35bb5ecb6ba6b78fbfcd563e286c79149651961f500a8042998c8/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
       bindings: {
         b: {
           obj: b,
@@ -230,15 +230,13 @@ new $App().synth();
 "
 `;
 
-exports[`wing compile -t tf-aws > proc.bcb8690cc463a83ae3c7eb76972f6ff9ee57451673027a90d396043e531b9f6e/index.js 1`] = `
+exports[`wing compile -t tf-aws > proc.e77b2aeb97c35bb5ecb6ba6b78fbfcd563e286c79149651961f500a8042998c8/index.js 1`] = `
 "async handle(e) {
   const { b, x } = this;
-  {
-    (await b.put(\\"file\\",\\"foo\\"));
-    {((cond) => {if (!cond) throw new Error(\`assertion failed: '((await b.get(\\"file\\")) === \\"foo\\")'\`)})(((await b.get(\\"file\\")) === \\"foo\\"))};
-    {((cond) => {if (!cond) throw new Error(\`assertion failed: '(12 === x)'\`)})((12 === x))};
-  }
-};
+  (await b.put(\\"file\\",\\"foo\\"));
+  {((cond) => {if (!cond) throw new Error(\`assertion failed: '((await b.get(\\"file\\")) === \\"foo\\")'\`)})(((await b.get(\\"file\\")) === \\"foo\\"))};
+  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(12 === x)'\`)})((12 === x))};
+}
 "
 `;
 

--- a/tools/hangar/__snapshots__/test_corpus/valid/capture_in_binary.w.ts.snap
+++ b/tools/hangar/__snapshots__/test_corpus/valid/capture_in_binary.w.ts.snap
@@ -195,22 +195,22 @@ class $Root extends $stdlib.core.Resource {
     const b = this.node.root.newAbstract(\\"@winglang/sdk.cloud.Bucket\\",this,\\"cloud.Bucket\\");
     const x = 12;
     const handler2 = new $stdlib.core.Inflight(this, \\"$Inflight1\\", {
-  code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.d3cc1deae5ea8972097ff15c11d688f395bd17117453789488a005b829eea245/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
-  bindings: {
-    b: {
-      obj: b,
-      ops: [\\"delete\\",\\"get\\",\\"get_json\\",\\"list\\",\\"public_url\\",\\"put\\",\\"put_json\\"]
-    },
-    x: {
-      obj: x,
-      ops: []
-    },
-  }
-});
+      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.bcb8690cc463a83ae3c7eb76972f6ff9ee57451673027a90d396043e531b9f6e/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
+      bindings: {
+        b: {
+          obj: b,
+          ops: [\\"delete\\",\\"get\\",\\"get_json\\",\\"list\\",\\"public_url\\",\\"put\\",\\"put_json\\"]
+        },
+        x: {
+          obj: x,
+          ops: []
+        },
+      }
+    })
+    ;
     this.node.root.newAbstract(\\"@winglang/sdk.cloud.Function\\",this,\\"test\\",handler2);
   }
 }
-
 class $App extends $AppBase {
   constructor() {
     super({ outdir: $outdir, name: \\"capture_in_binary\\", plugins: $plugins, isTestEnvironment: $wing_is_test });
@@ -226,16 +226,20 @@ class $App extends $AppBase {
     }
   }
 }
-
-new $App().synth();"
+new $App().synth();
+"
 `;
 
-exports[`wing compile -t tf-aws > proc.d3cc1deae5ea8972097ff15c11d688f395bd17117453789488a005b829eea245/index.js 1`] = `
-"async handle(e) { const { b, x } = this; {
-  (await b.put(\\"file\\",\\"foo\\"));
-  {((cond) => {if (!cond) throw new Error(\`assertion failed: '((await b.get(\\"file\\")) === \\"foo\\")'\`)})(((await b.get(\\"file\\")) === \\"foo\\"))};
-  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(12 === x)'\`)})((12 === x))};
-} };"
+exports[`wing compile -t tf-aws > proc.bcb8690cc463a83ae3c7eb76972f6ff9ee57451673027a90d396043e531b9f6e/index.js 1`] = `
+"async handle(e) {
+  const { b, x } = this;
+  {
+    (await b.put(\\"file\\",\\"foo\\"));
+    {((cond) => {if (!cond) throw new Error(\`assertion failed: '((await b.get(\\"file\\")) === \\"foo\\")'\`)})(((await b.get(\\"file\\")) === \\"foo\\"))};
+    {((cond) => {if (!cond) throw new Error(\`assertion failed: '(12 === x)'\`)})((12 === x))};
+  }
+};
+"
 `;
 
 exports[`wing test -t sim > stdout 1`] = `

--- a/tools/hangar/__snapshots__/test_corpus/valid/capture_primitives.w.ts.snap
+++ b/tools/hangar/__snapshots__/test_corpus/valid/capture_primitives.w.ts.snap
@@ -153,34 +153,34 @@ class $Root extends $stdlib.core.Resource {
     const my_second_bool = false;
     const my_dur = $stdlib.std.Duration.fromSeconds(600);
     const handler = new $stdlib.core.Inflight(this, \\"$Inflight1\\", {
-  code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.275873c041545c7a2de55149fb73b77f5b75da61d16914ceadd71c3445173d97/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
-  bindings: {
-    my_bool: {
-      obj: my_bool,
-      ops: []
-    },
-    my_dur: {
-      obj: my_dur,
-      ops: []
-    },
-    my_num: {
-      obj: my_num,
-      ops: []
-    },
-    my_second_bool: {
-      obj: my_second_bool,
-      ops: []
-    },
-    my_str: {
-      obj: my_str,
-      ops: []
-    },
-  }
-});
+      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.6b136da2c25def8c9f56c1a5878eb2db480b7ff94a95bde4abe293a5abf7cf72/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
+      bindings: {
+        my_bool: {
+          obj: my_bool,
+          ops: []
+        },
+        my_dur: {
+          obj: my_dur,
+          ops: []
+        },
+        my_num: {
+          obj: my_num,
+          ops: []
+        },
+        my_second_bool: {
+          obj: my_second_bool,
+          ops: []
+        },
+        my_str: {
+          obj: my_str,
+          ops: []
+        },
+      }
+    })
+    ;
     this.node.root.newAbstract(\\"@winglang/sdk.cloud.Function\\",this,\\"cloud.Function\\",handler);
   }
 }
-
 class $App extends $AppBase {
   constructor() {
     super({ outdir: $outdir, name: \\"capture_primitives\\", plugins: $plugins, isTestEnvironment: $wing_is_test });
@@ -196,27 +196,32 @@ class $App extends $AppBase {
     }
   }
 }
-
-new $App().synth();"
+new $App().synth();
+"
 `;
 
-exports[`wing compile -t tf-aws > proc.275873c041545c7a2de55149fb73b77f5b75da61d16914ceadd71c3445173d97/index.js 1`] = `
-"async handle(s) { const { my_bool, my_dur, my_num, my_second_bool, my_str } = this; {
-  {console.log(my_str)};
-  const n = my_num;
-  {console.log(\`\${n}\`)};
-  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(my_second_bool === false)'\`)})((my_second_bool === false))};
-  if (my_bool) {
-    {console.log(\\"bool=true\\")};
-  } else {
-    {console.log(\\"bool=false\\")};
+exports[`wing compile -t tf-aws > proc.6b136da2c25def8c9f56c1a5878eb2db480b7ff94a95bde4abe293a5abf7cf72/index.js 1`] = `
+"async handle(s) {
+  const { my_bool, my_dur, my_num, my_second_bool, my_str } = this;
+  {
+    {console.log(my_str)};
+    const n = my_num;
+    {console.log(\`\${n}\`)};
+    {((cond) => {if (!cond) throw new Error(\`assertion failed: '(my_second_bool === false)'\`)})((my_second_bool === false))};
+    if (my_bool) {
+      {console.log(\\"bool=true\\")};
+    }
+    else {
+      {console.log(\\"bool=false\\")};
+    }
+    const min = my_dur.minutes;
+    const sec = my_dur.seconds;
+    const hr = my_dur.hours;
+    const split = (await \`min=\${min} sec=\${sec} hr=\${hr}\`.split(\\" \\"));
+    {((cond) => {if (!cond) throw new Error(\`assertion failed: '(split.length === 3)'\`)})((split.length === 3))};
   }
-  const min = my_dur.minutes;
-  const sec = my_dur.seconds;
-  const hr = my_dur.hours;
-  const split = (await \`min=\${min} sec=\${sec} hr=\${hr}\`.split(\\" \\"));
-  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(split.length === 3)'\`)})((split.length === 3))};
-} };"
+};
+"
 `;
 
 exports[`wing test -t sim > stdout 1`] = `

--- a/tools/hangar/__snapshots__/test_corpus/valid/capture_primitives.w.ts.snap
+++ b/tools/hangar/__snapshots__/test_corpus/valid/capture_primitives.w.ts.snap
@@ -153,7 +153,7 @@ class $Root extends $stdlib.core.Resource {
     const my_second_bool = false;
     const my_dur = $stdlib.std.Duration.fromSeconds(600);
     const handler = new $stdlib.core.Inflight(this, \\"$Inflight1\\", {
-      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.6b136da2c25def8c9f56c1a5878eb2db480b7ff94a95bde4abe293a5abf7cf72/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
+      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.34e5b7de651594942ccd90c9d76355813afc895aa395fbda2c204aa36f7c3a85/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
       bindings: {
         my_bool: {
           obj: my_bool,
@@ -200,27 +200,25 @@ new $App().synth();
 "
 `;
 
-exports[`wing compile -t tf-aws > proc.6b136da2c25def8c9f56c1a5878eb2db480b7ff94a95bde4abe293a5abf7cf72/index.js 1`] = `
+exports[`wing compile -t tf-aws > proc.34e5b7de651594942ccd90c9d76355813afc895aa395fbda2c204aa36f7c3a85/index.js 1`] = `
 "async handle(s) {
   const { my_bool, my_dur, my_num, my_second_bool, my_str } = this;
-  {
-    {console.log(my_str)};
-    const n = my_num;
-    {console.log(\`\${n}\`)};
-    {((cond) => {if (!cond) throw new Error(\`assertion failed: '(my_second_bool === false)'\`)})((my_second_bool === false))};
-    if (my_bool) {
-      {console.log(\\"bool=true\\")};
-    }
-    else {
-      {console.log(\\"bool=false\\")};
-    }
-    const min = my_dur.minutes;
-    const sec = my_dur.seconds;
-    const hr = my_dur.hours;
-    const split = (await \`min=\${min} sec=\${sec} hr=\${hr}\`.split(\\" \\"));
-    {((cond) => {if (!cond) throw new Error(\`assertion failed: '(split.length === 3)'\`)})((split.length === 3))};
+  {console.log(my_str)};
+  const n = my_num;
+  {console.log(\`\${n}\`)};
+  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(my_second_bool === false)'\`)})((my_second_bool === false))};
+  if (my_bool) {
+    {console.log(\\"bool=true\\")};
   }
-};
+  else {
+    {console.log(\\"bool=false\\")};
+  }
+  const min = my_dur.minutes;
+  const sec = my_dur.seconds;
+  const hr = my_dur.hours;
+  const split = (await \`min=\${min} sec=\${sec} hr=\${hr}\`.split(\\" \\"));
+  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(split.length === 3)'\`)})((split.length === 3))};
+}
 "
 `;
 

--- a/tools/hangar/__snapshots__/test_corpus/valid/capture_resource_and_data.w.ts.snap
+++ b/tools/hangar/__snapshots__/test_corpus/valid/capture_resource_and_data.w.ts.snap
@@ -208,26 +208,26 @@ class $Root extends $stdlib.core.Resource {
     const res = this.node.root.newAbstract(\\"@winglang/sdk.cloud.Bucket\\",this,\\"cloud.Bucket\\");
     const queue = this.node.root.newAbstract(\\"@winglang/sdk.cloud.Queue\\",this,\\"cloud.Queue\\");
     const handler = new $stdlib.core.Inflight(this, \\"$Inflight1\\", {
-  code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.10149a479ee5940e90f4621a2bca78dda7429636b1f235fcd785b3e33c131537/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
-  bindings: {
-    data: {
-      obj: data,
-      ops: []
-    },
-    queue: {
-      obj: queue,
-      ops: [\\"approx_size\\",\\"purge\\",\\"push\\"]
-    },
-    res: {
-      obj: res,
-      ops: [\\"delete\\",\\"get\\",\\"get_json\\",\\"list\\",\\"public_url\\",\\"put\\",\\"put_json\\"]
-    },
-  }
-});
+      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.fcae47d3ad05e0d0348bf0f9f13cf495d253d77f340cae8cb710e665249e4c31/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
+      bindings: {
+        data: {
+          obj: data,
+          ops: []
+        },
+        queue: {
+          obj: queue,
+          ops: [\\"approx_size\\",\\"purge\\",\\"push\\"]
+        },
+        res: {
+          obj: res,
+          ops: [\\"delete\\",\\"get\\",\\"get_json\\",\\"list\\",\\"public_url\\",\\"put\\",\\"put_json\\"]
+        },
+      }
+    })
+    ;
     this.node.root.newAbstract(\\"@winglang/sdk.cloud.Function\\",this,\\"test\\",handler);
   }
 }
-
 class $App extends $AppBase {
   constructor() {
     super({ outdir: $outdir, name: \\"capture_resource_and_data\\", plugins: $plugins, isTestEnvironment: $wing_is_test });
@@ -243,17 +243,21 @@ class $App extends $AppBase {
     }
   }
 }
-
-new $App().synth();"
+new $App().synth();
+"
 `;
 
-exports[`wing compile -t tf-aws > proc.10149a479ee5940e90f4621a2bca78dda7429636b1f235fcd785b3e33c131537/index.js 1`] = `
-"async handle(e) { const { data, queue, res } = this; {
-  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(data.size === 3)'\`)})((data.size === 3))};
-  (await res.put(\\"file.txt\\",\\"world\\"));
-  {((cond) => {if (!cond) throw new Error(\`assertion failed: '((await res.get(\\"file.txt\\")) === \\"world\\")'\`)})(((await res.get(\\"file.txt\\")) === \\"world\\"))};
-  (await queue.push(\\"spirulina\\"));
-} };"
+exports[`wing compile -t tf-aws > proc.fcae47d3ad05e0d0348bf0f9f13cf495d253d77f340cae8cb710e665249e4c31/index.js 1`] = `
+"async handle(e) {
+  const { data, queue, res } = this;
+  {
+    {((cond) => {if (!cond) throw new Error(\`assertion failed: '(data.size === 3)'\`)})((data.size === 3))};
+    (await res.put(\\"file.txt\\",\\"world\\"));
+    {((cond) => {if (!cond) throw new Error(\`assertion failed: '((await res.get(\\"file.txt\\")) === \\"world\\")'\`)})(((await res.get(\\"file.txt\\")) === \\"world\\"))};
+    (await queue.push(\\"spirulina\\"));
+  }
+};
+"
 `;
 
 exports[`wing test -t sim > stdout 1`] = `

--- a/tools/hangar/__snapshots__/test_corpus/valid/capture_resource_and_data.w.ts.snap
+++ b/tools/hangar/__snapshots__/test_corpus/valid/capture_resource_and_data.w.ts.snap
@@ -208,7 +208,7 @@ class $Root extends $stdlib.core.Resource {
     const res = this.node.root.newAbstract(\\"@winglang/sdk.cloud.Bucket\\",this,\\"cloud.Bucket\\");
     const queue = this.node.root.newAbstract(\\"@winglang/sdk.cloud.Queue\\",this,\\"cloud.Queue\\");
     const handler = new $stdlib.core.Inflight(this, \\"$Inflight1\\", {
-      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.fcae47d3ad05e0d0348bf0f9f13cf495d253d77f340cae8cb710e665249e4c31/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
+      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.282c2371efeb58766c430a9fafcc2f6b12044c38815124df7fe9b4da83adc985/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
       bindings: {
         data: {
           obj: data,
@@ -247,16 +247,14 @@ new $App().synth();
 "
 `;
 
-exports[`wing compile -t tf-aws > proc.fcae47d3ad05e0d0348bf0f9f13cf495d253d77f340cae8cb710e665249e4c31/index.js 1`] = `
+exports[`wing compile -t tf-aws > proc.282c2371efeb58766c430a9fafcc2f6b12044c38815124df7fe9b4da83adc985/index.js 1`] = `
 "async handle(e) {
   const { data, queue, res } = this;
-  {
-    {((cond) => {if (!cond) throw new Error(\`assertion failed: '(data.size === 3)'\`)})((data.size === 3))};
-    (await res.put(\\"file.txt\\",\\"world\\"));
-    {((cond) => {if (!cond) throw new Error(\`assertion failed: '((await res.get(\\"file.txt\\")) === \\"world\\")'\`)})(((await res.get(\\"file.txt\\")) === \\"world\\"))};
-    (await queue.push(\\"spirulina\\"));
-  }
-};
+  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(data.size === 3)'\`)})((data.size === 3))};
+  (await res.put(\\"file.txt\\",\\"world\\"));
+  {((cond) => {if (!cond) throw new Error(\`assertion failed: '((await res.get(\\"file.txt\\")) === \\"world\\")'\`)})(((await res.get(\\"file.txt\\")) === \\"world\\"))};
+  (await queue.push(\\"spirulina\\"));
+}
 "
 `;
 

--- a/tools/hangar/__snapshots__/test_corpus/valid/capture_resource_with_no_inflight.w.ts.snap
+++ b/tools/hangar/__snapshots__/test_corpus/valid/capture_resource_with_no_inflight.w.ts.snap
@@ -2,12 +2,12 @@
 
 exports[`wing compile -t tf-aws > clients/A.inflight.js 1`] = `
 "class A  {
-constructor({ field }) {
-
-  this.field = field;
+  constructor({ field }) {
+    this.field = field;
+  }
 }
-}
-exports.A = A;"
+exports.A = A;
+"
 `;
 
 exports[`wing compile -t tf-aws > main.tf.json 1`] = `
@@ -158,33 +158,34 @@ class $Root extends $stdlib.core.Resource {
   constructor(scope, id) {
     super(scope, id);
     class A extends $stdlib.core.Resource {
-	constructor(scope, id, ) {
-	super(scope, id);
-{
-  this.field = \\"hey\\";
-}
-}
-	
-	_toInflight() {
-	const field_client = this._lift(this.field);
-	const self_client_path = \\"./clients/A.inflight.js\\".replace(/\\\\\\\\/g, \\"/\\");
-	return $stdlib.core.NodeJsCode.fromInline(\`(new (require(\\"\${self_client_path}\\")).A({field: \${field_client}}))\`);
-}
-}
-A._annotateInflight(\\"$init\\", {\\"this.field\\": { ops: [] }});
+      constructor(scope, id, ) {
+        super(scope, id);
+        this.field = \\"hey\\";
+      }
+      _toInflight() {
+        const field_client = this._lift(this.field);
+        const self_client_path = \\"./clients/A.inflight.js\\".replace(/\\\\\\\\/g, \\"/\\");
+        return $stdlib.core.NodeJsCode.fromInline(\`
+          (new (require(\\"\${self_client_path}\\")).A({
+            field: \${field_client},
+          }))
+        \`);
+      }
+    }
+    A._annotateInflight(\\"$init\\", {\\"this.field\\": { ops: [] }});
     const a = new A(this,\\"A\\");
     this.node.root.newAbstract(\\"@winglang/sdk.cloud.Function\\",this,\\"test\\",new $stdlib.core.Inflight(this, \\"$Inflight1\\", {
-  code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.b771192b636450edefdc8f4b596a6372d5b2520efa1fcdb75c51589c12a10c59/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
-  bindings: {
-    a: {
-      obj: a,
-      ops: []
-    },
-  }
-}));
+      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.55a01c3ddb40f9a32805e53e7adf385801e46be1b6884ac4c313dfd33211918e/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
+      bindings: {
+        a: {
+          obj: a,
+          ops: []
+        },
+      }
+    })
+    );
   }
 }
-
 class $App extends $AppBase {
   constructor() {
     super({ outdir: $outdir, name: \\"capture_resource_with_no_inflight\\", plugins: $plugins, isTestEnvironment: $wing_is_test });
@@ -200,14 +201,18 @@ class $App extends $AppBase {
     }
   }
 }
-
-new $App().synth();"
+new $App().synth();
+"
 `;
 
-exports[`wing compile -t tf-aws > proc.b771192b636450edefdc8f4b596a6372d5b2520efa1fcdb75c51589c12a10c59/index.js 1`] = `
-"async handle() { const { a } = this; {
-  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(\\"hey\\" === a.field)'\`)})((\\"hey\\" === a.field))};
-} };"
+exports[`wing compile -t tf-aws > proc.55a01c3ddb40f9a32805e53e7adf385801e46be1b6884ac4c313dfd33211918e/index.js 1`] = `
+"async handle() {
+  const { a } = this;
+  {
+    {((cond) => {if (!cond) throw new Error(\`assertion failed: '(\\"hey\\" === a.field)'\`)})((\\"hey\\" === a.field))};
+  }
+};
+"
 `;
 
 exports[`wing test -t sim > stdout 1`] = `

--- a/tools/hangar/__snapshots__/test_corpus/valid/capture_resource_with_no_inflight.w.ts.snap
+++ b/tools/hangar/__snapshots__/test_corpus/valid/capture_resource_with_no_inflight.w.ts.snap
@@ -175,7 +175,7 @@ class $Root extends $stdlib.core.Resource {
     A._annotateInflight(\\"$init\\", {\\"this.field\\": { ops: [] }});
     const a = new A(this,\\"A\\");
     this.node.root.newAbstract(\\"@winglang/sdk.cloud.Function\\",this,\\"test\\",new $stdlib.core.Inflight(this, \\"$Inflight1\\", {
-      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.55a01c3ddb40f9a32805e53e7adf385801e46be1b6884ac4c313dfd33211918e/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
+      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.81f22ed577c606e2abb5d01ab149b86464b35ffade7551b81842daccdbf2fb3e/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
       bindings: {
         a: {
           obj: a,
@@ -205,13 +205,11 @@ new $App().synth();
 "
 `;
 
-exports[`wing compile -t tf-aws > proc.55a01c3ddb40f9a32805e53e7adf385801e46be1b6884ac4c313dfd33211918e/index.js 1`] = `
+exports[`wing compile -t tf-aws > proc.81f22ed577c606e2abb5d01ab149b86464b35ffade7551b81842daccdbf2fb3e/index.js 1`] = `
 "async handle() {
   const { a } = this;
-  {
-    {((cond) => {if (!cond) throw new Error(\`assertion failed: '(\\"hey\\" === a.field)'\`)})((\\"hey\\" === a.field))};
-  }
-};
+  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(\\"hey\\" === a.field)'\`)})((\\"hey\\" === a.field))};
+}
 "
 `;
 

--- a/tools/hangar/__snapshots__/test_corpus/valid/captures.w.ts.snap
+++ b/tools/hangar/__snapshots__/test_corpus/valid/captures.w.ts.snap
@@ -464,7 +464,7 @@ class $Root extends $stdlib.core.Resource {
     const bucket3 = this.node.root.newAbstract(\\"@winglang/sdk.cloud.Bucket\\",this,\\"PrivateBucket\\",{ public: false });
     const queue = this.node.root.newAbstract(\\"@winglang/sdk.cloud.Queue\\",this,\\"cloud.Queue\\");
     const handler = new $stdlib.core.Inflight(this, \\"$Inflight1\\", {
-      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.e9af154c120f172367db49504c2c52d3a7cb74e8033b45e6bba2ad07ead66fbc/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
+      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.e9aa0b50add93f5d8b788d4e38afe0098f95fe48ac16d3ef991aa253313c8daf/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
       bindings: {
         bucket1: {
           obj: bucket1,
@@ -506,27 +506,25 @@ new $App().synth();
 "
 `;
 
-exports[`wing compile -t tf-aws > proc.e9af154c120f172367db49504c2c52d3a7cb74e8033b45e6bba2ad07ead66fbc/index.js 1`] = `
+exports[`wing compile -t tf-aws > proc.e9aa0b50add93f5d8b788d4e38afe0098f95fe48ac16d3ef991aa253313c8daf/index.js 1`] = `
 "async handle(event) {
   const { bucket1, bucket2, bucket3 } = this;
-  {
-    (await bucket1.put(\\"file.txt\\",\\"data\\"));
-    (await bucket2.get(\\"file.txt\\"));
-    (await bucket2.get(\\"file2.txt\\"));
-    (await bucket3.get(\\"file3.txt\\"));
-    for (const stuff of (await bucket1.list())) {
-      {console.log(stuff)};
-    }
-    {console.log((await bucket2.publicUrl(\\"file.txt\\")))};
-    try {
-      (await bucket1.publicUrl(\\"file.txt\\"));
-    }
-    catch ($error_error) {
-      const error = $error_error.message;
-      {console.log(error)};
-    }
+  (await bucket1.put(\\"file.txt\\",\\"data\\"));
+  (await bucket2.get(\\"file.txt\\"));
+  (await bucket2.get(\\"file2.txt\\"));
+  (await bucket3.get(\\"file3.txt\\"));
+  for (const stuff of (await bucket1.list())) {
+    {console.log(stuff)};
   }
-};
+  {console.log((await bucket2.publicUrl(\\"file.txt\\")))};
+  try {
+    (await bucket1.publicUrl(\\"file.txt\\"));
+  }
+  catch ($error_error) {
+    const error = $error_error.message;
+    {console.log(error)};
+  }
+}
 "
 `;
 

--- a/tools/hangar/__snapshots__/test_corpus/valid/captures.w.ts.snap
+++ b/tools/hangar/__snapshots__/test_corpus/valid/captures.w.ts.snap
@@ -459,34 +459,34 @@ class $Root extends $stdlib.core.Resource {
     super(scope, id);
     const bucket1 = this.node.root.newAbstract(\\"@winglang/sdk.cloud.Bucket\\",this,\\"cloud.Bucket\\");
     const bucket2 = this.node.root.newAbstract(\\"@winglang/sdk.cloud.Bucket\\",this,\\"PublicBucket\\",{
-\\"public\\": true,}
-);
+    \\"public\\": true,}
+    );
     const bucket3 = this.node.root.newAbstract(\\"@winglang/sdk.cloud.Bucket\\",this,\\"PrivateBucket\\",{ public: false });
     const queue = this.node.root.newAbstract(\\"@winglang/sdk.cloud.Queue\\",this,\\"cloud.Queue\\");
     const handler = new $stdlib.core.Inflight(this, \\"$Inflight1\\", {
-  code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.7117cacac13b5aec2868af198145d060294a0f8c3a40444eeae5b1f6002f9e77/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
-  bindings: {
-    bucket1: {
-      obj: bucket1,
-      ops: [\\"delete\\",\\"get\\",\\"get_json\\",\\"list\\",\\"public_url\\",\\"put\\",\\"put_json\\"]
-    },
-    bucket2: {
-      obj: bucket2,
-      ops: [\\"delete\\",\\"get\\",\\"get_json\\",\\"list\\",\\"public_url\\",\\"put\\",\\"put_json\\"]
-    },
-    bucket3: {
-      obj: bucket3,
-      ops: [\\"delete\\",\\"get\\",\\"get_json\\",\\"list\\",\\"public_url\\",\\"put\\",\\"put_json\\"]
-    },
-  }
-});
+      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.e9af154c120f172367db49504c2c52d3a7cb74e8033b45e6bba2ad07ead66fbc/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
+      bindings: {
+        bucket1: {
+          obj: bucket1,
+          ops: [\\"delete\\",\\"get\\",\\"get_json\\",\\"list\\",\\"public_url\\",\\"put\\",\\"put_json\\"]
+        },
+        bucket2: {
+          obj: bucket2,
+          ops: [\\"delete\\",\\"get\\",\\"get_json\\",\\"list\\",\\"public_url\\",\\"put\\",\\"put_json\\"]
+        },
+        bucket3: {
+          obj: bucket3,
+          ops: [\\"delete\\",\\"get\\",\\"get_json\\",\\"list\\",\\"public_url\\",\\"put\\",\\"put_json\\"]
+        },
+      }
+    })
+    ;
     (queue.addConsumer(handler,{ batchSize: 5 }));
     this.node.root.newAbstract(\\"@winglang/sdk.cloud.Function\\",this,\\"cloud.Function\\",handler,{ env: Object.freeze({}) });
     const empty_env = Object.freeze({});
     this.node.root.newAbstract(\\"@winglang/sdk.cloud.Function\\",this,\\"AnotherFunction\\",handler,{ env: empty_env });
   }
 }
-
 class $App extends $AppBase {
   constructor() {
     super({ outdir: $outdir, name: \\"captures\\", plugins: $plugins, isTestEnvironment: $wing_is_test });
@@ -502,33 +502,32 @@ class $App extends $AppBase {
     }
   }
 }
-
-new $App().synth();"
+new $App().synth();
+"
 `;
 
-exports[`wing compile -t tf-aws > proc.7117cacac13b5aec2868af198145d060294a0f8c3a40444eeae5b1f6002f9e77/index.js 1`] = `
-"async handle(event) { const { bucket1, bucket2, bucket3 } = this; {
-  (await bucket1.put(\\"file.txt\\",\\"data\\"));
-  (await bucket2.get(\\"file.txt\\"));
-  (await bucket2.get(\\"file2.txt\\"));
-  (await bucket3.get(\\"file3.txt\\"));
-  for (const stuff of (await bucket1.list())) {
-    {console.log(stuff)};
+exports[`wing compile -t tf-aws > proc.e9af154c120f172367db49504c2c52d3a7cb74e8033b45e6bba2ad07ead66fbc/index.js 1`] = `
+"async handle(event) {
+  const { bucket1, bucket2, bucket3 } = this;
+  {
+    (await bucket1.put(\\"file.txt\\",\\"data\\"));
+    (await bucket2.get(\\"file.txt\\"));
+    (await bucket2.get(\\"file2.txt\\"));
+    (await bucket3.get(\\"file3.txt\\"));
+    for (const stuff of (await bucket1.list())) {
+      {console.log(stuff)};
+    }
+    {console.log((await bucket2.publicUrl(\\"file.txt\\")))};
+    try {
+      (await bucket1.publicUrl(\\"file.txt\\"));
+    }
+    catch ($error_error) {
+      const error = $error_error.message;
+      {console.log(error)};
+    }
   }
-  {console.log((await bucket2.publicUrl(\\"file.txt\\")))};
-  try {
-  	{
-    (await bucket1.publicUrl(\\"file.txt\\"));
-  }
-  } catch ($error_error) {
-  	const error = $error_error.message;
-  	{
-    {console.log(error)};
-  }
-  } finally {
-  	
-  }
-} };"
+};
+"
 `;
 
 exports[`wing test -t sim > stdout 1`] = `

--- a/tools/hangar/__snapshots__/test_corpus/valid/container_types.w.ts.snap
+++ b/tools/hangar/__snapshots__/test_corpus/valid/container_types.w.ts.snap
@@ -260,7 +260,6 @@ class $Root extends $stdlib.core.Resource {
     {((cond) => {if (!cond) throw new Error(\`assertion failed: '(s7.has(1))'\`)})((s7.has(1)))};
   }
 }
-
 class $App extends $AppBase {
   constructor() {
     super({ outdir: $outdir, name: \\"container_types\\", plugins: $plugins, isTestEnvironment: $wing_is_test });
@@ -276,8 +275,8 @@ class $App extends $AppBase {
     }
   }
 }
-
-new $App().synth();"
+new $App().synth();
+"
 `;
 
 exports[`wing test -t sim > stdout 1`] = `

--- a/tools/hangar/__snapshots__/test_corpus/valid/doubler.w.ts.snap
+++ b/tools/hangar/__snapshots__/test_corpus/valid/doubler.w.ts.snap
@@ -2,17 +2,18 @@
 
 exports[`wing compile -t tf-aws > clients/Doubler.inflight.js 1`] = `
 "class Doubler  {
-constructor({ func }) {
-
-  this.func = func;
+  constructor({ func }) {
+    this.func = func;
+  }
+  async invoke(message)  {
+    {
+      (await this.func.handle(message));
+      (await this.func.handle(message));
+    }
+  }
 }
-async invoke(message)  {
-	{
-  (await this.func.handle(message));
-  (await this.func.handle(message));
-}
-}}
-exports.Doubler = Doubler;"
+exports.Doubler = Doubler;
+"
 `;
 
 exports[`wing compile -t tf-aws > main.tf.json 1`] = `
@@ -75,29 +76,30 @@ class $Root extends $stdlib.core.Resource {
   constructor(scope, id) {
     super(scope, id);
     class Doubler extends $stdlib.core.Resource {
-	constructor(scope, id, func) {
-	super(scope, id);
-{
-  this.func = func;
-}
-}
-	
-	_toInflight() {
-	const func_client = this._lift(this.func);
-	const self_client_path = \\"./clients/Doubler.inflight.js\\".replace(/\\\\\\\\/g, \\"/\\");
-	return $stdlib.core.NodeJsCode.fromInline(\`(new (require(\\"\${self_client_path}\\")).Doubler({func: \${func_client}}))\`);
-}
-}
-Doubler._annotateInflight(\\"invoke\\", {\\"this.func\\": { ops: [\\"handle\\"] }});
-Doubler._annotateInflight(\\"$init\\", {\\"this.func\\": { ops: [] }});
+      constructor(scope, id, func) {
+        super(scope, id);
+        this.func = func;
+      }
+      _toInflight() {
+        const func_client = this._lift(this.func);
+        const self_client_path = \\"./clients/Doubler.inflight.js\\".replace(/\\\\\\\\/g, \\"/\\");
+        return $stdlib.core.NodeJsCode.fromInline(\`
+          (new (require(\\"\${self_client_path}\\")).Doubler({
+            func: \${func_client},
+          }))
+        \`);
+      }
+    }
+    Doubler._annotateInflight(\\"invoke\\", {\\"this.func\\": { ops: [\\"handle\\"] }});
+    Doubler._annotateInflight(\\"$init\\", {\\"this.func\\": { ops: [] }});
     const fn = new Doubler(this,\\"Doubler\\",new $stdlib.core.Inflight(this, \\"$Inflight1\\", {
-  code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.0f7e6b0c659cb020f4ca84ac6c8de140b582a9fb74aaffae876e8edba62812f1/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
-  bindings: {
-  }
-}));
+      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.8d339fd16770e6eb6e8415aab19c881ae0171224411980a076559984bbc94d93/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
+      bindings: {
+      }
+    })
+    );
   }
 }
-
 class $App extends $AppBase {
   constructor() {
     super({ outdir: $outdir, name: \\"doubler\\", plugins: $plugins, isTestEnvironment: $wing_is_test });
@@ -113,14 +115,18 @@ class $App extends $AppBase {
     }
   }
 }
-
-new $App().synth();"
+new $App().synth();
+"
 `;
 
-exports[`wing compile -t tf-aws > proc.0f7e6b0c659cb020f4ca84ac6c8de140b582a9fb74aaffae876e8edba62812f1/index.js 1`] = `
-"async handle(m) { const {  } = this; {
-  return \`Hello \${m}!\`;
-} };"
+exports[`wing compile -t tf-aws > proc.8d339fd16770e6eb6e8415aab19c881ae0171224411980a076559984bbc94d93/index.js 1`] = `
+"async handle(m) {
+  const {  } = this;
+  {
+    return \`Hello \${m}!\`;
+  }
+};
+"
 `;
 
 exports[`wing test -t sim > stdout 1`] = `

--- a/tools/hangar/__snapshots__/test_corpus/valid/doubler.w.ts.snap
+++ b/tools/hangar/__snapshots__/test_corpus/valid/doubler.w.ts.snap
@@ -93,7 +93,7 @@ class $Root extends $stdlib.core.Resource {
     Doubler._annotateInflight(\\"invoke\\", {\\"this.func\\": { ops: [\\"handle\\"] }});
     Doubler._annotateInflight(\\"$init\\", {\\"this.func\\": { ops: [] }});
     const fn = new Doubler(this,\\"Doubler\\",new $stdlib.core.Inflight(this, \\"$Inflight1\\", {
-      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.8d339fd16770e6eb6e8415aab19c881ae0171224411980a076559984bbc94d93/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
+      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.1eb4781e85032ffc58e74255182bc1fdee5701b5098072dd29f4faf4f591d6aa/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
       bindings: {
       }
     })
@@ -119,13 +119,11 @@ new $App().synth();
 "
 `;
 
-exports[`wing compile -t tf-aws > proc.8d339fd16770e6eb6e8415aab19c881ae0171224411980a076559984bbc94d93/index.js 1`] = `
+exports[`wing compile -t tf-aws > proc.1eb4781e85032ffc58e74255182bc1fdee5701b5098072dd29f4faf4f591d6aa/index.js 1`] = `
 "async handle(m) {
   const {  } = this;
-  {
-    return \`Hello \${m}!\`;
-  }
-};
+  return \`Hello \${m}!\`;
+}
 "
 `;
 

--- a/tools/hangar/__snapshots__/test_corpus/valid/enums.w.ts.snap
+++ b/tools/hangar/__snapshots__/test_corpus/valid/enums.w.ts.snap
@@ -59,16 +59,15 @@ class $Root extends $stdlib.core.Resource {
   constructor(scope, id) {
     super(scope, id);
     const SomeEnum = Object.freeze((function (SomeEnum) {
-  SomeEnum[SomeEnum[\\"ONE\\"] = 0] = \\"ONE\\";
-  SomeEnum[SomeEnum[\\"TWO\\"] = 1] = \\"TWO\\";
-  SomeEnum[SomeEnum[\\"THREE\\"] = 2] = \\"THREE\\";
-  return SomeEnum;
-})({}));
+      SomeEnum[SomeEnum[\\"ONE\\"] = 0] = \\"ONE\\";
+      SomeEnum[SomeEnum[\\"TWO\\"] = 1] = \\"TWO\\";
+      SomeEnum[SomeEnum[\\"THREE\\"] = 2] = \\"THREE\\";
+      return SomeEnum;
+    })({}));
     const one = SomeEnum.ONE;
     const two = SomeEnum.TWO;
   }
 }
-
 class $App extends $AppBase {
   constructor() {
     super({ outdir: $outdir, name: \\"enums\\", plugins: $plugins, isTestEnvironment: $wing_is_test });
@@ -84,8 +83,8 @@ class $App extends $AppBase {
     }
   }
 }
-
-new $App().synth();"
+new $App().synth();
+"
 `;
 
 exports[`wing test -t sim > stdout 1`] = `

--- a/tools/hangar/__snapshots__/test_corpus/valid/expressions_binary_operators.w.ts.snap
+++ b/tools/hangar/__snapshots__/test_corpus/valid/expressions_binary_operators.w.ts.snap
@@ -77,7 +77,6 @@ class $Root extends $stdlib.core.Resource {
     {((cond) => {if (!cond) throw new Error(\`assertion failed: '(xynfj === 5)'\`)})((xynfj === 5))};
   }
 }
-
 class $App extends $AppBase {
   constructor() {
     super({ outdir: $outdir, name: \\"expressions_binary_operators\\", plugins: $plugins, isTestEnvironment: $wing_is_test });
@@ -93,8 +92,8 @@ class $App extends $AppBase {
     }
   }
 }
-
-new $App().synth();"
+new $App().synth();
+"
 `;
 
 exports[`wing test -t sim > stdout 1`] = `

--- a/tools/hangar/__snapshots__/test_corpus/valid/expressions_string_interpolation.w.ts.snap
+++ b/tools/hangar/__snapshots__/test_corpus/valid/expressions_string_interpolation.w.ts.snap
@@ -67,7 +67,6 @@ class $Root extends $stdlib.core.Resource {
     const ending_with_cool_strings = \`cool -> \${regular_string} \${number}\`;
   }
 }
-
 class $App extends $AppBase {
   constructor() {
     super({ outdir: $outdir, name: \\"expressions_string_interpolation\\", plugins: $plugins, isTestEnvironment: $wing_is_test });
@@ -83,8 +82,8 @@ class $App extends $AppBase {
     }
   }
 }
-
-new $App().synth();"
+new $App().synth();
+"
 `;
 
 exports[`wing test -t sim > stdout 1`] = `

--- a/tools/hangar/__snapshots__/test_corpus/valid/extern_implementation.w.ts.snap
+++ b/tools/hangar/__snapshots__/test_corpus/valid/extern_implementation.w.ts.snap
@@ -200,7 +200,7 @@ class $Root extends $stdlib.core.Resource {
     {((cond) => {if (!cond) throw new Error(\`assertion failed: '((Foo.v4()).length === 36)'\`)})(((Foo.v4()).length === 36))};
     const f = new Foo(this,\\"Foo\\");
     this.node.root.newAbstract(\\"@winglang/sdk.cloud.Function\\",this,\\"test:call\\",new $stdlib.core.Inflight(this, \\"$Inflight1\\", {
-      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.dbcbd8abccf0254a0146fe50fdd5cf4c36c5a86ecd9c8bf63bd60b23798759e8/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
+      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.104793feca8a0c99ea8c2876b3c2124f464b0b5bffc723938b058ed94174607f/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
       bindings: {
         f: {
           obj: f,
@@ -230,13 +230,11 @@ new $App().synth();
 "
 `;
 
-exports[`wing compile -t tf-aws > proc.dbcbd8abccf0254a0146fe50fdd5cf4c36c5a86ecd9c8bf63bd60b23798759e8/index.js 1`] = `
+exports[`wing compile -t tf-aws > proc.104793feca8a0c99ea8c2876b3c2124f464b0b5bffc723938b058ed94174607f/index.js 1`] = `
 "async handle() {
   const { f } = this;
-  {
-    (await f.call());
-  }
-};
+  (await f.call());
+}
 "
 `;
 

--- a/tools/hangar/__snapshots__/test_corpus/valid/extern_implementation.w.ts.snap
+++ b/tools/hangar/__snapshots__/test_corpus/valid/extern_implementation.w.ts.snap
@@ -2,28 +2,28 @@
 
 exports[`wing compile -t tf-aws > clients/Foo.inflight.js 1`] = `
 "class Foo  {
-constructor({  }) {
-
-
+  constructor({  }) {
+  }
+  static async regex_inflight(pattern, text)  {
+    return (require(require.resolve(\\"./external_js.js\\", {paths: [process.env.WING_PROJECT_DIR]}))[\\"regex_inflight\\"])(pattern, text)
+  }
+  static async get_uuid()  {
+    return (require(require.resolve(\\"./external_js.js\\", {paths: [process.env.WING_PROJECT_DIR]}))[\\"get_uuid\\"])()
+  }
+  static async get_data()  {
+    return (require(require.resolve(\\"./external_js.js\\", {paths: [process.env.WING_PROJECT_DIR]}))[\\"get_data\\"])()
+  }
+  async call()  {
+    {
+      {((cond) => {if (!cond) throw new Error(\`assertion failed: '(await Foo.regex_inflight(\\"[a-z]+-\\\\\\\\d+\\",\\"abc-123\\"))'\`)})((await Foo.regex_inflight(\\"[a-z]+-\\\\\\\\d+\\",\\"abc-123\\")))};
+      const uuid = (await Foo.get_uuid());
+      {((cond) => {if (!cond) throw new Error(\`assertion failed: '(uuid.length === 36)'\`)})((uuid.length === 36))};
+      {((cond) => {if (!cond) throw new Error(\`assertion failed: '((await Foo.get_data()) === \\"Cool data!\\")'\`)})(((await Foo.get_data()) === \\"Cool data!\\"))};
+    }
+  }
 }
-static async regex_inflight(pattern, text)  {
-	return (require(require.resolve(\\"./external_js.js\\", {paths: [process.env.WING_PROJECT_DIR]}))[\\"regex_inflight\\"])(pattern, text)
-}
-static async get_uuid()  {
-	return (require(require.resolve(\\"./external_js.js\\", {paths: [process.env.WING_PROJECT_DIR]}))[\\"get_uuid\\"])()
-}
-static async get_data()  {
-	return (require(require.resolve(\\"./external_js.js\\", {paths: [process.env.WING_PROJECT_DIR]}))[\\"get_data\\"])()
-}
-async call()  {
-	{
-  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(await Foo.regex_inflight(\\"[a-z]+-\\\\\\\\d+\\",\\"abc-123\\"))'\`)})((await Foo.regex_inflight(\\"[a-z]+-\\\\\\\\d+\\",\\"abc-123\\")))};
-  const uuid = (await Foo.get_uuid());
-  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(uuid.length === 36)'\`)})((uuid.length === 36))};
-  {((cond) => {if (!cond) throw new Error(\`assertion failed: '((await Foo.get_data()) === \\"Cool data!\\")'\`)})(((await Foo.get_data()) === \\"Cool data!\\"))};
-}
-}}
-exports.Foo = Foo;"
+exports.Foo = Foo;
+"
 `;
 
 exports[`wing compile -t tf-aws > main.tf.json 1`] = `
@@ -174,43 +174,43 @@ class $Root extends $stdlib.core.Resource {
   constructor(scope, id) {
     super(scope, id);
     class Foo extends $stdlib.core.Resource {
-	constructor(scope, id, ) {
-	super(scope, id);
-{
-}
-}
-	static get_greeting(name)  {
-	return (require(require.resolve(\\"./external_js.js\\", {paths: [process.env.WING_PROJECT_DIR]}))[\\"get_greeting\\"])(name)
-}
-static v4()  {
-	return (require(require.resolve(\\"uuid\\", {paths: [process.env.WING_PROJECT_DIR]}))[\\"v4\\"])()
-}
-	_toInflight() {
-	
-	const self_client_path = \\"./clients/Foo.inflight.js\\".replace(/\\\\\\\\/g, \\"/\\");
-	return $stdlib.core.NodeJsCode.fromInline(\`(new (require(\\"\${self_client_path}\\")).Foo({}))\`);
-}
-}
-Foo._annotateInflight(\\"regex_inflight\\", {});
-Foo._annotateInflight(\\"get_uuid\\", {});
-Foo._annotateInflight(\\"get_data\\", {});
-Foo._annotateInflight(\\"call\\", {});
-Foo._annotateInflight(\\"$init\\", {});
+      constructor(scope, id, ) {
+        super(scope, id);
+      }
+      static get_greeting(name)  {
+        return (require(require.resolve(\\"./external_js.js\\", {paths: [process.env.WING_PROJECT_DIR]}))[\\"get_greeting\\"])(name)
+      }
+      static v4()  {
+        return (require(require.resolve(\\"uuid\\", {paths: [process.env.WING_PROJECT_DIR]}))[\\"v4\\"])()
+      }
+      _toInflight() {
+        const self_client_path = \\"./clients/Foo.inflight.js\\".replace(/\\\\\\\\/g, \\"/\\");
+        return $stdlib.core.NodeJsCode.fromInline(\`
+          (new (require(\\"\${self_client_path}\\")).Foo({
+          }))
+        \`);
+      }
+    }
+    Foo._annotateInflight(\\"regex_inflight\\", {});
+    Foo._annotateInflight(\\"get_uuid\\", {});
+    Foo._annotateInflight(\\"get_data\\", {});
+    Foo._annotateInflight(\\"call\\", {});
+    Foo._annotateInflight(\\"$init\\", {});
     {((cond) => {if (!cond) throw new Error(\`assertion failed: '((Foo.get_greeting(\\"Wingding\\")) === \\"Hello, Wingding!\\")'\`)})(((Foo.get_greeting(\\"Wingding\\")) === \\"Hello, Wingding!\\"))};
     {((cond) => {if (!cond) throw new Error(\`assertion failed: '((Foo.v4()).length === 36)'\`)})(((Foo.v4()).length === 36))};
     const f = new Foo(this,\\"Foo\\");
     this.node.root.newAbstract(\\"@winglang/sdk.cloud.Function\\",this,\\"test:call\\",new $stdlib.core.Inflight(this, \\"$Inflight1\\", {
-  code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.07843d13880528eb093c8438f86267f529c160bc2f048435d6f2c77a50053a5c/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
-  bindings: {
-    f: {
-      obj: f,
-      ops: [\\"call\\",\\"get_data\\",\\"get_uuid\\",\\"regex_inflight\\"]
-    },
-  }
-}));
+      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.dbcbd8abccf0254a0146fe50fdd5cf4c36c5a86ecd9c8bf63bd60b23798759e8/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
+      bindings: {
+        f: {
+          obj: f,
+          ops: [\\"call\\",\\"get_data\\",\\"get_uuid\\",\\"regex_inflight\\"]
+        },
+      }
+    })
+    );
   }
 }
-
 class $App extends $AppBase {
   constructor() {
     super({ outdir: $outdir, name: \\"extern_implementation\\", plugins: $plugins, isTestEnvironment: $wing_is_test });
@@ -226,14 +226,18 @@ class $App extends $AppBase {
     }
   }
 }
-
-new $App().synth();"
+new $App().synth();
+"
 `;
 
-exports[`wing compile -t tf-aws > proc.07843d13880528eb093c8438f86267f529c160bc2f048435d6f2c77a50053a5c/index.js 1`] = `
-"async handle() { const { f } = this; {
-  (await f.call());
-} };"
+exports[`wing compile -t tf-aws > proc.dbcbd8abccf0254a0146fe50fdd5cf4c36c5a86ecd9c8bf63bd60b23798759e8/index.js 1`] = `
+"async handle() {
+  const { f } = this;
+  {
+    (await f.call());
+  }
+};
+"
 `;
 
 exports[`wing test -t sim > stdout 1`] = `

--- a/tools/hangar/__snapshots__/test_corpus/valid/file_counter.w.ts.snap
+++ b/tools/hangar/__snapshots__/test_corpus/valid/file_counter.w.ts.snap
@@ -241,7 +241,7 @@ class $Root extends $stdlib.core.Resource {
     const counter = this.node.root.newAbstract(\\"@winglang/sdk.cloud.Counter\\",this,\\"cloud.Counter\\",{ initial: 100 });
     const queue = this.node.root.newAbstract(\\"@winglang/sdk.cloud.Queue\\",this,\\"cloud.Queue\\",{ timeout: $stdlib.std.Duration.fromSeconds(10) });
     const handler = new $stdlib.core.Inflight(this, \\"$Inflight1\\", {
-      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.2cc882786455b8932e5cc3eec19c98d981c217ab774fc3769e1969704e0dec15/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
+      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.27b9b1acdf307e212f4288f000f9c2838cb38972f5055cd4dac4fd96baef0ee4/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
       bindings: {
         bucket: {
           obj: bucket,
@@ -276,15 +276,13 @@ new $App().synth();
 "
 `;
 
-exports[`wing compile -t tf-aws > proc.2cc882786455b8932e5cc3eec19c98d981c217ab774fc3769e1969704e0dec15/index.js 1`] = `
+exports[`wing compile -t tf-aws > proc.27b9b1acdf307e212f4288f000f9c2838cb38972f5055cd4dac4fd96baef0ee4/index.js 1`] = `
 "async handle(body) {
   const { bucket, counter } = this;
-  {
-    const next = (await counter.inc());
-    const key = \`myfile-\${\\"hi\\"}.txt\`;
-    (await bucket.put(key,body));
-  }
-};
+  const next = (await counter.inc());
+  const key = \`myfile-\${\\"hi\\"}.txt\`;
+  (await bucket.put(key,body));
+}
 "
 `;
 

--- a/tools/hangar/__snapshots__/test_corpus/valid/file_counter.w.ts.snap
+++ b/tools/hangar/__snapshots__/test_corpus/valid/file_counter.w.ts.snap
@@ -241,22 +241,22 @@ class $Root extends $stdlib.core.Resource {
     const counter = this.node.root.newAbstract(\\"@winglang/sdk.cloud.Counter\\",this,\\"cloud.Counter\\",{ initial: 100 });
     const queue = this.node.root.newAbstract(\\"@winglang/sdk.cloud.Queue\\",this,\\"cloud.Queue\\",{ timeout: $stdlib.std.Duration.fromSeconds(10) });
     const handler = new $stdlib.core.Inflight(this, \\"$Inflight1\\", {
-  code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.1ece6a476239c44d64d8b687b9e4389715198c49564defb8766e8b85b0f54620/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
-  bindings: {
-    bucket: {
-      obj: bucket,
-      ops: [\\"delete\\",\\"get\\",\\"get_json\\",\\"list\\",\\"public_url\\",\\"put\\",\\"put_json\\"]
-    },
-    counter: {
-      obj: counter,
-      ops: [\\"dec\\",\\"inc\\",\\"peek\\",\\"reset\\"]
-    },
-  }
-});
+      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.2cc882786455b8932e5cc3eec19c98d981c217ab774fc3769e1969704e0dec15/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
+      bindings: {
+        bucket: {
+          obj: bucket,
+          ops: [\\"delete\\",\\"get\\",\\"get_json\\",\\"list\\",\\"public_url\\",\\"put\\",\\"put_json\\"]
+        },
+        counter: {
+          obj: counter,
+          ops: [\\"dec\\",\\"inc\\",\\"peek\\",\\"reset\\"]
+        },
+      }
+    })
+    ;
     (queue.addConsumer(handler));
   }
 }
-
 class $App extends $AppBase {
   constructor() {
     super({ outdir: $outdir, name: \\"file_counter\\", plugins: $plugins, isTestEnvironment: $wing_is_test });
@@ -272,16 +272,20 @@ class $App extends $AppBase {
     }
   }
 }
-
-new $App().synth();"
+new $App().synth();
+"
 `;
 
-exports[`wing compile -t tf-aws > proc.1ece6a476239c44d64d8b687b9e4389715198c49564defb8766e8b85b0f54620/index.js 1`] = `
-"async handle(body) { const { bucket, counter } = this; {
-  const next = (await counter.inc());
-  const key = \`myfile-\${\\"hi\\"}.txt\`;
-  (await bucket.put(key,body));
-} };"
+exports[`wing compile -t tf-aws > proc.2cc882786455b8932e5cc3eec19c98d981c217ab774fc3769e1969704e0dec15/index.js 1`] = `
+"async handle(body) {
+  const { bucket, counter } = this;
+  {
+    const next = (await counter.inc());
+    const key = \`myfile-\${\\"hi\\"}.txt\`;
+    (await bucket.put(key,body));
+  }
+};
+"
 `;
 
 exports[`wing test -t sim > stdout 1`] = `

--- a/tools/hangar/__snapshots__/test_corpus/valid/for_loop.w.ts.snap
+++ b/tools/hangar/__snapshots__/test_corpus/valid/for_loop.w.ts.snap
@@ -287,7 +287,7 @@ class $Root extends $stdlib.core.Resource {
       {console.log(\`\${x}\`)};
     }
     this.node.root.newAbstract(\\"@winglang/sdk.cloud.Function\\",this,\\"cloud.Function\\",new $stdlib.core.Inflight(this, \\"$Inflight1\\", {
-      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.3a2547474bf9814787b8747cc48e611ed8f390e4209e4baecdf4e2e4923e8344/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
+      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.afc6fe59bb6cdbd81e9208755ab2c9288766e754ea8cfb86c9310de61739c683/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
       bindings: {
       }
     })
@@ -313,17 +313,15 @@ new $App().synth();
 "
 `;
 
-exports[`wing compile -t tf-aws > proc.3a2547474bf9814787b8747cc48e611ed8f390e4209e4baecdf4e2e4923e8344/index.js 1`] = `
+exports[`wing compile -t tf-aws > proc.afc6fe59bb6cdbd81e9208755ab2c9288766e754ea8cfb86c9310de61739c683/index.js 1`] = `
 "async handle(event) {
   const {  } = this;
-  {
-    for (const x of ((s,e,i) => { function* iterator(start,end,inclusive) { let i = start; let limit = inclusive ? ((end < start) ? end - 1 : end + 1) : end; while (i < limit) yield i++; while (i > limit) yield i--; }; return iterator(s,e,i); })(0,10,false)) {
-      {((cond) => {if (!cond) throw new Error(\`assertion failed: '(x <= 0)'\`)})((x <= 0))};
-      {((cond) => {if (!cond) throw new Error(\`assertion failed: '(x > 10)'\`)})((x > 10))};
-      {console.log(\`\${x}\`)};
-    }
+  for (const x of ((s,e,i) => { function* iterator(start,end,inclusive) { let i = start; let limit = inclusive ? ((end < start) ? end - 1 : end + 1) : end; while (i < limit) yield i++; while (i > limit) yield i--; }; return iterator(s,e,i); })(0,10,false)) {
+    {((cond) => {if (!cond) throw new Error(\`assertion failed: '(x <= 0)'\`)})((x <= 0))};
+    {((cond) => {if (!cond) throw new Error(\`assertion failed: '(x > 10)'\`)})((x > 10))};
+    {console.log(\`\${x}\`)};
   }
-};
+}
 "
 `;
 

--- a/tools/hangar/__snapshots__/test_corpus/valid/for_loop.w.ts.snap
+++ b/tools/hangar/__snapshots__/test_corpus/valid/for_loop.w.ts.snap
@@ -150,150 +150,150 @@ class $Root extends $stdlib.core.Resource {
     const words = Object.freeze([\\"wing\\", \\"lang\\", \\"dang\\"]);
     const unique_numbers = Object.freeze(new Set([1, 2, 3]));
     for (const word of words) {
-  for (const number of unique_numbers) {
-    {((cond) => {if (!cond) throw new Error(\`assertion failed: '(number > 0)'\`)})((number > 0))};
-    {console.log(\`\${word}: \${number}\`)};
-  }
-}
+      for (const number of unique_numbers) {
+        {((cond) => {if (!cond) throw new Error(\`assertion failed: '(number > 0)'\`)})((number > 0))};
+        {console.log(\`\${word}: \${number}\`)};
+      }
+    }
     let i = 0;
     for (const word of words) {
-  i = (i + 1);
-  let pre_break_hits = 0;
-  let post_break_hits = 0;
-  for (const number of unique_numbers) {
-    {((cond) => {if (!cond) throw new Error(\`assertion failed: '(number > 0)'\`)})((number > 0))};
-    {console.log(\`\${word}: \${number}\`)};
-    pre_break_hits = (pre_break_hits + 1);
-    if ((number === 2)) {
-      break;
+      i = (i + 1);
+      let pre_break_hits = 0;
+      let post_break_hits = 0;
+      for (const number of unique_numbers) {
+        {((cond) => {if (!cond) throw new Error(\`assertion failed: '(number > 0)'\`)})((number > 0))};
+        {console.log(\`\${word}: \${number}\`)};
+        pre_break_hits = (pre_break_hits + 1);
+        if ((number === 2)) {
+          break;
+        }
+        post_break_hits = (post_break_hits + 1);
+      }
+      {((cond) => {if (!cond) throw new Error(\`assertion failed: '(pre_break_hits === 2)'\`)})((pre_break_hits === 2))};
+      {((cond) => {if (!cond) throw new Error(\`assertion failed: '(post_break_hits === 1)'\`)})((post_break_hits === 1))};
     }
-    post_break_hits = (post_break_hits + 1);
-  }
-  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(pre_break_hits === 2)'\`)})((pre_break_hits === 2))};
-  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(post_break_hits === 1)'\`)})((post_break_hits === 1))};
-}
     {((cond) => {if (!cond) throw new Error(\`assertion failed: '(i === 3)'\`)})((i === 3))};
     let j = 0;
     for (const word of words) {
-  j = (j + 1);
-  let pre_continue_hits = 0;
-  let post_continue_hits = 0;
-  for (const number of unique_numbers) {
-    {((cond) => {if (!cond) throw new Error(\`assertion failed: '(number > 0)'\`)})((number > 0))};
-    {console.log(\`\${word}: \${number}\`)};
-    pre_continue_hits = (pre_continue_hits + 1);
-    if ((number > 0)) {
-      continue;
+      j = (j + 1);
+      let pre_continue_hits = 0;
+      let post_continue_hits = 0;
+      for (const number of unique_numbers) {
+        {((cond) => {if (!cond) throw new Error(\`assertion failed: '(number > 0)'\`)})((number > 0))};
+        {console.log(\`\${word}: \${number}\`)};
+        pre_continue_hits = (pre_continue_hits + 1);
+        if ((number > 0)) {
+          continue;
+        }
+        post_continue_hits = (post_continue_hits + 1);
+      }
+      {((cond) => {if (!cond) throw new Error(\`assertion failed: '(pre_continue_hits === 3)'\`)})((pre_continue_hits === 3))};
+      {((cond) => {if (!cond) throw new Error(\`assertion failed: '(post_continue_hits === 0)'\`)})((post_continue_hits === 0))};
     }
-    post_continue_hits = (post_continue_hits + 1);
-  }
-  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(pre_continue_hits === 3)'\`)})((pre_continue_hits === 3))};
-  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(post_continue_hits === 0)'\`)})((post_continue_hits === 0))};
-}
     {((cond) => {if (!cond) throw new Error(\`assertion failed: '(j === 3)'\`)})((j === 3))};
     {console.log(\\"---\\\\nfor x in 0..0 { ... }\\")};
     for (const x of $stdlib.std.Range.of(0, 0, false)) {
-  {((cond) => {if (!cond) throw new Error(\`assertion failed: 'false'\`)})(false)};
-}
+      {((cond) => {if (!cond) throw new Error(\`assertion failed: 'false'\`)})(false)};
+    }
     {console.log(\\"there's no value to iterate\\")};
     {console.log(\\"---\\\\nfor x in 0..=0 { ... }\\")};
     for (const x of $stdlib.std.Range.of(0, 0, true)) {
-  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(x === 0)'\`)})((x === 0))};
-  {console.log(\`\${x}\`)};
-}
+      {((cond) => {if (!cond) throw new Error(\`assertion failed: '(x === 0)'\`)})((x === 0))};
+      {console.log(\`\${x}\`)};
+    }
     {console.log(\\"---\\\\nfor x in 0..2 { ... }\\")};
     for (const x of $stdlib.std.Range.of(0, 2, false)) {
-  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(x >= 0)'\`)})((x >= 0))};
-  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(x < 2)'\`)})((x < 2))};
-  {console.log(\`\${x}\`)};
-}
+      {((cond) => {if (!cond) throw new Error(\`assertion failed: '(x >= 0)'\`)})((x >= 0))};
+      {((cond) => {if (!cond) throw new Error(\`assertion failed: '(x < 2)'\`)})((x < 2))};
+      {console.log(\`\${x}\`)};
+    }
     {console.log(\\"---\\\\nfor x in 0..=2 { ... }\\")};
     for (const x of $stdlib.std.Range.of(0, 2, true)) {
-  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(x >= 0)'\`)})((x >= 0))};
-  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(x <= 2)'\`)})((x <= 2))};
-  {console.log(\`\${x}\`)};
-}
+      {((cond) => {if (!cond) throw new Error(\`assertion failed: '(x >= 0)'\`)})((x >= 0))};
+      {((cond) => {if (!cond) throw new Error(\`assertion failed: '(x <= 2)'\`)})((x <= 2))};
+      {console.log(\`\${x}\`)};
+    }
     {console.log(\\"---\\\\nfor x in 2..0 { ... }\\")};
     for (const x of $stdlib.std.Range.of(2, 0, false)) {
-  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(x <= 2)'\`)})((x <= 2))};
-  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(x > 0)'\`)})((x > 0))};
-  {console.log(\`\${x}\`)};
-}
+      {((cond) => {if (!cond) throw new Error(\`assertion failed: '(x <= 2)'\`)})((x <= 2))};
+      {((cond) => {if (!cond) throw new Error(\`assertion failed: '(x > 0)'\`)})((x > 0))};
+      {console.log(\`\${x}\`)};
+    }
     {console.log(\\"---\\\\nfor x in 2..=0 { ... }\\")};
     for (const x of $stdlib.std.Range.of(2, 0, true)) {
-  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(x <= 2)'\`)})((x <= 2))};
-  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(x >= 0)'\`)})((x >= 0))};
-  {console.log(\`\${x}\`)};
-}
+      {((cond) => {if (!cond) throw new Error(\`assertion failed: '(x <= 2)'\`)})((x <= 2))};
+      {((cond) => {if (!cond) throw new Error(\`assertion failed: '(x >= 0)'\`)})((x >= 0))};
+      {console.log(\`\${x}\`)};
+    }
     {console.log(\\"---\\\\nfor x in 0..-2 { ... }\\")};
     for (const x of $stdlib.std.Range.of(0, (-2), false)) {
-  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(x <= 0)'\`)})((x <= 0))};
-  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(x > (-2))'\`)})((x > (-2)))};
-  {console.log(\`\${x}\`)};
-}
+      {((cond) => {if (!cond) throw new Error(\`assertion failed: '(x <= 0)'\`)})((x <= 0))};
+      {((cond) => {if (!cond) throw new Error(\`assertion failed: '(x > (-2))'\`)})((x > (-2)))};
+      {console.log(\`\${x}\`)};
+    }
     {console.log(\\"---\\\\nfor x in 0..=-2 { ... }\\")};
     for (const x of $stdlib.std.Range.of(0, (-2), true)) {
-  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(x <= 0)'\`)})((x <= 0))};
-  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(x > (-3))'\`)})((x > (-3)))};
-  {console.log(\`\${x}\`)};
-}
+      {((cond) => {if (!cond) throw new Error(\`assertion failed: '(x <= 0)'\`)})((x <= 0))};
+      {((cond) => {if (!cond) throw new Error(\`assertion failed: '(x > (-3))'\`)})((x > (-3)))};
+      {console.log(\`\${x}\`)};
+    }
     {console.log(\\"---\\\\nfor x in -2..0 { ... }\\")};
     for (const x of $stdlib.std.Range.of((-2), 0, false)) {
-  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(x >= (-2))'\`)})((x >= (-2)))};
-  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(x < 0)'\`)})((x < 0))};
-  {console.log(\`\${x}\`)};
-}
+      {((cond) => {if (!cond) throw new Error(\`assertion failed: '(x >= (-2))'\`)})((x >= (-2)))};
+      {((cond) => {if (!cond) throw new Error(\`assertion failed: '(x < 0)'\`)})((x < 0))};
+      {console.log(\`\${x}\`)};
+    }
     {console.log(\\"---\\\\nfor x in -2..=0 { ... }\\")};
     for (const x of $stdlib.std.Range.of((-2), 0, true)) {
-  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(x >= (-2))'\`)})((x >= (-2)))};
-  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(x <= 0)'\`)})((x <= 0))};
-  {console.log(\`\${x}\`)};
-}
+      {((cond) => {if (!cond) throw new Error(\`assertion failed: '(x >= (-2))'\`)})((x >= (-2)))};
+      {((cond) => {if (!cond) throw new Error(\`assertion failed: '(x <= 0)'\`)})((x <= 0))};
+      {console.log(\`\${x}\`)};
+    }
     const z = 2;
     {console.log(\\"---\\\\nfor x in 0..z { ... } <=> x = 2\\")};
     for (const x of $stdlib.std.Range.of(0, z, false)) {
-  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(x >= 0)'\`)})((x >= 0))};
-  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(x < 2)'\`)})((x < 2))};
-  {console.log(\`\${x}\`)};
-}
+      {((cond) => {if (!cond) throw new Error(\`assertion failed: '(x >= 0)'\`)})((x >= 0))};
+      {((cond) => {if (!cond) throw new Error(\`assertion failed: '(x < 2)'\`)})((x < 2))};
+      {console.log(\`\${x}\`)};
+    }
     {console.log(\\"---\\\\nfor x in 0..=z { ... } <=> x = 2\\")};
     for (const x of $stdlib.std.Range.of(0, z, true)) {
-  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(x >= 0)'\`)})((x >= 0))};
-  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(x <= 2)'\`)})((x <= 2))};
-  {console.log(\`\${x}\`)};
-}
+      {((cond) => {if (!cond) throw new Error(\`assertion failed: '(x >= 0)'\`)})((x >= 0))};
+      {((cond) => {if (!cond) throw new Error(\`assertion failed: '(x <= 2)'\`)})((x <= 2))};
+      {console.log(\`\${x}\`)};
+    }
     {console.log(\\"---\\\\nfor x in z..0 { ... } <=> x = 2\\")};
     for (const x of $stdlib.std.Range.of(z, 0, false)) {
-  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(x <= 2)'\`)})((x <= 2))};
-  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(x > 0)'\`)})((x > 0))};
-  {console.log(\`\${x}\`)};
-}
+      {((cond) => {if (!cond) throw new Error(\`assertion failed: '(x <= 2)'\`)})((x <= 2))};
+      {((cond) => {if (!cond) throw new Error(\`assertion failed: '(x > 0)'\`)})((x > 0))};
+      {console.log(\`\${x}\`)};
+    }
     {console.log(\\"---\\\\nfor x in 0..(z*2) { ... } <=> x = 2\\")};
     for (const x of $stdlib.std.Range.of(0, (z * 2), false)) {
-  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(x >= 0)'\`)})((x >= 0))};
-  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(x < 4)'\`)})((x < 4))};
-  {console.log(\`\${x}\`)};
-}
+      {((cond) => {if (!cond) throw new Error(\`assertion failed: '(x >= 0)'\`)})((x >= 0))};
+      {((cond) => {if (!cond) throw new Error(\`assertion failed: '(x < 4)'\`)})((x < 4))};
+      {console.log(\`\${x}\`)};
+    }
     {console.log(\\"---\\\\nfor x in 0..=(z*2) { ... } <=> x = 2\\")};
     for (const x of $stdlib.std.Range.of(0, (z * 2), true)) {
-  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(x >= 0)'\`)})((x >= 0))};
-  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(x <= 4)'\`)})((x <= 4))};
-  {console.log(\`\${x}\`)};
-}
+      {((cond) => {if (!cond) throw new Error(\`assertion failed: '(x >= 0)'\`)})((x >= 0))};
+      {((cond) => {if (!cond) throw new Error(\`assertion failed: '(x <= 4)'\`)})((x <= 4))};
+      {console.log(\`\${x}\`)};
+    }
     {console.log(\\"---\\\\nfor x in (z*2)..0 { ... } <=> x = 2\\")};
     for (const x of $stdlib.std.Range.of((z * 2), 0, false)) {
-  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(x <= 4)'\`)})((x <= 4))};
-  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(x > 0)'\`)})((x > 0))};
-  {console.log(\`\${x}\`)};
-}
+      {((cond) => {if (!cond) throw new Error(\`assertion failed: '(x <= 4)'\`)})((x <= 4))};
+      {((cond) => {if (!cond) throw new Error(\`assertion failed: '(x > 0)'\`)})((x > 0))};
+      {console.log(\`\${x}\`)};
+    }
     this.node.root.newAbstract(\\"@winglang/sdk.cloud.Function\\",this,\\"cloud.Function\\",new $stdlib.core.Inflight(this, \\"$Inflight1\\", {
-  code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.789cc11d9e18f97e881bce27c1f0d4cb6b1398d336aab52ba014674443c189ca/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
-  bindings: {
-  }
-}));
+      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.3a2547474bf9814787b8747cc48e611ed8f390e4209e4baecdf4e2e4923e8344/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
+      bindings: {
+      }
+    })
+    );
   }
 }
-
 class $App extends $AppBase {
   constructor() {
     super({ outdir: $outdir, name: \\"for_loop\\", plugins: $plugins, isTestEnvironment: $wing_is_test });
@@ -309,18 +309,22 @@ class $App extends $AppBase {
     }
   }
 }
-
-new $App().synth();"
+new $App().synth();
+"
 `;
 
-exports[`wing compile -t tf-aws > proc.789cc11d9e18f97e881bce27c1f0d4cb6b1398d336aab52ba014674443c189ca/index.js 1`] = `
-"async handle(event) { const {  } = this; {
-  for (const x of ((s,e,i) => { function* iterator(start,end,inclusive) { let i = start; let limit = inclusive ? ((end < start) ? end - 1 : end + 1) : end; while (i < limit) yield i++; while (i > limit) yield i--; }; return iterator(s,e,i); })(0,10,false)) {
-    {((cond) => {if (!cond) throw new Error(\`assertion failed: '(x <= 0)'\`)})((x <= 0))};
-    {((cond) => {if (!cond) throw new Error(\`assertion failed: '(x > 10)'\`)})((x > 10))};
-    {console.log(\`\${x}\`)};
+exports[`wing compile -t tf-aws > proc.3a2547474bf9814787b8747cc48e611ed8f390e4209e4baecdf4e2e4923e8344/index.js 1`] = `
+"async handle(event) {
+  const {  } = this;
+  {
+    for (const x of ((s,e,i) => { function* iterator(start,end,inclusive) { let i = start; let limit = inclusive ? ((end < start) ? end - 1 : end + 1) : end; while (i < limit) yield i++; while (i > limit) yield i--; }; return iterator(s,e,i); })(0,10,false)) {
+      {((cond) => {if (!cond) throw new Error(\`assertion failed: '(x <= 0)'\`)})((x <= 0))};
+      {((cond) => {if (!cond) throw new Error(\`assertion failed: '(x > 10)'\`)})((x > 10))};
+      {console.log(\`\${x}\`)};
+    }
   }
-} };"
+};
+"
 `;
 
 exports[`wing test -t sim > stdout 1`] = `

--- a/tools/hangar/__snapshots__/test_corpus/valid/forward_decl.w.ts.snap
+++ b/tools/hangar/__snapshots__/test_corpus/valid/forward_decl.w.ts.snap
@@ -2,12 +2,12 @@
 
 exports[`wing compile -t tf-aws > clients/R.inflight.js 1`] = `
 "class R  {
-constructor({ f }) {
-
-  this.f = f;
+  constructor({ f }) {
+    this.f = f;
+  }
 }
-}
-exports.R = R;"
+exports.R = R;
+"
 `;
 
 exports[`wing compile -t tf-aws > main.tf.json 1`] = `
@@ -69,37 +69,38 @@ class $Root extends $stdlib.core.Resource {
   constructor(scope, id) {
     super(scope, id);
     class R extends $stdlib.core.Resource {
-	constructor(scope, id, ) {
-	super(scope, id);
-{
-}
-}
-	 method2()  {
-	{
-  (this.method1());
-  {console.log(\`\${this.f}\`)};
-  (this.method2());
-}
-}
- method1()  {
-	{
-}
-}
-	_toInflight() {
-	const f_client = this._lift(this.f);
-	const self_client_path = \\"./clients/R.inflight.js\\".replace(/\\\\\\\\/g, \\"/\\");
-	return $stdlib.core.NodeJsCode.fromInline(\`(new (require(\\"\${self_client_path}\\")).R({f: \${f_client}}))\`);
-}
-}
-R._annotateInflight(\\"$init\\", {\\"this.f\\": { ops: [] }});
+      constructor(scope, id, ) {
+        super(scope, id);
+      }
+       method2()  {
+        {
+          (this.method1());
+          {console.log(\`\${this.f}\`)};
+          (this.method2());
+        }
+      }
+       method1()  {
+        {
+        }
+      }
+      _toInflight() {
+        const f_client = this._lift(this.f);
+        const self_client_path = \\"./clients/R.inflight.js\\".replace(/\\\\\\\\/g, \\"/\\");
+        return $stdlib.core.NodeJsCode.fromInline(\`
+          (new (require(\\"\${self_client_path}\\")).R({
+            f: \${f_client},
+          }))
+        \`);
+      }
+    }
+    R._annotateInflight(\\"$init\\", {\\"this.f\\": { ops: [] }});
     const x = \\"hi\\";
     if (true) {
-  {console.log(\`\${x}\`)};
-  const y = new R(this,\\"R\\");
-}
+      {console.log(\`\${x}\`)};
+      const y = new R(this,\\"R\\");
+    }
   }
 }
-
 class $App extends $AppBase {
   constructor() {
     super({ outdir: $outdir, name: \\"forward_decl\\", plugins: $plugins, isTestEnvironment: $wing_is_test });
@@ -115,8 +116,8 @@ class $App extends $AppBase {
     }
   }
 }
-
-new $App().synth();"
+new $App().synth();
+"
 `;
 
 exports[`wing test -t sim > stdout 1`] = `

--- a/tools/hangar/__snapshots__/test_corpus/valid/hello.w.ts.snap
+++ b/tools/hangar/__snapshots__/test_corpus/valid/hello.w.ts.snap
@@ -219,17 +219,17 @@ class $Root extends $stdlib.core.Resource {
     const bucket = this.node.root.newAbstract(\\"@winglang/sdk.cloud.Bucket\\",this,\\"cloud.Bucket\\");
     const queue = this.node.root.newAbstract(\\"@winglang/sdk.cloud.Queue\\",this,\\"cloud.Queue\\");
     (queue.addConsumer(new $stdlib.core.Inflight(this, \\"$Inflight1\\", {
-  code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.211d46e8ec3b5ce3e93872fcb29755356fb3566f5016eae5fcd6ec0f670ab580/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
-  bindings: {
-    bucket: {
-      obj: bucket,
-      ops: [\\"delete\\",\\"get\\",\\"get_json\\",\\"list\\",\\"public_url\\",\\"put\\",\\"put_json\\"]
-    },
-  }
-})));
+      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.b5086d63957503f7d06fd4a4f27138a23bae7547ef28e6b45de251d70f548a88/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
+      bindings: {
+        bucket: {
+          obj: bucket,
+          ops: [\\"delete\\",\\"get\\",\\"get_json\\",\\"list\\",\\"public_url\\",\\"put\\",\\"put_json\\"]
+        },
+      }
+    })
+    ));
   }
 }
-
 class $App extends $AppBase {
   constructor() {
     super({ outdir: $outdir, name: \\"hello\\", plugins: $plugins, isTestEnvironment: $wing_is_test });
@@ -245,14 +245,18 @@ class $App extends $AppBase {
     }
   }
 }
-
-new $App().synth();"
+new $App().synth();
+"
 `;
 
-exports[`wing compile -t tf-aws > proc.211d46e8ec3b5ce3e93872fcb29755356fb3566f5016eae5fcd6ec0f670ab580/index.js 1`] = `
-"async handle(message) { const { bucket } = this; {
-  (await bucket.put(\\"wing.txt\\",\`Hello, \${message}\`));
-} };"
+exports[`wing compile -t tf-aws > proc.b5086d63957503f7d06fd4a4f27138a23bae7547ef28e6b45de251d70f548a88/index.js 1`] = `
+"async handle(message) {
+  const { bucket } = this;
+  {
+    (await bucket.put(\\"wing.txt\\",\`Hello, \${message}\`));
+  }
+};
+"
 `;
 
 exports[`wing test -t sim > stdout 1`] = `

--- a/tools/hangar/__snapshots__/test_corpus/valid/hello.w.ts.snap
+++ b/tools/hangar/__snapshots__/test_corpus/valid/hello.w.ts.snap
@@ -219,7 +219,7 @@ class $Root extends $stdlib.core.Resource {
     const bucket = this.node.root.newAbstract(\\"@winglang/sdk.cloud.Bucket\\",this,\\"cloud.Bucket\\");
     const queue = this.node.root.newAbstract(\\"@winglang/sdk.cloud.Queue\\",this,\\"cloud.Queue\\");
     (queue.addConsumer(new $stdlib.core.Inflight(this, \\"$Inflight1\\", {
-      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.b5086d63957503f7d06fd4a4f27138a23bae7547ef28e6b45de251d70f548a88/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
+      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.fdee27e4278018f0b82e92c0802d58032ccc3a21ab51caba9154598b79bbf7f6/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
       bindings: {
         bucket: {
           obj: bucket,
@@ -249,13 +249,11 @@ new $App().synth();
 "
 `;
 
-exports[`wing compile -t tf-aws > proc.b5086d63957503f7d06fd4a4f27138a23bae7547ef28e6b45de251d70f548a88/index.js 1`] = `
+exports[`wing compile -t tf-aws > proc.fdee27e4278018f0b82e92c0802d58032ccc3a21ab51caba9154598b79bbf7f6/index.js 1`] = `
 "async handle(message) {
   const { bucket } = this;
-  {
-    (await bucket.put(\\"wing.txt\\",\`Hello, \${message}\`));
-  }
-};
+  (await bucket.put(\\"wing.txt\\",\`Hello, \${message}\`));
+}
 "
 `;
 

--- a/tools/hangar/__snapshots__/test_corpus/valid/identical_inflights.w.ts.snap
+++ b/tools/hangar/__snapshots__/test_corpus/valid/identical_inflights.w.ts.snap
@@ -59,13 +59,13 @@ class $Root extends $stdlib.core.Resource {
   constructor(scope, id) {
     super(scope, id);
     const x = new $stdlib.core.Inflight(this, \\"$Inflight1\\", {
-      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.d914176fd50bd7f565700006a31aa97b79d3ad17cee20c8e5ff2061d5cb74817/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
+      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
       bindings: {
       }
     })
     ;
     const y = new $stdlib.core.Inflight(this, \\"$Inflight2\\", {
-      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.d914176fd50bd7f565700006a31aa97b79d3ad17cee20c8e5ff2061d5cb74817/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
+      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
       bindings: {
       }
     })
@@ -91,12 +91,10 @@ new $App().synth();
 "
 `;
 
-exports[`wing compile -t tf-aws > proc.d914176fd50bd7f565700006a31aa97b79d3ad17cee20c8e5ff2061d5cb74817/index.js 1`] = `
+exports[`wing compile -t tf-aws > proc.e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/index.js 1`] = `
 "async handle() {
   const {  } = this;
-  {
-  }
-};
+}
 "
 `;
 

--- a/tools/hangar/__snapshots__/test_corpus/valid/identical_inflights.w.ts.snap
+++ b/tools/hangar/__snapshots__/test_corpus/valid/identical_inflights.w.ts.snap
@@ -59,18 +59,19 @@ class $Root extends $stdlib.core.Resource {
   constructor(scope, id) {
     super(scope, id);
     const x = new $stdlib.core.Inflight(this, \\"$Inflight1\\", {
-  code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.8eb95bcbc154530931e15fc418c8b1fe991095671409552099ea1aa596999ede/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
-  bindings: {
-  }
-});
+      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.d914176fd50bd7f565700006a31aa97b79d3ad17cee20c8e5ff2061d5cb74817/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
+      bindings: {
+      }
+    })
+    ;
     const y = new $stdlib.core.Inflight(this, \\"$Inflight2\\", {
-  code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.8eb95bcbc154530931e15fc418c8b1fe991095671409552099ea1aa596999ede/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
-  bindings: {
-  }
-});
+      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.d914176fd50bd7f565700006a31aa97b79d3ad17cee20c8e5ff2061d5cb74817/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
+      bindings: {
+      }
+    })
+    ;
   }
 }
-
 class $App extends $AppBase {
   constructor() {
     super({ outdir: $outdir, name: \\"identical_inflights\\", plugins: $plugins, isTestEnvironment: $wing_is_test });
@@ -86,13 +87,17 @@ class $App extends $AppBase {
     }
   }
 }
-
-new $App().synth();"
+new $App().synth();
+"
 `;
 
-exports[`wing compile -t tf-aws > proc.8eb95bcbc154530931e15fc418c8b1fe991095671409552099ea1aa596999ede/index.js 1`] = `
-"async handle() { const {  } = this; {
-} };"
+exports[`wing compile -t tf-aws > proc.d914176fd50bd7f565700006a31aa97b79d3ad17cee20c8e5ff2061d5cb74817/index.js 1`] = `
+"async handle() {
+  const {  } = this;
+  {
+  }
+};
+"
 `;
 
 exports[`wing test -t sim > stdout 1`] = `

--- a/tools/hangar/__snapshots__/test_corpus/valid/impl_interface.w.ts.snap
+++ b/tools/hangar/__snapshots__/test_corpus/valid/impl_interface.w.ts.snap
@@ -2,44 +2,44 @@
 
 exports[`wing compile -t tf-aws > clients/A.inflight.js 1`] = `
 "class A  {
-constructor({  }) {
-
-
+  constructor({  }) {
+  }
+  async handle(msg)  {
+    {
+      return;
+    }
+  }
 }
-async handle(msg)  {
-	{
-  return;
-}
-}}
-exports.A = A;"
+exports.A = A;
+"
 `;
 
 exports[`wing compile -t tf-aws > clients/Dog.inflight.js 1`] = `
 "class Dog  {
-constructor({  }) {
-
-
+  constructor({  }) {
+  }
+  async eat()  {
+    {
+      return;
+    }
+  }
 }
-async eat()  {
-	{
-  return;
-}
-}}
-exports.Dog = Dog;"
+exports.Dog = Dog;
+"
 `;
 
 exports[`wing compile -t tf-aws > clients/r.inflight.js 1`] = `
 "class r  {
-constructor({  }) {
-
-
+  constructor({  }) {
+  }
+  async method_2(x)  {
+    {
+      return x;
+    }
+  }
 }
-async method_2(x)  {
-	{
-  return x;
-}
-}}
-exports.r = r;"
+exports.r = r;
+"
 `;
 
 exports[`wing compile -t tf-aws > main.tf.json 1`] = `
@@ -102,73 +102,71 @@ class $Root extends $stdlib.core.Resource {
   constructor(scope, id) {
     super(scope, id);
     class A extends $stdlib.core.Resource {
-	constructor(scope, id, ) {
-	super(scope, id);
-{
-}
-}
-	
-	_toInflight() {
-	
-	const self_client_path = \\"./clients/A.inflight.js\\".replace(/\\\\\\\\/g, \\"/\\");
-	return $stdlib.core.NodeJsCode.fromInline(\`(new (require(\\"\${self_client_path}\\")).A({}))\`);
-}
-}
-A._annotateInflight(\\"handle\\", {});
-A._annotateInflight(\\"$init\\", {});
+      constructor(scope, id, ) {
+        super(scope, id);
+      }
+      _toInflight() {
+        const self_client_path = \\"./clients/A.inflight.js\\".replace(/\\\\\\\\/g, \\"/\\");
+        return $stdlib.core.NodeJsCode.fromInline(\`
+          (new (require(\\"\${self_client_path}\\")).A({
+          }))
+        \`);
+      }
+    }
+    A._annotateInflight(\\"handle\\", {});
+    A._annotateInflight(\\"$init\\", {});
     class r extends $stdlib.core.Resource {
-	constructor(scope, id, ) {
-	super(scope, id);
-{
-}
-}
-	 method_1(x)  {
-	{
-  return x;
-}
-}
- method_3(x)  {
-	{
-  return x;
-}
-}
-	_toInflight() {
-	
-	const self_client_path = \\"./clients/r.inflight.js\\".replace(/\\\\\\\\/g, \\"/\\");
-	return $stdlib.core.NodeJsCode.fromInline(\`(new (require(\\"\${self_client_path}\\")).r({}))\`);
-}
-}
-r._annotateInflight(\\"method_2\\", {});
-r._annotateInflight(\\"$init\\", {});
+      constructor(scope, id, ) {
+        super(scope, id);
+      }
+       method_1(x)  {
+        {
+          return x;
+        }
+      }
+       method_3(x)  {
+        {
+          return x;
+        }
+      }
+      _toInflight() {
+        const self_client_path = \\"./clients/r.inflight.js\\".replace(/\\\\\\\\/g, \\"/\\");
+        return $stdlib.core.NodeJsCode.fromInline(\`
+          (new (require(\\"\${self_client_path}\\")).r({
+          }))
+        \`);
+      }
+    }
+    r._annotateInflight(\\"method_2\\", {});
+    r._annotateInflight(\\"$init\\", {});
     class Dog extends $stdlib.core.Resource {
-	constructor(scope, id, ) {
-	super(scope, id);
-{
-}
-}
-	
-	_toInflight() {
-	
-	const self_client_path = \\"./clients/Dog.inflight.js\\".replace(/\\\\\\\\/g, \\"/\\");
-	return $stdlib.core.NodeJsCode.fromInline(\`(new (require(\\"\${self_client_path}\\")).Dog({}))\`);
-}
-}
-Dog._annotateInflight(\\"eat\\", {});
-Dog._annotateInflight(\\"$init\\", {});
+      constructor(scope, id, ) {
+        super(scope, id);
+      }
+      _toInflight() {
+        const self_client_path = \\"./clients/Dog.inflight.js\\".replace(/\\\\\\\\/g, \\"/\\");
+        return $stdlib.core.NodeJsCode.fromInline(\`
+          (new (require(\\"\${self_client_path}\\")).Dog({
+          }))
+        \`);
+      }
+    }
+    Dog._annotateInflight(\\"eat\\", {});
+    Dog._annotateInflight(\\"$init\\", {});
     const x = new A(this,\\"A\\");
     const y = new $stdlib.core.Inflight(this, \\"$Inflight1\\", {
-  code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.a5455e5c5848cfc293fcb861d9393d32e29a39f8dc8ac79c19dd5289279762fe/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
-  bindings: {
-    x: {
-      obj: x,
-      ops: []
-    },
-  }
-});
+      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.b4d79c39e5924e356f79589c2d4a3f0e55ebd13f7fbdeeec43c9e0c3f7633564/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
+      bindings: {
+        x: {
+          obj: x,
+          ops: []
+        },
+      }
+    })
+    ;
     const z = new Dog(this,\\"Dog\\");
   }
 }
-
 class $App extends $AppBase {
   constructor() {
     super({ outdir: $outdir, name: \\"impl_interface\\", plugins: $plugins, isTestEnvironment: $wing_is_test });
@@ -184,14 +182,18 @@ class $App extends $AppBase {
     }
   }
 }
-
-new $App().synth();"
+new $App().synth();
+"
 `;
 
-exports[`wing compile -t tf-aws > proc.a5455e5c5848cfc293fcb861d9393d32e29a39f8dc8ac79c19dd5289279762fe/index.js 1`] = `
-"async handle() { const { x } = this; {
-  (await x.handle(\\"hello world!\\"));
-} };"
+exports[`wing compile -t tf-aws > proc.b4d79c39e5924e356f79589c2d4a3f0e55ebd13f7fbdeeec43c9e0c3f7633564/index.js 1`] = `
+"async handle() {
+  const { x } = this;
+  {
+    (await x.handle(\\"hello world!\\"));
+  }
+};
+"
 `;
 
 exports[`wing test -t sim > stdout 1`] = `

--- a/tools/hangar/__snapshots__/test_corpus/valid/impl_interface.w.ts.snap
+++ b/tools/hangar/__snapshots__/test_corpus/valid/impl_interface.w.ts.snap
@@ -155,7 +155,7 @@ class $Root extends $stdlib.core.Resource {
     Dog._annotateInflight(\\"$init\\", {});
     const x = new A(this,\\"A\\");
     const y = new $stdlib.core.Inflight(this, \\"$Inflight1\\", {
-      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.b4d79c39e5924e356f79589c2d4a3f0e55ebd13f7fbdeeec43c9e0c3f7633564/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
+      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.4bb413397aac07073d75578d701a65d4cbd2b018b9ba7fd5fc1654fa9a3a8abe/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
       bindings: {
         x: {
           obj: x,
@@ -186,13 +186,11 @@ new $App().synth();
 "
 `;
 
-exports[`wing compile -t tf-aws > proc.b4d79c39e5924e356f79589c2d4a3f0e55ebd13f7fbdeeec43c9e0c3f7633564/index.js 1`] = `
+exports[`wing compile -t tf-aws > proc.4bb413397aac07073d75578d701a65d4cbd2b018b9ba7fd5fc1654fa9a3a8abe/index.js 1`] = `
 "async handle() {
   const { x } = this;
-  {
-    (await x.handle(\\"hello world!\\"));
-  }
-};
+  (await x.handle(\\"hello world!\\"));
+}
 "
 `;
 

--- a/tools/hangar/__snapshots__/test_corpus/valid/interface.w.ts.snap
+++ b/tools/hangar/__snapshots__/test_corpus/valid/interface.w.ts.snap
@@ -60,7 +60,6 @@ class $Root extends $stdlib.core.Resource {
     super(scope, id);
   }
 }
-
 class $App extends $AppBase {
   constructor() {
     super({ outdir: $outdir, name: \\"interface\\", plugins: $plugins, isTestEnvironment: $wing_is_test });
@@ -76,8 +75,8 @@ class $App extends $AppBase {
     }
   }
 }
-
-new $App().synth();"
+new $App().synth();
+"
 `;
 
 exports[`wing test -t sim > stdout 1`] = `

--- a/tools/hangar/__snapshots__/test_corpus/valid/json.w.ts.snap
+++ b/tools/hangar/__snapshots__/test_corpus/valid/json.w.ts.snap
@@ -2,12 +2,12 @@
 
 exports[`wing compile -t tf-aws > clients/Foo.inflight.js 1`] = `
 "class Foo  {
-constructor({ _sum_str }) {
-
-  this._sum_str = _sum_str;
+  constructor({ _sum_str }) {
+    this._sum_str = _sum_str;
+  }
 }
-}
-exports.Foo = Foo;"
+exports.Foo = Foo;
+"
 `;
 
 exports[`wing compile -t tf-aws > main.tf.json 1`] = `
@@ -69,20 +69,21 @@ class $Root extends $stdlib.core.Resource {
   constructor(scope, id) {
     super(scope, id);
     class Foo extends $stdlib.core.Resource {
-	constructor(scope, id, ) {
-	super(scope, id);
-{
-  this._sum_str = \\"wow!\\";
-}
-}
-	
-	_toInflight() {
-	const _sum_str_client = this._lift(this._sum_str);
-	const self_client_path = \\"./clients/Foo.inflight.js\\".replace(/\\\\\\\\/g, \\"/\\");
-	return $stdlib.core.NodeJsCode.fromInline(\`(new (require(\\"\${self_client_path}\\")).Foo({_sum_str: \${_sum_str_client}}))\`);
-}
-}
-Foo._annotateInflight(\\"$init\\", {\\"this._sum_str\\": { ops: [] }});
+      constructor(scope, id, ) {
+        super(scope, id);
+        this._sum_str = \\"wow!\\";
+      }
+      _toInflight() {
+        const _sum_str_client = this._lift(this._sum_str);
+        const self_client_path = \\"./clients/Foo.inflight.js\\".replace(/\\\\\\\\/g, \\"/\\");
+        return $stdlib.core.NodeJsCode.fromInline(\`
+          (new (require(\\"\${self_client_path}\\")).Foo({
+            _sum_str: \${_sum_str_client},
+          }))
+        \`);
+      }
+    }
+    Foo._annotateInflight(\\"$init\\", {\\"this._sum_str\\": { ops: [] }});
     const json_number = 123;
     const json_bool = true;
     const json_array = [1, 2, 3];
@@ -96,10 +97,11 @@ Foo._annotateInflight(\\"$init\\", {\\"this._sum_str\\": { ops: [] }});
     const jj1 = Object.freeze({\\"foo\\":some_number});
     const jj2 = [some_number, {\\"bar\\":some_number}];
     const get_str =  () =>  {
-	{
-  return \\"hello\\";
-}
-};
+      {
+        return \\"hello\\";
+      }
+    }
+    ;
     const jj3 = (get_str());
     {((cond) => {if (!cond) throw new Error(\`assertion failed: '(jj3 === \\"hello\\")'\`)})((jj3 === \\"hello\\"))};
     const f = new Foo(this,\\"Foo\\");
@@ -122,7 +124,6 @@ Foo._annotateInflight(\\"$init\\", {\\"this._sum_str\\": { ops: [] }});
     Object.freeze({\\"a\\":[1, 2, \\"world\\"],\\"b\\":[1, 2, \\"world\\"]});
   }
 }
-
 class $App extends $AppBase {
   constructor() {
     super({ outdir: $outdir, name: \\"json\\", plugins: $plugins, isTestEnvironment: $wing_is_test });
@@ -138,8 +139,8 @@ class $App extends $AppBase {
     }
   }
 }
-
-new $App().synth();"
+new $App().synth();
+"
 `;
 
 exports[`wing test -t sim > stdout 1`] = `

--- a/tools/hangar/__snapshots__/test_corpus/valid/json_bucket.w.ts.snap
+++ b/tools/hangar/__snapshots__/test_corpus/valid/json_bucket.w.ts.snap
@@ -273,42 +273,43 @@ class $Root extends $stdlib.core.Resource {
     const file_name = \\"file.json\\";
     const j = Object.freeze({\\"persons\\":[{\\"age\\":30,\\"name\\":\\"hasan\\",\\"fears\\":[\\"heights\\", \\"failure\\"]}]});
     const get_json = this.node.root.newAbstract(\\"@winglang/sdk.cloud.Function\\",this,\\"cloud.Function\\",new $stdlib.core.Inflight(this, \\"$Inflight1\\", {
-  code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.1dabd42192b8d28a57f44a84b644a18eb6fedb868257af123181c0ecec2c2a70/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
-  bindings: {
-    b: {
-      obj: b,
-      ops: [\\"delete\\",\\"get\\",\\"get_json\\",\\"list\\",\\"public_url\\",\\"put\\",\\"put_json\\"]
-    },
-    file_name: {
-      obj: file_name,
-      ops: []
-    },
-  }
-}));
+      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.74b4a3ecb19274271b108aecb535aaa5d9bf53d45245b5b9233d249a590c08ce/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
+      bindings: {
+        b: {
+          obj: b,
+          ops: [\\"delete\\",\\"get\\",\\"get_json\\",\\"list\\",\\"public_url\\",\\"put\\",\\"put_json\\"]
+        },
+        file_name: {
+          obj: file_name,
+          ops: []
+        },
+      }
+    })
+    );
     this.node.root.newAbstract(\\"@winglang/sdk.cloud.Function\\",this,\\"test:put\\",new $stdlib.core.Inflight(this, \\"$Inflight2\\", {
-  code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.742d4f24b17fb7f7f831acbd15487b30d36ad90d44229b79672a09f910cb6619/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
-  bindings: {
-    b: {
-      obj: b,
-      ops: [\\"delete\\",\\"get\\",\\"get_json\\",\\"list\\",\\"public_url\\",\\"put\\",\\"put_json\\"]
-    },
-    file_name: {
-      obj: file_name,
-      ops: []
-    },
-    get_json: {
-      obj: get_json,
-      ops: [\\"invoke\\"]
-    },
-    j: {
-      obj: j,
-      ops: []
-    },
-  }
-}));
+      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.309ee98b66ec384e5fffd13d569e24c1273a92c4f582d1f89c3738efdcb33138/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
+      bindings: {
+        b: {
+          obj: b,
+          ops: [\\"delete\\",\\"get\\",\\"get_json\\",\\"list\\",\\"public_url\\",\\"put\\",\\"put_json\\"]
+        },
+        file_name: {
+          obj: file_name,
+          ops: []
+        },
+        get_json: {
+          obj: get_json,
+          ops: [\\"invoke\\"]
+        },
+        j: {
+          obj: j,
+          ops: []
+        },
+      }
+    })
+    );
   }
 }
-
 class $App extends $AppBase {
   constructor() {
     super({ outdir: $outdir, name: \\"json_bucket\\", plugins: $plugins, isTestEnvironment: $wing_is_test });
@@ -324,22 +325,30 @@ class $App extends $AppBase {
     }
   }
 }
-
-new $App().synth();"
+new $App().synth();
+"
 `;
 
-exports[`wing compile -t tf-aws > proc.1dabd42192b8d28a57f44a84b644a18eb6fedb868257af123181c0ecec2c2a70/index.js 1`] = `
-"async handle(msg) { const { b, file_name } = this; {
-  const x = (await b.getJson(file_name));
-  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(((((x)[\\"persons\\"])[0])[\\"fears\\"])[1] === \\"failure\\")'\`)})((((((x)[\\"persons\\"])[0])[\\"fears\\"])[1] === \\"failure\\"))};
-} };"
+exports[`wing compile -t tf-aws > proc.74b4a3ecb19274271b108aecb535aaa5d9bf53d45245b5b9233d249a590c08ce/index.js 1`] = `
+"async handle(msg) {
+  const { b, file_name } = this;
+  {
+    const x = (await b.getJson(file_name));
+    {((cond) => {if (!cond) throw new Error(\`assertion failed: '(((((x)[\\"persons\\"])[0])[\\"fears\\"])[1] === \\"failure\\")'\`)})((((((x)[\\"persons\\"])[0])[\\"fears\\"])[1] === \\"failure\\"))};
+  }
+};
+"
 `;
 
-exports[`wing compile -t tf-aws > proc.742d4f24b17fb7f7f831acbd15487b30d36ad90d44229b79672a09f910cb6619/index.js 1`] = `
-"async handle(msg) { const { b, file_name, get_json, j } = this; {
-  (await b.putJson(file_name,j));
-  (await get_json.invoke(msg));
-} };"
+exports[`wing compile -t tf-aws > proc.309ee98b66ec384e5fffd13d569e24c1273a92c4f582d1f89c3738efdcb33138/index.js 1`] = `
+"async handle(msg) {
+  const { b, file_name, get_json, j } = this;
+  {
+    (await b.putJson(file_name,j));
+    (await get_json.invoke(msg));
+  }
+};
+"
 `;
 
 exports[`wing test -t sim > stdout 1`] = `

--- a/tools/hangar/__snapshots__/test_corpus/valid/json_bucket.w.ts.snap
+++ b/tools/hangar/__snapshots__/test_corpus/valid/json_bucket.w.ts.snap
@@ -273,7 +273,7 @@ class $Root extends $stdlib.core.Resource {
     const file_name = \\"file.json\\";
     const j = Object.freeze({\\"persons\\":[{\\"age\\":30,\\"name\\":\\"hasan\\",\\"fears\\":[\\"heights\\", \\"failure\\"]}]});
     const get_json = this.node.root.newAbstract(\\"@winglang/sdk.cloud.Function\\",this,\\"cloud.Function\\",new $stdlib.core.Inflight(this, \\"$Inflight1\\", {
-      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.74b4a3ecb19274271b108aecb535aaa5d9bf53d45245b5b9233d249a590c08ce/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
+      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.65da1a50b3f7d2621c34d29e0b410f0e504124beed71b58374c3bf728c7b80d9/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
       bindings: {
         b: {
           obj: b,
@@ -287,7 +287,7 @@ class $Root extends $stdlib.core.Resource {
     })
     );
     this.node.root.newAbstract(\\"@winglang/sdk.cloud.Function\\",this,\\"test:put\\",new $stdlib.core.Inflight(this, \\"$Inflight2\\", {
-      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.309ee98b66ec384e5fffd13d569e24c1273a92c4f582d1f89c3738efdcb33138/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
+      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.f9f9b40f387b4eb240575908f7968d76a559c71637db94a1aaf8124ca452f582/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
       bindings: {
         b: {
           obj: b,
@@ -329,25 +329,21 @@ new $App().synth();
 "
 `;
 
-exports[`wing compile -t tf-aws > proc.74b4a3ecb19274271b108aecb535aaa5d9bf53d45245b5b9233d249a590c08ce/index.js 1`] = `
+exports[`wing compile -t tf-aws > proc.65da1a50b3f7d2621c34d29e0b410f0e504124beed71b58374c3bf728c7b80d9/index.js 1`] = `
 "async handle(msg) {
   const { b, file_name } = this;
-  {
-    const x = (await b.getJson(file_name));
-    {((cond) => {if (!cond) throw new Error(\`assertion failed: '(((((x)[\\"persons\\"])[0])[\\"fears\\"])[1] === \\"failure\\")'\`)})((((((x)[\\"persons\\"])[0])[\\"fears\\"])[1] === \\"failure\\"))};
-  }
-};
+  const x = (await b.getJson(file_name));
+  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(((((x)[\\"persons\\"])[0])[\\"fears\\"])[1] === \\"failure\\")'\`)})((((((x)[\\"persons\\"])[0])[\\"fears\\"])[1] === \\"failure\\"))};
+}
 "
 `;
 
-exports[`wing compile -t tf-aws > proc.309ee98b66ec384e5fffd13d569e24c1273a92c4f582d1f89c3738efdcb33138/index.js 1`] = `
+exports[`wing compile -t tf-aws > proc.f9f9b40f387b4eb240575908f7968d76a559c71637db94a1aaf8124ca452f582/index.js 1`] = `
 "async handle(msg) {
   const { b, file_name, get_json, j } = this;
-  {
-    (await b.putJson(file_name,j));
-    (await get_json.invoke(msg));
-  }
-};
+  (await b.putJson(file_name,j));
+  (await get_json.invoke(msg));
+}
 "
 `;
 

--- a/tools/hangar/__snapshots__/test_corpus/valid/json_static.w.ts.snap
+++ b/tools/hangar/__snapshots__/test_corpus/valid/json_static.w.ts.snap
@@ -85,7 +85,6 @@ class $Root extends $stdlib.core.Resource {
     {((cond) => {if (!cond) throw new Error(\`assertion failed: '((args) => { if (typeof args !== \\"boolean\\") {throw new Error(\\"unable to parse \\" + typeof args + \\" \\" + args + \\" as a boolean\\")}; return JSON.parse(JSON.stringify(args)) })((json_of_many)[\\"c\\"])'\`)})(((args) => { if (typeof args !== \\"boolean\\") {throw new Error(\\"unable to parse \\" + typeof args + \\" \\" + args + \\" as a boolean\\")}; return JSON.parse(JSON.stringify(args)) })((json_of_many)[\\"c\\"]))};
   }
 }
-
 class $App extends $AppBase {
   constructor() {
     super({ outdir: $outdir, name: \\"json_static\\", plugins: $plugins, isTestEnvironment: $wing_is_test });
@@ -101,8 +100,8 @@ class $App extends $AppBase {
     }
   }
 }
-
-new $App().synth();"
+new $App().synth();
+"
 `;
 
 exports[`wing test -t sim > stdout 1`] = `

--- a/tools/hangar/__snapshots__/test_corpus/valid/mut_container_types.w.ts.snap
+++ b/tools/hangar/__snapshots__/test_corpus/valid/mut_container_types.w.ts.snap
@@ -225,7 +225,6 @@ class $Root extends $stdlib.core.Resource {
     {((cond) => {if (!cond) throw new Error(\`assertion failed: '(((m6)[\\"a\\"])[\\"foo\\"] === \\"bar\\")'\`)})((((m6)[\\"a\\"])[\\"foo\\"] === \\"bar\\"))};
   }
 }
-
 class $App extends $AppBase {
   constructor() {
     super({ outdir: $outdir, name: \\"mut_container_types\\", plugins: $plugins, isTestEnvironment: $wing_is_test });
@@ -241,8 +240,8 @@ class $App extends $AppBase {
     }
   }
 }
-
-new $App().synth();"
+new $App().synth();
+"
 `;
 
 exports[`wing test -t sim > stdout 1`] = `

--- a/tools/hangar/__snapshots__/test_corpus/valid/optionals.w.ts.snap
+++ b/tools/hangar/__snapshots__/test_corpus/valid/optionals.w.ts.snap
@@ -58,21 +58,18 @@ const $AppBase = __app(process.env.WING_TARGET);
 class $Root extends $stdlib.core.Resource {
   constructor(scope, id) {
     super(scope, id);
-    class Super
-    {
+    class Super {
       constructor()  {
         this.name = \\"Super\\";
       }
       name;
     }
-    class Sub extends Super
-    {
+    class Sub extends Super {
       constructor()  {
         this.name = \\"Sub\\";
       }
     }
-    class Sub1 extends Super
-    {
+    class Sub1 extends Super {
       constructor()  {
         this.name = \\"Sub\\";
       }

--- a/tools/hangar/__snapshots__/test_corpus/valid/optionals.w.ts.snap
+++ b/tools/hangar/__snapshots__/test_corpus/valid/optionals.w.ts.snap
@@ -59,35 +59,24 @@ class $Root extends $stdlib.core.Resource {
   constructor(scope, id) {
     super(scope, id);
     class Super
-{
-constructor()  {
-	{
-  this.name = \\"Super\\";
-}
-}
-name;
-
-}
+    {
+      constructor()  {
+        this.name = \\"Super\\";
+      }
+      name;
+    }
     class Sub extends Super
-{
-constructor()  {
-	{
-  this.name = \\"Sub\\";
-}
-}
-
-
-}
+    {
+      constructor()  {
+        this.name = \\"Sub\\";
+      }
+    }
     class Sub1 extends Super
-{
-constructor()  {
-	{
-  this.name = \\"Sub\\";
-}
-}
-
-
-}
+    {
+      constructor()  {
+        this.name = \\"Sub\\";
+      }
+    }
     const x = 4;
     {((cond) => {if (!cond) throw new Error(\`assertion failed: '(((x) != null) === true)'\`)})((((x) != null) === true))};
     {((cond) => {if (!cond) throw new Error(\`assertion failed: '((!((x) != null)) === false)'\`)})(((!((x) != null)) === false))};
@@ -99,7 +88,6 @@ constructor()  {
     {((cond) => {if (!cond) throw new Error(\`assertion failed: '(s.name === \\"Super\\")'\`)})((s.name === \\"Super\\"))};
   }
 }
-
 class $App extends $AppBase {
   constructor() {
     super({ outdir: $outdir, name: \\"optionals\\", plugins: $plugins, isTestEnvironment: $wing_is_test });
@@ -115,8 +103,8 @@ class $App extends $AppBase {
     }
   }
 }
-
-new $App().synth();"
+new $App().synth();
+"
 `;
 
 exports[`wing test -t sim > stdout 1`] = `

--- a/tools/hangar/__snapshots__/test_corpus/valid/primitive_methods.w.ts.snap
+++ b/tools/hangar/__snapshots__/test_corpus/valid/primitive_methods.w.ts.snap
@@ -61,18 +61,18 @@ class $Root extends $stdlib.core.Resource {
     const dur = $stdlib.std.Duration.fromSeconds(60);
     const dur2 = $stdlib.std.Duration.fromSeconds(600);
     const f =  (d) =>  {
-	{
-}
-};
+      {
+      }
+    }
+    ;
     const stringy = \`\${dur.minutes}:\${dur.seconds}\`;
     {console.log(stringy)};
     if ((stringy.includes(\\"60\\") && (((stringy.split(\\":\\")).at(0)) === \\"60\\"))) {
-  {console.log(\`\${stringy.length}!\`)};
-}
+      {console.log(\`\${stringy.length}!\`)};
+    }
     {((cond) => {if (!cond) throw new Error(\`assertion failed: '(((args) => { if (isNaN(args)) {throw new Error(\\"unable to parse \\\\\\"\\" + args + \\"\\\\\\" as a number\\")}; return parseInt(args) })(\\"123\\") === 123)'\`)})((((args) => { if (isNaN(args)) {throw new Error(\\"unable to parse \\\\\\"\\" + args + \\"\\\\\\" as a number\\")}; return parseInt(args) })(\\"123\\") === 123))};
   }
 }
-
 class $App extends $AppBase {
   constructor() {
     super({ outdir: $outdir, name: \\"primitive_methods\\", plugins: $plugins, isTestEnvironment: $wing_is_test });
@@ -88,8 +88,8 @@ class $App extends $AppBase {
     }
   }
 }
-
-new $App().synth();"
+new $App().synth();
+"
 `;
 
 exports[`wing test -t sim > stdout 1`] = `

--- a/tools/hangar/__snapshots__/test_corpus/valid/print.w.ts.snap
+++ b/tools/hangar/__snapshots__/test_corpus/valid/print.w.ts.snap
@@ -223,13 +223,13 @@ class $Root extends $stdlib.core.Resource {
     super(scope, id);
     {console.log(\\"preflight log\\")};
     this.node.root.newAbstract(\\"@winglang/sdk.cloud.Function\\",this,\\"test:log1\\",new $stdlib.core.Inflight(this, \\"$Inflight1\\", {
-      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.ceb355a9f94cf795c46371d35d8feb12bb9723e1ec280f49e374f6346ec4ecca/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
+      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.a4d16ad74e509f7ba53bb94a76d85ecfca8334031a4d57904b76d1b4fde85163/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
       bindings: {
       }
     })
     );
     this.node.root.newAbstract(\\"@winglang/sdk.cloud.Function\\",this,\\"test:log2\\",new $stdlib.core.Inflight(this, \\"$Inflight2\\", {
-      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.7cb19896159d0240a97e3f1d4cdca8c52774192fa1445ebfc17495e7fbc8ad43/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
+      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.be3fb7aaa77c217758a5cd7be43b3bb17d3f8d89ee3a8532005b78396dc4de64/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
       bindings: {
       }
     })
@@ -255,25 +255,21 @@ new $App().synth();
 "
 `;
 
-exports[`wing compile -t tf-aws > proc.7cb19896159d0240a97e3f1d4cdca8c52774192fa1445ebfc17495e7fbc8ad43/index.js 1`] = `
+exports[`wing compile -t tf-aws > proc.a4d16ad74e509f7ba53bb94a76d85ecfca8334031a4d57904b76d1b4fde85163/index.js 1`] = `
 "async handle() {
   const {  } = this;
-  {
-    {console.log(\\"inflight log 2.1\\")};
-    {console.log(\\"inflight log 2.2\\")};
-  }
-};
+  {console.log(\\"inflight log 1.1\\")};
+  {console.log(\\"inflight log 1.2\\")};
+}
 "
 `;
 
-exports[`wing compile -t tf-aws > proc.ceb355a9f94cf795c46371d35d8feb12bb9723e1ec280f49e374f6346ec4ecca/index.js 1`] = `
+exports[`wing compile -t tf-aws > proc.be3fb7aaa77c217758a5cd7be43b3bb17d3f8d89ee3a8532005b78396dc4de64/index.js 1`] = `
 "async handle() {
   const {  } = this;
-  {
-    {console.log(\\"inflight log 1.1\\")};
-    {console.log(\\"inflight log 1.2\\")};
-  }
-};
+  {console.log(\\"inflight log 2.1\\")};
+  {console.log(\\"inflight log 2.2\\")};
+}
 "
 `;
 

--- a/tools/hangar/__snapshots__/test_corpus/valid/print.w.ts.snap
+++ b/tools/hangar/__snapshots__/test_corpus/valid/print.w.ts.snap
@@ -223,18 +223,19 @@ class $Root extends $stdlib.core.Resource {
     super(scope, id);
     {console.log(\\"preflight log\\")};
     this.node.root.newAbstract(\\"@winglang/sdk.cloud.Function\\",this,\\"test:log1\\",new $stdlib.core.Inflight(this, \\"$Inflight1\\", {
-  code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.bf0feaf1bc98afc8eb1ba94d506b4dcd46af0da756a1a665f0e03f5a75b63422/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
-  bindings: {
-  }
-}));
+      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.ceb355a9f94cf795c46371d35d8feb12bb9723e1ec280f49e374f6346ec4ecca/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
+      bindings: {
+      }
+    })
+    );
     this.node.root.newAbstract(\\"@winglang/sdk.cloud.Function\\",this,\\"test:log2\\",new $stdlib.core.Inflight(this, \\"$Inflight2\\", {
-  code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.71a8edefcd0491d59b2cec2c14ce38019ce88de4e579784cec3340cc2e5a7d2d/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
-  bindings: {
-  }
-}));
+      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.7cb19896159d0240a97e3f1d4cdca8c52774192fa1445ebfc17495e7fbc8ad43/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
+      bindings: {
+      }
+    })
+    );
   }
 }
-
 class $App extends $AppBase {
   constructor() {
     super({ outdir: $outdir, name: \\"print\\", plugins: $plugins, isTestEnvironment: $wing_is_test });
@@ -250,22 +251,30 @@ class $App extends $AppBase {
     }
   }
 }
-
-new $App().synth();"
+new $App().synth();
+"
 `;
 
-exports[`wing compile -t tf-aws > proc.71a8edefcd0491d59b2cec2c14ce38019ce88de4e579784cec3340cc2e5a7d2d/index.js 1`] = `
-"async handle() { const {  } = this; {
-  {console.log(\\"inflight log 2.1\\")};
-  {console.log(\\"inflight log 2.2\\")};
-} };"
+exports[`wing compile -t tf-aws > proc.7cb19896159d0240a97e3f1d4cdca8c52774192fa1445ebfc17495e7fbc8ad43/index.js 1`] = `
+"async handle() {
+  const {  } = this;
+  {
+    {console.log(\\"inflight log 2.1\\")};
+    {console.log(\\"inflight log 2.2\\")};
+  }
+};
+"
 `;
 
-exports[`wing compile -t tf-aws > proc.bf0feaf1bc98afc8eb1ba94d506b4dcd46af0da756a1a665f0e03f5a75b63422/index.js 1`] = `
-"async handle() { const {  } = this; {
-  {console.log(\\"inflight log 1.1\\")};
-  {console.log(\\"inflight log 1.2\\")};
-} };"
+exports[`wing compile -t tf-aws > proc.ceb355a9f94cf795c46371d35d8feb12bb9723e1ec280f49e374f6346ec4ecca/index.js 1`] = `
+"async handle() {
+  const {  } = this;
+  {
+    {console.log(\\"inflight log 1.1\\")};
+    {console.log(\\"inflight log 1.2\\")};
+  }
+};
+"
 `;
 
 exports[`wing test -t sim > stdout 1`] = `

--- a/tools/hangar/__snapshots__/test_corpus/valid/reassignment.w.ts.snap
+++ b/tools/hangar/__snapshots__/test_corpus/valid/reassignment.w.ts.snap
@@ -2,12 +2,12 @@
 
 exports[`wing compile -t tf-aws > clients/R.inflight.js 1`] = `
 "class R  {
-constructor({ f1 }) {
-
-  this.f1 = f1;
+  constructor({ f1 }) {
+    this.f1 = f1;
+  }
 }
-}
-exports.R = R;"
+exports.R = R;
+"
 `;
 
 exports[`wing compile -t tf-aws > main.tf.json 1`] = `
@@ -69,27 +69,29 @@ class $Root extends $stdlib.core.Resource {
   constructor(scope, id) {
     super(scope, id);
     class R extends $stdlib.core.Resource {
-	constructor(scope, id, ) {
-	super(scope, id);
-{
-  if (true) {
-    this.f = 1;
-    this.f1 = 0;
-  }
-}
-}
-	 inc()  {
-	{
-  this.f = (this.f + 1);
-}
-}
-	_toInflight() {
-	const f1_client = this._lift(this.f1);
-	const self_client_path = \\"./clients/R.inflight.js\\".replace(/\\\\\\\\/g, \\"/\\");
-	return $stdlib.core.NodeJsCode.fromInline(\`(new (require(\\"\${self_client_path}\\")).R({f1: \${f1_client}}))\`);
-}
-}
-R._annotateInflight(\\"$init\\", {\\"this.f1\\": { ops: [] }});
+      constructor(scope, id, ) {
+        super(scope, id);
+        if (true) {
+          this.f = 1;
+          this.f1 = 0;
+        }
+      }
+       inc()  {
+        {
+          this.f = (this.f + 1);
+        }
+      }
+      _toInflight() {
+        const f1_client = this._lift(this.f1);
+        const self_client_path = \\"./clients/R.inflight.js\\".replace(/\\\\\\\\/g, \\"/\\");
+        return $stdlib.core.NodeJsCode.fromInline(\`
+          (new (require(\\"\${self_client_path}\\")).R({
+            f1: \${f1_client},
+          }))
+        \`);
+      }
+    }
+    R._annotateInflight(\\"$init\\", {\\"this.f1\\": { ops: [] }});
     let x = 5;
     {((cond) => {if (!cond) throw new Error(\`assertion failed: '(x === 5)'\`)})((x === 5))};
     x = (x + 1);
@@ -98,17 +100,17 @@ R._annotateInflight(\\"$init\\", {\\"this.f1\\": { ops: [] }});
     (r.inc());
     {((cond) => {if (!cond) throw new Error(\`assertion failed: '(r.f === 2)'\`)})((r.f === 2))};
     const f =  (arg) =>  {
-	{
-  arg = 0;
-  return arg;
-}
-};
+      {
+        arg = 0;
+        return arg;
+      }
+    }
+    ;
     const y = 1;
     {((cond) => {if (!cond) throw new Error(\`assertion failed: '((f(y)) === 0)'\`)})(((f(y)) === 0))};
     {((cond) => {if (!cond) throw new Error(\`assertion failed: '(y === 1)'\`)})((y === 1))};
   }
 }
-
 class $App extends $AppBase {
   constructor() {
     super({ outdir: $outdir, name: \\"reassignment\\", plugins: $plugins, isTestEnvironment: $wing_is_test });
@@ -124,8 +126,8 @@ class $App extends $AppBase {
     }
   }
 }
-
-new $App().synth();"
+new $App().synth();
+"
 `;
 
 exports[`wing test -t sim > stdout 1`] = `

--- a/tools/hangar/__snapshots__/test_corpus/valid/redis.w.ts.snap
+++ b/tools/hangar/__snapshots__/test_corpus/valid/redis.w.ts.snap
@@ -474,7 +474,7 @@ class $Root extends $stdlib.core.Resource {
     const r = this.node.root.newAbstract(\\"@winglang/sdk.redis.Redis\\",this,\\"redis.Redis\\");
     const r2 = this.node.root.newAbstract(\\"@winglang/sdk.redis.Redis\\",this,\\"r2\\");
     this.node.root.newAbstract(\\"@winglang/sdk.cloud.Function\\",this,\\"test\\",new $stdlib.core.Inflight(this, \\"$Inflight1\\", {
-      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.49c3e197119f2b404767dc4503ee7e474362ecc4dce047d6bf2f6412d4a1d996/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
+      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.2f327831adfa10066eee3b4bc7cb9e6ec48481f9990eda0b0d999afbedefe536/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
       bindings: {
         r: {
           obj: r,
@@ -508,19 +508,17 @@ new $App().synth();
 "
 `;
 
-exports[`wing compile -t tf-aws > proc.49c3e197119f2b404767dc4503ee7e474362ecc4dce047d6bf2f6412d4a1d996/index.js 1`] = `
+exports[`wing compile -t tf-aws > proc.2f327831adfa10066eee3b4bc7cb9e6ec48481f9990eda0b0d999afbedefe536/index.js 1`] = `
 "async handle(s) {
   const { r, r2 } = this;
-  {
-    const connection = (await r.rawClient());
-    (await connection.set(\\"wing\\",\\"does redis\\"));
-    const value = (await connection.get(\\"wing\\"));
-    {((cond) => {if (!cond) throw new Error(\`assertion failed: '(value === \\"does redis\\")'\`)})((value === \\"does redis\\"))};
-    (await r2.set(\\"wing\\",\\"does redis again\\"));
-    const value2 = (await r2.get(\\"wing\\"));
-    {((cond) => {if (!cond) throw new Error(\`assertion failed: '(value2 === \\"does redis again\\")'\`)})((value2 === \\"does redis again\\"))};
-  }
-};
+  const connection = (await r.rawClient());
+  (await connection.set(\\"wing\\",\\"does redis\\"));
+  const value = (await connection.get(\\"wing\\"));
+  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(value === \\"does redis\\")'\`)})((value === \\"does redis\\"))};
+  (await r2.set(\\"wing\\",\\"does redis again\\"));
+  const value2 = (await r2.get(\\"wing\\"));
+  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(value2 === \\"does redis again\\")'\`)})((value2 === \\"does redis again\\"))};
+}
 "
 `;
 

--- a/tools/hangar/__snapshots__/test_corpus/valid/redis.w.ts.snap
+++ b/tools/hangar/__snapshots__/test_corpus/valid/redis.w.ts.snap
@@ -523,3 +523,9 @@ exports[`wing compile -t tf-aws > proc.49c3e197119f2b404767dc4503ee7e474362ecc4d
 };
 "
 `;
+
+exports[`wing test -t sim > stdout 1`] = `
+"- Compiling to sim...
+✔ Compiling to sim...
+pass ─ redis.wsim » root/env0/test"
+`;

--- a/tools/hangar/__snapshots__/test_corpus/valid/redis.w.ts.snap
+++ b/tools/hangar/__snapshots__/test_corpus/valid/redis.w.ts.snap
@@ -474,21 +474,21 @@ class $Root extends $stdlib.core.Resource {
     const r = this.node.root.newAbstract(\\"@winglang/sdk.redis.Redis\\",this,\\"redis.Redis\\");
     const r2 = this.node.root.newAbstract(\\"@winglang/sdk.redis.Redis\\",this,\\"r2\\");
     this.node.root.newAbstract(\\"@winglang/sdk.cloud.Function\\",this,\\"test\\",new $stdlib.core.Inflight(this, \\"$Inflight1\\", {
-  code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.688f52a0df0aa6a192cac76b359ea0e230467a7e397877c650abb8c2aec4251a/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
-  bindings: {
-    r: {
-      obj: r,
-      ops: [\\"del\\",\\"get\\",\\"hget\\",\\"hset\\",\\"raw_client\\",\\"sadd\\",\\"set\\",\\"smembers\\",\\"url\\"]
-    },
-    r2: {
-      obj: r2,
-      ops: [\\"del\\",\\"get\\",\\"hget\\",\\"hset\\",\\"raw_client\\",\\"sadd\\",\\"set\\",\\"smembers\\",\\"url\\"]
-    },
-  }
-}));
+      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.49c3e197119f2b404767dc4503ee7e474362ecc4dce047d6bf2f6412d4a1d996/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
+      bindings: {
+        r: {
+          obj: r,
+          ops: [\\"del\\",\\"get\\",\\"hget\\",\\"hset\\",\\"raw_client\\",\\"sadd\\",\\"set\\",\\"smembers\\",\\"url\\"]
+        },
+        r2: {
+          obj: r2,
+          ops: [\\"del\\",\\"get\\",\\"hget\\",\\"hset\\",\\"raw_client\\",\\"sadd\\",\\"set\\",\\"smembers\\",\\"url\\"]
+        },
+      }
+    })
+    );
   }
 }
-
 class $App extends $AppBase {
   constructor() {
     super({ outdir: $outdir, name: \\"redis\\", plugins: $plugins, isTestEnvironment: $wing_is_test });
@@ -504,24 +504,22 @@ class $App extends $AppBase {
     }
   }
 }
-
-new $App().synth();"
+new $App().synth();
+"
 `;
 
-exports[`wing compile -t tf-aws > proc.688f52a0df0aa6a192cac76b359ea0e230467a7e397877c650abb8c2aec4251a/index.js 1`] = `
-"async handle(s) { const { r, r2 } = this; {
-  const connection = (await r.rawClient());
-  (await connection.set(\\"wing\\",\\"does redis\\"));
-  const value = (await connection.get(\\"wing\\"));
-  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(value === \\"does redis\\")'\`)})((value === \\"does redis\\"))};
-  (await r2.set(\\"wing\\",\\"does redis again\\"));
-  const value2 = (await r2.get(\\"wing\\"));
-  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(value2 === \\"does redis again\\")'\`)})((value2 === \\"does redis again\\"))};
-} };"
-`;
-
-exports[`wing test -t sim > stdout 1`] = `
-"- Compiling to sim...
-✔ Compiling to sim...
-pass ─ redis.wsim » root/env0/test"
+exports[`wing compile -t tf-aws > proc.49c3e197119f2b404767dc4503ee7e474362ecc4dce047d6bf2f6412d4a1d996/index.js 1`] = `
+"async handle(s) {
+  const { r, r2 } = this;
+  {
+    const connection = (await r.rawClient());
+    (await connection.set(\\"wing\\",\\"does redis\\"));
+    const value = (await connection.get(\\"wing\\"));
+    {((cond) => {if (!cond) throw new Error(\`assertion failed: '(value === \\"does redis\\")'\`)})((value === \\"does redis\\"))};
+    (await r2.set(\\"wing\\",\\"does redis again\\"));
+    const value2 = (await r2.get(\\"wing\\"));
+    {((cond) => {if (!cond) throw new Error(\`assertion failed: '(value2 === \\"does redis again\\")'\`)})((value2 === \\"does redis again\\"))};
+  }
+};
+"
 `;

--- a/tools/hangar/__snapshots__/test_corpus/valid/resource.w.ts.snap
+++ b/tools/hangar/__snapshots__/test_corpus/valid/resource.w.ts.snap
@@ -2,39 +2,41 @@
 
 exports[`wing compile -t tf-aws > clients/Bar.inflight.js 1`] = `
 "class Bar  {
-constructor({ b, foo, name }) {
-
-  this.b = b;
-  this.foo = foo;
-  this.name = name;
+  constructor({ b, foo, name }) {
+    this.b = b;
+    this.foo = foo;
+    this.name = name;
+  }
+  async my_method()  {
+    {
+      (await this.foo.foo_inc());
+      (await this.b.put(\\"foo\\",\`counter is: \${(await this.foo.foo_get())}\`));
+      return (await this.b.get(\\"foo\\"));
+    }
+  }
 }
-async my_method()  {
-	{
-  (await this.foo.foo_inc());
-  (await this.b.put(\\"foo\\",\`counter is: \${(await this.foo.foo_get())}\`));
-  return (await this.b.get(\\"foo\\"));
-}
-}}
-exports.Bar = Bar;"
+exports.Bar = Bar;
+"
 `;
 
 exports[`wing compile -t tf-aws > clients/Foo.inflight.js 1`] = `
 "class Foo  {
-constructor({ c }) {
-
-  this.c = c;
+  constructor({ c }) {
+    this.c = c;
+  }
+  async foo_inc()  {
+    {
+      (await this.c.inc());
+    }
+  }
+  async foo_get()  {
+    {
+      return (await this.c.peek());
+    }
+  }
 }
-async foo_inc()  {
-	{
-  (await this.c.inc());
-}
-}
-async foo_get()  {
-	{
-  return (await this.c.peek());
-}
-}}
-exports.Foo = Foo;"
+exports.Foo = Foo;
+"
 `;
 
 exports[`wing compile -t tf-aws > main.tf.json 1`] = `
@@ -250,60 +252,64 @@ class $Root extends $stdlib.core.Resource {
   constructor(scope, id) {
     super(scope, id);
     class Foo extends $stdlib.core.Resource {
-	constructor(scope, id, ) {
-	super(scope, id);
-{
-  this.c = this.node.root.newAbstract(\\"@winglang/sdk.cloud.Counter\\",this,\\"cloud.Counter\\");
-}
-}
-	
-	_toInflight() {
-	const c_client = this._lift(this.c);
-	const self_client_path = \\"./clients/Foo.inflight.js\\".replace(/\\\\\\\\/g, \\"/\\");
-	return $stdlib.core.NodeJsCode.fromInline(\`(new (require(\\"\${self_client_path}\\")).Foo({c: \${c_client}}))\`);
-}
-}
-Foo._annotateInflight(\\"foo_inc\\", {\\"this.c\\": { ops: [\\"inc\\"] }});
-Foo._annotateInflight(\\"foo_get\\", {\\"this.c\\": { ops: [\\"peek\\"] }});
-Foo._annotateInflight(\\"$init\\", {\\"this.c\\": { ops: [] }});
+      constructor(scope, id, ) {
+        super(scope, id);
+        this.c = this.node.root.newAbstract(\\"@winglang/sdk.cloud.Counter\\",this,\\"cloud.Counter\\");
+      }
+      _toInflight() {
+        const c_client = this._lift(this.c);
+        const self_client_path = \\"./clients/Foo.inflight.js\\".replace(/\\\\\\\\/g, \\"/\\");
+        return $stdlib.core.NodeJsCode.fromInline(\`
+          (new (require(\\"\${self_client_path}\\")).Foo({
+            c: \${c_client},
+          }))
+        \`);
+      }
+    }
+    Foo._annotateInflight(\\"foo_inc\\", {\\"this.c\\": { ops: [\\"inc\\"] }});
+    Foo._annotateInflight(\\"foo_get\\", {\\"this.c\\": { ops: [\\"peek\\"] }});
+    Foo._annotateInflight(\\"$init\\", {\\"this.c\\": { ops: [] }});
     class Bar extends $stdlib.core.Resource {
-	constructor(scope, id, name, b) {
-	super(scope, id);
-{
-  this.name = name;
-  this.b = b;
-  this.foo = new Foo(this,\\"Foo\\");
-}
-}
-	
-	_toInflight() {
-	const b_client = this._lift(this.b);
-const foo_client = this._lift(this.foo);
-const name_client = this._lift(this.name);
-	const self_client_path = \\"./clients/Bar.inflight.js\\".replace(/\\\\\\\\/g, \\"/\\");
-	return $stdlib.core.NodeJsCode.fromInline(\`(new (require(\\"\${self_client_path}\\")).Bar({b: \${b_client}, foo: \${foo_client}, name: \${name_client}}))\`);
-}
-}
-Bar._annotateInflight(\\"my_method\\", {\\"this.b\\": { ops: [\\"get\\",\\"put\\"] },\\"this.foo\\": { ops: [\\"foo_get\\",\\"foo_inc\\"] }});
-Bar._annotateInflight(\\"$init\\", {\\"this.b\\": { ops: [] },\\"this.foo\\": { ops: [] },\\"this.name\\": { ops: [] }});
+      constructor(scope, id, name, b) {
+        super(scope, id);
+        this.name = name;
+        this.b = b;
+        this.foo = new Foo(this,\\"Foo\\");
+      }
+      _toInflight() {
+        const b_client = this._lift(this.b);
+        const foo_client = this._lift(this.foo);
+        const name_client = this._lift(this.name);
+        const self_client_path = \\"./clients/Bar.inflight.js\\".replace(/\\\\\\\\/g, \\"/\\");
+        return $stdlib.core.NodeJsCode.fromInline(\`
+          (new (require(\\"\${self_client_path}\\")).Bar({
+            b: \${b_client},
+            foo: \${foo_client},
+            name: \${name_client},
+          }))
+        \`);
+      }
+    }
+    Bar._annotateInflight(\\"my_method\\", {\\"this.b\\": { ops: [\\"get\\",\\"put\\"] },\\"this.foo\\": { ops: [\\"foo_get\\",\\"foo_inc\\"] }});
+    Bar._annotateInflight(\\"$init\\", {\\"this.b\\": { ops: [] },\\"this.foo\\": { ops: [] },\\"this.name\\": { ops: [] }});
     const bucket = this.node.root.newAbstract(\\"@winglang/sdk.cloud.Bucket\\",this,\\"cloud.Bucket\\");
     const res = new Bar(this,\\"Bar\\",\\"Arr\\",bucket);
     this.node.root.newAbstract(\\"@winglang/sdk.cloud.Function\\",this,\\"test\\",new $stdlib.core.Inflight(this, \\"$Inflight1\\", {
-  code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.e50bc85b13df379286b4aa72aa88788422e26d9146adbc9bba989a8a59253a73/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
-  bindings: {
-    bucket: {
-      obj: bucket,
-      ops: [\\"delete\\",\\"get\\",\\"get_json\\",\\"list\\",\\"public_url\\",\\"put\\",\\"put_json\\"]
-    },
-    res: {
-      obj: res,
-      ops: [\\"my_method\\"]
-    },
-  }
-}));
+      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.ec55ba7622aa9e6126dbb9f42bd67d2cbcca23d3f18231e18b3865f1df7f741f/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
+      bindings: {
+        bucket: {
+          obj: bucket,
+          ops: [\\"delete\\",\\"get\\",\\"get_json\\",\\"list\\",\\"public_url\\",\\"put\\",\\"put_json\\"]
+        },
+        res: {
+          obj: res,
+          ops: [\\"my_method\\"]
+        },
+      }
+    })
+    );
   }
 }
-
 class $App extends $AppBase {
   constructor() {
     super({ outdir: $outdir, name: \\"resource\\", plugins: $plugins, isTestEnvironment: $wing_is_test });
@@ -319,16 +325,20 @@ class $App extends $AppBase {
     }
   }
 }
-
-new $App().synth();"
+new $App().synth();
+"
 `;
 
-exports[`wing compile -t tf-aws > proc.e50bc85b13df379286b4aa72aa88788422e26d9146adbc9bba989a8a59253a73/index.js 1`] = `
-"async handle() { const { bucket, res } = this; {
-  const s = (await res.my_method());
-  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(s === \\"counter is: 1\\")'\`)})((s === \\"counter is: 1\\"))};
-  {((cond) => {if (!cond) throw new Error(\`assertion failed: '((await bucket.list()).length === 1)'\`)})(((await bucket.list()).length === 1))};
-} };"
+exports[`wing compile -t tf-aws > proc.ec55ba7622aa9e6126dbb9f42bd67d2cbcca23d3f18231e18b3865f1df7f741f/index.js 1`] = `
+"async handle() {
+  const { bucket, res } = this;
+  {
+    const s = (await res.my_method());
+    {((cond) => {if (!cond) throw new Error(\`assertion failed: '(s === \\"counter is: 1\\")'\`)})((s === \\"counter is: 1\\"))};
+    {((cond) => {if (!cond) throw new Error(\`assertion failed: '((await bucket.list()).length === 1)'\`)})(((await bucket.list()).length === 1))};
+  }
+};
+"
 `;
 
 exports[`wing test -t sim > stdout 1`] = `

--- a/tools/hangar/__snapshots__/test_corpus/valid/resource.w.ts.snap
+++ b/tools/hangar/__snapshots__/test_corpus/valid/resource.w.ts.snap
@@ -295,7 +295,7 @@ class $Root extends $stdlib.core.Resource {
     const bucket = this.node.root.newAbstract(\\"@winglang/sdk.cloud.Bucket\\",this,\\"cloud.Bucket\\");
     const res = new Bar(this,\\"Bar\\",\\"Arr\\",bucket);
     this.node.root.newAbstract(\\"@winglang/sdk.cloud.Function\\",this,\\"test\\",new $stdlib.core.Inflight(this, \\"$Inflight1\\", {
-      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.ec55ba7622aa9e6126dbb9f42bd67d2cbcca23d3f18231e18b3865f1df7f741f/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
+      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.c2ebbdf06e2a1f4ff7d5b279cc90cfff8cb1ed8067171e583f1bcd844805f5e3/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
       bindings: {
         bucket: {
           obj: bucket,
@@ -329,15 +329,13 @@ new $App().synth();
 "
 `;
 
-exports[`wing compile -t tf-aws > proc.ec55ba7622aa9e6126dbb9f42bd67d2cbcca23d3f18231e18b3865f1df7f741f/index.js 1`] = `
+exports[`wing compile -t tf-aws > proc.c2ebbdf06e2a1f4ff7d5b279cc90cfff8cb1ed8067171e583f1bcd844805f5e3/index.js 1`] = `
 "async handle() {
   const { bucket, res } = this;
-  {
-    const s = (await res.my_method());
-    {((cond) => {if (!cond) throw new Error(\`assertion failed: '(s === \\"counter is: 1\\")'\`)})((s === \\"counter is: 1\\"))};
-    {((cond) => {if (!cond) throw new Error(\`assertion failed: '((await bucket.list()).length === 1)'\`)})(((await bucket.list()).length === 1))};
-  }
-};
+  const s = (await res.my_method());
+  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(s === \\"counter is: 1\\")'\`)})((s === \\"counter is: 1\\"))};
+  {((cond) => {if (!cond) throw new Error(\`assertion failed: '((await bucket.list()).length === 1)'\`)})(((await bucket.list()).length === 1))};
+}
 "
 `;
 

--- a/tools/hangar/__snapshots__/test_corpus/valid/resource_as_inflight_literal.w.ts.snap
+++ b/tools/hangar/__snapshots__/test_corpus/valid/resource_as_inflight_literal.w.ts.snap
@@ -252,7 +252,7 @@ class $Root extends $stdlib.core.Resource {
     Foo._annotateInflight(\\"$init\\", {});
     const fn = this.node.root.newAbstract(\\"@winglang/sdk.cloud.Function\\",this,\\"cloud.Function\\",new Foo(this,\\"Foo\\"));
     this.node.root.newAbstract(\\"@winglang/sdk.cloud.Function\\",this,\\"test\\",new $stdlib.core.Inflight(this, \\"$Inflight1\\", {
-      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.134a1fa1e8775e478955a845b51f0bd9591a1922c1812344bf8b51cba1f472b6/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
+      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.137cab8f078ac4d8dd242fc82417ae774fbaeaedf96937ad93f861344976bed7/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
       bindings: {
         fn: {
           obj: fn,
@@ -282,13 +282,11 @@ new $App().synth();
 "
 `;
 
-exports[`wing compile -t tf-aws > proc.134a1fa1e8775e478955a845b51f0bd9591a1922c1812344bf8b51cba1f472b6/index.js 1`] = `
+exports[`wing compile -t tf-aws > proc.137cab8f078ac4d8dd242fc82417ae774fbaeaedf96937ad93f861344976bed7/index.js 1`] = `
 "async handle() {
   const { fn } = this;
-  {
-    {((cond) => {if (!cond) throw new Error(\`assertion failed: '((await fn.invoke(\\"test\\")) === \\"hello world!\\")'\`)})(((await fn.invoke(\\"test\\")) === \\"hello world!\\"))};
-  }
-};
+  {((cond) => {if (!cond) throw new Error(\`assertion failed: '((await fn.invoke(\\"test\\")) === \\"hello world!\\")'\`)})(((await fn.invoke(\\"test\\")) === \\"hello world!\\"))};
+}
 "
 `;
 

--- a/tools/hangar/__snapshots__/test_corpus/valid/resource_as_inflight_literal.w.ts.snap
+++ b/tools/hangar/__snapshots__/test_corpus/valid/resource_as_inflight_literal.w.ts.snap
@@ -2,16 +2,16 @@
 
 exports[`wing compile -t tf-aws > clients/Foo.inflight.js 1`] = `
 "class Foo  {
-constructor({  }) {
-
-
+  constructor({  }) {
+  }
+  async handle(message)  {
+    {
+      return \\"hello world!\\";
+    }
+  }
 }
-async handle(message)  {
-	{
-  return \\"hello world!\\";
-}
-}}
-exports.Foo = Foo;"
+exports.Foo = Foo;
+"
 `;
 
 exports[`wing compile -t tf-aws > main.tf.json 1`] = `
@@ -237,33 +237,32 @@ class $Root extends $stdlib.core.Resource {
   constructor(scope, id) {
     super(scope, id);
     class Foo extends $stdlib.core.Resource {
-	constructor(scope, id, ) {
-	super(scope, id);
-{
-}
-}
-	
-	_toInflight() {
-	
-	const self_client_path = \\"./clients/Foo.inflight.js\\".replace(/\\\\\\\\/g, \\"/\\");
-	return $stdlib.core.NodeJsCode.fromInline(\`(new (require(\\"\${self_client_path}\\")).Foo({}))\`);
-}
-}
-Foo._annotateInflight(\\"handle\\", {});
-Foo._annotateInflight(\\"$init\\", {});
+      constructor(scope, id, ) {
+        super(scope, id);
+      }
+      _toInflight() {
+        const self_client_path = \\"./clients/Foo.inflight.js\\".replace(/\\\\\\\\/g, \\"/\\");
+        return $stdlib.core.NodeJsCode.fromInline(\`
+          (new (require(\\"\${self_client_path}\\")).Foo({
+          }))
+        \`);
+      }
+    }
+    Foo._annotateInflight(\\"handle\\", {});
+    Foo._annotateInflight(\\"$init\\", {});
     const fn = this.node.root.newAbstract(\\"@winglang/sdk.cloud.Function\\",this,\\"cloud.Function\\",new Foo(this,\\"Foo\\"));
     this.node.root.newAbstract(\\"@winglang/sdk.cloud.Function\\",this,\\"test\\",new $stdlib.core.Inflight(this, \\"$Inflight1\\", {
-  code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.917572587cf19c37eec89740530b1f8d71072e09ccaeb9cbd4a3121ba0794d2a/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
-  bindings: {
-    fn: {
-      obj: fn,
-      ops: [\\"invoke\\"]
-    },
-  }
-}));
+      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.134a1fa1e8775e478955a845b51f0bd9591a1922c1812344bf8b51cba1f472b6/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
+      bindings: {
+        fn: {
+          obj: fn,
+          ops: [\\"invoke\\"]
+        },
+      }
+    })
+    );
   }
 }
-
 class $App extends $AppBase {
   constructor() {
     super({ outdir: $outdir, name: \\"resource_as_inflight_literal\\", plugins: $plugins, isTestEnvironment: $wing_is_test });
@@ -279,14 +278,18 @@ class $App extends $AppBase {
     }
   }
 }
-
-new $App().synth();"
+new $App().synth();
+"
 `;
 
-exports[`wing compile -t tf-aws > proc.917572587cf19c37eec89740530b1f8d71072e09ccaeb9cbd4a3121ba0794d2a/index.js 1`] = `
-"async handle() { const { fn } = this; {
-  {((cond) => {if (!cond) throw new Error(\`assertion failed: '((await fn.invoke(\\"test\\")) === \\"hello world!\\")'\`)})(((await fn.invoke(\\"test\\")) === \\"hello world!\\"))};
-} };"
+exports[`wing compile -t tf-aws > proc.134a1fa1e8775e478955a845b51f0bd9591a1922c1812344bf8b51cba1f472b6/index.js 1`] = `
+"async handle() {
+  const { fn } = this;
+  {
+    {((cond) => {if (!cond) throw new Error(\`assertion failed: '((await fn.invoke(\\"test\\")) === \\"hello world!\\")'\`)})(((await fn.invoke(\\"test\\")) === \\"hello world!\\"))};
+  }
+};
+"
 `;
 
 exports[`wing test -t sim > stdout 1`] = `

--- a/tools/hangar/__snapshots__/test_corpus/valid/resource_captures.w.ts.snap
+++ b/tools/hangar/__snapshots__/test_corpus/valid/resource_captures.w.ts.snap
@@ -2,121 +2,123 @@
 
 exports[`wing compile -t tf-aws > clients/Another.inflight.js 1`] = `
 "class Another  {
-constructor({ first, my_field }) {
-
-  this.first = first;
-  this.my_field = my_field;
+  constructor({ first, my_field }) {
+    this.first = first;
+    this.my_field = my_field;
+  }
+  async meaning_of_life()  {
+    {
+      return 42;
+    }
+  }
+  async another_func()  {
+    {
+      return \\"42\\";
+    }
+  }
 }
-async meaning_of_life()  {
-	{
-  return 42;
-}
-}
-async another_func()  {
-	{
-  return \\"42\\";
-}
-}}
-exports.Another = Another;"
+exports.Another = Another;
+"
 `;
 
 exports[`wing compile -t tf-aws > clients/First.inflight.js 1`] = `
 "class First  {
-constructor({ my_resource }) {
-
-  this.my_resource = my_resource;
+  constructor({ my_resource }) {
+    this.my_resource = my_resource;
+  }
 }
-}
-exports.First = First;"
+exports.First = First;
+"
 `;
 
 exports[`wing compile -t tf-aws > clients/MyResource.inflight.js 1`] = `
 "class MyResource  {
-constructor({ another, array_of_str, ext_bucket, ext_num, map_of_num, my_bool, my_num, my_queue, my_resource, my_str, set_of_str, unused_resource }) {
-
-  this.another = another;
-  this.array_of_str = array_of_str;
-  this.ext_bucket = ext_bucket;
-  this.ext_num = ext_num;
-  this.map_of_num = map_of_num;
-  this.my_bool = my_bool;
-  this.my_num = my_num;
-  this.my_queue = my_queue;
-  this.my_resource = my_resource;
-  this.my_str = my_str;
-  this.set_of_str = set_of_str;
-  this.unused_resource = unused_resource;
+  constructor({ another, array_of_str, ext_bucket, ext_num, map_of_num, my_bool, my_num, my_queue, my_resource, my_str, set_of_str, unused_resource }) {
+    this.another = another;
+    this.array_of_str = array_of_str;
+    this.ext_bucket = ext_bucket;
+    this.ext_num = ext_num;
+    this.map_of_num = map_of_num;
+    this.my_bool = my_bool;
+    this.my_num = my_num;
+    this.my_queue = my_queue;
+    this.my_resource = my_resource;
+    this.my_str = my_str;
+    this.set_of_str = set_of_str;
+    this.unused_resource = unused_resource;
+  }
+  async test_no_capture()  {
+    {
+      const arr = Object.freeze([1, 2, 3]);
+      {((cond) => {if (!cond) throw new Error(\`assertion failed: '(arr.length === 3)'\`)})((arr.length === 3))};
+      {console.log(\`array.len=\${arr.length}\`)};
+    }
+  }
+  async test_capture_collections_of_data()  {
+    {
+      {((cond) => {if (!cond) throw new Error(\`assertion failed: '(this.array_of_str.length === 2)'\`)})((this.array_of_str.length === 2))};
+      {((cond) => {if (!cond) throw new Error(\`assertion failed: '((await this.array_of_str.at(0)) === \\"s1\\")'\`)})(((await this.array_of_str.at(0)) === \\"s1\\"))};
+      {((cond) => {if (!cond) throw new Error(\`assertion failed: '((await this.array_of_str.at(1)) === \\"s2\\")'\`)})(((await this.array_of_str.at(1)) === \\"s2\\"))};
+      {((cond) => {if (!cond) throw new Error(\`assertion failed: '((this.map_of_num)[\\"k1\\"] === 11)'\`)})(((this.map_of_num)[\\"k1\\"] === 11))};
+      {((cond) => {if (!cond) throw new Error(\`assertion failed: '((this.map_of_num)[\\"k2\\"] === 22)'\`)})(((this.map_of_num)[\\"k2\\"] === 22))};
+      {((cond) => {if (!cond) throw new Error(\`assertion failed: '(await this.set_of_str.has(\\"s1\\"))'\`)})((await this.set_of_str.has(\\"s1\\")))};
+      {((cond) => {if (!cond) throw new Error(\`assertion failed: '(await this.set_of_str.has(\\"s2\\"))'\`)})((await this.set_of_str.has(\\"s2\\")))};
+      {((cond) => {if (!cond) throw new Error(\`assertion failed: '(!(await this.set_of_str.has(\\"s3\\")))'\`)})((!(await this.set_of_str.has(\\"s3\\"))))};
+    }
+  }
+  async test_capture_primitives()  {
+    {
+      {((cond) => {if (!cond) throw new Error(\`assertion failed: '(this.my_str === \\"my_string\\")'\`)})((this.my_str === \\"my_string\\"))};
+      {((cond) => {if (!cond) throw new Error(\`assertion failed: '(this.my_num === 42)'\`)})((this.my_num === 42))};
+      {((cond) => {if (!cond) throw new Error(\`assertion failed: '(this.my_bool === true)'\`)})((this.my_bool === true))};
+    }
+  }
+  async test_capture_resource()  {
+    {
+      (await this.my_resource.put(\\"f1.txt\\",\\"f1\\"));
+      {((cond) => {if (!cond) throw new Error(\`assertion failed: '((await this.my_resource.get(\\"f1.txt\\")) === \\"f1\\")'\`)})(((await this.my_resource.get(\\"f1.txt\\")) === \\"f1\\"))};
+      {((cond) => {if (!cond) throw new Error(\`assertion failed: '((await this.my_resource.list()).length === 1)'\`)})(((await this.my_resource.list()).length === 1))};
+    }
+  }
+  async test_nested_preflight_field()  {
+    {
+      {((cond) => {if (!cond) throw new Error(\`assertion failed: '(this.another.my_field === \\"hello!\\")'\`)})((this.another.my_field === \\"hello!\\"))};
+      {console.log(\`field=\${this.another.my_field}\`)};
+    }
+  }
+  async test_nested_resource()  {
+    {
+      {((cond) => {if (!cond) throw new Error(\`assertion failed: '((await this.another.first.my_resource.list()).length === 0)'\`)})(((await this.another.first.my_resource.list()).length === 0))};
+      (await this.another.first.my_resource.put(\\"hello\\",this.my_str));
+      {console.log(\`this.another.first.my_resource:\${(await this.another.first.my_resource.get(\\"hello\\"))}\`)};
+    }
+  }
+  async test_expression_recursive()  {
+    {
+      (await this.my_queue.push(this.my_str));
+    }
+  }
+  async test_external()  {
+    {
+      {((cond) => {if (!cond) throw new Error(\`assertion failed: '((await this.ext_bucket.list()).length === 0)'\`)})(((await this.ext_bucket.list()).length === 0))};
+      {((cond) => {if (!cond) throw new Error(\`assertion failed: '(this.ext_num === 12)'\`)})((this.ext_num === 12))};
+    }
+  }
+  async test_user_defined_resource()  {
+    {
+      {((cond) => {if (!cond) throw new Error(\`assertion failed: '((await this.another.meaning_of_life()) === 42)'\`)})(((await this.another.meaning_of_life()) === 42))};
+      {((cond) => {if (!cond) throw new Error(\`assertion failed: '((await this.another.another_func()) === \\"42\\")'\`)})(((await this.another.another_func()) === \\"42\\"))};
+    }
+  }
+  async test_inflight_field()  {
+    {
+      this.inflight_field = 123;
+      {((cond) => {if (!cond) throw new Error(\`assertion failed: '(this.inflight_field === 123)'\`)})((this.inflight_field === 123))};
+    }
+  }
 }
-async test_no_capture()  {
-	{
-  const arr = Object.freeze([1, 2, 3]);
-  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(arr.length === 3)'\`)})((arr.length === 3))};
-  {console.log(\`array.len=\${arr.length}\`)};
-}
-}
-async test_capture_collections_of_data()  {
-	{
-  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(this.array_of_str.length === 2)'\`)})((this.array_of_str.length === 2))};
-  {((cond) => {if (!cond) throw new Error(\`assertion failed: '((await this.array_of_str.at(0)) === \\"s1\\")'\`)})(((await this.array_of_str.at(0)) === \\"s1\\"))};
-  {((cond) => {if (!cond) throw new Error(\`assertion failed: '((await this.array_of_str.at(1)) === \\"s2\\")'\`)})(((await this.array_of_str.at(1)) === \\"s2\\"))};
-  {((cond) => {if (!cond) throw new Error(\`assertion failed: '((this.map_of_num)[\\"k1\\"] === 11)'\`)})(((this.map_of_num)[\\"k1\\"] === 11))};
-  {((cond) => {if (!cond) throw new Error(\`assertion failed: '((this.map_of_num)[\\"k2\\"] === 22)'\`)})(((this.map_of_num)[\\"k2\\"] === 22))};
-  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(await this.set_of_str.has(\\"s1\\"))'\`)})((await this.set_of_str.has(\\"s1\\")))};
-  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(await this.set_of_str.has(\\"s2\\"))'\`)})((await this.set_of_str.has(\\"s2\\")))};
-  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(!(await this.set_of_str.has(\\"s3\\")))'\`)})((!(await this.set_of_str.has(\\"s3\\"))))};
-}
-}
-async test_capture_primitives()  {
-	{
-  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(this.my_str === \\"my_string\\")'\`)})((this.my_str === \\"my_string\\"))};
-  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(this.my_num === 42)'\`)})((this.my_num === 42))};
-  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(this.my_bool === true)'\`)})((this.my_bool === true))};
-}
-}
-async test_capture_resource()  {
-	{
-  (await this.my_resource.put(\\"f1.txt\\",\\"f1\\"));
-  {((cond) => {if (!cond) throw new Error(\`assertion failed: '((await this.my_resource.get(\\"f1.txt\\")) === \\"f1\\")'\`)})(((await this.my_resource.get(\\"f1.txt\\")) === \\"f1\\"))};
-  {((cond) => {if (!cond) throw new Error(\`assertion failed: '((await this.my_resource.list()).length === 1)'\`)})(((await this.my_resource.list()).length === 1))};
-}
-}
-async test_nested_preflight_field()  {
-	{
-  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(this.another.my_field === \\"hello!\\")'\`)})((this.another.my_field === \\"hello!\\"))};
-  {console.log(\`field=\${this.another.my_field}\`)};
-}
-}
-async test_nested_resource()  {
-	{
-  {((cond) => {if (!cond) throw new Error(\`assertion failed: '((await this.another.first.my_resource.list()).length === 0)'\`)})(((await this.another.first.my_resource.list()).length === 0))};
-  (await this.another.first.my_resource.put(\\"hello\\",this.my_str));
-  {console.log(\`this.another.first.my_resource:\${(await this.another.first.my_resource.get(\\"hello\\"))}\`)};
-}
-}
-async test_expression_recursive()  {
-	{
-  (await this.my_queue.push(this.my_str));
-}
-}
-async test_external()  {
-	{
-  {((cond) => {if (!cond) throw new Error(\`assertion failed: '((await this.ext_bucket.list()).length === 0)'\`)})(((await this.ext_bucket.list()).length === 0))};
-  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(this.ext_num === 12)'\`)})((this.ext_num === 12))};
-}
-}
-async test_user_defined_resource()  {
-	{
-  {((cond) => {if (!cond) throw new Error(\`assertion failed: '((await this.another.meaning_of_life()) === 42)'\`)})(((await this.another.meaning_of_life()) === 42))};
-  {((cond) => {if (!cond) throw new Error(\`assertion failed: '((await this.another.another_func()) === \\"42\\")'\`)})(((await this.another.another_func()) === \\"42\\"))};
-}
-}
-async test_inflight_field()  {
-	{
-  this.inflight_field = 123;
-  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(this.inflight_field === 123)'\`)})((this.inflight_field === 123))};
-}
-}}
-exports.MyResource = MyResource;"
+exports.MyResource = MyResource;
+"
 `;
 
 exports[`wing compile -t tf-aws > main.tf.json 1`] = `
@@ -426,104 +428,120 @@ class $Root extends $stdlib.core.Resource {
   constructor(scope, id) {
     super(scope, id);
     class First extends $stdlib.core.Resource {
-	constructor(scope, id, ) {
-	super(scope, id);
-{
-  this.my_resource = this.node.root.newAbstract(\\"@winglang/sdk.cloud.Bucket\\",this,\\"cloud.Bucket\\");
-}
-}
-	
-	_toInflight() {
-	const my_resource_client = this._lift(this.my_resource);
-	const self_client_path = \\"./clients/First.inflight.js\\".replace(/\\\\\\\\/g, \\"/\\");
-	return $stdlib.core.NodeJsCode.fromInline(\`(new (require(\\"\${self_client_path}\\")).First({my_resource: \${my_resource_client}}))\`);
-}
-}
-First._annotateInflight(\\"$init\\", {\\"this.my_resource\\": { ops: [] }});
+      constructor(scope, id, ) {
+        super(scope, id);
+        this.my_resource = this.node.root.newAbstract(\\"@winglang/sdk.cloud.Bucket\\",this,\\"cloud.Bucket\\");
+      }
+      _toInflight() {
+        const my_resource_client = this._lift(this.my_resource);
+        const self_client_path = \\"./clients/First.inflight.js\\".replace(/\\\\\\\\/g, \\"/\\");
+        return $stdlib.core.NodeJsCode.fromInline(\`
+          (new (require(\\"\${self_client_path}\\")).First({
+            my_resource: \${my_resource_client},
+          }))
+        \`);
+      }
+    }
+    First._annotateInflight(\\"$init\\", {\\"this.my_resource\\": { ops: [] }});
     class Another extends $stdlib.core.Resource {
-	constructor(scope, id, ) {
-	super(scope, id);
-{
-  this.my_field = \\"hello!\\";
-  this.first = new First(this,\\"First\\");
-}
-}
-	
-	_toInflight() {
-	const first_client = this._lift(this.first);
-const my_field_client = this._lift(this.my_field);
-	const self_client_path = \\"./clients/Another.inflight.js\\".replace(/\\\\\\\\/g, \\"/\\");
-	return $stdlib.core.NodeJsCode.fromInline(\`(new (require(\\"\${self_client_path}\\")).Another({first: \${first_client}, my_field: \${my_field_client}}))\`);
-}
-}
-Another._annotateInflight(\\"meaning_of_life\\", {});
-Another._annotateInflight(\\"another_func\\", {});
-Another._annotateInflight(\\"$init\\", {\\"this.first\\": { ops: [] },\\"this.my_field\\": { ops: [] }});
+      constructor(scope, id, ) {
+        super(scope, id);
+        this.my_field = \\"hello!\\";
+        this.first = new First(this,\\"First\\");
+      }
+      _toInflight() {
+        const first_client = this._lift(this.first);
+        const my_field_client = this._lift(this.my_field);
+        const self_client_path = \\"./clients/Another.inflight.js\\".replace(/\\\\\\\\/g, \\"/\\");
+        return $stdlib.core.NodeJsCode.fromInline(\`
+          (new (require(\\"\${self_client_path}\\")).Another({
+            first: \${first_client},
+            my_field: \${my_field_client},
+          }))
+        \`);
+      }
+    }
+    Another._annotateInflight(\\"meaning_of_life\\", {});
+    Another._annotateInflight(\\"another_func\\", {});
+    Another._annotateInflight(\\"$init\\", {\\"this.first\\": { ops: [] },\\"this.my_field\\": { ops: [] }});
     class MyResource extends $stdlib.core.Resource {
-	constructor(scope, id, external_bucket, external_num) {
-	super(scope, id);
-{
-  this.my_resource = this.node.root.newAbstract(\\"@winglang/sdk.cloud.Bucket\\",this,\\"cloud.Bucket\\");
-  this.my_str = \\"my_string\\";
-  this.my_num = 42;
-  this.my_bool = true;
-  this.array_of_str = Object.freeze([\\"s1\\", \\"s2\\"]);
-  this.map_of_num = Object.freeze({\\"k1\\":11,\\"k2\\":22});
-  this.set_of_str = Object.freeze(new Set([\\"s1\\", \\"s2\\", \\"s1\\"]));
-  this.another = new Another(this,\\"Another\\");
-  this.my_queue = this.node.root.newAbstract(\\"@winglang/sdk.cloud.Queue\\",this,\\"cloud.Queue\\");
-  this.ext_bucket = external_bucket;
-  this.ext_num = external_num;
-  this.unused_resource = this.node.root.newAbstract(\\"@winglang/sdk.cloud.Counter\\",this,\\"cloud.Counter\\");
-}
-}
-	 hello_preflight()  {
-	{
-  return this.another;
-}
-}
-	_toInflight() {
-	const another_client = this._lift(this.another);
-const array_of_str_client = this._lift(this.array_of_str);
-const ext_bucket_client = this._lift(this.ext_bucket);
-const ext_num_client = this._lift(this.ext_num);
-const map_of_num_client = this._lift(this.map_of_num);
-const my_bool_client = this._lift(this.my_bool);
-const my_num_client = this._lift(this.my_num);
-const my_queue_client = this._lift(this.my_queue);
-const my_resource_client = this._lift(this.my_resource);
-const my_str_client = this._lift(this.my_str);
-const set_of_str_client = this._lift(this.set_of_str);
-const unused_resource_client = this._lift(this.unused_resource);
-	const self_client_path = \\"./clients/MyResource.inflight.js\\".replace(/\\\\\\\\/g, \\"/\\");
-	return $stdlib.core.NodeJsCode.fromInline(\`(new (require(\\"\${self_client_path}\\")).MyResource({another: \${another_client}, array_of_str: \${array_of_str_client}, ext_bucket: \${ext_bucket_client}, ext_num: \${ext_num_client}, map_of_num: \${map_of_num_client}, my_bool: \${my_bool_client}, my_num: \${my_num_client}, my_queue: \${my_queue_client}, my_resource: \${my_resource_client}, my_str: \${my_str_client}, set_of_str: \${set_of_str_client}, unused_resource: \${unused_resource_client}}))\`);
-}
-}
-MyResource._annotateInflight(\\"test_no_capture\\", {});
-MyResource._annotateInflight(\\"test_capture_collections_of_data\\", {\\"this.array_of_str\\": { ops: [\\"at\\",\\"length\\"] },\\"this.map_of_num\\": { ops: [\\"get\\"] },\\"this.set_of_str\\": { ops: [\\"has\\"] }});
-MyResource._annotateInflight(\\"test_capture_primitives\\", {\\"this.my_bool\\": { ops: [] },\\"this.my_num\\": { ops: [] },\\"this.my_str\\": { ops: [] }});
-MyResource._annotateInflight(\\"test_capture_resource\\", {\\"this.my_resource\\": { ops: [\\"get\\",\\"list\\",\\"put\\"] }});
-MyResource._annotateInflight(\\"test_nested_preflight_field\\", {\\"this.another.my_field\\": { ops: [] }});
-MyResource._annotateInflight(\\"test_nested_resource\\", {\\"this.another.first.my_resource\\": { ops: [\\"get\\",\\"list\\",\\"put\\"] },\\"this.my_str\\": { ops: [] }});
-MyResource._annotateInflight(\\"test_expression_recursive\\", {\\"this.my_queue\\": { ops: [\\"push\\"] },\\"this.my_str\\": { ops: [] }});
-MyResource._annotateInflight(\\"test_external\\", {\\"this.ext_bucket\\": { ops: [\\"list\\"] },\\"this.ext_num\\": { ops: [] }});
-MyResource._annotateInflight(\\"test_user_defined_resource\\", {\\"this.another\\": { ops: [\\"another_func\\",\\"meaning_of_life\\"] }});
-MyResource._annotateInflight(\\"test_inflight_field\\", {});
-MyResource._annotateInflight(\\"$init\\", {\\"this.another\\": { ops: [] },\\"this.array_of_str\\": { ops: [] },\\"this.ext_bucket\\": { ops: [] },\\"this.ext_num\\": { ops: [] },\\"this.map_of_num\\": { ops: [] },\\"this.my_bool\\": { ops: [] },\\"this.my_num\\": { ops: [] },\\"this.my_queue\\": { ops: [] },\\"this.my_resource\\": { ops: [] },\\"this.my_str\\": { ops: [] },\\"this.set_of_str\\": { ops: [] },\\"this.unused_resource\\": { ops: [] }});
+      constructor(scope, id, external_bucket, external_num) {
+        super(scope, id);
+        this.my_resource = this.node.root.newAbstract(\\"@winglang/sdk.cloud.Bucket\\",this,\\"cloud.Bucket\\");
+        this.my_str = \\"my_string\\";
+        this.my_num = 42;
+        this.my_bool = true;
+        this.array_of_str = Object.freeze([\\"s1\\", \\"s2\\"]);
+        this.map_of_num = Object.freeze({\\"k1\\":11,\\"k2\\":22});
+        this.set_of_str = Object.freeze(new Set([\\"s1\\", \\"s2\\", \\"s1\\"]));
+        this.another = new Another(this,\\"Another\\");
+        this.my_queue = this.node.root.newAbstract(\\"@winglang/sdk.cloud.Queue\\",this,\\"cloud.Queue\\");
+        this.ext_bucket = external_bucket;
+        this.ext_num = external_num;
+        this.unused_resource = this.node.root.newAbstract(\\"@winglang/sdk.cloud.Counter\\",this,\\"cloud.Counter\\");
+      }
+       hello_preflight()  {
+        {
+          return this.another;
+        }
+      }
+      _toInflight() {
+        const another_client = this._lift(this.another);
+        const array_of_str_client = this._lift(this.array_of_str);
+        const ext_bucket_client = this._lift(this.ext_bucket);
+        const ext_num_client = this._lift(this.ext_num);
+        const map_of_num_client = this._lift(this.map_of_num);
+        const my_bool_client = this._lift(this.my_bool);
+        const my_num_client = this._lift(this.my_num);
+        const my_queue_client = this._lift(this.my_queue);
+        const my_resource_client = this._lift(this.my_resource);
+        const my_str_client = this._lift(this.my_str);
+        const set_of_str_client = this._lift(this.set_of_str);
+        const unused_resource_client = this._lift(this.unused_resource);
+        const self_client_path = \\"./clients/MyResource.inflight.js\\".replace(/\\\\\\\\/g, \\"/\\");
+        return $stdlib.core.NodeJsCode.fromInline(\`
+          (new (require(\\"\${self_client_path}\\")).MyResource({
+            another: \${another_client},
+            array_of_str: \${array_of_str_client},
+            ext_bucket: \${ext_bucket_client},
+            ext_num: \${ext_num_client},
+            map_of_num: \${map_of_num_client},
+            my_bool: \${my_bool_client},
+            my_num: \${my_num_client},
+            my_queue: \${my_queue_client},
+            my_resource: \${my_resource_client},
+            my_str: \${my_str_client},
+            set_of_str: \${set_of_str_client},
+            unused_resource: \${unused_resource_client},
+          }))
+        \`);
+      }
+    }
+    MyResource._annotateInflight(\\"test_no_capture\\", {});
+    MyResource._annotateInflight(\\"test_capture_collections_of_data\\", {\\"this.array_of_str\\": { ops: [\\"at\\",\\"length\\"] },\\"this.map_of_num\\": { ops: [\\"get\\"] },\\"this.set_of_str\\": { ops: [\\"has\\"] }});
+    MyResource._annotateInflight(\\"test_capture_primitives\\", {\\"this.my_bool\\": { ops: [] },\\"this.my_num\\": { ops: [] },\\"this.my_str\\": { ops: [] }});
+    MyResource._annotateInflight(\\"test_capture_resource\\", {\\"this.my_resource\\": { ops: [\\"get\\",\\"list\\",\\"put\\"] }});
+    MyResource._annotateInflight(\\"test_nested_preflight_field\\", {\\"this.another.my_field\\": { ops: [] }});
+    MyResource._annotateInflight(\\"test_nested_resource\\", {\\"this.another.first.my_resource\\": { ops: [\\"get\\",\\"list\\",\\"put\\"] },\\"this.my_str\\": { ops: [] }});
+    MyResource._annotateInflight(\\"test_expression_recursive\\", {\\"this.my_queue\\": { ops: [\\"push\\"] },\\"this.my_str\\": { ops: [] }});
+    MyResource._annotateInflight(\\"test_external\\", {\\"this.ext_bucket\\": { ops: [\\"list\\"] },\\"this.ext_num\\": { ops: [] }});
+    MyResource._annotateInflight(\\"test_user_defined_resource\\", {\\"this.another\\": { ops: [\\"another_func\\",\\"meaning_of_life\\"] }});
+    MyResource._annotateInflight(\\"test_inflight_field\\", {});
+    MyResource._annotateInflight(\\"$init\\", {\\"this.another\\": { ops: [] },\\"this.array_of_str\\": { ops: [] },\\"this.ext_bucket\\": { ops: [] },\\"this.ext_num\\": { ops: [] },\\"this.map_of_num\\": { ops: [] },\\"this.my_bool\\": { ops: [] },\\"this.my_num\\": { ops: [] },\\"this.my_queue\\": { ops: [] },\\"this.my_resource\\": { ops: [] },\\"this.my_str\\": { ops: [] },\\"this.set_of_str\\": { ops: [] },\\"this.unused_resource\\": { ops: [] }});
     const b = this.node.root.newAbstract(\\"@winglang/sdk.cloud.Bucket\\",this,\\"cloud.Bucket\\");
     const r = new MyResource(this,\\"MyResource\\",b,12);
     this.node.root.newAbstract(\\"@winglang/sdk.cloud.Function\\",this,\\"test\\",new $stdlib.core.Inflight(this, \\"$Inflight1\\", {
-  code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.036fd96aa6897235ab34914959c244c2e2cd336a59d3482f555cb6f4da320b4c/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
-  bindings: {
-    r: {
-      obj: r,
-      ops: [\\"test_capture_collections_of_data\\",\\"test_capture_primitives\\",\\"test_capture_resource\\",\\"test_expression_recursive\\",\\"test_external\\",\\"test_inflight_field\\",\\"test_nested_preflight_field\\",\\"test_nested_resource\\",\\"test_no_capture\\",\\"test_user_defined_resource\\"]
-    },
-  }
-}));
+      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.1c768d827b63c794c9b5f5796a8c77938cd1b026ff59a651cd87493ddfd49b22/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
+      bindings: {
+        r: {
+          obj: r,
+          ops: [\\"test_capture_collections_of_data\\",\\"test_capture_primitives\\",\\"test_capture_resource\\",\\"test_expression_recursive\\",\\"test_external\\",\\"test_inflight_field\\",\\"test_nested_preflight_field\\",\\"test_nested_resource\\",\\"test_no_capture\\",\\"test_user_defined_resource\\"]
+        },
+      }
+    })
+    );
   }
 }
-
 class $App extends $AppBase {
   constructor() {
     super({ outdir: $outdir, name: \\"resource_captures\\", plugins: $plugins, isTestEnvironment: $wing_is_test });
@@ -539,23 +557,27 @@ class $App extends $AppBase {
     }
   }
 }
-
-new $App().synth();"
+new $App().synth();
+"
 `;
 
-exports[`wing compile -t tf-aws > proc.036fd96aa6897235ab34914959c244c2e2cd336a59d3482f555cb6f4da320b4c/index.js 1`] = `
-"async handle() { const { r } = this; {
-  (await r.test_no_capture());
-  (await r.test_capture_collections_of_data());
-  (await r.test_capture_primitives());
-  (await r.test_capture_resource());
-  (await r.test_nested_preflight_field());
-  (await r.test_nested_resource());
-  (await r.test_expression_recursive());
-  (await r.test_external());
-  (await r.test_user_defined_resource());
-  (await r.test_inflight_field());
-} };"
+exports[`wing compile -t tf-aws > proc.1c768d827b63c794c9b5f5796a8c77938cd1b026ff59a651cd87493ddfd49b22/index.js 1`] = `
+"async handle() {
+  const { r } = this;
+  {
+    (await r.test_no_capture());
+    (await r.test_capture_collections_of_data());
+    (await r.test_capture_primitives());
+    (await r.test_capture_resource());
+    (await r.test_nested_preflight_field());
+    (await r.test_nested_resource());
+    (await r.test_expression_recursive());
+    (await r.test_external());
+    (await r.test_user_defined_resource());
+    (await r.test_inflight_field());
+  }
+};
+"
 `;
 
 exports[`wing test -t sim > stdout 1`] = `

--- a/tools/hangar/__snapshots__/test_corpus/valid/resource_captures.w.ts.snap
+++ b/tools/hangar/__snapshots__/test_corpus/valid/resource_captures.w.ts.snap
@@ -531,7 +531,7 @@ class $Root extends $stdlib.core.Resource {
     const b = this.node.root.newAbstract(\\"@winglang/sdk.cloud.Bucket\\",this,\\"cloud.Bucket\\");
     const r = new MyResource(this,\\"MyResource\\",b,12);
     this.node.root.newAbstract(\\"@winglang/sdk.cloud.Function\\",this,\\"test\\",new $stdlib.core.Inflight(this, \\"$Inflight1\\", {
-      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.1c768d827b63c794c9b5f5796a8c77938cd1b026ff59a651cd87493ddfd49b22/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
+      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.ec2c78b051aaf1991ae27a24d33eb54a2c0485ae738faa96c461adbe5b703e28/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
       bindings: {
         r: {
           obj: r,
@@ -561,22 +561,20 @@ new $App().synth();
 "
 `;
 
-exports[`wing compile -t tf-aws > proc.1c768d827b63c794c9b5f5796a8c77938cd1b026ff59a651cd87493ddfd49b22/index.js 1`] = `
+exports[`wing compile -t tf-aws > proc.ec2c78b051aaf1991ae27a24d33eb54a2c0485ae738faa96c461adbe5b703e28/index.js 1`] = `
 "async handle() {
   const { r } = this;
-  {
-    (await r.test_no_capture());
-    (await r.test_capture_collections_of_data());
-    (await r.test_capture_primitives());
-    (await r.test_capture_resource());
-    (await r.test_nested_preflight_field());
-    (await r.test_nested_resource());
-    (await r.test_expression_recursive());
-    (await r.test_external());
-    (await r.test_user_defined_resource());
-    (await r.test_inflight_field());
-  }
-};
+  (await r.test_no_capture());
+  (await r.test_capture_collections_of_data());
+  (await r.test_capture_primitives());
+  (await r.test_capture_resource());
+  (await r.test_nested_preflight_field());
+  (await r.test_nested_resource());
+  (await r.test_expression_recursive());
+  (await r.test_external());
+  (await r.test_user_defined_resource());
+  (await r.test_inflight_field());
+}
 "
 `;
 

--- a/tools/hangar/__snapshots__/test_corpus/valid/statements_if.w.ts.snap
+++ b/tools/hangar/__snapshots__/test_corpus/valid/statements_if.w.ts.snap
@@ -172,7 +172,7 @@ class $Root extends $stdlib.core.Resource {
       }
     }
     this.node.root.newAbstract(\\"@winglang/sdk.cloud.Function\\",this,\\"test\\",new $stdlib.core.Inflight(this, \\"$Inflight1\\", {
-      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.22d204aca1b8ff984bc409f5d2843f91f9a67d8500b7d318ea167b2d4a29677c/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
+      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.ab279327be755396ddd6a86db98293e7b609ca1f861184371a84a7d4cd59487b/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
       bindings: {
       }
     })
@@ -198,32 +198,30 @@ new $App().synth();
 "
 `;
 
-exports[`wing compile -t tf-aws > proc.22d204aca1b8ff984bc409f5d2843f91f9a67d8500b7d318ea167b2d4a29677c/index.js 1`] = `
+exports[`wing compile -t tf-aws > proc.ab279327be755396ddd6a86db98293e7b609ca1f861184371a84a7d4cd59487b/index.js 1`] = `
 "async handle(s) {
   const {  } = this;
-  {
-    if (true) {
-      const x = 2;
-      if ((true && ((x + 2) === 4))) {
-        if ((true && ((x + 3) === 4))) {
-          {((cond) => {if (!cond) throw new Error(\`assertion failed: 'false'\`)})(false)};
-        }
-        else if ((true && ((x + 3) === 6))) {
-          {((cond) => {if (!cond) throw new Error(\`assertion failed: 'false'\`)})(false)};
-        }
-        else if ((false || ((x + 3) === 5))) {
-          {((cond) => {if (!cond) throw new Error(\`assertion failed: 'true'\`)})(true)};
-        }
-        else {
-          {((cond) => {if (!cond) throw new Error(\`assertion failed: 'false'\`)})(false)};
-        }
+  if (true) {
+    const x = 2;
+    if ((true && ((x + 2) === 4))) {
+      if ((true && ((x + 3) === 4))) {
+        {((cond) => {if (!cond) throw new Error(\`assertion failed: 'false'\`)})(false)};
+      }
+      else if ((true && ((x + 3) === 6))) {
+        {((cond) => {if (!cond) throw new Error(\`assertion failed: 'false'\`)})(false)};
+      }
+      else if ((false || ((x + 3) === 5))) {
+        {((cond) => {if (!cond) throw new Error(\`assertion failed: 'true'\`)})(true)};
       }
       else {
         {((cond) => {if (!cond) throw new Error(\`assertion failed: 'false'\`)})(false)};
       }
     }
+    else {
+      {((cond) => {if (!cond) throw new Error(\`assertion failed: 'false'\`)})(false)};
+    }
   }
-};
+}
 "
 `;
 

--- a/tools/hangar/__snapshots__/test_corpus/valid/statements_if.w.ts.snap
+++ b/tools/hangar/__snapshots__/test_corpus/valid/statements_if.w.ts.snap
@@ -148,32 +148,37 @@ class $Root extends $stdlib.core.Resource {
   constructor(scope, id) {
     super(scope, id);
     if (true) {
-  const x = 2;
-  const f = false;
-  if ((true && ((x + 2) === 4))) {
-    if ((true && ((x + 3) === 4))) {
-      {((cond) => {if (!cond) throw new Error(\`assertion failed: 'false'\`)})(false)};
-    } else if ((true && ((x + 3) === 6))) {
-      {((cond) => {if (!cond) throw new Error(\`assertion failed: 'false'\`)})(false)};
-    } else if ((false || ((x + 3) === 5))) {
-      {((cond) => {if (!cond) throw new Error(\`assertion failed: 'true'\`)})(true)};
-    } else if ((!f)) {
-      {((cond) => {if (!cond) throw new Error(\`assertion failed: '(!(!(!f)))'\`)})((!(!(!f))))};
-    } else {
-      {((cond) => {if (!cond) throw new Error(\`assertion failed: 'false'\`)})(false)};
+      const x = 2;
+      const f = false;
+      if ((true && ((x + 2) === 4))) {
+        if ((true && ((x + 3) === 4))) {
+          {((cond) => {if (!cond) throw new Error(\`assertion failed: 'false'\`)})(false)};
+        }
+        else if ((true && ((x + 3) === 6))) {
+          {((cond) => {if (!cond) throw new Error(\`assertion failed: 'false'\`)})(false)};
+        }
+        else if ((false || ((x + 3) === 5))) {
+          {((cond) => {if (!cond) throw new Error(\`assertion failed: 'true'\`)})(true)};
+        }
+        else if ((!f)) {
+          {((cond) => {if (!cond) throw new Error(\`assertion failed: '(!(!(!f)))'\`)})((!(!(!f))))};
+        }
+        else {
+          {((cond) => {if (!cond) throw new Error(\`assertion failed: 'false'\`)})(false)};
+        }
+      }
+      else {
+        {((cond) => {if (!cond) throw new Error(\`assertion failed: 'false'\`)})(false)};
+      }
     }
-  } else {
-    {((cond) => {if (!cond) throw new Error(\`assertion failed: 'false'\`)})(false)};
-  }
-}
     this.node.root.newAbstract(\\"@winglang/sdk.cloud.Function\\",this,\\"test\\",new $stdlib.core.Inflight(this, \\"$Inflight1\\", {
-  code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.09c5e24751d9ba1246f91518f2f7f5c5d1102a09d0b1acff479ae27ad134090f/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
-  bindings: {
-  }
-}));
+      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.22d204aca1b8ff984bc409f5d2843f91f9a67d8500b7d318ea167b2d4a29677c/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
+      bindings: {
+      }
+    })
+    );
   }
 }
-
 class $App extends $AppBase {
   constructor() {
     super({ outdir: $outdir, name: \\"statements_if\\", plugins: $plugins, isTestEnvironment: $wing_is_test });
@@ -189,29 +194,37 @@ class $App extends $AppBase {
     }
   }
 }
-
-new $App().synth();"
+new $App().synth();
+"
 `;
 
-exports[`wing compile -t tf-aws > proc.09c5e24751d9ba1246f91518f2f7f5c5d1102a09d0b1acff479ae27ad134090f/index.js 1`] = `
-"async handle(s) { const {  } = this; {
-  if (true) {
-    const x = 2;
-    if ((true && ((x + 2) === 4))) {
-      if ((true && ((x + 3) === 4))) {
-        {((cond) => {if (!cond) throw new Error(\`assertion failed: 'false'\`)})(false)};
-      } else if ((true && ((x + 3) === 6))) {
-        {((cond) => {if (!cond) throw new Error(\`assertion failed: 'false'\`)})(false)};
-      } else if ((false || ((x + 3) === 5))) {
-        {((cond) => {if (!cond) throw new Error(\`assertion failed: 'true'\`)})(true)};
-      } else {
+exports[`wing compile -t tf-aws > proc.22d204aca1b8ff984bc409f5d2843f91f9a67d8500b7d318ea167b2d4a29677c/index.js 1`] = `
+"async handle(s) {
+  const {  } = this;
+  {
+    if (true) {
+      const x = 2;
+      if ((true && ((x + 2) === 4))) {
+        if ((true && ((x + 3) === 4))) {
+          {((cond) => {if (!cond) throw new Error(\`assertion failed: 'false'\`)})(false)};
+        }
+        else if ((true && ((x + 3) === 6))) {
+          {((cond) => {if (!cond) throw new Error(\`assertion failed: 'false'\`)})(false)};
+        }
+        else if ((false || ((x + 3) === 5))) {
+          {((cond) => {if (!cond) throw new Error(\`assertion failed: 'true'\`)})(true)};
+        }
+        else {
+          {((cond) => {if (!cond) throw new Error(\`assertion failed: 'false'\`)})(false)};
+        }
+      }
+      else {
         {((cond) => {if (!cond) throw new Error(\`assertion failed: 'false'\`)})(false)};
       }
-    } else {
-      {((cond) => {if (!cond) throw new Error(\`assertion failed: 'false'\`)})(false)};
     }
   }
-} };"
+};
+"
 `;
 
 exports[`wing test -t sim > stdout 1`] = `

--- a/tools/hangar/__snapshots__/test_corpus/valid/statements_variable_declarations.w.ts.snap
+++ b/tools/hangar/__snapshots__/test_corpus/valid/statements_variable_declarations.w.ts.snap
@@ -62,7 +62,6 @@ class $Root extends $stdlib.core.Resource {
     const y = x;
   }
 }
-
 class $App extends $AppBase {
   constructor() {
     super({ outdir: $outdir, name: \\"statements_variable_declarations\\", plugins: $plugins, isTestEnvironment: $wing_is_test });
@@ -78,8 +77,8 @@ class $App extends $AppBase {
     }
   }
 }
-
-new $App().synth();"
+new $App().synth();
+"
 `;
 
 exports[`wing test -t sim > stdout 1`] = `

--- a/tools/hangar/__snapshots__/test_corpus/valid/static_members.w.ts.snap
+++ b/tools/hangar/__snapshots__/test_corpus/valid/static_members.w.ts.snap
@@ -2,16 +2,17 @@
 
 exports[`wing compile -t tf-aws > clients/Foo.inflight.js 1`] = `
 "class Foo  {
-constructor({ instance_field }) {
-
-  this.instance_field = instance_field;
+  constructor({ instance_field }) {
+    this.instance_field = instance_field;
+  }
+  static async get_123()  {
+    {
+      return 123;
+    }
+  }
 }
-static async get_123()  {
-	{
-  return 123;
-}
-}}
-exports.Foo = Foo;"
+exports.Foo = Foo;
+"
 `;
 
 exports[`wing compile -t tf-aws > main.tf.json 1`] = `
@@ -162,36 +163,38 @@ class $Root extends $stdlib.core.Resource {
   constructor(scope, id) {
     super(scope, id);
     class Foo extends $stdlib.core.Resource {
-	constructor(scope, id, ) {
-	super(scope, id);
-{
-  this.instance_field = 100;
-}
-}
-	static m()  {
-	{
-  return 99;
-}
-}
-	_toInflight() {
-	const instance_field_client = this._lift(this.instance_field);
-	const self_client_path = \\"./clients/Foo.inflight.js\\".replace(/\\\\\\\\/g, \\"/\\");
-	return $stdlib.core.NodeJsCode.fromInline(\`(new (require(\\"\${self_client_path}\\")).Foo({instance_field: \${instance_field_client}}))\`);
-}
-}
-Foo._annotateInflight(\\"get_123\\", {});
-Foo._annotateInflight(\\"$init\\", {\\"this.instance_field\\": { ops: [] }});
+      constructor(scope, id, ) {
+        super(scope, id);
+        this.instance_field = 100;
+      }
+      static m()  {
+        {
+          return 99;
+        }
+      }
+      _toInflight() {
+        const instance_field_client = this._lift(this.instance_field);
+        const self_client_path = \\"./clients/Foo.inflight.js\\".replace(/\\\\\\\\/g, \\"/\\");
+        return $stdlib.core.NodeJsCode.fromInline(\`
+          (new (require(\\"\${self_client_path}\\")).Foo({
+            instance_field: \${instance_field_client},
+          }))
+        \`);
+      }
+    }
+    Foo._annotateInflight(\\"get_123\\", {});
+    Foo._annotateInflight(\\"$init\\", {\\"this.instance_field\\": { ops: [] }});
     const foo = new Foo(this,\\"Foo\\");
     {((cond) => {if (!cond) throw new Error(\`assertion failed: '(foo.instance_field === 100)'\`)})((foo.instance_field === 100))};
     {((cond) => {if (!cond) throw new Error(\`assertion failed: '((Foo.m()) === 99)'\`)})(((Foo.m()) === 99))};
     this.node.root.newAbstract(\\"@winglang/sdk.cloud.Function\\",this,\\"test\\",new $stdlib.core.Inflight(this, \\"$Inflight1\\", {
-  code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.3e3ded5aab7ad84970aba71e51b0f5571a6ab4ed41f41ae3461d977097e72746/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
-  bindings: {
-  }
-}));
+      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.925ca3c54d8c43de82580ba0cc25640e1b5a3b2b52e253b6f784b637c42f7065/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
+      bindings: {
+      }
+    })
+    );
   }
 }
-
 class $App extends $AppBase {
   constructor() {
     super({ outdir: $outdir, name: \\"static_members\\", plugins: $plugins, isTestEnvironment: $wing_is_test });
@@ -207,34 +210,35 @@ class $App extends $AppBase {
     }
   }
 }
-
-new $App().synth();"
+new $App().synth();
+"
 `;
 
-exports[`wing compile -t tf-aws > proc.3e3ded5aab7ad84970aba71e51b0f5571a6ab4ed41f41ae3461d977097e72746/index.js 1`] = `
-"async handle(s) { const {  } = this; {
-  class InflightClass
+exports[`wing compile -t tf-aws > proc.925ca3c54d8c43de82580ba0cc25640e1b5a3b2b52e253b6f784b637c42f7065/index.js 1`] = `
+"async handle(s) {
+  const {  } = this;
   {
-  constructor()  {
-  	{
+    class InflightClass
+    {
+      constructor()  {
+      }
+      async inflight_method()  {
+        {
+          return \\"Inflight method\\";
+        }
+      }
+      static async static_inflight_method()  {
+        {
+          return \\"Static inflight method\\";
+        }
+      }
+    }
+    const inflight_class = new InflightClass();
+    {((cond) => {if (!cond) throw new Error(\`assertion failed: '((await inflight_class.inflight_method()) === \\"Inflight method\\")'\`)})(((await inflight_class.inflight_method()) === \\"Inflight method\\"))};
+    {((cond) => {if (!cond) throw new Error(\`assertion failed: '((await InflightClass.static_inflight_method()) === \\"Static inflight method\\")'\`)})(((await InflightClass.static_inflight_method()) === \\"Static inflight method\\"))};
   }
-  }
-  
-  async inflight_method()  {
-  	{
-    return \\"Inflight method\\";
-  }
-  }
-  static async static_inflight_method()  {
-  	{
-    return \\"Static inflight method\\";
-  }
-  }
-  }
-  const inflight_class = new InflightClass();
-  {((cond) => {if (!cond) throw new Error(\`assertion failed: '((await inflight_class.inflight_method()) === \\"Inflight method\\")'\`)})(((await inflight_class.inflight_method()) === \\"Inflight method\\"))};
-  {((cond) => {if (!cond) throw new Error(\`assertion failed: '((await InflightClass.static_inflight_method()) === \\"Static inflight method\\")'\`)})(((await InflightClass.static_inflight_method()) === \\"Static inflight method\\"))};
-} };"
+};
+"
 `;
 
 exports[`wing test -t sim > stdout 1`] = `

--- a/tools/hangar/__snapshots__/test_corpus/valid/static_members.w.ts.snap
+++ b/tools/hangar/__snapshots__/test_corpus/valid/static_members.w.ts.snap
@@ -188,7 +188,7 @@ class $Root extends $stdlib.core.Resource {
     {((cond) => {if (!cond) throw new Error(\`assertion failed: '(foo.instance_field === 100)'\`)})((foo.instance_field === 100))};
     {((cond) => {if (!cond) throw new Error(\`assertion failed: '((Foo.m()) === 99)'\`)})(((Foo.m()) === 99))};
     this.node.root.newAbstract(\\"@winglang/sdk.cloud.Function\\",this,\\"test\\",new $stdlib.core.Inflight(this, \\"$Inflight1\\", {
-      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.b87a8ef9c3cdcef23adecd4c0a180b9d3a6f333845a0f5fb255a43b5f49bea87/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
+      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.9bc2ebe720b1ce33f8961b4d75e64753d2833d1a50029354c9ccba5d429d01f2/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
       bindings: {
       }
     })
@@ -214,29 +214,27 @@ new $App().synth();
 "
 `;
 
-exports[`wing compile -t tf-aws > proc.b87a8ef9c3cdcef23adecd4c0a180b9d3a6f333845a0f5fb255a43b5f49bea87/index.js 1`] = `
+exports[`wing compile -t tf-aws > proc.9bc2ebe720b1ce33f8961b4d75e64753d2833d1a50029354c9ccba5d429d01f2/index.js 1`] = `
 "async handle(s) {
   const {  } = this;
-  {
-    class InflightClass {
-      constructor()  {
-      }
-      async inflight_method()  {
-        {
-          return \\"Inflight method\\";
-        }
-      }
-      static async static_inflight_method()  {
-        {
-          return \\"Static inflight method\\";
-        }
+  class InflightClass {
+    constructor()  {
+    }
+    async inflight_method()  {
+      {
+        return \\"Inflight method\\";
       }
     }
-    const inflight_class = new InflightClass();
-    {((cond) => {if (!cond) throw new Error(\`assertion failed: '((await inflight_class.inflight_method()) === \\"Inflight method\\")'\`)})(((await inflight_class.inflight_method()) === \\"Inflight method\\"))};
-    {((cond) => {if (!cond) throw new Error(\`assertion failed: '((await InflightClass.static_inflight_method()) === \\"Static inflight method\\")'\`)})(((await InflightClass.static_inflight_method()) === \\"Static inflight method\\"))};
+    static async static_inflight_method()  {
+      {
+        return \\"Static inflight method\\";
+      }
+    }
   }
-};
+  const inflight_class = new InflightClass();
+  {((cond) => {if (!cond) throw new Error(\`assertion failed: '((await inflight_class.inflight_method()) === \\"Inflight method\\")'\`)})(((await inflight_class.inflight_method()) === \\"Inflight method\\"))};
+  {((cond) => {if (!cond) throw new Error(\`assertion failed: '((await InflightClass.static_inflight_method()) === \\"Static inflight method\\")'\`)})(((await InflightClass.static_inflight_method()) === \\"Static inflight method\\"))};
+}
 "
 `;
 

--- a/tools/hangar/__snapshots__/test_corpus/valid/static_members.w.ts.snap
+++ b/tools/hangar/__snapshots__/test_corpus/valid/static_members.w.ts.snap
@@ -188,7 +188,7 @@ class $Root extends $stdlib.core.Resource {
     {((cond) => {if (!cond) throw new Error(\`assertion failed: '(foo.instance_field === 100)'\`)})((foo.instance_field === 100))};
     {((cond) => {if (!cond) throw new Error(\`assertion failed: '((Foo.m()) === 99)'\`)})(((Foo.m()) === 99))};
     this.node.root.newAbstract(\\"@winglang/sdk.cloud.Function\\",this,\\"test\\",new $stdlib.core.Inflight(this, \\"$Inflight1\\", {
-      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.925ca3c54d8c43de82580ba0cc25640e1b5a3b2b52e253b6f784b637c42f7065/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
+      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.b87a8ef9c3cdcef23adecd4c0a180b9d3a6f333845a0f5fb255a43b5f49bea87/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
       bindings: {
       }
     })
@@ -214,12 +214,11 @@ new $App().synth();
 "
 `;
 
-exports[`wing compile -t tf-aws > proc.925ca3c54d8c43de82580ba0cc25640e1b5a3b2b52e253b6f784b637c42f7065/index.js 1`] = `
+exports[`wing compile -t tf-aws > proc.b87a8ef9c3cdcef23adecd4c0a180b9d3a6f333845a0f5fb255a43b5f49bea87/index.js 1`] = `
 "async handle(s) {
   const {  } = this;
   {
-    class InflightClass
-    {
+    class InflightClass {
       constructor()  {
       }
       async inflight_method()  {

--- a/tools/hangar/__snapshots__/test_corpus/valid/std_containers.w.ts.snap
+++ b/tools/hangar/__snapshots__/test_corpus/valid/std_containers.w.ts.snap
@@ -100,7 +100,6 @@ class $Root extends $stdlib.core.Resource {
     {((cond) => {if (!cond) throw new Error(\`assertion failed: '((((nested_map)[\\"a\\"])[\\"b\\"])[\\"c\\"] === \\"hello\\")'\`)})(((((nested_map)[\\"a\\"])[\\"b\\"])[\\"c\\"] === \\"hello\\"))};
   }
 }
-
 class $App extends $AppBase {
   constructor() {
     super({ outdir: $outdir, name: \\"std_containers\\", plugins: $plugins, isTestEnvironment: $wing_is_test });
@@ -116,8 +115,8 @@ class $App extends $AppBase {
     }
   }
 }
-
-new $App().synth();"
+new $App().synth();
+"
 `;
 
 exports[`wing test -t sim > stdout 1`] = `

--- a/tools/hangar/__snapshots__/test_corpus/valid/std_string.w.ts.snap
+++ b/tools/hangar/__snapshots__/test_corpus/valid/std_string.w.ts.snap
@@ -164,21 +164,21 @@ class $Root extends $stdlib.core.Resource {
     {((cond) => {if (!cond) throw new Error(\`assertion failed: '((\\"   some string   \\".trim()) === \\"some string\\")'\`)})(((\\"   some string   \\".trim()) === \\"some string\\"))};
     {((cond) => {if (!cond) throw new Error(\`assertion failed: '(\\"Some String\\".toLocaleUpperCase() === \\"SOME STRING\\")'\`)})((\\"Some String\\".toLocaleUpperCase() === \\"SOME STRING\\"))};
     this.node.root.newAbstract(\\"@winglang/sdk.cloud.Function\\",this,\\"test:string\\",new $stdlib.core.Inflight(this, \\"$Inflight1\\", {
-  code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.0fb01e81c63b003d77d6245e36ba84561e3e2d3268e69a7c975f81cfe7565fac/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
-  bindings: {
-    s1: {
-      obj: s1,
-      ops: []
-    },
-    s2: {
-      obj: s2,
-      ops: []
-    },
-  }
-}));
+      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.8c40a38c834eef68537687d4004058847a9c893a956fab30a6c530f32e6b51f3/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
+      bindings: {
+        s1: {
+          obj: s1,
+          ops: []
+        },
+        s2: {
+          obj: s2,
+          ops: []
+        },
+      }
+    })
+    );
   }
 }
-
 class $App extends $AppBase {
   constructor() {
     super({ outdir: $outdir, name: \\"std_string\\", plugins: $plugins, isTestEnvironment: $wing_is_test });
@@ -194,16 +194,20 @@ class $App extends $AppBase {
     }
   }
 }
-
-new $App().synth();"
+new $App().synth();
+"
 `;
 
-exports[`wing compile -t tf-aws > proc.0fb01e81c63b003d77d6245e36ba84561e3e2d3268e69a7c975f81cfe7565fac/index.js 1`] = `
-"async handle() { const { s1, s2 } = this; {
-  {console.log(\`index of \\\\\\"s\\\\\\" in s1 is \${s1.indexOf(\\"s\\")}\`)};
-  {console.log((await (await s1.split(\\" \\")).at(1)))};
-  {console.log((await s1.concat(s2)))};
-} };"
+exports[`wing compile -t tf-aws > proc.8c40a38c834eef68537687d4004058847a9c893a956fab30a6c530f32e6b51f3/index.js 1`] = `
+"async handle() {
+  const { s1, s2 } = this;
+  {
+    {console.log(\`index of \\\\\\"s\\\\\\" in s1 is \${s1.indexOf(\\"s\\")}\`)};
+    {console.log((await (await s1.split(\\" \\")).at(1)))};
+    {console.log((await s1.concat(s2)))};
+  }
+};
+"
 `;
 
 exports[`wing test -t sim > stdout 1`] = `

--- a/tools/hangar/__snapshots__/test_corpus/valid/std_string.w.ts.snap
+++ b/tools/hangar/__snapshots__/test_corpus/valid/std_string.w.ts.snap
@@ -164,7 +164,7 @@ class $Root extends $stdlib.core.Resource {
     {((cond) => {if (!cond) throw new Error(\`assertion failed: '((\\"   some string   \\".trim()) === \\"some string\\")'\`)})(((\\"   some string   \\".trim()) === \\"some string\\"))};
     {((cond) => {if (!cond) throw new Error(\`assertion failed: '(\\"Some String\\".toLocaleUpperCase() === \\"SOME STRING\\")'\`)})((\\"Some String\\".toLocaleUpperCase() === \\"SOME STRING\\"))};
     this.node.root.newAbstract(\\"@winglang/sdk.cloud.Function\\",this,\\"test:string\\",new $stdlib.core.Inflight(this, \\"$Inflight1\\", {
-      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.8c40a38c834eef68537687d4004058847a9c893a956fab30a6c530f32e6b51f3/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
+      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.9a4846d755bc1e93d1377b973079b3fb455a5196a4309ea68138302e1a6f3f65/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
       bindings: {
         s1: {
           obj: s1,
@@ -198,15 +198,13 @@ new $App().synth();
 "
 `;
 
-exports[`wing compile -t tf-aws > proc.8c40a38c834eef68537687d4004058847a9c893a956fab30a6c530f32e6b51f3/index.js 1`] = `
+exports[`wing compile -t tf-aws > proc.9a4846d755bc1e93d1377b973079b3fb455a5196a4309ea68138302e1a6f3f65/index.js 1`] = `
 "async handle() {
   const { s1, s2 } = this;
-  {
-    {console.log(\`index of \\\\\\"s\\\\\\" in s1 is \${s1.indexOf(\\"s\\")}\`)};
-    {console.log((await (await s1.split(\\" \\")).at(1)))};
-    {console.log((await s1.concat(s2)))};
-  }
-};
+  {console.log(\`index of \\\\\\"s\\\\\\" in s1 is \${s1.indexOf(\\"s\\")}\`)};
+  {console.log((await (await s1.split(\\" \\")).at(1)))};
+  {console.log((await s1.concat(s2)))};
+}
 "
 `;
 

--- a/tools/hangar/__snapshots__/test_corpus/valid/structs.w.ts.snap
+++ b/tools/hangar/__snapshots__/test_corpus/valid/structs.w.ts.snap
@@ -2,16 +2,17 @@
 
 exports[`wing compile -t tf-aws > clients/Foo.inflight.js 1`] = `
 "class Foo  {
-constructor({ data }) {
-
-  this.data = data;
+  constructor({ data }) {
+    this.data = data;
+  }
+  async get_stuff()  {
+    {
+      return this.data.field0;
+    }
+  }
 }
-async get_stuff()  {
-	{
-  return this.data.field0;
-}
-}}
-exports.Foo = Foo;"
+exports.Foo = Foo;
+"
 `;
 
 exports[`wing compile -t tf-aws > main.tf.json 1`] = `
@@ -73,41 +74,41 @@ class $Root extends $stdlib.core.Resource {
   constructor(scope, id) {
     super(scope, id);
     class Foo extends $stdlib.core.Resource {
-	constructor(scope, id, b) {
-	super(scope, id);
-{
-  this.data = b;
-}
-}
-	
-	_toInflight() {
-	const data_client = this._lift(this.data);
-	const self_client_path = \\"./clients/Foo.inflight.js\\".replace(/\\\\\\\\/g, \\"/\\");
-	return $stdlib.core.NodeJsCode.fromInline(\`(new (require(\\"\${self_client_path}\\")).Foo({data: \${data_client}}))\`);
-}
-}
-Foo._annotateInflight(\\"get_stuff\\", {\\"this.data.field0\\": { ops: [] }});
-Foo._annotateInflight(\\"$init\\", {\\"this.data\\": { ops: [] }});
+      constructor(scope, id, b) {
+        super(scope, id);
+        this.data = b;
+      }
+      _toInflight() {
+        const data_client = this._lift(this.data);
+        const self_client_path = \\"./clients/Foo.inflight.js\\".replace(/\\\\\\\\/g, \\"/\\");
+        return $stdlib.core.NodeJsCode.fromInline(\`
+          (new (require(\\"\${self_client_path}\\")).Foo({
+            data: \${data_client},
+          }))
+        \`);
+      }
+    }
+    Foo._annotateInflight(\\"get_stuff\\", {\\"this.data.field0\\": { ops: [] }});
+    Foo._annotateInflight(\\"$init\\", {\\"this.data\\": { ops: [] }});
     const x = {
-\\"field0\\": \\"Sup\\",}
-;
+    \\"field0\\": \\"Sup\\",}
+    ;
     const y = {
-\\"field0\\": \\"hello\\",
-\\"field1\\": 1,
-\\"field2\\": \\"world\\",
-\\"field3\\": {
-\\"field0\\": \\"foo\\",}
-,}
-;
+    \\"field0\\": \\"hello\\",
+    \\"field1\\": 1,
+    \\"field2\\": \\"world\\",
+    \\"field3\\": {
+    \\"field0\\": \\"foo\\",}
+    ,}
+    ;
     {((cond) => {if (!cond) throw new Error(\`assertion failed: '(x.field0 === \\"Sup\\")'\`)})((x.field0 === \\"Sup\\"))};
     {((cond) => {if (!cond) throw new Error(\`assertion failed: '(y.field1 === 1)'\`)})((y.field1 === 1))};
     {((cond) => {if (!cond) throw new Error(\`assertion failed: '(y.field3.field0 === \\"foo\\")'\`)})((y.field3.field0 === \\"foo\\"))};
     const s = {
-\\"a\\": \\"Boom baby\\",}
-;
+    \\"a\\": \\"Boom baby\\",}
+    ;
   }
 }
-
 class $App extends $AppBase {
   constructor() {
     super({ outdir: $outdir, name: \\"structs\\", plugins: $plugins, isTestEnvironment: $wing_is_test });
@@ -123,8 +124,8 @@ class $App extends $AppBase {
     }
   }
 }
-
-new $App().synth();"
+new $App().synth();
+"
 `;
 
 exports[`wing test -t sim > stdout 1`] = `

--- a/tools/hangar/__snapshots__/test_corpus/valid/symbol_shadow.w.ts.snap
+++ b/tools/hangar/__snapshots__/test_corpus/valid/symbol_shadow.w.ts.snap
@@ -2,12 +2,11 @@
 
 exports[`wing compile -t tf-aws > clients/A.inflight.js 1`] = `
 "class A  {
-constructor({  }) {
-
-
+  constructor({  }) {
+  }
 }
-}
-exports.A = A;"
+exports.A = A;
+"
 `;
 
 exports[`wing compile -t tf-aws > main.tf.json 1`] = `
@@ -380,63 +379,65 @@ class $Root extends $stdlib.core.Resource {
   constructor(scope, id) {
     super(scope, id);
     class A extends $stdlib.core.Resource {
-	constructor(scope, id, ) {
-	super(scope, id);
-{
-  const s = \\"in_resource\\";
-  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(s === \\"in_resource\\")'\`)})((s === \\"in_resource\\"))};
-  this.node.root.newAbstract(\\"@winglang/sdk.cloud.Function\\",this,\\"test:inflight in resource should capture the right scoped var\\",new $stdlib.core.Inflight(this, \\"$Inflight1\\", {
-    code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.8da45132c1b6dfa15702b3431ec3c8a45d068e4170f3a4b3283f5fc13f7a0a23/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
-    bindings: {
-      s: {
-        obj: s,
-        ops: []
-      },
+      constructor(scope, id, ) {
+        super(scope, id);
+        const s = \\"in_resource\\";
+        {((cond) => {if (!cond) throw new Error(\`assertion failed: '(s === \\"in_resource\\")'\`)})((s === \\"in_resource\\"))};
+        this.node.root.newAbstract(\\"@winglang/sdk.cloud.Function\\",this,\\"test:inflight in resource should capture the right scoped var\\",new $stdlib.core.Inflight(this, \\"$Inflight1\\", {
+          code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.6f145f1c1667b0c745dad1218d1e1100135f3ab98d0837593c658ab9201c41a4/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
+          bindings: {
+            s: {
+              obj: s,
+              ops: []
+            },
+          }
+        })
+        );
+      }
+      _toInflight() {
+        const self_client_path = \\"./clients/A.inflight.js\\".replace(/\\\\\\\\/g, \\"/\\");
+        return $stdlib.core.NodeJsCode.fromInline(\`
+          (new (require(\\"\${self_client_path}\\")).A({
+          }))
+        \`);
+      }
     }
-  }));
-}
-}
-	
-	_toInflight() {
-	
-	const self_client_path = \\"./clients/A.inflight.js\\".replace(/\\\\\\\\/g, \\"/\\");
-	return $stdlib.core.NodeJsCode.fromInline(\`(new (require(\\"\${self_client_path}\\")).A({}))\`);
-}
-}
-A._annotateInflight(\\"$init\\", {});
+    A._annotateInflight(\\"$init\\", {});
     const s = \\"top\\";
     if (true) {
-  const s = \\"inner\\";
-  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(s === \\"inner\\")'\`)})((s === \\"inner\\"))};
-  this.node.root.newAbstract(\\"@winglang/sdk.cloud.Function\\",this,\\"test:inflight nested should not capture the shadowed var\\",new $stdlib.core.Inflight(this, \\"$Inflight2\\", {
-    code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.cb5d71e68f43465f5d19d7f088bcec25b88020553caf1d69c04d5ca4ed5d207f/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
-    bindings: {
-      s: {
-        obj: s,
-        ops: []
-      },
+      const s = \\"inner\\";
+      {((cond) => {if (!cond) throw new Error(\`assertion failed: '(s === \\"inner\\")'\`)})((s === \\"inner\\"))};
+      this.node.root.newAbstract(\\"@winglang/sdk.cloud.Function\\",this,\\"test:inflight nested should not capture the shadowed var\\",new $stdlib.core.Inflight(this, \\"$Inflight2\\", {
+        code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.af52510e3810b6a52643caef46ebd071fddd767e2dc59b6f5d0b03f11a4a9ca0/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
+        bindings: {
+          s: {
+            obj: s,
+            ops: []
+          },
+        }
+      })
+      );
     }
-  }));
-}
     {((cond) => {if (!cond) throw new Error(\`assertion failed: '(s === \\"top\\")'\`)})((s === \\"top\\"))};
     new A(this,\\"A\\");
     this.node.root.newAbstract(\\"@winglang/sdk.cloud.Function\\",this,\\"test:inflight on top should capture top\\",new $stdlib.core.Inflight(this, \\"$Inflight3\\", {
-  code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.62da13ae32a0ac59873b38f570f2c36bb56acdf4cbc8c53bf38c5e409025bb02/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
-  bindings: {
-    s: {
-      obj: s,
-      ops: []
-    },
-  }
-}));
+      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.fb1a0ad83796bec8198b3ebbbf88934ea550d5429911f4844b47cd85f6ab1dc6/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
+      bindings: {
+        s: {
+          obj: s,
+          ops: []
+        },
+      }
+    })
+    );
     this.node.root.newAbstract(\\"@winglang/sdk.cloud.Function\\",this,\\"test:inside_inflight should capture the right scope\\",new $stdlib.core.Inflight(this, \\"$Inflight4\\", {
-  code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.58071421b869be15b2d199413c5dc715991c0a650cffd6235b0a0cbf57c1e4dd/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
-  bindings: {
-  }
-}));
+      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.130e03bf9d83a1f15b6b08ad4c5bf247883a3f8c720a64c4e088ac17f0871678/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
+      bindings: {
+      }
+    })
+    );
   }
 }
-
 class $App extends $AppBase {
   constructor() {
     super({ outdir: $outdir, name: \\"symbol_shadow\\", plugins: $plugins, isTestEnvironment: $wing_is_test });
@@ -452,33 +453,49 @@ class $App extends $AppBase {
     }
   }
 }
-
-new $App().synth();"
+new $App().synth();
+"
 `;
 
-exports[`wing compile -t tf-aws > proc.8da45132c1b6dfa15702b3431ec3c8a45d068e4170f3a4b3283f5fc13f7a0a23/index.js 1`] = `
-"async handle() { const { s } = this; {
-  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(s === \\"in_resource\\")'\`)})((s === \\"in_resource\\"))};
-} };"
+exports[`wing compile -t tf-aws > proc.6f145f1c1667b0c745dad1218d1e1100135f3ab98d0837593c658ab9201c41a4/index.js 1`] = `
+"async handle() {
+  const { s } = this;
+  {
+    {((cond) => {if (!cond) throw new Error(\`assertion failed: '(s === \\"in_resource\\")'\`)})((s === \\"in_resource\\"))};
+  }
+};
+"
 `;
 
-exports[`wing compile -t tf-aws > proc.62da13ae32a0ac59873b38f570f2c36bb56acdf4cbc8c53bf38c5e409025bb02/index.js 1`] = `
-"async handle() { const { s } = this; {
-  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(s === \\"top\\")'\`)})((s === \\"top\\"))};
-} };"
+exports[`wing compile -t tf-aws > proc.130e03bf9d83a1f15b6b08ad4c5bf247883a3f8c720a64c4e088ac17f0871678/index.js 1`] = `
+"async handle() {
+  const {  } = this;
+  {
+    const s = \\"inside_inflight\\";
+    {((cond) => {if (!cond) throw new Error(\`assertion failed: '(s === \\"inside_inflight\\")'\`)})((s === \\"inside_inflight\\"))};
+  }
+};
+"
 `;
 
-exports[`wing compile -t tf-aws > proc.58071421b869be15b2d199413c5dc715991c0a650cffd6235b0a0cbf57c1e4dd/index.js 1`] = `
-"async handle() { const {  } = this; {
-  const s = \\"inside_inflight\\";
-  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(s === \\"inside_inflight\\")'\`)})((s === \\"inside_inflight\\"))};
-} };"
+exports[`wing compile -t tf-aws > proc.af52510e3810b6a52643caef46ebd071fddd767e2dc59b6f5d0b03f11a4a9ca0/index.js 1`] = `
+"async handle() {
+  const { s } = this;
+  {
+    {((cond) => {if (!cond) throw new Error(\`assertion failed: '(s === \\"inner\\")'\`)})((s === \\"inner\\"))};
+  }
+};
+"
 `;
 
-exports[`wing compile -t tf-aws > proc.cb5d71e68f43465f5d19d7f088bcec25b88020553caf1d69c04d5ca4ed5d207f/index.js 1`] = `
-"async handle() { const { s } = this; {
-  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(s === \\"inner\\")'\`)})((s === \\"inner\\"))};
-} };"
+exports[`wing compile -t tf-aws > proc.fb1a0ad83796bec8198b3ebbbf88934ea550d5429911f4844b47cd85f6ab1dc6/index.js 1`] = `
+"async handle() {
+  const { s } = this;
+  {
+    {((cond) => {if (!cond) throw new Error(\`assertion failed: '(s === \\"top\\")'\`)})((s === \\"top\\"))};
+  }
+};
+"
 `;
 
 exports[`wing test -t sim > stdout 1`] = `

--- a/tools/hangar/__snapshots__/test_corpus/valid/symbol_shadow.w.ts.snap
+++ b/tools/hangar/__snapshots__/test_corpus/valid/symbol_shadow.w.ts.snap
@@ -384,7 +384,7 @@ class $Root extends $stdlib.core.Resource {
         const s = \\"in_resource\\";
         {((cond) => {if (!cond) throw new Error(\`assertion failed: '(s === \\"in_resource\\")'\`)})((s === \\"in_resource\\"))};
         this.node.root.newAbstract(\\"@winglang/sdk.cloud.Function\\",this,\\"test:inflight in resource should capture the right scoped var\\",new $stdlib.core.Inflight(this, \\"$Inflight1\\", {
-          code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.6f145f1c1667b0c745dad1218d1e1100135f3ab98d0837593c658ab9201c41a4/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
+          code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.e28eb0e2c84db9ebf39c60f781e33eb71437de9aea3c9e56527b5592b0d7f259/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
           bindings: {
             s: {
               obj: s,
@@ -408,7 +408,7 @@ class $Root extends $stdlib.core.Resource {
       const s = \\"inner\\";
       {((cond) => {if (!cond) throw new Error(\`assertion failed: '(s === \\"inner\\")'\`)})((s === \\"inner\\"))};
       this.node.root.newAbstract(\\"@winglang/sdk.cloud.Function\\",this,\\"test:inflight nested should not capture the shadowed var\\",new $stdlib.core.Inflight(this, \\"$Inflight2\\", {
-        code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.af52510e3810b6a52643caef46ebd071fddd767e2dc59b6f5d0b03f11a4a9ca0/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
+        code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.df438ca6138f58185d9c29cf9a58e1569a2c82980ef45ec3e718c6491e53bbbd/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
         bindings: {
           s: {
             obj: s,
@@ -421,7 +421,7 @@ class $Root extends $stdlib.core.Resource {
     {((cond) => {if (!cond) throw new Error(\`assertion failed: '(s === \\"top\\")'\`)})((s === \\"top\\"))};
     new A(this,\\"A\\");
     this.node.root.newAbstract(\\"@winglang/sdk.cloud.Function\\",this,\\"test:inflight on top should capture top\\",new $stdlib.core.Inflight(this, \\"$Inflight3\\", {
-      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.fb1a0ad83796bec8198b3ebbbf88934ea550d5429911f4844b47cd85f6ab1dc6/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
+      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.5ebfc1356186fe498d7c77085bf74da82ee2b4cc0d3396d5e240d89a689f5a70/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
       bindings: {
         s: {
           obj: s,
@@ -431,7 +431,7 @@ class $Root extends $stdlib.core.Resource {
     })
     );
     this.node.root.newAbstract(\\"@winglang/sdk.cloud.Function\\",this,\\"test:inside_inflight should capture the right scope\\",new $stdlib.core.Inflight(this, \\"$Inflight4\\", {
-      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.130e03bf9d83a1f15b6b08ad4c5bf247883a3f8c720a64c4e088ac17f0871678/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
+      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.b1aa79217b40a2b129132f76b7120cde0cb1ecc3a4b68bf48ee31594fa38cc4b/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
       bindings: {
       }
     })
@@ -457,44 +457,36 @@ new $App().synth();
 "
 `;
 
-exports[`wing compile -t tf-aws > proc.6f145f1c1667b0c745dad1218d1e1100135f3ab98d0837593c658ab9201c41a4/index.js 1`] = `
+exports[`wing compile -t tf-aws > proc.5ebfc1356186fe498d7c77085bf74da82ee2b4cc0d3396d5e240d89a689f5a70/index.js 1`] = `
 "async handle() {
   const { s } = this;
-  {
-    {((cond) => {if (!cond) throw new Error(\`assertion failed: '(s === \\"in_resource\\")'\`)})((s === \\"in_resource\\"))};
-  }
-};
+  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(s === \\"top\\")'\`)})((s === \\"top\\"))};
+}
 "
 `;
 
-exports[`wing compile -t tf-aws > proc.130e03bf9d83a1f15b6b08ad4c5bf247883a3f8c720a64c4e088ac17f0871678/index.js 1`] = `
+exports[`wing compile -t tf-aws > proc.b1aa79217b40a2b129132f76b7120cde0cb1ecc3a4b68bf48ee31594fa38cc4b/index.js 1`] = `
 "async handle() {
   const {  } = this;
-  {
-    const s = \\"inside_inflight\\";
-    {((cond) => {if (!cond) throw new Error(\`assertion failed: '(s === \\"inside_inflight\\")'\`)})((s === \\"inside_inflight\\"))};
-  }
-};
+  const s = \\"inside_inflight\\";
+  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(s === \\"inside_inflight\\")'\`)})((s === \\"inside_inflight\\"))};
+}
 "
 `;
 
-exports[`wing compile -t tf-aws > proc.af52510e3810b6a52643caef46ebd071fddd767e2dc59b6f5d0b03f11a4a9ca0/index.js 1`] = `
+exports[`wing compile -t tf-aws > proc.df438ca6138f58185d9c29cf9a58e1569a2c82980ef45ec3e718c6491e53bbbd/index.js 1`] = `
 "async handle() {
   const { s } = this;
-  {
-    {((cond) => {if (!cond) throw new Error(\`assertion failed: '(s === \\"inner\\")'\`)})((s === \\"inner\\"))};
-  }
-};
+  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(s === \\"inner\\")'\`)})((s === \\"inner\\"))};
+}
 "
 `;
 
-exports[`wing compile -t tf-aws > proc.fb1a0ad83796bec8198b3ebbbf88934ea550d5429911f4844b47cd85f6ab1dc6/index.js 1`] = `
+exports[`wing compile -t tf-aws > proc.e28eb0e2c84db9ebf39c60f781e33eb71437de9aea3c9e56527b5592b0d7f259/index.js 1`] = `
 "async handle() {
   const { s } = this;
-  {
-    {((cond) => {if (!cond) throw new Error(\`assertion failed: '(s === \\"top\\")'\`)})((s === \\"top\\"))};
-  }
-};
+  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(s === \\"in_resource\\")'\`)})((s === \\"in_resource\\"))};
+}
 "
 `;
 

--- a/tools/hangar/__snapshots__/test_corpus/valid/table.w.ts.snap
+++ b/tools/hangar/__snapshots__/test_corpus/valid/table.w.ts.snap
@@ -81,13 +81,12 @@ class $Root extends $stdlib.core.Resource {
   constructor(scope, id) {
     super(scope, id);
     const t = this.node.root.newAbstract(\\"@winglang/sdk.cloud.Table\\",this,\\"cloud.Table\\",{
-\\"name\\": \\"simple-table\\",
-\\"primaryKey\\": \\"id\\",
-\\"columns\\": Object.freeze({\\"id\\":cloud.ColumnType.STRING,\\"name\\":cloud.ColumnType.STRING,\\"age\\":cloud.ColumnType.NUMBER}),}
-);
+    \\"name\\": \\"simple-table\\",
+    \\"primaryKey\\": \\"id\\",
+    \\"columns\\": Object.freeze({\\"id\\":cloud.ColumnType.STRING,\\"name\\":cloud.ColumnType.STRING,\\"age\\":cloud.ColumnType.NUMBER}),}
+    );
   }
 }
-
 class $App extends $AppBase {
   constructor() {
     super({ outdir: $outdir, name: \\"table\\", plugins: $plugins, isTestEnvironment: $wing_is_test });
@@ -103,8 +102,8 @@ class $App extends $AppBase {
     }
   }
 }
-
-new $App().synth();"
+new $App().synth();
+"
 `;
 
 exports[`wing test -t sim > stdout 1`] = `

--- a/tools/hangar/__snapshots__/test_corpus/valid/test_bucket.w.ts.snap
+++ b/tools/hangar/__snapshots__/test_corpus/valid/test_bucket.w.ts.snap
@@ -270,7 +270,7 @@ class $Root extends $stdlib.core.Resource {
     super(scope, id);
     const b = this.node.root.newAbstract(\\"@winglang/sdk.cloud.Bucket\\",this,\\"cloud.Bucket\\");
     this.node.root.newAbstract(\\"@winglang/sdk.cloud.Function\\",this,\\"test:put\\",new $stdlib.core.Inflight(this, \\"$Inflight1\\", {
-      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.2631210173e5e563d8a37768307a981fbd07dc4fe329bb3ad7cbfdacbeea244d/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
+      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.412efe1236e70dc0c84a7db92a612d4405b678740d6d9a86f75c2c059a93e1b3/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
       bindings: {
         b: {
           obj: b,
@@ -280,7 +280,7 @@ class $Root extends $stdlib.core.Resource {
     })
     );
     this.node.root.newAbstract(\\"@winglang/sdk.cloud.Function\\",this,\\"test:get\\",new $stdlib.core.Inflight(this, \\"$Inflight2\\", {
-      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.159e5972b2f3406bb4e7bd89f188e78661839b2f4d1654d37b60c72e1e0dfe26/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
+      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.ac9708184e710f892c66bb4336569769a09d726ccc04b8ee83036b184d5bb763/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
       bindings: {
         b: {
           obj: b,
@@ -310,26 +310,22 @@ new $App().synth();
 "
 `;
 
-exports[`wing compile -t tf-aws > proc.159e5972b2f3406bb4e7bd89f188e78661839b2f4d1654d37b60c72e1e0dfe26/index.js 1`] = `
+exports[`wing compile -t tf-aws > proc.412efe1236e70dc0c84a7db92a612d4405b678740d6d9a86f75c2c059a93e1b3/index.js 1`] = `
 "async handle(_) {
   const { b } = this;
-  {
-    (await b.put(\\"hello.txt\\",\\"world\\"));
-    {((cond) => {if (!cond) throw new Error(\`assertion failed: '((await b.get(\\"hello.txt\\")) === \\"world\\")'\`)})(((await b.get(\\"hello.txt\\")) === \\"world\\"))};
-  }
-};
+  {((cond) => {if (!cond) throw new Error(\`assertion failed: '((await b.list()).length === 0)'\`)})(((await b.list()).length === 0))};
+  (await b.put(\\"hello.txt\\",\\"world\\"));
+  {((cond) => {if (!cond) throw new Error(\`assertion failed: '((await b.list()).length === 1)'\`)})(((await b.list()).length === 1))};
+}
 "
 `;
 
-exports[`wing compile -t tf-aws > proc.2631210173e5e563d8a37768307a981fbd07dc4fe329bb3ad7cbfdacbeea244d/index.js 1`] = `
+exports[`wing compile -t tf-aws > proc.ac9708184e710f892c66bb4336569769a09d726ccc04b8ee83036b184d5bb763/index.js 1`] = `
 "async handle(_) {
   const { b } = this;
-  {
-    {((cond) => {if (!cond) throw new Error(\`assertion failed: '((await b.list()).length === 0)'\`)})(((await b.list()).length === 0))};
-    (await b.put(\\"hello.txt\\",\\"world\\"));
-    {((cond) => {if (!cond) throw new Error(\`assertion failed: '((await b.list()).length === 1)'\`)})(((await b.list()).length === 1))};
-  }
-};
+  (await b.put(\\"hello.txt\\",\\"world\\"));
+  {((cond) => {if (!cond) throw new Error(\`assertion failed: '((await b.get(\\"hello.txt\\")) === \\"world\\")'\`)})(((await b.get(\\"hello.txt\\")) === \\"world\\"))};
+}
 "
 `;
 

--- a/tools/hangar/__snapshots__/test_corpus/valid/test_bucket.w.ts.snap
+++ b/tools/hangar/__snapshots__/test_corpus/valid/test_bucket.w.ts.snap
@@ -270,26 +270,27 @@ class $Root extends $stdlib.core.Resource {
     super(scope, id);
     const b = this.node.root.newAbstract(\\"@winglang/sdk.cloud.Bucket\\",this,\\"cloud.Bucket\\");
     this.node.root.newAbstract(\\"@winglang/sdk.cloud.Function\\",this,\\"test:put\\",new $stdlib.core.Inflight(this, \\"$Inflight1\\", {
-  code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.9f10a129b90bc1328dcb1e6194e3902931d1011d95e46825362ef5b06ec17380/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
-  bindings: {
-    b: {
-      obj: b,
-      ops: [\\"delete\\",\\"get\\",\\"get_json\\",\\"list\\",\\"public_url\\",\\"put\\",\\"put_json\\"]
-    },
-  }
-}));
+      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.2631210173e5e563d8a37768307a981fbd07dc4fe329bb3ad7cbfdacbeea244d/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
+      bindings: {
+        b: {
+          obj: b,
+          ops: [\\"delete\\",\\"get\\",\\"get_json\\",\\"list\\",\\"public_url\\",\\"put\\",\\"put_json\\"]
+        },
+      }
+    })
+    );
     this.node.root.newAbstract(\\"@winglang/sdk.cloud.Function\\",this,\\"test:get\\",new $stdlib.core.Inflight(this, \\"$Inflight2\\", {
-  code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.1b9abefaef8ce4230db863000273d2c12bacb97e33ac10e6c8b50341e415fdac/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
-  bindings: {
-    b: {
-      obj: b,
-      ops: [\\"delete\\",\\"get\\",\\"get_json\\",\\"list\\",\\"public_url\\",\\"put\\",\\"put_json\\"]
-    },
-  }
-}));
+      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.159e5972b2f3406bb4e7bd89f188e78661839b2f4d1654d37b60c72e1e0dfe26/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
+      bindings: {
+        b: {
+          obj: b,
+          ops: [\\"delete\\",\\"get\\",\\"get_json\\",\\"list\\",\\"public_url\\",\\"put\\",\\"put_json\\"]
+        },
+      }
+    })
+    );
   }
 }
-
 class $App extends $AppBase {
   constructor() {
     super({ outdir: $outdir, name: \\"test_bucket\\", plugins: $plugins, isTestEnvironment: $wing_is_test });
@@ -305,23 +306,31 @@ class $App extends $AppBase {
     }
   }
 }
-
-new $App().synth();"
+new $App().synth();
+"
 `;
 
-exports[`wing compile -t tf-aws > proc.1b9abefaef8ce4230db863000273d2c12bacb97e33ac10e6c8b50341e415fdac/index.js 1`] = `
-"async handle(_) { const { b } = this; {
-  (await b.put(\\"hello.txt\\",\\"world\\"));
-  {((cond) => {if (!cond) throw new Error(\`assertion failed: '((await b.get(\\"hello.txt\\")) === \\"world\\")'\`)})(((await b.get(\\"hello.txt\\")) === \\"world\\"))};
-} };"
+exports[`wing compile -t tf-aws > proc.159e5972b2f3406bb4e7bd89f188e78661839b2f4d1654d37b60c72e1e0dfe26/index.js 1`] = `
+"async handle(_) {
+  const { b } = this;
+  {
+    (await b.put(\\"hello.txt\\",\\"world\\"));
+    {((cond) => {if (!cond) throw new Error(\`assertion failed: '((await b.get(\\"hello.txt\\")) === \\"world\\")'\`)})(((await b.get(\\"hello.txt\\")) === \\"world\\"))};
+  }
+};
+"
 `;
 
-exports[`wing compile -t tf-aws > proc.9f10a129b90bc1328dcb1e6194e3902931d1011d95e46825362ef5b06ec17380/index.js 1`] = `
-"async handle(_) { const { b } = this; {
-  {((cond) => {if (!cond) throw new Error(\`assertion failed: '((await b.list()).length === 0)'\`)})(((await b.list()).length === 0))};
-  (await b.put(\\"hello.txt\\",\\"world\\"));
-  {((cond) => {if (!cond) throw new Error(\`assertion failed: '((await b.list()).length === 1)'\`)})(((await b.list()).length === 1))};
-} };"
+exports[`wing compile -t tf-aws > proc.2631210173e5e563d8a37768307a981fbd07dc4fe329bb3ad7cbfdacbeea244d/index.js 1`] = `
+"async handle(_) {
+  const { b } = this;
+  {
+    {((cond) => {if (!cond) throw new Error(\`assertion failed: '((await b.list()).length === 0)'\`)})(((await b.list()).length === 0))};
+    (await b.put(\\"hello.txt\\",\\"world\\"));
+    {((cond) => {if (!cond) throw new Error(\`assertion failed: '((await b.list()).length === 1)'\`)})(((await b.list()).length === 1))};
+  }
+};
+"
 `;
 
 exports[`wing test -t sim > stdout 1`] = `

--- a/tools/hangar/__snapshots__/test_corpus/valid/try_catch.w.ts.snap
+++ b/tools/hangar/__snapshots__/test_corpus/valid/try_catch.w.ts.snap
@@ -60,156 +60,109 @@ class $Root extends $stdlib.core.Resource {
     super(scope, id);
     let x = \\"\\";
     try {
-	{
-  {((msg) => {throw new Error(msg)})(\\"hello\\")};
-  x = \\"no way I got here\\";
-}
-} catch ($error_e) {
-	const e = $error_e.message;
-	{
-  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(e === \\"hello\\")'\`)})((e === \\"hello\\"))};
-  x = \\"caught\\";
-}
-} finally {
-	{
-  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(x === \\"caught\\")'\`)})((x === \\"caught\\"))};
-  x = \\"finally\\";
-};
-}
+      {((msg) => {throw new Error(msg)})(\\"hello\\")};
+      x = \\"no way I got here\\";
+    }
+    catch ($error_e) {
+      const e = $error_e.message;
+      {((cond) => {if (!cond) throw new Error(\`assertion failed: '(e === \\"hello\\")'\`)})((e === \\"hello\\"))};
+      x = \\"caught\\";
+    }
+    finally {
+      {((cond) => {if (!cond) throw new Error(\`assertion failed: '(x === \\"caught\\")'\`)})((x === \\"caught\\"))};
+      x = \\"finally\\";
+    }
     {((cond) => {if (!cond) throw new Error(\`assertion failed: '(x === \\"finally\\")'\`)})((x === \\"finally\\"))};
     try {
-	{
-  x = \\"I got here\\";
-}
-} catch ($error_e) {
-	const e = $error_e.message;
-	{
-  x = \\"caught\\";
-}
-} finally {
-	{
-  {((cond) => {if (!cond) throw new Error(\`assertion failed: '(x === \\"I got here\\")'\`)})((x === \\"I got here\\"))};
-  x = \\"finally\\";
-};
-}
+      x = \\"I got here\\";
+    }
+    catch ($error_e) {
+      const e = $error_e.message;
+      x = \\"caught\\";
+    }
+    finally {
+      {((cond) => {if (!cond) throw new Error(\`assertion failed: '(x === \\"I got here\\")'\`)})((x === \\"I got here\\"))};
+      x = \\"finally\\";
+    }
     {((cond) => {if (!cond) throw new Error(\`assertion failed: '(x === \\"finally\\")'\`)})((x === \\"finally\\"))};
     try {
-	{
-  {((msg) => {throw new Error(msg)})(\\"hello\\")};
-}
-} catch  {
-	
-	
-} finally {
-	{
-  x = \\"finally with no catch\\";
-};
-}
-    {((cond) => {if (!cond) throw new Error(\`assertion failed: '(x === \\"finally with no catch\\")'\`)})((x === \\"finally with no catch\\"))};
+      try {
+        {((msg) => {throw new Error(msg)})(\\"hello\\")};
+      }
+      finally {
+        x = \\"finally with no catch\\";
+      }
+      {((cond) => {if (!cond) throw new Error(\`assertion failed: '(x === \\"finally with no catch\\")'\`)})((x === \\"finally with no catch\\"))};
+    }
+    catch {
+    }
     try {
-	{
-}
-} catch  {
-	
-	
-} finally {
-	{
-  x = \\"finally with no catch and no exception\\";
-};
-}
+    }
+    finally {
+      x = \\"finally with no catch and no exception\\";
+    }
     {((cond) => {if (!cond) throw new Error(\`assertion failed: '(x === \\"finally with no catch and no exception\\")'\`)})((x === \\"finally with no catch and no exception\\"))};
     {((cond) => {if (!cond) throw new Error(\`assertion failed: '((( () =>  {
-	{
-  try {
-  	{
-  }
-  } catch  {
-  	
-  	
-  } finally {
-  	{
-    return 1;
-  };
-  }
-}
-})()) === 1)'\`)})(((( () =>  {
-	{
-  try {
-  	{
-  }
-  } catch  {
-  	
-  	
-  } finally {
-  	{
-    return 1;
-  };
-  }
-}
-})()) === 1))};
+      {
+        try {
+        }
+        finally {
+          return 1;
+        }
+      }
+    }
+    )()) === 1)'\`)})(((( () =>  {
+      {
+        try {
+        }
+        finally {
+          return 1;
+        }
+      }
+    }
+    )()) === 1))};
     {((cond) => {if (!cond) throw new Error(\`assertion failed: '((( () =>  {
-	{
-  try {
-  	{
-    {((msg) => {throw new Error(msg)})(\\"\\")};
-  }
-  } catch  {
-  	
-  	{
-    return 2;
-  }
-  } finally {
-  	
-  }
-}
-})()) === 2)'\`)})(((( () =>  {
-	{
-  try {
-  	{
-    {((msg) => {throw new Error(msg)})(\\"\\")};
-  }
-  } catch  {
-  	
-  	{
-    return 2;
-  }
-  } finally {
-  	
-  }
-}
-})()) === 2))};
+      {
+        try {
+          {((msg) => {throw new Error(msg)})(\\"\\")};
+        }
+        catch {
+          return 2;
+        }
+      }
+    }
+    )()) === 2)'\`)})(((( () =>  {
+      {
+        try {
+          {((msg) => {throw new Error(msg)})(\\"\\")};
+        }
+        catch {
+          return 2;
+        }
+      }
+    }
+    )()) === 2))};
     {((cond) => {if (!cond) throw new Error(\`assertion failed: '((( () =>  {
-	{
-  try {
-  	{
-    return 3;
-  }
-  } catch  {
-  	
-  	
-  } finally {
-  	{
-  };
-  }
-}
-})()) === 3)'\`)})(((( () =>  {
-	{
-  try {
-  	{
-    return 3;
-  }
-  } catch  {
-  	
-  	
-  } finally {
-  	{
-  };
+      {
+        try {
+          return 3;
+        }
+        finally {
+        }
+      }
+    }
+    )()) === 3)'\`)})(((( () =>  {
+      {
+        try {
+          return 3;
+        }
+        finally {
+        }
+      }
+    }
+    )()) === 3))};
   }
 }
-})()) === 3))};
-  }
-}
-
 class $App extends $AppBase {
   constructor() {
     super({ outdir: $outdir, name: \\"try_catch\\", plugins: $plugins, isTestEnvironment: $wing_is_test });
@@ -225,8 +178,8 @@ class $App extends $AppBase {
     }
   }
 }
-
-new $App().synth();"
+new $App().synth();
+"
 `;
 
 exports[`wing test -t sim > stdout 1`] = `

--- a/tools/hangar/__snapshots__/test_corpus/valid/while.w.ts.snap
+++ b/tools/hangar/__snapshots__/test_corpus/valid/while.w.ts.snap
@@ -59,37 +59,36 @@ class $Root extends $stdlib.core.Resource {
   constructor(scope, id) {
     super(scope, id);
     while (false) {
-  const x = 1;
-}
+      const x = 1;
+    }
     const y = 123;
     while ((y < 0)) {
-  const x = 1;
-}
+      const x = 1;
+    }
     let z = 0;
     while (true) {
-  z = (z + 1);
-  if ((z > 2)) {
-    break;
-  }
-}
+      z = (z + 1);
+      if ((z > 2)) {
+        break;
+      }
+    }
     {((cond) => {if (!cond) throw new Error(\`assertion failed: '(z === 3)'\`)})((z === 3))};
     while (true) {
-  break;
-}
+      break;
+    }
     let v = 0;
     let i = 0;
     while ((i < 10)) {
-  i = (i + 1);
-  if (((i % 2) === 0)) {
-    continue;
-  }
-  v = (v + 1);
-}
+      i = (i + 1);
+      if (((i % 2) === 0)) {
+        continue;
+      }
+      v = (v + 1);
+    }
     {((cond) => {if (!cond) throw new Error(\`assertion failed: '(i === 10)'\`)})((i === 10))};
     {((cond) => {if (!cond) throw new Error(\`assertion failed: '(v === 5)'\`)})((v === 5))};
   }
 }
-
 class $App extends $AppBase {
   constructor() {
     super({ outdir: $outdir, name: \\"while\\", plugins: $plugins, isTestEnvironment: $wing_is_test });
@@ -105,8 +104,8 @@ class $App extends $AppBase {
     }
   }
 }
-
-new $App().synth();"
+new $App().synth();
+"
 `;
 
 exports[`wing test -t sim > stdout 1`] = `

--- a/tools/hangar/__snapshots__/test_corpus/valid/while_loop_await.w.ts.snap
+++ b/tools/hangar/__snapshots__/test_corpus/valid/while_loop_await.w.ts.snap
@@ -173,13 +173,13 @@ class $Root extends $stdlib.core.Resource {
     super(scope, id);
     const queue = this.node.root.newAbstract(\\"@winglang/sdk.cloud.Queue\\",this,\\"cloud.Queue\\");
     const iterator = new $stdlib.core.Inflight(this, \\"$Inflight1\\", {
-      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.35c7ca89b5814275c882c0b56c746a8b10e37edc9c842b3660134b471228b34c/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
+      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.8df6c52d279b5b0f60f3073722d4666c96d8faf3bae7f82cf289c11a372daa9a/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
       bindings: {
       }
     })
     ;
     const handler = new $stdlib.core.Inflight(this, \\"$Inflight2\\", {
-      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.4183b57776a1d5b911b7a76115df35dd6b1a4c3dfbacc0e274e8ef25dcce441e/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
+      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.09104e27ddc37691caca765b1b7cb87ad5bcd5f01349ff19070fce915e60db2b/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
       bindings: {
       }
     })
@@ -206,26 +206,22 @@ new $App().synth();
 "
 `;
 
-exports[`wing compile -t tf-aws > proc.35c7ca89b5814275c882c0b56c746a8b10e37edc9c842b3660134b471228b34c/index.js 1`] = `
-"async handle(j) {
+exports[`wing compile -t tf-aws > proc.09104e27ddc37691caca765b1b7cb87ad5bcd5f01349ff19070fce915e60db2b/index.js 1`] = `
+"async handle(body) {
   const {  } = this;
-  {
-    return (j + 1);
+  const i = 0;
+  while (((await iterator(i)) < 3)) {
+    {console.log(\`\${i}\`)};
   }
-};
+}
 "
 `;
 
-exports[`wing compile -t tf-aws > proc.4183b57776a1d5b911b7a76115df35dd6b1a4c3dfbacc0e274e8ef25dcce441e/index.js 1`] = `
-"async handle(body) {
+exports[`wing compile -t tf-aws > proc.8df6c52d279b5b0f60f3073722d4666c96d8faf3bae7f82cf289c11a372daa9a/index.js 1`] = `
+"async handle(j) {
   const {  } = this;
-  {
-    const i = 0;
-    while (((await iterator(i)) < 3)) {
-      {console.log(\`\${i}\`)};
-    }
-  }
-};
+  return (j + 1);
+}
 "
 `;
 

--- a/tools/hangar/__snapshots__/test_corpus/valid/while_loop_await.w.ts.snap
+++ b/tools/hangar/__snapshots__/test_corpus/valid/while_loop_await.w.ts.snap
@@ -173,19 +173,20 @@ class $Root extends $stdlib.core.Resource {
     super(scope, id);
     const queue = this.node.root.newAbstract(\\"@winglang/sdk.cloud.Queue\\",this,\\"cloud.Queue\\");
     const iterator = new $stdlib.core.Inflight(this, \\"$Inflight1\\", {
-  code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.82d0059fdbaebaab6d1be68f497052f9d5b8662f4333952a6e9ad55f564e0c97/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
-  bindings: {
-  }
-});
+      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.35c7ca89b5814275c882c0b56c746a8b10e37edc9c842b3660134b471228b34c/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
+      bindings: {
+      }
+    })
+    ;
     const handler = new $stdlib.core.Inflight(this, \\"$Inflight2\\", {
-  code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.f259e8d1edc5d47946ec1a1f3aa23e59fe550255ec12b899cffb307ecf525df6/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
-  bindings: {
-  }
-});
+      code: $stdlib.core.NodeJsCode.fromFile(require.resolve(\\"./proc.4183b57776a1d5b911b7a76115df35dd6b1a4c3dfbacc0e274e8ef25dcce441e/index.js\\".replace(/\\\\\\\\/g, \\"/\\"))),
+      bindings: {
+      }
+    })
+    ;
     (queue.addConsumer(handler));
   }
 }
-
 class $App extends $AppBase {
   constructor() {
     super({ outdir: $outdir, name: \\"while_loop_await\\", plugins: $plugins, isTestEnvironment: $wing_is_test });
@@ -201,23 +202,31 @@ class $App extends $AppBase {
     }
   }
 }
-
-new $App().synth();"
+new $App().synth();
+"
 `;
 
-exports[`wing compile -t tf-aws > proc.82d0059fdbaebaab6d1be68f497052f9d5b8662f4333952a6e9ad55f564e0c97/index.js 1`] = `
-"async handle(j) { const {  } = this; {
-  return (j + 1);
-} };"
-`;
-
-exports[`wing compile -t tf-aws > proc.f259e8d1edc5d47946ec1a1f3aa23e59fe550255ec12b899cffb307ecf525df6/index.js 1`] = `
-"async handle(body) { const {  } = this; {
-  const i = 0;
-  while (((await iterator(i)) < 3)) {
-    {console.log(\`\${i}\`)};
+exports[`wing compile -t tf-aws > proc.35c7ca89b5814275c882c0b56c746a8b10e37edc9c842b3660134b471228b34c/index.js 1`] = `
+"async handle(j) {
+  const {  } = this;
+  {
+    return (j + 1);
   }
-} };"
+};
+"
+`;
+
+exports[`wing compile -t tf-aws > proc.4183b57776a1d5b911b7a76115df35dd6b1a4c3dfbacc0e274e8ef25dcce441e/index.js 1`] = `
+"async handle(body) {
+  const {  } = this;
+  {
+    const i = 0;
+    while (((await iterator(i)) < 3)) {
+      {console.log(\`\${i}\`)};
+    }
+  }
+};
+"
 `;
 
 exports[`wing test -t sim > stdout 1`] = `


### PR DESCRIPTION
Migrate all relevant jsification code to `CodeMaker` so that now javascript output is nicely indented and much more human readable.

### Testing

I've manually reviewed snapshots and verified that only formatting changes were introduced. Use "hide whitespace" in GitHub to review.



### Implementation Notes

Any `jsify_xxx` function that is expected to return a block of code (statement, code block, etc) now returns a `CodeMaker` object instead of a string. Then, we can compose these objects together using `add_code()`.

The `jsify_expression()` function, and any other function that returns a part of a sentence still returns a string, but we have updated `CodeMaker` to handle multiline strings properly by breaking them down and adding each line to preserve the indentation of the parent.

When we have chained blocks (`if/elseif/else` or `try/catch/finally`), we do this Instead of putting the `else` in the same line as the closing brackets:

    if (cond1) {
      // code
    }
    else if (cond2) {
      // code
    }
    else {
      // code
    }

I think that's okay.

### Misc

This change uncovered a latent bug in how `try/finally` works. Previously we used to always generate a `catch` block, **even if the code did not have one**. This means that if we had only a `try/finally` block, then the exception will not be thrown. Nice!

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.