### PR TITLE
fix: elif isn't highlighted as keyword

### DIFF
--- a/apps/vscode-wing/syntaxes/wing.tmLanguage.json
+++ b/apps/vscode-wing/syntaxes/wing.tmLanguage.json
@@ -109,7 +109,7 @@
       "patterns": [
         {
           "name": "keyword.control.flow.wing",
-          "match": "\\b(else|if|return|try|catch|finally|bring|as)\\b"
+          "match": "\\b(else|elif|if|return|try|catch|finally|bring|as)\\b"
         },
         {
           "name": "keyword.control.loop.wing",


### PR DESCRIPTION

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.