### PR TITLE
fix(compiler): mutarray can be assigned to an array

### DIFF
--- a/examples/tests/invalid/container_types.w
+++ b/examples/tests/invalid/container_types.w
@@ -18,3 +18,6 @@ let s3: Set<num> = [1, "2", 3];
 let s4 = Set<num>{1,2};
 let s5: Set<str> = s4;
 s1.some_random_method();
+
+let a: Array<str> = MutArray<str>[];
+//                  ^^^^^^^^^^^^^^^ Expected type to be "Array<str>", but got "MutArray<str>" instead

--- a/libs/wingc/src/type_check.rs
+++ b/libs/wingc/src/type_check.rs
@@ -482,12 +482,6 @@ impl Subtype for Type {
 				let r: &Type = r0;
 				l.is_subtype_of(r)
 			}
-			(Self::MutArray(l0), Self::Array(r0)) => {
-				// A MutArray type is a subtype of an Array type if the value type is a subtype of the other value type
-				let l: &Type = l0;
-				let r: &Type = r0;
-				l.is_subtype_of(r)
-			}
 			(Self::Map(l0), Self::Map(r0)) => {
 				// A Map type is a subtype of another Map type if the value type is a subtype of the other value type
 				let l: &Type = l0;

--- a/tools/hangar/__snapshots__/invalid.ts.snap
+++ b/tools/hangar/__snapshots__/invalid.ts.snap
@@ -286,6 +286,13 @@ error: Unknown symbol \\"some_random_method\\"
 20 | s1.some_random_method();
    |    ^^^^^^^^^^^^^^^^^^ Unknown symbol \\"some_random_method\\"
 
+
+error: Expected type to be \\"Array<str>\\", but got \\"MutArray<str>\\" instead
+   --> ../../../examples/tests/invalid/container_types.w:22:21
+   |
+22 | let a: Array<str> = MutArray<str>[];
+   |                     ^^^^^^^^^^^^^^^ Expected type to be \\"Array<str>\\", but got \\"MutArray<str>\\" instead
+
 "
 `;
 


### PR DESCRIPTION
Fixes #2249

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.