### PR TITLE
chore(compiler): inline inflight clients in preflight.js

### DIFF
--- a/libs/wingc/src/jsify/codemaker.rs
+++ b/libs/wingc/src/jsify/codemaker.rs
@@ -37,6 +37,15 @@ impl CodeMaker {
 		}
 	}
 
+	/// Emits multiple lines of code starting with the current indent,
+	/// escaping the code for use in JavaScript.
+	pub fn add_code_escaped(&mut self, code: CodeMaker) {
+		assert_eq!(code.indent, 0, "Cannot add code with indent");
+		for (indent, line) in code.lines {
+			self.lines.push((indent + self.indent, line.to_string_escaped()));
+		}
+	}
+
 	/// Decreases the current indent by one.
 	#[allow(dead_code)]
 	pub fn unindent(&mut self) {
@@ -52,6 +61,29 @@ impl CodeMaker {
 		let mut code = CodeMaker::default();
 		code.line(s);
 		code
+	}
+}
+
+trait ToStringEscaped {
+	fn to_string_escaped(&self) -> String;
+}
+
+impl ToStringEscaped for String {
+	fn to_string_escaped(&self) -> String {
+		let mut escaped = String::new();
+		for c in self.chars() {
+			match c {
+				'\'' => escaped.push_str("\\'"),
+				'\n' => escaped.push_str("\\n"),
+				'\r' => escaped.push_str("\\r"),
+				'\t' => escaped.push_str("\\t"),
+				'\\' => escaped.push_str("\\\\"),
+				'`' => escaped.push_str("\\`"),
+				'$' => escaped.push_str("\\$"),
+				_ => escaped.push(c),
+			}
+		}
+		escaped
 	}
 }
 

--- a/tools/hangar/__snapshots__/test_corpus/api.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/api.w_compile_tf-aws.md
@@ -1,23 +1,5 @@
 # [api.w](../../../../examples/tests/valid/api.w) | compile | tf-aws
 
-## clients/Foo.inflight.js
-```js
-class  Foo {
-  constructor({ api, stateful }) {
-    this.api = api;
-    this.stateful = stateful;
-  }
-  async handle(message)  {
-    {
-      const url = this.api.url;
-      {((cond) => {if (!cond) throw new Error(`assertion failed: 'url.startsWith("http://")'`)})(url.startsWith("http://"))};
-    }
-  }
-}
-exports.Foo = Foo;
-
-```
-
 ## main.tf.json
 ```json
 {
@@ -311,10 +293,21 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         const api_client = this._lift(this.api);
         const stateful_client = this._lift(this.stateful);
-        const self_client_path = "./clients/Foo.inflight.js".replace(/\\/g, "/");
         return $stdlib.core.NodeJsCode.fromInline(`
           (await (async () => {
-            const tmp = new (require("${self_client_path}")).Foo({
+            class  Foo {
+              constructor({ api, stateful }) {
+                this.api = api;
+                this.stateful = stateful;
+              }
+              async handle(message)  {
+                {
+                  const url = this.api.url;
+                  {((cond) => {if (!cond) throw new Error(\`assertion failed: \'url.startsWith("http://")\'\`)})(url.startsWith("http://"))};
+                }
+              }
+            }
+            const tmp = new Foo({
               api: ${api_client},
               stateful: ${stateful_client},
             });

--- a/tools/hangar/__snapshots__/test_corpus/api_path_vars.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/api_path_vars.w_compile_tf-aws.md
@@ -1,19 +1,5 @@
 # [api_path_vars.w](../../../../examples/tests/valid/api_path_vars.w) | compile | tf-aws
 
-## clients/Fetch.inflight.js
-```js
-class  Fetch {
-  constructor({ stateful }) {
-    this.stateful = stateful;
-  }
-  async get(url)  {
-    return (require("<ABSOLUTE_PATH>/api_path_vars.js")["get"])(url)
-  }
-}
-exports.Fetch = Fetch;
-
-```
-
 ## main.tf.json
 ```json
 {
@@ -285,10 +271,17 @@ class $Root extends $stdlib.std.Resource {
       }
       _toInflight() {
         const stateful_client = this._lift(this.stateful);
-        const self_client_path = "./clients/Fetch.inflight.js".replace(/\\/g, "/");
         return $stdlib.core.NodeJsCode.fromInline(`
           (await (async () => {
-            const tmp = new (require("${self_client_path}")).Fetch({
+            class  Fetch {
+              constructor({ stateful }) {
+                this.stateful = stateful;
+              }
+              async get(url)  {
+                return (require("<ABSOLUTE_PATH>/api_path_vars.js")["get"])(url)
+              }
+            }
+            const tmp = new Fetch({
               stateful: ${stateful_client},
             });
             if (tmp.$inflight_init) { await tmp.$inflight_init(); }

--- a/tools/hangar/__snapshots__/test_corpus/capture_resource_with_no_inflight.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/capture_resource_with_no_inflight.w_compile_tf-aws.md
@@ -1,17 +1,5 @@
 # [capture_resource_with_no_inflight.w](../../../../examples/tests/valid/capture_resource_with_no_inflight.w) | compile | tf-aws
 
-## clients/A.inflight.js
-```js
-class  A {
-  constructor({ field, stateful }) {
-    this.field = field;
-    this.stateful = stateful;
-  }
-}
-exports.A = A;
-
-```
-
 ## main.tf.json
 ```json
 {
@@ -150,10 +138,15 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         const field_client = this._lift(this.field);
         const stateful_client = this._lift(this.stateful);
-        const self_client_path = "./clients/A.inflight.js".replace(/\\/g, "/");
         return $stdlib.core.NodeJsCode.fromInline(`
           (await (async () => {
-            const tmp = new (require("${self_client_path}")).A({
+            class  A {
+              constructor({ field, stateful }) {
+                this.field = field;
+                this.stateful = stateful;
+              }
+            }
+            const tmp = new A({
               field: ${field_client},
               stateful: ${stateful_client},
             });

--- a/tools/hangar/__snapshots__/test_corpus/construct-base.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/construct-base.w_compile_tf-aws.md
@@ -1,16 +1,5 @@
 # [construct-base.w](../../../../examples/tests/valid/construct-base.w) | compile | tf-aws
 
-## clients/WingResource.inflight.js
-```js
-class  WingResource {
-  constructor({ stateful }) {
-    this.stateful = stateful;
-  }
-}
-exports.WingResource = WingResource;
-
-```
-
 ## main.tf.json
 ```json
 {
@@ -74,10 +63,14 @@ class $Root extends $stdlib.std.Resource {
       }
       _toInflight() {
         const stateful_client = this._lift(this.stateful);
-        const self_client_path = "./clients/WingResource.inflight.js".replace(/\\/g, "/");
         return $stdlib.core.NodeJsCode.fromInline(`
           (await (async () => {
-            const tmp = new (require("${self_client_path}")).WingResource({
+            class  WingResource {
+              constructor({ stateful }) {
+                this.stateful = stateful;
+              }
+            }
+            const tmp = new WingResource({
               stateful: ${stateful_client},
             });
             if (tmp.$inflight_init) { await tmp.$inflight_init(); }

--- a/tools/hangar/__snapshots__/test_corpus/doubler.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/doubler.w_compile_tf-aws.md
@@ -1,23 +1,5 @@
 # [doubler.w](../../../../examples/tests/valid/doubler.w) | compile | tf-aws
 
-## clients/Doubler.inflight.js
-```js
-class  Doubler {
-  constructor({ func, stateful }) {
-    this.func = func;
-    this.stateful = stateful;
-  }
-  async invoke(message)  {
-    {
-      (await this.func.handle(message));
-      (await this.func.handle(message));
-    }
-  }
-}
-exports.Doubler = Doubler;
-
-```
-
 ## main.tf.json
 ```json
 {
@@ -68,10 +50,21 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         const func_client = this._lift(this.func);
         const stateful_client = this._lift(this.stateful);
-        const self_client_path = "./clients/Doubler.inflight.js".replace(/\\/g, "/");
         return $stdlib.core.NodeJsCode.fromInline(`
           (await (async () => {
-            const tmp = new (require("${self_client_path}")).Doubler({
+            class  Doubler {
+              constructor({ func, stateful }) {
+                this.func = func;
+                this.stateful = stateful;
+              }
+              async invoke(message)  {
+                {
+                  (await this.func.handle(message));
+                  (await this.func.handle(message));
+                }
+              }
+            }
+            const tmp = new Doubler({
               func: ${func_client},
               stateful: ${stateful_client},
             });

--- a/tools/hangar/__snapshots__/test_corpus/extern_implementation.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/extern_implementation.w_compile_tf-aws.md
@@ -1,36 +1,5 @@
 # [extern_implementation.w](../../../../examples/tests/valid/extern_implementation.w) | compile | tf-aws
 
-## clients/Foo.inflight.js
-```js
-class  Foo {
-  constructor({ stateful }) {
-    this.stateful = stateful;
-  }
-  static async regex_inflight(pattern, text)  {
-    return (require("<ABSOLUTE_PATH>/external_js.js")["regex_inflight"])(pattern, text)
-  }
-  static async get_uuid()  {
-    return (require("<ABSOLUTE_PATH>/external_js.js")["get_uuid"])()
-  }
-  static async get_data()  {
-    return (require("<ABSOLUTE_PATH>/external_js.js")["get_data"])()
-  }
-  async print(msg)  {
-    return (require("<ABSOLUTE_PATH>/external_js.js")["print"])(msg)
-  }
-  async call()  {
-    {
-      {((cond) => {if (!cond) throw new Error(`assertion failed: '(await Foo.regex_inflight("[a-z]+-\\d+","abc-123"))'`)})((await Foo.regex_inflight("[a-z]+-\\d+","abc-123")))};
-      const uuid = (await Foo.get_uuid());
-      {((cond) => {if (!cond) throw new Error(`assertion failed: '(uuid.length === 36)'`)})((uuid.length === 36))};
-      {((cond) => {if (!cond) throw new Error(`assertion failed: '((await Foo.get_data()) === "Cool data!")'`)})(((await Foo.get_data()) === "Cool data!"))};
-    }
-  }
-}
-exports.Foo = Foo;
-
-```
-
 ## main.tf.json
 ```json
 {
@@ -238,10 +207,34 @@ class $Root extends $stdlib.std.Resource {
       }
       _toInflight() {
         const stateful_client = this._lift(this.stateful);
-        const self_client_path = "./clients/Foo.inflight.js".replace(/\\/g, "/");
         return $stdlib.core.NodeJsCode.fromInline(`
           (await (async () => {
-            const tmp = new (require("${self_client_path}")).Foo({
+            class  Foo {
+              constructor({ stateful }) {
+                this.stateful = stateful;
+              }
+              static async regex_inflight(pattern, text)  {
+                return (require("<ABSOLUTE_PATH>/external_js.js")["regex_inflight"])(pattern, text)
+              }
+              static async get_uuid()  {
+                return (require("<ABSOLUTE_PATH>/external_js.js")["get_uuid"])()
+              }
+              static async get_data()  {
+                return (require("<ABSOLUTE_PATH>/external_js.js")["get_data"])()
+              }
+              async print(msg)  {
+                return (require("<ABSOLUTE_PATH>/external_js.js")["print"])(msg)
+              }
+              async call()  {
+                {
+                  {((cond) => {if (!cond) throw new Error(\`assertion failed: \'(await Foo.regex_inflight("[a-z]+-\\\\d+","abc-123"))\'\`)})((await Foo.regex_inflight("[a-z]+-\\\\d+","abc-123")))};
+                  const uuid = (await Foo.get_uuid());
+                  {((cond) => {if (!cond) throw new Error(\`assertion failed: \'(uuid.length === 36)\'\`)})((uuid.length === 36))};
+                  {((cond) => {if (!cond) throw new Error(\`assertion failed: \'((await Foo.get_data()) === "Cool data!")\'\`)})(((await Foo.get_data()) === "Cool data!"))};
+                }
+              }
+            }
+            const tmp = new Foo({
               stateful: ${stateful_client},
             });
             if (tmp.$inflight_init) { await tmp.$inflight_init(); }

--- a/tools/hangar/__snapshots__/test_corpus/forward_decl.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/forward_decl.w_compile_tf-aws.md
@@ -1,17 +1,5 @@
 # [forward_decl.w](../../../../examples/tests/valid/forward_decl.w) | compile | tf-aws
 
-## clients/R.inflight.js
-```js
-class  R {
-  constructor({ f, stateful }) {
-    this.f = f;
-    this.stateful = stateful;
-  }
-}
-exports.R = R;
-
-```
-
 ## main.tf.json
 ```json
 {
@@ -71,10 +59,15 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         const f_client = this._lift(this.f);
         const stateful_client = this._lift(this.stateful);
-        const self_client_path = "./clients/R.inflight.js".replace(/\\/g, "/");
         return $stdlib.core.NodeJsCode.fromInline(`
           (await (async () => {
-            const tmp = new (require("${self_client_path}")).R({
+            class  R {
+              constructor({ f, stateful }) {
+                this.f = f;
+                this.stateful = stateful;
+              }
+            }
+            const tmp = new R({
               f: ${f_client},
               stateful: ${stateful_client},
             });

--- a/tools/hangar/__snapshots__/test_corpus/impl_interface.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/impl_interface.w_compile_tf-aws.md
@@ -1,53 +1,5 @@
 # [impl_interface.w](../../../../examples/tests/valid/impl_interface.w) | compile | tf-aws
 
-## clients/A.inflight.js
-```js
-class  A {
-  constructor({ stateful }) {
-    this.stateful = stateful;
-  }
-  async handle(msg)  {
-    {
-      return;
-    }
-  }
-}
-exports.A = A;
-
-```
-
-## clients/Dog.inflight.js
-```js
-class  Dog {
-  constructor({ stateful }) {
-    this.stateful = stateful;
-  }
-  async eat()  {
-    {
-      return;
-    }
-  }
-}
-exports.Dog = Dog;
-
-```
-
-## clients/r.inflight.js
-```js
-class  r {
-  constructor({ stateful }) {
-    this.stateful = stateful;
-  }
-  async method_2(x)  {
-    {
-      return x;
-    }
-  }
-}
-exports.r = r;
-
-```
-
 ## main.tf.json
 ```json
 {
@@ -96,10 +48,19 @@ class $Root extends $stdlib.std.Resource {
       }
       _toInflight() {
         const stateful_client = this._lift(this.stateful);
-        const self_client_path = "./clients/A.inflight.js".replace(/\\/g, "/");
         return $stdlib.core.NodeJsCode.fromInline(`
           (await (async () => {
-            const tmp = new (require("${self_client_path}")).A({
+            class  A {
+              constructor({ stateful }) {
+                this.stateful = stateful;
+              }
+              async handle(msg)  {
+                {
+                  return;
+                }
+              }
+            }
+            const tmp = new A({
               stateful: ${stateful_client},
             });
             if (tmp.$inflight_init) { await tmp.$inflight_init(); }
@@ -126,10 +87,19 @@ class $Root extends $stdlib.std.Resource {
       }
       _toInflight() {
         const stateful_client = this._lift(this.stateful);
-        const self_client_path = "./clients/r.inflight.js".replace(/\\/g, "/");
         return $stdlib.core.NodeJsCode.fromInline(`
           (await (async () => {
-            const tmp = new (require("${self_client_path}")).r({
+            class  r {
+              constructor({ stateful }) {
+                this.stateful = stateful;
+              }
+              async method_2(x)  {
+                {
+                  return x;
+                }
+              }
+            }
+            const tmp = new r({
               stateful: ${stateful_client},
             });
             if (tmp.$inflight_init) { await tmp.$inflight_init(); }
@@ -146,10 +116,19 @@ class $Root extends $stdlib.std.Resource {
       }
       _toInflight() {
         const stateful_client = this._lift(this.stateful);
-        const self_client_path = "./clients/Dog.inflight.js".replace(/\\/g, "/");
         return $stdlib.core.NodeJsCode.fromInline(`
           (await (async () => {
-            const tmp = new (require("${self_client_path}")).Dog({
+            class  Dog {
+              constructor({ stateful }) {
+                this.stateful = stateful;
+              }
+              async eat()  {
+                {
+                  return;
+                }
+              }
+            }
+            const tmp = new Dog({
               stateful: ${stateful_client},
             });
             if (tmp.$inflight_init) { await tmp.$inflight_init(); }

--- a/tools/hangar/__snapshots__/test_corpus/json.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/json.w_compile_tf-aws.md
@@ -1,17 +1,5 @@
 # [json.w](../../../../examples/tests/valid/json.w) | compile | tf-aws
 
-## clients/Foo.inflight.js
-```js
-class  Foo {
-  constructor({ _sum_str, stateful }) {
-    this._sum_str = _sum_str;
-    this.stateful = stateful;
-  }
-}
-exports.Foo = Foo;
-
-```
-
 ## main.tf.json
 ```json
 {
@@ -61,10 +49,15 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         const _sum_str_client = this._lift(this._sum_str);
         const stateful_client = this._lift(this.stateful);
-        const self_client_path = "./clients/Foo.inflight.js".replace(/\\/g, "/");
         return $stdlib.core.NodeJsCode.fromInline(`
           (await (async () => {
-            const tmp = new (require("${self_client_path}")).Foo({
+            class  Foo {
+              constructor({ _sum_str, stateful }) {
+                this._sum_str = _sum_str;
+                this.stateful = stateful;
+              }
+            }
+            const tmp = new Foo({
               _sum_str: ${_sum_str_client},
               stateful: ${stateful_client},
             });

--- a/tools/hangar/__snapshots__/test_corpus/reassignment.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/reassignment.w_compile_tf-aws.md
@@ -1,17 +1,5 @@
 # [reassignment.w](../../../../examples/tests/valid/reassignment.w) | compile | tf-aws
 
-## clients/R.inflight.js
-```js
-class  R {
-  constructor({ f1, stateful }) {
-    this.f1 = f1;
-    this.stateful = stateful;
-  }
-}
-exports.R = R;
-
-```
-
 ## main.tf.json
 ```json
 {
@@ -69,10 +57,15 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         const f1_client = this._lift(this.f1);
         const stateful_client = this._lift(this.stateful);
-        const self_client_path = "./clients/R.inflight.js".replace(/\\/g, "/");
         return $stdlib.core.NodeJsCode.fromInline(`
           (await (async () => {
-            const tmp = new (require("${self_client_path}")).R({
+            class  R {
+              constructor({ f1, stateful }) {
+                this.f1 = f1;
+                this.stateful = stateful;
+              }
+            }
+            const tmp = new R({
               f1: ${f1_client},
               stateful: ${stateful_client},
             });

--- a/tools/hangar/__snapshots__/test_corpus/resource.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/resource.w_compile_tf-aws.md
@@ -1,82 +1,5 @@
 # [resource.w](../../../../examples/tests/valid/resource.w) | compile | tf-aws
 
-## clients/Bar.inflight.js
-```js
-class  Bar {
-  constructor({ b, foo, name, stateful }) {
-    this.b = b;
-    this.foo = foo;
-    this.name = name;
-    this.stateful = stateful;
-  }
-  async my_method()  {
-    {
-      (await this.foo.foo_inc());
-      (await this.b.put("foo",`counter is: ${(await this.foo.foo_get())}`));
-      return (await this.b.get("foo"));
-    }
-  }
-}
-exports.Bar = Bar;
-
-```
-
-## clients/BigPublisher.inflight.js
-```js
-class  BigPublisher {
-  constructor({ b, b2, q, t, stateful }) {
-    this.b = b;
-    this.b2 = b2;
-    this.q = q;
-    this.t = t;
-    this.stateful = stateful;
-  }
-  async publish(s)  {
-    {
-      (await this.t.publish(s));
-      (await this.q.push(s));
-      (await this.b2.put("foo",s));
-    }
-  }
-  async getObjectCount()  {
-    {
-      return (await this.b.list()).length;
-    }
-  }
-}
-exports.BigPublisher = BigPublisher;
-
-```
-
-## clients/Foo.inflight.js
-```js
-class  Foo {
-  constructor({ c, stateful }) {
-    this.c = c;
-    this.stateful = stateful;
-  }
-  async $inflight_init()  {
-    {
-      this.inflight_field = 123;
-      (await this.c.inc(110));
-      (await this.c.dec(10));
-    }
-  }
-  async foo_inc()  {
-    {
-      (await this.c.inc());
-    }
-  }
-  async foo_get()  {
-    {
-      return (await this.c.peek());
-    }
-  }
-}
-exports.Foo = Foo;
-
-```
-
 ## main.tf.json
 ```json
 {
@@ -770,10 +693,32 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         const c_client = this._lift(this.c);
         const stateful_client = this._lift(this.stateful);
-        const self_client_path = "./clients/Foo.inflight.js".replace(/\\/g, "/");
         return $stdlib.core.NodeJsCode.fromInline(`
           (await (async () => {
-            const tmp = new (require("${self_client_path}")).Foo({
+            class  Foo {
+              constructor({ c, stateful }) {
+                this.c = c;
+                this.stateful = stateful;
+              }
+              async \$inflight_init()  {
+                {
+                  this.inflight_field = 123;
+                  (await this.c.inc(110));
+                  (await this.c.dec(10));
+                }
+              }
+              async foo_inc()  {
+                {
+                  (await this.c.inc());
+                }
+              }
+              async foo_get()  {
+                {
+                  return (await this.c.peek());
+                }
+              }
+            }
+            const tmp = new Foo({
               c: ${c_client},
               stateful: ${stateful_client},
             });
@@ -798,10 +743,24 @@ class $Root extends $stdlib.std.Resource {
         const foo_client = this._lift(this.foo);
         const name_client = this._lift(this.name);
         const stateful_client = this._lift(this.stateful);
-        const self_client_path = "./clients/Bar.inflight.js".replace(/\\/g, "/");
         return $stdlib.core.NodeJsCode.fromInline(`
           (await (async () => {
-            const tmp = new (require("${self_client_path}")).Bar({
+            class  Bar {
+              constructor({ b, foo, name, stateful }) {
+                this.b = b;
+                this.foo = foo;
+                this.name = name;
+                this.stateful = stateful;
+              }
+              async my_method()  {
+                {
+                  (await this.foo.foo_inc());
+                  (await this.b.put("foo",\`counter is: \${(await this.foo.foo_get())}\`));
+                  return (await this.b.get("foo"));
+                }
+              }
+            }
+            const tmp = new Bar({
               b: ${b_client},
               foo: ${foo_client},
               name: ${name_client},
@@ -859,10 +818,30 @@ class $Root extends $stdlib.std.Resource {
         const q_client = this._lift(this.q);
         const t_client = this._lift(this.t);
         const stateful_client = this._lift(this.stateful);
-        const self_client_path = "./clients/BigPublisher.inflight.js".replace(/\\/g, "/");
         return $stdlib.core.NodeJsCode.fromInline(`
           (await (async () => {
-            const tmp = new (require("${self_client_path}")).BigPublisher({
+            class  BigPublisher {
+              constructor({ b, b2, q, t, stateful }) {
+                this.b = b;
+                this.b2 = b2;
+                this.q = q;
+                this.t = t;
+                this.stateful = stateful;
+              }
+              async publish(s)  {
+                {
+                  (await this.t.publish(s));
+                  (await this.q.push(s));
+                  (await this.b2.put("foo",s));
+                }
+              }
+              async getObjectCount()  {
+                {
+                  return (await this.b.list()).length;
+                }
+              }
+            }
+            const tmp = new BigPublisher({
               b: ${b_client},
               b2: ${b2_client},
               q: ${q_client},

--- a/tools/hangar/__snapshots__/test_corpus/resource_as_inflight_literal.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/resource_as_inflight_literal.w_compile_tf-aws.md
@@ -1,21 +1,5 @@
 # [resource_as_inflight_literal.w](../../../../examples/tests/valid/resource_as_inflight_literal.w) | compile | tf-aws
 
-## clients/Foo.inflight.js
-```js
-class  Foo {
-  constructor({ stateful }) {
-    this.stateful = stateful;
-  }
-  async handle(message)  {
-    {
-      return "hello world!";
-    }
-  }
-}
-exports.Foo = Foo;
-
-```
-
 ## main.tf.json
 ```json
 {
@@ -218,10 +202,19 @@ class $Root extends $stdlib.std.Resource {
       }
       _toInflight() {
         const stateful_client = this._lift(this.stateful);
-        const self_client_path = "./clients/Foo.inflight.js".replace(/\\/g, "/");
         return $stdlib.core.NodeJsCode.fromInline(`
           (await (async () => {
-            const tmp = new (require("${self_client_path}")).Foo({
+            class  Foo {
+              constructor({ stateful }) {
+                this.stateful = stateful;
+              }
+              async handle(message)  {
+                {
+                  return "hello world!";
+                }
+              }
+            }
+            const tmp = new Foo({
               stateful: ${stateful_client},
             });
             if (tmp.$inflight_init) { await tmp.$inflight_init(); }

--- a/tools/hangar/__snapshots__/test_corpus/resource_captures.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/resource_captures.w_compile_tf-aws.md
@@ -1,132 +1,5 @@
 # [resource_captures.w](../../../../examples/tests/valid/resource_captures.w) | compile | tf-aws
 
-## clients/Another.inflight.js
-```js
-class  Another {
-  constructor({ first, my_field, stateful }) {
-    this.first = first;
-    this.my_field = my_field;
-    this.stateful = stateful;
-  }
-  async meaning_of_life()  {
-    {
-      return 42;
-    }
-  }
-  async another_func()  {
-    {
-      return "42";
-    }
-  }
-}
-exports.Another = Another;
-
-```
-
-## clients/First.inflight.js
-```js
-class  First {
-  constructor({ my_resource, stateful }) {
-    this.my_resource = my_resource;
-    this.stateful = stateful;
-  }
-}
-exports.First = First;
-
-```
-
-## clients/MyResource.inflight.js
-```js
-class  MyResource {
-  constructor({ another, array_of_str, ext_bucket, ext_num, map_of_num, my_bool, my_num, my_queue, my_resource, my_str, set_of_str, unused_resource, stateful }) {
-    this.another = another;
-    this.array_of_str = array_of_str;
-    this.ext_bucket = ext_bucket;
-    this.ext_num = ext_num;
-    this.map_of_num = map_of_num;
-    this.my_bool = my_bool;
-    this.my_num = my_num;
-    this.my_queue = my_queue;
-    this.my_resource = my_resource;
-    this.my_str = my_str;
-    this.set_of_str = set_of_str;
-    this.unused_resource = unused_resource;
-    this.stateful = stateful;
-  }
-  async test_no_capture()  {
-    {
-      const arr = Object.freeze([1, 2, 3]);
-      {((cond) => {if (!cond) throw new Error(`assertion failed: '(arr.length === 3)'`)})((arr.length === 3))};
-      {console.log(`array.len=${arr.length}`)};
-    }
-  }
-  async test_capture_collections_of_data()  {
-    {
-      {((cond) => {if (!cond) throw new Error(`assertion failed: '(this.array_of_str.length === 2)'`)})((this.array_of_str.length === 2))};
-      {((cond) => {if (!cond) throw new Error(`assertion failed: '((await this.array_of_str.at(0)) === "s1")'`)})(((await this.array_of_str.at(0)) === "s1"))};
-      {((cond) => {if (!cond) throw new Error(`assertion failed: '((await this.array_of_str.at(1)) === "s2")'`)})(((await this.array_of_str.at(1)) === "s2"))};
-      {((cond) => {if (!cond) throw new Error(`assertion failed: '((this.map_of_num)["k1"] === 11)'`)})(((this.map_of_num)["k1"] === 11))};
-      {((cond) => {if (!cond) throw new Error(`assertion failed: '((this.map_of_num)["k2"] === 22)'`)})(((this.map_of_num)["k2"] === 22))};
-      {((cond) => {if (!cond) throw new Error(`assertion failed: '(await this.set_of_str.has("s1"))'`)})((await this.set_of_str.has("s1")))};
-      {((cond) => {if (!cond) throw new Error(`assertion failed: '(await this.set_of_str.has("s2"))'`)})((await this.set_of_str.has("s2")))};
-      {((cond) => {if (!cond) throw new Error(`assertion failed: '(!(await this.set_of_str.has("s3")))'`)})((!(await this.set_of_str.has("s3"))))};
-    }
-  }
-  async test_capture_primitives()  {
-    {
-      {((cond) => {if (!cond) throw new Error(`assertion failed: '(this.my_str === "my_string")'`)})((this.my_str === "my_string"))};
-      {((cond) => {if (!cond) throw new Error(`assertion failed: '(this.my_num === 42)'`)})((this.my_num === 42))};
-      {((cond) => {if (!cond) throw new Error(`assertion failed: '(this.my_bool === true)'`)})((this.my_bool === true))};
-    }
-  }
-  async test_capture_resource()  {
-    {
-      (await this.my_resource.put("f1.txt","f1"));
-      {((cond) => {if (!cond) throw new Error(`assertion failed: '((await this.my_resource.get("f1.txt")) === "f1")'`)})(((await this.my_resource.get("f1.txt")) === "f1"))};
-      {((cond) => {if (!cond) throw new Error(`assertion failed: '((await this.my_resource.list()).length === 1)'`)})(((await this.my_resource.list()).length === 1))};
-    }
-  }
-  async test_nested_preflight_field()  {
-    {
-      {((cond) => {if (!cond) throw new Error(`assertion failed: '(this.another.my_field === "hello!")'`)})((this.another.my_field === "hello!"))};
-      {console.log(`field=${this.another.my_field}`)};
-    }
-  }
-  async test_nested_resource()  {
-    {
-      {((cond) => {if (!cond) throw new Error(`assertion failed: '((await this.another.first.my_resource.list()).length === 0)'`)})(((await this.another.first.my_resource.list()).length === 0))};
-      (await this.another.first.my_resource.put("hello",this.my_str));
-      {console.log(`this.another.first.my_resource:${(await this.another.first.my_resource.get("hello"))}`)};
-    }
-  }
-  async test_expression_recursive()  {
-    {
-      (await this.my_queue.push(this.my_str));
-    }
-  }
-  async test_external()  {
-    {
-      {((cond) => {if (!cond) throw new Error(`assertion failed: '((await this.ext_bucket.list()).length === 0)'`)})(((await this.ext_bucket.list()).length === 0))};
-      {((cond) => {if (!cond) throw new Error(`assertion failed: '(this.ext_num === 12)'`)})((this.ext_num === 12))};
-    }
-  }
-  async test_user_defined_resource()  {
-    {
-      {((cond) => {if (!cond) throw new Error(`assertion failed: '((await this.another.meaning_of_life()) === 42)'`)})(((await this.another.meaning_of_life()) === 42))};
-      {((cond) => {if (!cond) throw new Error(`assertion failed: '((await this.another.another_func()) === "42")'`)})(((await this.another.another_func()) === "42"))};
-    }
-  }
-  async test_inflight_field()  {
-    {
-      this.inflight_field = 123;
-      {((cond) => {if (!cond) throw new Error(`assertion failed: '(this.inflight_field === 123)'`)})((this.inflight_field === 123))};
-    }
-  }
-}
-exports.MyResource = MyResource;
-
-```
-
 ## main.tf.json
 ```json
 {
@@ -424,10 +297,15 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         const my_resource_client = this._lift(this.my_resource);
         const stateful_client = this._lift(this.stateful);
-        const self_client_path = "./clients/First.inflight.js".replace(/\\/g, "/");
         return $stdlib.core.NodeJsCode.fromInline(`
           (await (async () => {
-            const tmp = new (require("${self_client_path}")).First({
+            class  First {
+              constructor({ my_resource, stateful }) {
+                this.my_resource = my_resource;
+                this.stateful = stateful;
+              }
+            }
+            const tmp = new First({
               my_resource: ${my_resource_client},
               stateful: ${stateful_client},
             });
@@ -448,10 +326,26 @@ class $Root extends $stdlib.std.Resource {
         const first_client = this._lift(this.first);
         const my_field_client = this._lift(this.my_field);
         const stateful_client = this._lift(this.stateful);
-        const self_client_path = "./clients/Another.inflight.js".replace(/\\/g, "/");
         return $stdlib.core.NodeJsCode.fromInline(`
           (await (async () => {
-            const tmp = new (require("${self_client_path}")).Another({
+            class  Another {
+              constructor({ first, my_field, stateful }) {
+                this.first = first;
+                this.my_field = my_field;
+                this.stateful = stateful;
+              }
+              async meaning_of_life()  {
+                {
+                  return 42;
+                }
+              }
+              async another_func()  {
+                {
+                  return "42";
+                }
+              }
+            }
+            const tmp = new Another({
               first: ${first_client},
               my_field: ${my_field_client},
               stateful: ${stateful_client},
@@ -500,10 +394,95 @@ class $Root extends $stdlib.std.Resource {
         const set_of_str_client = this._lift(this.set_of_str);
         const unused_resource_client = this._lift(this.unused_resource);
         const stateful_client = this._lift(this.stateful);
-        const self_client_path = "./clients/MyResource.inflight.js".replace(/\\/g, "/");
         return $stdlib.core.NodeJsCode.fromInline(`
           (await (async () => {
-            const tmp = new (require("${self_client_path}")).MyResource({
+            class  MyResource {
+              constructor({ another, array_of_str, ext_bucket, ext_num, map_of_num, my_bool, my_num, my_queue, my_resource, my_str, set_of_str, unused_resource, stateful }) {
+                this.another = another;
+                this.array_of_str = array_of_str;
+                this.ext_bucket = ext_bucket;
+                this.ext_num = ext_num;
+                this.map_of_num = map_of_num;
+                this.my_bool = my_bool;
+                this.my_num = my_num;
+                this.my_queue = my_queue;
+                this.my_resource = my_resource;
+                this.my_str = my_str;
+                this.set_of_str = set_of_str;
+                this.unused_resource = unused_resource;
+                this.stateful = stateful;
+              }
+              async test_no_capture()  {
+                {
+                  const arr = Object.freeze([1, 2, 3]);
+                  {((cond) => {if (!cond) throw new Error(\`assertion failed: \'(arr.length === 3)\'\`)})((arr.length === 3))};
+                  {console.log(\`array.len=\${arr.length}\`)};
+                }
+              }
+              async test_capture_collections_of_data()  {
+                {
+                  {((cond) => {if (!cond) throw new Error(\`assertion failed: \'(this.array_of_str.length === 2)\'\`)})((this.array_of_str.length === 2))};
+                  {((cond) => {if (!cond) throw new Error(\`assertion failed: \'((await this.array_of_str.at(0)) === "s1")\'\`)})(((await this.array_of_str.at(0)) === "s1"))};
+                  {((cond) => {if (!cond) throw new Error(\`assertion failed: \'((await this.array_of_str.at(1)) === "s2")\'\`)})(((await this.array_of_str.at(1)) === "s2"))};
+                  {((cond) => {if (!cond) throw new Error(\`assertion failed: \'((this.map_of_num)["k1"] === 11)\'\`)})(((this.map_of_num)["k1"] === 11))};
+                  {((cond) => {if (!cond) throw new Error(\`assertion failed: \'((this.map_of_num)["k2"] === 22)\'\`)})(((this.map_of_num)["k2"] === 22))};
+                  {((cond) => {if (!cond) throw new Error(\`assertion failed: \'(await this.set_of_str.has("s1"))\'\`)})((await this.set_of_str.has("s1")))};
+                  {((cond) => {if (!cond) throw new Error(\`assertion failed: \'(await this.set_of_str.has("s2"))\'\`)})((await this.set_of_str.has("s2")))};
+                  {((cond) => {if (!cond) throw new Error(\`assertion failed: \'(!(await this.set_of_str.has("s3")))\'\`)})((!(await this.set_of_str.has("s3"))))};
+                }
+              }
+              async test_capture_primitives()  {
+                {
+                  {((cond) => {if (!cond) throw new Error(\`assertion failed: \'(this.my_str === "my_string")\'\`)})((this.my_str === "my_string"))};
+                  {((cond) => {if (!cond) throw new Error(\`assertion failed: \'(this.my_num === 42)\'\`)})((this.my_num === 42))};
+                  {((cond) => {if (!cond) throw new Error(\`assertion failed: \'(this.my_bool === true)\'\`)})((this.my_bool === true))};
+                }
+              }
+              async test_capture_resource()  {
+                {
+                  (await this.my_resource.put("f1.txt","f1"));
+                  {((cond) => {if (!cond) throw new Error(\`assertion failed: \'((await this.my_resource.get("f1.txt")) === "f1")\'\`)})(((await this.my_resource.get("f1.txt")) === "f1"))};
+                  {((cond) => {if (!cond) throw new Error(\`assertion failed: \'((await this.my_resource.list()).length === 1)\'\`)})(((await this.my_resource.list()).length === 1))};
+                }
+              }
+              async test_nested_preflight_field()  {
+                {
+                  {((cond) => {if (!cond) throw new Error(\`assertion failed: \'(this.another.my_field === "hello!")\'\`)})((this.another.my_field === "hello!"))};
+                  {console.log(\`field=\${this.another.my_field}\`)};
+                }
+              }
+              async test_nested_resource()  {
+                {
+                  {((cond) => {if (!cond) throw new Error(\`assertion failed: \'((await this.another.first.my_resource.list()).length === 0)\'\`)})(((await this.another.first.my_resource.list()).length === 0))};
+                  (await this.another.first.my_resource.put("hello",this.my_str));
+                  {console.log(\`this.another.first.my_resource:\${(await this.another.first.my_resource.get("hello"))}\`)};
+                }
+              }
+              async test_expression_recursive()  {
+                {
+                  (await this.my_queue.push(this.my_str));
+                }
+              }
+              async test_external()  {
+                {
+                  {((cond) => {if (!cond) throw new Error(\`assertion failed: \'((await this.ext_bucket.list()).length === 0)\'\`)})(((await this.ext_bucket.list()).length === 0))};
+                  {((cond) => {if (!cond) throw new Error(\`assertion failed: \'(this.ext_num === 12)\'\`)})((this.ext_num === 12))};
+                }
+              }
+              async test_user_defined_resource()  {
+                {
+                  {((cond) => {if (!cond) throw new Error(\`assertion failed: \'((await this.another.meaning_of_life()) === 42)\'\`)})(((await this.another.meaning_of_life()) === 42))};
+                  {((cond) => {if (!cond) throw new Error(\`assertion failed: \'((await this.another.another_func()) === "42")\'\`)})(((await this.another.another_func()) === "42"))};
+                }
+              }
+              async test_inflight_field()  {
+                {
+                  this.inflight_field = 123;
+                  {((cond) => {if (!cond) throw new Error(\`assertion failed: \'(this.inflight_field === 123)\'\`)})((this.inflight_field === 123))};
+                }
+              }
+            }
+            const tmp = new MyResource({
               another: ${another_client},
               array_of_str: ${array_of_str_client},
               ext_bucket: ${ext_bucket_client},

--- a/tools/hangar/__snapshots__/test_corpus/static_members.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/static_members.w_compile_tf-aws.md
@@ -1,22 +1,5 @@
 # [static_members.w](../../../../examples/tests/valid/static_members.w) | compile | tf-aws
 
-## clients/Foo.inflight.js
-```js
-class  Foo {
-  constructor({ instance_field, stateful }) {
-    this.instance_field = instance_field;
-    this.stateful = stateful;
-  }
-  static async get_123()  {
-    {
-      return 123;
-    }
-  }
-}
-exports.Foo = Foo;
-
-```
-
 ## main.tf.json
 ```json
 {
@@ -160,10 +143,20 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         const instance_field_client = this._lift(this.instance_field);
         const stateful_client = this._lift(this.stateful);
-        const self_client_path = "./clients/Foo.inflight.js".replace(/\\/g, "/");
         return $stdlib.core.NodeJsCode.fromInline(`
           (await (async () => {
-            const tmp = new (require("${self_client_path}")).Foo({
+            class  Foo {
+              constructor({ instance_field, stateful }) {
+                this.instance_field = instance_field;
+                this.stateful = stateful;
+              }
+              static async get_123()  {
+                {
+                  return 123;
+                }
+              }
+            }
+            const tmp = new Foo({
               instance_field: ${instance_field_client},
               stateful: ${stateful_client},
             });

--- a/tools/hangar/__snapshots__/test_corpus/structs.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/structs.w_compile_tf-aws.md
@@ -1,22 +1,5 @@
 # [structs.w](../../../../examples/tests/valid/structs.w) | compile | tf-aws
 
-## clients/Foo.inflight.js
-```js
-class  Foo {
-  constructor({ data, stateful }) {
-    this.data = data;
-    this.stateful = stateful;
-  }
-  async get_stuff()  {
-    {
-      return this.data.field0;
-    }
-  }
-}
-exports.Foo = Foo;
-
-```
-
 ## main.tf.json
 ```json
 {
@@ -66,10 +49,20 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         const data_client = this._lift(this.data);
         const stateful_client = this._lift(this.stateful);
-        const self_client_path = "./clients/Foo.inflight.js".replace(/\\/g, "/");
         return $stdlib.core.NodeJsCode.fromInline(`
           (await (async () => {
-            const tmp = new (require("${self_client_path}")).Foo({
+            class  Foo {
+              constructor({ data, stateful }) {
+                this.data = data;
+                this.stateful = stateful;
+              }
+              async get_stuff()  {
+                {
+                  return this.data.field0;
+                }
+              }
+            }
+            const tmp = new Foo({
               data: ${data_client},
               stateful: ${stateful_client},
             });

--- a/tools/hangar/__snapshots__/test_corpus/symbol_shadow.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/symbol_shadow.w_compile_tf-aws.md
@@ -1,16 +1,5 @@
 # [symbol_shadow.w](../../../../examples/tests/valid/symbol_shadow.w) | compile | tf-aws
 
-## clients/A.inflight.js
-```js
-class  A {
-  constructor({ stateful }) {
-    this.stateful = stateful;
-  }
-}
-exports.A = A;
-
-```
-
 ## main.tf.json
 ```json
 {
@@ -354,10 +343,14 @@ class $Root extends $stdlib.std.Resource {
       }
       _toInflight() {
         const stateful_client = this._lift(this.stateful);
-        const self_client_path = "./clients/A.inflight.js".replace(/\\/g, "/");
         return $stdlib.core.NodeJsCode.fromInline(`
           (await (async () => {
-            const tmp = new (require("${self_client_path}")).A({
+            class  A {
+              constructor({ stateful }) {
+                this.stateful = stateful;
+              }
+            }
+            const tmp = new A({
               stateful: ${stateful_client},
             });
             if (tmp.$inflight_init) { await tmp.$inflight_init(); }


### PR DESCRIPTION
Reduce the number of intermediate files generated by the compiler by putting inflights client code inside `preflight.js`, adjacent to the classes they're defined for.

The main motivation for this is to make it easier in a later PR to inline global variable values in the resource's context without having to inject them as class fields (see #1447). See the screenshot below of how we might jsify a `global_bucket` being used by an inflight method:

<img width="476" alt="Screenshot 2023-04-20 at 7 23 15 PM" src="https://user-images.githubusercontent.com/5008987/233506763-5025d7f7-ab71-439e-b06a-cac7e016f1a6.png">

(To get this working with permissions requires more work so I didn't include it in this PR).

This change might also have performance improvements since it reduces the number of `require` calls made by the simulator and the number of files the compiler has to emit. (Maybe the benchmark will indicate one way or another?)

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.