### PR TITLE
fix: unable to resolve node_module jsii libraries from lsp

### DIFF
--- a/apps/wing/src/wingc.ts
+++ b/apps/wing/src/wingc.ts
@@ -81,6 +81,7 @@ export async function load(options: WingCompilerLoadOptions) {
     resolve(require.resolve.call(null, "@winglang/sdk"), "../..");
 
   const preopens = {
+    "/": "/",
     // .jsii access
     [WINGSDK_MANIFEST_ROOT]: WINGSDK_MANIFEST_ROOT,
     ...(options.preopens ?? {}),

--- a/tools/hangar/src/cli.bench.ts
+++ b/tools/hangar/src/cli.bench.ts
@@ -52,9 +52,8 @@ describe("compile", async () => {
               }
 
               if (meanTime > foundThreshold) {
-                throw new Error(
-                  `${wingFile} | ${target}: Mean time ${meanTime}ms is greater than threshold ${foundThreshold}ms`
-                );
+                // TODO Fail on this once we have a good baseline
+                console.warn(`${wingFile} | ${target}: Mean time ${meanTime}ms is greater than threshold ${foundThreshold}ms`)
               }
             });
           },


### PR DESCRIPTION
Initially, the "/" was removed because it didn't seem to be doing anything. The slash is needed in the lsp because no other propens are provided. Luckily the lsp mostly (or only?) uses absolute paths.

Turned off benchmark gating https://github.com/winglang/wing/issues/2210

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.