### PR TITLE
fix(sdk): increasing sim api req limit to match aws'

### DIFF
--- a/libs/wingsdk/src/target-sim/api.inflight.ts
+++ b/libs/wingsdk/src/target-sim/api.inflight.ts
@@ -38,8 +38,10 @@ export class Api implements IApiClient, ISimulatorResourceInstance {
     this.app = express();
 
     // Parse request bodies as json.
-    this.app.use(express.json());
-    this.app.use(express.urlencoded({ extended: true }));
+    // matching the limit to aws api gateway's payload size limit:
+    // https://docs.aws.amazon.com/apigateway/latest/developerguide/limits.html
+    this.app.use(express.json({ limit: "10mb" }));
+    this.app.use(express.urlencoded({ extended: true, limit: "10mb" }));
 
     for (const route of this.routes) {
       const method = route.method.toLowerCase() as


### PR DESCRIPTION
increasing sim api request size limit to match aws api gateway payload size limit.

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.