### PR TITLE
fix(sdk): fix api.url validation regex

### DIFF
--- a/examples/tests/valid/api_valid_path.w
+++ b/examples/tests/valid/api_valid_path.w
@@ -10,57 +10,41 @@ let handler = inflight (req: cloud.ApiRequest): cloud.ApiResponse => {
   };
 };
 
-// invalid paths:
-try {
-  api.get("/test/{sup:er/:annoying//path}", handler);
-} catch error {
-  assert(error == "Invalid route /test/{sup:er/:annoying//path}. Routes and params should consist of alpha-numeric characters only.");
-}
+let test_invalid_path = (path:str) => {
+  let var error = "";
+  let expected = "Invalid route ${path}. Url cannot contain \":\", params contains only alpha-numeric chars or \"_\".";
+  try {
+    api.get(path, handler);
+  } catch e {
+    error = e;
+  }
+  assert(error == expected);
+};
 
-try {
-  api.get("/test/{::another:annoying:path}", handler);
-} catch error {
-  assert(error == "Invalid route /test/{::another:annoying:path}. Routes and params should consist of alpha-numeric characters only.");
-}
+let test_valid_path = (path:str) => {
+  let var error = "";
+  try {
+    api.get(path, handler);
+  } catch e {
+    error = e;
+  }
+  assert(error == "");
+};
 
-try {
-  api.get("/test/n0t_alphanumer1cPa:th", handler);
-} catch error {
-  assert(error == "Invalid route /test/n0t_alphanumer1cPa:th. Routes and params should consist of alpha-numeric characters only.");
-}
-
-try {
-  api.get("/test/path/{with}/{two:invali4d#}/variables", handler);
-} catch error {
-  assert(error == "Invalid route /test/path/{with}/{two:invali4d#}/variables. Routes and params should consist of alpha-numeric characters only.");
-}
-
-try {
-  api.get("/test/path/{unclosed", handler);
-} catch error {
-  assert(error == "Invalid route /test/path/{unclosed. Routes and params should consist of alpha-numeric characters only.");
-}
-
-try {
-  api.get("/test/m{issplaced}", handler);
-} catch error {
-  assert(error == "Invalid route /test/m{issplaced}. Routes and params should consist of alpha-numeric characters only.");
-}
-
-try {
-  api.get("/test/{misspla}ced", handler);
-} catch error {
-  assert(error == "Invalid route /test/{misspla}ced. Routes and params should consist of alpha-numeric characters only.");
-}
-try {
-  api.get("/test/{}/empty", handler);
-} catch error {
-  assert(error == "Invalid route /test/{}/empty. Routes and params should consist of alpha-numeric characters only.");
-}
+//invalid paths
+test_invalid_path("/test/{sup:er/:annoying//path}");
+test_invalid_path("/test/{::another:annoying:path}");
+test_invalid_path("/test/n0t_alphanumer1cPa:th");
+test_invalid_path("/test/path/{with}/{two:invali4d#}/variables");
+test_invalid_path("/test/path/{unclosed");
+test_invalid_path("/test/m{issplaced}");
+test_invalid_path("/test/{misspla}ced");
+test_invalid_path("/test/{}/empty");
+  
 
 // valid paths
-api.get("/test", handler);
-api.get("/test/alphanumer1cPa_th", handler);
-api.get("/test/regular/path", handler);
-api.get("/test/path/{with}/two/{variable_s}/f?bla=5&b=6", handler);
-api.get("/test/param/is/{last}", handler);
+test_valid_path("/test");
+test_valid_path("/test/alphanumer1cPa_th");
+test_valid_path("/test/regular/path");
+test_valid_path("/test/pa-th/{with}/two/{variable_s}/f?bla=5&b=6");
+test_valid_path("/test/param/is/{last}");

--- a/libs/wingsdk/src/cloud/api.ts
+++ b/libs/wingsdk/src/cloud/api.ts
@@ -160,15 +160,14 @@ export abstract class Api extends Resource {
   ): void;
   /**
    * validating route:
-   * checks if a string consists only from letters, digits, =, ?,
-   * or if has curly brackets- the part that inside the brackets is only letter or _, not empty and placed before and after "/"
+   * if has curly brackets pairs- the part that inside the brackets is only letter, digit or _, not empty and placed before and after "/"
    * @param route
    * @throws if the route is invalid
    */
   protected validateRoute(route: string) {
-    if (!/^([\w/1-9\?\=\&]|.+\/\{\w+\}(\/|$))*$/.test(route)) {
+    if (!/^([^\{\}\:\n]|.+\/\{\w+\}(\/|$))*$/g.test(route)) {
       throw new Error(
-        `Invalid route ${route}. Routes and params should consist of alpha-numeric characters only.`
+        `Invalid route ${route}. Url cannot contain ":", params contains only alpha-numeric chars or "_".`
       );
     }
   }


### PR DESCRIPTION
fixes #2056 
- fixing it to allow any char on the URL itself (aside ":") and `A-Za-z0-9_` chars on the param placeholders (since using express under the hood, following their documentation: https://expressjs.com/en/guide/routing.html#route-parameters)
[the new pattern is this](https://regexr.com/7c0sr)
- formatting the URL validity test a bit

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.