### PR TITLE
fix(sdk): aws bucket event actions swapped

### DIFF
--- a/libs/wingsdk/src/target-tf-aws/bucket.ts
+++ b/libs/wingsdk/src/target-tf-aws/bucket.ts
@@ -23,8 +23,8 @@ import {
 
 const EVENTS = {
   [BucketEventType.DELETE]: ["s3:ObjectRemoved:*"],
-  [BucketEventType.CREATE]: ["s3:ObjectCreated:Post"],
-  [BucketEventType.UPDATE]: ["s3:ObjectCreated:Put"],
+  [BucketEventType.CREATE]: ["s3:ObjectCreated:Put"],
+  [BucketEventType.UPDATE]: ["s3:ObjectCreated:Post"],
 };
 
 /**

--- a/libs/wingsdk/test/target-tf-aws/__snapshots__/bucket.test.ts.snap
+++ b/libs/wingsdk/test/target-tf-aws/__snapshots__/bucket.test.ts.snap
@@ -549,7 +549,7 @@ exports[`bucket with onCreate method 1`] = `
         \\"topic\\": [
           {
             \\"events\\": [
-              \\"s3:ObjectCreated:Post\\"
+              \\"s3:ObjectCreated:Put\\"
             ],
             \\"topic_arn\\": \\"\${aws_sns_topic.root_mybucket_mybucketoncreate_A862D5F2.arn}\\"
           }
@@ -1579,7 +1579,7 @@ exports[`bucket with onEvent method 1`] = `
         \\"topic\\": [
           {
             \\"events\\": [
-              \\"s3:ObjectCreated:Post\\"
+              \\"s3:ObjectCreated:Put\\"
             ],
             \\"topic_arn\\": \\"\${aws_sns_topic.root_mybucket_mybucketoncreate_A862D5F2.arn}\\"
           }
@@ -1607,7 +1607,7 @@ exports[`bucket with onEvent method 1`] = `
         \\"topic\\": [
           {
             \\"events\\": [
-              \\"s3:ObjectCreated:Put\\"
+              \\"s3:ObjectCreated:Post\\"
             ],
             \\"topic_arn\\": \\"\${aws_sns_topic.root_mybucket_mybucketonupdate_3B88F935.arn}\\"
           }
@@ -2530,7 +2530,7 @@ exports[`bucket with onUpdate method 1`] = `
         \\"topic\\": [
           {
             \\"events\\": [
-              \\"s3:ObjectCreated:Put\\"
+              \\"s3:ObjectCreated:Post\\"
             ],
             \\"topic_arn\\": \\"\${aws_sns_topic.root_mybucket_mybucketonupdate_3B88F935.arn}\\"
           }

--- a/tools/hangar/__snapshots__/test_corpus/bucket_events.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/bucket_events.w_compile_tf-aws.md
@@ -742,7 +742,7 @@
         "topic": [
           {
             "events": [
-              "s3:ObjectCreated:Post"
+              "s3:ObjectCreated:Put"
             ],
             "topic_arn": "${aws_sns_topic.root_b_boncreate_9124D168.arn}"
           }
@@ -782,7 +782,7 @@
         "topic": [
           {
             "events": [
-              "s3:ObjectCreated:Put"
+              "s3:ObjectCreated:Post"
             ],
             "topic_arn": "${aws_sns_topic.root_b_bonupdate_F11B4439.arn}"
           }
@@ -802,7 +802,7 @@
         "topic": [
           {
             "events": [
-              "s3:ObjectCreated:Post"
+              "s3:ObjectCreated:Put"
             ],
             "topic_arn": "${aws_sns_topic.root_other_otheroncreate_DCA3D2DD.arn}"
           }
@@ -842,7 +842,7 @@
         "topic": [
           {
             "events": [
-              "s3:ObjectCreated:Put"
+              "s3:ObjectCreated:Post"
             ],
             "topic_arn": "${aws_sns_topic.root_other_otheronupdate_3B763057.arn}"
           }

--- a/tools/hangar/__snapshots__/test_corpus/resource.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/resource.w_compile_tf-aws.md
@@ -526,7 +526,7 @@ exports.Foo = Foo;
         "topic": [
           {
             "events": [
-              "s3:ObjectCreated:Post"
+              "s3:ObjectCreated:Put"
             ],
             "topic_arn": "${aws_sns_topic.root_BigPublisher_b2_b2oncreate_DFA80519.arn}"
           }


### PR DESCRIPTION
After pulling out about all the hairs I have left I found out why my S3 object creates were not firing events to lambda 😄 

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.