### PR TITLE
feat(sdk): reference existing secrets

### DIFF
--- a/docs/04-reference/wingsdk-api.md
+++ b/docs/04-reference/wingsdk-api.md
@@ -2535,9 +2535,13 @@ name: str;
 ```
 
 - *Type:* str
-- *Default:* a generated name
+- *Default:* a new secret is provisioned with a generated name
 
 The secret's name.
+
+If no name is provided then a new secret is provisioned in the target.
+If a name is provided then the resource will reference an existing
+secret in the target.
 
 ---
 

--- a/libs/wingsdk/API.md
+++ b/libs/wingsdk/API.md
@@ -2528,9 +2528,13 @@ name: str;
 ```
 
 - *Type:* str
-- *Default:* a generated name
+- *Default:* a new secret is provisioned with a generated name
 
 The secret's name.
+
+If no name is provided then a new secret is provisioned in the target
+cloud. If a name is provided then the resource will reference an existing
+secret in the target cloud.
 
 ---
 

--- a/libs/wingsdk/API.md
+++ b/libs/wingsdk/API.md
@@ -2532,9 +2532,9 @@ name: str;
 
 The secret's name.
 
-If no name is provided then a new secret is provisioned in the target
-cloud. If a name is provided then the resource will reference an existing
-secret in the target cloud.
+If no name is provided then a new secret is provisioned in the target.
+If a name is provided then the resource will reference an existing
+secret in the target.
 
 ---
 

--- a/libs/wingsdk/src/cloud/secret.ts
+++ b/libs/wingsdk/src/cloud/secret.ts
@@ -14,7 +14,12 @@ export const SECRET_FQN = fqnForType("cloud.Secret");
 export interface SecretProps {
   /**
    * The secret's name.
-   * @default - a generated name
+   *
+   * If no name is provided then a new secret is provisioned in the target
+   * cloud. If a name is provided then the resource will reference an existing
+   * secret in the target cloud.
+   *
+   * @default - a new secret is provisioned with a generated name
    */
   readonly name?: string;
 }

--- a/libs/wingsdk/src/cloud/secret.ts
+++ b/libs/wingsdk/src/cloud/secret.ts
@@ -15,9 +15,9 @@ export interface SecretProps {
   /**
    * The secret's name.
    *
-   * If no name is provided then a new secret is provisioned in the target
-   * cloud. If a name is provided then the resource will reference an existing
-   * secret in the target cloud.
+   * If no name is provided then a new secret is provisioned in the target.
+   * If a name is provided then the resource will reference an existing
+   * secret in the target.
    *
    * @default - a new secret is provisioned with a generated name
    */

--- a/libs/wingsdk/src/target-awscdk/secret.ts
+++ b/libs/wingsdk/src/target-awscdk/secret.ts
@@ -1,4 +1,7 @@
-import { Secret as CdkSecret } from "aws-cdk-lib/aws-secretsmanager";
+import {
+  ISecret as ICdkSecret,
+  Secret as CdkSecret,
+} from "aws-cdk-lib/aws-secretsmanager";
 import { Construct } from "constructs";
 import { Function } from "./function";
 import * as cloud from "../cloud";
@@ -12,14 +15,14 @@ import { IInflightHost } from "../std";
  * @inflight `@winglang/sdk.cloud.ISecretClient`
  */
 export class Secret extends cloud.Secret {
-  private readonly secret: CdkSecret;
+  private readonly secret: ICdkSecret;
 
   constructor(scope: Construct, id: string, props: cloud.SecretProps = {}) {
     super(scope, id, props);
 
-    this.secret = new CdkSecret(this, "Default", {
-      secretName: props.name,
-    });
+    this.secret = props.name
+      ? CdkSecret.fromSecretNameV2(this, "Default", props.name)
+      : new CdkSecret(this, "Default");
   }
 
   /**

--- a/libs/wingsdk/src/target-tf-aws/secret.ts
+++ b/libs/wingsdk/src/target-tf-aws/secret.ts
@@ -1,5 +1,6 @@
 import { DataAwsSecretsmanagerSecret } from "@cdktf/provider-aws/lib/data-aws-secretsmanager-secret";
 import { SecretsmanagerSecret } from "@cdktf/provider-aws/lib/secretsmanager-secret";
+import { TerraformOutput } from "cdktf";
 import { Construct } from "constructs";
 import { Function } from "./function";
 import * as cloud from "../cloud";
@@ -26,11 +27,19 @@ export class Secret extends cloud.Secret {
   constructor(scope: Construct, id: string, props: cloud.SecretProps = {}) {
     super(scope, id, props);
 
-    this.secret = props.name
-      ? new DataAwsSecretsmanagerSecret(this, "Default", { name: props.name })
-      : new SecretsmanagerSecret(this, "Default", {
-          name: ResourceNames.generateName(this, NAME_OPTS),
-        });
+    if (props.name) {
+      this.secret = new DataAwsSecretsmanagerSecret(this, "Default", {
+        name: props.name,
+      });
+    } else {
+      this.secret = new SecretsmanagerSecret(this, "Default", {
+        name: ResourceNames.generateName(this, NAME_OPTS),
+      });
+
+      new TerraformOutput(this, "SecretArn", {
+        value: this.secret.arn,
+      });
+    }
   }
 
   /**

--- a/libs/wingsdk/src/target-tf-aws/secret.ts
+++ b/libs/wingsdk/src/target-tf-aws/secret.ts
@@ -1,3 +1,4 @@
+import { DataAwsSecretsmanagerSecret } from "@cdktf/provider-aws/lib/data-aws-secretsmanager-secret";
 import { SecretsmanagerSecret } from "@cdktf/provider-aws/lib/secretsmanager-secret";
 import { Construct } from "constructs";
 import { Function } from "./function";
@@ -20,14 +21,16 @@ const NAME_OPTS: NameOptions = {
  * @inflight `@winglang/sdk.cloud.ISecretClient`
  */
 export class Secret extends cloud.Secret {
-  private readonly secret: SecretsmanagerSecret;
+  private readonly secret: DataAwsSecretsmanagerSecret | SecretsmanagerSecret;
 
   constructor(scope: Construct, id: string, props: cloud.SecretProps = {}) {
     super(scope, id, props);
 
-    this.secret = new SecretsmanagerSecret(this, "Default", {
-      name: props.name ?? ResourceNames.generateName(this, NAME_OPTS),
-    });
+    this.secret = props.name
+      ? new DataAwsSecretsmanagerSecret(this, "Default", { name: props.name })
+      : new SecretsmanagerSecret(this, "Default", {
+          name: ResourceNames.generateName(this, NAME_OPTS),
+        });
   }
 
   /**

--- a/libs/wingsdk/test/target-awscdk/__snapshots__/secret.test.ts.snap
+++ b/libs/wingsdk/test/target-awscdk/__snapshots__/secret.test.ts.snap
@@ -13,16 +13,62 @@ exports[`default secret behavior 1`] = `
 }
 `;
 
-exports[`secret with a name 1`] = `
+exports[`default secret behavior 2`] = `
 {
-  "SecretA720EF05": {
-    "DeletionPolicy": "Delete",
-    "Properties": {
-      "GenerateSecretString": {},
-      "Name": "my-secret",
+  "SecretSecretArnC6DFE868": {
+    "Value": {
+      "Fn::Join": [
+        "-",
+        [
+          {
+            "Fn::Select": [
+              0,
+              {
+                "Fn::Split": [
+                  "-",
+                  {
+                    "Fn::Select": [
+                      6,
+                      {
+                        "Fn::Split": [
+                          ":",
+                          {
+                            "Ref": "SecretA720EF05",
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            "Fn::Select": [
+              1,
+              {
+                "Fn::Split": [
+                  "-",
+                  {
+                    "Fn::Select": [
+                      6,
+                      {
+                        "Fn::Split": [
+                          ":",
+                          {
+                            "Ref": "SecretA720EF05",
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      ],
     },
-    "Type": "AWS::SecretsManager::Secret",
-    "UpdateReplacePolicy": "Delete",
   },
 }
 `;

--- a/libs/wingsdk/test/target-tf-aws/__snapshots__/secret.test.ts.snap
+++ b/libs/wingsdk/test/target-tf-aws/__snapshots__/secret.test.ts.snap
@@ -5,6 +5,9 @@ exports[`default secret behavior 1`] = `
   \\"output\\": {
     \\"WING_TEST_RUNNER_FUNCTION_ARNS\\": {
       \\"value\\": \\"[]\\"
+    },
+    \\"root_Secret_SecretArn_0B7388CD\\": {
+      \\"value\\": \\"\${aws_secretsmanager_secret.root_Secret_E5F0F150.arn}\\"
     }
   },
   \\"resource\\": {
@@ -38,6 +41,14 @@ exports[`default secret behavior 2`] = `
                     },
                     "id": "Default",
                     "path": "root/Default/Secret/Default",
+                  },
+                  "SecretArn": {
+                    "constructInfo": {
+                      "fqn": "cdktf.TerraformOutput",
+                      "version": "0.15.2",
+                    },
+                    "id": "SecretArn",
+                    "path": "root/Default/Secret/SecretArn",
                   },
                 },
                 "constructInfo": {
@@ -124,16 +135,16 @@ exports[`default secret behavior 2`] = `
 
 exports[`secret with a name 1`] = `
 "{
-  \\"output\\": {
-    \\"WING_TEST_RUNNER_FUNCTION_ARNS\\": {
-      \\"value\\": \\"[]\\"
-    }
-  },
-  \\"resource\\": {
+  \\"data\\": {
     \\"aws_secretsmanager_secret\\": {
       \\"root_Secret_E5F0F150\\": {
         \\"name\\": \\"my-secret\\"
       }
+    }
+  },
+  \\"output\\": {
+    \\"WING_TEST_RUNNER_FUNCTION_ARNS\\": {
+      \\"value\\": \\"[]\\"
     }
   }
 }"


### PR DESCRIPTION
If a name is provided then the `cloud.Secret` references an existing secret
in the target cloud. If no name is provided then a new secret is provisioned
in the target cloud.

⚠️ It is no longer possible to provision a secret with a well-defined/well-known name.

Closes #2252 
 
*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.