### PR TITLE
chore: run canary test on release

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -3,6 +3,9 @@ on:
   schedule:
     - cron: '0 * * * *'
   workflow_dispatch: {}
+  release:
+    types:
+      - published
 
 jobs:
   install:


### PR DESCRIPTION
We run canary hourly, but we want to catch issues quickly upon release (assuming we weren't able to catch them before release)

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.