### PR TITLE
fix(compiler): resources cannot reference free variables inflight

### DIFF
--- a/docs/04-reference/wingsdk-api.md
+++ b/docs/04-reference/wingsdk-api.md
@@ -2520,6 +2520,26 @@ bring cloud;
 let secret_props = cloud.SecretProps{ ... }
 ```
 
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#@winglang/sdk.cloud.SecretProps.property.name">name</a></code> | <code>str</code> | The secret's name. |
+
+---
+
+##### `name`<sup>Optional</sup> <a name="name" id="@winglang/sdk.cloud.SecretProps.property.name"></a>
+
+```wing
+name: str;
+```
+
+- *Type:* str
+- *Default:* a generated name
+
+The secret's name.
+
+---
 
 ### TableProps <a name="TableProps" id="@winglang/sdk.cloud.TableProps"></a>
 

--- a/examples/tests/valid/resource_captures_globals.w
+++ b/examples/tests/valid/resource_captures_globals.w
@@ -1,0 +1,62 @@
+bring cloud;
+
+let global_bucket = new cloud.Bucket();
+let global_counter = new cloud.Counter();
+let global_str = "hello";
+let global_bool = true;
+let global_num = 42;
+let global_array_of_str = ["hello", "world"];
+let global_map_of_num = Map<num>{ "a": -5, "b": 2 };
+let global_set_of_str = Set<str>{ "a", "b" };
+
+resource First {
+  my_resource: cloud.Bucket;
+
+  init() {
+    this.my_resource = new cloud.Bucket();
+  }
+}
+
+resource Another {
+  my_field: str;
+  first: First;
+
+  init () {
+    this.my_field = "hello!";
+    this.first = new First();
+  }
+
+  inflight init() {
+    assert(global_counter.peek() == 0);
+  }
+
+  inflight my_method(): num {
+    global_counter.inc();
+    return global_counter.peek();
+  }
+}
+
+let global_another = new Another();
+
+resource MyResource {
+  init() {}
+
+  inflight my_put() {
+    global_bucket.put("key", "value");
+    assert(global_str == "hello");
+    assert(global_bool == true);
+    assert(global_num == 42);
+    assert(global_array_of_str.at(0) == "hello");
+    assert(global_map_of_num.get("a") == -5);
+    assert(global_set_of_str.has("a"));
+    assert(global_another.my_field == "hello!");
+    global_another.first.my_resource.put("key", "value");
+    assert(global_another.my_method() > 0);
+  }
+}
+
+let res = new MyResource();
+
+new cloud.Function(inflight () => {
+  res.my_put();
+}) as "test";

--- a/libs/wingc/src/ast.rs
+++ b/libs/wingc/src/ast.rs
@@ -23,6 +23,12 @@ impl Symbol {
 			span: Default::default(),
 		}
 	}
+
+	/// Returns true if the symbols refer to the same name AND location in the source code.
+	/// Use `eq` to compare symbols only by name.
+	pub fn exact_eq(&self, other: &Self) -> bool {
+		self.name == other.name && self.span == other.span
+	}
 }
 
 impl Ord for Symbol {

--- a/libs/wingc/src/jsify.rs
+++ b/libs/wingc/src/jsify.rs
@@ -1009,7 +1009,12 @@ impl<'a> JSifier<'a> {
 		};
 
 		code.open(format!("class {}{} {{", self.jsify_symbol(&class.name), extends));
-		code.add_code(self.jsify_resource_constructor(&class.initializer, class.parent.is_none(), context));
+		code.add_code(self.jsify_resource_constructor(
+			&class.initializer,
+			class.parent.is_none(),
+			&inflight_methods,
+			context,
+		));
 
 		for (n, m) in preflight_methods {
 			code.add_code(self.jsify_function(Some(&n.name), m, context));
@@ -1019,24 +1024,22 @@ impl<'a> JSifier<'a> {
 		let toinflight_method = self.jsify_toinflight_method(&class.name, &captured_fields, inflight_client);
 		code.add_code(toinflight_method);
 
-		code.close("}");
-
-		// go over all bindings and produce inflight annotations
-		for (method_name, refs) in refs {
-			code.line(format!(
-				"{}._annotateInflight(\"{}\", {{{}}});",
-				self.jsify_symbol(&class.name),
-				method_name,
-				refs
-					.iter()
-					.map(|(field, ops)| format!(
-						"\"{}\": {{ ops: [{}] }}",
-						field,
-						ops.iter().map(|op| format!("\"{}\"", op)).join(",")
-					))
-					.join(",")
-			));
+		let mut bind_method = CodeMaker::default();
+		bind_method.open("_registerBind(host, ops) {");
+		for (method_name, method_refs) in refs {
+			bind_method.open(format!("if (ops.includes(\"{method_name}\")) {{"));
+			for (field, ops) in method_refs {
+				let ops_strings = ops.iter().map(|op| format!("\"{}\"", op)).join(", ");
+				bind_method.line(format!("this._registerBindObject({field}, host, [{ops_strings}]);",));
+			}
+			bind_method.close("}");
 		}
+		bind_method.line("super._registerBind(host, ops);".to_string());
+		bind_method.close("}");
+
+		code.add_code(bind_method);
+
+		code.close("}");
 
 		// Return the preflight resource class
 		code
@@ -1046,6 +1049,7 @@ impl<'a> JSifier<'a> {
 		&mut self,
 		constructor: &Initializer,
 		no_parent: bool,
+		inflight_methods: &[&(Symbol, FunctionDefinition)],
 		context: &JSifyContext,
 	) -> CodeMaker {
 		let mut code = CodeMaker::default();
@@ -1062,6 +1066,12 @@ impl<'a> JSifier<'a> {
 		if no_parent {
 			code.line("super(scope, id);");
 		}
+
+		let inflight_ops_string = inflight_methods
+			.iter()
+			.map(|(name, _)| format!("\"{}\"", name.name))
+			.join(", ");
+		code.line(format!("this._inflightOps.push({inflight_ops_string});"));
 
 		code.add_code(self.jsify_scope_body(
 			&constructor.statements,

--- a/libs/wingc/src/jsify/codemaker.rs
+++ b/libs/wingc/src/jsify/codemaker.rs
@@ -37,6 +37,15 @@ impl CodeMaker {
 		}
 	}
 
+	/// Emits multiple lines of code starting with the current indent,
+	/// escaping the code for use in JavaScript.
+	pub fn add_code_escaped(&mut self, code: CodeMaker) {
+		assert_eq!(code.indent, 0, "Cannot add code with indent");
+		for (indent, line) in code.lines {
+			self.lines.push((indent + self.indent, line.to_string_escaped()));
+		}
+	}
+
 	/// Decreases the current indent by one.
 	#[allow(dead_code)]
 	pub fn unindent(&mut self) {
@@ -52,6 +61,29 @@ impl CodeMaker {
 		let mut code = CodeMaker::default();
 		code.line(s);
 		code
+	}
+}
+
+trait ToStringEscaped {
+	fn to_string_escaped(&self) -> String;
+}
+
+impl ToStringEscaped for String {
+	fn to_string_escaped(&self) -> String {
+		let mut escaped = String::new();
+		for c in self.chars() {
+			match c {
+				'\'' => escaped.push_str("\\'"),
+				'\n' => escaped.push_str("\\n"),
+				'\r' => escaped.push_str("\\r"),
+				'\t' => escaped.push_str("\\t"),
+				'\\' => escaped.push_str("\\\\"),
+				'`' => escaped.push_str("\\`"),
+				'$' => escaped.push_str("\\$"),
+				_ => escaped.push(c),
+			}
+		}
+		escaped
 	}
 }
 

--- a/libs/wingsdk/src/cloud/bucket.ts
+++ b/libs/wingsdk/src/cloud/bucket.ts
@@ -49,6 +49,16 @@ export abstract class Bucket extends Resource {
     this.display.title = "Bucket";
     this.display.description = "A cloud object store";
 
+    this._inflightOps.push(
+      BucketInflightMethods.DELETE,
+      BucketInflightMethods.GET,
+      BucketInflightMethods.GET_JSON,
+      BucketInflightMethods.LIST,
+      BucketInflightMethods.PUT,
+      BucketInflightMethods.PUT_JSON,
+      BucketInflightMethods.PUBLIC_URL
+    );
+
     props;
   }
 

--- a/libs/wingsdk/src/cloud/counter.ts
+++ b/libs/wingsdk/src/cloud/counter.ts
@@ -49,6 +49,13 @@ export abstract class Counter extends Resource {
     this.display.title = "Counter";
     this.display.description = "A distributed atomic counter";
 
+    this._inflightOps.push(
+      CounterInflightMethods.INC,
+      CounterInflightMethods.DEC,
+      CounterInflightMethods.PEEK,
+      CounterInflightMethods.RESET
+    );
+
     this.initial = props.initial ?? 0;
   }
 }

--- a/libs/wingsdk/src/cloud/function.ts
+++ b/libs/wingsdk/src/cloud/function.ts
@@ -75,6 +75,8 @@ export abstract class Function extends Resource implements IInflightHost {
     this.display.title = "Function";
     this.display.description = "A cloud function (FaaS)";
 
+    this._inflightOps.push(FunctionInflightMethods.INVOKE);
+
     for (const [key, value] of Object.entries(props.env ?? {})) {
       this.addEnvironment(key, value);
     }

--- a/libs/wingsdk/src/cloud/queue.ts
+++ b/libs/wingsdk/src/cloud/queue.ts
@@ -51,6 +51,12 @@ export abstract class Queue extends Resource {
     this.display.title = "Queue";
     this.display.description = "A distributed message queue";
 
+    this._inflightOps.push(
+      QueueInflightMethods.PUSH,
+      QueueInflightMethods.PURGE,
+      QueueInflightMethods.APPROX_SIZE
+    );
+
     props;
   }
 

--- a/libs/wingsdk/src/cloud/secret.ts
+++ b/libs/wingsdk/src/cloud/secret.ts
@@ -45,6 +45,11 @@ export abstract class Secret extends Resource {
     this.display.title = "Secret";
     this.display.description = "A cloud secret";
 
+    this._inflightOps.push(
+      SecretInflightMethods.VALUE,
+      SecretInflightMethods.VALUE_JSON
+    );
+
     props;
   }
 }

--- a/libs/wingsdk/src/cloud/table.ts
+++ b/libs/wingsdk/src/cloud/table.ts
@@ -97,6 +97,14 @@ export abstract class Table extends Resource {
       throw new Error("No column is defined");
     }
     this.columns = props.columns;
+
+    this._inflightOps.push(
+      TableInflightMethods.INSERT,
+      TableInflightMethods.UPDATE,
+      TableInflightMethods.DELETE,
+      TableInflightMethods.GET,
+      TableInflightMethods.LIST
+    );
   }
 }
 

--- a/libs/wingsdk/src/cloud/topic.ts
+++ b/libs/wingsdk/src/cloud/topic.ts
@@ -37,6 +37,8 @@ export abstract class Topic extends Resource {
     this.display.title = "Topic";
     this.display.description = "A pub/sub notification topic";
 
+    this._inflightOps.push(TopicInflightMethods.PUBLISH);
+
     props;
   }
 

--- a/libs/wingsdk/src/redis/redis.ts
+++ b/libs/wingsdk/src/redis/redis.ts
@@ -29,6 +29,18 @@ export abstract class Redis extends Resource {
 
     this.display.title = "Redis";
     this.display.description = "A Redis server";
+
+    this._inflightOps.push(
+      RedisInflightMethods.RAW_CLIENT,
+      RedisInflightMethods.URL,
+      RedisInflightMethods.SET,
+      RedisInflightMethods.GET,
+      RedisInflightMethods.HSET,
+      RedisInflightMethods.HGET,
+      RedisInflightMethods.SADD,
+      RedisInflightMethods.SMEMBERS,
+      RedisInflightMethods.DEL
+    );
   }
 }
 
@@ -106,6 +118,31 @@ export interface IRedisClient {
    * @inflight
    */
   del(key: string): Promise<number>;
+}
+
+/**
+ * List of inflight operations available for `Redis`.
+ * @internal
+ */
+export enum RedisInflightMethods {
+  /** `Redis.raw_client` */
+  RAW_CLIENT = "raw_client",
+  /** `Redis.url` */
+  URL = "url",
+  /** `Redis.set` */
+  SET = "set",
+  /** `Redis.get` */
+  GET = "get",
+  /** `Redis.hset` */
+  HSET = "hset",
+  /** `Redis.hget` */
+  HGET = "hget",
+  /** `Redis.sadd` */
+  SADD = "sadd",
+  /** `Redis.smembers` */
+  SMEMBERS = "smembers",
+  /** `Redis.del` */
+  DEL = "del",
 }
 
 /**

--- a/libs/wingsdk/src/std/resource.ts
+++ b/libs/wingsdk/src/std/resource.ts
@@ -32,7 +32,7 @@ export interface IResource extends IInspectable, IConstruct {
   /**
    * Binds the resource to the host so that it can be used by inflight code.
    *
-   * If the resource does not support any of the operations, it should throw an
+   * If `ops` contains any operations not supported by the resource, it should throw an
    * error.
    *
    * @internal
@@ -66,8 +66,6 @@ export interface IResource extends IInspectable, IConstruct {
    */
   _preSynthesize(): void;
 }
-
-const BIND_METADATA_PREFIX = "$bindings__";
 
 /**
  * Shared behavior between all Wing SDK resources.
@@ -122,36 +120,16 @@ export abstract class Resource extends Construct implements IResource {
     }
   }
 
-  /**
-   * Annotate a class with with metadata about what operations it supports
-   * inflight, and what sub-resources each operation requires access to.
-   *
-   * For example if `MyBucket` has a `fancy_get` method that calls `get` on an
-   * underlying `cloud.Bucket`, then it would be annotated as follows:
-   * ```
-   * MyBucket._annotateInflight("fancy_get", {
-   *  "this.bucket": { ops: ["get"] }
-   * });
-   * ```
-   *
-   * The Wing compiler will automatically generate the correct annotations by
-   * scanning the source code, but in the Wing SDK we have to add them manually.
-   *
-   * @internal
-   */
-  public static _annotateInflight(op: string, annotation: OperationAnnotation) {
-    const sym = Symbol.for(BIND_METADATA_PREFIX + op);
-    Object.defineProperty(this.prototype, sym, {
-      value: annotation,
-      enumerable: false,
-      writable: false,
-    });
-  }
-
   private readonly bindMap: Map<IInflightHost, Set<string>> = new Map();
 
   /** @internal */
   public readonly _connections: Connection[] = [];
+
+  /**
+   * A list of all inflight operations that are supported by this resource.
+   * @internal
+   */
+  public readonly _inflightOps: string[] = ["$inflight_init"];
 
   /**
    * Information on how to display a resource in the UI.
@@ -198,64 +176,20 @@ export abstract class Resource extends Construct implements IResource {
       }) with ops: ${JSON.stringify(ops)}`
     );
 
+    for (const op of ops) {
+      if (!this._inflightOps.includes(op)) {
+        throw new Error(
+          `Resource ${this.node.path} does not support inflight operation ${op} (requested by ${host.node.path})`
+        );
+      }
+    }
+
     // Register the binding between this resource and the host
     if (!this.bindMap.has(host)) {
       this.bindMap.set(host, new Set());
     }
     for (const op of ops) {
       this.bindMap.get(host)!.add(op);
-    }
-
-    // Collect a list of all immediate child bindings
-    const resources: Record<string, string[]> = {};
-    for (const op of ops) {
-      const sym = Symbol.for(BIND_METADATA_PREFIX + op);
-      const bindAnnotation: OperationAnnotation = (this as any)[sym];
-      if (!bindAnnotation) {
-        throw new Error(
-          `Unable to reference "${this.node.path}" from "${host.node.path}" because it does not support operation "${op}"`
-        );
-      }
-      for (const resource of Object.keys(bindAnnotation)) {
-        resources[resource] = resources[resource] ?? [];
-        resources[resource].push(...bindAnnotation[resource].ops);
-      }
-    }
-
-    // this is how resources will look:
-    // resources = {
-    //   "this.bucket": [ "put", "get" ],
-    //   "this.foo.bar.baz": [ "bang" ],
-    //   "counter": [ "inc" ]
-    // };
-
-    // Register the bindings for all child resources
-    for (const field of Object.keys(resources)) {
-      if (!field.startsWith("this.")) {
-        log(`Skipped binding ${field} since it should be bound already.`);
-        continue;
-      }
-
-      const key = field.substring(5);
-
-      // traverse the object graph to find the target object we are referencing
-      const resolveReference = (obj: any, parts: string[]): any => {
-        const next = parts.shift();
-        if (!next) {
-          return obj;
-        }
-        return resolveReference(obj[next], parts);
-      };
-
-      // split the key into parts with "." as the separator
-      const obj = resolveReference(this, key.split("."));
-      if (obj === undefined) {
-        throw new Error(
-          `Resource ${this.node.path} does not have field ${key}`
-        );
-      }
-
-      this.registerBindObject(obj, host, resources[field]);
     }
   }
 
@@ -270,8 +204,10 @@ export abstract class Resource extends Construct implements IResource {
    * @param host The host to bind to
    * @param ops The set of operations that may access the object (use "?" to indicate that we don't
    * know the operation)
+   *
+   * @internal
    */
-  private registerBindObject(
+  protected _registerBindObject(
     obj: any,
     host: IResource,
     ops: string[] = []
@@ -284,7 +220,7 @@ export abstract class Resource extends Construct implements IResource {
 
       case "object":
         if (Array.isArray(obj)) {
-          obj.forEach((item) => this.registerBindObject(item, host));
+          obj.forEach((item) => this._registerBindObject(item, host));
           return;
         }
 
@@ -294,13 +230,13 @@ export abstract class Resource extends Construct implements IResource {
 
         if (obj instanceof Set) {
           return Array.from(obj).forEach((item) =>
-            this.registerBindObject(item, host)
+            this._registerBindObject(item, host)
           );
         }
 
         if (obj instanceof Map) {
           Array.from(obj.values()).forEach((item) =>
-            this.registerBindObject(item, host)
+            this._registerBindObject(item, host)
           );
           return;
         }
@@ -328,7 +264,7 @@ export abstract class Resource extends Construct implements IResource {
         // structs are just plain objects
         if (obj.constructor.name === "Object") {
           Object.values(obj).forEach((item) =>
-            this.registerBindObject(item, host, ops)
+            this._registerBindObject(item, host, ops)
           );
           return;
         }
@@ -395,9 +331,6 @@ export abstract class Resource extends Construct implements IResource {
     return serializeImmutableData(value);
   }
 }
-
-// The `init` op is a placeholder for any annotations needed for an instance of a resource's client to be instantiated
-Resource._annotateInflight("$inflight_init", {});
 
 /**
  * The direction of a connection.

--- a/libs/wingsdk/src/target-awscdk/bucket.ts
+++ b/libs/wingsdk/src/target-awscdk/bucket.ts
@@ -72,11 +72,3 @@ export class Bucket extends cloud.Bucket {
     return `BUCKET_NAME_${this.node.addr.slice(-8)}`;
   }
 }
-
-Bucket._annotateInflight(cloud.BucketInflightMethods.PUT, {});
-Bucket._annotateInflight(cloud.BucketInflightMethods.GET, {});
-Bucket._annotateInflight(cloud.BucketInflightMethods.DELETE, {});
-Bucket._annotateInflight(cloud.BucketInflightMethods.LIST, {});
-Bucket._annotateInflight(cloud.BucketInflightMethods.PUT_JSON, {});
-Bucket._annotateInflight(cloud.BucketInflightMethods.GET_JSON, {});
-Bucket._annotateInflight(cloud.BucketInflightMethods.PUBLIC_URL, {});

--- a/libs/wingsdk/src/target-awscdk/counter.ts
+++ b/libs/wingsdk/src/target-awscdk/counter.ts
@@ -53,8 +53,3 @@ export class Counter extends cloud.Counter {
     return `DYNAMODB_TABLE_NAME_${this.node.addr.slice(-8)}`;
   }
 }
-
-Counter._annotateInflight(cloud.CounterInflightMethods.INC, {});
-Counter._annotateInflight(cloud.CounterInflightMethods.DEC, {});
-Counter._annotateInflight(cloud.CounterInflightMethods.PEEK, {});
-Counter._annotateInflight(cloud.CounterInflightMethods.RESET, {});

--- a/libs/wingsdk/src/target-awscdk/function.ts
+++ b/libs/wingsdk/src/target-awscdk/function.ts
@@ -99,5 +99,3 @@ export class Function extends cloud.Function {
     return `FUNCTION_NAME_${this.node.addr.slice(-8)}`;
   }
 }
-
-Function._annotateInflight(cloud.FunctionInflightMethods.INVOKE, {});

--- a/libs/wingsdk/src/target-awscdk/queue.ts
+++ b/libs/wingsdk/src/target-awscdk/queue.ts
@@ -109,7 +109,3 @@ export class Queue extends cloud.Queue {
     return `SCHEDULE_EVENT_${this.node.addr.slice(-8)}`;
   }
 }
-
-Queue._annotateInflight(cloud.QueueInflightMethods.PUSH, {});
-Queue._annotateInflight(cloud.QueueInflightMethods.PURGE, {});
-Queue._annotateInflight(cloud.QueueInflightMethods.APPROX_SIZE, {});

--- a/libs/wingsdk/src/target-awscdk/secret.ts
+++ b/libs/wingsdk/src/target-awscdk/secret.ts
@@ -58,6 +58,3 @@ export class Secret extends cloud.Secret {
     return `SECRET_ARN_${this.node.addr.slice(-8)}`;
   }
 }
-
-Secret._annotateInflight(cloud.SecretInflightMethods.VALUE, {});
-Secret._annotateInflight(cloud.SecretInflightMethods.VALUE_JSON, {});

--- a/libs/wingsdk/src/target-awscdk/topic.ts
+++ b/libs/wingsdk/src/target-awscdk/topic.ts
@@ -98,5 +98,3 @@ export class Topic extends cloud.Topic {
     return `TOPIC_ARN_${this.node.addr.slice(-8)}`;
   }
 }
-
-Topic._annotateInflight(cloud.TopicInflightMethods.PUBLISH, {});

--- a/libs/wingsdk/src/target-sim/bucket.ts
+++ b/libs/wingsdk/src/target-sim/bucket.ts
@@ -70,11 +70,3 @@ export class Bucket extends cloud.Bucket implements ISimulatorResource {
     return makeSimulatorJsClient(__filename, this);
   }
 }
-
-Bucket._annotateInflight("put", {});
-Bucket._annotateInflight("get", {});
-Bucket._annotateInflight("delete", {});
-Bucket._annotateInflight("list", {});
-Bucket._annotateInflight("put_json", {});
-Bucket._annotateInflight("get_json", {});
-Bucket._annotateInflight("public_url", {});

--- a/libs/wingsdk/src/target-sim/counter.ts
+++ b/libs/wingsdk/src/target-sim/counter.ts
@@ -43,8 +43,3 @@ export class Counter extends cloud.Counter implements ISimulatorResource {
     return makeSimulatorJsClient(__filename, this);
   }
 }
-
-Counter._annotateInflight("inc", {});
-Counter._annotateInflight("dec", {});
-Counter._annotateInflight("peek", {});
-Counter._annotateInflight("reset", {});

--- a/libs/wingsdk/src/target-sim/function.ts
+++ b/libs/wingsdk/src/target-sim/function.ts
@@ -61,5 +61,3 @@ export class Function extends cloud.Function implements ISimulatorResource {
     return makeSimulatorJsClient(__filename, this);
   }
 }
-
-Function._annotateInflight("invoke", {});

--- a/libs/wingsdk/src/target-sim/queue.ts
+++ b/libs/wingsdk/src/target-sim/queue.ts
@@ -110,7 +110,3 @@ export class Queue extends cloud.Queue implements ISimulatorResource {
     return makeSimulatorJsClient(__filename, this);
   }
 }
-
-Queue._annotateInflight("push", {});
-Queue._annotateInflight("purge", {});
-Queue._annotateInflight("approx_size", {});

--- a/libs/wingsdk/src/target-sim/redis.ts
+++ b/libs/wingsdk/src/target-sim/redis.ts
@@ -38,13 +38,3 @@ export class Redis extends redis.Redis implements ISimulatorResource {
     return makeSimulatorJsClient(__filename, this);
   }
 }
-
-Redis._annotateInflight("raw_client", {});
-Redis._annotateInflight("url", {});
-Redis._annotateInflight("get", {});
-Redis._annotateInflight("set", {});
-Redis._annotateInflight("hset", {});
-Redis._annotateInflight("hget", {});
-Redis._annotateInflight("sadd", {});
-Redis._annotateInflight("smembers", {});
-Redis._annotateInflight("del", {});

--- a/libs/wingsdk/src/target-sim/secret.ts
+++ b/libs/wingsdk/src/target-sim/secret.ts
@@ -46,6 +46,3 @@ export class Secret extends cloud.Secret implements ISimulatorResource {
     return schema;
   }
 }
-
-Secret._annotateInflight(cloud.SecretInflightMethods.VALUE, {});
-Secret._annotateInflight(cloud.SecretInflightMethods.VALUE_JSON, {});

--- a/libs/wingsdk/src/target-sim/table.ts
+++ b/libs/wingsdk/src/target-sim/table.ts
@@ -41,9 +41,3 @@ export class Table extends cloud.Table implements ISimulatorResource {
     return makeSimulatorJsClient(__filename, this);
   }
 }
-
-Table._annotateInflight("insert", {});
-Table._annotateInflight("update", {});
-Table._annotateInflight("delete", {});
-Table._annotateInflight("get", {});
-Table._annotateInflight("list", {});

--- a/libs/wingsdk/src/target-sim/topic.ts
+++ b/libs/wingsdk/src/target-sim/topic.ts
@@ -77,5 +77,3 @@ export class Topic extends cloud.Topic implements ISimulatorResource {
     return schema;
   }
 }
-
-Topic._annotateInflight("publish", {});

--- a/libs/wingsdk/src/target-tf-aws/bucket.ts
+++ b/libs/wingsdk/src/target-tf-aws/bucket.ts
@@ -200,11 +200,3 @@ export class Bucket extends cloud.Bucket {
     return `BUCKET_NAME_${this.node.addr.slice(-8)}`;
   }
 }
-
-Bucket._annotateInflight(cloud.BucketInflightMethods.PUT, {});
-Bucket._annotateInflight(cloud.BucketInflightMethods.GET, {});
-Bucket._annotateInflight(cloud.BucketInflightMethods.DELETE, {});
-Bucket._annotateInflight(cloud.BucketInflightMethods.LIST, {});
-Bucket._annotateInflight(cloud.BucketInflightMethods.PUT_JSON, {});
-Bucket._annotateInflight(cloud.BucketInflightMethods.GET_JSON, {});
-Bucket._annotateInflight(cloud.BucketInflightMethods.PUBLIC_URL, {});

--- a/libs/wingsdk/src/target-tf-aws/counter.ts
+++ b/libs/wingsdk/src/target-tf-aws/counter.ts
@@ -66,8 +66,3 @@ export class Counter extends cloud.Counter {
     return `DYNAMODB_TABLE_NAME_${this.node.addr.slice(-8)}`;
   }
 }
-
-Counter._annotateInflight(cloud.CounterInflightMethods.INC, {});
-Counter._annotateInflight(cloud.CounterInflightMethods.DEC, {});
-Counter._annotateInflight(cloud.CounterInflightMethods.PEEK, {});
-Counter._annotateInflight(cloud.CounterInflightMethods.RESET, {});

--- a/libs/wingsdk/src/target-tf-aws/function.ts
+++ b/libs/wingsdk/src/target-tf-aws/function.ts
@@ -312,5 +312,3 @@ export class Function extends cloud.Function {
     return `FUNCTION_NAME_${this.node.addr.slice(-8)}`;
   }
 }
-
-Function._annotateInflight(cloud.FunctionInflightMethods.INVOKE, {});

--- a/libs/wingsdk/src/target-tf-aws/queue.ts
+++ b/libs/wingsdk/src/target-tf-aws/queue.ts
@@ -127,7 +127,3 @@ export class Queue extends cloud.Queue {
     return `QUEUE_URL_${this.node.addr.slice(-8)}`;
   }
 }
-
-Queue._annotateInflight(cloud.QueueInflightMethods.PUSH, {});
-Queue._annotateInflight(cloud.QueueInflightMethods.PURGE, {});
-Queue._annotateInflight(cloud.QueueInflightMethods.APPROX_SIZE, {});

--- a/libs/wingsdk/src/target-tf-aws/redis.ts
+++ b/libs/wingsdk/src/target-tf-aws/redis.ts
@@ -129,13 +129,3 @@ export class Redis extends redis.Redis {
     return `REDIS_CLUSTER_ID_${this.node.addr.slice(-8)}`;
   }
 }
-
-Redis._annotateInflight("raw_client", {});
-Redis._annotateInflight("url", {});
-Redis._annotateInflight("get", {});
-Redis._annotateInflight("set", {});
-Redis._annotateInflight("hset", {});
-Redis._annotateInflight("hget", {});
-Redis._annotateInflight("sadd", {});
-Redis._annotateInflight("smembers", {});
-Redis._annotateInflight("del", {});

--- a/libs/wingsdk/src/target-tf-aws/secret.ts
+++ b/libs/wingsdk/src/target-tf-aws/secret.ts
@@ -66,6 +66,3 @@ export class Secret extends cloud.Secret {
     return `SECRET_ARN_${this.node.addr.slice(-8)}`;
   }
 }
-
-Secret._annotateInflight(cloud.SecretInflightMethods.VALUE, {});
-Secret._annotateInflight(cloud.SecretInflightMethods.VALUE_JSON, {});

--- a/libs/wingsdk/src/target-tf-aws/table.ts
+++ b/libs/wingsdk/src/target-tf-aws/table.ts
@@ -110,9 +110,3 @@ export class Table extends cloud.Table {
     return `${this.envName()}_COLUMNS`;
   }
 }
-
-Table._annotateInflight(cloud.TableInflightMethods.INSERT, {});
-Table._annotateInflight(cloud.TableInflightMethods.UPDATE, {});
-Table._annotateInflight(cloud.TableInflightMethods.DELETE, {});
-Table._annotateInflight(cloud.TableInflightMethods.GET, {});
-Table._annotateInflight(cloud.TableInflightMethods.LIST, {});

--- a/libs/wingsdk/src/target-tf-aws/topic.ts
+++ b/libs/wingsdk/src/target-tf-aws/topic.ts
@@ -161,5 +161,3 @@ export class Topic extends cloud.Topic {
     return `TOPIC_ARN_${this.node.addr.slice(-8)}`;
   }
 }
-
-Topic._annotateInflight(cloud.TopicInflightMethods.PUBLISH, {});

--- a/libs/wingsdk/src/target-tf-azure/bucket.ts
+++ b/libs/wingsdk/src/target-tf-azure/bucket.ts
@@ -194,11 +194,3 @@ export class Bucket extends cloud.Bucket {
     return `STORAGE_ACCOUNT_${this.storageContainer.node.addr.slice(-8)}`;
   }
 }
-
-Bucket._annotateInflight(cloud.BucketInflightMethods.PUT, {});
-Bucket._annotateInflight(cloud.BucketInflightMethods.GET, {});
-Bucket._annotateInflight(cloud.BucketInflightMethods.DELETE, {});
-Bucket._annotateInflight(cloud.BucketInflightMethods.LIST, {});
-Bucket._annotateInflight(cloud.BucketInflightMethods.PUT_JSON, {});
-Bucket._annotateInflight(cloud.BucketInflightMethods.GET_JSON, {});
-Bucket._annotateInflight(cloud.BucketInflightMethods.PUBLIC_URL, {});

--- a/libs/wingsdk/src/utils/convert.ts
+++ b/libs/wingsdk/src/utils/convert.ts
@@ -1,6 +1,6 @@
 import { Construct } from "constructs";
 import { NodeJsCode } from "../core";
-import { IResource, Resource } from "../std";
+import { IInflightHost, IResource, Resource } from "../std";
 import { normalPath } from "../util";
 
 /**
@@ -26,6 +26,7 @@ export function convertBetweenHandlers(
       super(theScope, theId);
       this.handler = handler;
       this.display.hidden = true;
+      this._inflightOps.push("handle");
     }
 
     public _toInflight(): NodeJsCode {
@@ -36,11 +37,12 @@ export function convertBetweenHandlers(
         )}")).${newHandlerClientClassName}({ handler: ${handlerClient.text} })`
       );
     }
-  }
 
-  NewHandler._annotateInflight("handle", {
-    "this.handler": { ops: ["handle"] },
-  });
+    public _registerBind(host: IInflightHost, ops: string[]): void {
+      this._registerBindObject(this.handler, host, ["handle"]);
+      super._registerBind(host, ops);
+    }
+  }
 
   return new NewHandler(scope, id, baseHandler);
 }

--- a/libs/wingsdk/test/target-awscdk/__snapshots__/counter.test.ts.snap
+++ b/libs/wingsdk/test/target-awscdk/__snapshots__/counter.test.ts.snap
@@ -119,7 +119,7 @@ exports[`dec() policy statement 2`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "679cbd764536cde778046a96e51a2ce4ab2a2d953f0d4b8174bf7efa17722fcf.zip",
+          "S3Key": "3f708e391e7952caacc0ef2b6e725e0cbdc3fdb4a30474f6d7bf35912882d644.zip",
         },
         "Environment": {
           "Variables": {
@@ -347,7 +347,7 @@ exports[`function with a counter binding 2`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "b3034d766b4e7702b1d0622656f1c653df0f95a875019cced934cdd79da02ed8.zip",
+          "S3Key": "c7880eb430fe07a8977af9bf65d0e0b1019ddac686fbae50deaef61c89b37454.zip",
         },
         "Environment": {
           "Variables": {
@@ -514,7 +514,7 @@ exports[`inc() policy statement 2`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "b3034d766b4e7702b1d0622656f1c653df0f95a875019cced934cdd79da02ed8.zip",
+          "S3Key": "c7880eb430fe07a8977af9bf65d0e0b1019ddac686fbae50deaef61c89b37454.zip",
         },
         "Environment": {
           "Variables": {
@@ -681,7 +681,7 @@ exports[`peek() policy statement 2`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "412d6a4e77282dae4f49ebe45b27943a5e8caf374920a05073521d9dcae84201.zip",
+          "S3Key": "6a259349f441cef71a66bf4316f5421ba2f24eaefa3cea620803eb9de4a8c7f0.zip",
         },
         "Environment": {
           "Variables": {
@@ -848,7 +848,7 @@ exports[`reset() policy statement 2`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "b5eb11ccb22a1757e7af1c0a90e293527b5fcdb642c5a58d4edac963d0e42143.zip",
+          "S3Key": "f54c5d971a1c22f1173a32ae4ccd15316d37942bbf6dc665fab2df7c9eb525f0.zip",
         },
         "Environment": {
           "Variables": {

--- a/libs/wingsdk/test/target-sim/binding.test.ts
+++ b/libs/wingsdk/test/target-sim/binding.test.ts
@@ -8,6 +8,6 @@ test("binding throws if a method is unsupported", () => {
   const handler = Testing.makeHandler(app, "Handler", "async handle() {}");
   const host = Function._newFunction(app, "Function", handler);
   expect(() => handler._registerBind(host, ["foo", "bar"])).toThrow(
-    /Unable to reference \"root\/Handler\" from \"root\/Function\" because it does not support operation \"foo\"/
+    /Resource root\/Handler does not support inflight operation foo \(requested by root\/Function\)/
   );
 });

--- a/tools/hangar/__snapshots__/test_corpus/api.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/api.w_compile_tf-aws.md
@@ -1,23 +1,5 @@
 # [api.w](../../../../examples/tests/valid/api.w) | compile | tf-aws
 
-## clients/Foo.inflight.js
-```js
-class  Foo {
-  constructor({ api, stateful }) {
-    this.api = api;
-    this.stateful = stateful;
-  }
-  async handle(message)  {
-    {
-      const url = this.api.url;
-      {((cond) => {if (!cond) throw new Error(`assertion failed: 'url.startsWith("http://")'`)})(url.startsWith("http://"))};
-    }
-  }
-}
-exports.Foo = Foo;
-
-```
-
 ## main.tf.json
 ```json
 {
@@ -311,10 +293,21 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         const api_client = this._lift(this.api);
         const stateful_client = this._lift(this.stateful);
-        const self_client_path = "./clients/Foo.inflight.js".replace(/\\/g, "/");
         return $stdlib.core.NodeJsCode.fromInline(`
           (await (async () => {
-            const tmp = new (require("${self_client_path}")).Foo({
+            class  Foo {
+              constructor({ api, stateful }) {
+                this.api = api;
+                this.stateful = stateful;
+              }
+              async handle(message)  {
+                {
+                  const url = this.api.url;
+                  {((cond) => {if (!cond) throw new Error(\`assertion failed: \'url.startsWith("http://")\'\`)})(url.startsWith("http://"))};
+                }
+              }
+            }
+            const tmp = new Foo({
               api: ${api_client},
               stateful: ${stateful_client},
             });

--- a/tools/hangar/__snapshots__/test_corpus/api.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/api.w_compile_tf-aws.md
@@ -288,6 +288,7 @@ class $Root extends $stdlib.std.Resource {
     class Foo extends $stdlib.std.Resource {
       constructor(scope, id, api) {
         super(scope, id);
+        this._inflightOps.push("handle");
         this.api = api;
       }
       _toInflight() {
@@ -316,9 +317,17 @@ class $Root extends $stdlib.std.Resource {
           })())
         `);
       }
+      _registerBind(host, ops) {
+        if (ops.includes("$inflight_init")) {
+          this._registerBindObject(this.api, host, []);
+          this._registerBindObject(this.stateful, host, []);
+        }
+        if (ops.includes("handle")) {
+          this._registerBindObject(this.api.url, host, []);
+        }
+        super._registerBind(host, ops);
+      }
     }
-    Foo._annotateInflight("$inflight_init", {"this.api": { ops: [] },"this.stateful": { ops: [] }});
-    Foo._annotateInflight("handle", {"this.api.url": { ops: [] }});
     const api = this.node.root.newAbstract("@winglang/sdk.cloud.Api",this,"cloud.Api");
     const counter = this.node.root.newAbstract("@winglang/sdk.cloud.Counter",this,"cloud.Counter");
     const handler = new $stdlib.core.Inflight(this, "$Inflight1", {

--- a/tools/hangar/__snapshots__/test_corpus/api_path_vars.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/api_path_vars.w_compile_tf-aws.md
@@ -1,19 +1,5 @@
 # [api_path_vars.w](../../../../examples/tests/valid/api_path_vars.w) | compile | tf-aws
 
-## clients/Fetch.inflight.js
-```js
-class  Fetch {
-  constructor({ stateful }) {
-    this.stateful = stateful;
-  }
-  async get(url)  {
-    return (require("<ABSOLUTE_PATH>/api_path_vars.js")["get"])(url)
-  }
-}
-exports.Fetch = Fetch;
-
-```
-
 ## main.tf.json
 ```json
 {
@@ -285,10 +271,17 @@ class $Root extends $stdlib.std.Resource {
       }
       _toInflight() {
         const stateful_client = this._lift(this.stateful);
-        const self_client_path = "./clients/Fetch.inflight.js".replace(/\\/g, "/");
         return $stdlib.core.NodeJsCode.fromInline(`
           (await (async () => {
-            const tmp = new (require("${self_client_path}")).Fetch({
+            class  Fetch {
+              constructor({ stateful }) {
+                this.stateful = stateful;
+              }
+              async get(url)  {
+                return (require("<ABSOLUTE_PATH>/api_path_vars.js")["get"])(url)
+              }
+            }
+            const tmp = new Fetch({
               stateful: ${stateful_client},
             });
             if (tmp.$inflight_init) { await tmp.$inflight_init(); }

--- a/tools/hangar/__snapshots__/test_corpus/api_path_vars.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/api_path_vars.w_compile_tf-aws.md
@@ -268,6 +268,7 @@ class $Root extends $stdlib.std.Resource {
     class Fetch extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
+        this._inflightOps.push("get");
       }
       _toInflight() {
         const stateful_client = this._lift(this.stateful);
@@ -289,9 +290,15 @@ class $Root extends $stdlib.std.Resource {
           })())
         `);
       }
+      _registerBind(host, ops) {
+        if (ops.includes("$inflight_init")) {
+          this._registerBindObject(this.stateful, host, []);
+        }
+        if (ops.includes("get")) {
+        }
+        super._registerBind(host, ops);
+      }
     }
-    Fetch._annotateInflight("$inflight_init", {"this.stateful": { ops: [] }});
-    Fetch._annotateInflight("get", {});
     const api = this.node.root.newAbstract("@winglang/sdk.cloud.Api",this,"cloud.Api");
     const handler = new $stdlib.core.Inflight(this, "$Inflight1", {
       code: $stdlib.core.NodeJsCode.fromFile(require.resolve("./proc1/index.js".replace(/\\/g, "/"))),

--- a/tools/hangar/__snapshots__/test_corpus/capture_resource_with_no_inflight.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/capture_resource_with_no_inflight.w_compile_tf-aws.md
@@ -1,17 +1,5 @@
 # [capture_resource_with_no_inflight.w](../../../../examples/tests/valid/capture_resource_with_no_inflight.w) | compile | tf-aws
 
-## clients/A.inflight.js
-```js
-class  A {
-  constructor({ field, stateful }) {
-    this.field = field;
-    this.stateful = stateful;
-  }
-}
-exports.A = A;
-
-```
-
 ## main.tf.json
 ```json
 {
@@ -150,10 +138,15 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         const field_client = this._lift(this.field);
         const stateful_client = this._lift(this.stateful);
-        const self_client_path = "./clients/A.inflight.js".replace(/\\/g, "/");
         return $stdlib.core.NodeJsCode.fromInline(`
           (await (async () => {
-            const tmp = new (require("${self_client_path}")).A({
+            class  A {
+              constructor({ field, stateful }) {
+                this.field = field;
+                this.stateful = stateful;
+              }
+            }
+            const tmp = new A({
               field: ${field_client},
               stateful: ${stateful_client},
             });

--- a/tools/hangar/__snapshots__/test_corpus/capture_resource_with_no_inflight.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/capture_resource_with_no_inflight.w_compile_tf-aws.md
@@ -133,6 +133,7 @@ class $Root extends $stdlib.std.Resource {
     class A extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
+        this._inflightOps.push();
         this.field = "hey";
       }
       _toInflight() {
@@ -155,8 +156,14 @@ class $Root extends $stdlib.std.Resource {
           })())
         `);
       }
+      _registerBind(host, ops) {
+        if (ops.includes("$inflight_init")) {
+          this._registerBindObject(this.field, host, []);
+          this._registerBindObject(this.stateful, host, []);
+        }
+        super._registerBind(host, ops);
+      }
     }
-    A._annotateInflight("$inflight_init", {"this.field": { ops: [] },"this.stateful": { ops: [] }});
     const a = new A(this,"A");
     this.node.root.newAbstract("@winglang/sdk.cloud.Function",this,"test",new $stdlib.core.Inflight(this, "$Inflight1", {
       code: $stdlib.core.NodeJsCode.fromFile(require.resolve("./proc1/index.js".replace(/\\/g, "/"))),

--- a/tools/hangar/__snapshots__/test_corpus/construct-base.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/construct-base.w_compile_tf-aws.md
@@ -59,6 +59,7 @@ class $Root extends $stdlib.std.Resource {
     class WingResource extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
+        this._inflightOps.push();
         {console.log(`my id is ${this.node.id}`)};
       }
       _toInflight() {
@@ -78,8 +79,13 @@ class $Root extends $stdlib.std.Resource {
           })())
         `);
       }
+      _registerBind(host, ops) {
+        if (ops.includes("$inflight_init")) {
+          this._registerBindObject(this.stateful, host, []);
+        }
+        super._registerBind(host, ops);
+      }
     }
-    WingResource._annotateInflight("$inflight_init", {"this.stateful": { ops: [] }});
     const get_path =  (c) =>  {
       {
         return c.node.path;

--- a/tools/hangar/__snapshots__/test_corpus/construct-base.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/construct-base.w_compile_tf-aws.md
@@ -1,16 +1,5 @@
 # [construct-base.w](../../../../examples/tests/valid/construct-base.w) | compile | tf-aws
 
-## clients/WingResource.inflight.js
-```js
-class  WingResource {
-  constructor({ stateful }) {
-    this.stateful = stateful;
-  }
-}
-exports.WingResource = WingResource;
-
-```
-
 ## main.tf.json
 ```json
 {
@@ -74,10 +63,14 @@ class $Root extends $stdlib.std.Resource {
       }
       _toInflight() {
         const stateful_client = this._lift(this.stateful);
-        const self_client_path = "./clients/WingResource.inflight.js".replace(/\\/g, "/");
         return $stdlib.core.NodeJsCode.fromInline(`
           (await (async () => {
-            const tmp = new (require("${self_client_path}")).WingResource({
+            class  WingResource {
+              constructor({ stateful }) {
+                this.stateful = stateful;
+              }
+            }
+            const tmp = new WingResource({
               stateful: ${stateful_client},
             });
             if (tmp.$inflight_init) { await tmp.$inflight_init(); }

--- a/tools/hangar/__snapshots__/test_corpus/doubler.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/doubler.w_compile_tf-aws.md
@@ -45,6 +45,7 @@ class $Root extends $stdlib.std.Resource {
     class Doubler extends $stdlib.std.Resource {
       constructor(scope, id, func) {
         super(scope, id);
+        this._inflightOps.push("invoke");
         this.func = func;
       }
       _toInflight() {
@@ -73,9 +74,17 @@ class $Root extends $stdlib.std.Resource {
           })())
         `);
       }
+      _registerBind(host, ops) {
+        if (ops.includes("$inflight_init")) {
+          this._registerBindObject(this.func, host, []);
+          this._registerBindObject(this.stateful, host, []);
+        }
+        if (ops.includes("invoke")) {
+          this._registerBindObject(this.func, host, ["handle"]);
+        }
+        super._registerBind(host, ops);
+      }
     }
-    Doubler._annotateInflight("$inflight_init", {"this.func": { ops: [] },"this.stateful": { ops: [] }});
-    Doubler._annotateInflight("invoke", {"this.func": { ops: ["handle"] }});
     const fn = new Doubler(this,"Doubler",new $stdlib.core.Inflight(this, "$Inflight1", {
       code: $stdlib.core.NodeJsCode.fromFile(require.resolve("./proc1/index.js".replace(/\\/g, "/"))),
       bindings: {

--- a/tools/hangar/__snapshots__/test_corpus/doubler.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/doubler.w_compile_tf-aws.md
@@ -1,23 +1,5 @@
 # [doubler.w](../../../../examples/tests/valid/doubler.w) | compile | tf-aws
 
-## clients/Doubler.inflight.js
-```js
-class  Doubler {
-  constructor({ func, stateful }) {
-    this.func = func;
-    this.stateful = stateful;
-  }
-  async invoke(message)  {
-    {
-      (await this.func.handle(message));
-      (await this.func.handle(message));
-    }
-  }
-}
-exports.Doubler = Doubler;
-
-```
-
 ## main.tf.json
 ```json
 {
@@ -68,10 +50,21 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         const func_client = this._lift(this.func);
         const stateful_client = this._lift(this.stateful);
-        const self_client_path = "./clients/Doubler.inflight.js".replace(/\\/g, "/");
         return $stdlib.core.NodeJsCode.fromInline(`
           (await (async () => {
-            const tmp = new (require("${self_client_path}")).Doubler({
+            class  Doubler {
+              constructor({ func, stateful }) {
+                this.func = func;
+                this.stateful = stateful;
+              }
+              async invoke(message)  {
+                {
+                  (await this.func.handle(message));
+                  (await this.func.handle(message));
+                }
+              }
+            }
+            const tmp = new Doubler({
               func: ${func_client},
               stateful: ${stateful_client},
             });

--- a/tools/hangar/__snapshots__/test_corpus/extern_implementation.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/extern_implementation.w_compile_tf-aws.md
@@ -198,6 +198,7 @@ class $Root extends $stdlib.std.Resource {
     class Foo extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
+        this._inflightOps.push("regex_inflight", "get_uuid", "get_data", "print", "call");
       }
       static get_greeting(name)  {
         return (require("<ABSOLUTE_PATH>/external_js.js")["get_greeting"])(name)
@@ -242,13 +243,23 @@ class $Root extends $stdlib.std.Resource {
           })())
         `);
       }
+      _registerBind(host, ops) {
+        if (ops.includes("$inflight_init")) {
+          this._registerBindObject(this.stateful, host, []);
+        }
+        if (ops.includes("call")) {
+        }
+        if (ops.includes("get_data")) {
+        }
+        if (ops.includes("get_uuid")) {
+        }
+        if (ops.includes("print")) {
+        }
+        if (ops.includes("regex_inflight")) {
+        }
+        super._registerBind(host, ops);
+      }
     }
-    Foo._annotateInflight("$inflight_init", {"this.stateful": { ops: [] }});
-    Foo._annotateInflight("call", {});
-    Foo._annotateInflight("get_data", {});
-    Foo._annotateInflight("get_uuid", {});
-    Foo._annotateInflight("print", {});
-    Foo._annotateInflight("regex_inflight", {});
     {((cond) => {if (!cond) throw new Error(`assertion failed: '((Foo.get_greeting("Wingding")) === "Hello, Wingding!")'`)})(((Foo.get_greeting("Wingding")) === "Hello, Wingding!"))};
     {((cond) => {if (!cond) throw new Error(`assertion failed: '((Foo.v4()).length === 36)'`)})(((Foo.v4()).length === 36))};
     const f = new Foo(this,"Foo");

--- a/tools/hangar/__snapshots__/test_corpus/extern_implementation.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/extern_implementation.w_compile_tf-aws.md
@@ -1,36 +1,5 @@
 # [extern_implementation.w](../../../../examples/tests/valid/extern_implementation.w) | compile | tf-aws
 
-## clients/Foo.inflight.js
-```js
-class  Foo {
-  constructor({ stateful }) {
-    this.stateful = stateful;
-  }
-  static async regex_inflight(pattern, text)  {
-    return (require("<ABSOLUTE_PATH>/external_js.js")["regex_inflight"])(pattern, text)
-  }
-  static async get_uuid()  {
-    return (require("<ABSOLUTE_PATH>/external_js.js")["get_uuid"])()
-  }
-  static async get_data()  {
-    return (require("<ABSOLUTE_PATH>/external_js.js")["get_data"])()
-  }
-  async print(msg)  {
-    return (require("<ABSOLUTE_PATH>/external_js.js")["print"])(msg)
-  }
-  async call()  {
-    {
-      {((cond) => {if (!cond) throw new Error(`assertion failed: '(await Foo.regex_inflight("[a-z]+-\\d+","abc-123"))'`)})((await Foo.regex_inflight("[a-z]+-\\d+","abc-123")))};
-      const uuid = (await Foo.get_uuid());
-      {((cond) => {if (!cond) throw new Error(`assertion failed: '(uuid.length === 36)'`)})((uuid.length === 36))};
-      {((cond) => {if (!cond) throw new Error(`assertion failed: '((await Foo.get_data()) === "Cool data!")'`)})(((await Foo.get_data()) === "Cool data!"))};
-    }
-  }
-}
-exports.Foo = Foo;
-
-```
-
 ## main.tf.json
 ```json
 {
@@ -238,10 +207,34 @@ class $Root extends $stdlib.std.Resource {
       }
       _toInflight() {
         const stateful_client = this._lift(this.stateful);
-        const self_client_path = "./clients/Foo.inflight.js".replace(/\\/g, "/");
         return $stdlib.core.NodeJsCode.fromInline(`
           (await (async () => {
-            const tmp = new (require("${self_client_path}")).Foo({
+            class  Foo {
+              constructor({ stateful }) {
+                this.stateful = stateful;
+              }
+              static async regex_inflight(pattern, text)  {
+                return (require("<ABSOLUTE_PATH>/external_js.js")["regex_inflight"])(pattern, text)
+              }
+              static async get_uuid()  {
+                return (require("<ABSOLUTE_PATH>/external_js.js")["get_uuid"])()
+              }
+              static async get_data()  {
+                return (require("<ABSOLUTE_PATH>/external_js.js")["get_data"])()
+              }
+              async print(msg)  {
+                return (require("<ABSOLUTE_PATH>/external_js.js")["print"])(msg)
+              }
+              async call()  {
+                {
+                  {((cond) => {if (!cond) throw new Error(\`assertion failed: \'(await Foo.regex_inflight("[a-z]+-\\\\d+","abc-123"))\'\`)})((await Foo.regex_inflight("[a-z]+-\\\\d+","abc-123")))};
+                  const uuid = (await Foo.get_uuid());
+                  {((cond) => {if (!cond) throw new Error(\`assertion failed: \'(uuid.length === 36)\'\`)})((uuid.length === 36))};
+                  {((cond) => {if (!cond) throw new Error(\`assertion failed: \'((await Foo.get_data()) === "Cool data!")\'\`)})(((await Foo.get_data()) === "Cool data!"))};
+                }
+              }
+            }
+            const tmp = new Foo({
               stateful: ${stateful_client},
             });
             if (tmp.$inflight_init) { await tmp.$inflight_init(); }

--- a/tools/hangar/__snapshots__/test_corpus/forward_decl.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/forward_decl.w_compile_tf-aws.md
@@ -44,6 +44,7 @@ class $Root extends $stdlib.std.Resource {
     class R extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
+        this._inflightOps.push();
       }
        method2()  {
         {
@@ -76,8 +77,14 @@ class $Root extends $stdlib.std.Resource {
           })())
         `);
       }
+      _registerBind(host, ops) {
+        if (ops.includes("$inflight_init")) {
+          this._registerBindObject(this.f, host, []);
+          this._registerBindObject(this.stateful, host, []);
+        }
+        super._registerBind(host, ops);
+      }
     }
-    R._annotateInflight("$inflight_init", {"this.f": { ops: [] },"this.stateful": { ops: [] }});
     const x = "hi";
     if (true) {
       {console.log(`${x}`)};

--- a/tools/hangar/__snapshots__/test_corpus/forward_decl.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/forward_decl.w_compile_tf-aws.md
@@ -1,17 +1,5 @@
 # [forward_decl.w](../../../../examples/tests/valid/forward_decl.w) | compile | tf-aws
 
-## clients/R.inflight.js
-```js
-class  R {
-  constructor({ f, stateful }) {
-    this.f = f;
-    this.stateful = stateful;
-  }
-}
-exports.R = R;
-
-```
-
 ## main.tf.json
 ```json
 {
@@ -71,10 +59,15 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         const f_client = this._lift(this.f);
         const stateful_client = this._lift(this.stateful);
-        const self_client_path = "./clients/R.inflight.js".replace(/\\/g, "/");
         return $stdlib.core.NodeJsCode.fromInline(`
           (await (async () => {
-            const tmp = new (require("${self_client_path}")).R({
+            class  R {
+              constructor({ f, stateful }) {
+                this.f = f;
+                this.stateful = stateful;
+              }
+            }
+            const tmp = new R({
               f: ${f_client},
               stateful: ${stateful_client},
             });

--- a/tools/hangar/__snapshots__/test_corpus/impl_interface.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/impl_interface.w_compile_tf-aws.md
@@ -45,6 +45,7 @@ class $Root extends $stdlib.std.Resource {
     class A extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
+        this._inflightOps.push("handle");
       }
       _toInflight() {
         const stateful_client = this._lift(this.stateful);
@@ -68,12 +69,19 @@ class $Root extends $stdlib.std.Resource {
           })())
         `);
       }
+      _registerBind(host, ops) {
+        if (ops.includes("$inflight_init")) {
+          this._registerBindObject(this.stateful, host, []);
+        }
+        if (ops.includes("handle")) {
+        }
+        super._registerBind(host, ops);
+      }
     }
-    A._annotateInflight("$inflight_init", {"this.stateful": { ops: [] }});
-    A._annotateInflight("handle", {});
     class r extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
+        this._inflightOps.push("method_2");
       }
        method_1(x)  {
         {
@@ -107,12 +115,19 @@ class $Root extends $stdlib.std.Resource {
           })())
         `);
       }
+      _registerBind(host, ops) {
+        if (ops.includes("$inflight_init")) {
+          this._registerBindObject(this.stateful, host, []);
+        }
+        if (ops.includes("method_2")) {
+        }
+        super._registerBind(host, ops);
+      }
     }
-    r._annotateInflight("$inflight_init", {"this.stateful": { ops: [] }});
-    r._annotateInflight("method_2", {});
     class Dog extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
+        this._inflightOps.push("eat");
       }
       _toInflight() {
         const stateful_client = this._lift(this.stateful);
@@ -136,9 +151,15 @@ class $Root extends $stdlib.std.Resource {
           })())
         `);
       }
+      _registerBind(host, ops) {
+        if (ops.includes("$inflight_init")) {
+          this._registerBindObject(this.stateful, host, []);
+        }
+        if (ops.includes("eat")) {
+        }
+        super._registerBind(host, ops);
+      }
     }
-    Dog._annotateInflight("$inflight_init", {"this.stateful": { ops: [] }});
-    Dog._annotateInflight("eat", {});
     const x = new A(this,"A");
     const y = new $stdlib.core.Inflight(this, "$Inflight1", {
       code: $stdlib.core.NodeJsCode.fromFile(require.resolve("./proc1/index.js".replace(/\\/g, "/"))),

--- a/tools/hangar/__snapshots__/test_corpus/impl_interface.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/impl_interface.w_compile_tf-aws.md
@@ -1,53 +1,5 @@
 # [impl_interface.w](../../../../examples/tests/valid/impl_interface.w) | compile | tf-aws
 
-## clients/A.inflight.js
-```js
-class  A {
-  constructor({ stateful }) {
-    this.stateful = stateful;
-  }
-  async handle(msg)  {
-    {
-      return;
-    }
-  }
-}
-exports.A = A;
-
-```
-
-## clients/Dog.inflight.js
-```js
-class  Dog {
-  constructor({ stateful }) {
-    this.stateful = stateful;
-  }
-  async eat()  {
-    {
-      return;
-    }
-  }
-}
-exports.Dog = Dog;
-
-```
-
-## clients/r.inflight.js
-```js
-class  r {
-  constructor({ stateful }) {
-    this.stateful = stateful;
-  }
-  async method_2(x)  {
-    {
-      return x;
-    }
-  }
-}
-exports.r = r;
-
-```
-
 ## main.tf.json
 ```json
 {
@@ -96,10 +48,19 @@ class $Root extends $stdlib.std.Resource {
       }
       _toInflight() {
         const stateful_client = this._lift(this.stateful);
-        const self_client_path = "./clients/A.inflight.js".replace(/\\/g, "/");
         return $stdlib.core.NodeJsCode.fromInline(`
           (await (async () => {
-            const tmp = new (require("${self_client_path}")).A({
+            class  A {
+              constructor({ stateful }) {
+                this.stateful = stateful;
+              }
+              async handle(msg)  {
+                {
+                  return;
+                }
+              }
+            }
+            const tmp = new A({
               stateful: ${stateful_client},
             });
             if (tmp.$inflight_init) { await tmp.$inflight_init(); }
@@ -126,10 +87,19 @@ class $Root extends $stdlib.std.Resource {
       }
       _toInflight() {
         const stateful_client = this._lift(this.stateful);
-        const self_client_path = "./clients/r.inflight.js".replace(/\\/g, "/");
         return $stdlib.core.NodeJsCode.fromInline(`
           (await (async () => {
-            const tmp = new (require("${self_client_path}")).r({
+            class  r {
+              constructor({ stateful }) {
+                this.stateful = stateful;
+              }
+              async method_2(x)  {
+                {
+                  return x;
+                }
+              }
+            }
+            const tmp = new r({
               stateful: ${stateful_client},
             });
             if (tmp.$inflight_init) { await tmp.$inflight_init(); }
@@ -146,10 +116,19 @@ class $Root extends $stdlib.std.Resource {
       }
       _toInflight() {
         const stateful_client = this._lift(this.stateful);
-        const self_client_path = "./clients/Dog.inflight.js".replace(/\\/g, "/");
         return $stdlib.core.NodeJsCode.fromInline(`
           (await (async () => {
-            const tmp = new (require("${self_client_path}")).Dog({
+            class  Dog {
+              constructor({ stateful }) {
+                this.stateful = stateful;
+              }
+              async eat()  {
+                {
+                  return;
+                }
+              }
+            }
+            const tmp = new Dog({
               stateful: ${stateful_client},
             });
             if (tmp.$inflight_init) { await tmp.$inflight_init(); }

--- a/tools/hangar/__snapshots__/test_corpus/json.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/json.w_compile_tf-aws.md
@@ -44,6 +44,7 @@ class $Root extends $stdlib.std.Resource {
     class Foo extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
+        this._inflightOps.push();
         this._sum_str = "wow!";
       }
       _toInflight() {
@@ -66,8 +67,14 @@ class $Root extends $stdlib.std.Resource {
           })())
         `);
       }
+      _registerBind(host, ops) {
+        if (ops.includes("$inflight_init")) {
+          this._registerBindObject(this._sum_str, host, []);
+          this._registerBindObject(this.stateful, host, []);
+        }
+        super._registerBind(host, ops);
+      }
     }
-    Foo._annotateInflight("$inflight_init", {"this._sum_str": { ops: [] },"this.stateful": { ops: [] }});
     const json_number = 123;
     const json_bool = true;
     const json_array = [1, 2, 3];

--- a/tools/hangar/__snapshots__/test_corpus/json.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/json.w_compile_tf-aws.md
@@ -1,17 +1,5 @@
 # [json.w](../../../../examples/tests/valid/json.w) | compile | tf-aws
 
-## clients/Foo.inflight.js
-```js
-class  Foo {
-  constructor({ _sum_str, stateful }) {
-    this._sum_str = _sum_str;
-    this.stateful = stateful;
-  }
-}
-exports.Foo = Foo;
-
-```
-
 ## main.tf.json
 ```json
 {
@@ -61,10 +49,15 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         const _sum_str_client = this._lift(this._sum_str);
         const stateful_client = this._lift(this.stateful);
-        const self_client_path = "./clients/Foo.inflight.js".replace(/\\/g, "/");
         return $stdlib.core.NodeJsCode.fromInline(`
           (await (async () => {
-            const tmp = new (require("${self_client_path}")).Foo({
+            class  Foo {
+              constructor({ _sum_str, stateful }) {
+                this._sum_str = _sum_str;
+                this.stateful = stateful;
+              }
+            }
+            const tmp = new Foo({
               _sum_str: ${_sum_str_client},
               stateful: ${stateful_client},
             });

--- a/tools/hangar/__snapshots__/test_corpus/reassignment.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/reassignment.w_compile_tf-aws.md
@@ -44,6 +44,7 @@ class $Root extends $stdlib.std.Resource {
     class R extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
+        this._inflightOps.push();
         if (true) {
           this.f = 1;
           this.f1 = 0;
@@ -74,8 +75,14 @@ class $Root extends $stdlib.std.Resource {
           })())
         `);
       }
+      _registerBind(host, ops) {
+        if (ops.includes("$inflight_init")) {
+          this._registerBindObject(this.f1, host, []);
+          this._registerBindObject(this.stateful, host, []);
+        }
+        super._registerBind(host, ops);
+      }
     }
-    R._annotateInflight("$inflight_init", {"this.f1": { ops: [] },"this.stateful": { ops: [] }});
     let x = 5;
     {((cond) => {if (!cond) throw new Error(`assertion failed: '(x === 5)'`)})((x === 5))};
     x = (x + 1);

--- a/tools/hangar/__snapshots__/test_corpus/reassignment.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/reassignment.w_compile_tf-aws.md
@@ -1,17 +1,5 @@
 # [reassignment.w](../../../../examples/tests/valid/reassignment.w) | compile | tf-aws
 
-## clients/R.inflight.js
-```js
-class  R {
-  constructor({ f1, stateful }) {
-    this.f1 = f1;
-    this.stateful = stateful;
-  }
-}
-exports.R = R;
-
-```
-
 ## main.tf.json
 ```json
 {
@@ -69,10 +57,15 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         const f1_client = this._lift(this.f1);
         const stateful_client = this._lift(this.stateful);
-        const self_client_path = "./clients/R.inflight.js".replace(/\\/g, "/");
         return $stdlib.core.NodeJsCode.fromInline(`
           (await (async () => {
-            const tmp = new (require("${self_client_path}")).R({
+            class  R {
+              constructor({ f1, stateful }) {
+                this.f1 = f1;
+                this.stateful = stateful;
+              }
+            }
+            const tmp = new R({
               f1: ${f1_client},
               stateful: ${stateful_client},
             });

--- a/tools/hangar/__snapshots__/test_corpus/resource.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/resource.w_compile_tf-aws.md
@@ -688,6 +688,7 @@ class $Root extends $stdlib.std.Resource {
     class Foo extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
+        this._inflightOps.push("foo_inc", "foo_get");
         this.c = this.node.root.newAbstract("@winglang/sdk.cloud.Counter",this,"cloud.Counter");
       }
       _toInflight() {
@@ -727,13 +728,24 @@ class $Root extends $stdlib.std.Resource {
           })())
         `);
       }
+      _registerBind(host, ops) {
+        if (ops.includes("$inflight_init")) {
+          this._registerBindObject(this.c, host, ["dec", "inc"]);
+          this._registerBindObject(this.stateful, host, []);
+        }
+        if (ops.includes("foo_get")) {
+          this._registerBindObject(this.c, host, ["peek"]);
+        }
+        if (ops.includes("foo_inc")) {
+          this._registerBindObject(this.c, host, ["inc"]);
+        }
+        super._registerBind(host, ops);
+      }
     }
-    Foo._annotateInflight("$inflight_init", {"this.c": { ops: ["dec","inc"] },"this.stateful": { ops: [] }});
-    Foo._annotateInflight("foo_get", {"this.c": { ops: ["peek"] }});
-    Foo._annotateInflight("foo_inc", {"this.c": { ops: ["inc"] }});
     class Bar extends $stdlib.std.Resource {
       constructor(scope, id, name, b) {
         super(scope, id);
+        this._inflightOps.push("my_method");
         this.name = name;
         this.b = b;
         this.foo = new Foo(this,"Foo");
@@ -771,12 +783,24 @@ class $Root extends $stdlib.std.Resource {
           })())
         `);
       }
+      _registerBind(host, ops) {
+        if (ops.includes("$inflight_init")) {
+          this._registerBindObject(this.b, host, []);
+          this._registerBindObject(this.foo, host, []);
+          this._registerBindObject(this.name, host, []);
+          this._registerBindObject(this.stateful, host, []);
+        }
+        if (ops.includes("my_method")) {
+          this._registerBindObject(this.b, host, ["get", "put"]);
+          this._registerBindObject(this.foo, host, ["foo_get", "foo_inc"]);
+        }
+        super._registerBind(host, ops);
+      }
     }
-    Bar._annotateInflight("$inflight_init", {"this.b": { ops: [] },"this.foo": { ops: [] },"this.name": { ops: [] },"this.stateful": { ops: [] }});
-    Bar._annotateInflight("my_method", {"this.b": { ops: ["get","put"] },"this.foo": { ops: ["foo_get","foo_inc"] }});
     class BigPublisher extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
+        this._inflightOps.push("publish", "getObjectCount");
         this.b = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this,"cloud.Bucket");
         this.b2 = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this,"b2");
         this.q = this.node.root.newAbstract("@winglang/sdk.cloud.Queue",this,"cloud.Queue");
@@ -853,10 +877,25 @@ class $Root extends $stdlib.std.Resource {
           })())
         `);
       }
+      _registerBind(host, ops) {
+        if (ops.includes("$inflight_init")) {
+          this._registerBindObject(this.b, host, []);
+          this._registerBindObject(this.b2, host, []);
+          this._registerBindObject(this.q, host, []);
+          this._registerBindObject(this.stateful, host, []);
+          this._registerBindObject(this.t, host, []);
+        }
+        if (ops.includes("getObjectCount")) {
+          this._registerBindObject(this.b, host, ["list"]);
+        }
+        if (ops.includes("publish")) {
+          this._registerBindObject(this.b2, host, ["put"]);
+          this._registerBindObject(this.q, host, ["push"]);
+          this._registerBindObject(this.t, host, ["publish"]);
+        }
+        super._registerBind(host, ops);
+      }
     }
-    BigPublisher._annotateInflight("$inflight_init", {"this.b": { ops: [] },"this.b2": { ops: [] },"this.q": { ops: [] },"this.stateful": { ops: [] },"this.t": { ops: [] }});
-    BigPublisher._annotateInflight("getObjectCount", {"this.b": { ops: ["list"] }});
-    BigPublisher._annotateInflight("publish", {"this.b2": { ops: ["put"] },"this.q": { ops: ["push"] },"this.t": { ops: ["publish"] }});
     const bucket = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this,"cloud.Bucket");
     const res = new Bar(this,"Bar","Arr",bucket);
     this.node.root.newAbstract("@winglang/sdk.cloud.Function",this,"test",new $stdlib.core.Inflight(this, "$Inflight4", {

--- a/tools/hangar/__snapshots__/test_corpus/resource.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/resource.w_compile_tf-aws.md
@@ -1,82 +1,5 @@
 # [resource.w](../../../../examples/tests/valid/resource.w) | compile | tf-aws
 
-## clients/Bar.inflight.js
-```js
-class  Bar {
-  constructor({ b, foo, name, stateful }) {
-    this.b = b;
-    this.foo = foo;
-    this.name = name;
-    this.stateful = stateful;
-  }
-  async my_method()  {
-    {
-      (await this.foo.foo_inc());
-      (await this.b.put("foo",`counter is: ${(await this.foo.foo_get())}`));
-      return (await this.b.get("foo"));
-    }
-  }
-}
-exports.Bar = Bar;
-
-```
-
-## clients/BigPublisher.inflight.js
-```js
-class  BigPublisher {
-  constructor({ b, b2, q, t, stateful }) {
-    this.b = b;
-    this.b2 = b2;
-    this.q = q;
-    this.t = t;
-    this.stateful = stateful;
-  }
-  async publish(s)  {
-    {
-      (await this.t.publish(s));
-      (await this.q.push(s));
-      (await this.b2.put("foo",s));
-    }
-  }
-  async getObjectCount()  {
-    {
-      return (await this.b.list()).length;
-    }
-  }
-}
-exports.BigPublisher = BigPublisher;
-
-```
-
-## clients/Foo.inflight.js
-```js
-class  Foo {
-  constructor({ c, stateful }) {
-    this.c = c;
-    this.stateful = stateful;
-  }
-  async $inflight_init()  {
-    {
-      this.inflight_field = 123;
-      (await this.c.inc(110));
-      (await this.c.dec(10));
-    }
-  }
-  async foo_inc()  {
-    {
-      (await this.c.inc());
-    }
-  }
-  async foo_get()  {
-    {
-      return (await this.c.peek());
-    }
-  }
-}
-exports.Foo = Foo;
-
-```
-
 ## main.tf.json
 ```json
 {
@@ -770,10 +693,32 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         const c_client = this._lift(this.c);
         const stateful_client = this._lift(this.stateful);
-        const self_client_path = "./clients/Foo.inflight.js".replace(/\\/g, "/");
         return $stdlib.core.NodeJsCode.fromInline(`
           (await (async () => {
-            const tmp = new (require("${self_client_path}")).Foo({
+            class  Foo {
+              constructor({ c, stateful }) {
+                this.c = c;
+                this.stateful = stateful;
+              }
+              async \$inflight_init()  {
+                {
+                  this.inflight_field = 123;
+                  (await this.c.inc(110));
+                  (await this.c.dec(10));
+                }
+              }
+              async foo_inc()  {
+                {
+                  (await this.c.inc());
+                }
+              }
+              async foo_get()  {
+                {
+                  return (await this.c.peek());
+                }
+              }
+            }
+            const tmp = new Foo({
               c: ${c_client},
               stateful: ${stateful_client},
             });
@@ -798,10 +743,24 @@ class $Root extends $stdlib.std.Resource {
         const foo_client = this._lift(this.foo);
         const name_client = this._lift(this.name);
         const stateful_client = this._lift(this.stateful);
-        const self_client_path = "./clients/Bar.inflight.js".replace(/\\/g, "/");
         return $stdlib.core.NodeJsCode.fromInline(`
           (await (async () => {
-            const tmp = new (require("${self_client_path}")).Bar({
+            class  Bar {
+              constructor({ b, foo, name, stateful }) {
+                this.b = b;
+                this.foo = foo;
+                this.name = name;
+                this.stateful = stateful;
+              }
+              async my_method()  {
+                {
+                  (await this.foo.foo_inc());
+                  (await this.b.put("foo",\`counter is: \${(await this.foo.foo_get())}\`));
+                  return (await this.b.get("foo"));
+                }
+              }
+            }
+            const tmp = new Bar({
               b: ${b_client},
               foo: ${foo_client},
               name: ${name_client},
@@ -859,10 +818,30 @@ class $Root extends $stdlib.std.Resource {
         const q_client = this._lift(this.q);
         const t_client = this._lift(this.t);
         const stateful_client = this._lift(this.stateful);
-        const self_client_path = "./clients/BigPublisher.inflight.js".replace(/\\/g, "/");
         return $stdlib.core.NodeJsCode.fromInline(`
           (await (async () => {
-            const tmp = new (require("${self_client_path}")).BigPublisher({
+            class  BigPublisher {
+              constructor({ b, b2, q, t, stateful }) {
+                this.b = b;
+                this.b2 = b2;
+                this.q = q;
+                this.t = t;
+                this.stateful = stateful;
+              }
+              async publish(s)  {
+                {
+                  (await this.t.publish(s));
+                  (await this.q.push(s));
+                  (await this.b2.put("foo",s));
+                }
+              }
+              async getObjectCount()  {
+                {
+                  return (await this.b.list()).length;
+                }
+              }
+            }
+            const tmp = new BigPublisher({
               b: ${b_client},
               b2: ${b2_client},
               q: ${q_client},

--- a/tools/hangar/__snapshots__/test_corpus/resource_as_inflight_literal.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/resource_as_inflight_literal.w_compile_tf-aws.md
@@ -1,21 +1,5 @@
 # [resource_as_inflight_literal.w](../../../../examples/tests/valid/resource_as_inflight_literal.w) | compile | tf-aws
 
-## clients/Foo.inflight.js
-```js
-class  Foo {
-  constructor({ stateful }) {
-    this.stateful = stateful;
-  }
-  async handle(message)  {
-    {
-      return "hello world!";
-    }
-  }
-}
-exports.Foo = Foo;
-
-```
-
 ## main.tf.json
 ```json
 {
@@ -218,10 +202,19 @@ class $Root extends $stdlib.std.Resource {
       }
       _toInflight() {
         const stateful_client = this._lift(this.stateful);
-        const self_client_path = "./clients/Foo.inflight.js".replace(/\\/g, "/");
         return $stdlib.core.NodeJsCode.fromInline(`
           (await (async () => {
-            const tmp = new (require("${self_client_path}")).Foo({
+            class  Foo {
+              constructor({ stateful }) {
+                this.stateful = stateful;
+              }
+              async handle(message)  {
+                {
+                  return "hello world!";
+                }
+              }
+            }
+            const tmp = new Foo({
               stateful: ${stateful_client},
             });
             if (tmp.$inflight_init) { await tmp.$inflight_init(); }

--- a/tools/hangar/__snapshots__/test_corpus/resource_as_inflight_literal.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/resource_as_inflight_literal.w_compile_tf-aws.md
@@ -199,6 +199,7 @@ class $Root extends $stdlib.std.Resource {
     class Foo extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
+        this._inflightOps.push("handle");
       }
       _toInflight() {
         const stateful_client = this._lift(this.stateful);
@@ -222,9 +223,15 @@ class $Root extends $stdlib.std.Resource {
           })())
         `);
       }
+      _registerBind(host, ops) {
+        if (ops.includes("$inflight_init")) {
+          this._registerBindObject(this.stateful, host, []);
+        }
+        if (ops.includes("handle")) {
+        }
+        super._registerBind(host, ops);
+      }
     }
-    Foo._annotateInflight("$inflight_init", {"this.stateful": { ops: [] }});
-    Foo._annotateInflight("handle", {});
     const fn = this.node.root.newAbstract("@winglang/sdk.cloud.Function",this,"cloud.Function",new Foo(this,"Foo"));
     this.node.root.newAbstract("@winglang/sdk.cloud.Function",this,"test",new $stdlib.core.Inflight(this, "$Inflight1", {
       code: $stdlib.core.NodeJsCode.fromFile(require.resolve("./proc1/index.js".replace(/\\/g, "/"))),

--- a/tools/hangar/__snapshots__/test_corpus/resource_captures.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/resource_captures.w_compile_tf-aws.md
@@ -292,6 +292,7 @@ class $Root extends $stdlib.std.Resource {
     class First extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
+        this._inflightOps.push();
         this.my_resource = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this,"cloud.Bucket");
       }
       _toInflight() {
@@ -314,11 +315,18 @@ class $Root extends $stdlib.std.Resource {
           })())
         `);
       }
+      _registerBind(host, ops) {
+        if (ops.includes("$inflight_init")) {
+          this._registerBindObject(this.my_resource, host, []);
+          this._registerBindObject(this.stateful, host, []);
+        }
+        super._registerBind(host, ops);
+      }
     }
-    First._annotateInflight("$inflight_init", {"this.my_resource": { ops: [] },"this.stateful": { ops: [] }});
     class Another extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
+        this._inflightOps.push("meaning_of_life", "another_func");
         this.my_field = "hello!";
         this.first = new First(this,"First");
       }
@@ -355,13 +363,23 @@ class $Root extends $stdlib.std.Resource {
           })())
         `);
       }
+      _registerBind(host, ops) {
+        if (ops.includes("$inflight_init")) {
+          this._registerBindObject(this.first, host, []);
+          this._registerBindObject(this.my_field, host, []);
+          this._registerBindObject(this.stateful, host, []);
+        }
+        if (ops.includes("another_func")) {
+        }
+        if (ops.includes("meaning_of_life")) {
+        }
+        super._registerBind(host, ops);
+      }
     }
-    Another._annotateInflight("$inflight_init", {"this.first": { ops: [] },"this.my_field": { ops: [] },"this.stateful": { ops: [] }});
-    Another._annotateInflight("another_func", {});
-    Another._annotateInflight("meaning_of_life", {});
     class MyResource extends $stdlib.std.Resource {
       constructor(scope, id, external_bucket, external_num) {
         super(scope, id);
+        this._inflightOps.push("test_no_capture", "test_capture_collections_of_data", "test_capture_primitives", "test_capture_resource", "test_nested_preflight_field", "test_nested_resource", "test_expression_recursive", "test_external", "test_user_defined_resource", "test_inflight_field");
         this.my_resource = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this,"cloud.Bucket");
         this.my_str = "my_string";
         this.my_num = 42;
@@ -502,18 +520,60 @@ class $Root extends $stdlib.std.Resource {
           })())
         `);
       }
+      _registerBind(host, ops) {
+        if (ops.includes("$inflight_init")) {
+          this._registerBindObject(this.another, host, []);
+          this._registerBindObject(this.array_of_str, host, []);
+          this._registerBindObject(this.ext_bucket, host, []);
+          this._registerBindObject(this.ext_num, host, []);
+          this._registerBindObject(this.map_of_num, host, []);
+          this._registerBindObject(this.my_bool, host, []);
+          this._registerBindObject(this.my_num, host, []);
+          this._registerBindObject(this.my_queue, host, []);
+          this._registerBindObject(this.my_resource, host, []);
+          this._registerBindObject(this.my_str, host, []);
+          this._registerBindObject(this.set_of_str, host, []);
+          this._registerBindObject(this.stateful, host, []);
+          this._registerBindObject(this.unused_resource, host, []);
+        }
+        if (ops.includes("test_capture_collections_of_data")) {
+          this._registerBindObject(this.array_of_str, host, ["at", "length"]);
+          this._registerBindObject(this.map_of_num, host, ["get"]);
+          this._registerBindObject(this.set_of_str, host, ["has"]);
+        }
+        if (ops.includes("test_capture_primitives")) {
+          this._registerBindObject(this.my_bool, host, []);
+          this._registerBindObject(this.my_num, host, []);
+          this._registerBindObject(this.my_str, host, []);
+        }
+        if (ops.includes("test_capture_resource")) {
+          this._registerBindObject(this.my_resource, host, ["get", "list", "put"]);
+        }
+        if (ops.includes("test_expression_recursive")) {
+          this._registerBindObject(this.my_queue, host, ["push"]);
+          this._registerBindObject(this.my_str, host, []);
+        }
+        if (ops.includes("test_external")) {
+          this._registerBindObject(this.ext_bucket, host, ["list"]);
+          this._registerBindObject(this.ext_num, host, []);
+        }
+        if (ops.includes("test_inflight_field")) {
+        }
+        if (ops.includes("test_nested_preflight_field")) {
+          this._registerBindObject(this.another.my_field, host, []);
+        }
+        if (ops.includes("test_nested_resource")) {
+          this._registerBindObject(this.another.first.my_resource, host, ["get", "list", "put"]);
+          this._registerBindObject(this.my_str, host, []);
+        }
+        if (ops.includes("test_no_capture")) {
+        }
+        if (ops.includes("test_user_defined_resource")) {
+          this._registerBindObject(this.another, host, ["another_func", "meaning_of_life"]);
+        }
+        super._registerBind(host, ops);
+      }
     }
-    MyResource._annotateInflight("$inflight_init", {"this.another": { ops: [] },"this.array_of_str": { ops: [] },"this.ext_bucket": { ops: [] },"this.ext_num": { ops: [] },"this.map_of_num": { ops: [] },"this.my_bool": { ops: [] },"this.my_num": { ops: [] },"this.my_queue": { ops: [] },"this.my_resource": { ops: [] },"this.my_str": { ops: [] },"this.set_of_str": { ops: [] },"this.stateful": { ops: [] },"this.unused_resource": { ops: [] }});
-    MyResource._annotateInflight("test_capture_collections_of_data", {"this.array_of_str": { ops: ["at","length"] },"this.map_of_num": { ops: ["get"] },"this.set_of_str": { ops: ["has"] }});
-    MyResource._annotateInflight("test_capture_primitives", {"this.my_bool": { ops: [] },"this.my_num": { ops: [] },"this.my_str": { ops: [] }});
-    MyResource._annotateInflight("test_capture_resource", {"this.my_resource": { ops: ["get","list","put"] }});
-    MyResource._annotateInflight("test_expression_recursive", {"this.my_queue": { ops: ["push"] },"this.my_str": { ops: [] }});
-    MyResource._annotateInflight("test_external", {"this.ext_bucket": { ops: ["list"] },"this.ext_num": { ops: [] }});
-    MyResource._annotateInflight("test_inflight_field", {});
-    MyResource._annotateInflight("test_nested_preflight_field", {"this.another.my_field": { ops: [] }});
-    MyResource._annotateInflight("test_nested_resource", {"this.another.first.my_resource": { ops: ["get","list","put"] },"this.my_str": { ops: [] }});
-    MyResource._annotateInflight("test_no_capture", {});
-    MyResource._annotateInflight("test_user_defined_resource", {"this.another": { ops: ["another_func","meaning_of_life"] }});
     const b = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this,"cloud.Bucket");
     const r = new MyResource(this,"MyResource",b,12);
     this.node.root.newAbstract("@winglang/sdk.cloud.Function",this,"test",new $stdlib.core.Inflight(this, "$Inflight1", {

--- a/tools/hangar/__snapshots__/test_corpus/resource_captures.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/resource_captures.w_compile_tf-aws.md
@@ -1,132 +1,5 @@
 # [resource_captures.w](../../../../examples/tests/valid/resource_captures.w) | compile | tf-aws
 
-## clients/Another.inflight.js
-```js
-class  Another {
-  constructor({ first, my_field, stateful }) {
-    this.first = first;
-    this.my_field = my_field;
-    this.stateful = stateful;
-  }
-  async meaning_of_life()  {
-    {
-      return 42;
-    }
-  }
-  async another_func()  {
-    {
-      return "42";
-    }
-  }
-}
-exports.Another = Another;
-
-```
-
-## clients/First.inflight.js
-```js
-class  First {
-  constructor({ my_resource, stateful }) {
-    this.my_resource = my_resource;
-    this.stateful = stateful;
-  }
-}
-exports.First = First;
-
-```
-
-## clients/MyResource.inflight.js
-```js
-class  MyResource {
-  constructor({ another, array_of_str, ext_bucket, ext_num, map_of_num, my_bool, my_num, my_queue, my_resource, my_str, set_of_str, unused_resource, stateful }) {
-    this.another = another;
-    this.array_of_str = array_of_str;
-    this.ext_bucket = ext_bucket;
-    this.ext_num = ext_num;
-    this.map_of_num = map_of_num;
-    this.my_bool = my_bool;
-    this.my_num = my_num;
-    this.my_queue = my_queue;
-    this.my_resource = my_resource;
-    this.my_str = my_str;
-    this.set_of_str = set_of_str;
-    this.unused_resource = unused_resource;
-    this.stateful = stateful;
-  }
-  async test_no_capture()  {
-    {
-      const arr = Object.freeze([1, 2, 3]);
-      {((cond) => {if (!cond) throw new Error(`assertion failed: '(arr.length === 3)'`)})((arr.length === 3))};
-      {console.log(`array.len=${arr.length}`)};
-    }
-  }
-  async test_capture_collections_of_data()  {
-    {
-      {((cond) => {if (!cond) throw new Error(`assertion failed: '(this.array_of_str.length === 2)'`)})((this.array_of_str.length === 2))};
-      {((cond) => {if (!cond) throw new Error(`assertion failed: '((await this.array_of_str.at(0)) === "s1")'`)})(((await this.array_of_str.at(0)) === "s1"))};
-      {((cond) => {if (!cond) throw new Error(`assertion failed: '((await this.array_of_str.at(1)) === "s2")'`)})(((await this.array_of_str.at(1)) === "s2"))};
-      {((cond) => {if (!cond) throw new Error(`assertion failed: '((this.map_of_num)["k1"] === 11)'`)})(((this.map_of_num)["k1"] === 11))};
-      {((cond) => {if (!cond) throw new Error(`assertion failed: '((this.map_of_num)["k2"] === 22)'`)})(((this.map_of_num)["k2"] === 22))};
-      {((cond) => {if (!cond) throw new Error(`assertion failed: '(await this.set_of_str.has("s1"))'`)})((await this.set_of_str.has("s1")))};
-      {((cond) => {if (!cond) throw new Error(`assertion failed: '(await this.set_of_str.has("s2"))'`)})((await this.set_of_str.has("s2")))};
-      {((cond) => {if (!cond) throw new Error(`assertion failed: '(!(await this.set_of_str.has("s3")))'`)})((!(await this.set_of_str.has("s3"))))};
-    }
-  }
-  async test_capture_primitives()  {
-    {
-      {((cond) => {if (!cond) throw new Error(`assertion failed: '(this.my_str === "my_string")'`)})((this.my_str === "my_string"))};
-      {((cond) => {if (!cond) throw new Error(`assertion failed: '(this.my_num === 42)'`)})((this.my_num === 42))};
-      {((cond) => {if (!cond) throw new Error(`assertion failed: '(this.my_bool === true)'`)})((this.my_bool === true))};
-    }
-  }
-  async test_capture_resource()  {
-    {
-      (await this.my_resource.put("f1.txt","f1"));
-      {((cond) => {if (!cond) throw new Error(`assertion failed: '((await this.my_resource.get("f1.txt")) === "f1")'`)})(((await this.my_resource.get("f1.txt")) === "f1"))};
-      {((cond) => {if (!cond) throw new Error(`assertion failed: '((await this.my_resource.list()).length === 1)'`)})(((await this.my_resource.list()).length === 1))};
-    }
-  }
-  async test_nested_preflight_field()  {
-    {
-      {((cond) => {if (!cond) throw new Error(`assertion failed: '(this.another.my_field === "hello!")'`)})((this.another.my_field === "hello!"))};
-      {console.log(`field=${this.another.my_field}`)};
-    }
-  }
-  async test_nested_resource()  {
-    {
-      {((cond) => {if (!cond) throw new Error(`assertion failed: '((await this.another.first.my_resource.list()).length === 0)'`)})(((await this.another.first.my_resource.list()).length === 0))};
-      (await this.another.first.my_resource.put("hello",this.my_str));
-      {console.log(`this.another.first.my_resource:${(await this.another.first.my_resource.get("hello"))}`)};
-    }
-  }
-  async test_expression_recursive()  {
-    {
-      (await this.my_queue.push(this.my_str));
-    }
-  }
-  async test_external()  {
-    {
-      {((cond) => {if (!cond) throw new Error(`assertion failed: '((await this.ext_bucket.list()).length === 0)'`)})(((await this.ext_bucket.list()).length === 0))};
-      {((cond) => {if (!cond) throw new Error(`assertion failed: '(this.ext_num === 12)'`)})((this.ext_num === 12))};
-    }
-  }
-  async test_user_defined_resource()  {
-    {
-      {((cond) => {if (!cond) throw new Error(`assertion failed: '((await this.another.meaning_of_life()) === 42)'`)})(((await this.another.meaning_of_life()) === 42))};
-      {((cond) => {if (!cond) throw new Error(`assertion failed: '((await this.another.another_func()) === "42")'`)})(((await this.another.another_func()) === "42"))};
-    }
-  }
-  async test_inflight_field()  {
-    {
-      this.inflight_field = 123;
-      {((cond) => {if (!cond) throw new Error(`assertion failed: '(this.inflight_field === 123)'`)})((this.inflight_field === 123))};
-    }
-  }
-}
-exports.MyResource = MyResource;
-
-```
-
 ## main.tf.json
 ```json
 {
@@ -424,10 +297,15 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         const my_resource_client = this._lift(this.my_resource);
         const stateful_client = this._lift(this.stateful);
-        const self_client_path = "./clients/First.inflight.js".replace(/\\/g, "/");
         return $stdlib.core.NodeJsCode.fromInline(`
           (await (async () => {
-            const tmp = new (require("${self_client_path}")).First({
+            class  First {
+              constructor({ my_resource, stateful }) {
+                this.my_resource = my_resource;
+                this.stateful = stateful;
+              }
+            }
+            const tmp = new First({
               my_resource: ${my_resource_client},
               stateful: ${stateful_client},
             });
@@ -448,10 +326,26 @@ class $Root extends $stdlib.std.Resource {
         const first_client = this._lift(this.first);
         const my_field_client = this._lift(this.my_field);
         const stateful_client = this._lift(this.stateful);
-        const self_client_path = "./clients/Another.inflight.js".replace(/\\/g, "/");
         return $stdlib.core.NodeJsCode.fromInline(`
           (await (async () => {
-            const tmp = new (require("${self_client_path}")).Another({
+            class  Another {
+              constructor({ first, my_field, stateful }) {
+                this.first = first;
+                this.my_field = my_field;
+                this.stateful = stateful;
+              }
+              async meaning_of_life()  {
+                {
+                  return 42;
+                }
+              }
+              async another_func()  {
+                {
+                  return "42";
+                }
+              }
+            }
+            const tmp = new Another({
               first: ${first_client},
               my_field: ${my_field_client},
               stateful: ${stateful_client},
@@ -500,10 +394,95 @@ class $Root extends $stdlib.std.Resource {
         const set_of_str_client = this._lift(this.set_of_str);
         const unused_resource_client = this._lift(this.unused_resource);
         const stateful_client = this._lift(this.stateful);
-        const self_client_path = "./clients/MyResource.inflight.js".replace(/\\/g, "/");
         return $stdlib.core.NodeJsCode.fromInline(`
           (await (async () => {
-            const tmp = new (require("${self_client_path}")).MyResource({
+            class  MyResource {
+              constructor({ another, array_of_str, ext_bucket, ext_num, map_of_num, my_bool, my_num, my_queue, my_resource, my_str, set_of_str, unused_resource, stateful }) {
+                this.another = another;
+                this.array_of_str = array_of_str;
+                this.ext_bucket = ext_bucket;
+                this.ext_num = ext_num;
+                this.map_of_num = map_of_num;
+                this.my_bool = my_bool;
+                this.my_num = my_num;
+                this.my_queue = my_queue;
+                this.my_resource = my_resource;
+                this.my_str = my_str;
+                this.set_of_str = set_of_str;
+                this.unused_resource = unused_resource;
+                this.stateful = stateful;
+              }
+              async test_no_capture()  {
+                {
+                  const arr = Object.freeze([1, 2, 3]);
+                  {((cond) => {if (!cond) throw new Error(\`assertion failed: \'(arr.length === 3)\'\`)})((arr.length === 3))};
+                  {console.log(\`array.len=\${arr.length}\`)};
+                }
+              }
+              async test_capture_collections_of_data()  {
+                {
+                  {((cond) => {if (!cond) throw new Error(\`assertion failed: \'(this.array_of_str.length === 2)\'\`)})((this.array_of_str.length === 2))};
+                  {((cond) => {if (!cond) throw new Error(\`assertion failed: \'((await this.array_of_str.at(0)) === "s1")\'\`)})(((await this.array_of_str.at(0)) === "s1"))};
+                  {((cond) => {if (!cond) throw new Error(\`assertion failed: \'((await this.array_of_str.at(1)) === "s2")\'\`)})(((await this.array_of_str.at(1)) === "s2"))};
+                  {((cond) => {if (!cond) throw new Error(\`assertion failed: \'((this.map_of_num)["k1"] === 11)\'\`)})(((this.map_of_num)["k1"] === 11))};
+                  {((cond) => {if (!cond) throw new Error(\`assertion failed: \'((this.map_of_num)["k2"] === 22)\'\`)})(((this.map_of_num)["k2"] === 22))};
+                  {((cond) => {if (!cond) throw new Error(\`assertion failed: \'(await this.set_of_str.has("s1"))\'\`)})((await this.set_of_str.has("s1")))};
+                  {((cond) => {if (!cond) throw new Error(\`assertion failed: \'(await this.set_of_str.has("s2"))\'\`)})((await this.set_of_str.has("s2")))};
+                  {((cond) => {if (!cond) throw new Error(\`assertion failed: \'(!(await this.set_of_str.has("s3")))\'\`)})((!(await this.set_of_str.has("s3"))))};
+                }
+              }
+              async test_capture_primitives()  {
+                {
+                  {((cond) => {if (!cond) throw new Error(\`assertion failed: \'(this.my_str === "my_string")\'\`)})((this.my_str === "my_string"))};
+                  {((cond) => {if (!cond) throw new Error(\`assertion failed: \'(this.my_num === 42)\'\`)})((this.my_num === 42))};
+                  {((cond) => {if (!cond) throw new Error(\`assertion failed: \'(this.my_bool === true)\'\`)})((this.my_bool === true))};
+                }
+              }
+              async test_capture_resource()  {
+                {
+                  (await this.my_resource.put("f1.txt","f1"));
+                  {((cond) => {if (!cond) throw new Error(\`assertion failed: \'((await this.my_resource.get("f1.txt")) === "f1")\'\`)})(((await this.my_resource.get("f1.txt")) === "f1"))};
+                  {((cond) => {if (!cond) throw new Error(\`assertion failed: \'((await this.my_resource.list()).length === 1)\'\`)})(((await this.my_resource.list()).length === 1))};
+                }
+              }
+              async test_nested_preflight_field()  {
+                {
+                  {((cond) => {if (!cond) throw new Error(\`assertion failed: \'(this.another.my_field === "hello!")\'\`)})((this.another.my_field === "hello!"))};
+                  {console.log(\`field=\${this.another.my_field}\`)};
+                }
+              }
+              async test_nested_resource()  {
+                {
+                  {((cond) => {if (!cond) throw new Error(\`assertion failed: \'((await this.another.first.my_resource.list()).length === 0)\'\`)})(((await this.another.first.my_resource.list()).length === 0))};
+                  (await this.another.first.my_resource.put("hello",this.my_str));
+                  {console.log(\`this.another.first.my_resource:\${(await this.another.first.my_resource.get("hello"))}\`)};
+                }
+              }
+              async test_expression_recursive()  {
+                {
+                  (await this.my_queue.push(this.my_str));
+                }
+              }
+              async test_external()  {
+                {
+                  {((cond) => {if (!cond) throw new Error(\`assertion failed: \'((await this.ext_bucket.list()).length === 0)\'\`)})(((await this.ext_bucket.list()).length === 0))};
+                  {((cond) => {if (!cond) throw new Error(\`assertion failed: \'(this.ext_num === 12)\'\`)})((this.ext_num === 12))};
+                }
+              }
+              async test_user_defined_resource()  {
+                {
+                  {((cond) => {if (!cond) throw new Error(\`assertion failed: \'((await this.another.meaning_of_life()) === 42)\'\`)})(((await this.another.meaning_of_life()) === 42))};
+                  {((cond) => {if (!cond) throw new Error(\`assertion failed: \'((await this.another.another_func()) === "42")\'\`)})(((await this.another.another_func()) === "42"))};
+                }
+              }
+              async test_inflight_field()  {
+                {
+                  this.inflight_field = 123;
+                  {((cond) => {if (!cond) throw new Error(\`assertion failed: \'(this.inflight_field === 123)\'\`)})((this.inflight_field === 123))};
+                }
+              }
+            }
+            const tmp = new MyResource({
               another: ${another_client},
               array_of_str: ${array_of_str_client},
               ext_bucket: ${ext_bucket_client},

--- a/tools/hangar/__snapshots__/test_corpus/resource_captures_globals.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/resource_captures_globals.w_compile_tf-aws.md
@@ -1,0 +1,449 @@
+# [resource_captures_globals.w](../../../../examples/tests/valid/resource_captures_globals.w) | compile | tf-aws
+
+## main.tf.json
+```json
+{
+  "//": {
+    "metadata": {
+      "backend": "local",
+      "stackName": "root",
+      "version": "0.15.2"
+    },
+    "outputs": {
+      "root": {
+        "Default": {
+          "cloud.TestRunner": {
+            "TestFunctionArns": "WING_TEST_RUNNER_FUNCTION_ARNS"
+          }
+        }
+      }
+    }
+  },
+  "output": {
+    "WING_TEST_RUNNER_FUNCTION_ARNS": {
+      "value": "[[\"root/Default/Default/test\",\"${aws_lambda_function.root_test_AAE85061.arn}\"]]"
+    }
+  },
+  "provider": {
+    "aws": [
+      {}
+    ]
+  },
+  "resource": {
+    "aws_dynamodb_table": {
+      "root_cloudCounter_E0AC1263": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/Default/cloud.Counter/Default",
+            "uniqueId": "root_cloudCounter_E0AC1263"
+          }
+        },
+        "attribute": [
+          {
+            "name": "id",
+            "type": "S"
+          }
+        ],
+        "billing_mode": "PAY_PER_REQUEST",
+        "hash_key": "id",
+        "name": "wing-counter-cloud.Counter-c866f225"
+      }
+    },
+    "aws_iam_role": {
+      "root_test_IamRole_6CDC2D16": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/Default/test/IamRole",
+            "uniqueId": "root_test_IamRole_6CDC2D16"
+          }
+        },
+        "assume_role_policy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Action\":\"sts:AssumeRole\",\"Principal\":{\"Service\":\"lambda.amazonaws.com\"},\"Effect\":\"Allow\"}]}"
+      }
+    },
+    "aws_iam_role_policy": {
+      "root_test_IamRolePolicy_474A6820": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/Default/test/IamRolePolicy",
+            "uniqueId": "root_test_IamRolePolicy_474A6820"
+          }
+        },
+        "policy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Action\":[\"s3:PutObject*\",\"s3:Abort*\"],\"Resource\":[\"${aws_s3_bucket.root_cloudBucket_4F3C4F53.arn}\",\"${aws_s3_bucket.root_cloudBucket_4F3C4F53.arn}/*\"],\"Effect\":\"Allow\"},{\"Action\":[\"dynamodb:UpdateItem\"],\"Resource\":[\"${aws_dynamodb_table.root_cloudCounter_E0AC1263.arn}\"],\"Effect\":\"Allow\"},{\"Action\":[\"dynamodb:GetItem\"],\"Resource\":[\"${aws_dynamodb_table.root_cloudCounter_E0AC1263.arn}\"],\"Effect\":\"Allow\"},{\"Action\":[\"s3:PutObject*\",\"s3:Abort*\"],\"Resource\":[\"${aws_s3_bucket.root_Another_First_cloudBucket_B4A67079.arn}\",\"${aws_s3_bucket.root_Another_First_cloudBucket_B4A67079.arn}/*\"],\"Effect\":\"Allow\"}]}",
+        "role": "${aws_iam_role.root_test_IamRole_6CDC2D16.name}"
+      }
+    },
+    "aws_iam_role_policy_attachment": {
+      "root_test_IamRolePolicyAttachment_1102A28A": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/Default/test/IamRolePolicyAttachment",
+            "uniqueId": "root_test_IamRolePolicyAttachment_1102A28A"
+          }
+        },
+        "policy_arn": "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+        "role": "${aws_iam_role.root_test_IamRole_6CDC2D16.name}"
+      }
+    },
+    "aws_lambda_function": {
+      "root_test_AAE85061": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/Default/test/Default",
+            "uniqueId": "root_test_AAE85061"
+          }
+        },
+        "environment": {
+          "variables": {
+            "BUCKET_NAME_ae5b06c6": "${aws_s3_bucket.root_Another_First_cloudBucket_B4A67079.bucket}",
+            "BUCKET_NAME_ae5b06c6_IS_PUBLIC": "false",
+            "BUCKET_NAME_d755b447": "${aws_s3_bucket.root_cloudBucket_4F3C4F53.bucket}",
+            "BUCKET_NAME_d755b447_IS_PUBLIC": "false",
+            "DYNAMODB_TABLE_NAME_49baa65c": "${aws_dynamodb_table.root_cloudCounter_E0AC1263.name}",
+            "WING_FUNCTION_NAME": "test-c8b6eece"
+          }
+        },
+        "function_name": "test-c8b6eece",
+        "handler": "index.handler",
+        "publish": true,
+        "role": "${aws_iam_role.root_test_IamRole_6CDC2D16.arn}",
+        "runtime": "nodejs16.x",
+        "s3_bucket": "${aws_s3_bucket.root_Code_02F3C603.bucket}",
+        "s3_key": "${aws_s3_object.root_test_S3Object_A16CD789.key}",
+        "timeout": 30,
+        "vpc_config": {
+          "security_group_ids": [],
+          "subnet_ids": []
+        }
+      }
+    },
+    "aws_s3_bucket": {
+      "root_Another_First_cloudBucket_B4A67079": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/Default/Another/First/cloud.Bucket/Default",
+            "uniqueId": "root_Another_First_cloudBucket_B4A67079"
+          }
+        },
+        "bucket_prefix": "cloud-bucket-c84d72a1-",
+        "force_destroy": false
+      },
+      "root_Code_02F3C603": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/Code",
+            "uniqueId": "root_Code_02F3C603"
+          }
+        },
+        "bucket_prefix": "code-c84a50b1-"
+      },
+      "root_cloudBucket_4F3C4F53": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/Default/cloud.Bucket/Default",
+            "uniqueId": "root_cloudBucket_4F3C4F53"
+          }
+        },
+        "bucket_prefix": "cloud-bucket-c87175e7-",
+        "force_destroy": false
+      }
+    },
+    "aws_s3_bucket_public_access_block": {
+      "root_Another_First_cloudBucket_PublicAccessBlock_E03A84DE": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/Default/Another/First/cloud.Bucket/PublicAccessBlock",
+            "uniqueId": "root_Another_First_cloudBucket_PublicAccessBlock_E03A84DE"
+          }
+        },
+        "block_public_acls": true,
+        "block_public_policy": true,
+        "bucket": "${aws_s3_bucket.root_Another_First_cloudBucket_B4A67079.bucket}",
+        "ignore_public_acls": true,
+        "restrict_public_buckets": true
+      },
+      "root_cloudBucket_PublicAccessBlock_319C1C2E": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/Default/cloud.Bucket/PublicAccessBlock",
+            "uniqueId": "root_cloudBucket_PublicAccessBlock_319C1C2E"
+          }
+        },
+        "block_public_acls": true,
+        "block_public_policy": true,
+        "bucket": "${aws_s3_bucket.root_cloudBucket_4F3C4F53.bucket}",
+        "ignore_public_acls": true,
+        "restrict_public_buckets": true
+      }
+    },
+    "aws_s3_bucket_server_side_encryption_configuration": {
+      "root_Another_First_cloudBucket_Encryption_1049825A": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/Default/Another/First/cloud.Bucket/Encryption",
+            "uniqueId": "root_Another_First_cloudBucket_Encryption_1049825A"
+          }
+        },
+        "bucket": "${aws_s3_bucket.root_Another_First_cloudBucket_B4A67079.bucket}",
+        "rule": [
+          {
+            "apply_server_side_encryption_by_default": {
+              "sse_algorithm": "AES256"
+            }
+          }
+        ]
+      },
+      "root_cloudBucket_Encryption_8ED0CD9C": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/Default/cloud.Bucket/Encryption",
+            "uniqueId": "root_cloudBucket_Encryption_8ED0CD9C"
+          }
+        },
+        "bucket": "${aws_s3_bucket.root_cloudBucket_4F3C4F53.bucket}",
+        "rule": [
+          {
+            "apply_server_side_encryption_by_default": {
+              "sse_algorithm": "AES256"
+            }
+          }
+        ]
+      }
+    },
+    "aws_s3_object": {
+      "root_test_S3Object_A16CD789": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/Default/test/S3Object",
+            "uniqueId": "root_test_S3Object_A16CD789"
+          }
+        },
+        "bucket": "${aws_s3_bucket.root_Code_02F3C603.bucket}",
+        "key": "<ASSET_KEY>",
+        "source": "<ASSET_SOURCE>"
+      }
+    }
+  }
+}
+```
+
+## preflight.js
+```js
+const $stdlib = require('@winglang/sdk');
+const $outdir = process.env.WING_SYNTH_DIR ?? ".";
+const $wing_is_test = process.env.WING_IS_TEST === "true";
+const $AppBase = $stdlib.core.App.for(process.env.WING_TARGET);
+const cloud = require('@winglang/sdk').cloud;
+class $Root extends $stdlib.std.Resource {
+  constructor(scope, id) {
+    super(scope, id);
+    class First extends $stdlib.std.Resource {
+      constructor(scope, id, ) {
+        super(scope, id);
+        this._inflightOps.push();
+        this.my_resource = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this,"cloud.Bucket");
+      }
+      _toInflight() {
+        const my_resource_client = this._lift(this.my_resource);
+        const stateful_client = this._lift(this.stateful);
+        return $stdlib.core.NodeJsCode.fromInline(`
+          (await (async () => {
+            class  First {
+              constructor({ my_resource, stateful }) {
+                this.my_resource = my_resource;
+                this.stateful = stateful;
+              }
+            }
+            const tmp = new First({
+              my_resource: ${my_resource_client},
+              stateful: ${stateful_client},
+            });
+            if (tmp.$inflight_init) { await tmp.$inflight_init(); }
+            return tmp;
+          })())
+        `);
+      }
+      _registerBind(host, ops) {
+        if (ops.includes("$inflight_init")) {
+          this._registerBindObject(this.my_resource, host, []);
+          this._registerBindObject(this.stateful, host, []);
+        }
+        super._registerBind(host, ops);
+      }
+    }
+    class Another extends $stdlib.std.Resource {
+      constructor(scope, id, ) {
+        super(scope, id);
+        this._inflightOps.push("my_method");
+        this.my_field = "hello!";
+        this.first = new First(this,"First");
+      }
+      _toInflight() {
+        const __global_counter_client = this._lift(global_counter);
+        const first_client = this._lift(this.first);
+        const my_field_client = this._lift(this.my_field);
+        const stateful_client = this._lift(this.stateful);
+        return $stdlib.core.NodeJsCode.fromInline(`
+          (await (async () => {
+            const global_counter = ${__global_counter_client};
+            class  Another {
+              constructor({ first, my_field, stateful }) {
+                this.first = first;
+                this.my_field = my_field;
+                this.stateful = stateful;
+              }
+              async \$inflight_init()  {
+                {
+                  {((cond) => {if (!cond) throw new Error(\`assertion failed: \'((await global_counter.peek()) === 0)\'\`)})(((await global_counter.peek()) === 0))};
+                }
+              }
+              async my_method()  {
+                {
+                  (await global_counter.inc());
+                  return (await global_counter.peek());
+                }
+              }
+            }
+            const tmp = new Another({
+              first: ${first_client},
+              my_field: ${my_field_client},
+              stateful: ${stateful_client},
+            });
+            if (tmp.$inflight_init) { await tmp.$inflight_init(); }
+            return tmp;
+          })())
+        `);
+      }
+      _registerBind(host, ops) {
+        if (ops.includes("$inflight_init")) {
+          this._registerBindObject(global_counter, host, ["peek"]);
+          this._registerBindObject(this.first, host, []);
+          this._registerBindObject(this.my_field, host, []);
+          this._registerBindObject(this.stateful, host, []);
+        }
+        if (ops.includes("my_method")) {
+          this._registerBindObject(global_counter, host, ["inc", "peek"]);
+        }
+        super._registerBind(host, ops);
+      }
+    }
+    class MyResource extends $stdlib.std.Resource {
+      constructor(scope, id, ) {
+        super(scope, id);
+        this._inflightOps.push("my_put");
+      }
+      _toInflight() {
+        const __global_another_client = this._lift(global_another);
+        const __global_bool_client = this._lift(global_bool);
+        const __global_map_of_num_client = this._lift(global_map_of_num);
+        const __global_bucket_client = this._lift(global_bucket);
+        const __global_num_client = this._lift(global_num);
+        const __global_str_client = this._lift(global_str);
+        const __global_array_of_str_client = this._lift(global_array_of_str);
+        const __global_set_of_str_client = this._lift(global_set_of_str);
+        const stateful_client = this._lift(this.stateful);
+        return $stdlib.core.NodeJsCode.fromInline(`
+          (await (async () => {
+            const global_another = ${__global_another_client};
+            const global_bool = ${__global_bool_client};
+            const global_map_of_num = ${__global_map_of_num_client};
+            const global_bucket = ${__global_bucket_client};
+            const global_num = ${__global_num_client};
+            const global_str = ${__global_str_client};
+            const global_array_of_str = ${__global_array_of_str_client};
+            const global_set_of_str = ${__global_set_of_str_client};
+            class  MyResource {
+              constructor({ stateful }) {
+                this.stateful = stateful;
+              }
+              async my_put()  {
+                {
+                  (await global_bucket.put("key","value"));
+                  {((cond) => {if (!cond) throw new Error(\`assertion failed: \'(global_str === "hello")\'\`)})((global_str === "hello"))};
+                  {((cond) => {if (!cond) throw new Error(\`assertion failed: \'(global_bool === true)\'\`)})((global_bool === true))};
+                  {((cond) => {if (!cond) throw new Error(\`assertion failed: \'(global_num === 42)\'\`)})((global_num === 42))};
+                  {((cond) => {if (!cond) throw new Error(\`assertion failed: \'((await global_array_of_str.at(0)) === "hello")\'\`)})(((await global_array_of_str.at(0)) === "hello"))};
+                  {((cond) => {if (!cond) throw new Error(\`assertion failed: \'((global_map_of_num)["a"] === (-5))\'\`)})(((global_map_of_num)["a"] === (-5)))};
+                  {((cond) => {if (!cond) throw new Error(\`assertion failed: \'(await global_set_of_str.has("a"))\'\`)})((await global_set_of_str.has("a")))};
+                  {((cond) => {if (!cond) throw new Error(\`assertion failed: \'(global_another.my_field === "hello!")\'\`)})((global_another.my_field === "hello!"))};
+                  (await global_another.first.my_resource.put("key","value"));
+                  {((cond) => {if (!cond) throw new Error(\`assertion failed: \'((await global_another.my_method()) > 0)\'\`)})(((await global_another.my_method()) > 0))};
+                }
+              }
+            }
+            const tmp = new MyResource({
+              stateful: ${stateful_client},
+            });
+            if (tmp.$inflight_init) { await tmp.$inflight_init(); }
+            return tmp;
+          })())
+        `);
+      }
+      _registerBind(host, ops) {
+        if (ops.includes("$inflight_init")) {
+          this._registerBindObject(this.stateful, host, []);
+        }
+        if (ops.includes("my_put")) {
+          this._registerBindObject(global_another, host, ["my_method"]);
+          this._registerBindObject(global_another.first.my_resource, host, ["put"]);
+          this._registerBindObject(global_another.my_field, host, []);
+          this._registerBindObject(global_array_of_str, host, ["at"]);
+          this._registerBindObject(global_bool, host, []);
+          this._registerBindObject(global_bucket, host, ["put"]);
+          this._registerBindObject(global_map_of_num, host, ["get"]);
+          this._registerBindObject(global_num, host, []);
+          this._registerBindObject(global_set_of_str, host, ["has"]);
+          this._registerBindObject(global_str, host, []);
+        }
+        super._registerBind(host, ops);
+      }
+    }
+    const global_bucket = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this,"cloud.Bucket");
+    const global_counter = this.node.root.newAbstract("@winglang/sdk.cloud.Counter",this,"cloud.Counter");
+    const global_str = "hello";
+    const global_bool = true;
+    const global_num = 42;
+    const global_array_of_str = Object.freeze(["hello", "world"]);
+    const global_map_of_num = Object.freeze({"a":(-5),"b":2});
+    const global_set_of_str = Object.freeze(new Set(["a", "b"]));
+    const global_another = new Another(this,"Another");
+    const res = new MyResource(this,"MyResource");
+    this.node.root.newAbstract("@winglang/sdk.cloud.Function",this,"test",new $stdlib.core.Inflight(this, "$Inflight1", {
+      code: $stdlib.core.NodeJsCode.fromFile(require.resolve("./proc1/index.js".replace(/\\/g, "/"))),
+      bindings: {
+        res: {
+          obj: res,
+          ops: ["my_put"]
+        },
+      }
+    })
+    );
+  }
+}
+class $App extends $AppBase {
+  constructor() {
+    super({ outdir: $outdir, name: "resource_captures_globals", plugins: $plugins, isTestEnvironment: $wing_is_test });
+    if ($wing_is_test) {
+      new $Root(this, "env0");
+      const $test_runner = this.testRunner;
+      const $tests = $test_runner.findTests();
+      for (let $i = 1; $i < $tests.length; $i++) {
+        new $Root(this, "env" + $i);
+      }
+    } else {
+      new $Root(this, "Default");
+    }
+  }
+}
+new $App().synth();
+
+```
+
+## proc1/index.js
+```js
+async handle() {
+  const { res } = this;
+  (await res.my_put());
+}
+
+```
+

--- a/tools/hangar/__snapshots__/test_corpus/resource_captures_globals.w_test_sim.md
+++ b/tools/hangar/__snapshots__/test_corpus/resource_captures_globals.w_test_sim.md
@@ -1,0 +1,9 @@
+# [resource_captures_globals.w](../../../../examples/tests/valid/resource_captures_globals.w) | test | sim
+
+## stdout.log
+```log
+- Compiling to sim...
+✔ Compiling to sim...
+pass ─ resource_captures_globals.wsim » root/env0/test
+```
+

--- a/tools/hangar/__snapshots__/test_corpus/static_members.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/static_members.w_compile_tf-aws.md
@@ -1,22 +1,5 @@
 # [static_members.w](../../../../examples/tests/valid/static_members.w) | compile | tf-aws
 
-## clients/Foo.inflight.js
-```js
-class  Foo {
-  constructor({ instance_field, stateful }) {
-    this.instance_field = instance_field;
-    this.stateful = stateful;
-  }
-  static async get_123()  {
-    {
-      return 123;
-    }
-  }
-}
-exports.Foo = Foo;
-
-```
-
 ## main.tf.json
 ```json
 {
@@ -160,10 +143,20 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         const instance_field_client = this._lift(this.instance_field);
         const stateful_client = this._lift(this.stateful);
-        const self_client_path = "./clients/Foo.inflight.js".replace(/\\/g, "/");
         return $stdlib.core.NodeJsCode.fromInline(`
           (await (async () => {
-            const tmp = new (require("${self_client_path}")).Foo({
+            class  Foo {
+              constructor({ instance_field, stateful }) {
+                this.instance_field = instance_field;
+                this.stateful = stateful;
+              }
+              static async get_123()  {
+                {
+                  return 123;
+                }
+              }
+            }
+            const tmp = new Foo({
               instance_field: ${instance_field_client},
               stateful: ${stateful_client},
             });

--- a/tools/hangar/__snapshots__/test_corpus/static_members.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/static_members.w_compile_tf-aws.md
@@ -133,6 +133,7 @@ class $Root extends $stdlib.std.Resource {
     class Foo extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
+        this._inflightOps.push("get_123");
         this.instance_field = 100;
       }
       static m()  {
@@ -165,9 +166,16 @@ class $Root extends $stdlib.std.Resource {
           })())
         `);
       }
+      _registerBind(host, ops) {
+        if (ops.includes("$inflight_init")) {
+          this._registerBindObject(this.instance_field, host, []);
+          this._registerBindObject(this.stateful, host, []);
+        }
+        if (ops.includes("get_123")) {
+        }
+        super._registerBind(host, ops);
+      }
     }
-    Foo._annotateInflight("$inflight_init", {"this.instance_field": { ops: [] },"this.stateful": { ops: [] }});
-    Foo._annotateInflight("get_123", {});
     const foo = new Foo(this,"Foo");
     {((cond) => {if (!cond) throw new Error(`assertion failed: '(foo.instance_field === 100)'`)})((foo.instance_field === 100))};
     {((cond) => {if (!cond) throw new Error(`assertion failed: '((Foo.m()) === 99)'`)})(((Foo.m()) === 99))};

--- a/tools/hangar/__snapshots__/test_corpus/structs.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/structs.w_compile_tf-aws.md
@@ -1,22 +1,5 @@
 # [structs.w](../../../../examples/tests/valid/structs.w) | compile | tf-aws
 
-## clients/Foo.inflight.js
-```js
-class  Foo {
-  constructor({ data, stateful }) {
-    this.data = data;
-    this.stateful = stateful;
-  }
-  async get_stuff()  {
-    {
-      return this.data.field0;
-    }
-  }
-}
-exports.Foo = Foo;
-
-```
-
 ## main.tf.json
 ```json
 {
@@ -66,10 +49,20 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         const data_client = this._lift(this.data);
         const stateful_client = this._lift(this.stateful);
-        const self_client_path = "./clients/Foo.inflight.js".replace(/\\/g, "/");
         return $stdlib.core.NodeJsCode.fromInline(`
           (await (async () => {
-            const tmp = new (require("${self_client_path}")).Foo({
+            class  Foo {
+              constructor({ data, stateful }) {
+                this.data = data;
+                this.stateful = stateful;
+              }
+              async get_stuff()  {
+                {
+                  return this.data.field0;
+                }
+              }
+            }
+            const tmp = new Foo({
               data: ${data_client},
               stateful: ${stateful_client},
             });

--- a/tools/hangar/__snapshots__/test_corpus/structs.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/structs.w_compile_tf-aws.md
@@ -44,6 +44,7 @@ class $Root extends $stdlib.std.Resource {
     class Foo extends $stdlib.std.Resource {
       constructor(scope, id, b) {
         super(scope, id);
+        this._inflightOps.push("get_stuff");
         this.data = b;
       }
       _toInflight() {
@@ -71,9 +72,17 @@ class $Root extends $stdlib.std.Resource {
           })())
         `);
       }
+      _registerBind(host, ops) {
+        if (ops.includes("$inflight_init")) {
+          this._registerBindObject(this.data, host, []);
+          this._registerBindObject(this.stateful, host, []);
+        }
+        if (ops.includes("get_stuff")) {
+          this._registerBindObject(this.data.field0, host, []);
+        }
+        super._registerBind(host, ops);
+      }
     }
-    Foo._annotateInflight("$inflight_init", {"this.data": { ops: [] },"this.stateful": { ops: [] }});
-    Foo._annotateInflight("get_stuff", {"this.data.field0": { ops: [] }});
     const x = {
     "field0": "Sup",}
     ;

--- a/tools/hangar/__snapshots__/test_corpus/symbol_shadow.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/symbol_shadow.w_compile_tf-aws.md
@@ -1,16 +1,5 @@
 # [symbol_shadow.w](../../../../examples/tests/valid/symbol_shadow.w) | compile | tf-aws
 
-## clients/A.inflight.js
-```js
-class  A {
-  constructor({ stateful }) {
-    this.stateful = stateful;
-  }
-}
-exports.A = A;
-
-```
-
 ## main.tf.json
 ```json
 {
@@ -354,10 +343,14 @@ class $Root extends $stdlib.std.Resource {
       }
       _toInflight() {
         const stateful_client = this._lift(this.stateful);
-        const self_client_path = "./clients/A.inflight.js".replace(/\\/g, "/");
         return $stdlib.core.NodeJsCode.fromInline(`
           (await (async () => {
-            const tmp = new (require("${self_client_path}")).A({
+            class  A {
+              constructor({ stateful }) {
+                this.stateful = stateful;
+              }
+            }
+            const tmp = new A({
               stateful: ${stateful_client},
             });
             if (tmp.$inflight_init) { await tmp.$inflight_init(); }

--- a/tools/hangar/__snapshots__/test_corpus/symbol_shadow.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/symbol_shadow.w_compile_tf-aws.md
@@ -328,6 +328,7 @@ class $Root extends $stdlib.std.Resource {
     class A extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
+        this._inflightOps.push();
         const s = "in_resource";
         {((cond) => {if (!cond) throw new Error(`assertion failed: '(s === "in_resource")'`)})((s === "in_resource"))};
         this.node.root.newAbstract("@winglang/sdk.cloud.Function",this,"test:inflight in resource should capture the right scoped var",new $stdlib.core.Inflight(this, "$Inflight1", {
@@ -358,8 +359,13 @@ class $Root extends $stdlib.std.Resource {
           })())
         `);
       }
+      _registerBind(host, ops) {
+        if (ops.includes("$inflight_init")) {
+          this._registerBindObject(this.stateful, host, []);
+        }
+        super._registerBind(host, ops);
+      }
     }
-    A._annotateInflight("$inflight_init", {"this.stateful": { ops: [] }});
     const s = "top";
     if (true) {
       const s = "inner";


### PR DESCRIPTION
Closes #1447

This pull request adds support for capturing [free variables](https://en.wikipedia.org/wiki/Free_variables_and_bound_variables) in resource classes, a feature that allows Wing to generate more expressive code for inflight clients. It implements a new visitor, modifies the code generation, and adds a new test case and a snapshot to verify the functionality.

The approach I've taken differs from the solution outlined in #1447. The original issue suggests that we transform free variables into resource fields. I saw some risks with this approach since all usages of the global value inside inflight constructors and inflight methods would also need to be transformed (for example, changing `global_bucket` to `this.global_bucket`), and tracking the list of these mappings so that they only apply to inflight code, and preventing name conflicts, could be tricky.

Instead, this PR augments jsification so that free variables are effectively also emitted as free variables in the JavaScript client code. 

I'm not sure this approach is any better, but it seems to work just as well for a number of cases I've tried.

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.