### PR TITLE
chore: add more wiggle room for benchmarks

### DIFF
--- a/examples/tests/valid/benchmarks/empty.w
+++ b/examples/tests/valid/benchmarks/empty.w
@@ -1,7 +1,7 @@
 /*\
 cases:
   - target: sim
-    maxMeanTime: 900
+    maxMeanTime: 2900
   - target: tf-aws
-    maxMeanTime: 1000
+    maxMeanTime: 3000
 \*/

--- a/examples/tests/valid/benchmarks/functions_1.w
+++ b/examples/tests/valid/benchmarks/functions_1.w
@@ -1,9 +1,9 @@
 /*\
 cases:
   - target: sim
-    maxMeanTime: 1000
+    maxMeanTime: 3000
   - target: tf-aws
-    maxMeanTime: 6000
+    maxMeanTime: 8000
 \*/
 
 bring cloud;

--- a/examples/tests/valid/benchmarks/functions_10.w
+++ b/examples/tests/valid/benchmarks/functions_10.w
@@ -1,9 +1,9 @@
 /*\
 cases:
   - target: sim
-    maxMeanTime: 1000
+    maxMeanTime: 3000
   - target: tf-aws
-    maxMeanTime: 20000
+    maxMeanTime: 22000
 \*/
 
 bring cloud;

--- a/examples/tests/valid/benchmarks/hello_world.w
+++ b/examples/tests/valid/benchmarks/hello_world.w
@@ -1,9 +1,9 @@
 /*\
 cases:
   - target: sim
-    maxMeanTime: 1000
+    maxMeanTime: 3000
   - target: tf-aws
-    maxMeanTime: 6000
+    maxMeanTime: 8000
 \*/
 
 bring cloud;

--- a/examples/tests/valid/benchmarks/jsii_big.w
+++ b/examples/tests/valid/benchmarks/jsii_big.w
@@ -1,9 +1,9 @@
 /*\
 cases:
   - target: sim
-    maxMeanTime: 9000
+    maxMeanTime: 11000
   - target: tf-aws
-    maxMeanTime: 9000
+    maxMeanTime: 11000
 \*/
 
 bring "@cdktf/provider-aws" as aws;

--- a/examples/tests/valid/benchmarks/jsii_small.w
+++ b/examples/tests/valid/benchmarks/jsii_small.w
@@ -1,9 +1,9 @@
 /*\
 cases:
   - target: sim
-    maxMeanTime: 900
+    maxMeanTime: 2900
   - target: tf-aws
-    maxMeanTime: 1000
+    maxMeanTime: 3000
 \*/
 
 bring "jsii-code-samples" as stuff;


### PR DESCRIPTION
Benchmarks were added with a limit to make sure we don't make wing any slower. I think the current limits may be too optimistic, so I added 2 seconds to all of them. 

I consider this **temporary** as we gain more data to create a more realistic target.

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.