### PR TITLE
chore: downgrade nx to fix argument forwarding issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,11 +8,11 @@
       "name": "monowingo",
       "hasInstallScript": true,
       "devDependencies": {
-        "@nrwl/devkit": "15.9.2",
+        "@nrwl/devkit": "15.7.2",
         "@nxrs/cargo": "^0.3.3",
         "changelogen": "^0.5.3",
         "npm-run-all": "^4.1.5",
-        "nx": "15.9.2",
+        "nx": "15.7.2",
         "semver": "^7.3.8"
       }
     },
@@ -52,24 +52,24 @@
       }
     },
     "node_modules/@nrwl/cli": {
-      "version": "15.9.2",
-      "resolved": "https://registry.npmjs.org/@nrwl/cli/-/cli-15.9.2.tgz",
-      "integrity": "sha512-QoCmyrcGakHAYTJaNBbOerRQAmqJHMYGCdqtQidV+aP9p1Dy33XxDELfhd+IYmGqngutXuEWChNpWNhPloLnoA==",
+      "version": "15.7.2",
+      "resolved": "https://registry.npmjs.org/@nrwl/cli/-/cli-15.7.2.tgz",
+      "integrity": "sha512-A/72FAW1e0ku8YB/PaCqN9BpVvciO83MS5F5bvX5PA8xCNqe1+iXp/5T2ASnN2lB9zR3fQJmvR7mHKTKQlqQQQ==",
       "dev": true,
       "dependencies": {
-        "nx": "15.9.2"
+        "nx": "15.7.2"
       }
     },
     "node_modules/@nrwl/devkit": {
-      "version": "15.9.2",
-      "resolved": "https://registry.npmjs.org/@nrwl/devkit/-/devkit-15.9.2.tgz",
-      "integrity": "sha512-2DvTstVZb91m+d4wqUJMBHQ3elxyabdmFE6/3aXmtOGeDxTyXyDzf/1O6JvBBiL8K6XC3ZYchjtxUHgxl/NJ5A==",
+      "version": "15.7.2",
+      "resolved": "https://registry.npmjs.org/@nrwl/devkit/-/devkit-15.7.2.tgz",
+      "integrity": "sha512-HMGi7L6w2g4IrYwhb04snD8Zr24Z/gzau5i9WUNkwzrjeR1xAm0Cc9WRre221zaeohtK11gyBt7BerT1tgkNwA==",
       "dev": true,
       "dependencies": {
+        "@phenomnomnominal/tsquery": "4.1.1",
         "ejs": "^3.1.7",
         "ignore": "^5.0.4",
         "semver": "7.3.4",
-        "tmp": "~0.2.1",
         "tslib": "^2.3.0"
       },
       "peerDependencies": {
@@ -92,9 +92,9 @@
       }
     },
     "node_modules/@nrwl/nx-darwin-arm64": {
-      "version": "15.9.2",
-      "resolved": "https://registry.npmjs.org/@nrwl/nx-darwin-arm64/-/nx-darwin-arm64-15.9.2.tgz",
-      "integrity": "sha512-Yv+OVsQt3C/hmWOC+YhJZQlsyph5w1BHfbp4jyCvV1ZXBbb8NdvwxgDHPWXxKPTc1EXuB7aEX3qzxM3/OWEUJg==",
+      "version": "15.7.2",
+      "resolved": "https://registry.npmjs.org/@nrwl/nx-darwin-arm64/-/nx-darwin-arm64-15.7.2.tgz",
+      "integrity": "sha512-F82exjuqkAkElSTxEcTFeLMhHpbGiccfTQh2VjXMS+ONldxM+Kd7atJjtUG8wKNXfg0lxxjjAdnzLy3iBuN/HQ==",
       "cpu": [
         "arm64"
       ],
@@ -108,9 +108,9 @@
       }
     },
     "node_modules/@nrwl/nx-darwin-x64": {
-      "version": "15.9.2",
-      "resolved": "https://registry.npmjs.org/@nrwl/nx-darwin-x64/-/nx-darwin-x64-15.9.2.tgz",
-      "integrity": "sha512-qHfdluHlPzV0UHOwj1ZJ+qNEhzfLGiBuy1cOth4BSzDlvMnkuqBWoprfaXoztzYcus2NSILY1/7b3Jw4DAWmMw==",
+      "version": "15.7.2",
+      "resolved": "https://registry.npmjs.org/@nrwl/nx-darwin-x64/-/nx-darwin-x64-15.7.2.tgz",
+      "integrity": "sha512-MNT7Bxz6yhoVLCgGpR0NtVkj20SER1CbrCaY7tmsKVNY9iA/EOZhz9qa3LeA1KZ4lw8Gpi2vD42mOngn7Mwr7w==",
       "cpu": [
         "x64"
       ],
@@ -124,9 +124,9 @@
       }
     },
     "node_modules/@nrwl/nx-linux-arm-gnueabihf": {
-      "version": "15.9.2",
-      "resolved": "https://registry.npmjs.org/@nrwl/nx-linux-arm-gnueabihf/-/nx-linux-arm-gnueabihf-15.9.2.tgz",
-      "integrity": "sha512-0GzwbablosnYnnJDCJvAeZv8LlelSrNwUnGhe43saeoZdAew35Ay1E34zBrg/GCGTASuz+knEEYFM+gDD9Mc6A==",
+      "version": "15.7.2",
+      "resolved": "https://registry.npmjs.org/@nrwl/nx-linux-arm-gnueabihf/-/nx-linux-arm-gnueabihf-15.7.2.tgz",
+      "integrity": "sha512-QGyPkYnZ9LnUnuCzrP50bwsMJ9n6r8K2bNC1sQQwioijY+4MHNL+bMTOGWc8+lYBP7Ju3gpTqozGV3FQVkaM2w==",
       "cpu": [
         "arm"
       ],
@@ -140,9 +140,9 @@
       }
     },
     "node_modules/@nrwl/nx-linux-arm64-gnu": {
-      "version": "15.9.2",
-      "resolved": "https://registry.npmjs.org/@nrwl/nx-linux-arm64-gnu/-/nx-linux-arm64-gnu-15.9.2.tgz",
-      "integrity": "sha512-3mFIY7iUTPG45hSIRaM2DmraCy8W6hNoArAGRrTgYw40BIJHtLrW+Rt7DLyvVXaYCvrKugWOKtxC+jG7kpIZVA==",
+      "version": "15.7.2",
+      "resolved": "https://registry.npmjs.org/@nrwl/nx-linux-arm64-gnu/-/nx-linux-arm64-gnu-15.7.2.tgz",
+      "integrity": "sha512-HqufFVIvuunfChEFGkIhsLhhQjWLTFcCH2aQBSNesHpm6AhFVRGyokNu+PT6NNobr+BTrqJMocBqNQR1uvSyRQ==",
       "cpu": [
         "arm64"
       ],
@@ -156,9 +156,9 @@
       }
     },
     "node_modules/@nrwl/nx-linux-arm64-musl": {
-      "version": "15.9.2",
-      "resolved": "https://registry.npmjs.org/@nrwl/nx-linux-arm64-musl/-/nx-linux-arm64-musl-15.9.2.tgz",
-      "integrity": "sha512-FNBnXEtockwxZa4I3NqggrJp0YIbNokJvt/clrICP+ijOacdUDkv8mJedavobkFsRsNq9gzCbRbUScKymrOLrg==",
+      "version": "15.7.2",
+      "resolved": "https://registry.npmjs.org/@nrwl/nx-linux-arm64-musl/-/nx-linux-arm64-musl-15.7.2.tgz",
+      "integrity": "sha512-9B8q6I/OVyQuYe+Yg2wNyxza/CsbvejIUsrK3QGGWUwHlkklqOSmUOHyTrcyMHUSped6CWPyKdIywngYOQzltQ==",
       "cpu": [
         "arm64"
       ],
@@ -172,9 +172,9 @@
       }
     },
     "node_modules/@nrwl/nx-linux-x64-gnu": {
-      "version": "15.9.2",
-      "resolved": "https://registry.npmjs.org/@nrwl/nx-linux-x64-gnu/-/nx-linux-x64-gnu-15.9.2.tgz",
-      "integrity": "sha512-gHWsP5lbe4FNQCa1Q/VLxIuik+BqAOcSzyPjdUa4gCDcbxPa8xiE57PgXB5E1XUzOWNnDTlXa/Ll07/TIuKuog==",
+      "version": "15.7.2",
+      "resolved": "https://registry.npmjs.org/@nrwl/nx-linux-x64-gnu/-/nx-linux-x64-gnu-15.7.2.tgz",
+      "integrity": "sha512-8/6WtQn4derYKUWu5SxWWM+1dGihSZXMhDW9l/sXOr/qbMZu3XBmM2XZSguw/+p9gEVHcMmN0+D+Cai+q6/vDQ==",
       "cpu": [
         "x64"
       ],
@@ -188,9 +188,9 @@
       }
     },
     "node_modules/@nrwl/nx-linux-x64-musl": {
-      "version": "15.9.2",
-      "resolved": "https://registry.npmjs.org/@nrwl/nx-linux-x64-musl/-/nx-linux-x64-musl-15.9.2.tgz",
-      "integrity": "sha512-EaFUukCbmoHsYECX2AS4pxXH933yesBFVvBgD38DkoFDxDoJMVt6JqYwm+d5R7S4R2P9U3l++aurljQTRq567Q==",
+      "version": "15.7.2",
+      "resolved": "https://registry.npmjs.org/@nrwl/nx-linux-x64-musl/-/nx-linux-x64-musl-15.7.2.tgz",
+      "integrity": "sha512-c5SbqYZZBeBHhH5E30xwb4cHzCMVa/GQMCyTpZgsS/AHAPHbdkv+pO6bxxALvLPTyimcub7V+xbLCL7rgALzyw==",
       "cpu": [
         "x64"
       ],
@@ -204,9 +204,9 @@
       }
     },
     "node_modules/@nrwl/nx-win32-arm64-msvc": {
-      "version": "15.9.2",
-      "resolved": "https://registry.npmjs.org/@nrwl/nx-win32-arm64-msvc/-/nx-win32-arm64-msvc-15.9.2.tgz",
-      "integrity": "sha512-PGAe7QMr51ivx1X3avvs8daNlvv1wGo3OFrobjlu5rSyjC1Y3qHwT9+wdlwzNZ93FIqWOq09s+rE5gfZRfpdAg==",
+      "version": "15.7.2",
+      "resolved": "https://registry.npmjs.org/@nrwl/nx-win32-arm64-msvc/-/nx-win32-arm64-msvc-15.7.2.tgz",
+      "integrity": "sha512-gWD/+gSO3XBma8PHX1Dp86fM6EcntHFfa7n/BISwDFkZ19MfV/gK6HbO847fkD6I34/IcDM/z1PsFwoIpTeoow==",
       "cpu": [
         "arm64"
       ],
@@ -220,9 +220,9 @@
       }
     },
     "node_modules/@nrwl/nx-win32-x64-msvc": {
-      "version": "15.9.2",
-      "resolved": "https://registry.npmjs.org/@nrwl/nx-win32-x64-msvc/-/nx-win32-x64-msvc-15.9.2.tgz",
-      "integrity": "sha512-Q8onNzhuAZ0l9DNkm8D4Z1AEIzJr8JiT4L2fVBLYrV/R75C2HS3q7lzvfo6oqMY6mXge1cFPcrTtg3YXBQaSWA==",
+      "version": "15.7.2",
+      "resolved": "https://registry.npmjs.org/@nrwl/nx-win32-x64-msvc/-/nx-win32-x64-msvc-15.7.2.tgz",
+      "integrity": "sha512-ARE4qGPgk+e+pSm0uPhHan5UCRtwNYc5ddVNS88NFrVoDTPm5MxYLGdvLnshWWio/Bx526FcwUMSCBWSW8HIFw==",
       "cpu": [
         "x64"
       ],
@@ -236,12 +236,12 @@
       }
     },
     "node_modules/@nrwl/tao": {
-      "version": "15.9.2",
-      "resolved": "https://registry.npmjs.org/@nrwl/tao/-/tao-15.9.2.tgz",
-      "integrity": "sha512-+LqNC37w9c6q6Ukdpf0z0tt1PQFNi4gwhHpJvkYQiKRETHjyrrlyqTNEPEyA7PI62RuYC6VrpVw2gzI7ufqZEA==",
+      "version": "15.7.2",
+      "resolved": "https://registry.npmjs.org/@nrwl/tao/-/tao-15.7.2.tgz",
+      "integrity": "sha512-srx9heMIt/QIyuqfewiVYbRpFcD/2pHkTkrEEUKspPd25kzAL2adcAITQKVCHI7/VS2sPdDR67pVsGQPZFBMRQ==",
       "dev": true,
       "dependencies": {
-        "nx": "15.9.2"
+        "nx": "15.7.2"
       },
       "bin": {
         "tao": "index.js"
@@ -275,6 +275,18 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@phenomnomnominal/tsquery": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@phenomnomnominal/tsquery/-/tsquery-4.1.1.tgz",
+      "integrity": "sha512-jjMmK1tnZbm1Jq5a7fBliM4gQwjxMU7TFoRNwIyzwlO+eHPRCFv/Nv+H/Gi1jc3WR7QURG8D5d0Tn12YGrUqBQ==",
+      "dev": true,
+      "dependencies": {
+        "esquery": "^1.0.1"
+      },
+      "peerDependencies": {
+        "typescript": "^3 || ^4"
       }
     },
     "node_modules/@yarnpkg/lockfile": {
@@ -1012,6 +1024,27 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.5.0.tgz",
+      "integrity": "sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==",
+      "dev": true,
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0"
       }
     },
     "node_modules/execa": {
@@ -2324,14 +2357,14 @@
       }
     },
     "node_modules/nx": {
-      "version": "15.9.2",
-      "resolved": "https://registry.npmjs.org/nx/-/nx-15.9.2.tgz",
-      "integrity": "sha512-wtcs+wsuplSckvgk+bV+/XuGlo+sVWzSG0RpgWBjQYeqA3QsVFEAPVY66Z5cSoukDbTV77ddcAjEw+Rz8oOR1A==",
+      "version": "15.7.2",
+      "resolved": "https://registry.npmjs.org/nx/-/nx-15.7.2.tgz",
+      "integrity": "sha512-VRb+CZCji3G4ikdMAGoh6TeU9Q6n5atRwqRSFhUX63er8zhlMvWHLskPMZC4q/81edo/E7RhbmEVUD5MB0JoeA==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
-        "@nrwl/cli": "15.9.2",
-        "@nrwl/tao": "15.9.2",
+        "@nrwl/cli": "15.7.2",
+        "@nrwl/tao": "15.7.2",
         "@parcel/watcher": "2.0.4",
         "@yarnpkg/lockfile": "^1.1.0",
         "@yarnpkg/parsers": "^3.0.0-rc.18",
@@ -2370,15 +2403,15 @@
         "nx": "bin/nx.js"
       },
       "optionalDependencies": {
-        "@nrwl/nx-darwin-arm64": "15.9.2",
-        "@nrwl/nx-darwin-x64": "15.9.2",
-        "@nrwl/nx-linux-arm-gnueabihf": "15.9.2",
-        "@nrwl/nx-linux-arm64-gnu": "15.9.2",
-        "@nrwl/nx-linux-arm64-musl": "15.9.2",
-        "@nrwl/nx-linux-x64-gnu": "15.9.2",
-        "@nrwl/nx-linux-x64-musl": "15.9.2",
-        "@nrwl/nx-win32-arm64-msvc": "15.9.2",
-        "@nrwl/nx-win32-x64-msvc": "15.9.2"
+        "@nrwl/nx-darwin-arm64": "15.7.2",
+        "@nrwl/nx-darwin-x64": "15.7.2",
+        "@nrwl/nx-linux-arm-gnueabihf": "15.7.2",
+        "@nrwl/nx-linux-arm64-gnu": "15.7.2",
+        "@nrwl/nx-linux-arm64-musl": "15.7.2",
+        "@nrwl/nx-linux-x64-gnu": "15.7.2",
+        "@nrwl/nx-linux-x64-musl": "15.7.2",
+        "@nrwl/nx-win32-arm64-msvc": "15.7.2",
+        "@nrwl/nx-win32-x64-msvc": "15.7.2"
       },
       "peerDependencies": {
         "@swc-node/register": "^1.4.2",
@@ -3264,6 +3297,20 @@
       "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
       "dev": true
     },
+    "node_modules/typescript": {
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
     "node_modules/ufo": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.1.1.tgz",
@@ -3464,24 +3511,24 @@
       }
     },
     "@nrwl/cli": {
-      "version": "15.9.2",
-      "resolved": "https://registry.npmjs.org/@nrwl/cli/-/cli-15.9.2.tgz",
-      "integrity": "sha512-QoCmyrcGakHAYTJaNBbOerRQAmqJHMYGCdqtQidV+aP9p1Dy33XxDELfhd+IYmGqngutXuEWChNpWNhPloLnoA==",
+      "version": "15.7.2",
+      "resolved": "https://registry.npmjs.org/@nrwl/cli/-/cli-15.7.2.tgz",
+      "integrity": "sha512-A/72FAW1e0ku8YB/PaCqN9BpVvciO83MS5F5bvX5PA8xCNqe1+iXp/5T2ASnN2lB9zR3fQJmvR7mHKTKQlqQQQ==",
       "dev": true,
       "requires": {
-        "nx": "15.9.2"
+        "nx": "15.7.2"
       }
     },
     "@nrwl/devkit": {
-      "version": "15.9.2",
-      "resolved": "https://registry.npmjs.org/@nrwl/devkit/-/devkit-15.9.2.tgz",
-      "integrity": "sha512-2DvTstVZb91m+d4wqUJMBHQ3elxyabdmFE6/3aXmtOGeDxTyXyDzf/1O6JvBBiL8K6XC3ZYchjtxUHgxl/NJ5A==",
+      "version": "15.7.2",
+      "resolved": "https://registry.npmjs.org/@nrwl/devkit/-/devkit-15.7.2.tgz",
+      "integrity": "sha512-HMGi7L6w2g4IrYwhb04snD8Zr24Z/gzau5i9WUNkwzrjeR1xAm0Cc9WRre221zaeohtK11gyBt7BerT1tgkNwA==",
       "dev": true,
       "requires": {
+        "@phenomnomnominal/tsquery": "4.1.1",
         "ejs": "^3.1.7",
         "ignore": "^5.0.4",
         "semver": "7.3.4",
-        "tmp": "~0.2.1",
         "tslib": "^2.3.0"
       },
       "dependencies": {
@@ -3497,75 +3544,75 @@
       }
     },
     "@nrwl/nx-darwin-arm64": {
-      "version": "15.9.2",
-      "resolved": "https://registry.npmjs.org/@nrwl/nx-darwin-arm64/-/nx-darwin-arm64-15.9.2.tgz",
-      "integrity": "sha512-Yv+OVsQt3C/hmWOC+YhJZQlsyph5w1BHfbp4jyCvV1ZXBbb8NdvwxgDHPWXxKPTc1EXuB7aEX3qzxM3/OWEUJg==",
+      "version": "15.7.2",
+      "resolved": "https://registry.npmjs.org/@nrwl/nx-darwin-arm64/-/nx-darwin-arm64-15.7.2.tgz",
+      "integrity": "sha512-F82exjuqkAkElSTxEcTFeLMhHpbGiccfTQh2VjXMS+ONldxM+Kd7atJjtUG8wKNXfg0lxxjjAdnzLy3iBuN/HQ==",
       "dev": true,
       "optional": true
     },
     "@nrwl/nx-darwin-x64": {
-      "version": "15.9.2",
-      "resolved": "https://registry.npmjs.org/@nrwl/nx-darwin-x64/-/nx-darwin-x64-15.9.2.tgz",
-      "integrity": "sha512-qHfdluHlPzV0UHOwj1ZJ+qNEhzfLGiBuy1cOth4BSzDlvMnkuqBWoprfaXoztzYcus2NSILY1/7b3Jw4DAWmMw==",
+      "version": "15.7.2",
+      "resolved": "https://registry.npmjs.org/@nrwl/nx-darwin-x64/-/nx-darwin-x64-15.7.2.tgz",
+      "integrity": "sha512-MNT7Bxz6yhoVLCgGpR0NtVkj20SER1CbrCaY7tmsKVNY9iA/EOZhz9qa3LeA1KZ4lw8Gpi2vD42mOngn7Mwr7w==",
       "dev": true,
       "optional": true
     },
     "@nrwl/nx-linux-arm-gnueabihf": {
-      "version": "15.9.2",
-      "resolved": "https://registry.npmjs.org/@nrwl/nx-linux-arm-gnueabihf/-/nx-linux-arm-gnueabihf-15.9.2.tgz",
-      "integrity": "sha512-0GzwbablosnYnnJDCJvAeZv8LlelSrNwUnGhe43saeoZdAew35Ay1E34zBrg/GCGTASuz+knEEYFM+gDD9Mc6A==",
+      "version": "15.7.2",
+      "resolved": "https://registry.npmjs.org/@nrwl/nx-linux-arm-gnueabihf/-/nx-linux-arm-gnueabihf-15.7.2.tgz",
+      "integrity": "sha512-QGyPkYnZ9LnUnuCzrP50bwsMJ9n6r8K2bNC1sQQwioijY+4MHNL+bMTOGWc8+lYBP7Ju3gpTqozGV3FQVkaM2w==",
       "dev": true,
       "optional": true
     },
     "@nrwl/nx-linux-arm64-gnu": {
-      "version": "15.9.2",
-      "resolved": "https://registry.npmjs.org/@nrwl/nx-linux-arm64-gnu/-/nx-linux-arm64-gnu-15.9.2.tgz",
-      "integrity": "sha512-3mFIY7iUTPG45hSIRaM2DmraCy8W6hNoArAGRrTgYw40BIJHtLrW+Rt7DLyvVXaYCvrKugWOKtxC+jG7kpIZVA==",
+      "version": "15.7.2",
+      "resolved": "https://registry.npmjs.org/@nrwl/nx-linux-arm64-gnu/-/nx-linux-arm64-gnu-15.7.2.tgz",
+      "integrity": "sha512-HqufFVIvuunfChEFGkIhsLhhQjWLTFcCH2aQBSNesHpm6AhFVRGyokNu+PT6NNobr+BTrqJMocBqNQR1uvSyRQ==",
       "dev": true,
       "optional": true
     },
     "@nrwl/nx-linux-arm64-musl": {
-      "version": "15.9.2",
-      "resolved": "https://registry.npmjs.org/@nrwl/nx-linux-arm64-musl/-/nx-linux-arm64-musl-15.9.2.tgz",
-      "integrity": "sha512-FNBnXEtockwxZa4I3NqggrJp0YIbNokJvt/clrICP+ijOacdUDkv8mJedavobkFsRsNq9gzCbRbUScKymrOLrg==",
+      "version": "15.7.2",
+      "resolved": "https://registry.npmjs.org/@nrwl/nx-linux-arm64-musl/-/nx-linux-arm64-musl-15.7.2.tgz",
+      "integrity": "sha512-9B8q6I/OVyQuYe+Yg2wNyxza/CsbvejIUsrK3QGGWUwHlkklqOSmUOHyTrcyMHUSped6CWPyKdIywngYOQzltQ==",
       "dev": true,
       "optional": true
     },
     "@nrwl/nx-linux-x64-gnu": {
-      "version": "15.9.2",
-      "resolved": "https://registry.npmjs.org/@nrwl/nx-linux-x64-gnu/-/nx-linux-x64-gnu-15.9.2.tgz",
-      "integrity": "sha512-gHWsP5lbe4FNQCa1Q/VLxIuik+BqAOcSzyPjdUa4gCDcbxPa8xiE57PgXB5E1XUzOWNnDTlXa/Ll07/TIuKuog==",
+      "version": "15.7.2",
+      "resolved": "https://registry.npmjs.org/@nrwl/nx-linux-x64-gnu/-/nx-linux-x64-gnu-15.7.2.tgz",
+      "integrity": "sha512-8/6WtQn4derYKUWu5SxWWM+1dGihSZXMhDW9l/sXOr/qbMZu3XBmM2XZSguw/+p9gEVHcMmN0+D+Cai+q6/vDQ==",
       "dev": true,
       "optional": true
     },
     "@nrwl/nx-linux-x64-musl": {
-      "version": "15.9.2",
-      "resolved": "https://registry.npmjs.org/@nrwl/nx-linux-x64-musl/-/nx-linux-x64-musl-15.9.2.tgz",
-      "integrity": "sha512-EaFUukCbmoHsYECX2AS4pxXH933yesBFVvBgD38DkoFDxDoJMVt6JqYwm+d5R7S4R2P9U3l++aurljQTRq567Q==",
+      "version": "15.7.2",
+      "resolved": "https://registry.npmjs.org/@nrwl/nx-linux-x64-musl/-/nx-linux-x64-musl-15.7.2.tgz",
+      "integrity": "sha512-c5SbqYZZBeBHhH5E30xwb4cHzCMVa/GQMCyTpZgsS/AHAPHbdkv+pO6bxxALvLPTyimcub7V+xbLCL7rgALzyw==",
       "dev": true,
       "optional": true
     },
     "@nrwl/nx-win32-arm64-msvc": {
-      "version": "15.9.2",
-      "resolved": "https://registry.npmjs.org/@nrwl/nx-win32-arm64-msvc/-/nx-win32-arm64-msvc-15.9.2.tgz",
-      "integrity": "sha512-PGAe7QMr51ivx1X3avvs8daNlvv1wGo3OFrobjlu5rSyjC1Y3qHwT9+wdlwzNZ93FIqWOq09s+rE5gfZRfpdAg==",
+      "version": "15.7.2",
+      "resolved": "https://registry.npmjs.org/@nrwl/nx-win32-arm64-msvc/-/nx-win32-arm64-msvc-15.7.2.tgz",
+      "integrity": "sha512-gWD/+gSO3XBma8PHX1Dp86fM6EcntHFfa7n/BISwDFkZ19MfV/gK6HbO847fkD6I34/IcDM/z1PsFwoIpTeoow==",
       "dev": true,
       "optional": true
     },
     "@nrwl/nx-win32-x64-msvc": {
-      "version": "15.9.2",
-      "resolved": "https://registry.npmjs.org/@nrwl/nx-win32-x64-msvc/-/nx-win32-x64-msvc-15.9.2.tgz",
-      "integrity": "sha512-Q8onNzhuAZ0l9DNkm8D4Z1AEIzJr8JiT4L2fVBLYrV/R75C2HS3q7lzvfo6oqMY6mXge1cFPcrTtg3YXBQaSWA==",
+      "version": "15.7.2",
+      "resolved": "https://registry.npmjs.org/@nrwl/nx-win32-x64-msvc/-/nx-win32-x64-msvc-15.7.2.tgz",
+      "integrity": "sha512-ARE4qGPgk+e+pSm0uPhHan5UCRtwNYc5ddVNS88NFrVoDTPm5MxYLGdvLnshWWio/Bx526FcwUMSCBWSW8HIFw==",
       "dev": true,
       "optional": true
     },
     "@nrwl/tao": {
-      "version": "15.9.2",
-      "resolved": "https://registry.npmjs.org/@nrwl/tao/-/tao-15.9.2.tgz",
-      "integrity": "sha512-+LqNC37w9c6q6Ukdpf0z0tt1PQFNi4gwhHpJvkYQiKRETHjyrrlyqTNEPEyA7PI62RuYC6VrpVw2gzI7ufqZEA==",
+      "version": "15.7.2",
+      "resolved": "https://registry.npmjs.org/@nrwl/tao/-/tao-15.7.2.tgz",
+      "integrity": "sha512-srx9heMIt/QIyuqfewiVYbRpFcD/2pHkTkrEEUKspPd25kzAL2adcAITQKVCHI7/VS2sPdDR67pVsGQPZFBMRQ==",
       "dev": true,
       "requires": {
-        "nx": "15.9.2"
+        "nx": "15.7.2"
       }
     },
     "@nxrs/cargo": {
@@ -3585,6 +3632,15 @@
       "requires": {
         "node-addon-api": "^3.2.1",
         "node-gyp-build": "^4.3.0"
+      }
+    },
+    "@phenomnomnominal/tsquery": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@phenomnomnominal/tsquery/-/tsquery-4.1.1.tgz",
+      "integrity": "sha512-jjMmK1tnZbm1Jq5a7fBliM4gQwjxMU7TFoRNwIyzwlO+eHPRCFv/Nv+H/Gi1jc3WR7QURG8D5d0Tn12YGrUqBQ==",
+      "dev": true,
+      "requires": {
+        "esquery": "^1.0.1"
       }
     },
     "@yarnpkg/lockfile": {
@@ -4135,6 +4191,21 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true
+    },
+    "esquery": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.5.0.tgz",
+      "integrity": "sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==",
+      "dev": true,
+      "requires": {
+        "estraverse": "^5.1.0"
+      }
+    },
+    "estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
       "dev": true
     },
     "execa": {
@@ -5070,22 +5141,22 @@
       }
     },
     "nx": {
-      "version": "15.9.2",
-      "resolved": "https://registry.npmjs.org/nx/-/nx-15.9.2.tgz",
-      "integrity": "sha512-wtcs+wsuplSckvgk+bV+/XuGlo+sVWzSG0RpgWBjQYeqA3QsVFEAPVY66Z5cSoukDbTV77ddcAjEw+Rz8oOR1A==",
+      "version": "15.7.2",
+      "resolved": "https://registry.npmjs.org/nx/-/nx-15.7.2.tgz",
+      "integrity": "sha512-VRb+CZCji3G4ikdMAGoh6TeU9Q6n5atRwqRSFhUX63er8zhlMvWHLskPMZC4q/81edo/E7RhbmEVUD5MB0JoeA==",
       "dev": true,
       "requires": {
-        "@nrwl/cli": "15.9.2",
-        "@nrwl/nx-darwin-arm64": "15.9.2",
-        "@nrwl/nx-darwin-x64": "15.9.2",
-        "@nrwl/nx-linux-arm-gnueabihf": "15.9.2",
-        "@nrwl/nx-linux-arm64-gnu": "15.9.2",
-        "@nrwl/nx-linux-arm64-musl": "15.9.2",
-        "@nrwl/nx-linux-x64-gnu": "15.9.2",
-        "@nrwl/nx-linux-x64-musl": "15.9.2",
-        "@nrwl/nx-win32-arm64-msvc": "15.9.2",
-        "@nrwl/nx-win32-x64-msvc": "15.9.2",
-        "@nrwl/tao": "15.9.2",
+        "@nrwl/cli": "15.7.2",
+        "@nrwl/nx-darwin-arm64": "15.7.2",
+        "@nrwl/nx-darwin-x64": "15.7.2",
+        "@nrwl/nx-linux-arm-gnueabihf": "15.7.2",
+        "@nrwl/nx-linux-arm64-gnu": "15.7.2",
+        "@nrwl/nx-linux-arm64-musl": "15.7.2",
+        "@nrwl/nx-linux-x64-gnu": "15.7.2",
+        "@nrwl/nx-linux-x64-musl": "15.7.2",
+        "@nrwl/nx-win32-arm64-msvc": "15.7.2",
+        "@nrwl/nx-win32-x64-msvc": "15.7.2",
+        "@nrwl/tao": "15.7.2",
         "@parcel/watcher": "2.0.4",
         "@yarnpkg/lockfile": "^1.1.0",
         "@yarnpkg/parsers": "^3.0.0-rc.18",
@@ -5747,6 +5818,13 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
       "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
       "dev": true
+    },
+    "typescript": {
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "dev": true,
+      "peer": true
     },
     "ufo": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "monowingo",
   "devDependencies": {
-    "@nrwl/devkit": "15.9.2",
+    "@nrwl/devkit": "15.7.2",
     "@nxrs/cargo": "^0.3.3",
     "changelogen": "^0.5.3",
     "npm-run-all": "^4.1.5",
-    "nx": "15.9.2",
+    "nx": "15.7.2",
     "semver": "^7.3.8"
   },
   "scripts": {


### PR DESCRIPTION
In newer versions of nx, commands like `npx nx wing -- compile -t sim ../../examples/tests/valid/hello.w` no longer work.


Issue: https://github.com/nrwl/nx/issues/16499


*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.