### PR TITLE
chore(repo): remove instead word from bug label

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -13,14 +13,14 @@ body:
 - type: textarea
   id: i-tried-this
   attributes:
-    label: "I tried this"
+    label: "I tried this:"
     placeholder: "What did you try to do? A code snippet or exact command line is ideal."
   validations:
     required: true
 - type: textarea
   id: instead-what-happened
   attributes:
-    label: "Instead, this happened"
+    label: "This happened:"
     placeholder: "What happend instead of what you've expected?"
   validations:
     required: true


### PR DESCRIPTION
The recent change in this template was to replace the order of the expected and the actual result. The "instead" word was relevant before but doesn't make sense now.



*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.