### PR TITLE
feat(sdk): try parse static method for json

### DIFF
--- a/docs/04-reference/wingsdk-api.md
+++ b/docs/04-reference/wingsdk-api.md
@@ -2520,6 +2520,26 @@ bring cloud;
 let secret_props = cloud.SecretProps{ ... }
 ```
 
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#@winglang/sdk.cloud.SecretProps.property.name">name</a></code> | <code>str</code> | The secret's name. |
+
+---
+
+##### `name`<sup>Optional</sup> <a name="name" id="@winglang/sdk.cloud.SecretProps.property.name"></a>
+
+```wing
+name: str;
+```
+
+- *Type:* str
+- *Default:* a generated name
+
+The secret's name.
+
+---
 
 ### TableProps <a name="TableProps" id="@winglang/sdk.cloud.TableProps"></a>
 
@@ -3500,6 +3520,7 @@ The index of the element in the Json Array to return.
 | <code><a href="#@winglang/sdk.std.Json.keys">keys</a></code> | Returns the keys from the Json object. |
 | <code><a href="#@winglang/sdk.std.Json.parse">parse</a></code> | Parse a string into a Json. |
 | <code><a href="#@winglang/sdk.std.Json.stringify">stringify</a></code> | Formats Json as string. |
+| <code><a href="#@winglang/sdk.std.Json.tryParse">try_parse</a></code> | Try to parse a string into a Json. |
 | <code><a href="#@winglang/sdk.std.Json.values">values</a></code> | Returns the values from the Json. |
 
 ---
@@ -3625,6 +3646,24 @@ to format as string.
 ###### `indent`<sup>Optional</sup> <a name="indent" id="@winglang/sdk.std.Json.stringify.parameter.indent"></a>
 
 - *Type:* num
+
+---
+
+##### `try_parse` <a name="try_parse" id="@winglang/sdk.std.Json.tryParse"></a>
+
+```wing
+bring std;
+
+std.Json.try_parse(str: str)
+```
+
+Try to parse a string into a Json.
+
+###### `str`<sup>Required</sup> <a name="str" id="@winglang/sdk.std.Json.tryParse.parameter.str"></a>
+
+- *Type:* str
+
+to parse as Json.
 
 ---
 

--- a/examples/tests/valid/json_static.w
+++ b/examples/tests/valid/json_static.w
@@ -25,6 +25,11 @@ let s = "{\"a\": 123, \"b\": {\"c\": 456, \"d\": 789}}";
 let j = Json.parse(s);
 assert(Json.keys(j).length == 2);
 
+// Try parse string
+let invalid_json = "invalid";
+let try_parsed = Json.try_parse(invalid_json) ?? Json { key: "value" };
+assert(try_parsed.get("key") == "value");
+
 // Format to string
 let jj = Json {a: 123, b: {c: 456, d: 789}};
 let ss = Json.stringify(jj);

--- a/libs/wingsdk/API.md
+++ b/libs/wingsdk/API.md
@@ -3513,6 +3513,7 @@ The index of the element in the Json Array to return.
 | <code><a href="#@winglang/sdk.std.Json.keys">keys</a></code> | Returns the keys from the Json object. |
 | <code><a href="#@winglang/sdk.std.Json.parse">parse</a></code> | Parse a string into a Json. |
 | <code><a href="#@winglang/sdk.std.Json.stringify">stringify</a></code> | Formats Json as string. |
+| <code><a href="#@winglang/sdk.std.Json.tryParse">try_parse</a></code> | Try to parse a string into a Json. |
 | <code><a href="#@winglang/sdk.std.Json.values">values</a></code> | Returns the values from the Json. |
 
 ---
@@ -3638,6 +3639,24 @@ to format as string.
 ###### `indent`<sup>Optional</sup> <a name="indent" id="@winglang/sdk.std.Json.stringify.parameter.indent"></a>
 
 - *Type:* num
+
+---
+
+##### `try_parse` <a name="try_parse" id="@winglang/sdk.std.Json.tryParse"></a>
+
+```wing
+bring std;
+
+std.Json.try_parse(str: str)
+```
+
+Try to parse a string into a Json.
+
+###### `str`<sup>Required</sup> <a name="str" id="@winglang/sdk.std.Json.tryParse.parameter.str"></a>
+
+- *Type:* str
+
+to parse as Json.
 
 ---
 

--- a/libs/wingsdk/src/std/json.ts
+++ b/libs/wingsdk/src/std/json.ts
@@ -98,6 +98,19 @@ export class Json {
   }
 
   /**
+   * Try to parse a string into a Json
+   *
+   * @macro ((args) => { try { return JSON.parse(args); } catch (err) { return undefined; } })($args$)
+   *
+   * @param str to parse as Json
+   * @returns Json representation of the string or undefined if string is not parsable
+   */
+  public static tryParse(str: string): Json | undefined {
+    str;
+    throw new Error("Macro");
+  }
+
+  /**
    * Returns a specified element from the Json.
    *
    * @macro ($self$)[$args$]

--- a/tools/hangar/__snapshots__/test_corpus/json_static.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/json_static.w_compile_tf-aws.md
@@ -57,6 +57,9 @@ class $Root extends $stdlib.std.Resource {
     const s = "{\"a\": 123, \"b\": {\"c\": 456, \"d\": 789}}";
     const j = (JSON.parse(s));
     {((cond) => {if (!cond) throw new Error(`assertion failed: '((Object.keys(j)).length === 2)'`)})(((Object.keys(j)).length === 2))};
+    const invalid_json = "invalid";
+    const try_parsed = (((args) => { try { return JSON.parse(args); } catch (err) { return undefined; } })(invalid_json) ?? Object.freeze({"key":"value"}));
+    {((cond) => {if (!cond) throw new Error(`assertion failed: '((try_parsed)["key"] === "value")'`)})(((try_parsed)["key"] === "value"))};
     const jj = Object.freeze({"a":123,"b":{"c":456,"d":789}});
     const ss = ((args) => { return JSON.stringify(args[0], null, args[1]) })([jj]);
     {((cond) => {if (!cond) throw new Error(`assertion failed: '(ss === "{\"a\":123,\"b\":{\"c\":456,\"d\":789}}")'`)})((ss === "{\"a\":123,\"b\":{\"c\":456,\"d\":789}}"))};


### PR DESCRIPTION
Add `try_parse()` static method on `Json`.



*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.