### PR TITLE
feat: concat (`++`) operator

### DIFF
--- a/docs/04-reference/winglang-spec.md
+++ b/docs/04-reference/winglang-spec.md
@@ -2540,15 +2540,30 @@ Ternary or conditional operators are not supported.
 
 ---
 
-#### 6.3.4 Operator Precedence
+#### 6.3.4 Other Operators
+
+| Operator | Description       | Example  |
+| -------- | ----------------- | -------- |
+| `?`      | Optional test     | `a?`     |
+| `??`     | Unwrap-or-default | `a ?? b` |
+| `++`     | Concatenate       | `a ++ b` |
+
+[`▲ top`][top]
+
+---
+
+#### 6.3.5 Operator Precedence
 
 | Operator             | Notes                                             |
 | -------------------- | ------------------------------------------------- |
 | ()                   | Parentheses                                       |
-| **                   | Power                                    |
+| **                   | Power                                             |
+| ?                    | Optional test                                     |
 | -x                   | Unary minus                                       |
 | \*, /, \\, %         | Multiplication, Division, Floor division, Modulus |
 | +, -                 | Addition, Subtraction                             |
+| ++                   | Concatenate                                       |
+| ??                   | Unwrap-or-default                                 |
 | ==, !=, >, >=, <, <= | Comparisons, Identity, operators                  |
 | !                    | Logical NOT                                       |
 | &&                   | Logical AND                                       |
@@ -2564,7 +2579,7 @@ determined by associativity.
 
 ---
 
-#### 6.3.5 Short Circuiting
+#### 6.3.6 Short Circuiting
 
 For the built-in logical NOT operators, the result is `true` if the operand is
 `false`. Otherwise, the result is `false`.
@@ -2604,7 +2619,7 @@ if x != nil {
 
 ---
 
-#### 6.3.6 Equality
+#### 6.3.7 Equality
 
 Of the operators supported, the following can be used with non-numeric operands:
 

--- a/examples/tests/valid/concat_operator.w
+++ b/examples/tests/valid/concat_operator.w
@@ -1,0 +1,8 @@
+let x = 5;
+let message = "count: " ++ x.to_str();
+assert(message == "count: 5");
+log(message);
+
+let d = "d";
+let multiple_concats = "a" ++ "b" ++ "c${d}";
+assert(multiple_concats == "abcd");

--- a/libs/tree-sitter-wing/grammar.js
+++ b/libs/tree-sitter-wing/grammar.js
@@ -7,6 +7,7 @@ const PREC = {
   EQUAL: 60,
   RELATIONAL: 70,
   UNWRAP_OR: 80,
+  CONCAT: 85,
   SHIFT: 90,
   ADD: 100,
   MULTIPLY: 110,
@@ -547,6 +548,7 @@ module.exports = grammar({
         //['>>', PREC.SHIFT],
         //['>>>', PREC.SHIFT],
         ["??", PREC.UNWRAP_OR],
+        ["++", PREC.CONCAT],
       ];
 
       return choice(

--- a/libs/wingc/src/ast.rs
+++ b/libs/wingc/src/ast.rs
@@ -587,6 +587,7 @@ pub enum BinaryOperator {
 	LogicalAnd,
 	LogicalOr,
 	UnwrapOr,
+	Concat,
 }
 
 #[derive(Debug)]

--- a/libs/wingc/src/jsify.rs
+++ b/libs/wingc/src/jsify.rs
@@ -475,6 +475,7 @@ impl<'a> JSifier<'a> {
 						// this is inline with how wing jsifies optionals
 						"??"
 					}
+					BinaryOperator::Concat => "+",
 				};
 				format!("({} {} {})", js_left, js_op, js_right)
 			}

--- a/libs/wingc/src/lib.rs
+++ b/libs/wingc/src/lib.rs
@@ -59,6 +59,7 @@ const WINGSDK_MUT_ARRAY: &'static str = "std.MutableArray";
 const WINGSDK_SET: &'static str = "std.ImmutableSet";
 const WINGSDK_MUT_SET: &'static str = "std.MutableSet";
 const WINGSDK_STRING: &'static str = "std.String";
+const WINGSDK_NUMBER: &'static str = "std.Number";
 const WINGSDK_JSON: &'static str = "std.Json";
 const WINGSDK_MUT_JSON: &'static str = "std.MutJson";
 const WINGSDK_RESOURCE: &'static str = "core.Resource";

--- a/libs/wingc/src/parser.rs
+++ b/libs/wingc/src/parser.rs
@@ -976,6 +976,7 @@ impl<'s> Parser<'s> {
 						"\\" => BinaryOperator::FloorDiv,
 						"**" => BinaryOperator::Power,
 						"??" => BinaryOperator::UnwrapOr,
+						"++" => BinaryOperator::Concat,
 						"ERROR" => self.add_error::<BinaryOperator>("Expected binary operator", expression_node)?,
 						other => return self.report_unimplemented_grammar(other, "binary operator", expression_node),
 					},

--- a/libs/wingc/src/type_check.rs
+++ b/libs/wingc/src/type_check.rs
@@ -9,8 +9,8 @@ use crate::ast::{
 use crate::diagnostic::{Diagnostic, DiagnosticLevel, Diagnostics, TypeError};
 use crate::{
 	debug, WINGSDK_ARRAY, WINGSDK_ASSEMBLY_NAME, WINGSDK_CLOUD_MODULE, WINGSDK_DURATION, WINGSDK_FS_MODULE, WINGSDK_JSON,
-	WINGSDK_MAP, WINGSDK_MUT_ARRAY, WINGSDK_MUT_JSON, WINGSDK_MUT_MAP, WINGSDK_MUT_SET, WINGSDK_REDIS_MODULE,
-	WINGSDK_SET, WINGSDK_STD_MODULE, WINGSDK_STRING,
+	WINGSDK_MAP, WINGSDK_MUT_ARRAY, WINGSDK_MUT_JSON, WINGSDK_MUT_MAP, WINGSDK_MUT_SET, WINGSDK_NUMBER,
+	WINGSDK_REDIS_MODULE, WINGSDK_SET, WINGSDK_STD_MODULE, WINGSDK_STRING,
 };
 use derivative::Derivative;
 use indexmap::{IndexMap, IndexSet};
@@ -1201,6 +1201,11 @@ impl<'a> TypeChecker<'a> {
 							self.validate_type(rtype, inner_type, right);
 							inner_type
 						}
+					}
+					BinaryOperator::Concat => {
+						self.validate_type(ltype, self.types.string(), left);
+						self.validate_type(rtype, self.types.string(), right);
+						self.types.string()
 					}
 				}
 			}
@@ -2995,6 +3000,16 @@ impl<'a> TypeChecker<'a> {
 					Type::String => self.get_property_from_class_like(
 						env
 							.lookup_nested_str(WINGSDK_STRING, None)
+							.unwrap()
+							.as_type()
+							.unwrap()
+							.as_class()
+							.unwrap(),
+						property,
+					),
+					Type::Number => self.get_property_from_class_like(
+						env
+							.lookup_nested_str(WINGSDK_NUMBER, None)
 							.unwrap()
 							.as_type()
 							.unwrap()

--- a/libs/wingsdk/src/std/number.ts
+++ b/libs/wingsdk/src/std/number.ts
@@ -29,4 +29,15 @@ export class Number {
     str;
     throw new Error("Macro");
   }
+
+  /**
+   * Converts the number into a string.
+   *
+   * @macro $self$.toString()
+   *
+   * @returns a string.
+   */
+  public toStr(): string {
+    throw new Error("Abstract");
+  }
 }


### PR DESCRIPTION
Introduces a concatenation operator to the language. Using string interpolation or calling `x.concat(y)` can be cumbersome for simple use cases, and `++` offers a simple way to join strings together. The syntax is inspired by languages like Haskell and Grain, and makes it unambiguous that the result will be a string and not a number.

The concat operator does not implicitly convert types into strings. If you want to concatenate a string with a number, you need to first convert the number to a string by calling `x.to_str()` for example.

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.