### PR TITLE
fix(docs): testing programmatically broken due to new default scope

### DIFF
--- a/docs/02-getting-started/06-simulator.md
+++ b/docs/02-getting-started/06-simulator.md
@@ -70,14 +70,14 @@ Now that our app is running, lets trigger a message on the queue
 For example, we can list all the resources in the app:
 
 ```js
- const queue = simulator.getResource("root/cloud.Queue"); // retrieve the queue resource
+ const queue = simulator.getResource("root/Default/cloud.Queue"); // retrieve the queue resource
  await queue.push("Wing")
 ```
 
 ## Viewing generated file
 
 ```js
-const bucket = simulator.getResource("root/cloud.Bucket"); // retrieve the bucket resource
+const bucket = simulator.getResource("root/Default/cloud.Bucket"); // retrieve the bucket resource
 await bucket.list() // will show available files
 await bucket.get("wing.txt") // will show the file content
 ```


### PR DESCRIPTION
We recently added the `Default` scope, so resources which used to wonder carelessly directly under `root/` are now under `root/Default/`. This broke the ["Testing programmatically" section on our getting started guide](https://docs.winglang.io/getting-started/simulator).
Fixes #2202 
*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.