### PR TITLE
chore(sdk): better error message in sim when no secrets file

### DIFF
--- a/libs/wingsdk/src/target-sim/secret.inflight.ts
+++ b/libs/wingsdk/src/target-sim/secret.inflight.ts
@@ -23,7 +23,9 @@ export class Secret implements ISecretClient, ISimulatorResourceInstance {
 
     this.secretsFile = path.join(os.homedir(), ".wing", "secrets.json");
     if (!fs.existsSync(this.secretsFile)) {
-      throw new Error(`No secrets file found at ${this.secretsFile}`);
+      throw new Error(
+        `No secrets file found at ${this.secretsFile} while looking for secret ${props.name}`
+      );
     }
 
     this.name = props.name;


### PR DESCRIPTION
Add the name of the secret we are looking for.



*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.