### PR TITLE
fix(sdk): api use event maps

### DIFF
--- a/docs/04-reference/wingsdk-api.md
+++ b/docs/04-reference/wingsdk-api.md
@@ -37,30 +37,30 @@ new cloud.Api(props?: ApiProps)
 
 | **Name** | **Description** |
 | --- | --- |
-| <code><a href="#@winglang/sdk.cloud.Api.connect">connect</a></code> | Add a inflight handler to the api for CONNECT requests on the given route. |
-| <code><a href="#@winglang/sdk.cloud.Api.delete">delete</a></code> | Add a inflight handler to the api for DELETE requests on the given route. |
-| <code><a href="#@winglang/sdk.cloud.Api.get">get</a></code> | Add a inflight handler to the api for GET requests on the given route. |
-| <code><a href="#@winglang/sdk.cloud.Api.head">head</a></code> | Add a inflight handler to the api for HEAD requests on the given route. |
-| <code><a href="#@winglang/sdk.cloud.Api.options">options</a></code> | Add a inflight handler to the api for OPTIONS requests on the given route. |
-| <code><a href="#@winglang/sdk.cloud.Api.patch">patch</a></code> | Add a inflight handler to the api for PATCH requests on the given route. |
-| <code><a href="#@winglang/sdk.cloud.Api.post">post</a></code> | Add a inflight handler to the api for POST requests on the given route. |
-| <code><a href="#@winglang/sdk.cloud.Api.put">put</a></code> | Add a inflight handler to the api for PUT requests on the given route. |
+| <code><a href="#@winglang/sdk.cloud.Api.connect">connect</a></code> | Add a inflight handler to the api for CONNECT requests on the given path. |
+| <code><a href="#@winglang/sdk.cloud.Api.delete">delete</a></code> | Add a inflight handler to the api for DELETE requests on the given path. |
+| <code><a href="#@winglang/sdk.cloud.Api.get">get</a></code> | Add a inflight handler to the api for GET requests on the given path. |
+| <code><a href="#@winglang/sdk.cloud.Api.head">head</a></code> | Add a inflight handler to the api for HEAD requests on the given path. |
+| <code><a href="#@winglang/sdk.cloud.Api.options">options</a></code> | Add a inflight handler to the api for OPTIONS requests on the given path. |
+| <code><a href="#@winglang/sdk.cloud.Api.patch">patch</a></code> | Add a inflight handler to the api for PATCH requests on the given path. |
+| <code><a href="#@winglang/sdk.cloud.Api.post">post</a></code> | Add a inflight handler to the api for POST requests on the given path. |
+| <code><a href="#@winglang/sdk.cloud.Api.put">put</a></code> | Add a inflight handler to the api for PUT requests on the given path. |
 
 ---
 
 ##### `connect` <a name="connect" id="@winglang/sdk.cloud.Api.connect"></a>
 
 ```wing
-connect(route: str, inflight: IApiEndpointHandler, props?: ApiConnectProps): void
+connect(path: str, inflight: IApiEndpointHandler, props?: ApiConnectProps): void
 ```
 
-Add a inflight handler to the api for CONNECT requests on the given route.
+Add a inflight handler to the api for CONNECT requests on the given path.
 
-###### `route`<sup>Required</sup> <a name="route" id="@winglang/sdk.cloud.Api.connect.parameter.route"></a>
+###### `path`<sup>Required</sup> <a name="path" id="@winglang/sdk.cloud.Api.connect.parameter.path"></a>
 
 - *Type:* str
 
-The route to handle CONNECT requests for.
+The path to handle CONNECT requests for.
 
 ---
 
@@ -83,16 +83,16 @@ Options for the route.
 ##### `delete` <a name="delete" id="@winglang/sdk.cloud.Api.delete"></a>
 
 ```wing
-delete(route: str, inflight: IApiEndpointHandler, props?: ApiDeleteProps): void
+delete(path: str, inflight: IApiEndpointHandler, props?: ApiDeleteProps): void
 ```
 
-Add a inflight handler to the api for DELETE requests on the given route.
+Add a inflight handler to the api for DELETE requests on the given path.
 
-###### `route`<sup>Required</sup> <a name="route" id="@winglang/sdk.cloud.Api.delete.parameter.route"></a>
+###### `path`<sup>Required</sup> <a name="path" id="@winglang/sdk.cloud.Api.delete.parameter.path"></a>
 
 - *Type:* str
 
-The route to handle DELETE requests for.
+The path to handle DELETE requests for.
 
 ---
 
@@ -115,16 +115,16 @@ Options for the route.
 ##### `get` <a name="get" id="@winglang/sdk.cloud.Api.get"></a>
 
 ```wing
-get(route: str, inflight: IApiEndpointHandler, props?: ApiGetProps): void
+get(path: str, inflight: IApiEndpointHandler, props?: ApiGetProps): void
 ```
 
-Add a inflight handler to the api for GET requests on the given route.
+Add a inflight handler to the api for GET requests on the given path.
 
-###### `route`<sup>Required</sup> <a name="route" id="@winglang/sdk.cloud.Api.get.parameter.route"></a>
+###### `path`<sup>Required</sup> <a name="path" id="@winglang/sdk.cloud.Api.get.parameter.path"></a>
 
 - *Type:* str
 
-The route to handle GET requests for.
+The path to handle GET requests for.
 
 ---
 
@@ -147,16 +147,16 @@ Options for the route.
 ##### `head` <a name="head" id="@winglang/sdk.cloud.Api.head"></a>
 
 ```wing
-head(route: str, inflight: IApiEndpointHandler, props?: ApiHeadProps): void
+head(path: str, inflight: IApiEndpointHandler, props?: ApiHeadProps): void
 ```
 
-Add a inflight handler to the api for HEAD requests on the given route.
+Add a inflight handler to the api for HEAD requests on the given path.
 
-###### `route`<sup>Required</sup> <a name="route" id="@winglang/sdk.cloud.Api.head.parameter.route"></a>
+###### `path`<sup>Required</sup> <a name="path" id="@winglang/sdk.cloud.Api.head.parameter.path"></a>
 
 - *Type:* str
 
-The route to handle HEAD requests for.
+The path to handle HEAD requests for.
 
 ---
 
@@ -179,16 +179,16 @@ Options for the route.
 ##### `options` <a name="options" id="@winglang/sdk.cloud.Api.options"></a>
 
 ```wing
-options(route: str, inflight: IApiEndpointHandler, props?: ApiOptionsProps): void
+options(path: str, inflight: IApiEndpointHandler, props?: ApiOptionsProps): void
 ```
 
-Add a inflight handler to the api for OPTIONS requests on the given route.
+Add a inflight handler to the api for OPTIONS requests on the given path.
 
-###### `route`<sup>Required</sup> <a name="route" id="@winglang/sdk.cloud.Api.options.parameter.route"></a>
+###### `path`<sup>Required</sup> <a name="path" id="@winglang/sdk.cloud.Api.options.parameter.path"></a>
 
 - *Type:* str
 
-The route to handle OPTIONS requests for.
+The path to handle OPTIONS requests for.
 
 ---
 
@@ -211,16 +211,16 @@ Options for the route.
 ##### `patch` <a name="patch" id="@winglang/sdk.cloud.Api.patch"></a>
 
 ```wing
-patch(route: str, inflight: IApiEndpointHandler, props?: ApiPatchProps): void
+patch(path: str, inflight: IApiEndpointHandler, props?: ApiPatchProps): void
 ```
 
-Add a inflight handler to the api for PATCH requests on the given route.
+Add a inflight handler to the api for PATCH requests on the given path.
 
-###### `route`<sup>Required</sup> <a name="route" id="@winglang/sdk.cloud.Api.patch.parameter.route"></a>
+###### `path`<sup>Required</sup> <a name="path" id="@winglang/sdk.cloud.Api.patch.parameter.path"></a>
 
 - *Type:* str
 
-The route to handle PATCH requests for.
+The path to handle PATCH requests for.
 
 ---
 
@@ -243,16 +243,16 @@ Options for the route.
 ##### `post` <a name="post" id="@winglang/sdk.cloud.Api.post"></a>
 
 ```wing
-post(route: str, inflight: IApiEndpointHandler, props?: ApiPostProps): void
+post(path: str, inflight: IApiEndpointHandler, props?: ApiPostProps): void
 ```
 
-Add a inflight handler to the api for POST requests on the given route.
+Add a inflight handler to the api for POST requests on the given path.
 
-###### `route`<sup>Required</sup> <a name="route" id="@winglang/sdk.cloud.Api.post.parameter.route"></a>
+###### `path`<sup>Required</sup> <a name="path" id="@winglang/sdk.cloud.Api.post.parameter.path"></a>
 
 - *Type:* str
 
-The route to handle POST requests for.
+The path to handle POST requests for.
 
 ---
 
@@ -275,16 +275,16 @@ Options for the route.
 ##### `put` <a name="put" id="@winglang/sdk.cloud.Api.put"></a>
 
 ```wing
-put(route: str, inflight: IApiEndpointHandler, props?: ApiPutProps): void
+put(path: str, inflight: IApiEndpointHandler, props?: ApiPutProps): void
 ```
 
-Add a inflight handler to the api for PUT requests on the given route.
+Add a inflight handler to the api for PUT requests on the given path.
 
-###### `route`<sup>Required</sup> <a name="route" id="@winglang/sdk.cloud.Api.put.parameter.route"></a>
+###### `path`<sup>Required</sup> <a name="path" id="@winglang/sdk.cloud.Api.put.parameter.path"></a>
 
 - *Type:* str
 
-The route to handle PUT requests for.
+The path to handle PUT requests for.
 
 ---
 

--- a/libs/wingsdk/API.md
+++ b/libs/wingsdk/API.md
@@ -30,30 +30,30 @@ new cloud.Api(props?: ApiProps)
 
 | **Name** | **Description** |
 | --- | --- |
-| <code><a href="#@winglang/sdk.cloud.Api.connect">connect</a></code> | Add a inflight handler to the api for CONNECT requests on the given route. |
-| <code><a href="#@winglang/sdk.cloud.Api.delete">delete</a></code> | Add a inflight handler to the api for DELETE requests on the given route. |
-| <code><a href="#@winglang/sdk.cloud.Api.get">get</a></code> | Add a inflight handler to the api for GET requests on the given route. |
-| <code><a href="#@winglang/sdk.cloud.Api.head">head</a></code> | Add a inflight handler to the api for HEAD requests on the given route. |
-| <code><a href="#@winglang/sdk.cloud.Api.options">options</a></code> | Add a inflight handler to the api for OPTIONS requests on the given route. |
-| <code><a href="#@winglang/sdk.cloud.Api.patch">patch</a></code> | Add a inflight handler to the api for PATCH requests on the given route. |
-| <code><a href="#@winglang/sdk.cloud.Api.post">post</a></code> | Add a inflight handler to the api for POST requests on the given route. |
-| <code><a href="#@winglang/sdk.cloud.Api.put">put</a></code> | Add a inflight handler to the api for PUT requests on the given route. |
+| <code><a href="#@winglang/sdk.cloud.Api.connect">connect</a></code> | Add a inflight handler to the api for CONNECT requests on the given path. |
+| <code><a href="#@winglang/sdk.cloud.Api.delete">delete</a></code> | Add a inflight handler to the api for DELETE requests on the given path. |
+| <code><a href="#@winglang/sdk.cloud.Api.get">get</a></code> | Add a inflight handler to the api for GET requests on the given path. |
+| <code><a href="#@winglang/sdk.cloud.Api.head">head</a></code> | Add a inflight handler to the api for HEAD requests on the given path. |
+| <code><a href="#@winglang/sdk.cloud.Api.options">options</a></code> | Add a inflight handler to the api for OPTIONS requests on the given path. |
+| <code><a href="#@winglang/sdk.cloud.Api.patch">patch</a></code> | Add a inflight handler to the api for PATCH requests on the given path. |
+| <code><a href="#@winglang/sdk.cloud.Api.post">post</a></code> | Add a inflight handler to the api for POST requests on the given path. |
+| <code><a href="#@winglang/sdk.cloud.Api.put">put</a></code> | Add a inflight handler to the api for PUT requests on the given path. |
 
 ---
 
 ##### `connect` <a name="connect" id="@winglang/sdk.cloud.Api.connect"></a>
 
 ```wing
-connect(route: str, inflight: IApiEndpointHandler, props?: ApiConnectProps): void
+connect(path: str, inflight: IApiEndpointHandler, props?: ApiConnectProps): void
 ```
 
-Add a inflight handler to the api for CONNECT requests on the given route.
+Add a inflight handler to the api for CONNECT requests on the given path.
 
-###### `route`<sup>Required</sup> <a name="route" id="@winglang/sdk.cloud.Api.connect.parameter.route"></a>
+###### `path`<sup>Required</sup> <a name="path" id="@winglang/sdk.cloud.Api.connect.parameter.path"></a>
 
 - *Type:* str
 
-The route to handle CONNECT requests for.
+The path to handle CONNECT requests for.
 
 ---
 
@@ -76,16 +76,16 @@ Options for the route.
 ##### `delete` <a name="delete" id="@winglang/sdk.cloud.Api.delete"></a>
 
 ```wing
-delete(route: str, inflight: IApiEndpointHandler, props?: ApiDeleteProps): void
+delete(path: str, inflight: IApiEndpointHandler, props?: ApiDeleteProps): void
 ```
 
-Add a inflight handler to the api for DELETE requests on the given route.
+Add a inflight handler to the api for DELETE requests on the given path.
 
-###### `route`<sup>Required</sup> <a name="route" id="@winglang/sdk.cloud.Api.delete.parameter.route"></a>
+###### `path`<sup>Required</sup> <a name="path" id="@winglang/sdk.cloud.Api.delete.parameter.path"></a>
 
 - *Type:* str
 
-The route to handle DELETE requests for.
+The path to handle DELETE requests for.
 
 ---
 
@@ -108,16 +108,16 @@ Options for the route.
 ##### `get` <a name="get" id="@winglang/sdk.cloud.Api.get"></a>
 
 ```wing
-get(route: str, inflight: IApiEndpointHandler, props?: ApiGetProps): void
+get(path: str, inflight: IApiEndpointHandler, props?: ApiGetProps): void
 ```
 
-Add a inflight handler to the api for GET requests on the given route.
+Add a inflight handler to the api for GET requests on the given path.
 
-###### `route`<sup>Required</sup> <a name="route" id="@winglang/sdk.cloud.Api.get.parameter.route"></a>
+###### `path`<sup>Required</sup> <a name="path" id="@winglang/sdk.cloud.Api.get.parameter.path"></a>
 
 - *Type:* str
 
-The route to handle GET requests for.
+The path to handle GET requests for.
 
 ---
 
@@ -140,16 +140,16 @@ Options for the route.
 ##### `head` <a name="head" id="@winglang/sdk.cloud.Api.head"></a>
 
 ```wing
-head(route: str, inflight: IApiEndpointHandler, props?: ApiHeadProps): void
+head(path: str, inflight: IApiEndpointHandler, props?: ApiHeadProps): void
 ```
 
-Add a inflight handler to the api for HEAD requests on the given route.
+Add a inflight handler to the api for HEAD requests on the given path.
 
-###### `route`<sup>Required</sup> <a name="route" id="@winglang/sdk.cloud.Api.head.parameter.route"></a>
+###### `path`<sup>Required</sup> <a name="path" id="@winglang/sdk.cloud.Api.head.parameter.path"></a>
 
 - *Type:* str
 
-The route to handle HEAD requests for.
+The path to handle HEAD requests for.
 
 ---
 
@@ -172,16 +172,16 @@ Options for the route.
 ##### `options` <a name="options" id="@winglang/sdk.cloud.Api.options"></a>
 
 ```wing
-options(route: str, inflight: IApiEndpointHandler, props?: ApiOptionsProps): void
+options(path: str, inflight: IApiEndpointHandler, props?: ApiOptionsProps): void
 ```
 
-Add a inflight handler to the api for OPTIONS requests on the given route.
+Add a inflight handler to the api for OPTIONS requests on the given path.
 
-###### `route`<sup>Required</sup> <a name="route" id="@winglang/sdk.cloud.Api.options.parameter.route"></a>
+###### `path`<sup>Required</sup> <a name="path" id="@winglang/sdk.cloud.Api.options.parameter.path"></a>
 
 - *Type:* str
 
-The route to handle OPTIONS requests for.
+The path to handle OPTIONS requests for.
 
 ---
 
@@ -204,16 +204,16 @@ Options for the route.
 ##### `patch` <a name="patch" id="@winglang/sdk.cloud.Api.patch"></a>
 
 ```wing
-patch(route: str, inflight: IApiEndpointHandler, props?: ApiPatchProps): void
+patch(path: str, inflight: IApiEndpointHandler, props?: ApiPatchProps): void
 ```
 
-Add a inflight handler to the api for PATCH requests on the given route.
+Add a inflight handler to the api for PATCH requests on the given path.
 
-###### `route`<sup>Required</sup> <a name="route" id="@winglang/sdk.cloud.Api.patch.parameter.route"></a>
+###### `path`<sup>Required</sup> <a name="path" id="@winglang/sdk.cloud.Api.patch.parameter.path"></a>
 
 - *Type:* str
 
-The route to handle PATCH requests for.
+The path to handle PATCH requests for.
 
 ---
 
@@ -236,16 +236,16 @@ Options for the route.
 ##### `post` <a name="post" id="@winglang/sdk.cloud.Api.post"></a>
 
 ```wing
-post(route: str, inflight: IApiEndpointHandler, props?: ApiPostProps): void
+post(path: str, inflight: IApiEndpointHandler, props?: ApiPostProps): void
 ```
 
-Add a inflight handler to the api for POST requests on the given route.
+Add a inflight handler to the api for POST requests on the given path.
 
-###### `route`<sup>Required</sup> <a name="route" id="@winglang/sdk.cloud.Api.post.parameter.route"></a>
+###### `path`<sup>Required</sup> <a name="path" id="@winglang/sdk.cloud.Api.post.parameter.path"></a>
 
 - *Type:* str
 
-The route to handle POST requests for.
+The path to handle POST requests for.
 
 ---
 
@@ -268,16 +268,16 @@ Options for the route.
 ##### `put` <a name="put" id="@winglang/sdk.cloud.Api.put"></a>
 
 ```wing
-put(route: str, inflight: IApiEndpointHandler, props?: ApiPutProps): void
+put(path: str, inflight: IApiEndpointHandler, props?: ApiPutProps): void
 ```
 
-Add a inflight handler to the api for PUT requests on the given route.
+Add a inflight handler to the api for PUT requests on the given path.
 
-###### `route`<sup>Required</sup> <a name="route" id="@winglang/sdk.cloud.Api.put.parameter.route"></a>
+###### `path`<sup>Required</sup> <a name="path" id="@winglang/sdk.cloud.Api.put.parameter.path"></a>
 
 - *Type:* str
 
-The route to handle PUT requests for.
+The path to handle PUT requests for.
 
 ---
 

--- a/libs/wingsdk/src/cloud/api.ts
+++ b/libs/wingsdk/src/cloud/api.ts
@@ -164,8 +164,9 @@ export abstract class Api extends Resource {
    * if has curly brackets pairs- the part that inside the brackets is only letter, digit or _, not empty and placed before and after "/"
    * @param path
    * @throws if the path is invalid
+   * @internal
    */
-  protected validatePath(path: string) {
+  protected _validatePath(path: string) {
     if (!/^([^\{\}\:\n]|.+\/\{\w+\}(\/|$))*$/g.test(path)) {
       throw new Error(
         `Invalid path ${path}. Url cannot contain ":", params contains only alpha-numeric chars or "_".`

--- a/libs/wingsdk/src/cloud/api.ts
+++ b/libs/wingsdk/src/cloud/api.ts
@@ -65,137 +65,136 @@ export abstract class Api extends Resource {
     this.display.description = "A REST API endpoint";
   }
   /**
-   * Add a inflight handler to the api for GET requests on the given route.
-   * @param route The route to handle GET requests for.
+   * Add a inflight handler to the api for GET requests on the given path.
+   * @param path The path to handle GET requests for.
    * @param inflight The function to handle the request.
    * @param props Options for the route.
    */
   public abstract get(
-    route: string,
+    path: string,
     inflight: IApiEndpointHandler,
     props?: ApiGetProps
   ): void;
 
   /**
-   * Add a inflight handler to the api for POST requests on the given route.
-   * @param route The route to handle POST requests for.
+   * Add a inflight handler to the api for POST requests on the given path.
+   * @param path The path to handle POST requests for.
    * @param inflight The function to handle the request.
    * @param props Options for the route.
    */
   public abstract post(
-    route: string,
+    path: string,
     inflight: IApiEndpointHandler,
     props?: ApiPostProps
   ): void;
 
   /**
-   * Add a inflight handler to the api for PUT requests on the given route.
-   * @param route The route to handle PUT requests for.
+   * Add a inflight handler to the api for PUT requests on the given path.
+   * @param path The path to handle PUT requests for.
    * @param inflight The function to handle the request.
    * @param props Options for the route.
    */
   public abstract put(
-    route: string,
+    path: string,
     inflight: IApiEndpointHandler,
     props?: ApiPutProps
   ): void;
 
   /**
-   * Add a inflight handler to the api for DELETE requests on the given route.
-   * @param route The route to handle DELETE requests for.
+   * Add a inflight handler to the api for DELETE requests on the given path.
+   * @param path The path to handle DELETE requests for.
    * @param inflight The function to handle the request.
    * @param props Options for the route.
    */
   public abstract delete(
-    route: string,
+    path: string,
     inflight: IApiEndpointHandler,
     props?: ApiDeleteProps
   ): void;
 
   /**
-   * Add a inflight handler to the api for PATCH requests on the given route.
-   * @param route The route to handle PATCH requests for.
+   * Add a inflight handler to the api for PATCH requests on the given path.
+   * @param path The path to handle PATCH requests for.
    * @param inflight The function to handle the request.
    * @param props Options for the route.
    */
   public abstract patch(
-    route: string,
+    path: string,
     inflight: IApiEndpointHandler,
     props?: ApiPatchProps
   ): void;
 
   /**
-   * Add a inflight handler to the api for OPTIONS requests on the given route.
-   * @param route The route to handle OPTIONS requests for.
+   * Add a inflight handler to the api for OPTIONS requests on the given path.
+   * @param path The path to handle OPTIONS requests for.
    * @param inflight The function to handle the request.
    * @param props Options for the route.
    */
   public abstract options(
-    route: string,
+    path: string,
     inflight: IApiEndpointHandler,
     props?: ApiOptionsProps
   ): void;
 
   /**
-   * Add a inflight handler to the api for HEAD requests on the given route.
-   * @param route The route to handle HEAD requests for.
+   * Add a inflight handler to the api for HEAD requests on the given path.
+   * @param path The path to handle HEAD requests for.
    * @param inflight The function to handle the request.
    * @param props Options for the route.
    */
   public abstract head(
-    route: string,
+    path: string,
     inflight: IApiEndpointHandler,
     props?: ApiHeadProps
   ): void;
 
   /**
-   * Add a inflight handler to the api for CONNECT requests on the given route.
-   * @param route The route to handle CONNECT requests for.
+   * Add a inflight handler to the api for CONNECT requests on the given path.
+   * @param path The path to handle CONNECT requests for.
    * @param inflight The function to handle the request.
    * @param props Options for the route.
    */
   public abstract connect(
-    route: string,
+    path: string,
     inflight: IApiEndpointHandler,
     props?: ApiConnectProps
   ): void;
   /**
-   * validating route:
+   * validating path:
    * if has curly brackets pairs- the part that inside the brackets is only letter, digit or _, not empty and placed before and after "/"
-   * @param route
-   * @throws if the route is invalid
-   * @internal
+   * @param path
+   * @throws if the path is invalid
    */
-  protected _validateRoute(route: string) {
-    if (!/^([^\{\}\:\n]|.+\/\{\w+\}(\/|$))*$/g.test(route)) {
+  protected validatePath(path: string) {
+    if (!/^([^\{\}\:\n]|.+\/\{\w+\}(\/|$))*$/g.test(path)) {
       throw new Error(
-        `Invalid route ${route}. Url cannot contain ":", params contains only alpha-numeric chars or "_".`
+        `Invalid path ${path}. Url cannot contain ":", params contains only alpha-numeric chars or "_".`
       );
     }
   }
 
   /**
    * Add a route to the api spec.
-   * @param route The route to add.
+   * @param path The path to add.
    * @param method The method to add.
    * @param apiSpecExtension The extension to add to the api spec for this route and method.
    *
    * @internal
    * */
   public _addToSpec(
-    route: string,
+    path: string,
     method: string,
     apiSpecExtension: OpenApiSpecExtension
   ) {
-    if (this.apiSpec.paths[route]?.[method.toLowerCase()]) {
+    if (this.apiSpec.paths[path]?.[method.toLowerCase()]) {
       throw new Error(
-        `Endpoint for path '${route}' and method '${method}' already exists`
+        `Endpoint for path '${path}' and method '${method}' already exists`
       );
     }
     const operationId = `${method.toLowerCase()}${
-      route === "/" ? "" : route.replace("/", "-")
+      path === "/" ? "" : path.replace("/", "-")
     }`;
-    const pathParams = route.match(/{(.*?)}/g);
+    const pathParams = path.match(/{(.*?)}/g);
     const pathParameters: any[] = [];
     if (pathParams) {
       pathParams.forEach((param) => {
@@ -223,8 +222,8 @@ export abstract class Api extends Resource {
         ...apiSpecExtension,
       },
     };
-    this.apiSpec.paths[route] = {
-      ...this.apiSpec.paths[route],
+    this.apiSpec.paths[path] = {
+      ...this.apiSpec.paths[path],
       ...methodSpec,
     };
   }

--- a/libs/wingsdk/src/target-sim/api.inflight.ts
+++ b/libs/wingsdk/src/target-sim/api.inflight.ts
@@ -6,6 +6,7 @@ import {
   ApiRoute,
   ApiSchema,
   API_TYPE,
+  EventSubscription,
 } from "./schema-resources";
 import {
   ApiRequest,
@@ -20,10 +21,11 @@ import {
   ISimulatorContext,
   ISimulatorResourceInstance,
 } from "../testing/simulator";
+import { IEventPublisher } from "./event-mapping";
 
 const LOCALHOST_ADDRESS = "127.0.0.1";
 
-export class Api implements IApiClient, ISimulatorResourceInstance {
+export class Api implements IApiClient, ISimulatorResourceInstance, IEventPublisher {
   private readonly routes: ApiRoute[];
   private readonly context: ISimulatorContext;
   private readonly app: express.Application;
@@ -31,7 +33,8 @@ export class Api implements IApiClient, ISimulatorResourceInstance {
   private url: string | undefined;
 
   constructor(props: ApiSchema["props"], context: ISimulatorContext) {
-    this.routes = props.routes ?? [];
+    props;
+    this.routes = [];
     this.context = context;
 
     // Set up an express server that handles the routes.
@@ -42,70 +45,83 @@ export class Api implements IApiClient, ISimulatorResourceInstance {
     // https://docs.aws.amazon.com/apigateway/latest/developerguide/limits.html
     this.app.use(express.json({ limit: "10mb" }));
     this.app.use(express.urlencoded({ extended: true, limit: "10mb" }));
+  }
 
-    for (const route of this.routes) {
-      const method = route.method.toLowerCase() as
-        | "get"
-        | "post"
-        | "put"
-        | "delete"
-        | "head"
-        | "options"
-        | "patch"
-        | "connect";
+  public async addEventSubscription(subscriber: string, subscriptionProps: EventSubscription): Promise<void> {
+    const routes = (subscriptionProps as any).routes as ApiRoute[];
+    routes.forEach((r) => {
+      const s = {
+        functionHandle: subscriber,
+        method: r.method,
+        path: r.path
+      };
+      this.routes.push(s)
+      this.populateRoute(s, subscriber);
+    })
+  }
 
-      const fnClient = this.context.findInstance(
-        route.functionHandle
-      ) as IFunctionClient & ISimulatorResourceInstance;
-      if (!fnClient) {
-        throw new Error("No function client found!");
-      }
+  private populateRoute(route: ApiRoute, functionHandle: string): void {
+    const method = route.method.toLowerCase() as
+      | "get"
+      | "post"
+      | "put"
+      | "delete"
+      | "head"
+      | "options"
+      | "patch"
+      | "connect";
 
-      this.app[method](
-        transformRoutePath(route.route),
-        async (
-          req: express.Request,
-          res: express.Response,
-          next: express.NextFunction
-        ) => {
-          const body = req.body;
-          this.addTrace(
-            `Processing "${route.method} ${route.route}" (body=${JSON.stringify(
-              body
-            )}, params=${JSON.stringify(req.params)}).`
+    const fnClient = this.context.findInstance(
+      functionHandle
+    ) as IFunctionClient & ISimulatorResourceInstance;
+    if (!fnClient) {
+      throw new Error("No function client found!");
+    }
+
+    this.app[method](
+      transformRoutePath(route.path),
+      async (
+        req: express.Request,
+        res: express.Response,
+        next: express.NextFunction
+      ) => {
+        const body = req.body;
+        this.addTrace(
+          `Processing "${route.method} ${route.path}" (body=${JSON.stringify(
+            body
+          )}, params=${JSON.stringify(req.params)}).`
+        );
+
+        const apiRequest = transformRequest(req);
+
+        try {
+          const response = await fnClient.invoke(
+            // TODO: clean up once cloud.Function is typed as `inflight (Json): Json`
+            apiRequest as unknown as string
           );
 
-          const apiRequest = transformRequest(req);
-
-          try {
-            const response = await fnClient.invoke(
-              // TODO: clean up once cloud.Function is typed as `inflight (Json): Json`
-              apiRequest as unknown as string
+          // TODO: clean up once cloud.Function is typed as `inflight (Json): Json`
+          if (!isApiResponse(response)) {
+            throw new Error(
+              `Expected an ApiResponse struct, found ${JSON.stringify(
+                response
+              )}`
             );
-
-            // TODO: clean up once cloud.Function is typed as `inflight (Json): Json`
-            if (!isApiResponse(response)) {
-              throw new Error(
-                `Expected an ApiResponse struct, found ${JSON.stringify(
-                  response
-                )}`
-              );
-            }
-
-            res.status(response.status);
-            for (const [key, value] of Object.entries(response.headers ?? {})) {
-              res.set(key, value);
-            }
-            res.send(JSON.stringify(response.body));
-            this.addTrace(
-              `${route.method} ${route.route} - ${response.status}.`
-            );
-          } catch (err) {
-            return next(err);
           }
+
+          res.status(response.status);
+          for (const [key, value] of Object.entries(response.headers ?? {})) {
+            res.set(key, value);
+          }
+          res.send(JSON.stringify(response.body));
+          this.addTrace(
+            `${route.method} ${route.path} - ${response.status}.`
+          );
+        } catch (err) {
+          return next(err);
         }
-      );
-    }
+      }
+    );
   }
 
   public async init(): Promise<ApiAttributes> {

--- a/libs/wingsdk/src/target-sim/api.inflight.ts
+++ b/libs/wingsdk/src/target-sim/api.inflight.ts
@@ -1,6 +1,7 @@
 import { Server } from "http";
 import { AddressInfo } from "net";
 import express from "express";
+import { IEventPublisher } from "./event-mapping";
 import {
   ApiAttributes,
   ApiRoute,
@@ -21,11 +22,12 @@ import {
   ISimulatorContext,
   ISimulatorResourceInstance,
 } from "../testing/simulator";
-import { IEventPublisher } from "./event-mapping";
 
 const LOCALHOST_ADDRESS = "127.0.0.1";
 
-export class Api implements IApiClient, ISimulatorResourceInstance, IEventPublisher {
+export class Api
+  implements IApiClient, ISimulatorResourceInstance, IEventPublisher
+{
   private readonly routes: ApiRoute[];
   private readonly context: ISimulatorContext;
   private readonly app: express.Application;
@@ -47,17 +49,20 @@ export class Api implements IApiClient, ISimulatorResourceInstance, IEventPublis
     this.app.use(express.urlencoded({ extended: true, limit: "10mb" }));
   }
 
-  public async addEventSubscription(subscriber: string, subscriptionProps: EventSubscription): Promise<void> {
+  public async addEventSubscription(
+    subscriber: string,
+    subscriptionProps: EventSubscription
+  ): Promise<void> {
     const routes = (subscriptionProps as any).routes as ApiRoute[];
     routes.forEach((r) => {
       const s = {
         functionHandle: subscriber,
         method: r.method,
-        path: r.path
+        path: r.path,
       };
-      this.routes.push(s)
+      this.routes.push(s);
       this.populateRoute(s, subscriber);
-    })
+    });
   }
 
   private populateRoute(route: ApiRoute, functionHandle: string): void {
@@ -114,9 +119,7 @@ export class Api implements IApiClient, ISimulatorResourceInstance, IEventPublis
             res.set(key, value);
           }
           res.send(JSON.stringify(response.body));
-          this.addTrace(
-            `${route.method} ${route.path} - ${response.status}.`
-          );
+          this.addTrace(`${route.method} ${route.path} - ${response.status}.`);
         } catch (err) {
           return next(err);
         }

--- a/libs/wingsdk/src/target-sim/api.ts
+++ b/libs/wingsdk/src/target-sim/api.ts
@@ -1,3 +1,4 @@
+import { EventMapping } from "./event-mapping";
 import { Function } from "./function";
 import { ISimulatorResource } from "./resource";
 import { ApiSchema, API_TYPE, ApiRoute } from "./schema-resources";
@@ -7,7 +8,6 @@ import * as cloud from "../cloud";
 import * as core from "../core";
 import { IInflightHost, Resource } from "../std";
 import { BaseResourceSchema } from "../testing/simulator";
-import { EventMapping } from "./event-mapping";
 
 /**
  * Simulator implementation of `cloud.Api`.
@@ -15,7 +15,7 @@ import { EventMapping } from "./event-mapping";
  * @inflight `@winglang/sdk.cloud.IApiClient`
  */
 export class Api extends cloud.Api implements ISimulatorResource {
-  private eventMappings: {[key: string]: EventMapping} = {};
+  private eventMappings: { [key: string]: EventMapping } = {};
 
   public get url(): string {
     return simulatorAttrToken(this, "url");
@@ -35,10 +35,11 @@ export class Api extends cloud.Api implements ISimulatorResource {
 
     if (existingFn) {
       const event = this.eventMappings[eventId];
-      const routes = (event.eventProps.subscriptionProps as any).routes as ApiRoute[];
+      const routes = (event.eventProps.subscriptionProps as any)
+        .routes as ApiRoute[];
       routes.push({
         path,
-        method
+        method,
       });
 
       this.eventMappings[eventId] = event;
@@ -57,9 +58,9 @@ export class Api extends cloud.Api implements ISimulatorResource {
           {
             path,
             method,
-          }
-        ]
-      }
+          },
+        ],
+      },
     });
     this.eventMappings[eventId] = eventMapping;
 
@@ -72,7 +73,7 @@ export class Api extends cloud.Api implements ISimulatorResource {
     inflight: cloud.IApiEndpointHandler,
     props: any
   ): void {
-    this._validatePath(route);
+    this._validatePath(path);
 
     this._addToSpec(path, method, undefined);
 
@@ -200,7 +201,7 @@ export class Api extends cloud.Api implements ISimulatorResource {
     const schema: ApiSchema = {
       type: API_TYPE,
       path: this.node.path,
-      props: { },
+      props: {},
       attrs: {} as any,
     };
     return schema;

--- a/libs/wingsdk/src/target-sim/event-mapping.ts
+++ b/libs/wingsdk/src/target-sim/event-mapping.ts
@@ -46,16 +46,20 @@ export interface EventMappingProps {
  */
 export class EventMapping extends Resource implements ISimulatorResource {
   public readonly stateful = true;
-  private readonly eventProps: EventMappingProps;
+  private readonly _eventProps: EventMappingProps;
 
   constructor(scope: Construct, id: string, props: EventMappingProps) {
     super(scope, id);
-    this.eventProps = props;
+    this._eventProps = props;
     this.display.hidden = true;
 
     // Add dependencies to the publisher and subscriber
     this.node.addDependency(props.subscriber);
     this.node.addDependency(props.publisher);
+  }
+
+  public get eventProps(): EventMappingProps {
+    return this._eventProps;
   }
 
   public toSimulator(): BaseResourceSchema {

--- a/libs/wingsdk/src/target-sim/schema-resources.ts
+++ b/libs/wingsdk/src/target-sim/schema-resources.ts
@@ -24,7 +24,7 @@ export type PublisherHandle = string;
 /** Schema for cloud.Api */
 export interface ApiSchema extends BaseResourceSchema {
   readonly type: typeof API_TYPE;
-  readonly props: { };
+  readonly props: {};
   readonly attrs: ApiAttributes & BaseResourceAttributes;
 }
 

--- a/libs/wingsdk/src/target-sim/schema-resources.ts
+++ b/libs/wingsdk/src/target-sim/schema-resources.ts
@@ -24,11 +24,13 @@ export type PublisherHandle = string;
 /** Schema for cloud.Api */
 export interface ApiSchema extends BaseResourceSchema {
   readonly type: typeof API_TYPE;
-  readonly props: {
-    /** The routes that the API should handle. */
-    readonly routes: ApiRoute[];
-  };
+  readonly props: { };
   readonly attrs: ApiAttributes & BaseResourceAttributes;
+}
+
+export interface ApiEventSubscription extends EventSubscription {
+  /** Subscribed routes */
+  readonly routes: ApiRoute[];
 }
 
 /** Runtime attributes for cloud.Api */
@@ -39,12 +41,10 @@ export interface ApiAttributes {
 
 /** Schema for cloud.Api.props.routes */
 export interface ApiRoute {
-  /** The route to handle. */
-  readonly route: string;
+  /** The path to handle. */
+  readonly path: string;
   /** The HTTP method to handle. */
   readonly method: HttpMethod;
-  /** The function that should be called when the route is hit. */
-  readonly functionHandle: FunctionHandle;
 }
 
 /** Schema for cloud.Function */

--- a/libs/wingsdk/src/target-tf-aws/api.ts
+++ b/libs/wingsdk/src/target-tf-aws/api.ts
@@ -64,7 +64,7 @@ export class Api extends cloud.Api {
     if (props) {
       console.warn("Api.get does not support props yet");
     }
-    this._validateRoute(route);
+    this._validatePath(path);
 
     const fn = this.addHandler(inflight);
     const apiSpecEndpoint = this.api.addEndpoint(path, "GET", fn);
@@ -91,7 +91,7 @@ export class Api extends cloud.Api {
     if (props) {
       console.warn("Api.post does not support props yet");
     }
-    this._validateRoute(route);
+    this._validatePath(path);
 
     const fn = this.addHandler(inflight);
     const apiSpecEndpoint = this.api.addEndpoint(path, "POST", fn);
@@ -118,7 +118,7 @@ export class Api extends cloud.Api {
     if (props) {
       console.warn("Api.put does not support props yet");
     }
-    this._validateRoute(route);
+    this._validatePath(path);
 
     const fn = this.addHandler(inflight);
     const apiSpecEndpoint = this.api.addEndpoint(path, "PUT", fn);
@@ -145,7 +145,7 @@ export class Api extends cloud.Api {
     if (props) {
       console.warn("Api.delete does not support props yet");
     }
-    this._validateRoute(route);
+    this._validatePath(path);
 
     const fn = this.addHandler(inflight);
     const apiSpecEndpoint = this.api.addEndpoint(path, "DELETE", fn);
@@ -172,7 +172,7 @@ export class Api extends cloud.Api {
     if (props) {
       console.warn("Api.patch does not support props yet");
     }
-    this._validateRoute(route);
+    this._validatePath(path);
 
     const fn = this.addHandler(inflight);
     const apiSpecEndpoint = this.api.addEndpoint(path, "PATCH", fn);
@@ -199,7 +199,7 @@ export class Api extends cloud.Api {
     if (props) {
       console.warn("Api.options does not support props yet");
     }
-    this._validateRoute(route);
+    this._validatePath(path);
 
     const fn = this.addHandler(inflight);
     const apiSpecEndpoint = this.api.addEndpoint(path, "OPTIONS", fn);
@@ -226,7 +226,7 @@ export class Api extends cloud.Api {
     if (props) {
       console.warn("Api.head does not support props yet");
     }
-    this._validateRoute(route);
+    this._validatePath(path);
 
     const fn = this.addHandler(inflight);
     const apiSpecEndpoint = this.api.addEndpoint(path, "HEAD", fn);
@@ -253,7 +253,7 @@ export class Api extends cloud.Api {
     if (props) {
       console.warn("Api.connect does not support props yet");
     }
-    this._validateRoute(route);
+    this._validatePath(path);
 
     const fn = this.addHandler(inflight);
     const apiSpecEndpoint = this.api.addEndpoint(path, "CONNECT", fn);

--- a/libs/wingsdk/src/target-tf-aws/api.ts
+++ b/libs/wingsdk/src/target-tf-aws/api.ts
@@ -51,13 +51,13 @@ export class Api extends cloud.Api {
   }
 
   /**
-   * Add a inflight to handle GET requests to a route.
-   * @param route Route to add
+   * Add a inflight to handle GET requests to a path.
+   * @param path path to add
    * @param inflight Inflight to handle request
    * @param props Additional props
    */
   public get(
-    route: string,
+    path: string,
     inflight: cloud.IApiEndpointHandler,
     props?: cloud.ApiGetProps
   ): void {
@@ -67,8 +67,8 @@ export class Api extends cloud.Api {
     this._validateRoute(route);
 
     const fn = this.addHandler(inflight);
-    const apiSpecEndpoint = this.api.addEndpoint(route, "GET", fn);
-    this._addToSpec(route, "GET", apiSpecEndpoint);
+    const apiSpecEndpoint = this.api.addEndpoint(path, "GET", fn);
+    this._addToSpec(path, "GET", apiSpecEndpoint);
 
     Resource.addConnection({
       from: this,
@@ -78,13 +78,13 @@ export class Api extends cloud.Api {
   }
 
   /**
-   * Add a inflight to handle POST requests to a route.
-   * @param route Route to add
+   * Add a inflight to handle POST requests to a path.
+   * @param path path to add
    * @param inflight Inflight to handle request
    * @param props Additional props
    */
   public post(
-    route: string,
+    path: string,
     inflight: cloud.IApiEndpointHandler,
     props?: cloud.ApiPostProps
   ): void {
@@ -94,8 +94,8 @@ export class Api extends cloud.Api {
     this._validateRoute(route);
 
     const fn = this.addHandler(inflight);
-    const apiSpecEndpoint = this.api.addEndpoint(route, "POST", fn);
-    this._addToSpec(route, "POST", apiSpecEndpoint);
+    const apiSpecEndpoint = this.api.addEndpoint(path, "POST", fn);
+    this._addToSpec(path, "POST", apiSpecEndpoint);
 
     Resource.addConnection({
       from: this,
@@ -105,13 +105,13 @@ export class Api extends cloud.Api {
   }
 
   /**
-   * Add a inflight to handle PUT requests to a route.
-   * @param route Route to add
+   * Add a inflight to handle PUT requests to a path.
+   * @param path path to add
    * @param inflight Inflight to handle request
    * @param props Additional props
    */
   public put(
-    route: string,
+    path: string,
     inflight: cloud.IApiEndpointHandler,
     props?: cloud.ApiPutProps
   ): void {
@@ -121,8 +121,8 @@ export class Api extends cloud.Api {
     this._validateRoute(route);
 
     const fn = this.addHandler(inflight);
-    const apiSpecEndpoint = this.api.addEndpoint(route, "PUT", fn);
-    this._addToSpec(route, "PUT", apiSpecEndpoint);
+    const apiSpecEndpoint = this.api.addEndpoint(path, "PUT", fn);
+    this._addToSpec(path, "PUT", apiSpecEndpoint);
 
     Resource.addConnection({
       from: this,
@@ -132,13 +132,13 @@ export class Api extends cloud.Api {
   }
 
   /**
-   * Add a inflight to handle DELETE requests to a route.
-   * @param route Route to add
+   * Add a inflight to handle DELETE requests to a path.
+   * @param path path to add
    * @param inflight Inflight to handle request
    * @param props Additional props
    */
   public delete(
-    route: string,
+    path: string,
     inflight: cloud.IApiEndpointHandler,
     props?: cloud.ApiDeleteProps
   ): void {
@@ -148,8 +148,8 @@ export class Api extends cloud.Api {
     this._validateRoute(route);
 
     const fn = this.addHandler(inflight);
-    const apiSpecEndpoint = this.api.addEndpoint(route, "DELETE", fn);
-    this._addToSpec(route, "DELETE", apiSpecEndpoint);
+    const apiSpecEndpoint = this.api.addEndpoint(path, "DELETE", fn);
+    this._addToSpec(path, "DELETE", apiSpecEndpoint);
 
     Resource.addConnection({
       from: this,
@@ -159,13 +159,13 @@ export class Api extends cloud.Api {
   }
 
   /**
-   * Add a inflight to handle PATCH requests to a route.
-   * @param route Route to add
+   * Add a inflight to handle PATCH requests to a path.
+   * @param path path to add
    * @param inflight Inflight to handle request
    * @param props Additional props
    */
   public patch(
-    route: string,
+    path: string,
     inflight: cloud.IApiEndpointHandler,
     props?: cloud.ApiPatchProps
   ): void {
@@ -175,8 +175,8 @@ export class Api extends cloud.Api {
     this._validateRoute(route);
 
     const fn = this.addHandler(inflight);
-    const apiSpecEndpoint = this.api.addEndpoint(route, "PATCH", fn);
-    this._addToSpec(route, "PATCH", apiSpecEndpoint);
+    const apiSpecEndpoint = this.api.addEndpoint(path, "PATCH", fn);
+    this._addToSpec(path, "PATCH", apiSpecEndpoint);
 
     Resource.addConnection({
       from: this,
@@ -186,13 +186,13 @@ export class Api extends cloud.Api {
   }
 
   /**
-   * Add a inflight to handle OPTIONS requests to a route.
-   * @param route Route to add
+   * Add a inflight to handle OPTIONS requests to a path.
+   * @param path path to add
    * @param inflight Inflight to handle request
    * @param props Additional props
    */
   public options(
-    route: string,
+    path: string,
     inflight: cloud.IApiEndpointHandler,
     props?: cloud.ApiOptionsProps
   ): void {
@@ -202,8 +202,8 @@ export class Api extends cloud.Api {
     this._validateRoute(route);
 
     const fn = this.addHandler(inflight);
-    const apiSpecEndpoint = this.api.addEndpoint(route, "OPTIONS", fn);
-    this._addToSpec(route, "OPTIONS", apiSpecEndpoint);
+    const apiSpecEndpoint = this.api.addEndpoint(path, "OPTIONS", fn);
+    this._addToSpec(path, "OPTIONS", apiSpecEndpoint);
 
     Resource.addConnection({
       from: this,
@@ -213,13 +213,13 @@ export class Api extends cloud.Api {
   }
 
   /**
-   * Add a inflight to handle HEAD requests to a route.
-   * @param route Route to add
+   * Add a inflight to handle HEAD requests to a path.
+   * @param path path to add
    * @param inflight Inflight to handle request
    * @param props Additional props
    */
   public head(
-    route: string,
+    path: string,
     inflight: cloud.IApiEndpointHandler,
     props?: cloud.ApiHeadProps
   ): void {
@@ -229,8 +229,8 @@ export class Api extends cloud.Api {
     this._validateRoute(route);
 
     const fn = this.addHandler(inflight);
-    const apiSpecEndpoint = this.api.addEndpoint(route, "HEAD", fn);
-    this._addToSpec(route, "HEAD", apiSpecEndpoint);
+    const apiSpecEndpoint = this.api.addEndpoint(path, "HEAD", fn);
+    this._addToSpec(path, "HEAD", apiSpecEndpoint);
 
     Resource.addConnection({
       from: this,
@@ -240,13 +240,13 @@ export class Api extends cloud.Api {
   }
 
   /**
-   * Add a inflight to handle CONNECT requests to a route.
-   * @param route Route to add
+   * Add a inflight to handle CONNECT requests to a path.
+   * @param path path to add
    * @param inflight Inflight to handle request
    * @param props Additional props
    */
   public connect(
-    route: string,
+    path: string,
     inflight: cloud.IApiEndpointHandler,
     props?: cloud.ApiConnectProps
   ): void {
@@ -256,8 +256,8 @@ export class Api extends cloud.Api {
     this._validateRoute(route);
 
     const fn = this.addHandler(inflight);
-    const apiSpecEndpoint = this.api.addEndpoint(route, "CONNECT", fn);
-    this._addToSpec(route, "CONNECT", apiSpecEndpoint);
+    const apiSpecEndpoint = this.api.addEndpoint(path, "CONNECT", fn);
+    this._addToSpec(path, "CONNECT", apiSpecEndpoint);
 
     Resource.addConnection({
       from: this,

--- a/libs/wingsdk/test/target-sim/__snapshots__/api.test.ts.snap
+++ b/libs/wingsdk/test/target-sim/__snapshots__/api.test.ts.snap
@@ -6,9 +6,11 @@ exports[`api handler can read the request params 1`] = `
   "wingsdk.cloud.Function created.",
   "Server listening on http://127.0.0.1:<port>",
   "wingsdk.cloud.Api created.",
+  "wingsdk.sim.EventMapping created.",
   "Processing \\"GET /hello\\" (body={}, params={}).",
   "Invoke (payload={\\"headers\\":{\\"host\\":\\"127.0.0.1:<port>\\",\\"connection\\":\\"keep-alive\\",\\"accept\\":\\"*/*\\",\\"accept-language\\":\\"*\\",\\"sec-fetch-mode\\":\\"cors\\",\\"user-agent\\":\\"undici\\",\\"accept-encoding\\":\\"gzip, deflate\\"},\\"body\\":{},\\"method\\":\\"GET\\",\\"path\\":\\"/hello\\",\\"query\\":{\\"foo\\":\\"bar\\",\\"bar\\":\\"baz\\"},\\"vars\\":{}}).",
   "GET /hello - 200.",
+  "wingsdk.sim.EventMapping deleted.",
   "Closing server on http://127.0.0.1:<port>",
   "wingsdk.cloud.Api deleted.",
   "wingsdk.cloud.Function deleted.",
@@ -56,16 +58,25 @@ return class Handler {
       {
         "attrs": {},
         "path": "root/my_api",
-        "props": {
-          "routes": [
-            {
-              "functionHandle": "\${root/my_api/my_api-OnRequestHandler-e645076f#attrs.handle}",
-              "method": "GET",
-              "route": "/hello",
-            },
-          ],
-        },
+        "props": {},
         "type": "wingsdk.cloud.Api",
+      },
+      {
+        "attrs": {},
+        "path": "root/my_api/my_api-ApiEventMapping-e645076f",
+        "props": {
+          "publisher": "\${root/my_api#attrs.handle}",
+          "subscriber": "\${root/my_api/my_api-OnRequestHandler-e645076f#attrs.handle}",
+          "subscriptionProps": {
+            "routes": [
+              {
+                "method": "GET",
+                "path": "/hello",
+              },
+            ],
+          },
+        },
+        "type": "wingsdk.sim.EventMapping",
       },
     ],
     "sdkVersion": "0.0.0",
@@ -120,6 +131,21 @@ return class Handler {
             "wing:resource:stateful": true,
           },
           "children": {
+            "my_api-ApiEventMapping-e645076f": {
+              "attributes": {
+                "wing:resource:connections": [],
+                "wing:resource:stateful": true,
+              },
+              "constructInfo": {
+                "fqn": "constructs.Construct",
+                "version": "10.1.245",
+              },
+              "display": {
+                "hidden": true,
+              },
+              "id": "my_api-ApiEventMapping-e645076f",
+              "path": "root/my_api/my_api-ApiEventMapping-e645076f",
+            },
             "my_api-OnRequestHandler-e645076f": {
               "attributes": {
                 "wing:resource:connections": [
@@ -174,9 +200,11 @@ exports[`api handler can read the request path 1`] = `
   "wingsdk.cloud.Function created.",
   "Server listening on http://127.0.0.1:<port>",
   "wingsdk.cloud.Api created.",
+  "wingsdk.sim.EventMapping created.",
   "Processing \\"GET /hello\\" (body={}, params={}).",
   "Invoke (payload={\\"headers\\":{\\"host\\":\\"127.0.0.1:<port>\\",\\"connection\\":\\"keep-alive\\",\\"accept\\":\\"*/*\\",\\"accept-language\\":\\"*\\",\\"sec-fetch-mode\\":\\"cors\\",\\"user-agent\\":\\"undici\\",\\"accept-encoding\\":\\"gzip, deflate\\"},\\"body\\":{},\\"method\\":\\"GET\\",\\"path\\":\\"/hello\\",\\"query\\":{},\\"vars\\":{}}).",
   "GET /hello - 200.",
+  "wingsdk.sim.EventMapping deleted.",
   "Closing server on http://127.0.0.1:<port>",
   "wingsdk.cloud.Api deleted.",
   "wingsdk.cloud.Function deleted.",
@@ -224,16 +252,25 @@ return class Handler {
       {
         "attrs": {},
         "path": "root/my_api",
-        "props": {
-          "routes": [
-            {
-              "functionHandle": "\${root/my_api/my_api-OnRequestHandler-e645076f#attrs.handle}",
-              "method": "GET",
-              "route": "/hello",
-            },
-          ],
-        },
+        "props": {},
         "type": "wingsdk.cloud.Api",
+      },
+      {
+        "attrs": {},
+        "path": "root/my_api/my_api-ApiEventMapping-e645076f",
+        "props": {
+          "publisher": "\${root/my_api#attrs.handle}",
+          "subscriber": "\${root/my_api/my_api-OnRequestHandler-e645076f#attrs.handle}",
+          "subscriptionProps": {
+            "routes": [
+              {
+                "method": "GET",
+                "path": "/hello",
+              },
+            ],
+          },
+        },
+        "type": "wingsdk.sim.EventMapping",
       },
     ],
     "sdkVersion": "0.0.0",
@@ -288,6 +325,21 @@ return class Handler {
             "wing:resource:stateful": true,
           },
           "children": {
+            "my_api-ApiEventMapping-e645076f": {
+              "attributes": {
+                "wing:resource:connections": [],
+                "wing:resource:stateful": true,
+              },
+              "constructInfo": {
+                "fqn": "constructs.Construct",
+                "version": "10.1.245",
+              },
+              "display": {
+                "hidden": true,
+              },
+              "id": "my_api-ApiEventMapping-e645076f",
+              "path": "root/my_api/my_api-ApiEventMapping-e645076f",
+            },
             "my_api-OnRequestHandler-e645076f": {
               "attributes": {
                 "wing:resource:connections": [
@@ -342,9 +394,11 @@ exports[`api handler can set response headers 1`] = `
   "wingsdk.cloud.Function created.",
   "Server listening on http://127.0.0.1:<port>",
   "wingsdk.cloud.Api created.",
+  "wingsdk.sim.EventMapping created.",
   "Processing \\"GET /hello\\" (body={}, params={}).",
   "Invoke (payload={\\"headers\\":{\\"host\\":\\"127.0.0.1:<port>\\",\\"connection\\":\\"keep-alive\\",\\"foo\\":\\"bar\\",\\"accept\\":\\"*/*\\",\\"accept-language\\":\\"*\\",\\"sec-fetch-mode\\":\\"cors\\",\\"user-agent\\":\\"undici\\",\\"accept-encoding\\":\\"gzip, deflate\\"},\\"body\\":{},\\"method\\":\\"GET\\",\\"path\\":\\"/hello\\",\\"query\\":{},\\"vars\\":{}}).",
   "GET /hello - 200.",
+  "wingsdk.sim.EventMapping deleted.",
   "Closing server on http://127.0.0.1:<port>",
   "wingsdk.cloud.Api deleted.",
   "wingsdk.cloud.Function deleted.",
@@ -392,16 +446,25 @@ return class Handler {
       {
         "attrs": {},
         "path": "root/my_api",
-        "props": {
-          "routes": [
-            {
-              "functionHandle": "\${root/my_api/my_api-OnRequestHandler-e645076f#attrs.handle}",
-              "method": "GET",
-              "route": "/hello",
-            },
-          ],
-        },
+        "props": {},
         "type": "wingsdk.cloud.Api",
+      },
+      {
+        "attrs": {},
+        "path": "root/my_api/my_api-ApiEventMapping-e645076f",
+        "props": {
+          "publisher": "\${root/my_api#attrs.handle}",
+          "subscriber": "\${root/my_api/my_api-OnRequestHandler-e645076f#attrs.handle}",
+          "subscriptionProps": {
+            "routes": [
+              {
+                "method": "GET",
+                "path": "/hello",
+              },
+            ],
+          },
+        },
+        "type": "wingsdk.sim.EventMapping",
       },
     ],
     "sdkVersion": "0.0.0",
@@ -456,6 +519,21 @@ return class Handler {
             "wing:resource:stateful": true,
           },
           "children": {
+            "my_api-ApiEventMapping-e645076f": {
+              "attributes": {
+                "wing:resource:connections": [],
+                "wing:resource:stateful": true,
+              },
+              "constructInfo": {
+                "fqn": "constructs.Construct",
+                "version": "10.1.245",
+              },
+              "display": {
+                "hidden": true,
+              },
+              "id": "my_api-ApiEventMapping-e645076f",
+              "path": "root/my_api/my_api-ApiEventMapping-e645076f",
+            },
             "my_api-OnRequestHandler-e645076f": {
               "attributes": {
                 "wing:resource:connections": [
@@ -510,6 +588,7 @@ exports[`api supports every method type 1`] = `
   "wingsdk.cloud.Function created.",
   "Server listening on http://127.0.0.1:<port>",
   "wingsdk.cloud.Api created.",
+  "wingsdk.sim.EventMapping created.",
   "Processing \\"GET /hello\\" (body={}, params={}).",
   "Invoke (payload={\\"headers\\":{\\"host\\":\\"127.0.0.1:<port>\\",\\"connection\\":\\"keep-alive\\",\\"accept\\":\\"*/*\\",\\"accept-language\\":\\"*\\",\\"sec-fetch-mode\\":\\"cors\\",\\"user-agent\\":\\"undici\\",\\"accept-encoding\\":\\"gzip, deflate\\"},\\"body\\":{},\\"method\\":\\"GET\\",\\"path\\":\\"/hello\\",\\"query\\":{},\\"vars\\":{}}).",
   "GET /hello - 200.",
@@ -531,6 +610,7 @@ exports[`api supports every method type 1`] = `
   "Processing \\"PATCH /hello\\" (body={}, params={}).",
   "Invoke (payload={\\"headers\\":{\\"host\\":\\"127.0.0.1:<port>\\",\\"connection\\":\\"keep-alive\\",\\"accept\\":\\"*/*\\",\\"accept-language\\":\\"*\\",\\"sec-fetch-mode\\":\\"cors\\",\\"user-agent\\":\\"undici\\",\\"accept-encoding\\":\\"gzip, deflate\\",\\"content-length\\":\\"0\\"},\\"body\\":{},\\"method\\":\\"PATCH\\",\\"path\\":\\"/hello\\",\\"query\\":{},\\"vars\\":{}}).",
   "PATCH /hello - 200.",
+  "wingsdk.sim.EventMapping deleted.",
   "Closing server on http://127.0.0.1:<port>",
   "wingsdk.cloud.Api deleted.",
   "wingsdk.cloud.Function deleted.",
@@ -578,46 +658,49 @@ return class Handler {
       {
         "attrs": {},
         "path": "root/my_api",
-        "props": {
-          "routes": [
-            {
-              "functionHandle": "\${root/my_api/my_api-OnRequestHandler-e645076f#attrs.handle}",
-              "method": "GET",
-              "route": "/hello",
-            },
-            {
-              "functionHandle": "\${root/my_api/my_api-OnRequestHandler-e645076f#attrs.handle}",
-              "method": "POST",
-              "route": "/hello",
-            },
-            {
-              "functionHandle": "\${root/my_api/my_api-OnRequestHandler-e645076f#attrs.handle}",
-              "method": "PUT",
-              "route": "/hello",
-            },
-            {
-              "functionHandle": "\${root/my_api/my_api-OnRequestHandler-e645076f#attrs.handle}",
-              "method": "DELETE",
-              "route": "/hello",
-            },
-            {
-              "functionHandle": "\${root/my_api/my_api-OnRequestHandler-e645076f#attrs.handle}",
-              "method": "HEAD",
-              "route": "/hello",
-            },
-            {
-              "functionHandle": "\${root/my_api/my_api-OnRequestHandler-e645076f#attrs.handle}",
-              "method": "OPTIONS",
-              "route": "/hello",
-            },
-            {
-              "functionHandle": "\${root/my_api/my_api-OnRequestHandler-e645076f#attrs.handle}",
-              "method": "PATCH",
-              "route": "/hello",
-            },
-          ],
-        },
+        "props": {},
         "type": "wingsdk.cloud.Api",
+      },
+      {
+        "attrs": {},
+        "path": "root/my_api/my_api-ApiEventMapping-e645076f",
+        "props": {
+          "publisher": "\${root/my_api#attrs.handle}",
+          "subscriber": "\${root/my_api/my_api-OnRequestHandler-e645076f#attrs.handle}",
+          "subscriptionProps": {
+            "routes": [
+              {
+                "method": "GET",
+                "path": "/hello",
+              },
+              {
+                "method": "POST",
+                "path": "/hello",
+              },
+              {
+                "method": "PUT",
+                "path": "/hello",
+              },
+              {
+                "method": "DELETE",
+                "path": "/hello",
+              },
+              {
+                "method": "HEAD",
+                "path": "/hello",
+              },
+              {
+                "method": "OPTIONS",
+                "path": "/hello",
+              },
+              {
+                "method": "PATCH",
+                "path": "/hello",
+              },
+            ],
+          },
+        },
+        "type": "wingsdk.sim.EventMapping",
       },
     ],
     "sdkVersion": "0.0.0",
@@ -708,6 +791,21 @@ return class Handler {
             "wing:resource:stateful": true,
           },
           "children": {
+            "my_api-ApiEventMapping-e645076f": {
+              "attributes": {
+                "wing:resource:connections": [],
+                "wing:resource:stateful": true,
+              },
+              "constructInfo": {
+                "fqn": "constructs.Construct",
+                "version": "10.1.245",
+              },
+              "display": {
+                "hidden": true,
+              },
+              "id": "my_api-ApiEventMapping-e645076f",
+              "path": "root/my_api/my_api-ApiEventMapping-e645076f",
+            },
             "my_api-OnRequestHandler-e645076f": {
               "attributes": {
                 "wing:resource:connections": [
@@ -832,21 +930,29 @@ return class Handler {
       {
         "attrs": {},
         "path": "root/my_api",
-        "props": {
-          "routes": [
-            {
-              "functionHandle": "\${root/my_api/my_api-OnRequestHandler-e645076f#attrs.handle}",
-              "method": "GET",
-              "route": "/hello/foo",
-            },
-            {
-              "functionHandle": "\${root/my_api/my_api-OnRequestHandler-e645076f#attrs.handle}",
-              "method": "GET",
-              "route": "/hello/bat",
-            },
-          ],
-        },
+        "props": {},
         "type": "wingsdk.cloud.Api",
+      },
+      {
+        "attrs": {},
+        "path": "root/my_api/my_api-ApiEventMapping-e645076f",
+        "props": {
+          "publisher": "\${root/my_api#attrs.handle}",
+          "subscriber": "\${root/my_api/my_api-OnRequestHandler-e645076f#attrs.handle}",
+          "subscriptionProps": {
+            "routes": [
+              {
+                "method": "GET",
+                "path": "/hello/foo",
+              },
+              {
+                "method": "GET",
+                "path": "/hello/bat",
+              },
+            ],
+          },
+        },
+        "type": "wingsdk.sim.EventMapping",
       },
     ],
     "sdkVersion": "0.0.0",
@@ -901,6 +1007,21 @@ return class Handler {
             "wing:resource:stateful": true,
           },
           "children": {
+            "my_api-ApiEventMapping-e645076f": {
+              "attributes": {
+                "wing:resource:connections": [],
+                "wing:resource:stateful": true,
+              },
+              "constructInfo": {
+                "fqn": "constructs.Construct",
+                "version": "10.1.245",
+              },
+              "display": {
+                "hidden": true,
+              },
+              "id": "my_api-ApiEventMapping-e645076f",
+              "path": "root/my_api/my_api-ApiEventMapping-e645076f",
+            },
             "my_api-OnRequestHandler-e645076f": {
               "attributes": {
                 "wing:resource:connections": [
@@ -953,18 +1074,22 @@ exports[`api with multiple methods on same route 1`] = `
 [
   "wingsdk.cloud.TestRunner created.",
   "wingsdk.cloud.Function created.",
-  "wingsdk.cloud.Function created.",
   "Server listening on http://127.0.0.1:<port>",
   "wingsdk.cloud.Api created.",
+  "wingsdk.sim.EventMapping created.",
+  "wingsdk.cloud.Function created.",
+  "wingsdk.sim.EventMapping created.",
   "Processing \\"GET /hello\\" (body={}, params={}).",
   "Invoke (payload={\\"headers\\":{\\"host\\":\\"127.0.0.1:<port>\\",\\"connection\\":\\"keep-alive\\",\\"accept\\":\\"*/*\\",\\"accept-language\\":\\"*\\",\\"sec-fetch-mode\\":\\"cors\\",\\"user-agent\\":\\"undici\\",\\"accept-encoding\\":\\"gzip, deflate\\"},\\"body\\":{},\\"method\\":\\"GET\\",\\"path\\":\\"/hello\\",\\"query\\":{},\\"vars\\":{}}).",
   "GET /hello - 200.",
   "Processing \\"POST /hello\\" (body={}, params={}).",
   "Invoke (payload={\\"headers\\":{\\"host\\":\\"127.0.0.1:<port>\\",\\"connection\\":\\"keep-alive\\",\\"accept\\":\\"*/*\\",\\"accept-language\\":\\"*\\",\\"sec-fetch-mode\\":\\"cors\\",\\"user-agent\\":\\"undici\\",\\"accept-encoding\\":\\"gzip, deflate\\",\\"content-length\\":\\"0\\"},\\"body\\":{},\\"method\\":\\"POST\\",\\"path\\":\\"/hello\\",\\"query\\":{},\\"vars\\":{}}).",
   "POST /hello - 200.",
+  "wingsdk.sim.EventMapping deleted.",
+  "wingsdk.cloud.Function deleted.",
+  "wingsdk.sim.EventMapping deleted.",
   "Closing server on http://127.0.0.1:<port>",
   "wingsdk.cloud.Api deleted.",
-  "wingsdk.cloud.Function deleted.",
   "wingsdk.cloud.Function deleted.",
   "wingsdk.cloud.TestRunner deleted.",
 ]
@@ -1023,6 +1148,29 @@ return class Handler {
       },
       {
         "attrs": {},
+        "path": "root/my_api",
+        "props": {},
+        "type": "wingsdk.cloud.Api",
+      },
+      {
+        "attrs": {},
+        "path": "root/my_api/my_api-ApiEventMapping-7c48a9f0",
+        "props": {
+          "publisher": "\${root/my_api#attrs.handle}",
+          "subscriber": "\${root/my_api/my_api-OnRequestHandler-7c48a9f0#attrs.handle}",
+          "subscriptionProps": {
+            "routes": [
+              {
+                "method": "GET",
+                "path": "/hello",
+              },
+            ],
+          },
+        },
+        "type": "wingsdk.sim.EventMapping",
+      },
+      {
+        "attrs": {},
         "path": "root/my_api/my_api-OnRequestHandler-f6d90a7f",
         "props": {
           "environmentVariables": {},
@@ -1034,22 +1182,20 @@ return class Handler {
       },
       {
         "attrs": {},
-        "path": "root/my_api",
+        "path": "root/my_api/my_api-ApiEventMapping-f6d90a7f",
         "props": {
-          "routes": [
-            {
-              "functionHandle": "\${root/my_api/my_api-OnRequestHandler-7c48a9f0#attrs.handle}",
-              "method": "GET",
-              "route": "/hello",
-            },
-            {
-              "functionHandle": "\${root/my_api/my_api-OnRequestHandler-f6d90a7f#attrs.handle}",
-              "method": "POST",
-              "route": "/hello",
-            },
-          ],
+          "publisher": "\${root/my_api#attrs.handle}",
+          "subscriber": "\${root/my_api/my_api-OnRequestHandler-f6d90a7f#attrs.handle}",
+          "subscriptionProps": {
+            "routes": [
+              {
+                "method": "POST",
+                "path": "/hello",
+              },
+            ],
+          },
         },
-        "type": "wingsdk.cloud.Api",
+        "type": "wingsdk.sim.EventMapping",
       },
     ],
     "sdkVersion": "0.0.0",
@@ -1127,6 +1273,36 @@ return class Handler {
             "wing:resource:stateful": true,
           },
           "children": {
+            "my_api-ApiEventMapping-7c48a9f0": {
+              "attributes": {
+                "wing:resource:connections": [],
+                "wing:resource:stateful": true,
+              },
+              "constructInfo": {
+                "fqn": "constructs.Construct",
+                "version": "10.1.245",
+              },
+              "display": {
+                "hidden": true,
+              },
+              "id": "my_api-ApiEventMapping-7c48a9f0",
+              "path": "root/my_api/my_api-ApiEventMapping-7c48a9f0",
+            },
+            "my_api-ApiEventMapping-f6d90a7f": {
+              "attributes": {
+                "wing:resource:connections": [],
+                "wing:resource:stateful": true,
+              },
+              "constructInfo": {
+                "fqn": "constructs.Construct",
+                "version": "10.1.245",
+              },
+              "display": {
+                "hidden": true,
+              },
+              "id": "my_api-ApiEventMapping-f6d90a7f",
+              "path": "root/my_api/my_api-ApiEventMapping-f6d90a7f",
+            },
             "my_api-OnRequestHandler-7c48a9f0": {
               "attributes": {
                 "wing:resource:connections": [
@@ -1202,18 +1378,22 @@ exports[`api with multiple routes 1`] = `
 [
   "wingsdk.cloud.TestRunner created.",
   "wingsdk.cloud.Function created.",
-  "wingsdk.cloud.Function created.",
   "Server listening on http://127.0.0.1:<port>",
   "wingsdk.cloud.Api created.",
+  "wingsdk.sim.EventMapping created.",
+  "wingsdk.cloud.Function created.",
+  "wingsdk.sim.EventMapping created.",
   "Processing \\"GET /hello/world\\" (body={}, params={}).",
   "Invoke (payload={\\"headers\\":{\\"host\\":\\"127.0.0.1:<port>\\",\\"connection\\":\\"keep-alive\\",\\"accept\\":\\"*/*\\",\\"accept-language\\":\\"*\\",\\"sec-fetch-mode\\":\\"cors\\",\\"user-agent\\":\\"undici\\",\\"accept-encoding\\":\\"gzip, deflate\\"},\\"body\\":{},\\"method\\":\\"GET\\",\\"path\\":\\"/hello/world\\",\\"query\\":{},\\"vars\\":{}}).",
   "GET /hello/world - 200.",
   "Processing \\"GET /hello/wingnuts\\" (body={}, params={}).",
   "Invoke (payload={\\"headers\\":{\\"host\\":\\"127.0.0.1:<port>\\",\\"connection\\":\\"keep-alive\\",\\"accept\\":\\"*/*\\",\\"accept-language\\":\\"*\\",\\"sec-fetch-mode\\":\\"cors\\",\\"user-agent\\":\\"undici\\",\\"accept-encoding\\":\\"gzip, deflate\\"},\\"body\\":{},\\"method\\":\\"GET\\",\\"path\\":\\"/hello/wingnuts\\",\\"query\\":{},\\"vars\\":{}}).",
   "GET /hello/wingnuts - 200.",
+  "wingsdk.sim.EventMapping deleted.",
+  "wingsdk.cloud.Function deleted.",
+  "wingsdk.sim.EventMapping deleted.",
   "Closing server on http://127.0.0.1:<port>",
   "wingsdk.cloud.Api deleted.",
-  "wingsdk.cloud.Function deleted.",
   "wingsdk.cloud.Function deleted.",
   "wingsdk.cloud.TestRunner deleted.",
 ]
@@ -1272,6 +1452,29 @@ return class Handler {
       },
       {
         "attrs": {},
+        "path": "root/my_api",
+        "props": {},
+        "type": "wingsdk.cloud.Api",
+      },
+      {
+        "attrs": {},
+        "path": "root/my_api/my_api-ApiEventMapping-7c48a9f0",
+        "props": {
+          "publisher": "\${root/my_api#attrs.handle}",
+          "subscriber": "\${root/my_api/my_api-OnRequestHandler-7c48a9f0#attrs.handle}",
+          "subscriptionProps": {
+            "routes": [
+              {
+                "method": "GET",
+                "path": "/hello/world",
+              },
+            ],
+          },
+        },
+        "type": "wingsdk.sim.EventMapping",
+      },
+      {
+        "attrs": {},
         "path": "root/my_api/my_api-OnRequestHandler-f6d90a7f",
         "props": {
           "environmentVariables": {},
@@ -1283,22 +1486,20 @@ return class Handler {
       },
       {
         "attrs": {},
-        "path": "root/my_api",
+        "path": "root/my_api/my_api-ApiEventMapping-f6d90a7f",
         "props": {
-          "routes": [
-            {
-              "functionHandle": "\${root/my_api/my_api-OnRequestHandler-7c48a9f0#attrs.handle}",
-              "method": "GET",
-              "route": "/hello/world",
-            },
-            {
-              "functionHandle": "\${root/my_api/my_api-OnRequestHandler-f6d90a7f#attrs.handle}",
-              "method": "GET",
-              "route": "/hello/wingnuts",
-            },
-          ],
+          "publisher": "\${root/my_api#attrs.handle}",
+          "subscriber": "\${root/my_api/my_api-OnRequestHandler-f6d90a7f#attrs.handle}",
+          "subscriptionProps": {
+            "routes": [
+              {
+                "method": "GET",
+                "path": "/hello/wingnuts",
+              },
+            ],
+          },
         },
-        "type": "wingsdk.cloud.Api",
+        "type": "wingsdk.sim.EventMapping",
       },
     ],
     "sdkVersion": "0.0.0",
@@ -1376,6 +1577,36 @@ return class Handler {
             "wing:resource:stateful": true,
           },
           "children": {
+            "my_api-ApiEventMapping-7c48a9f0": {
+              "attributes": {
+                "wing:resource:connections": [],
+                "wing:resource:stateful": true,
+              },
+              "constructInfo": {
+                "fqn": "constructs.Construct",
+                "version": "10.1.245",
+              },
+              "display": {
+                "hidden": true,
+              },
+              "id": "my_api-ApiEventMapping-7c48a9f0",
+              "path": "root/my_api/my_api-ApiEventMapping-7c48a9f0",
+            },
+            "my_api-ApiEventMapping-f6d90a7f": {
+              "attributes": {
+                "wing:resource:connections": [],
+                "wing:resource:stateful": true,
+              },
+              "constructInfo": {
+                "fqn": "constructs.Construct",
+                "version": "10.1.245",
+              },
+              "display": {
+                "hidden": true,
+              },
+              "id": "my_api-ApiEventMapping-f6d90a7f",
+              "path": "root/my_api/my_api-ApiEventMapping-f6d90a7f",
+            },
             "my_api-OnRequestHandler-7c48a9f0": {
               "attributes": {
                 "wing:resource:connections": [
@@ -1453,9 +1684,11 @@ exports[`api with one GET route 1`] = `
   "wingsdk.cloud.Function created.",
   "Server listening on http://127.0.0.1:<port>",
   "wingsdk.cloud.Api created.",
+  "wingsdk.sim.EventMapping created.",
   "Processing \\"GET /hello\\" (body={}, params={}).",
   "Invoke (payload={\\"headers\\":{\\"host\\":\\"127.0.0.1:<port>\\",\\"connection\\":\\"keep-alive\\",\\"accept\\":\\"*/*\\",\\"accept-language\\":\\"*\\",\\"sec-fetch-mode\\":\\"cors\\",\\"user-agent\\":\\"undici\\",\\"accept-encoding\\":\\"gzip, deflate\\"},\\"body\\":{},\\"method\\":\\"GET\\",\\"path\\":\\"/hello\\",\\"query\\":{},\\"vars\\":{}}).",
   "GET /hello - 200.",
+  "wingsdk.sim.EventMapping deleted.",
   "Closing server on http://127.0.0.1:<port>",
   "wingsdk.cloud.Api deleted.",
   "wingsdk.cloud.Function deleted.",
@@ -1503,16 +1736,25 @@ return class Handler {
       {
         "attrs": {},
         "path": "root/my_api",
-        "props": {
-          "routes": [
-            {
-              "functionHandle": "\${root/my_api/my_api-OnRequestHandler-e645076f#attrs.handle}",
-              "method": "GET",
-              "route": "/hello",
-            },
-          ],
-        },
+        "props": {},
         "type": "wingsdk.cloud.Api",
+      },
+      {
+        "attrs": {},
+        "path": "root/my_api/my_api-ApiEventMapping-e645076f",
+        "props": {
+          "publisher": "\${root/my_api#attrs.handle}",
+          "subscriber": "\${root/my_api/my_api-OnRequestHandler-e645076f#attrs.handle}",
+          "subscriptionProps": {
+            "routes": [
+              {
+                "method": "GET",
+                "path": "/hello",
+              },
+            ],
+          },
+        },
+        "type": "wingsdk.sim.EventMapping",
       },
     ],
     "sdkVersion": "0.0.0",
@@ -1567,6 +1809,21 @@ return class Handler {
             "wing:resource:stateful": true,
           },
           "children": {
+            "my_api-ApiEventMapping-e645076f": {
+              "attributes": {
+                "wing:resource:connections": [],
+                "wing:resource:stateful": true,
+              },
+              "constructInfo": {
+                "fqn": "constructs.Construct",
+                "version": "10.1.245",
+              },
+              "display": {
+                "hidden": true,
+              },
+              "id": "my_api-ApiEventMapping-e645076f",
+              "path": "root/my_api/my_api-ApiEventMapping-e645076f",
+            },
             "my_api-OnRequestHandler-e645076f": {
               "attributes": {
                 "wing:resource:connections": [
@@ -1621,9 +1878,11 @@ exports[`api with one GET route with request params 1`] = `
   "wingsdk.cloud.Function created.",
   "Server listening on http://127.0.0.1:<port>",
   "wingsdk.cloud.Api created.",
+  "wingsdk.sim.EventMapping created.",
   "Processing \\"GET /users/{name}\\" (body={}, params={\\"name\\":\\"tsuf\\"}).",
   "Invoke (payload={\\"headers\\":{\\"host\\":\\"127.0.0.1:<port>\\",\\"connection\\":\\"keep-alive\\",\\"accept\\":\\"*/*\\",\\"accept-language\\":\\"*\\",\\"sec-fetch-mode\\":\\"cors\\",\\"user-agent\\":\\"undici\\",\\"accept-encoding\\":\\"gzip, deflate\\"},\\"body\\":{},\\"method\\":\\"GET\\",\\"path\\":\\"/users/tsuf\\",\\"query\\":{},\\"vars\\":{\\"name\\":\\"tsuf\\"}}).",
   "GET /users/{name} - 200.",
+  "wingsdk.sim.EventMapping deleted.",
   "Closing server on http://127.0.0.1:<port>",
   "wingsdk.cloud.Api deleted.",
   "wingsdk.cloud.Function deleted.",
@@ -1671,16 +1930,25 @@ return class Handler {
       {
         "attrs": {},
         "path": "root/my_api",
-        "props": {
-          "routes": [
-            {
-              "functionHandle": "\${root/my_api/my_api-OnRequestHandler-e645076f#attrs.handle}",
-              "method": "GET",
-              "route": "/users/{name}",
-            },
-          ],
-        },
+        "props": {},
         "type": "wingsdk.cloud.Api",
+      },
+      {
+        "attrs": {},
+        "path": "root/my_api/my_api-ApiEventMapping-e645076f",
+        "props": {
+          "publisher": "\${root/my_api#attrs.handle}",
+          "subscriber": "\${root/my_api/my_api-OnRequestHandler-e645076f#attrs.handle}",
+          "subscriptionProps": {
+            "routes": [
+              {
+                "method": "GET",
+                "path": "/users/{name}",
+              },
+            ],
+          },
+        },
+        "type": "wingsdk.sim.EventMapping",
       },
     ],
     "sdkVersion": "0.0.0",
@@ -1735,6 +2003,21 @@ return class Handler {
             "wing:resource:stateful": true,
           },
           "children": {
+            "my_api-ApiEventMapping-e645076f": {
+              "attributes": {
+                "wing:resource:connections": [],
+                "wing:resource:stateful": true,
+              },
+              "constructInfo": {
+                "fqn": "constructs.Construct",
+                "version": "10.1.245",
+              },
+              "display": {
+                "hidden": true,
+              },
+              "id": "my_api-ApiEventMapping-e645076f",
+              "path": "root/my_api/my_api-ApiEventMapping-e645076f",
+            },
             "my_api-OnRequestHandler-e645076f": {
               "attributes": {
                 "wing:resource:connections": [
@@ -1789,9 +2072,11 @@ exports[`api with one POST route, with body 1`] = `
   "wingsdk.cloud.Function created.",
   "Server listening on http://127.0.0.1:<port>",
   "wingsdk.cloud.Api created.",
+  "wingsdk.sim.EventMapping created.",
   "Processing \\"POST /hello\\" (body={\\"message\\":\\"hello world\\"}, params={}).",
   "Invoke (payload={\\"headers\\":{\\"host\\":\\"127.0.0.1:<port>\\",\\"connection\\":\\"keep-alive\\",\\"content-type\\":\\"application/json\\",\\"accept\\":\\"*/*\\",\\"accept-language\\":\\"*\\",\\"sec-fetch-mode\\":\\"cors\\",\\"user-agent\\":\\"undici\\",\\"accept-encoding\\":\\"gzip, deflate\\",\\"content-length\\":\\"25\\"},\\"body\\":{\\"message\\":\\"hello world\\"},\\"method\\":\\"POST\\",\\"path\\":\\"/hello\\",\\"query\\":{},\\"vars\\":{}}).",
   "POST /hello - 200.",
+  "wingsdk.sim.EventMapping deleted.",
   "Closing server on http://127.0.0.1:<port>",
   "wingsdk.cloud.Api deleted.",
   "wingsdk.cloud.Function deleted.",
@@ -1839,16 +2124,25 @@ return class Handler {
       {
         "attrs": {},
         "path": "root/my_api",
-        "props": {
-          "routes": [
-            {
-              "functionHandle": "\${root/my_api/my_api-OnRequestHandler-e645076f#attrs.handle}",
-              "method": "POST",
-              "route": "/hello",
-            },
-          ],
-        },
+        "props": {},
         "type": "wingsdk.cloud.Api",
+      },
+      {
+        "attrs": {},
+        "path": "root/my_api/my_api-ApiEventMapping-e645076f",
+        "props": {
+          "publisher": "\${root/my_api#attrs.handle}",
+          "subscriber": "\${root/my_api/my_api-OnRequestHandler-e645076f#attrs.handle}",
+          "subscriptionProps": {
+            "routes": [
+              {
+                "method": "POST",
+                "path": "/hello",
+              },
+            ],
+          },
+        },
+        "type": "wingsdk.sim.EventMapping",
       },
     ],
     "sdkVersion": "0.0.0",
@@ -1903,6 +2197,21 @@ return class Handler {
             "wing:resource:stateful": true,
           },
           "children": {
+            "my_api-ApiEventMapping-e645076f": {
+              "attributes": {
+                "wing:resource:connections": [],
+                "wing:resource:stateful": true,
+              },
+              "constructInfo": {
+                "fqn": "constructs.Construct",
+                "version": "10.1.245",
+              },
+              "display": {
+                "hidden": true,
+              },
+              "id": "my_api-ApiEventMapping-e645076f",
+              "path": "root/my_api/my_api-ApiEventMapping-e645076f",
+            },
             "my_api-OnRequestHandler-e645076f": {
               "attributes": {
                 "wing:resource:connections": [
@@ -1957,9 +2266,11 @@ exports[`api with one POST route, with body urlencoded 1`] = `
   "wingsdk.cloud.Function created.",
   "Server listening on http://127.0.0.1:<port>",
   "wingsdk.cloud.Api created.",
+  "wingsdk.sim.EventMapping created.",
   "Processing \\"POST /hello\\" (body={\\"message\\":\\"hello world\\"}, params={}).",
   "Invoke (payload={\\"headers\\":{\\"host\\":\\"127.0.0.1:<port>\\",\\"connection\\":\\"keep-alive\\",\\"content-type\\":\\"application/x-www-form-urlencoded;charset=UTF-8\\",\\"accept\\":\\"*/*\\",\\"accept-language\\":\\"*\\",\\"sec-fetch-mode\\":\\"cors\\",\\"user-agent\\":\\"undici\\",\\"accept-encoding\\":\\"gzip, deflate\\",\\"content-length\\":\\"19\\"},\\"body\\":{\\"message\\":\\"hello world\\"},\\"method\\":\\"POST\\",\\"path\\":\\"/hello\\",\\"query\\":{},\\"vars\\":{}}).",
   "POST /hello - 200.",
+  "wingsdk.sim.EventMapping deleted.",
   "Closing server on http://127.0.0.1:<port>",
   "wingsdk.cloud.Api deleted.",
   "wingsdk.cloud.Function deleted.",
@@ -2007,16 +2318,25 @@ return class Handler {
       {
         "attrs": {},
         "path": "root/my_api",
-        "props": {
-          "routes": [
-            {
-              "functionHandle": "\${root/my_api/my_api-OnRequestHandler-e645076f#attrs.handle}",
-              "method": "POST",
-              "route": "/hello",
-            },
-          ],
-        },
+        "props": {},
         "type": "wingsdk.cloud.Api",
+      },
+      {
+        "attrs": {},
+        "path": "root/my_api/my_api-ApiEventMapping-e645076f",
+        "props": {
+          "publisher": "\${root/my_api#attrs.handle}",
+          "subscriber": "\${root/my_api/my_api-OnRequestHandler-e645076f#attrs.handle}",
+          "subscriptionProps": {
+            "routes": [
+              {
+                "method": "POST",
+                "path": "/hello",
+              },
+            ],
+          },
+        },
+        "type": "wingsdk.sim.EventMapping",
       },
     ],
     "sdkVersion": "0.0.0",
@@ -2071,6 +2391,21 @@ return class Handler {
             "wing:resource:stateful": true,
           },
           "children": {
+            "my_api-ApiEventMapping-e645076f": {
+              "attributes": {
+                "wing:resource:connections": [],
+                "wing:resource:stateful": true,
+              },
+              "constructInfo": {
+                "fqn": "constructs.Construct",
+                "version": "10.1.245",
+              },
+              "display": {
+                "hidden": true,
+              },
+              "id": "my_api-ApiEventMapping-e645076f",
+              "path": "root/my_api/my_api-ApiEventMapping-e645076f",
+            },
             "my_api-OnRequestHandler-e645076f": {
               "attributes": {
                 "wing:resource:connections": [
@@ -2134,9 +2469,7 @@ exports[`create an api 1`] = `
       {
         "attrs": {},
         "path": "root/my_api",
-        "props": {
-          "routes": [],
-        },
+        "props": {},
         "type": "wingsdk.cloud.Api",
       },
     ],

--- a/libs/wingsdk/test/target-sim/api.test.ts
+++ b/libs/wingsdk/test/target-sim/api.test.ts
@@ -34,9 +34,7 @@ test("create an api", async () => {
       url: expect.any(String),
     },
     path: "root/my_api",
-    props: {
-      routes: [],
-    },
+    props: { },
     type: "wingsdk.cloud.Api",
   });
   await s.stop();

--- a/libs/wingsdk/test/target-sim/api.test.ts
+++ b/libs/wingsdk/test/target-sim/api.test.ts
@@ -34,7 +34,7 @@ test("create an api", async () => {
       url: expect.any(String),
     },
     path: "root/my_api",
-    props: { },
+    props: {},
     type: "wingsdk.cloud.Api",
   });
   await s.stop();


### PR DESCRIPTION
Closes: https://github.com/winglang/wing/issues/2141

- [ ] Update wing spec to use path vocab

**Misc:**
- refactored `route` vocabulary to `path` to fit the proper definitions of the terms and be more inline with popular framework vocabulary of the terms.

See: 
- https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html#api-gateway-simple-proxy-for-lambda-input-format
- https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html#api-gateway-set-up-lambda-proxy-integration-on-proxy-resource
- https://expressjs.com/en/4x/api.html#router 

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.