### PR TITLE
chore(sdk): remove binding symbol magic

### DIFF
--- a/libs/wingc/src/jsify.rs
+++ b/libs/wingc/src/jsify.rs
@@ -1068,11 +1068,13 @@ impl<'a> JSifier<'a> {
 			code.line("super(scope, id);");
 		}
 
-		let inflight_ops_string = inflight_methods
-			.iter()
-			.map(|(name, _)| format!("\"{}\"", name.name))
-			.join(", ");
-		code.line(format!("this._addInflightOps({inflight_ops_string});"));
+		if inflight_methods.len() > 0 {
+			let inflight_ops_string = inflight_methods
+				.iter()
+				.map(|(name, _)| format!("\"{}\"", name.name))
+				.join(", ");
+			code.line(format!("this._addInflightOps({inflight_ops_string});"));
+		}
 
 		code.add_code(self.jsify_scope_body(
 			&constructor.statements,

--- a/libs/wingc/src/jsify.rs
+++ b/libs/wingc/src/jsify.rs
@@ -1072,7 +1072,7 @@ impl<'a> JSifier<'a> {
 			.iter()
 			.map(|(name, _)| format!("\"{}\"", name.name))
 			.join(", ");
-		code.line(format!("this._inflightOps.push({inflight_ops_string});"));
+		code.line(format!("this._addInflightOps({inflight_ops_string});"));
 
 		code.add_code(self.jsify_scope_body(
 			&constructor.statements,

--- a/libs/wingsdk/src/cloud/bucket.ts
+++ b/libs/wingsdk/src/cloud/bucket.ts
@@ -49,7 +49,7 @@ export abstract class Bucket extends Resource {
     this.display.title = "Bucket";
     this.display.description = "A cloud object store";
 
-    this._inflightOps.push(
+    this._addInflightOps(
       BucketInflightMethods.DELETE,
       BucketInflightMethods.GET,
       BucketInflightMethods.GET_JSON,

--- a/libs/wingsdk/src/cloud/bucket.ts
+++ b/libs/wingsdk/src/cloud/bucket.ts
@@ -49,6 +49,16 @@ export abstract class Bucket extends Resource {
     this.display.title = "Bucket";
     this.display.description = "A cloud object store";
 
+    this._inflightOps.push(
+      BucketInflightMethods.DELETE,
+      BucketInflightMethods.GET,
+      BucketInflightMethods.GET_JSON,
+      BucketInflightMethods.LIST,
+      BucketInflightMethods.PUT,
+      BucketInflightMethods.PUT_JSON,
+      BucketInflightMethods.PUBLIC_URL
+    );
+
     props;
   }
 

--- a/libs/wingsdk/src/cloud/counter.ts
+++ b/libs/wingsdk/src/cloud/counter.ts
@@ -49,7 +49,7 @@ export abstract class Counter extends Resource {
     this.display.title = "Counter";
     this.display.description = "A distributed atomic counter";
 
-    this._inflightOps.push(
+    this._addInflightOps(
       CounterInflightMethods.INC,
       CounterInflightMethods.DEC,
       CounterInflightMethods.PEEK,

--- a/libs/wingsdk/src/cloud/counter.ts
+++ b/libs/wingsdk/src/cloud/counter.ts
@@ -49,6 +49,13 @@ export abstract class Counter extends Resource {
     this.display.title = "Counter";
     this.display.description = "A distributed atomic counter";
 
+    this._inflightOps.push(
+      CounterInflightMethods.INC,
+      CounterInflightMethods.DEC,
+      CounterInflightMethods.PEEK,
+      CounterInflightMethods.RESET
+    );
+
     this.initial = props.initial ?? 0;
   }
 }

--- a/libs/wingsdk/src/cloud/function.ts
+++ b/libs/wingsdk/src/cloud/function.ts
@@ -75,7 +75,7 @@ export abstract class Function extends Resource implements IInflightHost {
     this.display.title = "Function";
     this.display.description = "A cloud function (FaaS)";
 
-    this._inflightOps.push(FunctionInflightMethods.INVOKE);
+    this._addInflightOps(FunctionInflightMethods.INVOKE);
 
     for (const [key, value] of Object.entries(props.env ?? {})) {
       this.addEnvironment(key, value);

--- a/libs/wingsdk/src/cloud/function.ts
+++ b/libs/wingsdk/src/cloud/function.ts
@@ -75,6 +75,8 @@ export abstract class Function extends Resource implements IInflightHost {
     this.display.title = "Function";
     this.display.description = "A cloud function (FaaS)";
 
+    this._inflightOps.push(FunctionInflightMethods.INVOKE);
+
     for (const [key, value] of Object.entries(props.env ?? {})) {
       this.addEnvironment(key, value);
     }

--- a/libs/wingsdk/src/cloud/queue.ts
+++ b/libs/wingsdk/src/cloud/queue.ts
@@ -51,6 +51,12 @@ export abstract class Queue extends Resource {
     this.display.title = "Queue";
     this.display.description = "A distributed message queue";
 
+    this._inflightOps.push(
+      QueueInflightMethods.PUSH,
+      QueueInflightMethods.PURGE,
+      QueueInflightMethods.APPROX_SIZE
+    );
+
     props;
   }
 

--- a/libs/wingsdk/src/cloud/queue.ts
+++ b/libs/wingsdk/src/cloud/queue.ts
@@ -51,7 +51,7 @@ export abstract class Queue extends Resource {
     this.display.title = "Queue";
     this.display.description = "A distributed message queue";
 
-    this._inflightOps.push(
+    this._addInflightOps(
       QueueInflightMethods.PUSH,
       QueueInflightMethods.PURGE,
       QueueInflightMethods.APPROX_SIZE

--- a/libs/wingsdk/src/cloud/secret.ts
+++ b/libs/wingsdk/src/cloud/secret.ts
@@ -50,6 +50,11 @@ export abstract class Secret extends Resource {
     this.display.title = "Secret";
     this.display.description = "A cloud secret";
 
+    this._inflightOps.push(
+      SecretInflightMethods.VALUE,
+      SecretInflightMethods.VALUE_JSON
+    );
+
     props;
   }
 }

--- a/libs/wingsdk/src/cloud/secret.ts
+++ b/libs/wingsdk/src/cloud/secret.ts
@@ -50,7 +50,7 @@ export abstract class Secret extends Resource {
     this.display.title = "Secret";
     this.display.description = "A cloud secret";
 
-    this._inflightOps.push(
+    this._addInflightOps(
       SecretInflightMethods.VALUE,
       SecretInflightMethods.VALUE_JSON
     );

--- a/libs/wingsdk/src/cloud/table.ts
+++ b/libs/wingsdk/src/cloud/table.ts
@@ -98,7 +98,7 @@ export abstract class Table extends Resource {
     }
     this.columns = props.columns;
 
-    this._inflightOps.push(
+    this._addInflightOps(
       TableInflightMethods.INSERT,
       TableInflightMethods.UPDATE,
       TableInflightMethods.DELETE,

--- a/libs/wingsdk/src/cloud/table.ts
+++ b/libs/wingsdk/src/cloud/table.ts
@@ -97,6 +97,14 @@ export abstract class Table extends Resource {
       throw new Error("No column is defined");
     }
     this.columns = props.columns;
+
+    this._inflightOps.push(
+      TableInflightMethods.INSERT,
+      TableInflightMethods.UPDATE,
+      TableInflightMethods.DELETE,
+      TableInflightMethods.GET,
+      TableInflightMethods.LIST
+    );
   }
 }
 

--- a/libs/wingsdk/src/cloud/topic.ts
+++ b/libs/wingsdk/src/cloud/topic.ts
@@ -37,7 +37,7 @@ export abstract class Topic extends Resource {
     this.display.title = "Topic";
     this.display.description = "A pub/sub notification topic";
 
-    this._inflightOps.push(TopicInflightMethods.PUBLISH);
+    this._addInflightOps(TopicInflightMethods.PUBLISH);
 
     props;
   }

--- a/libs/wingsdk/src/cloud/topic.ts
+++ b/libs/wingsdk/src/cloud/topic.ts
@@ -37,6 +37,8 @@ export abstract class Topic extends Resource {
     this.display.title = "Topic";
     this.display.description = "A pub/sub notification topic";
 
+    this._inflightOps.push(TopicInflightMethods.PUBLISH);
+
     props;
   }
 

--- a/libs/wingsdk/src/core/internal.ts
+++ b/libs/wingsdk/src/core/internal.ts
@@ -37,7 +37,7 @@ export function makeHandler(
       this.display.description = display?.description;
       this.display.hidden = display?.hidden;
 
-      this._inflightOps.push("handle");
+      this._addInflightOps("handle");
     }
 
     public _toInflight(): NodeJsCode {

--- a/libs/wingsdk/src/redis/redis.ts
+++ b/libs/wingsdk/src/redis/redis.ts
@@ -29,6 +29,18 @@ export abstract class Redis extends Resource {
 
     this.display.title = "Redis";
     this.display.description = "A Redis server";
+
+    this._inflightOps.push(
+      RedisInflightMethods.RAW_CLIENT,
+      RedisInflightMethods.URL,
+      RedisInflightMethods.SET,
+      RedisInflightMethods.GET,
+      RedisInflightMethods.HSET,
+      RedisInflightMethods.HGET,
+      RedisInflightMethods.SADD,
+      RedisInflightMethods.SMEMBERS,
+      RedisInflightMethods.DEL
+    );
   }
 }
 
@@ -106,6 +118,31 @@ export interface IRedisClient {
    * @inflight
    */
   del(key: string): Promise<number>;
+}
+
+/**
+ * List of inflight operations available for `Redis`.
+ * @internal
+ */
+export enum RedisInflightMethods {
+  /** `Redis.raw_client` */
+  RAW_CLIENT = "raw_client",
+  /** `Redis.url` */
+  URL = "url",
+  /** `Redis.set` */
+  SET = "set",
+  /** `Redis.get` */
+  GET = "get",
+  /** `Redis.hset` */
+  HSET = "hset",
+  /** `Redis.hget` */
+  HGET = "hget",
+  /** `Redis.sadd` */
+  SADD = "sadd",
+  /** `Redis.smembers` */
+  SMEMBERS = "smembers",
+  /** `Redis.del` */
+  DEL = "del",
 }
 
 /**

--- a/libs/wingsdk/src/redis/redis.ts
+++ b/libs/wingsdk/src/redis/redis.ts
@@ -30,7 +30,7 @@ export abstract class Redis extends Resource {
     this.display.title = "Redis";
     this.display.description = "A Redis server";
 
-    this._inflightOps.push(
+    this._addInflightOps(
       RedisInflightMethods.RAW_CLIENT,
       RedisInflightMethods.URL,
       RedisInflightMethods.SET,

--- a/libs/wingsdk/src/std/resource.ts
+++ b/libs/wingsdk/src/std/resource.ts
@@ -127,9 +127,8 @@ export abstract class Resource extends Construct implements IResource {
 
   /**
    * A list of all inflight operations that are supported by this resource.
-   * @internal
    */
-  public readonly _inflightOps: string[] = ["$inflight_init"];
+  private readonly inflightOps: string[] = ["$inflight_init"];
 
   /**
    * Information on how to display a resource in the UI.
@@ -145,6 +144,18 @@ export abstract class Resource extends Construct implements IResource {
    * with a fresh copy without any consequences.
    */
   public readonly stateful: boolean = false;
+
+  /**
+   * Record that this resource supports the given inflight operation.
+   *
+   * This is used to give better error messages if the compiler attempts to bind
+   * a resource with an operation that is not supported.
+   *
+   * @internal
+   */
+  public _addInflightOps(...ops: string[]) {
+    this.inflightOps.push(...ops);
+  }
 
   /**
    * Binds the resource to the host so that it can be used by inflight code.
@@ -177,7 +188,7 @@ export abstract class Resource extends Construct implements IResource {
     );
 
     for (const op of ops) {
-      if (!this._inflightOps.includes(op)) {
+      if (!this.inflightOps.includes(op)) {
         throw new Error(
           `Resource ${this.node.path} does not support inflight operation ${op} (requested by ${host.node.path})`
         );

--- a/libs/wingsdk/src/std/resource.ts
+++ b/libs/wingsdk/src/std/resource.ts
@@ -32,7 +32,7 @@ export interface IResource extends IInspectable, IConstruct {
   /**
    * Binds the resource to the host so that it can be used by inflight code.
    *
-   * If the resource does not support any of the operations, it should throw an
+   * If `ops` contains any operations not supported by the resource, it should throw an
    * error.
    *
    * @internal
@@ -66,8 +66,6 @@ export interface IResource extends IInspectable, IConstruct {
    */
   _preSynthesize(): void;
 }
-
-const BIND_METADATA_PREFIX = "$bindings__";
 
 /**
  * Shared behavior between all Wing SDK resources.
@@ -122,36 +120,16 @@ export abstract class Resource extends Construct implements IResource {
     }
   }
 
-  /**
-   * Annotate a class with with metadata about what operations it supports
-   * inflight, and what sub-resources each operation requires access to.
-   *
-   * For example if `MyBucket` has a `fancy_get` method that calls `get` on an
-   * underlying `cloud.Bucket`, then it would be annotated as follows:
-   * ```
-   * MyBucket._annotateInflight("fancy_get", {
-   *  "this.bucket": { ops: ["get"] }
-   * });
-   * ```
-   *
-   * The Wing compiler will automatically generate the correct annotations by
-   * scanning the source code, but in the Wing SDK we have to add them manually.
-   *
-   * @internal
-   */
-  public static _annotateInflight(op: string, annotation: OperationAnnotation) {
-    const sym = Symbol.for(BIND_METADATA_PREFIX + op);
-    Object.defineProperty(this.prototype, sym, {
-      value: annotation,
-      enumerable: false,
-      writable: false,
-    });
-  }
-
   private readonly bindMap: Map<IInflightHost, Set<string>> = new Map();
 
   /** @internal */
   public readonly _connections: Connection[] = [];
+
+  /**
+   * A list of all inflight operations that are supported by this resource.
+   * @internal
+   */
+  public readonly _inflightOps: string[] = ["$inflight_init"];
 
   /**
    * Information on how to display a resource in the UI.
@@ -198,64 +176,20 @@ export abstract class Resource extends Construct implements IResource {
       }) with ops: ${JSON.stringify(ops)}`
     );
 
+    for (const op of ops) {
+      if (!this._inflightOps.includes(op)) {
+        throw new Error(
+          `Resource ${this.node.path} does not support inflight operation ${op} (requested by ${host.node.path})`
+        );
+      }
+    }
+
     // Register the binding between this resource and the host
     if (!this.bindMap.has(host)) {
       this.bindMap.set(host, new Set());
     }
     for (const op of ops) {
       this.bindMap.get(host)!.add(op);
-    }
-
-    // Collect a list of all immediate child bindings
-    const resources: Record<string, string[]> = {};
-    for (const op of ops) {
-      const sym = Symbol.for(BIND_METADATA_PREFIX + op);
-      const bindAnnotation: OperationAnnotation = (this as any)[sym];
-      if (!bindAnnotation) {
-        throw new Error(
-          `Unable to reference "${this.node.path}" from "${host.node.path}" because it does not support operation "${op}"`
-        );
-      }
-      for (const resource of Object.keys(bindAnnotation)) {
-        resources[resource] = resources[resource] ?? [];
-        resources[resource].push(...bindAnnotation[resource].ops);
-      }
-    }
-
-    // this is how resources will look:
-    // resources = {
-    //   "this.bucket": [ "put", "get" ],
-    //   "this.foo.bar.baz": [ "bang" ],
-    //   "counter": [ "inc" ]
-    // };
-
-    // Register the bindings for all child resources
-    for (const field of Object.keys(resources)) {
-      if (!field.startsWith("this.")) {
-        log(`Skipped binding ${field} since it should be bound already.`);
-        continue;
-      }
-
-      const key = field.substring(5);
-
-      // traverse the object graph to find the target object we are referencing
-      const resolveReference = (obj: any, parts: string[]): any => {
-        const next = parts.shift();
-        if (!next) {
-          return obj;
-        }
-        return resolveReference(obj[next], parts);
-      };
-
-      // split the key into parts with "." as the separator
-      const obj = resolveReference(this, key.split("."));
-      if (obj === undefined) {
-        throw new Error(
-          `Resource ${this.node.path} does not have field ${key}`
-        );
-      }
-
-      this.registerBindObject(obj, host, resources[field]);
     }
   }
 
@@ -270,8 +204,10 @@ export abstract class Resource extends Construct implements IResource {
    * @param host The host to bind to
    * @param ops The set of operations that may access the object (use "?" to indicate that we don't
    * know the operation)
+   *
+   * @internal
    */
-  private registerBindObject(
+  protected _registerBindObject(
     obj: any,
     host: IResource,
     ops: string[] = []
@@ -284,7 +220,7 @@ export abstract class Resource extends Construct implements IResource {
 
       case "object":
         if (Array.isArray(obj)) {
-          obj.forEach((item) => this.registerBindObject(item, host));
+          obj.forEach((item) => this._registerBindObject(item, host));
           return;
         }
 
@@ -294,13 +230,13 @@ export abstract class Resource extends Construct implements IResource {
 
         if (obj instanceof Set) {
           return Array.from(obj).forEach((item) =>
-            this.registerBindObject(item, host)
+            this._registerBindObject(item, host)
           );
         }
 
         if (obj instanceof Map) {
           Array.from(obj.values()).forEach((item) =>
-            this.registerBindObject(item, host)
+            this._registerBindObject(item, host)
           );
           return;
         }
@@ -328,7 +264,7 @@ export abstract class Resource extends Construct implements IResource {
         // structs are just plain objects
         if (obj.constructor.name === "Object") {
           Object.values(obj).forEach((item) =>
-            this.registerBindObject(item, host, ops)
+            this._registerBindObject(item, host, ops)
           );
           return;
         }
@@ -395,9 +331,6 @@ export abstract class Resource extends Construct implements IResource {
     return serializeImmutableData(value);
   }
 }
-
-// The `init` op is a placeholder for any annotations needed for an instance of a resource's client to be instantiated
-Resource._annotateInflight("$inflight_init", {});
 
 /**
  * The direction of a connection.

--- a/libs/wingsdk/src/target-awscdk/bucket.ts
+++ b/libs/wingsdk/src/target-awscdk/bucket.ts
@@ -72,11 +72,3 @@ export class Bucket extends cloud.Bucket {
     return `BUCKET_NAME_${this.node.addr.slice(-8)}`;
   }
 }
-
-Bucket._annotateInflight(cloud.BucketInflightMethods.PUT, {});
-Bucket._annotateInflight(cloud.BucketInflightMethods.GET, {});
-Bucket._annotateInflight(cloud.BucketInflightMethods.DELETE, {});
-Bucket._annotateInflight(cloud.BucketInflightMethods.LIST, {});
-Bucket._annotateInflight(cloud.BucketInflightMethods.PUT_JSON, {});
-Bucket._annotateInflight(cloud.BucketInflightMethods.GET_JSON, {});
-Bucket._annotateInflight(cloud.BucketInflightMethods.PUBLIC_URL, {});

--- a/libs/wingsdk/src/target-awscdk/counter.ts
+++ b/libs/wingsdk/src/target-awscdk/counter.ts
@@ -53,8 +53,3 @@ export class Counter extends cloud.Counter {
     return `DYNAMODB_TABLE_NAME_${this.node.addr.slice(-8)}`;
   }
 }
-
-Counter._annotateInflight(cloud.CounterInflightMethods.INC, {});
-Counter._annotateInflight(cloud.CounterInflightMethods.DEC, {});
-Counter._annotateInflight(cloud.CounterInflightMethods.PEEK, {});
-Counter._annotateInflight(cloud.CounterInflightMethods.RESET, {});

--- a/libs/wingsdk/src/target-awscdk/function.ts
+++ b/libs/wingsdk/src/target-awscdk/function.ts
@@ -99,5 +99,3 @@ export class Function extends cloud.Function {
     return `FUNCTION_NAME_${this.node.addr.slice(-8)}`;
   }
 }
-
-Function._annotateInflight(cloud.FunctionInflightMethods.INVOKE, {});

--- a/libs/wingsdk/src/target-awscdk/queue.ts
+++ b/libs/wingsdk/src/target-awscdk/queue.ts
@@ -109,7 +109,3 @@ export class Queue extends cloud.Queue {
     return `SCHEDULE_EVENT_${this.node.addr.slice(-8)}`;
   }
 }
-
-Queue._annotateInflight(cloud.QueueInflightMethods.PUSH, {});
-Queue._annotateInflight(cloud.QueueInflightMethods.PURGE, {});
-Queue._annotateInflight(cloud.QueueInflightMethods.APPROX_SIZE, {});

--- a/libs/wingsdk/src/target-awscdk/secret.ts
+++ b/libs/wingsdk/src/target-awscdk/secret.ts
@@ -70,6 +70,3 @@ export class Secret extends cloud.Secret {
     return `SECRET_ARN_${this.node.addr.slice(-8)}`;
   }
 }
-
-Secret._annotateInflight(cloud.SecretInflightMethods.VALUE, {});
-Secret._annotateInflight(cloud.SecretInflightMethods.VALUE_JSON, {});

--- a/libs/wingsdk/src/target-awscdk/topic.ts
+++ b/libs/wingsdk/src/target-awscdk/topic.ts
@@ -98,5 +98,3 @@ export class Topic extends cloud.Topic {
     return `TOPIC_ARN_${this.node.addr.slice(-8)}`;
   }
 }
-
-Topic._annotateInflight(cloud.TopicInflightMethods.PUBLISH, {});

--- a/libs/wingsdk/src/target-sim/bucket.ts
+++ b/libs/wingsdk/src/target-sim/bucket.ts
@@ -70,11 +70,3 @@ export class Bucket extends cloud.Bucket implements ISimulatorResource {
     return makeSimulatorJsClient(__filename, this);
   }
 }
-
-Bucket._annotateInflight("put", {});
-Bucket._annotateInflight("get", {});
-Bucket._annotateInflight("delete", {});
-Bucket._annotateInflight("list", {});
-Bucket._annotateInflight("put_json", {});
-Bucket._annotateInflight("get_json", {});
-Bucket._annotateInflight("public_url", {});

--- a/libs/wingsdk/src/target-sim/counter.ts
+++ b/libs/wingsdk/src/target-sim/counter.ts
@@ -43,8 +43,3 @@ export class Counter extends cloud.Counter implements ISimulatorResource {
     return makeSimulatorJsClient(__filename, this);
   }
 }
-
-Counter._annotateInflight("inc", {});
-Counter._annotateInflight("dec", {});
-Counter._annotateInflight("peek", {});
-Counter._annotateInflight("reset", {});

--- a/libs/wingsdk/src/target-sim/function.ts
+++ b/libs/wingsdk/src/target-sim/function.ts
@@ -61,5 +61,3 @@ export class Function extends cloud.Function implements ISimulatorResource {
     return makeSimulatorJsClient(__filename, this);
   }
 }
-
-Function._annotateInflight("invoke", {});

--- a/libs/wingsdk/src/target-sim/queue.ts
+++ b/libs/wingsdk/src/target-sim/queue.ts
@@ -110,7 +110,3 @@ export class Queue extends cloud.Queue implements ISimulatorResource {
     return makeSimulatorJsClient(__filename, this);
   }
 }
-
-Queue._annotateInflight("push", {});
-Queue._annotateInflight("purge", {});
-Queue._annotateInflight("approx_size", {});

--- a/libs/wingsdk/src/target-sim/redis.ts
+++ b/libs/wingsdk/src/target-sim/redis.ts
@@ -38,13 +38,3 @@ export class Redis extends redis.Redis implements ISimulatorResource {
     return makeSimulatorJsClient(__filename, this);
   }
 }
-
-Redis._annotateInflight("raw_client", {});
-Redis._annotateInflight("url", {});
-Redis._annotateInflight("get", {});
-Redis._annotateInflight("set", {});
-Redis._annotateInflight("hset", {});
-Redis._annotateInflight("hget", {});
-Redis._annotateInflight("sadd", {});
-Redis._annotateInflight("smembers", {});
-Redis._annotateInflight("del", {});

--- a/libs/wingsdk/src/target-sim/secret.ts
+++ b/libs/wingsdk/src/target-sim/secret.ts
@@ -46,6 +46,3 @@ export class Secret extends cloud.Secret implements ISimulatorResource {
     return schema;
   }
 }
-
-Secret._annotateInflight(cloud.SecretInflightMethods.VALUE, {});
-Secret._annotateInflight(cloud.SecretInflightMethods.VALUE_JSON, {});

--- a/libs/wingsdk/src/target-sim/table.ts
+++ b/libs/wingsdk/src/target-sim/table.ts
@@ -41,9 +41,3 @@ export class Table extends cloud.Table implements ISimulatorResource {
     return makeSimulatorJsClient(__filename, this);
   }
 }
-
-Table._annotateInflight("insert", {});
-Table._annotateInflight("update", {});
-Table._annotateInflight("delete", {});
-Table._annotateInflight("get", {});
-Table._annotateInflight("list", {});

--- a/libs/wingsdk/src/target-sim/topic.ts
+++ b/libs/wingsdk/src/target-sim/topic.ts
@@ -77,5 +77,3 @@ export class Topic extends cloud.Topic implements ISimulatorResource {
     return schema;
   }
 }
-
-Topic._annotateInflight("publish", {});

--- a/libs/wingsdk/src/target-tf-aws/bucket.ts
+++ b/libs/wingsdk/src/target-tf-aws/bucket.ts
@@ -200,11 +200,3 @@ export class Bucket extends cloud.Bucket {
     return `BUCKET_NAME_${this.node.addr.slice(-8)}`;
   }
 }
-
-Bucket._annotateInflight(cloud.BucketInflightMethods.PUT, {});
-Bucket._annotateInflight(cloud.BucketInflightMethods.GET, {});
-Bucket._annotateInflight(cloud.BucketInflightMethods.DELETE, {});
-Bucket._annotateInflight(cloud.BucketInflightMethods.LIST, {});
-Bucket._annotateInflight(cloud.BucketInflightMethods.PUT_JSON, {});
-Bucket._annotateInflight(cloud.BucketInflightMethods.GET_JSON, {});
-Bucket._annotateInflight(cloud.BucketInflightMethods.PUBLIC_URL, {});

--- a/libs/wingsdk/src/target-tf-aws/counter.ts
+++ b/libs/wingsdk/src/target-tf-aws/counter.ts
@@ -66,8 +66,3 @@ export class Counter extends cloud.Counter {
     return `DYNAMODB_TABLE_NAME_${this.node.addr.slice(-8)}`;
   }
 }
-
-Counter._annotateInflight(cloud.CounterInflightMethods.INC, {});
-Counter._annotateInflight(cloud.CounterInflightMethods.DEC, {});
-Counter._annotateInflight(cloud.CounterInflightMethods.PEEK, {});
-Counter._annotateInflight(cloud.CounterInflightMethods.RESET, {});

--- a/libs/wingsdk/src/target-tf-aws/function.ts
+++ b/libs/wingsdk/src/target-tf-aws/function.ts
@@ -312,5 +312,3 @@ export class Function extends cloud.Function {
     return `FUNCTION_NAME_${this.node.addr.slice(-8)}`;
   }
 }
-
-Function._annotateInflight(cloud.FunctionInflightMethods.INVOKE, {});

--- a/libs/wingsdk/src/target-tf-aws/queue.ts
+++ b/libs/wingsdk/src/target-tf-aws/queue.ts
@@ -127,7 +127,3 @@ export class Queue extends cloud.Queue {
     return `QUEUE_URL_${this.node.addr.slice(-8)}`;
   }
 }
-
-Queue._annotateInflight(cloud.QueueInflightMethods.PUSH, {});
-Queue._annotateInflight(cloud.QueueInflightMethods.PURGE, {});
-Queue._annotateInflight(cloud.QueueInflightMethods.APPROX_SIZE, {});

--- a/libs/wingsdk/src/target-tf-aws/redis.ts
+++ b/libs/wingsdk/src/target-tf-aws/redis.ts
@@ -129,13 +129,3 @@ export class Redis extends redis.Redis {
     return `REDIS_CLUSTER_ID_${this.node.addr.slice(-8)}`;
   }
 }
-
-Redis._annotateInflight("raw_client", {});
-Redis._annotateInflight("url", {});
-Redis._annotateInflight("get", {});
-Redis._annotateInflight("set", {});
-Redis._annotateInflight("hset", {});
-Redis._annotateInflight("hget", {});
-Redis._annotateInflight("sadd", {});
-Redis._annotateInflight("smembers", {});
-Redis._annotateInflight("del", {});

--- a/libs/wingsdk/src/target-tf-aws/secret.ts
+++ b/libs/wingsdk/src/target-tf-aws/secret.ts
@@ -78,6 +78,3 @@ export class Secret extends cloud.Secret {
     return `SECRET_ARN_${this.node.addr.slice(-8)}`;
   }
 }
-
-Secret._annotateInflight(cloud.SecretInflightMethods.VALUE, {});
-Secret._annotateInflight(cloud.SecretInflightMethods.VALUE_JSON, {});

--- a/libs/wingsdk/src/target-tf-aws/table.ts
+++ b/libs/wingsdk/src/target-tf-aws/table.ts
@@ -110,9 +110,3 @@ export class Table extends cloud.Table {
     return `${this.envName()}_COLUMNS`;
   }
 }
-
-Table._annotateInflight(cloud.TableInflightMethods.INSERT, {});
-Table._annotateInflight(cloud.TableInflightMethods.UPDATE, {});
-Table._annotateInflight(cloud.TableInflightMethods.DELETE, {});
-Table._annotateInflight(cloud.TableInflightMethods.GET, {});
-Table._annotateInflight(cloud.TableInflightMethods.LIST, {});

--- a/libs/wingsdk/src/target-tf-aws/topic.ts
+++ b/libs/wingsdk/src/target-tf-aws/topic.ts
@@ -161,5 +161,3 @@ export class Topic extends cloud.Topic {
     return `TOPIC_ARN_${this.node.addr.slice(-8)}`;
   }
 }
-
-Topic._annotateInflight(cloud.TopicInflightMethods.PUBLISH, {});

--- a/libs/wingsdk/src/target-tf-azure/bucket.ts
+++ b/libs/wingsdk/src/target-tf-azure/bucket.ts
@@ -194,11 +194,3 @@ export class Bucket extends cloud.Bucket {
     return `STORAGE_ACCOUNT_${this.storageContainer.node.addr.slice(-8)}`;
   }
 }
-
-Bucket._annotateInflight(cloud.BucketInflightMethods.PUT, {});
-Bucket._annotateInflight(cloud.BucketInflightMethods.GET, {});
-Bucket._annotateInflight(cloud.BucketInflightMethods.DELETE, {});
-Bucket._annotateInflight(cloud.BucketInflightMethods.LIST, {});
-Bucket._annotateInflight(cloud.BucketInflightMethods.PUT_JSON, {});
-Bucket._annotateInflight(cloud.BucketInflightMethods.GET_JSON, {});
-Bucket._annotateInflight(cloud.BucketInflightMethods.PUBLIC_URL, {});

--- a/libs/wingsdk/src/utils/convert.ts
+++ b/libs/wingsdk/src/utils/convert.ts
@@ -26,7 +26,7 @@ export function convertBetweenHandlers(
       super(theScope, theId);
       this.handler = handler;
       this.display.hidden = true;
-      this._inflightOps.push("handle");
+      this._addInflightOps("handle");
     }
 
     public _toInflight(): NodeJsCode {

--- a/libs/wingsdk/src/utils/convert.ts
+++ b/libs/wingsdk/src/utils/convert.ts
@@ -1,6 +1,6 @@
 import { Construct } from "constructs";
 import { NodeJsCode } from "../core";
-import { IResource, Resource } from "../std";
+import { IInflightHost, IResource, Resource } from "../std";
 import { normalPath } from "../util";
 
 /**
@@ -26,6 +26,7 @@ export function convertBetweenHandlers(
       super(theScope, theId);
       this.handler = handler;
       this.display.hidden = true;
+      this._inflightOps.push("handle");
     }
 
     public _toInflight(): NodeJsCode {
@@ -36,11 +37,12 @@ export function convertBetweenHandlers(
         )}")).${newHandlerClientClassName}({ handler: ${handlerClient.text} })`
       );
     }
-  }
 
-  NewHandler._annotateInflight("handle", {
-    "this.handler": { ops: ["handle"] },
-  });
+    public _registerBind(host: IInflightHost, ops: string[]): void {
+      this._registerBindObject(this.handler, host, ["handle"]);
+      super._registerBind(host, ops);
+    }
+  }
 
   return new NewHandler(scope, id, baseHandler);
 }

--- a/libs/wingsdk/test/target-awscdk/__snapshots__/counter.test.ts.snap
+++ b/libs/wingsdk/test/target-awscdk/__snapshots__/counter.test.ts.snap
@@ -119,7 +119,7 @@ exports[`dec() policy statement 2`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "ad35edc138f350a9331626c2154549c77595090606845499ead1babbee8b7497.zip",
+          "S3Key": "266500021bfc4d9b7e6a5a9a0a0e715e60fa2868e86486bc32937dd097299da2.zip",
         },
         "Environment": {
           "Variables": {
@@ -347,7 +347,7 @@ exports[`function with a counter binding 2`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "e63e7993bd34c7951a0442ec4c39d1504e9d1b64c633db6ef924160622f5e1c9.zip",
+          "S3Key": "5c0d2e0af35801fac9cdf4e98c65c360076fbd5b9c9c7fec3a3c25fff8d0793f.zip",
         },
         "Environment": {
           "Variables": {
@@ -514,7 +514,7 @@ exports[`inc() policy statement 2`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "e63e7993bd34c7951a0442ec4c39d1504e9d1b64c633db6ef924160622f5e1c9.zip",
+          "S3Key": "5c0d2e0af35801fac9cdf4e98c65c360076fbd5b9c9c7fec3a3c25fff8d0793f.zip",
         },
         "Environment": {
           "Variables": {
@@ -681,7 +681,7 @@ exports[`peek() policy statement 2`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "a48c558a29ca68e4af788e28d94d4c5806eb2606ba9628976cf7b75296120a48.zip",
+          "S3Key": "c8faeb25102ea2df0e9028bcaa5e66c1be8b1b04c886a4b2a11f897c40af2480.zip",
         },
         "Environment": {
           "Variables": {
@@ -848,7 +848,7 @@ exports[`reset() policy statement 2`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "319e4285e62a61d310e1a52f349fe913c89cb8dce3ad2f669b261dad1f7f1911.zip",
+          "S3Key": "d9b22dda8a097ddeaab7e56a7a163fc3a1baed0ec326a01e7eaa0b185a3b490b.zip",
         },
         "Environment": {
           "Variables": {

--- a/libs/wingsdk/test/target-sim/binding.test.ts
+++ b/libs/wingsdk/test/target-sim/binding.test.ts
@@ -8,6 +8,6 @@ test("binding throws if a method is unsupported", () => {
   const handler = Testing.makeHandler(app, "Handler", "async handle() {}");
   const host = Function._newFunction(app, "Function", handler);
   expect(() => handler._registerBind(host, ["foo", "bar"])).toThrow(
-    /Unable to reference \"root\/Handler\" from \"root\/Function\" because it does not support operation \"foo\"/
+    /Resource root\/Handler does not support inflight operation foo \(requested by root\/Function\)/
   );
 });

--- a/tools/hangar/__snapshots__/test_corpus/api.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/api.w_compile_tf-aws.md
@@ -306,7 +306,7 @@ class $Root extends $stdlib.std.Resource {
     class Foo extends $stdlib.std.Resource {
       constructor(scope, id, api) {
         super(scope, id);
-        this._inflightOps.push("handle");
+        this._addInflightOps("handle");
         this.api = api;
       }
       _toInflight() {

--- a/tools/hangar/__snapshots__/test_corpus/api.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/api.w_compile_tf-aws.md
@@ -306,6 +306,7 @@ class $Root extends $stdlib.std.Resource {
     class Foo extends $stdlib.std.Resource {
       constructor(scope, id, api) {
         super(scope, id);
+        this._inflightOps.push("handle");
         this.api = api;
       }
       _toInflight() {
@@ -323,9 +324,17 @@ class $Root extends $stdlib.std.Resource {
           })())
         `);
       }
+      _registerBind(host, ops) {
+        if (ops.includes("$inflight_init")) {
+          this._registerBindObject(this.api, host, []);
+          this._registerBindObject(this.stateful, host, []);
+        }
+        if (ops.includes("handle")) {
+          this._registerBindObject(this.api.url, host, []);
+        }
+        super._registerBind(host, ops);
+      }
     }
-    Foo._annotateInflight("$inflight_init", {"this.api": { ops: [] },"this.stateful": { ops: [] }});
-    Foo._annotateInflight("handle", {"this.api.url": { ops: [] }});
     const api = this.node.root.newAbstract("@winglang/sdk.cloud.Api",this,"cloud.Api");
     const counter = this.node.root.newAbstract("@winglang/sdk.cloud.Counter",this,"cloud.Counter");
     const handler = new $stdlib.core.Inflight(this, "$Inflight1", {

--- a/tools/hangar/__snapshots__/test_corpus/api_path_vars.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/api_path_vars.w_compile_tf-aws.md
@@ -282,6 +282,7 @@ class $Root extends $stdlib.std.Resource {
     class Fetch extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
+        this._inflightOps.push("get");
       }
       _toInflight() {
         const stateful_client = this._lift(this.stateful);
@@ -296,9 +297,15 @@ class $Root extends $stdlib.std.Resource {
           })())
         `);
       }
+      _registerBind(host, ops) {
+        if (ops.includes("$inflight_init")) {
+          this._registerBindObject(this.stateful, host, []);
+        }
+        if (ops.includes("get")) {
+        }
+        super._registerBind(host, ops);
+      }
     }
-    Fetch._annotateInflight("$inflight_init", {"this.stateful": { ops: [] }});
-    Fetch._annotateInflight("get", {});
     const api = this.node.root.newAbstract("@winglang/sdk.cloud.Api",this,"cloud.Api");
     const handler = new $stdlib.core.Inflight(this, "$Inflight1", {
       code: $stdlib.core.NodeJsCode.fromFile(require.resolve("./proc1/index.js".replace(/\\/g, "/"))),

--- a/tools/hangar/__snapshots__/test_corpus/api_path_vars.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/api_path_vars.w_compile_tf-aws.md
@@ -282,7 +282,7 @@ class $Root extends $stdlib.std.Resource {
     class Fetch extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
-        this._inflightOps.push("get");
+        this._addInflightOps("get");
       }
       _toInflight() {
         const stateful_client = this._lift(this.stateful);

--- a/tools/hangar/__snapshots__/test_corpus/capture_resource_with_no_inflight.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/capture_resource_with_no_inflight.w_compile_tf-aws.md
@@ -145,7 +145,7 @@ class $Root extends $stdlib.std.Resource {
     class A extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
-        this._inflightOps.push();
+        this._addInflightOps();
         this.field = "hey";
       }
       _toInflight() {

--- a/tools/hangar/__snapshots__/test_corpus/capture_resource_with_no_inflight.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/capture_resource_with_no_inflight.w_compile_tf-aws.md
@@ -145,6 +145,7 @@ class $Root extends $stdlib.std.Resource {
     class A extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
+        this._inflightOps.push();
         this.field = "hey";
       }
       _toInflight() {
@@ -162,8 +163,14 @@ class $Root extends $stdlib.std.Resource {
           })())
         `);
       }
+      _registerBind(host, ops) {
+        if (ops.includes("$inflight_init")) {
+          this._registerBindObject(this.field, host, []);
+          this._registerBindObject(this.stateful, host, []);
+        }
+        super._registerBind(host, ops);
+      }
     }
-    A._annotateInflight("$inflight_init", {"this.field": { ops: [] },"this.stateful": { ops: [] }});
     const a = new A(this,"A");
     this.node.root.newAbstract("@winglang/sdk.cloud.Function",this,"test",new $stdlib.core.Inflight(this, "$Inflight1", {
       code: $stdlib.core.NodeJsCode.fromFile(require.resolve("./proc1/index.js".replace(/\\/g, "/"))),

--- a/tools/hangar/__snapshots__/test_corpus/capture_resource_with_no_inflight.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/capture_resource_with_no_inflight.w_compile_tf-aws.md
@@ -145,7 +145,6 @@ class $Root extends $stdlib.std.Resource {
     class A extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
-        this._addInflightOps();
         this.field = "hey";
       }
       _toInflight() {

--- a/tools/hangar/__snapshots__/test_corpus/construct-base.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/construct-base.w_compile_tf-aws.md
@@ -70,7 +70,7 @@ class $Root extends $stdlib.std.Resource {
     class WingResource extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
-        this._inflightOps.push();
+        this._addInflightOps();
         {console.log(`my id is ${this.node.id}`)};
       }
       _toInflight() {

--- a/tools/hangar/__snapshots__/test_corpus/construct-base.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/construct-base.w_compile_tf-aws.md
@@ -70,7 +70,6 @@ class $Root extends $stdlib.std.Resource {
     class WingResource extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
-        this._addInflightOps();
         {console.log(`my id is ${this.node.id}`)};
       }
       _toInflight() {

--- a/tools/hangar/__snapshots__/test_corpus/construct-base.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/construct-base.w_compile_tf-aws.md
@@ -70,6 +70,7 @@ class $Root extends $stdlib.std.Resource {
     class WingResource extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
+        this._inflightOps.push();
         {console.log(`my id is ${this.node.id}`)};
       }
       _toInflight() {
@@ -85,8 +86,13 @@ class $Root extends $stdlib.std.Resource {
           })())
         `);
       }
+      _registerBind(host, ops) {
+        if (ops.includes("$inflight_init")) {
+          this._registerBindObject(this.stateful, host, []);
+        }
+        super._registerBind(host, ops);
+      }
     }
-    WingResource._annotateInflight("$inflight_init", {"this.stateful": { ops: [] }});
     const get_path =  (c) =>  {
       {
         return c.node.path;

--- a/tools/hangar/__snapshots__/test_corpus/doubler.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/doubler.w_compile_tf-aws.md
@@ -63,6 +63,7 @@ class $Root extends $stdlib.std.Resource {
     class Doubler extends $stdlib.std.Resource {
       constructor(scope, id, func) {
         super(scope, id);
+        this._inflightOps.push("invoke");
         this.func = func;
       }
       _toInflight() {
@@ -80,9 +81,17 @@ class $Root extends $stdlib.std.Resource {
           })())
         `);
       }
+      _registerBind(host, ops) {
+        if (ops.includes("$inflight_init")) {
+          this._registerBindObject(this.func, host, []);
+          this._registerBindObject(this.stateful, host, []);
+        }
+        if (ops.includes("invoke")) {
+          this._registerBindObject(this.func, host, ["handle"]);
+        }
+        super._registerBind(host, ops);
+      }
     }
-    Doubler._annotateInflight("$inflight_init", {"this.func": { ops: [] },"this.stateful": { ops: [] }});
-    Doubler._annotateInflight("invoke", {"this.func": { ops: ["handle"] }});
     const fn = new Doubler(this,"Doubler",new $stdlib.core.Inflight(this, "$Inflight1", {
       code: $stdlib.core.NodeJsCode.fromFile(require.resolve("./proc1/index.js".replace(/\\/g, "/"))),
       bindings: {

--- a/tools/hangar/__snapshots__/test_corpus/doubler.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/doubler.w_compile_tf-aws.md
@@ -63,7 +63,7 @@ class $Root extends $stdlib.std.Resource {
     class Doubler extends $stdlib.std.Resource {
       constructor(scope, id, func) {
         super(scope, id);
-        this._inflightOps.push("invoke");
+        this._addInflightOps("invoke");
         this.func = func;
       }
       _toInflight() {

--- a/tools/hangar/__snapshots__/test_corpus/extern_implementation.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/extern_implementation.w_compile_tf-aws.md
@@ -229,6 +229,7 @@ class $Root extends $stdlib.std.Resource {
     class Foo extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
+        this._inflightOps.push("regex_inflight", "get_uuid", "get_data", "print", "call");
       }
       static get_greeting(name)  {
         return (require("<ABSOLUTE_PATH>/external_js.js")["get_greeting"])(name)
@@ -249,13 +250,23 @@ class $Root extends $stdlib.std.Resource {
           })())
         `);
       }
+      _registerBind(host, ops) {
+        if (ops.includes("$inflight_init")) {
+          this._registerBindObject(this.stateful, host, []);
+        }
+        if (ops.includes("call")) {
+        }
+        if (ops.includes("get_data")) {
+        }
+        if (ops.includes("get_uuid")) {
+        }
+        if (ops.includes("print")) {
+        }
+        if (ops.includes("regex_inflight")) {
+        }
+        super._registerBind(host, ops);
+      }
     }
-    Foo._annotateInflight("$inflight_init", {"this.stateful": { ops: [] }});
-    Foo._annotateInflight("call", {});
-    Foo._annotateInflight("get_data", {});
-    Foo._annotateInflight("get_uuid", {});
-    Foo._annotateInflight("print", {});
-    Foo._annotateInflight("regex_inflight", {});
     {((cond) => {if (!cond) throw new Error(`assertion failed: '((Foo.get_greeting("Wingding")) === "Hello, Wingding!")'`)})(((Foo.get_greeting("Wingding")) === "Hello, Wingding!"))};
     {((cond) => {if (!cond) throw new Error(`assertion failed: '((Foo.v4()).length === 36)'`)})(((Foo.v4()).length === 36))};
     const f = new Foo(this,"Foo");

--- a/tools/hangar/__snapshots__/test_corpus/extern_implementation.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/extern_implementation.w_compile_tf-aws.md
@@ -229,7 +229,7 @@ class $Root extends $stdlib.std.Resource {
     class Foo extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
-        this._inflightOps.push("regex_inflight", "get_uuid", "get_data", "print", "call");
+        this._addInflightOps("regex_inflight", "get_uuid", "get_data", "print", "call");
       }
       static get_greeting(name)  {
         return (require("<ABSOLUTE_PATH>/external_js.js")["get_greeting"])(name)

--- a/tools/hangar/__snapshots__/test_corpus/forward_decl.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/forward_decl.w_compile_tf-aws.md
@@ -56,7 +56,6 @@ class $Root extends $stdlib.std.Resource {
     class R extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
-        this._addInflightOps();
       }
        method2()  {
         {

--- a/tools/hangar/__snapshots__/test_corpus/forward_decl.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/forward_decl.w_compile_tf-aws.md
@@ -56,6 +56,7 @@ class $Root extends $stdlib.std.Resource {
     class R extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
+        this._inflightOps.push();
       }
        method2()  {
         {
@@ -83,8 +84,14 @@ class $Root extends $stdlib.std.Resource {
           })())
         `);
       }
+      _registerBind(host, ops) {
+        if (ops.includes("$inflight_init")) {
+          this._registerBindObject(this.f, host, []);
+          this._registerBindObject(this.stateful, host, []);
+        }
+        super._registerBind(host, ops);
+      }
     }
-    R._annotateInflight("$inflight_init", {"this.f": { ops: [] },"this.stateful": { ops: [] }});
     const x = "hi";
     if (true) {
       {console.log(`${x}`)};

--- a/tools/hangar/__snapshots__/test_corpus/forward_decl.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/forward_decl.w_compile_tf-aws.md
@@ -56,7 +56,7 @@ class $Root extends $stdlib.std.Resource {
     class R extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
-        this._inflightOps.push();
+        this._addInflightOps();
       }
        method2()  {
         {

--- a/tools/hangar/__snapshots__/test_corpus/impl_interface.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/impl_interface.w_compile_tf-aws.md
@@ -93,7 +93,7 @@ class $Root extends $stdlib.std.Resource {
     class A extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
-        this._inflightOps.push("handle");
+        this._addInflightOps("handle");
       }
       _toInflight() {
         const stateful_client = this._lift(this.stateful);
@@ -120,7 +120,7 @@ class $Root extends $stdlib.std.Resource {
     class r extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
-        this._inflightOps.push("method_2");
+        this._addInflightOps("method_2");
       }
        method_1(x)  {
         {
@@ -157,7 +157,7 @@ class $Root extends $stdlib.std.Resource {
     class Dog extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
-        this._inflightOps.push("eat");
+        this._addInflightOps("eat");
       }
       _toInflight() {
         const stateful_client = this._lift(this.stateful);

--- a/tools/hangar/__snapshots__/test_corpus/impl_interface.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/impl_interface.w_compile_tf-aws.md
@@ -93,6 +93,7 @@ class $Root extends $stdlib.std.Resource {
     class A extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
+        this._inflightOps.push("handle");
       }
       _toInflight() {
         const stateful_client = this._lift(this.stateful);
@@ -107,12 +108,19 @@ class $Root extends $stdlib.std.Resource {
           })())
         `);
       }
+      _registerBind(host, ops) {
+        if (ops.includes("$inflight_init")) {
+          this._registerBindObject(this.stateful, host, []);
+        }
+        if (ops.includes("handle")) {
+        }
+        super._registerBind(host, ops);
+      }
     }
-    A._annotateInflight("$inflight_init", {"this.stateful": { ops: [] }});
-    A._annotateInflight("handle", {});
     class r extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
+        this._inflightOps.push("method_2");
       }
        method_1(x)  {
         {
@@ -137,12 +145,19 @@ class $Root extends $stdlib.std.Resource {
           })())
         `);
       }
+      _registerBind(host, ops) {
+        if (ops.includes("$inflight_init")) {
+          this._registerBindObject(this.stateful, host, []);
+        }
+        if (ops.includes("method_2")) {
+        }
+        super._registerBind(host, ops);
+      }
     }
-    r._annotateInflight("$inflight_init", {"this.stateful": { ops: [] }});
-    r._annotateInflight("method_2", {});
     class Dog extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
+        this._inflightOps.push("eat");
       }
       _toInflight() {
         const stateful_client = this._lift(this.stateful);
@@ -157,9 +172,15 @@ class $Root extends $stdlib.std.Resource {
           })())
         `);
       }
+      _registerBind(host, ops) {
+        if (ops.includes("$inflight_init")) {
+          this._registerBindObject(this.stateful, host, []);
+        }
+        if (ops.includes("eat")) {
+        }
+        super._registerBind(host, ops);
+      }
     }
-    Dog._annotateInflight("$inflight_init", {"this.stateful": { ops: [] }});
-    Dog._annotateInflight("eat", {});
     const x = new A(this,"A");
     const y = new $stdlib.core.Inflight(this, "$Inflight1", {
       code: $stdlib.core.NodeJsCode.fromFile(require.resolve("./proc1/index.js".replace(/\\/g, "/"))),

--- a/tools/hangar/__snapshots__/test_corpus/json.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/json.w_compile_tf-aws.md
@@ -56,7 +56,6 @@ class $Root extends $stdlib.std.Resource {
     class Foo extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
-        this._addInflightOps();
         this._sum_str = "wow!";
       }
       _toInflight() {

--- a/tools/hangar/__snapshots__/test_corpus/json.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/json.w_compile_tf-aws.md
@@ -56,6 +56,7 @@ class $Root extends $stdlib.std.Resource {
     class Foo extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
+        this._inflightOps.push();
         this._sum_str = "wow!";
       }
       _toInflight() {
@@ -73,8 +74,14 @@ class $Root extends $stdlib.std.Resource {
           })())
         `);
       }
+      _registerBind(host, ops) {
+        if (ops.includes("$inflight_init")) {
+          this._registerBindObject(this._sum_str, host, []);
+          this._registerBindObject(this.stateful, host, []);
+        }
+        super._registerBind(host, ops);
+      }
     }
-    Foo._annotateInflight("$inflight_init", {"this._sum_str": { ops: [] },"this.stateful": { ops: [] }});
     const json_number = 123;
     const json_bool = true;
     const json_array = [1, 2, 3];

--- a/tools/hangar/__snapshots__/test_corpus/json.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/json.w_compile_tf-aws.md
@@ -56,7 +56,7 @@ class $Root extends $stdlib.std.Resource {
     class Foo extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
-        this._inflightOps.push();
+        this._addInflightOps();
         this._sum_str = "wow!";
       }
       _toInflight() {

--- a/tools/hangar/__snapshots__/test_corpus/reassignment.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/reassignment.w_compile_tf-aws.md
@@ -56,7 +56,7 @@ class $Root extends $stdlib.std.Resource {
     class R extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
-        this._inflightOps.push();
+        this._addInflightOps();
         if (true) {
           this.f = 1;
           this.f1 = 0;

--- a/tools/hangar/__snapshots__/test_corpus/reassignment.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/reassignment.w_compile_tf-aws.md
@@ -56,7 +56,6 @@ class $Root extends $stdlib.std.Resource {
     class R extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
-        this._addInflightOps();
         if (true) {
           this.f = 1;
           this.f1 = 0;

--- a/tools/hangar/__snapshots__/test_corpus/reassignment.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/reassignment.w_compile_tf-aws.md
@@ -56,6 +56,7 @@ class $Root extends $stdlib.std.Resource {
     class R extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
+        this._inflightOps.push();
         if (true) {
           this.f = 1;
           this.f1 = 0;
@@ -81,8 +82,14 @@ class $Root extends $stdlib.std.Resource {
           })())
         `);
       }
+      _registerBind(host, ops) {
+        if (ops.includes("$inflight_init")) {
+          this._registerBindObject(this.f1, host, []);
+          this._registerBindObject(this.stateful, host, []);
+        }
+        super._registerBind(host, ops);
+      }
     }
-    R._annotateInflight("$inflight_init", {"this.f1": { ops: [] },"this.stateful": { ops: [] }});
     let x = 5;
     {((cond) => {if (!cond) throw new Error(`assertion failed: '(x === 5)'`)})((x === 5))};
     x = (x + 1);

--- a/tools/hangar/__snapshots__/test_corpus/resource.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/resource.w_compile_tf-aws.md
@@ -765,6 +765,7 @@ class $Root extends $stdlib.std.Resource {
     class Foo extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
+        this._inflightOps.push("foo_inc", "foo_get");
         this.c = this.node.root.newAbstract("@winglang/sdk.cloud.Counter",this,"cloud.Counter");
       }
       _toInflight() {
@@ -782,13 +783,24 @@ class $Root extends $stdlib.std.Resource {
           })())
         `);
       }
+      _registerBind(host, ops) {
+        if (ops.includes("$inflight_init")) {
+          this._registerBindObject(this.c, host, ["dec", "inc"]);
+          this._registerBindObject(this.stateful, host, []);
+        }
+        if (ops.includes("foo_get")) {
+          this._registerBindObject(this.c, host, ["peek"]);
+        }
+        if (ops.includes("foo_inc")) {
+          this._registerBindObject(this.c, host, ["inc"]);
+        }
+        super._registerBind(host, ops);
+      }
     }
-    Foo._annotateInflight("$inflight_init", {"this.c": { ops: ["dec","inc"] },"this.stateful": { ops: [] }});
-    Foo._annotateInflight("foo_get", {"this.c": { ops: ["peek"] }});
-    Foo._annotateInflight("foo_inc", {"this.c": { ops: ["inc"] }});
     class Bar extends $stdlib.std.Resource {
       constructor(scope, id, name, b) {
         super(scope, id);
+        this._inflightOps.push("my_method");
         this.name = name;
         this.b = b;
         this.foo = new Foo(this,"Foo");
@@ -812,12 +824,24 @@ class $Root extends $stdlib.std.Resource {
           })())
         `);
       }
+      _registerBind(host, ops) {
+        if (ops.includes("$inflight_init")) {
+          this._registerBindObject(this.b, host, []);
+          this._registerBindObject(this.foo, host, []);
+          this._registerBindObject(this.name, host, []);
+          this._registerBindObject(this.stateful, host, []);
+        }
+        if (ops.includes("my_method")) {
+          this._registerBindObject(this.b, host, ["get", "put"]);
+          this._registerBindObject(this.foo, host, ["foo_get", "foo_inc"]);
+        }
+        super._registerBind(host, ops);
+      }
     }
-    Bar._annotateInflight("$inflight_init", {"this.b": { ops: [] },"this.foo": { ops: [] },"this.name": { ops: [] },"this.stateful": { ops: [] }});
-    Bar._annotateInflight("my_method", {"this.b": { ops: ["get","put"] },"this.foo": { ops: ["foo_get","foo_inc"] }});
     class BigPublisher extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
+        this._inflightOps.push("publish", "getObjectCount");
         this.b = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this,"cloud.Bucket");
         this.b2 = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this,"b2");
         this.q = this.node.root.newAbstract("@winglang/sdk.cloud.Queue",this,"cloud.Queue");
@@ -874,10 +898,25 @@ class $Root extends $stdlib.std.Resource {
           })())
         `);
       }
+      _registerBind(host, ops) {
+        if (ops.includes("$inflight_init")) {
+          this._registerBindObject(this.b, host, []);
+          this._registerBindObject(this.b2, host, []);
+          this._registerBindObject(this.q, host, []);
+          this._registerBindObject(this.stateful, host, []);
+          this._registerBindObject(this.t, host, []);
+        }
+        if (ops.includes("getObjectCount")) {
+          this._registerBindObject(this.b, host, ["list"]);
+        }
+        if (ops.includes("publish")) {
+          this._registerBindObject(this.b2, host, ["put"]);
+          this._registerBindObject(this.q, host, ["push"]);
+          this._registerBindObject(this.t, host, ["publish"]);
+        }
+        super._registerBind(host, ops);
+      }
     }
-    BigPublisher._annotateInflight("$inflight_init", {"this.b": { ops: [] },"this.b2": { ops: [] },"this.q": { ops: [] },"this.stateful": { ops: [] },"this.t": { ops: [] }});
-    BigPublisher._annotateInflight("getObjectCount", {"this.b": { ops: ["list"] }});
-    BigPublisher._annotateInflight("publish", {"this.b2": { ops: ["put"] },"this.q": { ops: ["push"] },"this.t": { ops: ["publish"] }});
     const bucket = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this,"cloud.Bucket");
     const res = new Bar(this,"Bar","Arr",bucket);
     this.node.root.newAbstract("@winglang/sdk.cloud.Function",this,"test",new $stdlib.core.Inflight(this, "$Inflight4", {

--- a/tools/hangar/__snapshots__/test_corpus/resource.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/resource.w_compile_tf-aws.md
@@ -765,7 +765,7 @@ class $Root extends $stdlib.std.Resource {
     class Foo extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
-        this._inflightOps.push("foo_inc", "foo_get");
+        this._addInflightOps("foo_inc", "foo_get");
         this.c = this.node.root.newAbstract("@winglang/sdk.cloud.Counter",this,"cloud.Counter");
       }
       _toInflight() {
@@ -800,7 +800,7 @@ class $Root extends $stdlib.std.Resource {
     class Bar extends $stdlib.std.Resource {
       constructor(scope, id, name, b) {
         super(scope, id);
-        this._inflightOps.push("my_method");
+        this._addInflightOps("my_method");
         this.name = name;
         this.b = b;
         this.foo = new Foo(this,"Foo");
@@ -841,7 +841,7 @@ class $Root extends $stdlib.std.Resource {
     class BigPublisher extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
-        this._inflightOps.push("publish", "getObjectCount");
+        this._addInflightOps("publish", "getObjectCount");
         this.b = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this,"cloud.Bucket");
         this.b2 = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this,"b2");
         this.q = this.node.root.newAbstract("@winglang/sdk.cloud.Queue",this,"cloud.Queue");

--- a/tools/hangar/__snapshots__/test_corpus/resource_as_inflight_literal.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/resource_as_inflight_literal.w_compile_tf-aws.md
@@ -215,6 +215,7 @@ class $Root extends $stdlib.std.Resource {
     class Foo extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
+        this._inflightOps.push("handle");
       }
       _toInflight() {
         const stateful_client = this._lift(this.stateful);
@@ -229,9 +230,15 @@ class $Root extends $stdlib.std.Resource {
           })())
         `);
       }
+      _registerBind(host, ops) {
+        if (ops.includes("$inflight_init")) {
+          this._registerBindObject(this.stateful, host, []);
+        }
+        if (ops.includes("handle")) {
+        }
+        super._registerBind(host, ops);
+      }
     }
-    Foo._annotateInflight("$inflight_init", {"this.stateful": { ops: [] }});
-    Foo._annotateInflight("handle", {});
     const fn = this.node.root.newAbstract("@winglang/sdk.cloud.Function",this,"cloud.Function",new Foo(this,"Foo"));
     this.node.root.newAbstract("@winglang/sdk.cloud.Function",this,"test",new $stdlib.core.Inflight(this, "$Inflight1", {
       code: $stdlib.core.NodeJsCode.fromFile(require.resolve("./proc1/index.js".replace(/\\/g, "/"))),

--- a/tools/hangar/__snapshots__/test_corpus/resource_as_inflight_literal.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/resource_as_inflight_literal.w_compile_tf-aws.md
@@ -215,7 +215,7 @@ class $Root extends $stdlib.std.Resource {
     class Foo extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
-        this._inflightOps.push("handle");
+        this._addInflightOps("handle");
       }
       _toInflight() {
         const stateful_client = this._lift(this.stateful);

--- a/tools/hangar/__snapshots__/test_corpus/resource_captures.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/resource_captures.w_compile_tf-aws.md
@@ -425,6 +425,7 @@ class $Root extends $stdlib.std.Resource {
     class First extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
+        this._inflightOps.push();
         this.my_resource = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this,"cloud.Bucket");
       }
       _toInflight() {
@@ -442,11 +443,18 @@ class $Root extends $stdlib.std.Resource {
           })())
         `);
       }
+      _registerBind(host, ops) {
+        if (ops.includes("$inflight_init")) {
+          this._registerBindObject(this.my_resource, host, []);
+          this._registerBindObject(this.stateful, host, []);
+        }
+        super._registerBind(host, ops);
+      }
     }
-    First._annotateInflight("$inflight_init", {"this.my_resource": { ops: [] },"this.stateful": { ops: [] }});
     class Another extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
+        this._inflightOps.push("meaning_of_life", "another_func");
         this.my_field = "hello!";
         this.first = new First(this,"First");
       }
@@ -467,13 +475,23 @@ class $Root extends $stdlib.std.Resource {
           })())
         `);
       }
+      _registerBind(host, ops) {
+        if (ops.includes("$inflight_init")) {
+          this._registerBindObject(this.first, host, []);
+          this._registerBindObject(this.my_field, host, []);
+          this._registerBindObject(this.stateful, host, []);
+        }
+        if (ops.includes("another_func")) {
+        }
+        if (ops.includes("meaning_of_life")) {
+        }
+        super._registerBind(host, ops);
+      }
     }
-    Another._annotateInflight("$inflight_init", {"this.first": { ops: [] },"this.my_field": { ops: [] },"this.stateful": { ops: [] }});
-    Another._annotateInflight("another_func", {});
-    Another._annotateInflight("meaning_of_life", {});
     class MyResource extends $stdlib.std.Resource {
       constructor(scope, id, external_bucket, external_num) {
         super(scope, id);
+        this._inflightOps.push("test_no_capture", "test_capture_collections_of_data", "test_capture_primitives", "test_capture_optional", "test_capture_resource", "test_nested_preflight_field", "test_nested_resource", "test_expression_recursive", "test_external", "test_user_defined_resource", "test_inflight_field");
         this.my_resource = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this,"cloud.Bucket");
         this.my_str = "my_string";
         this.my_num = 42;
@@ -532,19 +550,64 @@ class $Root extends $stdlib.std.Resource {
           })())
         `);
       }
+      _registerBind(host, ops) {
+        if (ops.includes("$inflight_init")) {
+          this._registerBindObject(this.another, host, []);
+          this._registerBindObject(this.array_of_str, host, []);
+          this._registerBindObject(this.ext_bucket, host, []);
+          this._registerBindObject(this.ext_num, host, []);
+          this._registerBindObject(this.map_of_num, host, []);
+          this._registerBindObject(this.my_bool, host, []);
+          this._registerBindObject(this.my_num, host, []);
+          this._registerBindObject(this.my_opt_str, host, []);
+          this._registerBindObject(this.my_queue, host, []);
+          this._registerBindObject(this.my_resource, host, []);
+          this._registerBindObject(this.my_str, host, []);
+          this._registerBindObject(this.set_of_str, host, []);
+          this._registerBindObject(this.stateful, host, []);
+          this._registerBindObject(this.unused_resource, host, []);
+        }
+        if (ops.includes("test_capture_collections_of_data")) {
+          this._registerBindObject(this.array_of_str, host, ["at", "length"]);
+          this._registerBindObject(this.map_of_num, host, ["get"]);
+          this._registerBindObject(this.set_of_str, host, ["has"]);
+        }
+        if (ops.includes("test_capture_optional")) {
+          this._registerBindObject(this.my_opt_str, host, []);
+        }
+        if (ops.includes("test_capture_primitives")) {
+          this._registerBindObject(this.my_bool, host, []);
+          this._registerBindObject(this.my_num, host, []);
+          this._registerBindObject(this.my_str, host, []);
+        }
+        if (ops.includes("test_capture_resource")) {
+          this._registerBindObject(this.my_resource, host, ["get", "list", "put"]);
+        }
+        if (ops.includes("test_expression_recursive")) {
+          this._registerBindObject(this.my_queue, host, ["push"]);
+          this._registerBindObject(this.my_str, host, []);
+        }
+        if (ops.includes("test_external")) {
+          this._registerBindObject(this.ext_bucket, host, ["list"]);
+          this._registerBindObject(this.ext_num, host, []);
+        }
+        if (ops.includes("test_inflight_field")) {
+        }
+        if (ops.includes("test_nested_preflight_field")) {
+          this._registerBindObject(this.another.my_field, host, []);
+        }
+        if (ops.includes("test_nested_resource")) {
+          this._registerBindObject(this.another.first.my_resource, host, ["get", "list", "put"]);
+          this._registerBindObject(this.my_str, host, []);
+        }
+        if (ops.includes("test_no_capture")) {
+        }
+        if (ops.includes("test_user_defined_resource")) {
+          this._registerBindObject(this.another, host, ["another_func", "meaning_of_life"]);
+        }
+        super._registerBind(host, ops);
+      }
     }
-    MyResource._annotateInflight("$inflight_init", {"this.another": { ops: [] },"this.array_of_str": { ops: [] },"this.ext_bucket": { ops: [] },"this.ext_num": { ops: [] },"this.map_of_num": { ops: [] },"this.my_bool": { ops: [] },"this.my_num": { ops: [] },"this.my_opt_str": { ops: [] },"this.my_queue": { ops: [] },"this.my_resource": { ops: [] },"this.my_str": { ops: [] },"this.set_of_str": { ops: [] },"this.stateful": { ops: [] },"this.unused_resource": { ops: [] }});
-    MyResource._annotateInflight("test_capture_collections_of_data", {"this.array_of_str": { ops: ["at","length"] },"this.map_of_num": { ops: ["get"] },"this.set_of_str": { ops: ["has"] }});
-    MyResource._annotateInflight("test_capture_optional", {"this.my_opt_str": { ops: [] }});
-    MyResource._annotateInflight("test_capture_primitives", {"this.my_bool": { ops: [] },"this.my_num": { ops: [] },"this.my_str": { ops: [] }});
-    MyResource._annotateInflight("test_capture_resource", {"this.my_resource": { ops: ["get","list","put"] }});
-    MyResource._annotateInflight("test_expression_recursive", {"this.my_queue": { ops: ["push"] },"this.my_str": { ops: [] }});
-    MyResource._annotateInflight("test_external", {"this.ext_bucket": { ops: ["list"] },"this.ext_num": { ops: [] }});
-    MyResource._annotateInflight("test_inflight_field", {});
-    MyResource._annotateInflight("test_nested_preflight_field", {"this.another.my_field": { ops: [] }});
-    MyResource._annotateInflight("test_nested_resource", {"this.another.first.my_resource": { ops: ["get","list","put"] },"this.my_str": { ops: [] }});
-    MyResource._annotateInflight("test_no_capture", {});
-    MyResource._annotateInflight("test_user_defined_resource", {"this.another": { ops: ["another_func","meaning_of_life"] }});
     const b = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this,"cloud.Bucket");
     const r = new MyResource(this,"MyResource",b,12);
     this.node.root.newAbstract("@winglang/sdk.cloud.Function",this,"test",new $stdlib.core.Inflight(this, "$Inflight1", {

--- a/tools/hangar/__snapshots__/test_corpus/resource_captures.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/resource_captures.w_compile_tf-aws.md
@@ -425,7 +425,6 @@ class $Root extends $stdlib.std.Resource {
     class First extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
-        this._addInflightOps();
         this.my_resource = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this,"cloud.Bucket");
       }
       _toInflight() {

--- a/tools/hangar/__snapshots__/test_corpus/resource_captures.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/resource_captures.w_compile_tf-aws.md
@@ -425,7 +425,7 @@ class $Root extends $stdlib.std.Resource {
     class First extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
-        this._inflightOps.push();
+        this._addInflightOps();
         this.my_resource = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this,"cloud.Bucket");
       }
       _toInflight() {
@@ -454,7 +454,7 @@ class $Root extends $stdlib.std.Resource {
     class Another extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
-        this._inflightOps.push("meaning_of_life", "another_func");
+        this._addInflightOps("meaning_of_life", "another_func");
         this.my_field = "hello!";
         this.first = new First(this,"First");
       }
@@ -491,7 +491,7 @@ class $Root extends $stdlib.std.Resource {
     class MyResource extends $stdlib.std.Resource {
       constructor(scope, id, external_bucket, external_num) {
         super(scope, id);
-        this._inflightOps.push("test_no_capture", "test_capture_collections_of_data", "test_capture_primitives", "test_capture_optional", "test_capture_resource", "test_nested_preflight_field", "test_nested_resource", "test_expression_recursive", "test_external", "test_user_defined_resource", "test_inflight_field");
+        this._addInflightOps("test_no_capture", "test_capture_collections_of_data", "test_capture_primitives", "test_capture_optional", "test_capture_resource", "test_nested_preflight_field", "test_nested_resource", "test_expression_recursive", "test_external", "test_user_defined_resource", "test_inflight_field");
         this.my_resource = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this,"cloud.Bucket");
         this.my_str = "my_string";
         this.my_num = 42;

--- a/tools/hangar/__snapshots__/test_corpus/static_members.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/static_members.w_compile_tf-aws.md
@@ -150,6 +150,7 @@ class $Root extends $stdlib.std.Resource {
     class Foo extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
+        this._inflightOps.push("get_123");
         this.instance_field = 100;
       }
       static m()  {
@@ -172,9 +173,16 @@ class $Root extends $stdlib.std.Resource {
           })())
         `);
       }
+      _registerBind(host, ops) {
+        if (ops.includes("$inflight_init")) {
+          this._registerBindObject(this.instance_field, host, []);
+          this._registerBindObject(this.stateful, host, []);
+        }
+        if (ops.includes("get_123")) {
+        }
+        super._registerBind(host, ops);
+      }
     }
-    Foo._annotateInflight("$inflight_init", {"this.instance_field": { ops: [] },"this.stateful": { ops: [] }});
-    Foo._annotateInflight("get_123", {});
     const foo = new Foo(this,"Foo");
     {((cond) => {if (!cond) throw new Error(`assertion failed: '(foo.instance_field === 100)'`)})((foo.instance_field === 100))};
     {((cond) => {if (!cond) throw new Error(`assertion failed: '((Foo.m()) === 99)'`)})(((Foo.m()) === 99))};

--- a/tools/hangar/__snapshots__/test_corpus/static_members.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/static_members.w_compile_tf-aws.md
@@ -150,7 +150,7 @@ class $Root extends $stdlib.std.Resource {
     class Foo extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
-        this._inflightOps.push("get_123");
+        this._addInflightOps("get_123");
         this.instance_field = 100;
       }
       static m()  {

--- a/tools/hangar/__snapshots__/test_corpus/structs.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/structs.w_compile_tf-aws.md
@@ -61,7 +61,7 @@ class $Root extends $stdlib.std.Resource {
     class Foo extends $stdlib.std.Resource {
       constructor(scope, id, b) {
         super(scope, id);
-        this._inflightOps.push("get_stuff");
+        this._addInflightOps("get_stuff");
         this.data = b;
       }
       _toInflight() {

--- a/tools/hangar/__snapshots__/test_corpus/structs.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/structs.w_compile_tf-aws.md
@@ -61,6 +61,7 @@ class $Root extends $stdlib.std.Resource {
     class Foo extends $stdlib.std.Resource {
       constructor(scope, id, b) {
         super(scope, id);
+        this._inflightOps.push("get_stuff");
         this.data = b;
       }
       _toInflight() {
@@ -78,9 +79,17 @@ class $Root extends $stdlib.std.Resource {
           })())
         `);
       }
+      _registerBind(host, ops) {
+        if (ops.includes("$inflight_init")) {
+          this._registerBindObject(this.data, host, []);
+          this._registerBindObject(this.stateful, host, []);
+        }
+        if (ops.includes("get_stuff")) {
+          this._registerBindObject(this.data.field0, host, []);
+        }
+        super._registerBind(host, ops);
+      }
     }
-    Foo._annotateInflight("$inflight_init", {"this.data": { ops: [] },"this.stateful": { ops: [] }});
-    Foo._annotateInflight("get_stuff", {"this.data.field0": { ops: [] }});
     const x = {
     "field0": "Sup",}
     ;

--- a/tools/hangar/__snapshots__/test_corpus/symbol_shadow.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/symbol_shadow.w_compile_tf-aws.md
@@ -339,7 +339,6 @@ class $Root extends $stdlib.std.Resource {
     class A extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
-        this._addInflightOps();
         const s = "in_resource";
         {((cond) => {if (!cond) throw new Error(`assertion failed: '(s === "in_resource")'`)})((s === "in_resource"))};
         this.node.root.newAbstract("@winglang/sdk.cloud.Function",this,"test:inflight in resource should capture the right scoped var",new $stdlib.core.Inflight(this, "$Inflight1", {

--- a/tools/hangar/__snapshots__/test_corpus/symbol_shadow.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/symbol_shadow.w_compile_tf-aws.md
@@ -339,6 +339,7 @@ class $Root extends $stdlib.std.Resource {
     class A extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
+        this._inflightOps.push();
         const s = "in_resource";
         {((cond) => {if (!cond) throw new Error(`assertion failed: '(s === "in_resource")'`)})((s === "in_resource"))};
         this.node.root.newAbstract("@winglang/sdk.cloud.Function",this,"test:inflight in resource should capture the right scoped var",new $stdlib.core.Inflight(this, "$Inflight1", {
@@ -365,8 +366,13 @@ class $Root extends $stdlib.std.Resource {
           })())
         `);
       }
+      _registerBind(host, ops) {
+        if (ops.includes("$inflight_init")) {
+          this._registerBindObject(this.stateful, host, []);
+        }
+        super._registerBind(host, ops);
+      }
     }
-    A._annotateInflight("$inflight_init", {"this.stateful": { ops: [] }});
     const s = "top";
     if (true) {
       const s = "inner";

--- a/tools/hangar/__snapshots__/test_corpus/symbol_shadow.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/symbol_shadow.w_compile_tf-aws.md
@@ -339,7 +339,7 @@ class $Root extends $stdlib.std.Resource {
     class A extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
-        this._inflightOps.push();
+        this._addInflightOps();
         const s = "in_resource";
         {((cond) => {if (!cond) throw new Error(`assertion failed: '(s === "in_resource")'`)})((s === "in_resource"))};
         this.node.root.newAbstract("@winglang/sdk.cloud.Function",this,"test:inflight in resource should capture the right scoped var",new $stdlib.core.Inflight(this, "$Inflight1", {


### PR DESCRIPTION
This PR removes some of the "magic" in the SDK that we had to support binding annotations.

The conceptual idea behind the binding system is simple: the compiler annotates each resource with a set of facts that each say "if operation X is used on this resource, then this resource transitively needs to use operations Y on Z". Then, the SDK uses the facts to `bind` each resource to the inflight host (typically a `cloud.Function`) that needs to use it. The `bind` method gives each resource an opportunity to grant IAM permissions, environment variables, or other capabilities to the inflight host based on what operations are being used on it.

For example, when an AWS `cloud.Bucket` is told that an inflight host wants to call `put` on it, it can grant the inflight host `s3:PutObject` permissions, and set an environment variable with the bucket's ARN.

We had a clever way of registering these facts into the system, where the static method `Resource._annotateInflight(<fact>)` would add a fact to a hidden property of the class that can be accessed by all class instances. Unfortunately it requires the facts to always describe **resources or data that belong to the class**, like `this.data` or `this.child_bucket`.

This approach has held up well so far, but it doesn't extend for cases where a resource needs to delegate the inflight host to bind to resources that are NOT field members -- such as for binding to a global bucket (see #1447). So instead, this PR rewinds our approach a bit so that resources override the `_registerBind` methods directly. This extends the amount of code in `preflight.js` files but I think it's an ok trade-off.

An `_addInflightOps` method has been added to maintain the existing behavior where if an inflight host requests to use operations from a resource that the resource does not support, it will still throw an error. (This is aimed to prevent hard-to-uncover compiler bugs in the future).

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.