### PR TITLE
feat(sdk): aws functions share code asset bucket

### DIFF
--- a/libs/wingsdk/src/target-tf-aws/app.ts
+++ b/libs/wingsdk/src/target-tf-aws/app.ts
@@ -10,7 +10,7 @@ import { Subnet } from "@cdktf/provider-aws/lib/subnet";
 import { Vpc } from "@cdktf/provider-aws/lib/vpc";
 import { Construct } from "constructs";
 import { Api } from "./api";
-import { Bucket } from "./bucket";
+import { BUCKET_PREFIX_OPTS, Bucket } from "./bucket";
 import { Counter } from "./counter";
 import { Function } from "./function";
 import { Queue } from "./queue";
@@ -33,6 +33,7 @@ import {
 import { CdktfApp, AppProps } from "../core";
 import { REDIS_FQN } from "../redis";
 import { NameOptions, ResourceNames } from "../utils/resource-names";
+import { S3Bucket } from "@cdktf/provider-aws/lib/s3-bucket";
 
 /**
  * An app that knows how to synthesize constructs into a Terraform configuration
@@ -47,6 +48,8 @@ export class App extends CdktfApp {
   private awsRegionProvider?: DataAwsRegion;
   private awsAccountIdProvider?: DataAwsCallerIdentity;
   private _vpc?: Vpc;
+  private _codeBucket?: S3Bucket;
+
   /** Subnets shared across app */
   public subnets: { [key: string]: Subnet };
 
@@ -120,6 +123,17 @@ export class App extends CdktfApp {
       this.awsRegionProvider = new DataAwsRegion(this, "Region");
     }
     return this.awsRegionProvider.name;
+  }
+
+  public get codeBucket(): S3Bucket {
+    if(this._codeBucket) {
+      return this._codeBucket;
+    }
+    const bucket = new S3Bucket(this, "Code");
+    const bucketPrefix = ResourceNames.generateName(bucket, BUCKET_PREFIX_OPTS);
+    bucket.bucketPrefix = bucketPrefix;
+    this._codeBucket = bucket;
+    return this._codeBucket;
   }
 
   /**

--- a/libs/wingsdk/src/target-tf-aws/app.ts
+++ b/libs/wingsdk/src/target-tf-aws/app.ts
@@ -6,6 +6,7 @@ import { NatGateway } from "@cdktf/provider-aws/lib/nat-gateway";
 import { AwsProvider } from "@cdktf/provider-aws/lib/provider";
 import { RouteTable } from "@cdktf/provider-aws/lib/route-table";
 import { RouteTableAssociation } from "@cdktf/provider-aws/lib/route-table-association";
+import { S3Bucket } from "@cdktf/provider-aws/lib/s3-bucket";
 import { Subnet } from "@cdktf/provider-aws/lib/subnet";
 import { Vpc } from "@cdktf/provider-aws/lib/vpc";
 import { Construct } from "constructs";
@@ -33,7 +34,6 @@ import {
 import { CdktfApp, AppProps } from "../core";
 import { REDIS_FQN } from "../redis";
 import { NameOptions, ResourceNames } from "../utils/resource-names";
-import { S3Bucket } from "@cdktf/provider-aws/lib/s3-bucket";
 
 /**
  * An app that knows how to synthesize constructs into a Terraform configuration
@@ -126,7 +126,7 @@ export class App extends CdktfApp {
   }
 
   public get codeBucket(): S3Bucket {
-    if(this._codeBucket) {
+    if (this._codeBucket) {
       return this._codeBucket;
     }
     const bucket = new S3Bucket(this, "Code");

--- a/libs/wingsdk/src/target-tf-aws/function.ts
+++ b/libs/wingsdk/src/target-tf-aws/function.ts
@@ -4,17 +4,16 @@ import { IamRolePolicy } from "@cdktf/provider-aws/lib/iam-role-policy";
 import { IamRolePolicyAttachment } from "@cdktf/provider-aws/lib/iam-role-policy-attachment";
 import { LambdaFunction } from "@cdktf/provider-aws/lib/lambda-function";
 import { LambdaPermission } from "@cdktf/provider-aws/lib/lambda-permission";
-import { S3Bucket } from "@cdktf/provider-aws/lib/s3-bucket";
 import { S3Object } from "@cdktf/provider-aws/lib/s3-object";
 import { AssetType, Lazy, TerraformAsset } from "cdktf";
 import { Construct } from "constructs";
-import { BUCKET_PREFIX_OPTS } from "./bucket";
 import * as cloud from "../cloud";
 import * as core from "../core";
 import { PolicyStatement } from "../shared-aws";
 import { Duration } from "../std/duration";
 import { createBundle } from "../utils/bundling";
 import { NameOptions, ResourceNames } from "../utils/resource-names";
+import { App } from "./app";
 
 /**
  * Function names are limited to 64 characters.
@@ -93,9 +92,8 @@ export class Function extends cloud.Function {
 
     // Create unique S3 bucket for hosting Lambda code
     // TODO: share all code in a single bucket https://github.com/winglang/wing/issues/178
-    const bucket = new S3Bucket(this, "Code");
-    const bucketPrefix = ResourceNames.generateName(bucket, BUCKET_PREFIX_OPTS);
-    bucket.bucketPrefix = bucketPrefix;
+    const app = App.of(this) as App;
+    const bucket = app.codeBucket;
 
     // Choose an object name so that:
     // - whenever code changes, the object name changes

--- a/libs/wingsdk/src/target-tf-aws/function.ts
+++ b/libs/wingsdk/src/target-tf-aws/function.ts
@@ -7,13 +7,13 @@ import { LambdaPermission } from "@cdktf/provider-aws/lib/lambda-permission";
 import { S3Object } from "@cdktf/provider-aws/lib/s3-object";
 import { AssetType, Lazy, TerraformAsset } from "cdktf";
 import { Construct } from "constructs";
+import { App } from "./app";
 import * as cloud from "../cloud";
 import * as core from "../core";
 import { PolicyStatement } from "../shared-aws";
 import { Duration } from "../std/duration";
 import { createBundle } from "../utils/bundling";
 import { NameOptions, ResourceNames } from "../utils/resource-names";
-import { App } from "./app";
 
 /**
  * Function names are limited to 64 characters.

--- a/libs/wingsdk/src/target-tf-aws/function.ts
+++ b/libs/wingsdk/src/target-tf-aws/function.ts
@@ -91,7 +91,6 @@ export class Function extends cloud.Function {
     });
 
     // Create unique S3 bucket for hosting Lambda code
-    // TODO: share all code in a single bucket https://github.com/winglang/wing/issues/178
     const app = App.of(this) as App;
     const bucket = app.codeBucket;
 

--- a/libs/wingsdk/test/target-tf-aws/__snapshots__/bucket.test.ts.snap
+++ b/libs/wingsdk/test/target-tf-aws/__snapshots__/bucket.test.ts.snap
@@ -514,7 +514,7 @@ exports[`bucket with onCreate method 1`] = `
         \\"publish\\": true,
         \\"role\\": \\"\${aws_iam_role.root_mybucket_mybucketoncreateOnMessage2c90a36b_IamRole_048D6026.arn}\\",
         \\"runtime\\": \\"nodejs16.x\\",
-        \\"s3_bucket\\": \\"\${aws_s3_bucket.root_mybucket_mybucketoncreateOnMessage2c90a36b_Code_3804774D.bucket}\\",
+        \\"s3_bucket\\": \\"\${aws_s3_bucket.root_Code_02F3C603.bucket}\\",
         \\"s3_key\\": \\"\${aws_s3_object.root_mybucket_mybucketoncreateOnMessage2c90a36b_S3Object_DDC97BAE.key}\\",
         \\"timeout\\": 30,
         \\"vpc_config\\": {
@@ -532,12 +532,12 @@ exports[`bucket with onCreate method 1`] = `
       }
     },
     \\"aws_s3_bucket\\": {
+      \\"root_Code_02F3C603\\": {
+        \\"bucket_prefix\\": \\"code-c84a50b1-\\"
+      },
       \\"root_mybucket_E5DAA363\\": {
         \\"bucket_prefix\\": \\"my-bucket-c8045fcc-\\",
         \\"force_destroy\\": false
-      },
-      \\"root_mybucket_mybucketoncreateOnMessage2c90a36b_Code_3804774D\\": {
-        \\"bucket_prefix\\": \\"code-c8663a19-\\"
       }
     },
     \\"aws_s3_bucket_notification\\": {
@@ -576,7 +576,7 @@ exports[`bucket with onCreate method 1`] = `
     },
     \\"aws_s3_object\\": {
       \\"root_mybucket_mybucketoncreateOnMessage2c90a36b_S3Object_DDC97BAE\\": {
-        \\"bucket\\": \\"\${aws_s3_bucket.root_mybucket_mybucketoncreateOnMessage2c90a36b_Code_3804774D.bucket}\\",
+        \\"bucket\\": \\"\${aws_s3_bucket.root_Code_02F3C603.bucket}\\",
         \\"key\\": \\"<key>\\",
         \\"source\\": \\"<source>\\"
       }
@@ -611,6 +611,14 @@ exports[`bucket with onCreate method 2`] = `
         "children": {
           "Default": {
             "children": {
+              "Code": {
+                "constructInfo": {
+                  "fqn": "@cdktf/provider-aws.s3Bucket.S3Bucket",
+                  "version": "12.0.2",
+                },
+                "id": "Code",
+                "path": "root/Default/Code",
+              },
               "aws": {
                 "constructInfo": {
                   "fqn": "@cdktf/provider-aws.provider.AwsProvider",
@@ -803,14 +811,6 @@ exports[`bucket with onCreate method 2`] = `
                         "id": "Asset",
                         "path": "root/Default/my_bucket/my_bucket-on_create-OnMessage-2c90a36b/Asset",
                       },
-                      "Code": {
-                        "constructInfo": {
-                          "fqn": "@cdktf/provider-aws.s3Bucket.S3Bucket",
-                          "version": "12.0.2",
-                        },
-                        "id": "Code",
-                        "path": "root/Default/my_bucket/my_bucket-on_create-OnMessage-2c90a36b/Code",
-                      },
                       "Default": {
                         "constructInfo": {
                           "fqn": "@cdktf/provider-aws.lambdaFunction.LambdaFunction",
@@ -993,7 +993,7 @@ exports[`bucket with onDelete method 1`] = `
         \\"publish\\": true,
         \\"role\\": \\"\${aws_iam_role.root_mybucket_mybucketondeleteOnMessagef22c8a47_IamRole_86A910D1.arn}\\",
         \\"runtime\\": \\"nodejs16.x\\",
-        \\"s3_bucket\\": \\"\${aws_s3_bucket.root_mybucket_mybucketondeleteOnMessagef22c8a47_Code_23AF5F43.bucket}\\",
+        \\"s3_bucket\\": \\"\${aws_s3_bucket.root_Code_02F3C603.bucket}\\",
         \\"s3_key\\": \\"\${aws_s3_object.root_mybucket_mybucketondeleteOnMessagef22c8a47_S3Object_2F148230.key}\\",
         \\"timeout\\": 30,
         \\"vpc_config\\": {
@@ -1011,12 +1011,12 @@ exports[`bucket with onDelete method 1`] = `
       }
     },
     \\"aws_s3_bucket\\": {
+      \\"root_Code_02F3C603\\": {
+        \\"bucket_prefix\\": \\"code-c84a50b1-\\"
+      },
       \\"root_mybucket_E5DAA363\\": {
         \\"bucket_prefix\\": \\"my-bucket-c8045fcc-\\",
         \\"force_destroy\\": false
-      },
-      \\"root_mybucket_mybucketondeleteOnMessagef22c8a47_Code_23AF5F43\\": {
-        \\"bucket_prefix\\": \\"code-c8ee90a3-\\"
       }
     },
     \\"aws_s3_bucket_notification\\": {
@@ -1055,7 +1055,7 @@ exports[`bucket with onDelete method 1`] = `
     },
     \\"aws_s3_object\\": {
       \\"root_mybucket_mybucketondeleteOnMessagef22c8a47_S3Object_2F148230\\": {
-        \\"bucket\\": \\"\${aws_s3_bucket.root_mybucket_mybucketondeleteOnMessagef22c8a47_Code_23AF5F43.bucket}\\",
+        \\"bucket\\": \\"\${aws_s3_bucket.root_Code_02F3C603.bucket}\\",
         \\"key\\": \\"<key>\\",
         \\"source\\": \\"<source>\\"
       }
@@ -1090,6 +1090,14 @@ exports[`bucket with onDelete method 2`] = `
         "children": {
           "Default": {
             "children": {
+              "Code": {
+                "constructInfo": {
+                  "fqn": "@cdktf/provider-aws.s3Bucket.S3Bucket",
+                  "version": "12.0.2",
+                },
+                "id": "Code",
+                "path": "root/Default/Code",
+              },
               "aws": {
                 "constructInfo": {
                   "fqn": "@cdktf/provider-aws.provider.AwsProvider",
@@ -1281,14 +1289,6 @@ exports[`bucket with onDelete method 2`] = `
                         },
                         "id": "Asset",
                         "path": "root/Default/my_bucket/my_bucket-on_delete-OnMessage-f22c8a47/Asset",
-                      },
-                      "Code": {
-                        "constructInfo": {
-                          "fqn": "@cdktf/provider-aws.s3Bucket.S3Bucket",
-                          "version": "12.0.2",
-                        },
-                        "id": "Code",
-                        "path": "root/Default/my_bucket/my_bucket-on_delete-OnMessage-f22c8a47/Code",
                       },
                       "Default": {
                         "constructInfo": {
@@ -1494,7 +1494,7 @@ exports[`bucket with onEvent method 1`] = `
         \\"publish\\": true,
         \\"role\\": \\"\${aws_iam_role.root_mybucket_mybucketoncreateOnMessage2c90a36b_IamRole_048D6026.arn}\\",
         \\"runtime\\": \\"nodejs16.x\\",
-        \\"s3_bucket\\": \\"\${aws_s3_bucket.root_mybucket_mybucketoncreateOnMessage2c90a36b_Code_3804774D.bucket}\\",
+        \\"s3_bucket\\": \\"\${aws_s3_bucket.root_Code_02F3C603.bucket}\\",
         \\"s3_key\\": \\"\${aws_s3_object.root_mybucket_mybucketoncreateOnMessage2c90a36b_S3Object_DDC97BAE.key}\\",
         \\"timeout\\": 30,
         \\"vpc_config\\": {
@@ -1513,7 +1513,7 @@ exports[`bucket with onEvent method 1`] = `
         \\"publish\\": true,
         \\"role\\": \\"\${aws_iam_role.root_mybucket_mybucketondeleteOnMessagef22c8a47_IamRole_86A910D1.arn}\\",
         \\"runtime\\": \\"nodejs16.x\\",
-        \\"s3_bucket\\": \\"\${aws_s3_bucket.root_mybucket_mybucketondeleteOnMessagef22c8a47_Code_23AF5F43.bucket}\\",
+        \\"s3_bucket\\": \\"\${aws_s3_bucket.root_Code_02F3C603.bucket}\\",
         \\"s3_key\\": \\"\${aws_s3_object.root_mybucket_mybucketondeleteOnMessagef22c8a47_S3Object_2F148230.key}\\",
         \\"timeout\\": 30,
         \\"vpc_config\\": {
@@ -1532,7 +1532,7 @@ exports[`bucket with onEvent method 1`] = `
         \\"publish\\": true,
         \\"role\\": \\"\${aws_iam_role.root_mybucket_mybucketonupdateOnMessage32b7a290_IamRole_C2D0AC31.arn}\\",
         \\"runtime\\": \\"nodejs16.x\\",
-        \\"s3_bucket\\": \\"\${aws_s3_bucket.root_mybucket_mybucketonupdateOnMessage32b7a290_Code_0DCA9F7A.bucket}\\",
+        \\"s3_bucket\\": \\"\${aws_s3_bucket.root_Code_02F3C603.bucket}\\",
         \\"s3_key\\": \\"\${aws_s3_object.root_mybucket_mybucketonupdateOnMessage32b7a290_S3Object_DD9A4CB9.key}\\",
         \\"timeout\\": 30,
         \\"vpc_config\\": {
@@ -1562,18 +1562,12 @@ exports[`bucket with onEvent method 1`] = `
       }
     },
     \\"aws_s3_bucket\\": {
+      \\"root_Code_02F3C603\\": {
+        \\"bucket_prefix\\": \\"code-c84a50b1-\\"
+      },
       \\"root_mybucket_E5DAA363\\": {
         \\"bucket_prefix\\": \\"my-bucket-c8045fcc-\\",
         \\"force_destroy\\": false
-      },
-      \\"root_mybucket_mybucketoncreateOnMessage2c90a36b_Code_3804774D\\": {
-        \\"bucket_prefix\\": \\"code-c8663a19-\\"
-      },
-      \\"root_mybucket_mybucketondeleteOnMessagef22c8a47_Code_23AF5F43\\": {
-        \\"bucket_prefix\\": \\"code-c8ee90a3-\\"
-      },
-      \\"root_mybucket_mybucketonupdateOnMessage32b7a290_Code_0DCA9F7A\\": {
-        \\"bucket_prefix\\": \\"code-c8864029-\\"
       }
     },
     \\"aws_s3_bucket_notification\\": {
@@ -1640,17 +1634,17 @@ exports[`bucket with onEvent method 1`] = `
     },
     \\"aws_s3_object\\": {
       \\"root_mybucket_mybucketoncreateOnMessage2c90a36b_S3Object_DDC97BAE\\": {
-        \\"bucket\\": \\"\${aws_s3_bucket.root_mybucket_mybucketoncreateOnMessage2c90a36b_Code_3804774D.bucket}\\",
+        \\"bucket\\": \\"\${aws_s3_bucket.root_Code_02F3C603.bucket}\\",
         \\"key\\": \\"<key>\\",
         \\"source\\": \\"<source>\\"
       },
       \\"root_mybucket_mybucketondeleteOnMessagef22c8a47_S3Object_2F148230\\": {
-        \\"bucket\\": \\"\${aws_s3_bucket.root_mybucket_mybucketondeleteOnMessagef22c8a47_Code_23AF5F43.bucket}\\",
+        \\"bucket\\": \\"\${aws_s3_bucket.root_Code_02F3C603.bucket}\\",
         \\"key\\": \\"<key>\\",
         \\"source\\": \\"<source>\\"
       },
       \\"root_mybucket_mybucketonupdateOnMessage32b7a290_S3Object_DD9A4CB9\\": {
-        \\"bucket\\": \\"\${aws_s3_bucket.root_mybucket_mybucketonupdateOnMessage32b7a290_Code_0DCA9F7A.bucket}\\",
+        \\"bucket\\": \\"\${aws_s3_bucket.root_Code_02F3C603.bucket}\\",
         \\"key\\": \\"<key>\\",
         \\"source\\": \\"<source>\\"
       }
@@ -1709,6 +1703,14 @@ exports[`bucket with onEvent method 2`] = `
         "children": {
           "Default": {
             "children": {
+              "Code": {
+                "constructInfo": {
+                  "fqn": "@cdktf/provider-aws.s3Bucket.S3Bucket",
+                  "version": "12.0.2",
+                },
+                "id": "Code",
+                "path": "root/Default/Code",
+              },
               "aws": {
                 "constructInfo": {
                   "fqn": "@cdktf/provider-aws.provider.AwsProvider",
@@ -1941,14 +1943,6 @@ exports[`bucket with onEvent method 2`] = `
                         "id": "Asset",
                         "path": "root/Default/my_bucket/my_bucket-on_create-OnMessage-2c90a36b/Asset",
                       },
-                      "Code": {
-                        "constructInfo": {
-                          "fqn": "@cdktf/provider-aws.s3Bucket.S3Bucket",
-                          "version": "12.0.2",
-                        },
-                        "id": "Code",
-                        "path": "root/Default/my_bucket/my_bucket-on_create-OnMessage-2c90a36b/Code",
-                      },
                       "Default": {
                         "constructInfo": {
                           "fqn": "@cdktf/provider-aws.lambdaFunction.LambdaFunction",
@@ -2112,14 +2106,6 @@ exports[`bucket with onEvent method 2`] = `
                         "id": "Asset",
                         "path": "root/Default/my_bucket/my_bucket-on_delete-OnMessage-f22c8a47/Asset",
                       },
-                      "Code": {
-                        "constructInfo": {
-                          "fqn": "@cdktf/provider-aws.s3Bucket.S3Bucket",
-                          "version": "12.0.2",
-                        },
-                        "id": "Code",
-                        "path": "root/Default/my_bucket/my_bucket-on_delete-OnMessage-f22c8a47/Code",
-                      },
                       "Default": {
                         "constructInfo": {
                           "fqn": "@cdktf/provider-aws.lambdaFunction.LambdaFunction",
@@ -2282,14 +2268,6 @@ exports[`bucket with onEvent method 2`] = `
                         },
                         "id": "Asset",
                         "path": "root/Default/my_bucket/my_bucket-on_update-OnMessage-32b7a290/Asset",
-                      },
-                      "Code": {
-                        "constructInfo": {
-                          "fqn": "@cdktf/provider-aws.s3Bucket.S3Bucket",
-                          "version": "12.0.2",
-                        },
-                        "id": "Code",
-                        "path": "root/Default/my_bucket/my_bucket-on_update-OnMessage-32b7a290/Code",
                       },
                       "Default": {
                         "constructInfo": {
@@ -2517,7 +2495,7 @@ exports[`bucket with onUpdate method 1`] = `
         \\"publish\\": true,
         \\"role\\": \\"\${aws_iam_role.root_mybucket_mybucketonupdateOnMessage32b7a290_IamRole_C2D0AC31.arn}\\",
         \\"runtime\\": \\"nodejs16.x\\",
-        \\"s3_bucket\\": \\"\${aws_s3_bucket.root_mybucket_mybucketonupdateOnMessage32b7a290_Code_0DCA9F7A.bucket}\\",
+        \\"s3_bucket\\": \\"\${aws_s3_bucket.root_Code_02F3C603.bucket}\\",
         \\"s3_key\\": \\"\${aws_s3_object.root_mybucket_mybucketonupdateOnMessage32b7a290_S3Object_DD9A4CB9.key}\\",
         \\"timeout\\": 30,
         \\"vpc_config\\": {
@@ -2535,12 +2513,12 @@ exports[`bucket with onUpdate method 1`] = `
       }
     },
     \\"aws_s3_bucket\\": {
+      \\"root_Code_02F3C603\\": {
+        \\"bucket_prefix\\": \\"code-c84a50b1-\\"
+      },
       \\"root_mybucket_E5DAA363\\": {
         \\"bucket_prefix\\": \\"my-bucket-c8045fcc-\\",
         \\"force_destroy\\": false
-      },
-      \\"root_mybucket_mybucketonupdateOnMessage32b7a290_Code_0DCA9F7A\\": {
-        \\"bucket_prefix\\": \\"code-c8864029-\\"
       }
     },
     \\"aws_s3_bucket_notification\\": {
@@ -2579,7 +2557,7 @@ exports[`bucket with onUpdate method 1`] = `
     },
     \\"aws_s3_object\\": {
       \\"root_mybucket_mybucketonupdateOnMessage32b7a290_S3Object_DD9A4CB9\\": {
-        \\"bucket\\": \\"\${aws_s3_bucket.root_mybucket_mybucketonupdateOnMessage32b7a290_Code_0DCA9F7A.bucket}\\",
+        \\"bucket\\": \\"\${aws_s3_bucket.root_Code_02F3C603.bucket}\\",
         \\"key\\": \\"<key>\\",
         \\"source\\": \\"<source>\\"
       }
@@ -2614,6 +2592,14 @@ exports[`bucket with onUpdate method 2`] = `
         "children": {
           "Default": {
             "children": {
+              "Code": {
+                "constructInfo": {
+                  "fqn": "@cdktf/provider-aws.s3Bucket.S3Bucket",
+                  "version": "12.0.2",
+                },
+                "id": "Code",
+                "path": "root/Default/Code",
+              },
               "aws": {
                 "constructInfo": {
                   "fqn": "@cdktf/provider-aws.provider.AwsProvider",
@@ -2805,14 +2791,6 @@ exports[`bucket with onUpdate method 2`] = `
                         },
                         "id": "Asset",
                         "path": "root/Default/my_bucket/my_bucket-on_update-OnMessage-32b7a290/Asset",
-                      },
-                      "Code": {
-                        "constructInfo": {
-                          "fqn": "@cdktf/provider-aws.s3Bucket.S3Bucket",
-                          "version": "12.0.2",
-                        },
-                        "id": "Code",
-                        "path": "root/Default/my_bucket/my_bucket-on_update-OnMessage-32b7a290/Code",
                       },
                       "Default": {
                         "constructInfo": {

--- a/libs/wingsdk/test/target-tf-aws/__snapshots__/captures.test.ts.snap
+++ b/libs/wingsdk/test/target-tf-aws/__snapshots__/captures.test.ts.snap
@@ -81,7 +81,7 @@ exports[`function with a function binding 3`] = `
         \\"publish\\": true,
         \\"role\\": \\"\${aws_iam_role.root_Function1_IamRole_7017166A.arn}\\",
         \\"runtime\\": \\"nodejs16.x\\",
-        \\"s3_bucket\\": \\"\${aws_s3_bucket.root_Function1_Code_9E57A288.bucket}\\",
+        \\"s3_bucket\\": \\"\${aws_s3_bucket.root_Code_02F3C603.bucket}\\",
         \\"s3_key\\": \\"\${aws_s3_object.root_Function1_S3Object_AA76C357.key}\\",
         \\"timeout\\": 30,
         \\"vpc_config\\": {
@@ -101,7 +101,7 @@ exports[`function with a function binding 3`] = `
         \\"publish\\": true,
         \\"role\\": \\"\${aws_iam_role.root_Function2_IamRole_1D1C491F.arn}\\",
         \\"runtime\\": \\"nodejs16.x\\",
-        \\"s3_bucket\\": \\"\${aws_s3_bucket.root_Function2_Code_F5825D80.bucket}\\",
+        \\"s3_bucket\\": \\"\${aws_s3_bucket.root_Code_02F3C603.bucket}\\",
         \\"s3_key\\": \\"\${aws_s3_object.root_Function2_S3Object_7E3557EA.key}\\",
         \\"timeout\\": 30,
         \\"vpc_config\\": {
@@ -111,21 +111,18 @@ exports[`function with a function binding 3`] = `
       }
     },
     \\"aws_s3_bucket\\": {
-      \\"root_Function1_Code_9E57A288\\": {
-        \\"bucket_prefix\\": \\"code-c89a4138-\\"
-      },
-      \\"root_Function2_Code_F5825D80\\": {
-        \\"bucket_prefix\\": \\"code-c8247f41-\\"
+      \\"root_Code_02F3C603\\": {
+        \\"bucket_prefix\\": \\"code-c84a50b1-\\"
       }
     },
     \\"aws_s3_object\\": {
       \\"root_Function1_S3Object_AA76C357\\": {
-        \\"bucket\\": \\"\${aws_s3_bucket.root_Function1_Code_9E57A288.bucket}\\",
+        \\"bucket\\": \\"\${aws_s3_bucket.root_Code_02F3C603.bucket}\\",
         \\"key\\": \\"<key>\\",
         \\"source\\": \\"<source>\\"
       },
       \\"root_Function2_S3Object_7E3557EA\\": {
-        \\"bucket\\": \\"\${aws_s3_bucket.root_Function2_Code_F5825D80.bucket}\\",
+        \\"bucket\\": \\"\${aws_s3_bucket.root_Code_02F3C603.bucket}\\",
         \\"key\\": \\"<key>\\",
         \\"source\\": \\"<source>\\"
       }
@@ -220,7 +217,7 @@ exports[`function with a queue binding 3`] = `
         \\"publish\\": true,
         \\"role\\": \\"\${aws_iam_role.root_Function_IamRole_88AD864C.arn}\\",
         \\"runtime\\": \\"nodejs16.x\\",
-        \\"s3_bucket\\": \\"\${aws_s3_bucket.root_Function_Code_794C2A8A.bucket}\\",
+        \\"s3_bucket\\": \\"\${aws_s3_bucket.root_Code_02F3C603.bucket}\\",
         \\"s3_key\\": \\"\${aws_s3_object.root_Function_S3Object_A62722D8.key}\\",
         \\"timeout\\": 30,
         \\"vpc_config\\": {
@@ -239,7 +236,7 @@ exports[`function with a queue binding 3`] = `
         \\"publish\\": true,
         \\"role\\": \\"\${aws_iam_role.root_QueueAddConsumer5cb7e554_IamRole_81BC72C0.arn}\\",
         \\"runtime\\": \\"nodejs16.x\\",
-        \\"s3_bucket\\": \\"\${aws_s3_bucket.root_QueueAddConsumer5cb7e554_Code_E6740DA4.bucket}\\",
+        \\"s3_bucket\\": \\"\${aws_s3_bucket.root_Code_02F3C603.bucket}\\",
         \\"s3_key\\": \\"\${aws_s3_object.root_QueueAddConsumer5cb7e554_S3Object_DA510611.key}\\",
         \\"timeout\\": 30,
         \\"vpc_config\\": {
@@ -249,21 +246,18 @@ exports[`function with a queue binding 3`] = `
       }
     },
     \\"aws_s3_bucket\\": {
-      \\"root_Function_Code_794C2A8A\\": {
-        \\"bucket_prefix\\": \\"code-c87cd513-\\"
-      },
-      \\"root_QueueAddConsumer5cb7e554_Code_E6740DA4\\": {
-        \\"bucket_prefix\\": \\"code-c8dff992-\\"
+      \\"root_Code_02F3C603\\": {
+        \\"bucket_prefix\\": \\"code-c84a50b1-\\"
       }
     },
     \\"aws_s3_object\\": {
       \\"root_Function_S3Object_A62722D8\\": {
-        \\"bucket\\": \\"\${aws_s3_bucket.root_Function_Code_794C2A8A.bucket}\\",
+        \\"bucket\\": \\"\${aws_s3_bucket.root_Code_02F3C603.bucket}\\",
         \\"key\\": \\"<key>\\",
         \\"source\\": \\"<source>\\"
       },
       \\"root_QueueAddConsumer5cb7e554_S3Object_DA510611\\": {
-        \\"bucket\\": \\"\${aws_s3_bucket.root_QueueAddConsumer5cb7e554_Code_E6740DA4.bucket}\\",
+        \\"bucket\\": \\"\${aws_s3_bucket.root_Code_02F3C603.bucket}\\",
         \\"key\\": \\"<key>\\",
         \\"source\\": \\"<source>\\"
       }
@@ -331,7 +325,7 @@ exports[`function with bucket binding > put operation 2`] = `
         \\"publish\\": true,
         \\"role\\": \\"\${aws_iam_role.root_Function_IamRole_88AD864C.arn}\\",
         \\"runtime\\": \\"nodejs16.x\\",
-        \\"s3_bucket\\": \\"\${aws_s3_bucket.root_Function_Code_794C2A8A.bucket}\\",
+        \\"s3_bucket\\": \\"\${aws_s3_bucket.root_Code_02F3C603.bucket}\\",
         \\"s3_key\\": \\"\${aws_s3_object.root_Function_S3Object_A62722D8.key}\\",
         \\"timeout\\": 30,
         \\"vpc_config\\": {
@@ -345,8 +339,8 @@ exports[`function with bucket binding > put operation 2`] = `
         \\"bucket_prefix\\": \\"bucket-c88fdc5f-\\",
         \\"force_destroy\\": false
       },
-      \\"root_Function_Code_794C2A8A\\": {
-        \\"bucket_prefix\\": \\"code-c87cd513-\\"
+      \\"root_Code_02F3C603\\": {
+        \\"bucket_prefix\\": \\"code-c84a50b1-\\"
       }
     },
     \\"aws_s3_bucket_public_access_block\\": {
@@ -372,7 +366,7 @@ exports[`function with bucket binding > put operation 2`] = `
     },
     \\"aws_s3_object\\": {
       \\"root_Function_S3Object_A62722D8\\": {
-        \\"bucket\\": \\"\${aws_s3_bucket.root_Function_Code_794C2A8A.bucket}\\",
+        \\"bucket\\": \\"\${aws_s3_bucket.root_Code_02F3C603.bucket}\\",
         \\"key\\": \\"<key>\\",
         \\"source\\": \\"<source>\\"
       }
@@ -429,7 +423,7 @@ exports[`two functions reusing the same IFunctionHandler 1`] = `
         \\"publish\\": true,
         \\"role\\": \\"\${aws_iam_role.root_Function1_IamRole_7017166A.arn}\\",
         \\"runtime\\": \\"nodejs16.x\\",
-        \\"s3_bucket\\": \\"\${aws_s3_bucket.root_Function1_Code_9E57A288.bucket}\\",
+        \\"s3_bucket\\": \\"\${aws_s3_bucket.root_Code_02F3C603.bucket}\\",
         \\"s3_key\\": \\"\${aws_s3_object.root_Function1_S3Object_AA76C357.key}\\",
         \\"timeout\\": 30,
         \\"vpc_config\\": {
@@ -448,7 +442,7 @@ exports[`two functions reusing the same IFunctionHandler 1`] = `
         \\"publish\\": true,
         \\"role\\": \\"\${aws_iam_role.root_Function2_IamRole_1D1C491F.arn}\\",
         \\"runtime\\": \\"nodejs16.x\\",
-        \\"s3_bucket\\": \\"\${aws_s3_bucket.root_Function2_Code_F5825D80.bucket}\\",
+        \\"s3_bucket\\": \\"\${aws_s3_bucket.root_Code_02F3C603.bucket}\\",
         \\"s3_key\\": \\"\${aws_s3_object.root_Function2_S3Object_7E3557EA.key}\\",
         \\"timeout\\": 30,
         \\"vpc_config\\": {
@@ -458,21 +452,18 @@ exports[`two functions reusing the same IFunctionHandler 1`] = `
       }
     },
     \\"aws_s3_bucket\\": {
-      \\"root_Function1_Code_9E57A288\\": {
-        \\"bucket_prefix\\": \\"code-c89a4138-\\"
-      },
-      \\"root_Function2_Code_F5825D80\\": {
-        \\"bucket_prefix\\": \\"code-c8247f41-\\"
+      \\"root_Code_02F3C603\\": {
+        \\"bucket_prefix\\": \\"code-c84a50b1-\\"
       }
     },
     \\"aws_s3_object\\": {
       \\"root_Function1_S3Object_AA76C357\\": {
-        \\"bucket\\": \\"\${aws_s3_bucket.root_Function1_Code_9E57A288.bucket}\\",
+        \\"bucket\\": \\"\${aws_s3_bucket.root_Code_02F3C603.bucket}\\",
         \\"key\\": \\"<key>\\",
         \\"source\\": \\"<source>\\"
       },
       \\"root_Function2_S3Object_7E3557EA\\": {
-        \\"bucket\\": \\"\${aws_s3_bucket.root_Function2_Code_F5825D80.bucket}\\",
+        \\"bucket\\": \\"\${aws_s3_bucket.root_Code_02F3C603.bucket}\\",
         \\"key\\": \\"<key>\\",
         \\"source\\": \\"<source>\\"
       }

--- a/libs/wingsdk/test/target-tf-aws/__snapshots__/counter.test.ts.snap
+++ b/libs/wingsdk/test/target-tf-aws/__snapshots__/counter.test.ts.snap
@@ -311,7 +311,7 @@ exports[`dec() policy statement 1`] = `
         \\"publish\\": true,
         \\"role\\": \\"\${aws_iam_role.root_Function_IamRole_88AD864C.arn}\\",
         \\"runtime\\": \\"nodejs16.x\\",
-        \\"s3_bucket\\": \\"\${aws_s3_bucket.root_Function_Code_794C2A8A.bucket}\\",
+        \\"s3_bucket\\": \\"\${aws_s3_bucket.root_Code_02F3C603.bucket}\\",
         \\"s3_key\\": \\"\${aws_s3_object.root_Function_S3Object_A62722D8.key}\\",
         \\"timeout\\": 30,
         \\"vpc_config\\": {
@@ -321,13 +321,13 @@ exports[`dec() policy statement 1`] = `
       }
     },
     \\"aws_s3_bucket\\": {
-      \\"root_Function_Code_794C2A8A\\": {
-        \\"bucket_prefix\\": \\"code-c87cd513-\\"
+      \\"root_Code_02F3C603\\": {
+        \\"bucket_prefix\\": \\"code-c84a50b1-\\"
       }
     },
     \\"aws_s3_object\\": {
       \\"root_Function_S3Object_A62722D8\\": {
-        \\"bucket\\": \\"\${aws_s3_bucket.root_Function_Code_794C2A8A.bucket}\\",
+        \\"bucket\\": \\"\${aws_s3_bucket.root_Code_02F3C603.bucket}\\",
         \\"key\\": \\"<key>\\",
         \\"source\\": \\"<source>\\"
       }
@@ -344,6 +344,14 @@ exports[`dec() policy statement 2`] = `
         "children": {
           "Default": {
             "children": {
+              "Code": {
+                "constructInfo": {
+                  "fqn": "@cdktf/provider-aws.s3Bucket.S3Bucket",
+                  "version": "12.0.2",
+                },
+                "id": "Code",
+                "path": "root/Default/Code",
+              },
               "Counter": {
                 "attributes": {
                   "wing:resource:connections": [
@@ -397,14 +405,6 @@ exports[`dec() policy statement 2`] = `
                     },
                     "id": "Asset",
                     "path": "root/Default/Function/Asset",
-                  },
-                  "Code": {
-                    "constructInfo": {
-                      "fqn": "@cdktf/provider-aws.s3Bucket.S3Bucket",
-                      "version": "12.0.2",
-                    },
-                    "id": "Code",
-                    "path": "root/Default/Function/Code",
                   },
                   "Default": {
                     "constructInfo": {
@@ -640,7 +640,7 @@ exports[`function with a counter binding 2`] = `
         \\"publish\\": true,
         \\"role\\": \\"\${aws_iam_role.root_Function_IamRole_88AD864C.arn}\\",
         \\"runtime\\": \\"nodejs16.x\\",
-        \\"s3_bucket\\": \\"\${aws_s3_bucket.root_Function_Code_794C2A8A.bucket}\\",
+        \\"s3_bucket\\": \\"\${aws_s3_bucket.root_Code_02F3C603.bucket}\\",
         \\"s3_key\\": \\"\${aws_s3_object.root_Function_S3Object_A62722D8.key}\\",
         \\"timeout\\": 30,
         \\"vpc_config\\": {
@@ -650,13 +650,13 @@ exports[`function with a counter binding 2`] = `
       }
     },
     \\"aws_s3_bucket\\": {
-      \\"root_Function_Code_794C2A8A\\": {
-        \\"bucket_prefix\\": \\"code-c87cd513-\\"
+      \\"root_Code_02F3C603\\": {
+        \\"bucket_prefix\\": \\"code-c84a50b1-\\"
       }
     },
     \\"aws_s3_object\\": {
       \\"root_Function_S3Object_A62722D8\\": {
-        \\"bucket\\": \\"\${aws_s3_bucket.root_Function_Code_794C2A8A.bucket}\\",
+        \\"bucket\\": \\"\${aws_s3_bucket.root_Code_02F3C603.bucket}\\",
         \\"key\\": \\"<key>\\",
         \\"source\\": \\"<source>\\"
       }
@@ -673,6 +673,14 @@ exports[`function with a counter binding 3`] = `
         "children": {
           "Default": {
             "children": {
+              "Code": {
+                "constructInfo": {
+                  "fqn": "@cdktf/provider-aws.s3Bucket.S3Bucket",
+                  "version": "12.0.2",
+                },
+                "id": "Code",
+                "path": "root/Default/Code",
+              },
               "Counter": {
                 "attributes": {
                   "wing:resource:connections": [
@@ -726,14 +734,6 @@ exports[`function with a counter binding 3`] = `
                     },
                     "id": "Asset",
                     "path": "root/Default/Function/Asset",
-                  },
-                  "Code": {
-                    "constructInfo": {
-                      "fqn": "@cdktf/provider-aws.s3Bucket.S3Bucket",
-                      "version": "12.0.2",
-                    },
-                    "id": "Code",
-                    "path": "root/Default/Function/Code",
                   },
                   "Default": {
                     "constructInfo": {
@@ -926,7 +926,7 @@ exports[`inc() policy statement 1`] = `
         \\"publish\\": true,
         \\"role\\": \\"\${aws_iam_role.root_Function_IamRole_88AD864C.arn}\\",
         \\"runtime\\": \\"nodejs16.x\\",
-        \\"s3_bucket\\": \\"\${aws_s3_bucket.root_Function_Code_794C2A8A.bucket}\\",
+        \\"s3_bucket\\": \\"\${aws_s3_bucket.root_Code_02F3C603.bucket}\\",
         \\"s3_key\\": \\"\${aws_s3_object.root_Function_S3Object_A62722D8.key}\\",
         \\"timeout\\": 30,
         \\"vpc_config\\": {
@@ -936,13 +936,13 @@ exports[`inc() policy statement 1`] = `
       }
     },
     \\"aws_s3_bucket\\": {
-      \\"root_Function_Code_794C2A8A\\": {
-        \\"bucket_prefix\\": \\"code-c87cd513-\\"
+      \\"root_Code_02F3C603\\": {
+        \\"bucket_prefix\\": \\"code-c84a50b1-\\"
       }
     },
     \\"aws_s3_object\\": {
       \\"root_Function_S3Object_A62722D8\\": {
-        \\"bucket\\": \\"\${aws_s3_bucket.root_Function_Code_794C2A8A.bucket}\\",
+        \\"bucket\\": \\"\${aws_s3_bucket.root_Code_02F3C603.bucket}\\",
         \\"key\\": \\"<key>\\",
         \\"source\\": \\"<source>\\"
       }
@@ -959,6 +959,14 @@ exports[`inc() policy statement 2`] = `
         "children": {
           "Default": {
             "children": {
+              "Code": {
+                "constructInfo": {
+                  "fqn": "@cdktf/provider-aws.s3Bucket.S3Bucket",
+                  "version": "12.0.2",
+                },
+                "id": "Code",
+                "path": "root/Default/Code",
+              },
               "Counter": {
                 "attributes": {
                   "wing:resource:connections": [
@@ -1012,14 +1020,6 @@ exports[`inc() policy statement 2`] = `
                     },
                     "id": "Asset",
                     "path": "root/Default/Function/Asset",
-                  },
-                  "Code": {
-                    "constructInfo": {
-                      "fqn": "@cdktf/provider-aws.s3Bucket.S3Bucket",
-                      "version": "12.0.2",
-                    },
-                    "id": "Code",
-                    "path": "root/Default/Function/Code",
                   },
                   "Default": {
                     "constructInfo": {
@@ -1212,7 +1212,7 @@ exports[`peek() policy statement 1`] = `
         \\"publish\\": true,
         \\"role\\": \\"\${aws_iam_role.root_Function_IamRole_88AD864C.arn}\\",
         \\"runtime\\": \\"nodejs16.x\\",
-        \\"s3_bucket\\": \\"\${aws_s3_bucket.root_Function_Code_794C2A8A.bucket}\\",
+        \\"s3_bucket\\": \\"\${aws_s3_bucket.root_Code_02F3C603.bucket}\\",
         \\"s3_key\\": \\"\${aws_s3_object.root_Function_S3Object_A62722D8.key}\\",
         \\"timeout\\": 30,
         \\"vpc_config\\": {
@@ -1222,13 +1222,13 @@ exports[`peek() policy statement 1`] = `
       }
     },
     \\"aws_s3_bucket\\": {
-      \\"root_Function_Code_794C2A8A\\": {
-        \\"bucket_prefix\\": \\"code-c87cd513-\\"
+      \\"root_Code_02F3C603\\": {
+        \\"bucket_prefix\\": \\"code-c84a50b1-\\"
       }
     },
     \\"aws_s3_object\\": {
       \\"root_Function_S3Object_A62722D8\\": {
-        \\"bucket\\": \\"\${aws_s3_bucket.root_Function_Code_794C2A8A.bucket}\\",
+        \\"bucket\\": \\"\${aws_s3_bucket.root_Code_02F3C603.bucket}\\",
         \\"key\\": \\"<key>\\",
         \\"source\\": \\"<source>\\"
       }
@@ -1245,6 +1245,14 @@ exports[`peek() policy statement 2`] = `
         "children": {
           "Default": {
             "children": {
+              "Code": {
+                "constructInfo": {
+                  "fqn": "@cdktf/provider-aws.s3Bucket.S3Bucket",
+                  "version": "12.0.2",
+                },
+                "id": "Code",
+                "path": "root/Default/Code",
+              },
               "Counter": {
                 "attributes": {
                   "wing:resource:connections": [
@@ -1298,14 +1306,6 @@ exports[`peek() policy statement 2`] = `
                     },
                     "id": "Asset",
                     "path": "root/Default/Function/Asset",
-                  },
-                  "Code": {
-                    "constructInfo": {
-                      "fqn": "@cdktf/provider-aws.s3Bucket.S3Bucket",
-                      "version": "12.0.2",
-                    },
-                    "id": "Code",
-                    "path": "root/Default/Function/Code",
                   },
                   "Default": {
                     "constructInfo": {
@@ -1628,7 +1628,7 @@ exports[`reset() policy statement 1`] = `
         \\"publish\\": true,
         \\"role\\": \\"\${aws_iam_role.root_Function_IamRole_88AD864C.arn}\\",
         \\"runtime\\": \\"nodejs16.x\\",
-        \\"s3_bucket\\": \\"\${aws_s3_bucket.root_Function_Code_794C2A8A.bucket}\\",
+        \\"s3_bucket\\": \\"\${aws_s3_bucket.root_Code_02F3C603.bucket}\\",
         \\"s3_key\\": \\"\${aws_s3_object.root_Function_S3Object_A62722D8.key}\\",
         \\"timeout\\": 30,
         \\"vpc_config\\": {
@@ -1638,13 +1638,13 @@ exports[`reset() policy statement 1`] = `
       }
     },
     \\"aws_s3_bucket\\": {
-      \\"root_Function_Code_794C2A8A\\": {
-        \\"bucket_prefix\\": \\"code-c87cd513-\\"
+      \\"root_Code_02F3C603\\": {
+        \\"bucket_prefix\\": \\"code-c84a50b1-\\"
       }
     },
     \\"aws_s3_object\\": {
       \\"root_Function_S3Object_A62722D8\\": {
-        \\"bucket\\": \\"\${aws_s3_bucket.root_Function_Code_794C2A8A.bucket}\\",
+        \\"bucket\\": \\"\${aws_s3_bucket.root_Code_02F3C603.bucket}\\",
         \\"key\\": \\"<key>\\",
         \\"source\\": \\"<source>\\"
       }
@@ -1661,6 +1661,14 @@ exports[`reset() policy statement 2`] = `
         "children": {
           "Default": {
             "children": {
+              "Code": {
+                "constructInfo": {
+                  "fqn": "@cdktf/provider-aws.s3Bucket.S3Bucket",
+                  "version": "12.0.2",
+                },
+                "id": "Code",
+                "path": "root/Default/Code",
+              },
               "Counter": {
                 "attributes": {
                   "wing:resource:connections": [
@@ -1714,14 +1722,6 @@ exports[`reset() policy statement 2`] = `
                     },
                     "id": "Asset",
                     "path": "root/Default/Function/Asset",
-                  },
-                  "Code": {
-                    "constructInfo": {
-                      "fqn": "@cdktf/provider-aws.s3Bucket.S3Bucket",
-                      "version": "12.0.2",
-                    },
-                    "id": "Code",
-                    "path": "root/Default/Function/Code",
                   },
                   "Default": {
                     "constructInfo": {

--- a/libs/wingsdk/test/target-tf-aws/__snapshots__/function.test.ts.snap
+++ b/libs/wingsdk/test/target-tf-aws/__snapshots__/function.test.ts.snap
@@ -37,7 +37,7 @@ exports[`basic function 1`] = `
         \\"publish\\": true,
         \\"role\\": \\"\${aws_iam_role.root_Function_IamRole_88AD864C.arn}\\",
         \\"runtime\\": \\"nodejs16.x\\",
-        \\"s3_bucket\\": \\"\${aws_s3_bucket.root_Function_Code_794C2A8A.bucket}\\",
+        \\"s3_bucket\\": \\"\${aws_s3_bucket.root_Code_02F3C603.bucket}\\",
         \\"s3_key\\": \\"\${aws_s3_object.root_Function_S3Object_A62722D8.key}\\",
         \\"timeout\\": 30,
         \\"vpc_config\\": {
@@ -47,13 +47,13 @@ exports[`basic function 1`] = `
       }
     },
     \\"aws_s3_bucket\\": {
-      \\"root_Function_Code_794C2A8A\\": {
-        \\"bucket_prefix\\": \\"code-c87cd513-\\"
+      \\"root_Code_02F3C603\\": {
+        \\"bucket_prefix\\": \\"code-c84a50b1-\\"
       }
     },
     \\"aws_s3_object\\": {
       \\"root_Function_S3Object_A62722D8\\": {
-        \\"bucket\\": \\"\${aws_s3_bucket.root_Function_Code_794C2A8A.bucket}\\",
+        \\"bucket\\": \\"\${aws_s3_bucket.root_Code_02F3C603.bucket}\\",
         \\"key\\": \\"<key>\\",
         \\"source\\": \\"<source>\\"
       }
@@ -70,6 +70,14 @@ exports[`basic function 2`] = `
         "children": {
           "Default": {
             "children": {
+              "Code": {
+                "constructInfo": {
+                  "fqn": "@cdktf/provider-aws.s3Bucket.S3Bucket",
+                  "version": "12.0.2",
+                },
+                "id": "Code",
+                "path": "root/Default/Code",
+              },
               "Function": {
                 "attributes": {
                   "wing:resource:connections": [],
@@ -83,14 +91,6 @@ exports[`basic function 2`] = `
                     },
                     "id": "Asset",
                     "path": "root/Default/Function/Asset",
-                  },
-                  "Code": {
-                    "constructInfo": {
-                      "fqn": "@cdktf/provider-aws.s3Bucket.S3Bucket",
-                      "version": "12.0.2",
-                    },
-                    "id": "Code",
-                    "path": "root/Default/Function/Code",
                   },
                   "Default": {
                     "constructInfo": {
@@ -271,7 +271,7 @@ exports[`basic function with environment variables 1`] = `
         \\"publish\\": true,
         \\"role\\": \\"\${aws_iam_role.root_Function_IamRole_88AD864C.arn}\\",
         \\"runtime\\": \\"nodejs16.x\\",
-        \\"s3_bucket\\": \\"\${aws_s3_bucket.root_Function_Code_794C2A8A.bucket}\\",
+        \\"s3_bucket\\": \\"\${aws_s3_bucket.root_Code_02F3C603.bucket}\\",
         \\"s3_key\\": \\"\${aws_s3_object.root_Function_S3Object_A62722D8.key}\\",
         \\"timeout\\": 30,
         \\"vpc_config\\": {
@@ -281,13 +281,13 @@ exports[`basic function with environment variables 1`] = `
       }
     },
     \\"aws_s3_bucket\\": {
-      \\"root_Function_Code_794C2A8A\\": {
-        \\"bucket_prefix\\": \\"code-c87cd513-\\"
+      \\"root_Code_02F3C603\\": {
+        \\"bucket_prefix\\": \\"code-c84a50b1-\\"
       }
     },
     \\"aws_s3_object\\": {
       \\"root_Function_S3Object_A62722D8\\": {
-        \\"bucket\\": \\"\${aws_s3_bucket.root_Function_Code_794C2A8A.bucket}\\",
+        \\"bucket\\": \\"\${aws_s3_bucket.root_Code_02F3C603.bucket}\\",
         \\"key\\": \\"<key>\\",
         \\"source\\": \\"<source>\\"
       }
@@ -304,6 +304,14 @@ exports[`basic function with environment variables 2`] = `
         "children": {
           "Default": {
             "children": {
+              "Code": {
+                "constructInfo": {
+                  "fqn": "@cdktf/provider-aws.s3Bucket.S3Bucket",
+                  "version": "12.0.2",
+                },
+                "id": "Code",
+                "path": "root/Default/Code",
+              },
               "Function": {
                 "attributes": {
                   "wing:resource:connections": [],
@@ -317,14 +325,6 @@ exports[`basic function with environment variables 2`] = `
                     },
                     "id": "Asset",
                     "path": "root/Default/Function/Asset",
-                  },
-                  "Code": {
-                    "constructInfo": {
-                      "fqn": "@cdktf/provider-aws.s3Bucket.S3Bucket",
-                      "version": "12.0.2",
-                    },
-                    "id": "Code",
-                    "path": "root/Default/Function/Code",
                   },
                   "Default": {
                     "constructInfo": {
@@ -504,7 +504,7 @@ exports[`basic function with memory size specified 1`] = `
         \\"publish\\": true,
         \\"role\\": \\"\${aws_iam_role.root_Function_IamRole_88AD864C.arn}\\",
         \\"runtime\\": \\"nodejs16.x\\",
-        \\"s3_bucket\\": \\"\${aws_s3_bucket.root_Function_Code_794C2A8A.bucket}\\",
+        \\"s3_bucket\\": \\"\${aws_s3_bucket.root_Code_02F3C603.bucket}\\",
         \\"s3_key\\": \\"\${aws_s3_object.root_Function_S3Object_A62722D8.key}\\",
         \\"timeout\\": 30,
         \\"vpc_config\\": {
@@ -514,13 +514,13 @@ exports[`basic function with memory size specified 1`] = `
       }
     },
     \\"aws_s3_bucket\\": {
-      \\"root_Function_Code_794C2A8A\\": {
-        \\"bucket_prefix\\": \\"code-c87cd513-\\"
+      \\"root_Code_02F3C603\\": {
+        \\"bucket_prefix\\": \\"code-c84a50b1-\\"
       }
     },
     \\"aws_s3_object\\": {
       \\"root_Function_S3Object_A62722D8\\": {
-        \\"bucket\\": \\"\${aws_s3_bucket.root_Function_Code_794C2A8A.bucket}\\",
+        \\"bucket\\": \\"\${aws_s3_bucket.root_Code_02F3C603.bucket}\\",
         \\"key\\": \\"<key>\\",
         \\"source\\": \\"<source>\\"
       }
@@ -537,6 +537,14 @@ exports[`basic function with memory size specified 2`] = `
         "children": {
           "Default": {
             "children": {
+              "Code": {
+                "constructInfo": {
+                  "fqn": "@cdktf/provider-aws.s3Bucket.S3Bucket",
+                  "version": "12.0.2",
+                },
+                "id": "Code",
+                "path": "root/Default/Code",
+              },
               "Function": {
                 "attributes": {
                   "wing:resource:connections": [],
@@ -550,14 +558,6 @@ exports[`basic function with memory size specified 2`] = `
                     },
                     "id": "Asset",
                     "path": "root/Default/Function/Asset",
-                  },
-                  "Code": {
-                    "constructInfo": {
-                      "fqn": "@cdktf/provider-aws.s3Bucket.S3Bucket",
-                      "version": "12.0.2",
-                    },
-                    "id": "Code",
-                    "path": "root/Default/Function/Code",
                   },
                   "Default": {
                     "constructInfo": {
@@ -736,7 +736,7 @@ exports[`basic function with timeout explicitly set 1`] = `
         \\"publish\\": true,
         \\"role\\": \\"\${aws_iam_role.root_Function_IamRole_88AD864C.arn}\\",
         \\"runtime\\": \\"nodejs16.x\\",
-        \\"s3_bucket\\": \\"\${aws_s3_bucket.root_Function_Code_794C2A8A.bucket}\\",
+        \\"s3_bucket\\": \\"\${aws_s3_bucket.root_Code_02F3C603.bucket}\\",
         \\"s3_key\\": \\"\${aws_s3_object.root_Function_S3Object_A62722D8.key}\\",
         \\"timeout\\": 30,
         \\"vpc_config\\": {
@@ -746,13 +746,13 @@ exports[`basic function with timeout explicitly set 1`] = `
       }
     },
     \\"aws_s3_bucket\\": {
-      \\"root_Function_Code_794C2A8A\\": {
-        \\"bucket_prefix\\": \\"code-c87cd513-\\"
+      \\"root_Code_02F3C603\\": {
+        \\"bucket_prefix\\": \\"code-c84a50b1-\\"
       }
     },
     \\"aws_s3_object\\": {
       \\"root_Function_S3Object_A62722D8\\": {
-        \\"bucket\\": \\"\${aws_s3_bucket.root_Function_Code_794C2A8A.bucket}\\",
+        \\"bucket\\": \\"\${aws_s3_bucket.root_Code_02F3C603.bucket}\\",
         \\"key\\": \\"<key>\\",
         \\"source\\": \\"<source>\\"
       }
@@ -769,6 +769,14 @@ exports[`basic function with timeout explicitly set 2`] = `
         "children": {
           "Default": {
             "children": {
+              "Code": {
+                "constructInfo": {
+                  "fqn": "@cdktf/provider-aws.s3Bucket.S3Bucket",
+                  "version": "12.0.2",
+                },
+                "id": "Code",
+                "path": "root/Default/Code",
+              },
               "Function": {
                 "attributes": {
                   "wing:resource:connections": [],
@@ -782,14 +790,6 @@ exports[`basic function with timeout explicitly set 2`] = `
                     },
                     "id": "Asset",
                     "path": "root/Default/Function/Asset",
-                  },
-                  "Code": {
-                    "constructInfo": {
-                      "fqn": "@cdktf/provider-aws.s3Bucket.S3Bucket",
-                      "version": "12.0.2",
-                    },
-                    "id": "Code",
-                    "path": "root/Default/Function/Code",
                   },
                   "Default": {
                     "constructInfo": {
@@ -968,7 +968,7 @@ exports[`function name valid 1`] = `
         \\"publish\\": true,
         \\"role\\": \\"\${aws_iam_role.root_TheMightyFunction01_IamRole_34EB69E9.arn}\\",
         \\"runtime\\": \\"nodejs16.x\\",
-        \\"s3_bucket\\": \\"\${aws_s3_bucket.root_TheMightyFunction01_Code_019941EA.bucket}\\",
+        \\"s3_bucket\\": \\"\${aws_s3_bucket.root_Code_02F3C603.bucket}\\",
         \\"s3_key\\": \\"\${aws_s3_object.root_TheMightyFunction01_S3Object_6949E35F.key}\\",
         \\"timeout\\": 30,
         \\"vpc_config\\": {
@@ -978,13 +978,13 @@ exports[`function name valid 1`] = `
       }
     },
     \\"aws_s3_bucket\\": {
-      \\"root_TheMightyFunction01_Code_019941EA\\": {
-        \\"bucket_prefix\\": \\"code-c825ce49-\\"
+      \\"root_Code_02F3C603\\": {
+        \\"bucket_prefix\\": \\"code-c84a50b1-\\"
       }
     },
     \\"aws_s3_object\\": {
       \\"root_TheMightyFunction01_S3Object_6949E35F\\": {
-        \\"bucket\\": \\"\${aws_s3_bucket.root_TheMightyFunction01_Code_019941EA.bucket}\\",
+        \\"bucket\\": \\"\${aws_s3_bucket.root_Code_02F3C603.bucket}\\",
         \\"key\\": \\"<key>\\",
         \\"source\\": \\"<source>\\"
       }
@@ -1001,6 +1001,14 @@ exports[`function name valid 2`] = `
         "children": {
           "Default": {
             "children": {
+              "Code": {
+                "constructInfo": {
+                  "fqn": "@cdktf/provider-aws.s3Bucket.S3Bucket",
+                  "version": "12.0.2",
+                },
+                "id": "Code",
+                "path": "root/Default/Code",
+              },
               "Handler": {
                 "attributes": {
                   "wing:resource:connections": [],
@@ -1031,14 +1039,6 @@ exports[`function name valid 2`] = `
                     },
                     "id": "Asset",
                     "path": "root/Default/The-Mighty_Function-01/Asset",
-                  },
-                  "Code": {
-                    "constructInfo": {
-                      "fqn": "@cdktf/provider-aws.s3Bucket.S3Bucket",
-                      "version": "12.0.2",
-                    },
-                    "id": "Code",
-                    "path": "root/Default/The-Mighty_Function-01/Code",
                   },
                   "Default": {
                     "constructInfo": {
@@ -1200,7 +1200,7 @@ exports[`replace invalid character from function name 1`] = `
         \\"publish\\": true,
         \\"role\\": \\"\${aws_iam_role.root_TheMightyFunction_IamRole_DF8277B4.arn}\\",
         \\"runtime\\": \\"nodejs16.x\\",
-        \\"s3_bucket\\": \\"\${aws_s3_bucket.root_TheMightyFunction_Code_28F77D89.bucket}\\",
+        \\"s3_bucket\\": \\"\${aws_s3_bucket.root_Code_02F3C603.bucket}\\",
         \\"s3_key\\": \\"\${aws_s3_object.root_TheMightyFunction_S3Object_D0A75871.key}\\",
         \\"timeout\\": 30,
         \\"vpc_config\\": {
@@ -1210,13 +1210,13 @@ exports[`replace invalid character from function name 1`] = `
       }
     },
     \\"aws_s3_bucket\\": {
-      \\"root_TheMightyFunction_Code_28F77D89\\": {
-        \\"bucket_prefix\\": \\"code-c8cf0523-\\"
+      \\"root_Code_02F3C603\\": {
+        \\"bucket_prefix\\": \\"code-c84a50b1-\\"
       }
     },
     \\"aws_s3_object\\": {
       \\"root_TheMightyFunction_S3Object_D0A75871\\": {
-        \\"bucket\\": \\"\${aws_s3_bucket.root_TheMightyFunction_Code_28F77D89.bucket}\\",
+        \\"bucket\\": \\"\${aws_s3_bucket.root_Code_02F3C603.bucket}\\",
         \\"key\\": \\"<key>\\",
         \\"source\\": \\"<source>\\"
       }
@@ -1233,6 +1233,14 @@ exports[`replace invalid character from function name 2`] = `
         "children": {
           "Default": {
             "children": {
+              "Code": {
+                "constructInfo": {
+                  "fqn": "@cdktf/provider-aws.s3Bucket.S3Bucket",
+                  "version": "12.0.2",
+                },
+                "id": "Code",
+                "path": "root/Default/Code",
+              },
               "Handler": {
                 "attributes": {
                   "wing:resource:connections": [],
@@ -1263,14 +1271,6 @@ exports[`replace invalid character from function name 2`] = `
                     },
                     "id": "Asset",
                     "path": "root/Default/The%Mighty$Function/Asset",
-                  },
-                  "Code": {
-                    "constructInfo": {
-                      "fqn": "@cdktf/provider-aws.s3Bucket.S3Bucket",
-                      "version": "12.0.2",
-                    },
-                    "id": "Code",
-                    "path": "root/Default/The%Mighty$Function/Code",
                   },
                   "Default": {
                     "constructInfo": {

--- a/libs/wingsdk/test/target-tf-aws/__snapshots__/logger.test.ts.snap
+++ b/libs/wingsdk/test/target-tf-aws/__snapshots__/logger.test.ts.snap
@@ -54,7 +54,7 @@ exports[`inflight function uses a logger 2`] = `
         \\"publish\\": true,
         \\"role\\": \\"\${aws_iam_role.root_Function_IamRole_88AD864C.arn}\\",
         \\"runtime\\": \\"nodejs16.x\\",
-        \\"s3_bucket\\": \\"\${aws_s3_bucket.root_Function_Code_794C2A8A.bucket}\\",
+        \\"s3_bucket\\": \\"\${aws_s3_bucket.root_Code_02F3C603.bucket}\\",
         \\"s3_key\\": \\"\${aws_s3_object.root_Function_S3Object_A62722D8.key}\\",
         \\"timeout\\": 30,
         \\"vpc_config\\": {
@@ -64,13 +64,13 @@ exports[`inflight function uses a logger 2`] = `
       }
     },
     \\"aws_s3_bucket\\": {
-      \\"root_Function_Code_794C2A8A\\": {
-        \\"bucket_prefix\\": \\"code-c87cd513-\\"
+      \\"root_Code_02F3C603\\": {
+        \\"bucket_prefix\\": \\"code-c84a50b1-\\"
       }
     },
     \\"aws_s3_object\\": {
       \\"root_Function_S3Object_A62722D8\\": {
-        \\"bucket\\": \\"\${aws_s3_bucket.root_Function_Code_794C2A8A.bucket}\\",
+        \\"bucket\\": \\"\${aws_s3_bucket.root_Code_02F3C603.bucket}\\",
         \\"key\\": \\"<key>\\",
         \\"source\\": \\"<source>\\"
       }

--- a/libs/wingsdk/test/target-tf-aws/__snapshots__/queue.test.ts.snap
+++ b/libs/wingsdk/test/target-tf-aws/__snapshots__/queue.test.ts.snap
@@ -290,7 +290,7 @@ exports[`queue with a consumer function 2`] = `
         \\"publish\\": true,
         \\"role\\": \\"\${aws_iam_role.root_QueueAddConsumerc5395e41_IamRole_11C209FD.arn}\\",
         \\"runtime\\": \\"nodejs16.x\\",
-        \\"s3_bucket\\": \\"\${aws_s3_bucket.root_QueueAddConsumerc5395e41_Code_4409437D.bucket}\\",
+        \\"s3_bucket\\": \\"\${aws_s3_bucket.root_Code_02F3C603.bucket}\\",
         \\"s3_key\\": \\"\${aws_s3_object.root_QueueAddConsumerc5395e41_S3Object_B837411C.key}\\",
         \\"timeout\\": 30,
         \\"vpc_config\\": {
@@ -300,13 +300,13 @@ exports[`queue with a consumer function 2`] = `
       }
     },
     \\"aws_s3_bucket\\": {
-      \\"root_QueueAddConsumerc5395e41_Code_4409437D\\": {
-        \\"bucket_prefix\\": \\"code-c8839c77-\\"
+      \\"root_Code_02F3C603\\": {
+        \\"bucket_prefix\\": \\"code-c84a50b1-\\"
       }
     },
     \\"aws_s3_object\\": {
       \\"root_QueueAddConsumerc5395e41_S3Object_B837411C\\": {
-        \\"bucket\\": \\"\${aws_s3_bucket.root_QueueAddConsumerc5395e41_Code_4409437D.bucket}\\",
+        \\"bucket\\": \\"\${aws_s3_bucket.root_Code_02F3C603.bucket}\\",
         \\"key\\": \\"<key>\\",
         \\"source\\": \\"<source>\\"
       }
@@ -329,6 +329,14 @@ exports[`queue with a consumer function 3`] = `
         "children": {
           "Default": {
             "children": {
+              "Code": {
+                "constructInfo": {
+                  "fqn": "@cdktf/provider-aws.s3Bucket.S3Bucket",
+                  "version": "12.0.2",
+                },
+                "id": "Code",
+                "path": "root/Default/Code",
+              },
               "Handler": {
                 "attributes": {
                   "wing:resource:connections": [
@@ -420,14 +428,6 @@ exports[`queue with a consumer function 3`] = `
                     },
                     "id": "Asset",
                     "path": "root/Default/Queue-AddConsumer-c5395e41/Asset",
-                  },
-                  "Code": {
-                    "constructInfo": {
-                      "fqn": "@cdktf/provider-aws.s3Bucket.S3Bucket",
-                      "version": "12.0.2",
-                    },
-                    "id": "Code",
-                    "path": "root/Default/Queue-AddConsumer-c5395e41/Code",
                   },
                   "Default": {
                     "constructInfo": {

--- a/libs/wingsdk/test/target-tf-aws/__snapshots__/schedule.test.ts.snap
+++ b/libs/wingsdk/test/target-tf-aws/__snapshots__/schedule.test.ts.snap
@@ -49,7 +49,7 @@ exports[`schedule behavior with cron 1`] = `
         \\"publish\\": true,
         \\"role\\": \\"\${aws_iam_role.root_ScheduleOnTickc5395e41_IamRole_D42951B2.arn}\\",
         \\"runtime\\": \\"nodejs16.x\\",
-        \\"s3_bucket\\": \\"\${aws_s3_bucket.root_ScheduleOnTickc5395e41_Code_C7AC6B0A.bucket}\\",
+        \\"s3_bucket\\": \\"\${aws_s3_bucket.root_Code_02F3C603.bucket}\\",
         \\"s3_key\\": \\"\${aws_s3_object.root_ScheduleOnTickc5395e41_S3Object_DE498BA0.key}\\",
         \\"timeout\\": 30,
         \\"vpc_config\\": {
@@ -68,13 +68,13 @@ exports[`schedule behavior with cron 1`] = `
       }
     },
     \\"aws_s3_bucket\\": {
-      \\"root_ScheduleOnTickc5395e41_Code_C7AC6B0A\\": {
-        \\"bucket_prefix\\": \\"code-c88e84cc-\\"
+      \\"root_Code_02F3C603\\": {
+        \\"bucket_prefix\\": \\"code-c84a50b1-\\"
       }
     },
     \\"aws_s3_object\\": {
       \\"root_ScheduleOnTickc5395e41_S3Object_DE498BA0\\": {
-        \\"bucket\\": \\"\${aws_s3_bucket.root_ScheduleOnTickc5395e41_Code_C7AC6B0A.bucket}\\",
+        \\"bucket\\": \\"\${aws_s3_bucket.root_Code_02F3C603.bucket}\\",
         \\"key\\": \\"<key>\\",
         \\"source\\": \\"<source>\\"
       }
@@ -91,6 +91,14 @@ exports[`schedule behavior with cron 2`] = `
         "children": {
           "Default": {
             "children": {
+              "Code": {
+                "constructInfo": {
+                  "fqn": "@cdktf/provider-aws.s3Bucket.S3Bucket",
+                  "version": "12.0.2",
+                },
+                "id": "Code",
+                "path": "root/Default/Code",
+              },
               "Handler": {
                 "attributes": {
                   "wing:resource:connections": [
@@ -182,14 +190,6 @@ exports[`schedule behavior with cron 2`] = `
                     },
                     "id": "Asset",
                     "path": "root/Default/Schedule-OnTick-c5395e41/Asset",
-                  },
-                  "Code": {
-                    "constructInfo": {
-                      "fqn": "@cdktf/provider-aws.s3Bucket.S3Bucket",
-                      "version": "12.0.2",
-                    },
-                    "id": "Code",
-                    "path": "root/Default/Schedule-OnTick-c5395e41/Code",
                   },
                   "Default": {
                     "constructInfo": {
@@ -386,7 +386,7 @@ exports[`schedule behavior with rate 1`] = `
         \\"publish\\": true,
         \\"role\\": \\"\${aws_iam_role.root_ScheduleOnTickc5395e41_IamRole_D42951B2.arn}\\",
         \\"runtime\\": \\"nodejs16.x\\",
-        \\"s3_bucket\\": \\"\${aws_s3_bucket.root_ScheduleOnTickc5395e41_Code_C7AC6B0A.bucket}\\",
+        \\"s3_bucket\\": \\"\${aws_s3_bucket.root_Code_02F3C603.bucket}\\",
         \\"s3_key\\": \\"\${aws_s3_object.root_ScheduleOnTickc5395e41_S3Object_DE498BA0.key}\\",
         \\"timeout\\": 30,
         \\"vpc_config\\": {
@@ -405,13 +405,13 @@ exports[`schedule behavior with rate 1`] = `
       }
     },
     \\"aws_s3_bucket\\": {
-      \\"root_ScheduleOnTickc5395e41_Code_C7AC6B0A\\": {
-        \\"bucket_prefix\\": \\"code-c88e84cc-\\"
+      \\"root_Code_02F3C603\\": {
+        \\"bucket_prefix\\": \\"code-c84a50b1-\\"
       }
     },
     \\"aws_s3_object\\": {
       \\"root_ScheduleOnTickc5395e41_S3Object_DE498BA0\\": {
-        \\"bucket\\": \\"\${aws_s3_bucket.root_ScheduleOnTickc5395e41_Code_C7AC6B0A.bucket}\\",
+        \\"bucket\\": \\"\${aws_s3_bucket.root_Code_02F3C603.bucket}\\",
         \\"key\\": \\"<key>\\",
         \\"source\\": \\"<source>\\"
       }
@@ -428,6 +428,14 @@ exports[`schedule behavior with rate 2`] = `
         "children": {
           "Default": {
             "children": {
+              "Code": {
+                "constructInfo": {
+                  "fqn": "@cdktf/provider-aws.s3Bucket.S3Bucket",
+                  "version": "12.0.2",
+                },
+                "id": "Code",
+                "path": "root/Default/Code",
+              },
               "Handler": {
                 "attributes": {
                   "wing:resource:connections": [
@@ -519,14 +527,6 @@ exports[`schedule behavior with rate 2`] = `
                     },
                     "id": "Asset",
                     "path": "root/Default/Schedule-OnTick-c5395e41/Asset",
-                  },
-                  "Code": {
-                    "constructInfo": {
-                      "fqn": "@cdktf/provider-aws.s3Bucket.S3Bucket",
-                      "version": "12.0.2",
-                    },
-                    "id": "Code",
-                    "path": "root/Default/Schedule-OnTick-c5395e41/Code",
                   },
                   "Default": {
                     "constructInfo": {
@@ -738,7 +738,7 @@ exports[`schedule with two functions 1`] = `
         \\"publish\\": true,
         \\"role\\": \\"\${aws_iam_role.root_ScheduleOnTick0a615500_IamRole_CDDD9C52.arn}\\",
         \\"runtime\\": \\"nodejs16.x\\",
-        \\"s3_bucket\\": \\"\${aws_s3_bucket.root_ScheduleOnTick0a615500_Code_12A9FE62.bucket}\\",
+        \\"s3_bucket\\": \\"\${aws_s3_bucket.root_Code_02F3C603.bucket}\\",
         \\"s3_key\\": \\"\${aws_s3_object.root_ScheduleOnTick0a615500_S3Object_EB395932.key}\\",
         \\"timeout\\": 30,
         \\"vpc_config\\": {
@@ -757,7 +757,7 @@ exports[`schedule with two functions 1`] = `
         \\"publish\\": true,
         \\"role\\": \\"\${aws_iam_role.root_ScheduleOnTick7b33bcba_IamRole_02FDC318.arn}\\",
         \\"runtime\\": \\"nodejs16.x\\",
-        \\"s3_bucket\\": \\"\${aws_s3_bucket.root_ScheduleOnTick7b33bcba_Code_4537EF5B.bucket}\\",
+        \\"s3_bucket\\": \\"\${aws_s3_bucket.root_Code_02F3C603.bucket}\\",
         \\"s3_key\\": \\"\${aws_s3_object.root_ScheduleOnTick7b33bcba_S3Object_4D569B28.key}\\",
         \\"timeout\\": 30,
         \\"vpc_config\\": {
@@ -783,21 +783,18 @@ exports[`schedule with two functions 1`] = `
       }
     },
     \\"aws_s3_bucket\\": {
-      \\"root_ScheduleOnTick0a615500_Code_12A9FE62\\": {
-        \\"bucket_prefix\\": \\"code-c86b51ff-\\"
-      },
-      \\"root_ScheduleOnTick7b33bcba_Code_4537EF5B\\": {
-        \\"bucket_prefix\\": \\"code-c8f7fd57-\\"
+      \\"root_Code_02F3C603\\": {
+        \\"bucket_prefix\\": \\"code-c84a50b1-\\"
       }
     },
     \\"aws_s3_object\\": {
       \\"root_ScheduleOnTick0a615500_S3Object_EB395932\\": {
-        \\"bucket\\": \\"\${aws_s3_bucket.root_ScheduleOnTick0a615500_Code_12A9FE62.bucket}\\",
+        \\"bucket\\": \\"\${aws_s3_bucket.root_Code_02F3C603.bucket}\\",
         \\"key\\": \\"<key>\\",
         \\"source\\": \\"<source>\\"
       },
       \\"root_ScheduleOnTick7b33bcba_S3Object_4D569B28\\": {
-        \\"bucket\\": \\"\${aws_s3_bucket.root_ScheduleOnTick7b33bcba_Code_4537EF5B.bucket}\\",
+        \\"bucket\\": \\"\${aws_s3_bucket.root_Code_02F3C603.bucket}\\",
         \\"key\\": \\"<key>\\",
         \\"source\\": \\"<source>\\"
       }
@@ -814,6 +811,14 @@ exports[`schedule with two functions 2`] = `
         "children": {
           "Default": {
             "children": {
+              "Code": {
+                "constructInfo": {
+                  "fqn": "@cdktf/provider-aws.s3Bucket.S3Bucket",
+                  "version": "12.0.2",
+                },
+                "id": "Code",
+                "path": "root/Default/Code",
+              },
               "Handler1": {
                 "attributes": {
                   "wing:resource:connections": [
@@ -944,14 +949,6 @@ exports[`schedule with two functions 2`] = `
                     "id": "Asset",
                     "path": "root/Default/Schedule-OnTick-0a615500/Asset",
                   },
-                  "Code": {
-                    "constructInfo": {
-                      "fqn": "@cdktf/provider-aws.s3Bucket.S3Bucket",
-                      "version": "12.0.2",
-                    },
-                    "id": "Code",
-                    "path": "root/Default/Schedule-OnTick-0a615500/Code",
-                  },
                   "Default": {
                     "constructInfo": {
                       "fqn": "@cdktf/provider-aws.lambdaFunction.LambdaFunction",
@@ -1038,14 +1035,6 @@ exports[`schedule with two functions 2`] = `
                     },
                     "id": "Asset",
                     "path": "root/Default/Schedule-OnTick-7b33bcba/Asset",
-                  },
-                  "Code": {
-                    "constructInfo": {
-                      "fqn": "@cdktf/provider-aws.s3Bucket.S3Bucket",
-                      "version": "12.0.2",
-                    },
-                    "id": "Code",
-                    "path": "root/Default/Schedule-OnTick-7b33bcba/Code",
                   },
                   "Default": {
                     "constructInfo": {

--- a/libs/wingsdk/test/target-tf-aws/__snapshots__/table.test.ts.snap
+++ b/libs/wingsdk/test/target-tf-aws/__snapshots__/table.test.ts.snap
@@ -95,7 +95,7 @@ exports[`function with a table binding 2`] = `
         \\"publish\\": true,
         \\"role\\": \\"\${aws_iam_role.root_Function_IamRole_88AD864C.arn}\\",
         \\"runtime\\": \\"nodejs16.x\\",
-        \\"s3_bucket\\": \\"\${aws_s3_bucket.root_Function_Code_794C2A8A.bucket}\\",
+        \\"s3_bucket\\": \\"\${aws_s3_bucket.root_Code_02F3C603.bucket}\\",
         \\"s3_key\\": \\"\${aws_s3_object.root_Function_S3Object_A62722D8.key}\\",
         \\"timeout\\": 30,
         \\"vpc_config\\": {
@@ -105,13 +105,13 @@ exports[`function with a table binding 2`] = `
       }
     },
     \\"aws_s3_bucket\\": {
-      \\"root_Function_Code_794C2A8A\\": {
-        \\"bucket_prefix\\": \\"code-c87cd513-\\"
+      \\"root_Code_02F3C603\\": {
+        \\"bucket_prefix\\": \\"code-c84a50b1-\\"
       }
     },
     \\"aws_s3_object\\": {
       \\"root_Function_S3Object_A62722D8\\": {
-        \\"bucket\\": \\"\${aws_s3_bucket.root_Function_Code_794C2A8A.bucket}\\",
+        \\"bucket\\": \\"\${aws_s3_bucket.root_Code_02F3C603.bucket}\\",
         \\"key\\": \\"<key>\\",
         \\"source\\": \\"<source>\\"
       }
@@ -128,6 +128,14 @@ exports[`function with a table binding 3`] = `
         "children": {
           "Default": {
             "children": {
+              "Code": {
+                "constructInfo": {
+                  "fqn": "@cdktf/provider-aws.s3Bucket.S3Bucket",
+                  "version": "12.0.2",
+                },
+                "id": "Code",
+                "path": "root/Default/Code",
+              },
               "Function": {
                 "attributes": {
                   "wing:resource:connections": [
@@ -148,14 +156,6 @@ exports[`function with a table binding 3`] = `
                     },
                     "id": "Asset",
                     "path": "root/Default/Function/Asset",
-                  },
-                  "Code": {
-                    "constructInfo": {
-                      "fqn": "@cdktf/provider-aws.s3Bucket.S3Bucket",
-                      "version": "12.0.2",
-                    },
-                    "id": "Code",
-                    "path": "root/Default/Function/Code",
                   },
                   "Default": {
                     "constructInfo": {

--- a/libs/wingsdk/test/target-tf-aws/__snapshots__/topic.test.ts.snap
+++ b/libs/wingsdk/test/target-tf-aws/__snapshots__/topic.test.ts.snap
@@ -418,7 +418,7 @@ exports[`topic with subscriber function 2`] = `
         \\"publish\\": true,
         \\"role\\": \\"\${aws_iam_role.root_TopicOnMessagec5395e41_IamRole_9BB6BE88.arn}\\",
         \\"runtime\\": \\"nodejs16.x\\",
-        \\"s3_bucket\\": \\"\${aws_s3_bucket.root_TopicOnMessagec5395e41_Code_97E7E354.bucket}\\",
+        \\"s3_bucket\\": \\"\${aws_s3_bucket.root_Code_02F3C603.bucket}\\",
         \\"s3_key\\": \\"\${aws_s3_object.root_TopicOnMessagec5395e41_S3Object_D172367F.key}\\",
         \\"timeout\\": 30,
         \\"vpc_config\\": {
@@ -436,13 +436,13 @@ exports[`topic with subscriber function 2`] = `
       }
     },
     \\"aws_s3_bucket\\": {
-      \\"root_TopicOnMessagec5395e41_Code_97E7E354\\": {
-        \\"bucket_prefix\\": \\"code-c8092503-\\"
+      \\"root_Code_02F3C603\\": {
+        \\"bucket_prefix\\": \\"code-c84a50b1-\\"
       }
     },
     \\"aws_s3_object\\": {
       \\"root_TopicOnMessagec5395e41_S3Object_D172367F\\": {
-        \\"bucket\\": \\"\${aws_s3_bucket.root_TopicOnMessagec5395e41_Code_97E7E354.bucket}\\",
+        \\"bucket\\": \\"\${aws_s3_bucket.root_Code_02F3C603.bucket}\\",
         \\"key\\": \\"<key>\\",
         \\"source\\": \\"<source>\\"
       }
@@ -471,6 +471,14 @@ exports[`topic with subscriber function 3`] = `
         "children": {
           "Default": {
             "children": {
+              "Code": {
+                "constructInfo": {
+                  "fqn": "@cdktf/provider-aws.s3Bucket.S3Bucket",
+                  "version": "12.0.2",
+                },
+                "id": "Code",
+                "path": "root/Default/Code",
+              },
               "Handler": {
                 "attributes": {
                   "wing:resource:connections": [
@@ -562,14 +570,6 @@ exports[`topic with subscriber function 3`] = `
                     },
                     "id": "Asset",
                     "path": "root/Default/Topic-OnMessage-c5395e41/Asset",
-                  },
-                  "Code": {
-                    "constructInfo": {
-                      "fqn": "@cdktf/provider-aws.s3Bucket.S3Bucket",
-                      "version": "12.0.2",
-                    },
-                    "id": "Code",
-                    "path": "root/Default/Topic-OnMessage-c5395e41/Code",
                   },
                   "Default": {
                     "constructInfo": {

--- a/libs/wingsdk/test/target-tf-aws/topic.test.ts
+++ b/libs/wingsdk/test/target-tf-aws/topic.test.ts
@@ -84,7 +84,7 @@ test("topic with multiple subscribers", () => {
   );
   expect(tfResourcesOfCount(output, "aws_lambda_function")).toEqual(2);
   expect(tfResourcesOfCount(output, "aws_lambda_permission")).toEqual(2);
-  expect(tfResourcesOfCount(output, "aws_s3_bucket")).toEqual(2);
+  expect(tfResourcesOfCount(output, "aws_s3_bucket")).toEqual(1);
   expect(tfResourcesOfCount(output, "aws_s3_object")).toEqual(2);
   expect(tfResourcesOfCount(output, "aws_sns_topic_subscription")).toEqual(2);
 });

--- a/tools/hangar/__snapshots__/plugins.ts.snap
+++ b/tools/hangar/__snapshots__/plugins.ts.snap
@@ -98,7 +98,7 @@ exports[`Plugin examples > AWS target plugins > permission-boundary.js 1`] = `
         "publish": true,
         "role": "\${aws_iam_role.root_cloudQueueAddConsumere46e5cb7_IamRole_AE43C8FE.arn}",
         "runtime": "nodejs16.x",
-        "s3_bucket": "\${aws_s3_bucket.root_cloudQueueAddConsumere46e5cb7_Code_8AFA6947.bucket}",
+        "s3_bucket": "\${aws_s3_bucket.root_Code_02F3C603.bucket}",
         "s3_key": "\${aws_s3_object.root_cloudQueueAddConsumere46e5cb7_S3Object_343EB2E4.key}",
         "timeout": 30,
         "vpc_config": {
@@ -108,6 +108,15 @@ exports[`Plugin examples > AWS target plugins > permission-boundary.js 1`] = `
       },
     },
     "aws_s3_bucket": {
+      "root_Code_02F3C603": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/Code",
+            "uniqueId": "root_Code_02F3C603",
+          },
+        },
+        "bucket_prefix": "code-c84a50b1-",
+      },
       "root_cloudBucket_4F3C4F53": {
         "//": {
           "metadata": {
@@ -117,15 +126,6 @@ exports[`Plugin examples > AWS target plugins > permission-boundary.js 1`] = `
         },
         "bucket_prefix": "cloud-bucket-c87175e7-",
         "force_destroy": false,
-      },
-      "root_cloudQueueAddConsumere46e5cb7_Code_8AFA6947": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/cloud.Queue-AddConsumer-e46e5cb7/Code",
-            "uniqueId": "root_cloudQueueAddConsumere46e5cb7_Code_8AFA6947",
-          },
-        },
-        "bucket_prefix": "code-c882cbfb-",
       },
     },
     "aws_s3_bucket_public_access_block": {
@@ -169,7 +169,7 @@ exports[`Plugin examples > AWS target plugins > permission-boundary.js 1`] = `
             "uniqueId": "root_cloudQueueAddConsumere46e5cb7_S3Object_343EB2E4",
           },
         },
-        "bucket": "\${aws_s3_bucket.root_cloudQueueAddConsumere46e5cb7_Code_8AFA6947.bucket}",
+        "bucket": "\${aws_s3_bucket.root_Code_02F3C603.bucket}",
         "key": "<ASSET_KEY>",
         "source": "<ASSET_SOURCE>",
       },
@@ -219,6 +219,16 @@ exports[`Plugin examples > AWS target plugins > replicate-s3.js 1`] = `
   },
   "resource": {
     "aws_iam_policy": {
+      "root_ReplicaCodePolicy_45CC5F7D": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/ReplicaCodePolicy",
+            "uniqueId": "root_ReplicaCodePolicy_45CC5F7D",
+          },
+        },
+        "name": "some-prefix\${aws_s3_bucket.root_Code_02F3C603.bucket}",
+        "policy": "{\\"Version\\":\\"2012-10-17\\",\\"Statement\\":[{\\"Action\\":[\\"s3:GetReplicationConfiguration\\",\\"s3:ListBucket\\"],\\"Effect\\":\\"Allow\\",\\"Resource\\":[\\"\${aws_s3_bucket.root_Code_02F3C603.arn}\\",\\"\${aws_s3_bucket.root_Code_02F3C603.arn}/*\\"]},{\\"Action\\":[\\"s3:GetObjectVersionForReplication\\",\\"s3:GetObjectVersionAcl\\",\\"s3:GetObjectVersionTagging\\"],\\"Effect\\":\\"Allow\\",\\"Resource\\":\\"\${aws_s3_bucket.root_Code_02F3C603.arn}/*\\"},{\\"Action\\":[\\"s3:ReplicateObject\\",\\"s3:ReplicateDelete\\",\\"s3:ReplicateTags\\"],\\"Effect\\":\\"Allow\\",\\"Resource\\":\\"\${aws_s3_bucket.root_ReplicaCode_EC5CE972.arn}/*\\"}]}",
+      },
       "root_cloudBucket_ReplicaDefaultPolicy_CF3D8930": {
         "//": {
           "metadata": {
@@ -229,18 +239,21 @@ exports[`Plugin examples > AWS target plugins > replicate-s3.js 1`] = `
         "name": "some-prefix\${aws_s3_bucket.root_cloudBucket_4F3C4F53.bucket}",
         "policy": "{\\"Version\\":\\"2012-10-17\\",\\"Statement\\":[{\\"Action\\":[\\"s3:GetReplicationConfiguration\\",\\"s3:ListBucket\\"],\\"Effect\\":\\"Allow\\",\\"Resource\\":[\\"\${aws_s3_bucket.root_cloudBucket_4F3C4F53.arn}\\",\\"\${aws_s3_bucket.root_cloudBucket_4F3C4F53.arn}/*\\"]},{\\"Action\\":[\\"s3:GetObjectVersionForReplication\\",\\"s3:GetObjectVersionAcl\\",\\"s3:GetObjectVersionTagging\\"],\\"Effect\\":\\"Allow\\",\\"Resource\\":\\"\${aws_s3_bucket.root_cloudBucket_4F3C4F53.arn}/*\\"},{\\"Action\\":[\\"s3:ReplicateObject\\",\\"s3:ReplicateDelete\\",\\"s3:ReplicateTags\\"],\\"Effect\\":\\"Allow\\",\\"Resource\\":\\"\${aws_s3_bucket.root_cloudBucket_ReplicaDefault_FAA1B938.arn}/*\\"}]}",
       },
-      "root_cloudQueueAddConsumere46e5cb7_ReplicaCodePolicy_456572A2": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/cloud.Queue-AddConsumer-e46e5cb7/ReplicaCodePolicy",
-            "uniqueId": "root_cloudQueueAddConsumere46e5cb7_ReplicaCodePolicy_456572A2",
-          },
-        },
-        "name": "some-prefix\${aws_s3_bucket.root_cloudQueueAddConsumere46e5cb7_Code_8AFA6947.bucket}",
-        "policy": "{\\"Version\\":\\"2012-10-17\\",\\"Statement\\":[{\\"Action\\":[\\"s3:GetReplicationConfiguration\\",\\"s3:ListBucket\\"],\\"Effect\\":\\"Allow\\",\\"Resource\\":[\\"\${aws_s3_bucket.root_cloudQueueAddConsumere46e5cb7_Code_8AFA6947.arn}\\",\\"\${aws_s3_bucket.root_cloudQueueAddConsumere46e5cb7_Code_8AFA6947.arn}/*\\"]},{\\"Action\\":[\\"s3:GetObjectVersionForReplication\\",\\"s3:GetObjectVersionAcl\\",\\"s3:GetObjectVersionTagging\\"],\\"Effect\\":\\"Allow\\",\\"Resource\\":\\"\${aws_s3_bucket.root_cloudQueueAddConsumere46e5cb7_Code_8AFA6947.arn}/*\\"},{\\"Action\\":[\\"s3:ReplicateObject\\",\\"s3:ReplicateDelete\\",\\"s3:ReplicateTags\\"],\\"Effect\\":\\"Allow\\",\\"Resource\\":\\"\${aws_s3_bucket.root_cloudQueueAddConsumere46e5cb7_ReplicaCode_ED5CBA2E.arn}/*\\"}]}",
-      },
     },
     "aws_iam_policy_attachment": {
+      "root_ReplicaCodePolicyAttachment_BC537D23": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/ReplicaCodePolicyAttachment",
+            "uniqueId": "root_ReplicaCodePolicyAttachment_BC537D23",
+          },
+        },
+        "name": "some-prefixpolicy-attachment\${aws_s3_bucket.root_Code_02F3C603.bucket}",
+        "policy_arn": "\${aws_iam_policy.root_ReplicaCodePolicy_45CC5F7D.arn}",
+        "roles": [
+          "\${aws_iam_role.root_ReplicaCodeRole_E6CC0FD1.name}",
+        ],
+      },
       "root_cloudBucket_ReplicaDefaultPolicyAttachment_CDFF3C3B": {
         "//": {
           "metadata": {
@@ -254,21 +267,18 @@ exports[`Plugin examples > AWS target plugins > replicate-s3.js 1`] = `
           "\${aws_iam_role.root_cloudBucket_ReplicaDefaultRole_F6AC926C.name}",
         ],
       },
-      "root_cloudQueueAddConsumere46e5cb7_ReplicaCodePolicyAttachment_F4E9BAD5": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/cloud.Queue-AddConsumer-e46e5cb7/ReplicaCodePolicyAttachment",
-            "uniqueId": "root_cloudQueueAddConsumere46e5cb7_ReplicaCodePolicyAttachment_F4E9BAD5",
-          },
-        },
-        "name": "some-prefixpolicy-attachment\${aws_s3_bucket.root_cloudQueueAddConsumere46e5cb7_Code_8AFA6947.bucket}",
-        "policy_arn": "\${aws_iam_policy.root_cloudQueueAddConsumere46e5cb7_ReplicaCodePolicy_456572A2.arn}",
-        "roles": [
-          "\${aws_iam_role.root_cloudQueueAddConsumere46e5cb7_ReplicaCodeRole_A49F3850.name}",
-        ],
-      },
     },
     "aws_iam_role": {
+      "root_ReplicaCodeRole_E6CC0FD1": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/ReplicaCodeRole",
+            "uniqueId": "root_ReplicaCodeRole_E6CC0FD1",
+          },
+        },
+        "assume_role_policy": "{\\"Version\\":\\"2012-10-17\\",\\"Statement\\":[{\\"Action\\":\\"sts:AssumeRole\\",\\"Principal\\":{\\"Service\\":\\"s3.amazonaws.com\\"},\\"Effect\\":\\"Allow\\",\\"Sid\\":\\"AllowS3Replication\\"}]}",
+        "name": "some-prefix\${aws_s3_bucket.root_Code_02F3C603.bucket}",
+      },
       "root_cloudBucket_ReplicaDefaultRole_F6AC926C": {
         "//": {
           "metadata": {
@@ -287,16 +297,6 @@ exports[`Plugin examples > AWS target plugins > replicate-s3.js 1`] = `
           },
         },
         "assume_role_policy": "{\\"Version\\":\\"2012-10-17\\",\\"Statement\\":[{\\"Action\\":\\"sts:AssumeRole\\",\\"Principal\\":{\\"Service\\":\\"lambda.amazonaws.com\\"},\\"Effect\\":\\"Allow\\"}]}",
-      },
-      "root_cloudQueueAddConsumere46e5cb7_ReplicaCodeRole_A49F3850": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/cloud.Queue-AddConsumer-e46e5cb7/ReplicaCodeRole",
-            "uniqueId": "root_cloudQueueAddConsumere46e5cb7_ReplicaCodeRole_A49F3850",
-          },
-        },
-        "assume_role_policy": "{\\"Version\\":\\"2012-10-17\\",\\"Statement\\":[{\\"Action\\":\\"sts:AssumeRole\\",\\"Principal\\":{\\"Service\\":\\"s3.amazonaws.com\\"},\\"Effect\\":\\"Allow\\",\\"Sid\\":\\"AllowS3Replication\\"}]}",
-        "name": "some-prefix\${aws_s3_bucket.root_cloudQueueAddConsumere46e5cb7_Code_8AFA6947.bucket}",
       },
     },
     "aws_iam_role_policy": {
@@ -356,7 +356,7 @@ exports[`Plugin examples > AWS target plugins > replicate-s3.js 1`] = `
         "publish": true,
         "role": "\${aws_iam_role.root_cloudQueueAddConsumere46e5cb7_IamRole_AE43C8FE.arn}",
         "runtime": "nodejs16.x",
-        "s3_bucket": "\${aws_s3_bucket.root_cloudQueueAddConsumere46e5cb7_Code_8AFA6947.bucket}",
+        "s3_bucket": "\${aws_s3_bucket.root_Code_02F3C603.bucket}",
         "s3_key": "\${aws_s3_object.root_cloudQueueAddConsumere46e5cb7_S3Object_343EB2E4.key}",
         "timeout": 30,
         "vpc_config": {
@@ -366,6 +366,24 @@ exports[`Plugin examples > AWS target plugins > replicate-s3.js 1`] = `
       },
     },
     "aws_s3_bucket": {
+      "root_Code_02F3C603": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/Code",
+            "uniqueId": "root_Code_02F3C603",
+          },
+        },
+        "bucket_prefix": "code-c84a50b1-",
+      },
+      "root_ReplicaCode_EC5CE972": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/ReplicaCode",
+            "uniqueId": "root_ReplicaCode_EC5CE972",
+          },
+        },
+        "bucket": "some-prefix\${aws_s3_bucket.root_Code_02F3C603.bucket}",
+      },
       "root_cloudBucket_4F3C4F53": {
         "//": {
           "metadata": {
@@ -385,24 +403,6 @@ exports[`Plugin examples > AWS target plugins > replicate-s3.js 1`] = `
         },
         "bucket": "some-prefix\${aws_s3_bucket.root_cloudBucket_4F3C4F53.bucket}",
       },
-      "root_cloudQueueAddConsumere46e5cb7_Code_8AFA6947": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/cloud.Queue-AddConsumer-e46e5cb7/Code",
-            "uniqueId": "root_cloudQueueAddConsumere46e5cb7_Code_8AFA6947",
-          },
-        },
-        "bucket_prefix": "code-c882cbfb-",
-      },
-      "root_cloudQueueAddConsumere46e5cb7_ReplicaCode_ED5CBA2E": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/cloud.Queue-AddConsumer-e46e5cb7/ReplicaCode",
-            "uniqueId": "root_cloudQueueAddConsumere46e5cb7_ReplicaCode_ED5CBA2E",
-          },
-        },
-        "bucket": "some-prefix\${aws_s3_bucket.root_cloudQueueAddConsumere46e5cb7_Code_8AFA6947.bucket}",
-      },
     },
     "aws_s3_bucket_public_access_block": {
       "root_cloudBucket_PublicAccessBlock_319C1C2E": {
@@ -420,6 +420,30 @@ exports[`Plugin examples > AWS target plugins > replicate-s3.js 1`] = `
       },
     },
     "aws_s3_bucket_replication_configuration": {
+      "root_ReplicaCodeConfig_D751EDC8": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/ReplicaCodeConfig",
+            "uniqueId": "root_ReplicaCodeConfig_D751EDC8",
+          },
+        },
+        "bucket": "\${aws_s3_bucket.root_Code_02F3C603.id}",
+        "depends_on": [
+          "aws_s3_bucket_versioning.root_ReplicaCodeVersioning_236B3629",
+          "aws_s3_bucket_versioning.root_SourceCodeVersioning_8C94F5B3",
+        ],
+        "role": "\${aws_iam_role.root_ReplicaCodeRole_E6CC0FD1.arn}",
+        "rule": [
+          {
+            "destination": {
+              "bucket": "\${aws_s3_bucket.root_ReplicaCode_EC5CE972.arn}",
+              "storage_class": "STANDARD",
+            },
+            "id": "some-prefix\${aws_s3_bucket.root_Code_02F3C603.bucket}",
+            "status": "Enabled",
+          },
+        ],
+      },
       "root_cloudBucket_ReplicaDefaultConfig_0CC8C208": {
         "//": {
           "metadata": {
@@ -444,30 +468,6 @@ exports[`Plugin examples > AWS target plugins > replicate-s3.js 1`] = `
           },
         ],
       },
-      "root_cloudQueueAddConsumere46e5cb7_ReplicaCodeConfig_5BF64962": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/cloud.Queue-AddConsumer-e46e5cb7/ReplicaCodeConfig",
-            "uniqueId": "root_cloudQueueAddConsumere46e5cb7_ReplicaCodeConfig_5BF64962",
-          },
-        },
-        "bucket": "\${aws_s3_bucket.root_cloudQueueAddConsumere46e5cb7_Code_8AFA6947.id}",
-        "depends_on": [
-          "aws_s3_bucket_versioning.root_cloudQueueAddConsumere46e5cb7_ReplicaCodeVersioning_9A981135",
-          "aws_s3_bucket_versioning.root_cloudQueueAddConsumere46e5cb7_SourceCodeVersioning_D9341870",
-        ],
-        "role": "\${aws_iam_role.root_cloudQueueAddConsumere46e5cb7_ReplicaCodeRole_A49F3850.arn}",
-        "rule": [
-          {
-            "destination": {
-              "bucket": "\${aws_s3_bucket.root_cloudQueueAddConsumere46e5cb7_ReplicaCode_ED5CBA2E.arn}",
-              "storage_class": "STANDARD",
-            },
-            "id": "some-prefix\${aws_s3_bucket.root_cloudQueueAddConsumere46e5cb7_Code_8AFA6947.bucket}",
-            "status": "Enabled",
-          },
-        ],
-      },
     },
     "aws_s3_bucket_server_side_encryption_configuration": {
       "root_cloudBucket_Encryption_8ED0CD9C": {
@@ -488,6 +488,30 @@ exports[`Plugin examples > AWS target plugins > replicate-s3.js 1`] = `
       },
     },
     "aws_s3_bucket_versioning": {
+      "root_ReplicaCodeVersioning_236B3629": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/ReplicaCodeVersioning",
+            "uniqueId": "root_ReplicaCodeVersioning_236B3629",
+          },
+        },
+        "bucket": "\${aws_s3_bucket.root_ReplicaCode_EC5CE972.id}",
+        "versioning_configuration": {
+          "status": "Enabled",
+        },
+      },
+      "root_SourceCodeVersioning_8C94F5B3": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/SourceCodeVersioning",
+            "uniqueId": "root_SourceCodeVersioning_8C94F5B3",
+          },
+        },
+        "bucket": "\${aws_s3_bucket.root_Code_02F3C603.id}",
+        "versioning_configuration": {
+          "status": "Enabled",
+        },
+      },
       "root_cloudBucket_ReplicaDefaultVersioning_EB8534D6": {
         "//": {
           "metadata": {
@@ -512,30 +536,6 @@ exports[`Plugin examples > AWS target plugins > replicate-s3.js 1`] = `
           "status": "Enabled",
         },
       },
-      "root_cloudQueueAddConsumere46e5cb7_ReplicaCodeVersioning_9A981135": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/cloud.Queue-AddConsumer-e46e5cb7/ReplicaCodeVersioning",
-            "uniqueId": "root_cloudQueueAddConsumere46e5cb7_ReplicaCodeVersioning_9A981135",
-          },
-        },
-        "bucket": "\${aws_s3_bucket.root_cloudQueueAddConsumere46e5cb7_ReplicaCode_ED5CBA2E.id}",
-        "versioning_configuration": {
-          "status": "Enabled",
-        },
-      },
-      "root_cloudQueueAddConsumere46e5cb7_SourceCodeVersioning_D9341870": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/cloud.Queue-AddConsumer-e46e5cb7/SourceCodeVersioning",
-            "uniqueId": "root_cloudQueueAddConsumere46e5cb7_SourceCodeVersioning_D9341870",
-          },
-        },
-        "bucket": "\${aws_s3_bucket.root_cloudQueueAddConsumere46e5cb7_Code_8AFA6947.id}",
-        "versioning_configuration": {
-          "status": "Enabled",
-        },
-      },
     },
     "aws_s3_object": {
       "root_cloudQueueAddConsumere46e5cb7_S3Object_343EB2E4": {
@@ -545,7 +545,7 @@ exports[`Plugin examples > AWS target plugins > replicate-s3.js 1`] = `
             "uniqueId": "root_cloudQueueAddConsumere46e5cb7_S3Object_343EB2E4",
           },
         },
-        "bucket": "\${aws_s3_bucket.root_cloudQueueAddConsumere46e5cb7_Code_8AFA6947.bucket}",
+        "bucket": "\${aws_s3_bucket.root_Code_02F3C603.bucket}",
         "key": "<ASSET_KEY>",
         "source": "<ASSET_SOURCE>",
       },
@@ -662,7 +662,7 @@ exports[`Plugin examples > AWS target plugins > tf-s3-backend.js 1`] = `
         "publish": true,
         "role": "\${aws_iam_role.root_cloudQueueAddConsumere46e5cb7_IamRole_AE43C8FE.arn}",
         "runtime": "nodejs16.x",
-        "s3_bucket": "\${aws_s3_bucket.root_cloudQueueAddConsumere46e5cb7_Code_8AFA6947.bucket}",
+        "s3_bucket": "\${aws_s3_bucket.root_Code_02F3C603.bucket}",
         "s3_key": "\${aws_s3_object.root_cloudQueueAddConsumere46e5cb7_S3Object_343EB2E4.key}",
         "timeout": 30,
         "vpc_config": {
@@ -672,6 +672,15 @@ exports[`Plugin examples > AWS target plugins > tf-s3-backend.js 1`] = `
       },
     },
     "aws_s3_bucket": {
+      "root_Code_02F3C603": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/Code",
+            "uniqueId": "root_Code_02F3C603",
+          },
+        },
+        "bucket_prefix": "code-c84a50b1-",
+      },
       "root_cloudBucket_4F3C4F53": {
         "//": {
           "metadata": {
@@ -681,15 +690,6 @@ exports[`Plugin examples > AWS target plugins > tf-s3-backend.js 1`] = `
         },
         "bucket_prefix": "cloud-bucket-c87175e7-",
         "force_destroy": false,
-      },
-      "root_cloudQueueAddConsumere46e5cb7_Code_8AFA6947": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/cloud.Queue-AddConsumer-e46e5cb7/Code",
-            "uniqueId": "root_cloudQueueAddConsumere46e5cb7_Code_8AFA6947",
-          },
-        },
-        "bucket_prefix": "code-c882cbfb-",
       },
     },
     "aws_s3_bucket_public_access_block": {
@@ -733,7 +733,7 @@ exports[`Plugin examples > AWS target plugins > tf-s3-backend.js 1`] = `
             "uniqueId": "root_cloudQueueAddConsumere46e5cb7_S3Object_343EB2E4",
           },
         },
-        "bucket": "\${aws_s3_bucket.root_cloudQueueAddConsumere46e5cb7_Code_8AFA6947.bucket}",
+        "bucket": "\${aws_s3_bucket.root_Code_02F3C603.bucket}",
         "key": "<ASSET_KEY>",
         "source": "<ASSET_SOURCE>",
       },

--- a/tools/hangar/__snapshots__/test_corpus/api.w/compile/tf-aws/main.tf.json
+++ b/tools/hangar/__snapshots__/test_corpus/api.w/compile/tf-aws/main.tf.json
@@ -153,7 +153,7 @@
         "publish": true,
         "role": "${aws_iam_role.root_cloudApi_cloudApiOnRequeste46e5cb7_IamRole_15046B29.arn}",
         "runtime": "nodejs16.x",
-        "s3_bucket": "${aws_s3_bucket.root_cloudApi_cloudApiOnRequeste46e5cb7_Code_42BF847C.bucket}",
+        "s3_bucket": "${aws_s3_bucket.root_Code_02F3C603.bucket}",
         "s3_key": "${aws_s3_object.root_cloudApi_cloudApiOnRequeste46e5cb7_S3Object_69EE2256.key}",
         "timeout": 30,
         "vpc_config": {
@@ -178,14 +178,14 @@
       },
     },
     "aws_s3_bucket": {
-      "root_cloudApi_cloudApiOnRequeste46e5cb7_Code_42BF847C": {
+      "root_Code_02F3C603": {
         "//": {
           "metadata": {
-            "path": "root/Default/Default/cloud.Api/cloud.Api-OnRequest-e46e5cb7/Code",
-            "uniqueId": "root_cloudApi_cloudApiOnRequeste46e5cb7_Code_42BF847C",
+            "path": "root/Default/Code",
+            "uniqueId": "root_Code_02F3C603",
           },
         },
-        "bucket_prefix": "code-c8f42a3b-",
+        "bucket_prefix": "code-c84a50b1-",
       },
     },
     "aws_s3_object": {
@@ -196,7 +196,7 @@
             "uniqueId": "root_cloudApi_cloudApiOnRequeste46e5cb7_S3Object_69EE2256",
           },
         },
-        "bucket": "${aws_s3_bucket.root_cloudApi_cloudApiOnRequeste46e5cb7_Code_42BF847C.bucket}",
+        "bucket": "${aws_s3_bucket.root_Code_02F3C603.bucket}",
         "key": "<ASSET_KEY>",
         "source": "<ASSET_SOURCE>",
       },

--- a/tools/hangar/__snapshots__/test_corpus/api_path_vars.w/compile/tf-aws/main.tf.json
+++ b/tools/hangar/__snapshots__/test_corpus/api_path_vars.w/compile/tf-aws/main.tf.json
@@ -162,7 +162,7 @@
         "publish": true,
         "role": "${aws_iam_role.root_cloudApi_cloudApiOnRequeste46e5cb7_IamRole_15046B29.arn}",
         "runtime": "nodejs16.x",
-        "s3_bucket": "${aws_s3_bucket.root_cloudApi_cloudApiOnRequeste46e5cb7_Code_42BF847C.bucket}",
+        "s3_bucket": "${aws_s3_bucket.root_Code_02F3C603.bucket}",
         "s3_key": "${aws_s3_object.root_cloudApi_cloudApiOnRequeste46e5cb7_S3Object_69EE2256.key}",
         "timeout": 30,
         "vpc_config": {
@@ -188,7 +188,7 @@
         "publish": true,
         "role": "${aws_iam_role.root_test_IamRole_6CDC2D16.arn}",
         "runtime": "nodejs16.x",
-        "s3_bucket": "${aws_s3_bucket.root_test_Code_2D131EC2.bucket}",
+        "s3_bucket": "${aws_s3_bucket.root_Code_02F3C603.bucket}",
         "s3_key": "${aws_s3_object.root_test_S3Object_A16CD789.key}",
         "timeout": 30,
         "vpc_config": {
@@ -213,23 +213,14 @@
       },
     },
     "aws_s3_bucket": {
-      "root_cloudApi_cloudApiOnRequeste46e5cb7_Code_42BF847C": {
+      "root_Code_02F3C603": {
         "//": {
           "metadata": {
-            "path": "root/Default/Default/cloud.Api/cloud.Api-OnRequest-e46e5cb7/Code",
-            "uniqueId": "root_cloudApi_cloudApiOnRequeste46e5cb7_Code_42BF847C",
+            "path": "root/Default/Code",
+            "uniqueId": "root_Code_02F3C603",
           },
         },
-        "bucket_prefix": "code-c8f42a3b-",
-      },
-      "root_test_Code_2D131EC2": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/test/Code",
-            "uniqueId": "root_test_Code_2D131EC2",
-          },
-        },
-        "bucket_prefix": "code-c883c33b-",
+        "bucket_prefix": "code-c84a50b1-",
       },
     },
     "aws_s3_object": {
@@ -240,7 +231,7 @@
             "uniqueId": "root_cloudApi_cloudApiOnRequeste46e5cb7_S3Object_69EE2256",
           },
         },
-        "bucket": "${aws_s3_bucket.root_cloudApi_cloudApiOnRequeste46e5cb7_Code_42BF847C.bucket}",
+        "bucket": "${aws_s3_bucket.root_Code_02F3C603.bucket}",
         "key": "<ASSET_KEY>",
         "source": "<ASSET_SOURCE>",
       },
@@ -251,7 +242,7 @@
             "uniqueId": "root_test_S3Object_A16CD789",
           },
         },
-        "bucket": "${aws_s3_bucket.root_test_Code_2D131EC2.bucket}",
+        "bucket": "${aws_s3_bucket.root_Code_02F3C603.bucket}",
         "key": "<ASSET_KEY>",
         "source": "<ASSET_SOURCE>",
       },

--- a/tools/hangar/__snapshots__/test_corpus/api_valid_path.w/compile/tf-aws/main.tf.json
+++ b/tools/hangar/__snapshots__/test_corpus/api_valid_path.w/compile/tf-aws/main.tf.json
@@ -133,7 +133,7 @@
         "publish": true,
         "role": "${aws_iam_role.root_cloudApi_cloudApiOnRequeste46e5cb7_IamRole_15046B29.arn}",
         "runtime": "nodejs16.x",
-        "s3_bucket": "${aws_s3_bucket.root_cloudApi_cloudApiOnRequeste46e5cb7_Code_42BF847C.bucket}",
+        "s3_bucket": "${aws_s3_bucket.root_Code_02F3C603.bucket}",
         "s3_key": "${aws_s3_object.root_cloudApi_cloudApiOnRequeste46e5cb7_S3Object_69EE2256.key}",
         "timeout": 30,
         "vpc_config": {
@@ -210,14 +210,14 @@
       },
     },
     "aws_s3_bucket": {
-      "root_cloudApi_cloudApiOnRequeste46e5cb7_Code_42BF847C": {
+      "root_Code_02F3C603": {
         "//": {
           "metadata": {
-            "path": "root/Default/Default/cloud.Api/cloud.Api-OnRequest-e46e5cb7/Code",
-            "uniqueId": "root_cloudApi_cloudApiOnRequeste46e5cb7_Code_42BF847C",
+            "path": "root/Default/Code",
+            "uniqueId": "root_Code_02F3C603",
           },
         },
-        "bucket_prefix": "code-c8f42a3b-",
+        "bucket_prefix": "code-c84a50b1-",
       },
     },
     "aws_s3_object": {
@@ -228,7 +228,7 @@
             "uniqueId": "root_cloudApi_cloudApiOnRequeste46e5cb7_S3Object_69EE2256",
           },
         },
-        "bucket": "${aws_s3_bucket.root_cloudApi_cloudApiOnRequeste46e5cb7_Code_42BF847C.bucket}",
+        "bucket": "${aws_s3_bucket.root_Code_02F3C603.bucket}",
         "key": "<ASSET_KEY>",
         "source": "<ASSET_SOURCE>",
       },

--- a/tools/hangar/__snapshots__/test_corpus/asynchronous_model_implicit_await_in_functions.w/compile/tf-aws/main.tf.json
+++ b/tools/hangar/__snapshots__/test_corpus/asynchronous_model_implicit_await_in_functions.w/compile/tf-aws/main.tf.json
@@ -109,7 +109,7 @@
         "publish": true,
         "role": "${aws_iam_role.root_func_IamRole_EE572BCE.arn}",
         "runtime": "nodejs16.x",
-        "s3_bucket": "${aws_s3_bucket.root_func_Code_58BA0E0E.bucket}",
+        "s3_bucket": "${aws_s3_bucket.root_Code_02F3C603.bucket}",
         "s3_key": "${aws_s3_object.root_func_S3Object_F6163647.key}",
         "timeout": 30,
         "vpc_config": {
@@ -134,7 +134,7 @@
         "publish": true,
         "role": "${aws_iam_role.root_strtostr_IamRole_305ACAF8.arn}",
         "runtime": "nodejs16.x",
-        "s3_bucket": "${aws_s3_bucket.root_strtostr_Code_5BA38746.bucket}",
+        "s3_bucket": "${aws_s3_bucket.root_Code_02F3C603.bucket}",
         "s3_key": "${aws_s3_object.root_strtostr_S3Object_C6E06A09.key}",
         "timeout": 30,
         "vpc_config": {
@@ -144,23 +144,14 @@
       },
     },
     "aws_s3_bucket": {
-      "root_func_Code_58BA0E0E": {
+      "root_Code_02F3C603": {
         "//": {
           "metadata": {
-            "path": "root/Default/Default/func/Code",
-            "uniqueId": "root_func_Code_58BA0E0E",
+            "path": "root/Default/Code",
+            "uniqueId": "root_Code_02F3C603",
           },
         },
-        "bucket_prefix": "code-c80d7959-",
-      },
-      "root_strtostr_Code_5BA38746": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/str_to_str/Code",
-            "uniqueId": "root_strtostr_Code_5BA38746",
-          },
-        },
-        "bucket_prefix": "code-c8b8906a-",
+        "bucket_prefix": "code-c84a50b1-",
       },
     },
     "aws_s3_object": {
@@ -171,7 +162,7 @@
             "uniqueId": "root_func_S3Object_F6163647",
           },
         },
-        "bucket": "${aws_s3_bucket.root_func_Code_58BA0E0E.bucket}",
+        "bucket": "${aws_s3_bucket.root_Code_02F3C603.bucket}",
         "key": "<ASSET_KEY>",
         "source": "<ASSET_SOURCE>",
       },
@@ -182,7 +173,7 @@
             "uniqueId": "root_strtostr_S3Object_C6E06A09",
           },
         },
-        "bucket": "${aws_s3_bucket.root_strtostr_Code_5BA38746.bucket}",
+        "bucket": "${aws_s3_bucket.root_Code_02F3C603.bucket}",
         "key": "<ASSET_KEY>",
         "source": "<ASSET_SOURCE>",
       },

--- a/tools/hangar/__snapshots__/test_corpus/bring_jsii.w/compile/tf-aws/main.tf.json
+++ b/tools/hangar/__snapshots__/test_corpus/bring_jsii.w/compile/tf-aws/main.tf.json
@@ -79,7 +79,7 @@
         "publish": true,
         "role": "${aws_iam_role.root_testsayhello_IamRole_CD3CFB9C.arn}",
         "runtime": "nodejs16.x",
-        "s3_bucket": "${aws_s3_bucket.root_testsayhello_Code_D4453363.bucket}",
+        "s3_bucket": "${aws_s3_bucket.root_Code_02F3C603.bucket}",
         "s3_key": "${aws_s3_object.root_testsayhello_S3Object_A9281CAB.key}",
         "timeout": 30,
         "vpc_config": {
@@ -89,14 +89,14 @@
       },
     },
     "aws_s3_bucket": {
-      "root_testsayhello_Code_D4453363": {
+      "root_Code_02F3C603": {
         "//": {
           "metadata": {
-            "path": "root/Default/Default/test:say_hello/Code",
-            "uniqueId": "root_testsayhello_Code_D4453363",
+            "path": "root/Default/Code",
+            "uniqueId": "root_Code_02F3C603",
           },
         },
-        "bucket_prefix": "code-c89e1bce-",
+        "bucket_prefix": "code-c84a50b1-",
       },
     },
     "aws_s3_object": {
@@ -107,7 +107,7 @@
             "uniqueId": "root_testsayhello_S3Object_A9281CAB",
           },
         },
-        "bucket": "${aws_s3_bucket.root_testsayhello_Code_D4453363.bucket}",
+        "bucket": "${aws_s3_bucket.root_Code_02F3C603.bucket}",
         "key": "<ASSET_KEY>",
         "source": "<ASSET_SOURCE>",
       },

--- a/tools/hangar/__snapshots__/test_corpus/bring_jsii_path.w/compile/tf-aws/main.tf.json
+++ b/tools/hangar/__snapshots__/test_corpus/bring_jsii_path.w/compile/tf-aws/main.tf.json
@@ -79,7 +79,7 @@
         "publish": true,
         "role": "${aws_iam_role.root_testsayhello_IamRole_CD3CFB9C.arn}",
         "runtime": "nodejs16.x",
-        "s3_bucket": "${aws_s3_bucket.root_testsayhello_Code_D4453363.bucket}",
+        "s3_bucket": "${aws_s3_bucket.root_Code_02F3C603.bucket}",
         "s3_key": "${aws_s3_object.root_testsayhello_S3Object_A9281CAB.key}",
         "timeout": 30,
         "vpc_config": {
@@ -89,14 +89,14 @@
       },
     },
     "aws_s3_bucket": {
-      "root_testsayhello_Code_D4453363": {
+      "root_Code_02F3C603": {
         "//": {
           "metadata": {
-            "path": "root/Default/Default/test:say_hello/Code",
-            "uniqueId": "root_testsayhello_Code_D4453363",
+            "path": "root/Default/Code",
+            "uniqueId": "root_Code_02F3C603",
           },
         },
-        "bucket_prefix": "code-c89e1bce-",
+        "bucket_prefix": "code-c84a50b1-",
       },
     },
     "aws_s3_object": {
@@ -107,7 +107,7 @@
             "uniqueId": "root_testsayhello_S3Object_A9281CAB",
           },
         },
-        "bucket": "${aws_s3_bucket.root_testsayhello_Code_D4453363.bucket}",
+        "bucket": "${aws_s3_bucket.root_Code_02F3C603.bucket}",
         "key": "<ASSET_KEY>",
         "source": "<ASSET_SOURCE>",
       },

--- a/tools/hangar/__snapshots__/test_corpus/bucket_events.w/compile/tf-aws/main.tf.json
+++ b/tools/hangar/__snapshots__/test_corpus/bucket_events.w/compile/tf-aws/main.tf.json
@@ -342,7 +342,7 @@
         "publish": true,
         "role": "${aws_iam_role.root_b_boncreateOnMessage8588493f_IamRole_F4D6A039.arn}",
         "runtime": "nodejs16.x",
-        "s3_bucket": "${aws_s3_bucket.root_b_boncreateOnMessage8588493f_Code_1C657564.bucket}",
+        "s3_bucket": "${aws_s3_bucket.root_Code_02F3C603.bucket}",
         "s3_key": "${aws_s3_object.root_b_boncreateOnMessage8588493f_S3Object_B05EA5EC.key}",
         "timeout": 30,
         "vpc_config": {
@@ -367,7 +367,7 @@
         "publish": true,
         "role": "${aws_iam_role.root_b_boncreateOnMessage88f6f7aa_IamRole_94993205.arn}",
         "runtime": "nodejs16.x",
-        "s3_bucket": "${aws_s3_bucket.root_b_boncreateOnMessage88f6f7aa_Code_9A928412.bucket}",
+        "s3_bucket": "${aws_s3_bucket.root_Code_02F3C603.bucket}",
         "s3_key": "${aws_s3_object.root_b_boncreateOnMessage88f6f7aa_S3Object_27A1B997.key}",
         "timeout": 30,
         "vpc_config": {
@@ -392,7 +392,7 @@
         "publish": true,
         "role": "${aws_iam_role.root_b_bondeleteOnMessage6e8b2f6c_IamRole_935D5999.arn}",
         "runtime": "nodejs16.x",
-        "s3_bucket": "${aws_s3_bucket.root_b_bondeleteOnMessage6e8b2f6c_Code_71B9ABD7.bucket}",
+        "s3_bucket": "${aws_s3_bucket.root_Code_02F3C603.bucket}",
         "s3_key": "${aws_s3_object.root_b_bondeleteOnMessage6e8b2f6c_S3Object_AA587BEA.key}",
         "timeout": 30,
         "vpc_config": {
@@ -419,7 +419,7 @@
         "publish": true,
         "role": "${aws_iam_role.root_b_bondeleteOnMessagedece1815_IamRole_0A3F666E.arn}",
         "runtime": "nodejs16.x",
-        "s3_bucket": "${aws_s3_bucket.root_b_bondeleteOnMessagedece1815_Code_A146A488.bucket}",
+        "s3_bucket": "${aws_s3_bucket.root_Code_02F3C603.bucket}",
         "s3_key": "${aws_s3_object.root_b_bondeleteOnMessagedece1815_S3Object_9F2FF12D.key}",
         "timeout": 30,
         "vpc_config": {
@@ -444,7 +444,7 @@
         "publish": true,
         "role": "${aws_iam_role.root_b_bonupdateOnMessage8b441417_IamRole_5980156B.arn}",
         "runtime": "nodejs16.x",
-        "s3_bucket": "${aws_s3_bucket.root_b_bonupdateOnMessage8b441417_Code_FEEDBA8A.bucket}",
+        "s3_bucket": "${aws_s3_bucket.root_Code_02F3C603.bucket}",
         "s3_key": "${aws_s3_object.root_b_bonupdateOnMessage8b441417_S3Object_E72D02CB.key}",
         "timeout": 30,
         "vpc_config": {
@@ -471,7 +471,7 @@
         "publish": true,
         "role": "${aws_iam_role.root_b_bonupdateOnMessagec7d8cc3e_IamRole_1B0D38A4.arn}",
         "runtime": "nodejs16.x",
-        "s3_bucket": "${aws_s3_bucket.root_b_bonupdateOnMessagec7d8cc3e_Code_45CB7D01.bucket}",
+        "s3_bucket": "${aws_s3_bucket.root_Code_02F3C603.bucket}",
         "s3_key": "${aws_s3_object.root_b_bonupdateOnMessagec7d8cc3e_S3Object_A082E479.key}",
         "timeout": 30,
         "vpc_config": {
@@ -496,7 +496,7 @@
         "publish": true,
         "role": "${aws_iam_role.root_other_otheroncreateOnMessage1a259cac_IamRole_B903D23C.arn}",
         "runtime": "nodejs16.x",
-        "s3_bucket": "${aws_s3_bucket.root_other_otheroncreateOnMessage1a259cac_Code_743CAA28.bucket}",
+        "s3_bucket": "${aws_s3_bucket.root_Code_02F3C603.bucket}",
         "s3_key": "${aws_s3_object.root_other_otheroncreateOnMessage1a259cac_S3Object_61C37281.key}",
         "timeout": 30,
         "vpc_config": {
@@ -521,7 +521,7 @@
         "publish": true,
         "role": "${aws_iam_role.root_other_otherondeleteOnMessage2e31a750_IamRole_45188816.arn}",
         "runtime": "nodejs16.x",
-        "s3_bucket": "${aws_s3_bucket.root_other_otherondeleteOnMessage2e31a750_Code_8A4E099A.bucket}",
+        "s3_bucket": "${aws_s3_bucket.root_Code_02F3C603.bucket}",
         "s3_key": "${aws_s3_object.root_other_otherondeleteOnMessage2e31a750_S3Object_5A3687E9.key}",
         "timeout": 30,
         "vpc_config": {
@@ -546,7 +546,7 @@
         "publish": true,
         "role": "${aws_iam_role.root_other_otheronupdateOnMessage02fb2142_IamRole_9D20DEAB.arn}",
         "runtime": "nodejs16.x",
-        "s3_bucket": "${aws_s3_bucket.root_other_otheronupdateOnMessage02fb2142_Code_A21BB0DF.bucket}",
+        "s3_bucket": "${aws_s3_bucket.root_Code_02F3C603.bucket}",
         "s3_key": "${aws_s3_object.root_other_otheronupdateOnMessage02fb2142_S3Object_7641A6CE.key}",
         "timeout": 30,
         "vpc_config": {
@@ -573,7 +573,7 @@
         "publish": true,
         "role": "${aws_iam_role.root_test_IamRole_6CDC2D16.arn}",
         "runtime": "nodejs16.x",
-        "s3_bucket": "${aws_s3_bucket.root_test_Code_2D131EC2.bucket}",
+        "s3_bucket": "${aws_s3_bucket.root_Code_02F3C603.bucket}",
         "s3_key": "${aws_s3_object.root_test_S3Object_A16CD789.key}",
         "timeout": 30,
         "vpc_config": {
@@ -693,6 +693,15 @@
       },
     },
     "aws_s3_bucket": {
+      "root_Code_02F3C603": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/Code",
+            "uniqueId": "root_Code_02F3C603",
+          },
+        },
+        "bucket_prefix": "code-c84a50b1-",
+      },
       "root_b_6D0D1E6D": {
         "//": {
           "metadata": {
@@ -703,60 +712,6 @@
         "bucket_prefix": "b-c81aa40d-",
         "force_destroy": false,
       },
-      "root_b_boncreateOnMessage8588493f_Code_1C657564": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/b/b-on_create-OnMessage-8588493f/Code",
-            "uniqueId": "root_b_boncreateOnMessage8588493f_Code_1C657564",
-          },
-        },
-        "bucket_prefix": "code-c83d0b2e-",
-      },
-      "root_b_boncreateOnMessage88f6f7aa_Code_9A928412": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/b/b-on_create-OnMessage-88f6f7aa/Code",
-            "uniqueId": "root_b_boncreateOnMessage88f6f7aa_Code_9A928412",
-          },
-        },
-        "bucket_prefix": "code-c8b13ddd-",
-      },
-      "root_b_bondeleteOnMessage6e8b2f6c_Code_71B9ABD7": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/b/b-on_delete-OnMessage-6e8b2f6c/Code",
-            "uniqueId": "root_b_bondeleteOnMessage6e8b2f6c_Code_71B9ABD7",
-          },
-        },
-        "bucket_prefix": "code-c801d9dc-",
-      },
-      "root_b_bondeleteOnMessagedece1815_Code_A146A488": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/b/b-on_delete-OnMessage-dece1815/Code",
-            "uniqueId": "root_b_bondeleteOnMessagedece1815_Code_A146A488",
-          },
-        },
-        "bucket_prefix": "code-c87a77de-",
-      },
-      "root_b_bonupdateOnMessage8b441417_Code_FEEDBA8A": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/b/b-on_update-OnMessage-8b441417/Code",
-            "uniqueId": "root_b_bonupdateOnMessage8b441417_Code_FEEDBA8A",
-          },
-        },
-        "bucket_prefix": "code-c8303a0e-",
-      },
-      "root_b_bonupdateOnMessagec7d8cc3e_Code_45CB7D01": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/b/b-on_update-OnMessage-c7d8cc3e/Code",
-            "uniqueId": "root_b_bonupdateOnMessagec7d8cc3e_Code_45CB7D01",
-          },
-        },
-        "bucket_prefix": "code-c8c5320e-",
-      },
       "root_other_26932ECB": {
         "//": {
           "metadata": {
@@ -766,42 +721,6 @@
         },
         "bucket_prefix": "other-c87420a2-",
         "force_destroy": false,
-      },
-      "root_other_otheroncreateOnMessage1a259cac_Code_743CAA28": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/other/other-on_create-OnMessage-1a259cac/Code",
-            "uniqueId": "root_other_otheroncreateOnMessage1a259cac_Code_743CAA28",
-          },
-        },
-        "bucket_prefix": "code-c834709a-",
-      },
-      "root_other_otherondeleteOnMessage2e31a750_Code_8A4E099A": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/other/other-on_delete-OnMessage-2e31a750/Code",
-            "uniqueId": "root_other_otherondeleteOnMessage2e31a750_Code_8A4E099A",
-          },
-        },
-        "bucket_prefix": "code-c8b328df-",
-      },
-      "root_other_otheronupdateOnMessage02fb2142_Code_A21BB0DF": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/other/other-on_update-OnMessage-02fb2142/Code",
-            "uniqueId": "root_other_otheronupdateOnMessage02fb2142_Code_A21BB0DF",
-          },
-        },
-        "bucket_prefix": "code-c830b886-",
-      },
-      "root_test_Code_2D131EC2": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/test/Code",
-            "uniqueId": "root_test_Code_2D131EC2",
-          },
-        },
-        "bucket_prefix": "code-c883c33b-",
       },
     },
     "aws_s3_bucket_notification": {
@@ -996,7 +915,7 @@
             "uniqueId": "root_b_boncreateOnMessage8588493f_S3Object_B05EA5EC",
           },
         },
-        "bucket": "${aws_s3_bucket.root_b_boncreateOnMessage8588493f_Code_1C657564.bucket}",
+        "bucket": "${aws_s3_bucket.root_Code_02F3C603.bucket}",
         "key": "<ASSET_KEY>",
         "source": "<ASSET_SOURCE>",
       },
@@ -1007,7 +926,7 @@
             "uniqueId": "root_b_boncreateOnMessage88f6f7aa_S3Object_27A1B997",
           },
         },
-        "bucket": "${aws_s3_bucket.root_b_boncreateOnMessage88f6f7aa_Code_9A928412.bucket}",
+        "bucket": "${aws_s3_bucket.root_Code_02F3C603.bucket}",
         "key": "<ASSET_KEY>",
         "source": "<ASSET_SOURCE>",
       },
@@ -1018,7 +937,7 @@
             "uniqueId": "root_b_bondeleteOnMessage6e8b2f6c_S3Object_AA587BEA",
           },
         },
-        "bucket": "${aws_s3_bucket.root_b_bondeleteOnMessage6e8b2f6c_Code_71B9ABD7.bucket}",
+        "bucket": "${aws_s3_bucket.root_Code_02F3C603.bucket}",
         "key": "<ASSET_KEY>",
         "source": "<ASSET_SOURCE>",
       },
@@ -1029,7 +948,7 @@
             "uniqueId": "root_b_bondeleteOnMessagedece1815_S3Object_9F2FF12D",
           },
         },
-        "bucket": "${aws_s3_bucket.root_b_bondeleteOnMessagedece1815_Code_A146A488.bucket}",
+        "bucket": "${aws_s3_bucket.root_Code_02F3C603.bucket}",
         "key": "<ASSET_KEY>",
         "source": "<ASSET_SOURCE>",
       },
@@ -1040,7 +959,7 @@
             "uniqueId": "root_b_bonupdateOnMessage8b441417_S3Object_E72D02CB",
           },
         },
-        "bucket": "${aws_s3_bucket.root_b_bonupdateOnMessage8b441417_Code_FEEDBA8A.bucket}",
+        "bucket": "${aws_s3_bucket.root_Code_02F3C603.bucket}",
         "key": "<ASSET_KEY>",
         "source": "<ASSET_SOURCE>",
       },
@@ -1051,7 +970,7 @@
             "uniqueId": "root_b_bonupdateOnMessagec7d8cc3e_S3Object_A082E479",
           },
         },
-        "bucket": "${aws_s3_bucket.root_b_bonupdateOnMessagec7d8cc3e_Code_45CB7D01.bucket}",
+        "bucket": "${aws_s3_bucket.root_Code_02F3C603.bucket}",
         "key": "<ASSET_KEY>",
         "source": "<ASSET_SOURCE>",
       },
@@ -1062,7 +981,7 @@
             "uniqueId": "root_other_otheroncreateOnMessage1a259cac_S3Object_61C37281",
           },
         },
-        "bucket": "${aws_s3_bucket.root_other_otheroncreateOnMessage1a259cac_Code_743CAA28.bucket}",
+        "bucket": "${aws_s3_bucket.root_Code_02F3C603.bucket}",
         "key": "<ASSET_KEY>",
         "source": "<ASSET_SOURCE>",
       },
@@ -1073,7 +992,7 @@
             "uniqueId": "root_other_otherondeleteOnMessage2e31a750_S3Object_5A3687E9",
           },
         },
-        "bucket": "${aws_s3_bucket.root_other_otherondeleteOnMessage2e31a750_Code_8A4E099A.bucket}",
+        "bucket": "${aws_s3_bucket.root_Code_02F3C603.bucket}",
         "key": "<ASSET_KEY>",
         "source": "<ASSET_SOURCE>",
       },
@@ -1084,7 +1003,7 @@
             "uniqueId": "root_other_otheronupdateOnMessage02fb2142_S3Object_7641A6CE",
           },
         },
-        "bucket": "${aws_s3_bucket.root_other_otheronupdateOnMessage02fb2142_Code_A21BB0DF.bucket}",
+        "bucket": "${aws_s3_bucket.root_Code_02F3C603.bucket}",
         "key": "<ASSET_KEY>",
         "source": "<ASSET_SOURCE>",
       },
@@ -1095,7 +1014,7 @@
             "uniqueId": "root_test_S3Object_A16CD789",
           },
         },
-        "bucket": "${aws_s3_bucket.root_test_Code_2D131EC2.bucket}",
+        "bucket": "${aws_s3_bucket.root_Code_02F3C603.bucket}",
         "key": "<ASSET_KEY>",
         "source": "<ASSET_SOURCE>",
       },

--- a/tools/hangar/__snapshots__/test_corpus/bucket_keys.w/compile/tf-aws/main.tf.json
+++ b/tools/hangar/__snapshots__/test_corpus/bucket_keys.w/compile/tf-aws/main.tf.json
@@ -81,7 +81,7 @@
         "publish": true,
         "role": "${aws_iam_role.root_test_IamRole_6CDC2D16.arn}",
         "runtime": "nodejs16.x",
-        "s3_bucket": "${aws_s3_bucket.root_test_Code_2D131EC2.bucket}",
+        "s3_bucket": "${aws_s3_bucket.root_Code_02F3C603.bucket}",
         "s3_key": "${aws_s3_object.root_test_S3Object_A16CD789.key}",
         "timeout": 30,
         "vpc_config": {
@@ -91,6 +91,15 @@
       },
     },
     "aws_s3_bucket": {
+      "root_Code_02F3C603": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/Code",
+            "uniqueId": "root_Code_02F3C603",
+          },
+        },
+        "bucket_prefix": "code-c84a50b1-",
+      },
       "root_cloudBucket_4F3C4F53": {
         "//": {
           "metadata": {
@@ -100,15 +109,6 @@
         },
         "bucket_prefix": "cloud-bucket-c87175e7-",
         "force_destroy": false,
-      },
-      "root_test_Code_2D131EC2": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/test/Code",
-            "uniqueId": "root_test_Code_2D131EC2",
-          },
-        },
-        "bucket_prefix": "code-c883c33b-",
       },
     },
     "aws_s3_bucket_public_access_block": {
@@ -152,7 +152,7 @@
             "uniqueId": "root_test_S3Object_A16CD789",
           },
         },
-        "bucket": "${aws_s3_bucket.root_test_Code_2D131EC2.bucket}",
+        "bucket": "${aws_s3_bucket.root_Code_02F3C603.bucket}",
         "key": "<ASSET_KEY>",
         "source": "<ASSET_SOURCE>",
       },

--- a/tools/hangar/__snapshots__/test_corpus/capture_containers.w/compile/tf-aws/main.tf.json
+++ b/tools/hangar/__snapshots__/test_corpus/capture_containers.w/compile/tf-aws/main.tf.json
@@ -79,7 +79,7 @@
         "publish": true,
         "role": "${aws_iam_role.root_test_IamRole_6CDC2D16.arn}",
         "runtime": "nodejs16.x",
-        "s3_bucket": "${aws_s3_bucket.root_test_Code_2D131EC2.bucket}",
+        "s3_bucket": "${aws_s3_bucket.root_Code_02F3C603.bucket}",
         "s3_key": "${aws_s3_object.root_test_S3Object_A16CD789.key}",
         "timeout": 30,
         "vpc_config": {
@@ -89,14 +89,14 @@
       },
     },
     "aws_s3_bucket": {
-      "root_test_Code_2D131EC2": {
+      "root_Code_02F3C603": {
         "//": {
           "metadata": {
-            "path": "root/Default/Default/test/Code",
-            "uniqueId": "root_test_Code_2D131EC2",
+            "path": "root/Default/Code",
+            "uniqueId": "root_Code_02F3C603",
           },
         },
-        "bucket_prefix": "code-c883c33b-",
+        "bucket_prefix": "code-c84a50b1-",
       },
     },
     "aws_s3_object": {
@@ -107,7 +107,7 @@
             "uniqueId": "root_test_S3Object_A16CD789",
           },
         },
-        "bucket": "${aws_s3_bucket.root_test_Code_2D131EC2.bucket}",
+        "bucket": "${aws_s3_bucket.root_Code_02F3C603.bucket}",
         "key": "<ASSET_KEY>",
         "source": "<ASSET_SOURCE>",
       },

--- a/tools/hangar/__snapshots__/test_corpus/capture_containers_of_resources.w/compile/tf-aws/main.tf.json
+++ b/tools/hangar/__snapshots__/test_corpus/capture_containers_of_resources.w/compile/tf-aws/main.tf.json
@@ -84,7 +84,7 @@
         "publish": true,
         "role": "${aws_iam_role.root_test_IamRole_6CDC2D16.arn}",
         "runtime": "nodejs16.x",
-        "s3_bucket": "${aws_s3_bucket.root_test_Code_2D131EC2.bucket}",
+        "s3_bucket": "${aws_s3_bucket.root_Code_02F3C603.bucket}",
         "s3_key": "${aws_s3_object.root_test_S3Object_A16CD789.key}",
         "timeout": 30,
         "vpc_config": {
@@ -94,6 +94,15 @@
       },
     },
     "aws_s3_bucket": {
+      "root_Code_02F3C603": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/Code",
+            "uniqueId": "root_Code_02F3C603",
+          },
+        },
+        "bucket_prefix": "code-c84a50b1-",
+      },
       "root_b1_A5C8D4B7": {
         "//": {
           "metadata": {
@@ -113,15 +122,6 @@
         },
         "bucket_prefix": "b2-c844cd88-",
         "force_destroy": false,
-      },
-      "root_test_Code_2D131EC2": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/test/Code",
-            "uniqueId": "root_test_Code_2D131EC2",
-          },
-        },
-        "bucket_prefix": "code-c883c33b-",
       },
     },
     "aws_s3_bucket_public_access_block": {
@@ -194,7 +194,7 @@
             "uniqueId": "root_test_S3Object_A16CD789",
           },
         },
-        "bucket": "${aws_s3_bucket.root_test_Code_2D131EC2.bucket}",
+        "bucket": "${aws_s3_bucket.root_Code_02F3C603.bucket}",
         "key": "<ASSET_KEY>",
         "source": "<ASSET_SOURCE>",
       },

--- a/tools/hangar/__snapshots__/test_corpus/capture_in_binary.w/compile/tf-aws/main.tf.json
+++ b/tools/hangar/__snapshots__/test_corpus/capture_in_binary.w/compile/tf-aws/main.tf.json
@@ -81,7 +81,7 @@
         "publish": true,
         "role": "${aws_iam_role.root_test_IamRole_6CDC2D16.arn}",
         "runtime": "nodejs16.x",
-        "s3_bucket": "${aws_s3_bucket.root_test_Code_2D131EC2.bucket}",
+        "s3_bucket": "${aws_s3_bucket.root_Code_02F3C603.bucket}",
         "s3_key": "${aws_s3_object.root_test_S3Object_A16CD789.key}",
         "timeout": 30,
         "vpc_config": {
@@ -91,6 +91,15 @@
       },
     },
     "aws_s3_bucket": {
+      "root_Code_02F3C603": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/Code",
+            "uniqueId": "root_Code_02F3C603",
+          },
+        },
+        "bucket_prefix": "code-c84a50b1-",
+      },
       "root_cloudBucket_4F3C4F53": {
         "//": {
           "metadata": {
@@ -100,15 +109,6 @@
         },
         "bucket_prefix": "cloud-bucket-c87175e7-",
         "force_destroy": false,
-      },
-      "root_test_Code_2D131EC2": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/test/Code",
-            "uniqueId": "root_test_Code_2D131EC2",
-          },
-        },
-        "bucket_prefix": "code-c883c33b-",
       },
     },
     "aws_s3_bucket_public_access_block": {
@@ -152,7 +152,7 @@
             "uniqueId": "root_test_S3Object_A16CD789",
           },
         },
-        "bucket": "${aws_s3_bucket.root_test_Code_2D131EC2.bucket}",
+        "bucket": "${aws_s3_bucket.root_Code_02F3C603.bucket}",
         "key": "<ASSET_KEY>",
         "source": "<ASSET_SOURCE>",
       },

--- a/tools/hangar/__snapshots__/test_corpus/capture_primitives.w/compile/tf-aws/main.tf.json
+++ b/tools/hangar/__snapshots__/test_corpus/capture_primitives.w/compile/tf-aws/main.tf.json
@@ -79,7 +79,7 @@
         "publish": true,
         "role": "${aws_iam_role.root_cloudFunction_IamRole_DAEC3578.arn}",
         "runtime": "nodejs16.x",
-        "s3_bucket": "${aws_s3_bucket.root_cloudFunction_Code_2F6A7948.bucket}",
+        "s3_bucket": "${aws_s3_bucket.root_Code_02F3C603.bucket}",
         "s3_key": "${aws_s3_object.root_cloudFunction_S3Object_C8435368.key}",
         "timeout": 30,
         "vpc_config": {
@@ -89,14 +89,14 @@
       },
     },
     "aws_s3_bucket": {
-      "root_cloudFunction_Code_2F6A7948": {
+      "root_Code_02F3C603": {
         "//": {
           "metadata": {
-            "path": "root/Default/Default/cloud.Function/Code",
-            "uniqueId": "root_cloudFunction_Code_2F6A7948",
+            "path": "root/Default/Code",
+            "uniqueId": "root_Code_02F3C603",
           },
         },
-        "bucket_prefix": "code-c8d4206f-",
+        "bucket_prefix": "code-c84a50b1-",
       },
     },
     "aws_s3_object": {
@@ -107,7 +107,7 @@
             "uniqueId": "root_cloudFunction_S3Object_C8435368",
           },
         },
-        "bucket": "${aws_s3_bucket.root_cloudFunction_Code_2F6A7948.bucket}",
+        "bucket": "${aws_s3_bucket.root_Code_02F3C603.bucket}",
         "key": "<ASSET_KEY>",
         "source": "<ASSET_SOURCE>",
       },

--- a/tools/hangar/__snapshots__/test_corpus/capture_resource_and_data.w/compile/tf-aws/main.tf.json
+++ b/tools/hangar/__snapshots__/test_corpus/capture_resource_and_data.w/compile/tf-aws/main.tf.json
@@ -82,7 +82,7 @@
         "publish": true,
         "role": "${aws_iam_role.root_test_IamRole_6CDC2D16.arn}",
         "runtime": "nodejs16.x",
-        "s3_bucket": "${aws_s3_bucket.root_test_Code_2D131EC2.bucket}",
+        "s3_bucket": "${aws_s3_bucket.root_Code_02F3C603.bucket}",
         "s3_key": "${aws_s3_object.root_test_S3Object_A16CD789.key}",
         "timeout": 30,
         "vpc_config": {
@@ -92,6 +92,15 @@
       },
     },
     "aws_s3_bucket": {
+      "root_Code_02F3C603": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/Code",
+            "uniqueId": "root_Code_02F3C603",
+          },
+        },
+        "bucket_prefix": "code-c84a50b1-",
+      },
       "root_cloudBucket_4F3C4F53": {
         "//": {
           "metadata": {
@@ -101,15 +110,6 @@
         },
         "bucket_prefix": "cloud-bucket-c87175e7-",
         "force_destroy": false,
-      },
-      "root_test_Code_2D131EC2": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/test/Code",
-            "uniqueId": "root_test_Code_2D131EC2",
-          },
-        },
-        "bucket_prefix": "code-c883c33b-",
       },
     },
     "aws_s3_bucket_public_access_block": {
@@ -153,7 +153,7 @@
             "uniqueId": "root_test_S3Object_A16CD789",
           },
         },
-        "bucket": "${aws_s3_bucket.root_test_Code_2D131EC2.bucket}",
+        "bucket": "${aws_s3_bucket.root_Code_02F3C603.bucket}",
         "key": "<ASSET_KEY>",
         "source": "<ASSET_SOURCE>",
       },

--- a/tools/hangar/__snapshots__/test_corpus/capture_resource_with_no_inflight.w/compile/tf-aws/main.tf.json
+++ b/tools/hangar/__snapshots__/test_corpus/capture_resource_with_no_inflight.w/compile/tf-aws/main.tf.json
@@ -79,7 +79,7 @@
         "publish": true,
         "role": "${aws_iam_role.root_test_IamRole_6CDC2D16.arn}",
         "runtime": "nodejs16.x",
-        "s3_bucket": "${aws_s3_bucket.root_test_Code_2D131EC2.bucket}",
+        "s3_bucket": "${aws_s3_bucket.root_Code_02F3C603.bucket}",
         "s3_key": "${aws_s3_object.root_test_S3Object_A16CD789.key}",
         "timeout": 30,
         "vpc_config": {
@@ -89,14 +89,14 @@
       },
     },
     "aws_s3_bucket": {
-      "root_test_Code_2D131EC2": {
+      "root_Code_02F3C603": {
         "//": {
           "metadata": {
-            "path": "root/Default/Default/test/Code",
-            "uniqueId": "root_test_Code_2D131EC2",
+            "path": "root/Default/Code",
+            "uniqueId": "root_Code_02F3C603",
           },
         },
-        "bucket_prefix": "code-c883c33b-",
+        "bucket_prefix": "code-c84a50b1-",
       },
     },
     "aws_s3_object": {
@@ -107,7 +107,7 @@
             "uniqueId": "root_test_S3Object_A16CD789",
           },
         },
-        "bucket": "${aws_s3_bucket.root_test_Code_2D131EC2.bucket}",
+        "bucket": "${aws_s3_bucket.root_Code_02F3C603.bucket}",
         "key": "<ASSET_KEY>",
         "source": "<ASSET_SOURCE>",
       },

--- a/tools/hangar/__snapshots__/test_corpus/captures.w/compile/tf-aws/main.tf.json
+++ b/tools/hangar/__snapshots__/test_corpus/captures.w/compile/tf-aws/main.tf.json
@@ -156,7 +156,7 @@
         "publish": true,
         "role": "${aws_iam_role.root_AnotherFunction_IamRole_09A4D8EF.arn}",
         "runtime": "nodejs16.x",
-        "s3_bucket": "${aws_s3_bucket.root_AnotherFunction_Code_B0183137.bucket}",
+        "s3_bucket": "${aws_s3_bucket.root_Code_02F3C603.bucket}",
         "s3_key": "${aws_s3_object.root_AnotherFunction_S3Object_5AD7E879.key}",
         "timeout": 30,
         "vpc_config": {
@@ -187,7 +187,7 @@
         "publish": true,
         "role": "${aws_iam_role.root_cloudFunction_IamRole_DAEC3578.arn}",
         "runtime": "nodejs16.x",
-        "s3_bucket": "${aws_s3_bucket.root_cloudFunction_Code_2F6A7948.bucket}",
+        "s3_bucket": "${aws_s3_bucket.root_Code_02F3C603.bucket}",
         "s3_key": "${aws_s3_object.root_cloudFunction_S3Object_C8435368.key}",
         "timeout": 30,
         "vpc_config": {
@@ -218,7 +218,7 @@
         "publish": true,
         "role": "${aws_iam_role.root_cloudQueueAddConsumere46e5cb7_IamRole_AE43C8FE.arn}",
         "runtime": "nodejs16.x",
-        "s3_bucket": "${aws_s3_bucket.root_cloudQueueAddConsumere46e5cb7_Code_8AFA6947.bucket}",
+        "s3_bucket": "${aws_s3_bucket.root_Code_02F3C603.bucket}",
         "s3_key": "${aws_s3_object.root_cloudQueueAddConsumere46e5cb7_S3Object_343EB2E4.key}",
         "timeout": 30,
         "vpc_config": {
@@ -228,14 +228,14 @@
       },
     },
     "aws_s3_bucket": {
-      "root_AnotherFunction_Code_B0183137": {
+      "root_Code_02F3C603": {
         "//": {
           "metadata": {
-            "path": "root/Default/Default/AnotherFunction/Code",
-            "uniqueId": "root_AnotherFunction_Code_B0183137",
+            "path": "root/Default/Code",
+            "uniqueId": "root_Code_02F3C603",
           },
         },
-        "bucket_prefix": "code-c8326137-",
+        "bucket_prefix": "code-c84a50b1-",
       },
       "root_PrivateBucket_82B4DCC5": {
         "//": {
@@ -266,24 +266,6 @@
         },
         "bucket_prefix": "cloud-bucket-c87175e7-",
         "force_destroy": false,
-      },
-      "root_cloudFunction_Code_2F6A7948": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/cloud.Function/Code",
-            "uniqueId": "root_cloudFunction_Code_2F6A7948",
-          },
-        },
-        "bucket_prefix": "code-c8d4206f-",
-      },
-      "root_cloudQueueAddConsumere46e5cb7_Code_8AFA6947": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/cloud.Queue-AddConsumer-e46e5cb7/Code",
-            "uniqueId": "root_cloudQueueAddConsumere46e5cb7_Code_8AFA6947",
-          },
-        },
-        "bucket_prefix": "code-c882cbfb-",
       },
     },
     "aws_s3_bucket_policy": {
@@ -384,7 +366,7 @@
             "uniqueId": "root_AnotherFunction_S3Object_5AD7E879",
           },
         },
-        "bucket": "${aws_s3_bucket.root_AnotherFunction_Code_B0183137.bucket}",
+        "bucket": "${aws_s3_bucket.root_Code_02F3C603.bucket}",
         "key": "<ASSET_KEY>",
         "source": "<ASSET_SOURCE>",
       },
@@ -395,7 +377,7 @@
             "uniqueId": "root_cloudFunction_S3Object_C8435368",
           },
         },
-        "bucket": "${aws_s3_bucket.root_cloudFunction_Code_2F6A7948.bucket}",
+        "bucket": "${aws_s3_bucket.root_Code_02F3C603.bucket}",
         "key": "<ASSET_KEY>",
         "source": "<ASSET_SOURCE>",
       },
@@ -406,7 +388,7 @@
             "uniqueId": "root_cloudQueueAddConsumere46e5cb7_S3Object_343EB2E4",
           },
         },
-        "bucket": "${aws_s3_bucket.root_cloudQueueAddConsumere46e5cb7_Code_8AFA6947.bucket}",
+        "bucket": "${aws_s3_bucket.root_Code_02F3C603.bucket}",
         "key": "<ASSET_KEY>",
         "source": "<ASSET_SOURCE>",
       },

--- a/tools/hangar/__snapshots__/test_corpus/extern_implementation.w/compile/tf-aws/main.tf.json
+++ b/tools/hangar/__snapshots__/test_corpus/extern_implementation.w/compile/tf-aws/main.tf.json
@@ -108,7 +108,7 @@
         "publish": true,
         "role": "${aws_iam_role.root_testcall_IamRole_ACAC0DA1.arn}",
         "runtime": "nodejs16.x",
-        "s3_bucket": "${aws_s3_bucket.root_testcall_Code_A13B9FEB.bucket}",
+        "s3_bucket": "${aws_s3_bucket.root_Code_02F3C603.bucket}",
         "s3_key": "${aws_s3_object.root_testcall_S3Object_7FFD9CF8.key}",
         "timeout": 30,
         "vpc_config": {
@@ -133,7 +133,7 @@
         "publish": true,
         "role": "${aws_iam_role.root_testconsole_IamRole_73B3A70E.arn}",
         "runtime": "nodejs16.x",
-        "s3_bucket": "${aws_s3_bucket.root_testconsole_Code_68C2DD48.bucket}",
+        "s3_bucket": "${aws_s3_bucket.root_Code_02F3C603.bucket}",
         "s3_key": "${aws_s3_object.root_testconsole_S3Object_DC38E410.key}",
         "timeout": 30,
         "vpc_config": {
@@ -143,23 +143,14 @@
       },
     },
     "aws_s3_bucket": {
-      "root_testcall_Code_A13B9FEB": {
+      "root_Code_02F3C603": {
         "//": {
           "metadata": {
-            "path": "root/Default/Default/test:call/Code",
-            "uniqueId": "root_testcall_Code_A13B9FEB",
+            "path": "root/Default/Code",
+            "uniqueId": "root_Code_02F3C603",
           },
         },
-        "bucket_prefix": "code-c8f81179-",
-      },
-      "root_testconsole_Code_68C2DD48": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/test:console/Code",
-            "uniqueId": "root_testconsole_Code_68C2DD48",
-          },
-        },
-        "bucket_prefix": "code-c842d248-",
+        "bucket_prefix": "code-c84a50b1-",
       },
     },
     "aws_s3_object": {
@@ -170,7 +161,7 @@
             "uniqueId": "root_testcall_S3Object_7FFD9CF8",
           },
         },
-        "bucket": "${aws_s3_bucket.root_testcall_Code_A13B9FEB.bucket}",
+        "bucket": "${aws_s3_bucket.root_Code_02F3C603.bucket}",
         "key": "<ASSET_KEY>",
         "source": "<ASSET_SOURCE>",
       },
@@ -181,7 +172,7 @@
             "uniqueId": "root_testconsole_S3Object_DC38E410",
           },
         },
-        "bucket": "${aws_s3_bucket.root_testconsole_Code_68C2DD48.bucket}",
+        "bucket": "${aws_s3_bucket.root_Code_02F3C603.bucket}",
         "key": "<ASSET_KEY>",
         "source": "<ASSET_SOURCE>",
       },

--- a/tools/hangar/__snapshots__/test_corpus/file_counter.w/compile/tf-aws/main.tf.json
+++ b/tools/hangar/__snapshots__/test_corpus/file_counter.w/compile/tf-aws/main.tf.json
@@ -114,7 +114,7 @@
         "publish": true,
         "role": "${aws_iam_role.root_cloudQueueAddConsumere46e5cb7_IamRole_AE43C8FE.arn}",
         "runtime": "nodejs16.x",
-        "s3_bucket": "${aws_s3_bucket.root_cloudQueueAddConsumere46e5cb7_Code_8AFA6947.bucket}",
+        "s3_bucket": "${aws_s3_bucket.root_Code_02F3C603.bucket}",
         "s3_key": "${aws_s3_object.root_cloudQueueAddConsumere46e5cb7_S3Object_343EB2E4.key}",
         "timeout": 30,
         "vpc_config": {
@@ -124,6 +124,15 @@
       },
     },
     "aws_s3_bucket": {
+      "root_Code_02F3C603": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/Code",
+            "uniqueId": "root_Code_02F3C603",
+          },
+        },
+        "bucket_prefix": "code-c84a50b1-",
+      },
       "root_cloudBucket_4F3C4F53": {
         "//": {
           "metadata": {
@@ -133,15 +142,6 @@
         },
         "bucket_prefix": "cloud-bucket-c87175e7-",
         "force_destroy": false,
-      },
-      "root_cloudQueueAddConsumere46e5cb7_Code_8AFA6947": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/cloud.Queue-AddConsumer-e46e5cb7/Code",
-            "uniqueId": "root_cloudQueueAddConsumere46e5cb7_Code_8AFA6947",
-          },
-        },
-        "bucket_prefix": "code-c882cbfb-",
       },
     },
     "aws_s3_bucket_public_access_block": {
@@ -185,7 +185,7 @@
             "uniqueId": "root_cloudQueueAddConsumere46e5cb7_S3Object_343EB2E4",
           },
         },
-        "bucket": "${aws_s3_bucket.root_cloudQueueAddConsumere46e5cb7_Code_8AFA6947.bucket}",
+        "bucket": "${aws_s3_bucket.root_Code_02F3C603.bucket}",
         "key": "<ASSET_KEY>",
         "source": "<ASSET_SOURCE>",
       },

--- a/tools/hangar/__snapshots__/test_corpus/for_loop.w/compile/tf-aws/main.tf.json
+++ b/tools/hangar/__snapshots__/test_corpus/for_loop.w/compile/tf-aws/main.tf.json
@@ -79,7 +79,7 @@
         "publish": true,
         "role": "${aws_iam_role.root_cloudFunction_IamRole_DAEC3578.arn}",
         "runtime": "nodejs16.x",
-        "s3_bucket": "${aws_s3_bucket.root_cloudFunction_Code_2F6A7948.bucket}",
+        "s3_bucket": "${aws_s3_bucket.root_Code_02F3C603.bucket}",
         "s3_key": "${aws_s3_object.root_cloudFunction_S3Object_C8435368.key}",
         "timeout": 30,
         "vpc_config": {
@@ -89,14 +89,14 @@
       },
     },
     "aws_s3_bucket": {
-      "root_cloudFunction_Code_2F6A7948": {
+      "root_Code_02F3C603": {
         "//": {
           "metadata": {
-            "path": "root/Default/Default/cloud.Function/Code",
-            "uniqueId": "root_cloudFunction_Code_2F6A7948",
+            "path": "root/Default/Code",
+            "uniqueId": "root_Code_02F3C603",
           },
         },
-        "bucket_prefix": "code-c8d4206f-",
+        "bucket_prefix": "code-c84a50b1-",
       },
     },
     "aws_s3_object": {
@@ -107,7 +107,7 @@
             "uniqueId": "root_cloudFunction_S3Object_C8435368",
           },
         },
-        "bucket": "${aws_s3_bucket.root_cloudFunction_Code_2F6A7948.bucket}",
+        "bucket": "${aws_s3_bucket.root_Code_02F3C603.bucket}",
         "key": "<ASSET_KEY>",
         "source": "<ASSET_SOURCE>",
       },

--- a/tools/hangar/__snapshots__/test_corpus/hello.w/compile/tf-aws/main.tf.json
+++ b/tools/hangar/__snapshots__/test_corpus/hello.w/compile/tf-aws/main.tf.json
@@ -94,7 +94,7 @@
         "publish": true,
         "role": "${aws_iam_role.root_cloudQueueAddConsumere46e5cb7_IamRole_AE43C8FE.arn}",
         "runtime": "nodejs16.x",
-        "s3_bucket": "${aws_s3_bucket.root_cloudQueueAddConsumere46e5cb7_Code_8AFA6947.bucket}",
+        "s3_bucket": "${aws_s3_bucket.root_Code_02F3C603.bucket}",
         "s3_key": "${aws_s3_object.root_cloudQueueAddConsumere46e5cb7_S3Object_343EB2E4.key}",
         "timeout": 30,
         "vpc_config": {
@@ -104,6 +104,15 @@
       },
     },
     "aws_s3_bucket": {
+      "root_Code_02F3C603": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/Code",
+            "uniqueId": "root_Code_02F3C603",
+          },
+        },
+        "bucket_prefix": "code-c84a50b1-",
+      },
       "root_cloudBucket_4F3C4F53": {
         "//": {
           "metadata": {
@@ -113,15 +122,6 @@
         },
         "bucket_prefix": "cloud-bucket-c87175e7-",
         "force_destroy": false,
-      },
-      "root_cloudQueueAddConsumere46e5cb7_Code_8AFA6947": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/cloud.Queue-AddConsumer-e46e5cb7/Code",
-            "uniqueId": "root_cloudQueueAddConsumere46e5cb7_Code_8AFA6947",
-          },
-        },
-        "bucket_prefix": "code-c882cbfb-",
       },
     },
     "aws_s3_bucket_public_access_block": {
@@ -165,7 +165,7 @@
             "uniqueId": "root_cloudQueueAddConsumere46e5cb7_S3Object_343EB2E4",
           },
         },
-        "bucket": "${aws_s3_bucket.root_cloudQueueAddConsumere46e5cb7_Code_8AFA6947.bucket}",
+        "bucket": "${aws_s3_bucket.root_Code_02F3C603.bucket}",
         "key": "<ASSET_KEY>",
         "source": "<ASSET_SOURCE>",
       },

--- a/tools/hangar/__snapshots__/test_corpus/json_bucket.w/compile/tf-aws/main.tf.json
+++ b/tools/hangar/__snapshots__/test_corpus/json_bucket.w/compile/tf-aws/main.tf.json
@@ -110,7 +110,7 @@
         "publish": true,
         "role": "${aws_iam_role.root_cloudFunction_IamRole_DAEC3578.arn}",
         "runtime": "nodejs16.x",
-        "s3_bucket": "${aws_s3_bucket.root_cloudFunction_Code_2F6A7948.bucket}",
+        "s3_bucket": "${aws_s3_bucket.root_Code_02F3C603.bucket}",
         "s3_key": "${aws_s3_object.root_cloudFunction_S3Object_C8435368.key}",
         "timeout": 30,
         "vpc_config": {
@@ -138,7 +138,7 @@
         "publish": true,
         "role": "${aws_iam_role.root_testput_IamRole_1BBF32A6.arn}",
         "runtime": "nodejs16.x",
-        "s3_bucket": "${aws_s3_bucket.root_testput_Code_DE7653AD.bucket}",
+        "s3_bucket": "${aws_s3_bucket.root_Code_02F3C603.bucket}",
         "s3_key": "${aws_s3_object.root_testput_S3Object_30BF1DDD.key}",
         "timeout": 30,
         "vpc_config": {
@@ -148,6 +148,15 @@
       },
     },
     "aws_s3_bucket": {
+      "root_Code_02F3C603": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/Code",
+            "uniqueId": "root_Code_02F3C603",
+          },
+        },
+        "bucket_prefix": "code-c84a50b1-",
+      },
       "root_cloudBucket_4F3C4F53": {
         "//": {
           "metadata": {
@@ -157,24 +166,6 @@
         },
         "bucket_prefix": "cloud-bucket-c87175e7-",
         "force_destroy": false,
-      },
-      "root_cloudFunction_Code_2F6A7948": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/cloud.Function/Code",
-            "uniqueId": "root_cloudFunction_Code_2F6A7948",
-          },
-        },
-        "bucket_prefix": "code-c8d4206f-",
-      },
-      "root_testput_Code_DE7653AD": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/test:put/Code",
-            "uniqueId": "root_testput_Code_DE7653AD",
-          },
-        },
-        "bucket_prefix": "code-c8ab7128-",
       },
     },
     "aws_s3_bucket_public_access_block": {
@@ -218,7 +209,7 @@
             "uniqueId": "root_cloudFunction_S3Object_C8435368",
           },
         },
-        "bucket": "${aws_s3_bucket.root_cloudFunction_Code_2F6A7948.bucket}",
+        "bucket": "${aws_s3_bucket.root_Code_02F3C603.bucket}",
         "key": "<ASSET_KEY>",
         "source": "<ASSET_SOURCE>",
       },
@@ -229,7 +220,7 @@
             "uniqueId": "root_testput_S3Object_30BF1DDD",
           },
         },
-        "bucket": "${aws_s3_bucket.root_testput_Code_DE7653AD.bucket}",
+        "bucket": "${aws_s3_bucket.root_Code_02F3C603.bucket}",
         "key": "<ASSET_KEY>",
         "source": "<ASSET_SOURCE>",
       },

--- a/tools/hangar/__snapshots__/test_corpus/print.w/compile/tf-aws/main.tf.json
+++ b/tools/hangar/__snapshots__/test_corpus/print.w/compile/tf-aws/main.tf.json
@@ -108,7 +108,7 @@
         "publish": true,
         "role": "${aws_iam_role.root_testlog1_IamRole_3D62ABEB.arn}",
         "runtime": "nodejs16.x",
-        "s3_bucket": "${aws_s3_bucket.root_testlog1_Code_49F9C67F.bucket}",
+        "s3_bucket": "${aws_s3_bucket.root_Code_02F3C603.bucket}",
         "s3_key": "${aws_s3_object.root_testlog1_S3Object_95AE7AEC.key}",
         "timeout": 30,
         "vpc_config": {
@@ -133,7 +133,7 @@
         "publish": true,
         "role": "${aws_iam_role.root_testlog2_IamRole_7773EE80.arn}",
         "runtime": "nodejs16.x",
-        "s3_bucket": "${aws_s3_bucket.root_testlog2_Code_F54FF962.bucket}",
+        "s3_bucket": "${aws_s3_bucket.root_Code_02F3C603.bucket}",
         "s3_key": "${aws_s3_object.root_testlog2_S3Object_93F5CD8E.key}",
         "timeout": 30,
         "vpc_config": {
@@ -143,23 +143,14 @@
       },
     },
     "aws_s3_bucket": {
-      "root_testlog1_Code_49F9C67F": {
+      "root_Code_02F3C603": {
         "//": {
           "metadata": {
-            "path": "root/Default/Default/test:log1/Code",
-            "uniqueId": "root_testlog1_Code_49F9C67F",
+            "path": "root/Default/Code",
+            "uniqueId": "root_Code_02F3C603",
           },
         },
-        "bucket_prefix": "code-c84d326c-",
-      },
-      "root_testlog2_Code_F54FF962": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/test:log2/Code",
-            "uniqueId": "root_testlog2_Code_F54FF962",
-          },
-        },
-        "bucket_prefix": "code-c86426d8-",
+        "bucket_prefix": "code-c84a50b1-",
       },
     },
     "aws_s3_object": {
@@ -170,7 +161,7 @@
             "uniqueId": "root_testlog1_S3Object_95AE7AEC",
           },
         },
-        "bucket": "${aws_s3_bucket.root_testlog1_Code_49F9C67F.bucket}",
+        "bucket": "${aws_s3_bucket.root_Code_02F3C603.bucket}",
         "key": "<ASSET_KEY>",
         "source": "<ASSET_SOURCE>",
       },
@@ -181,7 +172,7 @@
             "uniqueId": "root_testlog2_S3Object_93F5CD8E",
           },
         },
-        "bucket": "${aws_s3_bucket.root_testlog2_Code_F54FF962.bucket}",
+        "bucket": "${aws_s3_bucket.root_Code_02F3C603.bucket}",
         "key": "<ASSET_KEY>",
         "source": "<ASSET_SOURCE>",
       },

--- a/tools/hangar/__snapshots__/test_corpus/redis.w/compile/tf-aws/main.tf.json
+++ b/tools/hangar/__snapshots__/test_corpus/redis.w/compile/tf-aws/main.tf.json
@@ -171,7 +171,7 @@
         "publish": true,
         "role": "${aws_iam_role.root_test_IamRole_6CDC2D16.arn}",
         "runtime": "nodejs16.x",
-        "s3_bucket": "${aws_s3_bucket.root_test_Code_2D131EC2.bucket}",
+        "s3_bucket": "${aws_s3_bucket.root_Code_02F3C603.bucket}",
         "s3_key": "${aws_s3_object.root_test_S3Object_A16CD789.key}",
         "timeout": 30,
         "vpc_config": {
@@ -286,14 +286,14 @@
       },
     },
     "aws_s3_bucket": {
-      "root_test_Code_2D131EC2": {
+      "root_Code_02F3C603": {
         "//": {
           "metadata": {
-            "path": "root/Default/Default/test/Code",
-            "uniqueId": "root_test_Code_2D131EC2",
+            "path": "root/Default/Code",
+            "uniqueId": "root_Code_02F3C603",
           },
         },
-        "bucket_prefix": "code-c883c33b-",
+        "bucket_prefix": "code-c84a50b1-",
       },
     },
     "aws_s3_object": {
@@ -304,7 +304,7 @@
             "uniqueId": "root_test_S3Object_A16CD789",
           },
         },
-        "bucket": "${aws_s3_bucket.root_test_Code_2D131EC2.bucket}",
+        "bucket": "${aws_s3_bucket.root_Code_02F3C603.bucket}",
         "key": "<ASSET_KEY>",
         "source": "<ASSET_SOURCE>",
       },

--- a/tools/hangar/__snapshots__/test_corpus/resource.w/compile/tf-aws/main.tf.json
+++ b/tools/hangar/__snapshots__/test_corpus/resource.w/compile/tf-aws/main.tf.json
@@ -101,7 +101,7 @@
         "publish": true,
         "role": "${aws_iam_role.root_test_IamRole_6CDC2D16.arn}",
         "runtime": "nodejs16.x",
-        "s3_bucket": "${aws_s3_bucket.root_test_Code_2D131EC2.bucket}",
+        "s3_bucket": "${aws_s3_bucket.root_Code_02F3C603.bucket}",
         "s3_key": "${aws_s3_object.root_test_S3Object_A16CD789.key}",
         "timeout": 30,
         "vpc_config": {
@@ -111,6 +111,15 @@
       },
     },
     "aws_s3_bucket": {
+      "root_Code_02F3C603": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/Code",
+            "uniqueId": "root_Code_02F3C603",
+          },
+        },
+        "bucket_prefix": "code-c84a50b1-",
+      },
       "root_cloudBucket_4F3C4F53": {
         "//": {
           "metadata": {
@@ -120,15 +129,6 @@
         },
         "bucket_prefix": "cloud-bucket-c87175e7-",
         "force_destroy": false,
-      },
-      "root_test_Code_2D131EC2": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/test/Code",
-            "uniqueId": "root_test_Code_2D131EC2",
-          },
-        },
-        "bucket_prefix": "code-c883c33b-",
       },
     },
     "aws_s3_bucket_public_access_block": {
@@ -172,7 +172,7 @@
             "uniqueId": "root_test_S3Object_A16CD789",
           },
         },
-        "bucket": "${aws_s3_bucket.root_test_Code_2D131EC2.bucket}",
+        "bucket": "${aws_s3_bucket.root_Code_02F3C603.bucket}",
         "key": "<ASSET_KEY>",
         "source": "<ASSET_SOURCE>",
       },

--- a/tools/hangar/__snapshots__/test_corpus/resource_as_inflight_literal.w/compile/tf-aws/main.tf.json
+++ b/tools/hangar/__snapshots__/test_corpus/resource_as_inflight_literal.w/compile/tf-aws/main.tf.json
@@ -108,7 +108,7 @@
         "publish": true,
         "role": "${aws_iam_role.root_cloudFunction_IamRole_DAEC3578.arn}",
         "runtime": "nodejs16.x",
-        "s3_bucket": "${aws_s3_bucket.root_cloudFunction_Code_2F6A7948.bucket}",
+        "s3_bucket": "${aws_s3_bucket.root_Code_02F3C603.bucket}",
         "s3_key": "${aws_s3_object.root_cloudFunction_S3Object_C8435368.key}",
         "timeout": 30,
         "vpc_config": {
@@ -134,7 +134,7 @@
         "publish": true,
         "role": "${aws_iam_role.root_test_IamRole_6CDC2D16.arn}",
         "runtime": "nodejs16.x",
-        "s3_bucket": "${aws_s3_bucket.root_test_Code_2D131EC2.bucket}",
+        "s3_bucket": "${aws_s3_bucket.root_Code_02F3C603.bucket}",
         "s3_key": "${aws_s3_object.root_test_S3Object_A16CD789.key}",
         "timeout": 30,
         "vpc_config": {
@@ -144,23 +144,14 @@
       },
     },
     "aws_s3_bucket": {
-      "root_cloudFunction_Code_2F6A7948": {
+      "root_Code_02F3C603": {
         "//": {
           "metadata": {
-            "path": "root/Default/Default/cloud.Function/Code",
-            "uniqueId": "root_cloudFunction_Code_2F6A7948",
+            "path": "root/Default/Code",
+            "uniqueId": "root_Code_02F3C603",
           },
         },
-        "bucket_prefix": "code-c8d4206f-",
-      },
-      "root_test_Code_2D131EC2": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/test/Code",
-            "uniqueId": "root_test_Code_2D131EC2",
-          },
-        },
-        "bucket_prefix": "code-c883c33b-",
+        "bucket_prefix": "code-c84a50b1-",
       },
     },
     "aws_s3_object": {
@@ -171,7 +162,7 @@
             "uniqueId": "root_cloudFunction_S3Object_C8435368",
           },
         },
-        "bucket": "${aws_s3_bucket.root_cloudFunction_Code_2F6A7948.bucket}",
+        "bucket": "${aws_s3_bucket.root_Code_02F3C603.bucket}",
         "key": "<ASSET_KEY>",
         "source": "<ASSET_SOURCE>",
       },
@@ -182,7 +173,7 @@
             "uniqueId": "root_test_S3Object_A16CD789",
           },
         },
-        "bucket": "${aws_s3_bucket.root_test_Code_2D131EC2.bucket}",
+        "bucket": "${aws_s3_bucket.root_Code_02F3C603.bucket}",
         "key": "<ASSET_KEY>",
         "source": "<ASSET_SOURCE>",
       },

--- a/tools/hangar/__snapshots__/test_corpus/resource_captures.w/compile/tf-aws/main.tf.json
+++ b/tools/hangar/__snapshots__/test_corpus/resource_captures.w/compile/tf-aws/main.tf.json
@@ -106,7 +106,7 @@
         "publish": true,
         "role": "${aws_iam_role.root_test_IamRole_6CDC2D16.arn}",
         "runtime": "nodejs16.x",
-        "s3_bucket": "${aws_s3_bucket.root_test_Code_2D131EC2.bucket}",
+        "s3_bucket": "${aws_s3_bucket.root_Code_02F3C603.bucket}",
         "s3_key": "${aws_s3_object.root_test_S3Object_A16CD789.key}",
         "timeout": 30,
         "vpc_config": {
@@ -116,6 +116,15 @@
       },
     },
     "aws_s3_bucket": {
+      "root_Code_02F3C603": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/Code",
+            "uniqueId": "root_Code_02F3C603",
+          },
+        },
+        "bucket_prefix": "code-c84a50b1-",
+      },
       "root_MyResource_Another_First_cloudBucket_5E92C18E": {
         "//": {
           "metadata": {
@@ -145,15 +154,6 @@
         },
         "bucket_prefix": "cloud-bucket-c87175e7-",
         "force_destroy": false,
-      },
-      "root_test_Code_2D131EC2": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/test/Code",
-            "uniqueId": "root_test_Code_2D131EC2",
-          },
-        },
-        "bucket_prefix": "code-c883c33b-",
       },
     },
     "aws_s3_bucket_public_access_block": {
@@ -255,7 +255,7 @@
             "uniqueId": "root_test_S3Object_A16CD789",
           },
         },
-        "bucket": "${aws_s3_bucket.root_test_Code_2D131EC2.bucket}",
+        "bucket": "${aws_s3_bucket.root_Code_02F3C603.bucket}",
         "key": "<ASSET_KEY>",
         "source": "<ASSET_SOURCE>",
       },

--- a/tools/hangar/__snapshots__/test_corpus/statements_if.w/compile/tf-aws/main.tf.json
+++ b/tools/hangar/__snapshots__/test_corpus/statements_if.w/compile/tf-aws/main.tf.json
@@ -79,7 +79,7 @@
         "publish": true,
         "role": "${aws_iam_role.root_test_IamRole_6CDC2D16.arn}",
         "runtime": "nodejs16.x",
-        "s3_bucket": "${aws_s3_bucket.root_test_Code_2D131EC2.bucket}",
+        "s3_bucket": "${aws_s3_bucket.root_Code_02F3C603.bucket}",
         "s3_key": "${aws_s3_object.root_test_S3Object_A16CD789.key}",
         "timeout": 30,
         "vpc_config": {
@@ -89,14 +89,14 @@
       },
     },
     "aws_s3_bucket": {
-      "root_test_Code_2D131EC2": {
+      "root_Code_02F3C603": {
         "//": {
           "metadata": {
-            "path": "root/Default/Default/test/Code",
-            "uniqueId": "root_test_Code_2D131EC2",
+            "path": "root/Default/Code",
+            "uniqueId": "root_Code_02F3C603",
           },
         },
-        "bucket_prefix": "code-c883c33b-",
+        "bucket_prefix": "code-c84a50b1-",
       },
     },
     "aws_s3_object": {
@@ -107,7 +107,7 @@
             "uniqueId": "root_test_S3Object_A16CD789",
           },
         },
-        "bucket": "${aws_s3_bucket.root_test_Code_2D131EC2.bucket}",
+        "bucket": "${aws_s3_bucket.root_Code_02F3C603.bucket}",
         "key": "<ASSET_KEY>",
         "source": "<ASSET_SOURCE>",
       },

--- a/tools/hangar/__snapshots__/test_corpus/static_members.w/compile/tf-aws/main.tf.json
+++ b/tools/hangar/__snapshots__/test_corpus/static_members.w/compile/tf-aws/main.tf.json
@@ -79,7 +79,7 @@
         "publish": true,
         "role": "${aws_iam_role.root_test_IamRole_6CDC2D16.arn}",
         "runtime": "nodejs16.x",
-        "s3_bucket": "${aws_s3_bucket.root_test_Code_2D131EC2.bucket}",
+        "s3_bucket": "${aws_s3_bucket.root_Code_02F3C603.bucket}",
         "s3_key": "${aws_s3_object.root_test_S3Object_A16CD789.key}",
         "timeout": 30,
         "vpc_config": {
@@ -89,14 +89,14 @@
       },
     },
     "aws_s3_bucket": {
-      "root_test_Code_2D131EC2": {
+      "root_Code_02F3C603": {
         "//": {
           "metadata": {
-            "path": "root/Default/Default/test/Code",
-            "uniqueId": "root_test_Code_2D131EC2",
+            "path": "root/Default/Code",
+            "uniqueId": "root_Code_02F3C603",
           },
         },
-        "bucket_prefix": "code-c883c33b-",
+        "bucket_prefix": "code-c84a50b1-",
       },
     },
     "aws_s3_object": {
@@ -107,7 +107,7 @@
             "uniqueId": "root_test_S3Object_A16CD789",
           },
         },
-        "bucket": "${aws_s3_bucket.root_test_Code_2D131EC2.bucket}",
+        "bucket": "${aws_s3_bucket.root_Code_02F3C603.bucket}",
         "key": "<ASSET_KEY>",
         "source": "<ASSET_SOURCE>",
       },

--- a/tools/hangar/__snapshots__/test_corpus/std_string.w/compile/tf-aws/main.tf.json
+++ b/tools/hangar/__snapshots__/test_corpus/std_string.w/compile/tf-aws/main.tf.json
@@ -79,7 +79,7 @@
         "publish": true,
         "role": "${aws_iam_role.root_teststring_IamRole_A23B11BC.arn}",
         "runtime": "nodejs16.x",
-        "s3_bucket": "${aws_s3_bucket.root_teststring_Code_042172E8.bucket}",
+        "s3_bucket": "${aws_s3_bucket.root_Code_02F3C603.bucket}",
         "s3_key": "${aws_s3_object.root_teststring_S3Object_9049C921.key}",
         "timeout": 30,
         "vpc_config": {
@@ -89,14 +89,14 @@
       },
     },
     "aws_s3_bucket": {
-      "root_teststring_Code_042172E8": {
+      "root_Code_02F3C603": {
         "//": {
           "metadata": {
-            "path": "root/Default/Default/test:string/Code",
-            "uniqueId": "root_teststring_Code_042172E8",
+            "path": "root/Default/Code",
+            "uniqueId": "root_Code_02F3C603",
           },
         },
-        "bucket_prefix": "code-c8c4d274-",
+        "bucket_prefix": "code-c84a50b1-",
       },
     },
     "aws_s3_object": {
@@ -107,7 +107,7 @@
             "uniqueId": "root_teststring_S3Object_9049C921",
           },
         },
-        "bucket": "${aws_s3_bucket.root_teststring_Code_042172E8.bucket}",
+        "bucket": "${aws_s3_bucket.root_Code_02F3C603.bucket}",
         "key": "<ASSET_KEY>",
         "source": "<ASSET_SOURCE>",
       },

--- a/tools/hangar/__snapshots__/test_corpus/symbol_shadow.w/compile/tf-aws/main.tf.json
+++ b/tools/hangar/__snapshots__/test_corpus/symbol_shadow.w/compile/tf-aws/main.tf.json
@@ -166,7 +166,7 @@
         "publish": true,
         "role": "${aws_iam_role.root_A_testinflightinresourceshouldcapturetherightscopedvar_IamRole_5FB68186.arn}",
         "runtime": "nodejs16.x",
-        "s3_bucket": "${aws_s3_bucket.root_A_testinflightinresourceshouldcapturetherightscopedvar_Code_470A0E83.bucket}",
+        "s3_bucket": "${aws_s3_bucket.root_Code_02F3C603.bucket}",
         "s3_key": "${aws_s3_object.root_A_testinflightinresourceshouldcapturetherightscopedvar_S3Object_4C07FA3E.key}",
         "timeout": 30,
         "vpc_config": {
@@ -191,7 +191,7 @@
         "publish": true,
         "role": "${aws_iam_role.root_testinflightnestedshouldnotcapturetheshadowedvar_IamRole_5890FA19.arn}",
         "runtime": "nodejs16.x",
-        "s3_bucket": "${aws_s3_bucket.root_testinflightnestedshouldnotcapturetheshadowedvar_Code_56F93BD5.bucket}",
+        "s3_bucket": "${aws_s3_bucket.root_Code_02F3C603.bucket}",
         "s3_key": "${aws_s3_object.root_testinflightnestedshouldnotcapturetheshadowedvar_S3Object_C99A3326.key}",
         "timeout": 30,
         "vpc_config": {
@@ -216,7 +216,7 @@
         "publish": true,
         "role": "${aws_iam_role.root_testinflightontopshouldcapturetop_IamRole_E3EDF4E3.arn}",
         "runtime": "nodejs16.x",
-        "s3_bucket": "${aws_s3_bucket.root_testinflightontopshouldcapturetop_Code_F50B9894.bucket}",
+        "s3_bucket": "${aws_s3_bucket.root_Code_02F3C603.bucket}",
         "s3_key": "${aws_s3_object.root_testinflightontopshouldcapturetop_S3Object_75B26800.key}",
         "timeout": 30,
         "vpc_config": {
@@ -241,7 +241,7 @@
         "publish": true,
         "role": "${aws_iam_role.root_testinsideinflightshouldcapturetherightscope_IamRole_AC6104A8.arn}",
         "runtime": "nodejs16.x",
-        "s3_bucket": "${aws_s3_bucket.root_testinsideinflightshouldcapturetherightscope_Code_0FC24998.bucket}",
+        "s3_bucket": "${aws_s3_bucket.root_Code_02F3C603.bucket}",
         "s3_key": "${aws_s3_object.root_testinsideinflightshouldcapturetherightscope_S3Object_33BC24EC.key}",
         "timeout": 30,
         "vpc_config": {
@@ -251,41 +251,14 @@
       },
     },
     "aws_s3_bucket": {
-      "root_A_testinflightinresourceshouldcapturetherightscopedvar_Code_470A0E83": {
+      "root_Code_02F3C603": {
         "//": {
           "metadata": {
-            "path": "root/Default/Default/A/test:inflight in resource should capture the right scoped var/Code",
-            "uniqueId": "root_A_testinflightinresourceshouldcapturetherightscopedvar_Code_470A0E83",
+            "path": "root/Default/Code",
+            "uniqueId": "root_Code_02F3C603",
           },
         },
-        "bucket_prefix": "code-c8acbe1c-",
-      },
-      "root_testinflightnestedshouldnotcapturetheshadowedvar_Code_56F93BD5": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/test:inflight nested should not capture the shadowed var/Code",
-            "uniqueId": "root_testinflightnestedshouldnotcapturetheshadowedvar_Code_56F93BD5",
-          },
-        },
-        "bucket_prefix": "code-c8907873-",
-      },
-      "root_testinflightontopshouldcapturetop_Code_F50B9894": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/test:inflight on top should capture top/Code",
-            "uniqueId": "root_testinflightontopshouldcapturetop_Code_F50B9894",
-          },
-        },
-        "bucket_prefix": "code-c8f3b71f-",
-      },
-      "root_testinsideinflightshouldcapturetherightscope_Code_0FC24998": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/test:inside_inflight should capture the right scope/Code",
-            "uniqueId": "root_testinsideinflightshouldcapturetherightscope_Code_0FC24998",
-          },
-        },
-        "bucket_prefix": "code-c847b2c0-",
+        "bucket_prefix": "code-c84a50b1-",
       },
     },
     "aws_s3_object": {
@@ -296,7 +269,7 @@
             "uniqueId": "root_A_testinflightinresourceshouldcapturetherightscopedvar_S3Object_4C07FA3E",
           },
         },
-        "bucket": "${aws_s3_bucket.root_A_testinflightinresourceshouldcapturetherightscopedvar_Code_470A0E83.bucket}",
+        "bucket": "${aws_s3_bucket.root_Code_02F3C603.bucket}",
         "key": "<ASSET_KEY>",
         "source": "<ASSET_SOURCE>",
       },
@@ -307,7 +280,7 @@
             "uniqueId": "root_testinflightnestedshouldnotcapturetheshadowedvar_S3Object_C99A3326",
           },
         },
-        "bucket": "${aws_s3_bucket.root_testinflightnestedshouldnotcapturetheshadowedvar_Code_56F93BD5.bucket}",
+        "bucket": "${aws_s3_bucket.root_Code_02F3C603.bucket}",
         "key": "<ASSET_KEY>",
         "source": "<ASSET_SOURCE>",
       },
@@ -318,7 +291,7 @@
             "uniqueId": "root_testinflightontopshouldcapturetop_S3Object_75B26800",
           },
         },
-        "bucket": "${aws_s3_bucket.root_testinflightontopshouldcapturetop_Code_F50B9894.bucket}",
+        "bucket": "${aws_s3_bucket.root_Code_02F3C603.bucket}",
         "key": "<ASSET_KEY>",
         "source": "<ASSET_SOURCE>",
       },
@@ -329,7 +302,7 @@
             "uniqueId": "root_testinsideinflightshouldcapturetherightscope_S3Object_33BC24EC",
           },
         },
-        "bucket": "${aws_s3_bucket.root_testinsideinflightshouldcapturetherightscope_Code_0FC24998.bucket}",
+        "bucket": "${aws_s3_bucket.root_Code_02F3C603.bucket}",
         "key": "<ASSET_KEY>",
         "source": "<ASSET_SOURCE>",
       },

--- a/tools/hangar/__snapshots__/test_corpus/test_bucket.w/compile/tf-aws/main.tf.json
+++ b/tools/hangar/__snapshots__/test_corpus/test_bucket.w/compile/tf-aws/main.tf.json
@@ -110,7 +110,7 @@
         "publish": true,
         "role": "${aws_iam_role.root_testget_IamRole_DD77F38A.arn}",
         "runtime": "nodejs16.x",
-        "s3_bucket": "${aws_s3_bucket.root_testget_Code_EC989716.bucket}",
+        "s3_bucket": "${aws_s3_bucket.root_Code_02F3C603.bucket}",
         "s3_key": "${aws_s3_object.root_testget_S3Object_071392B9.key}",
         "timeout": 30,
         "vpc_config": {
@@ -137,7 +137,7 @@
         "publish": true,
         "role": "${aws_iam_role.root_testput_IamRole_1BBF32A6.arn}",
         "runtime": "nodejs16.x",
-        "s3_bucket": "${aws_s3_bucket.root_testput_Code_DE7653AD.bucket}",
+        "s3_bucket": "${aws_s3_bucket.root_Code_02F3C603.bucket}",
         "s3_key": "${aws_s3_object.root_testput_S3Object_30BF1DDD.key}",
         "timeout": 30,
         "vpc_config": {
@@ -147,6 +147,15 @@
       },
     },
     "aws_s3_bucket": {
+      "root_Code_02F3C603": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/Code",
+            "uniqueId": "root_Code_02F3C603",
+          },
+        },
+        "bucket_prefix": "code-c84a50b1-",
+      },
       "root_cloudBucket_4F3C4F53": {
         "//": {
           "metadata": {
@@ -156,24 +165,6 @@
         },
         "bucket_prefix": "cloud-bucket-c87175e7-",
         "force_destroy": false,
-      },
-      "root_testget_Code_EC989716": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/test:get/Code",
-            "uniqueId": "root_testget_Code_EC989716",
-          },
-        },
-        "bucket_prefix": "code-c8071909-",
-      },
-      "root_testput_Code_DE7653AD": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/test:put/Code",
-            "uniqueId": "root_testput_Code_DE7653AD",
-          },
-        },
-        "bucket_prefix": "code-c8ab7128-",
       },
     },
     "aws_s3_bucket_public_access_block": {
@@ -217,7 +208,7 @@
             "uniqueId": "root_testget_S3Object_071392B9",
           },
         },
-        "bucket": "${aws_s3_bucket.root_testget_Code_EC989716.bucket}",
+        "bucket": "${aws_s3_bucket.root_Code_02F3C603.bucket}",
         "key": "<ASSET_KEY>",
         "source": "<ASSET_SOURCE>",
       },
@@ -228,7 +219,7 @@
             "uniqueId": "root_testput_S3Object_30BF1DDD",
           },
         },
-        "bucket": "${aws_s3_bucket.root_testput_Code_DE7653AD.bucket}",
+        "bucket": "${aws_s3_bucket.root_Code_02F3C603.bucket}",
         "key": "<ASSET_KEY>",
         "source": "<ASSET_SOURCE>",
       },

--- a/tools/hangar/__snapshots__/test_corpus/while_loop_await.w/compile/tf-aws/main.tf.json
+++ b/tools/hangar/__snapshots__/test_corpus/while_loop_await.w/compile/tf-aws/main.tf.json
@@ -92,7 +92,7 @@
         "publish": true,
         "role": "${aws_iam_role.root_cloudQueueAddConsumerb3f3d188_IamRole_DE9F8DCD.arn}",
         "runtime": "nodejs16.x",
-        "s3_bucket": "${aws_s3_bucket.root_cloudQueueAddConsumerb3f3d188_Code_84147B09.bucket}",
+        "s3_bucket": "${aws_s3_bucket.root_Code_02F3C603.bucket}",
         "s3_key": "${aws_s3_object.root_cloudQueueAddConsumerb3f3d188_S3Object_E185C166.key}",
         "timeout": 30,
         "vpc_config": {
@@ -102,14 +102,14 @@
       },
     },
     "aws_s3_bucket": {
-      "root_cloudQueueAddConsumerb3f3d188_Code_84147B09": {
+      "root_Code_02F3C603": {
         "//": {
           "metadata": {
-            "path": "root/Default/Default/cloud.Queue-AddConsumer-b3f3d188/Code",
-            "uniqueId": "root_cloudQueueAddConsumerb3f3d188_Code_84147B09",
+            "path": "root/Default/Code",
+            "uniqueId": "root_Code_02F3C603",
           },
         },
-        "bucket_prefix": "code-c84c4bec-",
+        "bucket_prefix": "code-c84a50b1-",
       },
     },
     "aws_s3_object": {
@@ -120,7 +120,7 @@
             "uniqueId": "root_cloudQueueAddConsumerb3f3d188_S3Object_E185C166",
           },
         },
-        "bucket": "${aws_s3_bucket.root_cloudQueueAddConsumerb3f3d188_Code_84147B09.bucket}",
+        "bucket": "${aws_s3_bucket.root_Code_02F3C603.bucket}",
         "key": "<ASSET_KEY>",
         "source": "<ASSET_SOURCE>",
       },


### PR DESCRIPTION
This change makes all functions within an `tf-aws` app share the same asset bucket. Below we can see I was able to deploy the following code: 
```js
bring cloud;

let b = new cloud.Bucket();
let c = new cloud.Counter();

new cloud.Function(inflight () => {
  let index = c.inc();
  b.put("func-1-${index}.txt", "cool stuff");
}) as "func-1";  

new cloud.Function(inflight () => {
  let index = c.inc();
  b.put("func-2-${index}.txt", "cool stuff");
}) as "func-2";

new cloud.Function(inflight () => {
  let index = c.inc();
  b.put("func-3-${index}.txt", "cool stuff");
}) as "func-3";  
```

With a single code bucket rather than 3
**BEFORE**
![image](https://user-images.githubusercontent.com/45375125/232352647-89671d17-b10d-4f22-94ee-507a22267946.png)

**AFTER**
![image](https://user-images.githubusercontent.com/45375125/232352663-d47fea14-827e-41df-a233-f0c91c0cb03c.png)

Within the single code bucket all the assets have unique keys already:
![image](https://user-images.githubusercontent.com/45375125/232352697-72a703a7-d83f-48ff-aa91-aa056a75c8fd.png)

This change was inspired by @RaphaelManke 's poor AWS account filled with buckets for the wingathon 😂 

Closes: https://github.com/winglang/wing/issues/178

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.