### PR TITLE
fix: cloning winglang docsite repo failing in "npm run docs"

### DIFF
--- a/scripts/docsite.sh
+++ b/scripts/docsite.sh
@@ -11,7 +11,13 @@ if [ ! -d $workdir ]; then
   mkdir -p $workdir
   cd $workdir
   echo "🍄 Cloning winglang/docsite into ${workdir}..."
-  git clone --depth=1 git@github.com:winglang/docsite.git .
+  git clone --depth=1 https://github.com/winglang/docsite.git .
+  if [ $? != 0 ]; then
+    rm -rf $workdir
+    echo "🍄 Removed ${workdir} because git clone failed."
+    echo "❗ Failed to setup winglang documentation site locally!"
+    exit 1
+  fi
 else
   echo "🍄 Updating winglang/docsite in ${workdir}..."
   cd $workdir


### PR DESCRIPTION
Changes git cloning method to https instead of SSH. Also added a condition to gracefully exit the script after removing the created directory to prevent further actions unnecessarily running and throwing errors  in case of a git clone failure.

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.