### PR TITLE
fix(sdk): aws topic onmessage parameter

### DIFF
--- a/libs/wingsdk/src/shared-aws/topic.onmessage.inflight.ts
+++ b/libs/wingsdk/src/shared-aws/topic.onmessage.inflight.ts
@@ -12,7 +12,7 @@ export class TopicOnMessageHandlerClient
   }
   public async handle(event: any) {
     for (const record of event.Records ?? []) {
-      await this.handler.handle(record.Sns);
+      await this.handler.handle(record.Sns.Message);
     }
   }
 }

--- a/libs/wingsdk/src/target-tf-aws/bucket.onevent.inflight.ts
+++ b/libs/wingsdk/src/target-tf-aws/bucket.onevent.inflight.ts
@@ -5,9 +5,9 @@ export class BucketEventHandlerClient implements IBucketEventHandlerClient {
   constructor({ handler }: { handler: IFunctionHandlerClient }) {
     this.handler = handler;
   }
-  public async handle(event: any) {
+  public async handle(event: string) {
     try {
-      const message = JSON.parse(event?.Message);
+      const message = JSON.parse(event);
       if (message?.Event === "s3:TestEvent") {
         // aws sends a test event to the topic before of the actual one, we're ignoring it for now
         return;

--- a/libs/wingsdk/test/target-awscdk/__snapshots__/topic.test.ts.snap
+++ b/libs/wingsdk/test/target-awscdk/__snapshots__/topic.test.ts.snap
@@ -96,7 +96,7 @@ exports[`topic with multiple subscribers 3`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "c195f3e583aef1c8e9ae42d8847b8f823252dced3e7bb3e41888548920fb5b33.zip",
+          "S3Key": "70c96f4eb085d5d4284b479242d4d486d9bda405b98f6fc817ece5ead39f2bf2.zip",
         },
         "Handler": "index.handler",
         "Role": {
@@ -181,7 +181,7 @@ exports[`topic with multiple subscribers 3`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "d5b8db618dff7b39ab32c5fbc419a8507bf83270033eb01fe8055c59352fa227.zip",
+          "S3Key": "15c5f36c8226db19dde5bfd00330127a4accccaa3e12cc960aab9c3de7ad1709.zip",
         },
         "Handler": "index.handler",
         "Role": {
@@ -325,7 +325,7 @@ exports[`topic with subscriber function 2`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "44204424f8c22e0657f59753f9370401c83c5a1a9cb30cb05cedc3650130cf41.zip",
+          "S3Key": "4cb297fb007d66c747b23d2179881c6d2bb17d6f9c074160f22414c1d5c700d0.zip",
         },
         "Handler": "index.handler",
         "Role": {


### PR DESCRIPTION
Change the `Topic.on_message` handle parameter on AWS to be the actual message, which aligns the behavior with the simulator.

Fixes #2223 
  
*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.