### PR TITLE
fix: lsp completion does not show namespaced types or static members

### DIFF
--- a/libs/tree-sitter-wing/grammar.js
+++ b/libs/tree-sitter-wing/grammar.js
@@ -63,6 +63,7 @@ module.exports = grammar({
     custom_type: ($) =>
       prec.right(seq(
         field("object", $._type_identifier),
+        // While the final "fields" identifier is optional in this grammar, upstream parsing will fail if it is not present
         repeat(seq(".", optional(field("fields", $._type_identifier))))
       )),
 
@@ -80,6 +81,7 @@ module.exports = grammar({
             )
           ),
           choice(".", "?."),
+          // While the "property" identifier is optional in this grammar, upstream parsing will fail if it is not present
           optional(field("property", $._member_identifier))
         )
       ),
@@ -399,6 +401,7 @@ module.exports = grammar({
       prec.right(seq(
         "new",
         field("class", choice($.custom_type, $.mutable_container_type)),
+        // While "args" is optional in this grammar, upstream parsing will fail if it is not present
         field("args", optional($.argument_list)),
         field("id", optional($.new_object_id)),
         field("scope", optional($.new_object_scope))

--- a/libs/tree-sitter-wing/grammar.js
+++ b/libs/tree-sitter-wing/grammar.js
@@ -61,10 +61,10 @@ module.exports = grammar({
     _reference_identifier: ($) => alias($.identifier, $.reference_identifier),
 
     custom_type: ($) =>
-      seq(
+      prec.right(seq(
         field("object", $._type_identifier),
         repeat(seq(".", optional(field("fields", $._type_identifier))))
-      ),
+      )),
 
     nested_identifier: ($) =>
       prec(
@@ -396,13 +396,13 @@ module.exports = grammar({
       ),
 
     new_expression: ($) =>
-      seq(
+      prec.right(seq(
         "new",
         field("class", choice($.custom_type, $.mutable_container_type)),
-        field("args", $.argument_list),
+        field("args", optional($.argument_list)),
         field("id", optional($.new_object_id)),
         field("scope", optional($.new_object_scope))
-      ),
+      )),
 
     new_object_id: ($) => seq("as", $.string),
 

--- a/libs/wingc/src/ast.rs
+++ b/libs/wingc/src/ast.rs
@@ -216,7 +216,7 @@ impl FunctionSignature {
 				return_type: self.return_type.clone(),
 				phase: self.phase,
 			}),
-			// TODO
+			// Function signatures may not necessarily have spans
 			span: Default::default(),
 		}
 	}

--- a/libs/wingc/src/ast.rs
+++ b/libs/wingc/src/ast.rs
@@ -99,7 +99,13 @@ impl Display for Phase {
 }
 
 #[derive(Debug, Clone)]
-pub enum TypeAnnotation {
+pub struct TypeAnnotation {
+	pub kind: TypeAnnotationKind,
+	pub span: WingSpan,
+}
+
+#[derive(Debug, Clone)]
+pub enum TypeAnnotationKind {
 	Number,
 	String,
 	Bool,
@@ -145,25 +151,31 @@ impl Display for UserDefinedType {
 	}
 }
 
-impl Display for TypeAnnotation {
+impl Display for TypeAnnotationKind {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		match self {
-			TypeAnnotation::Number => write!(f, "num"),
-			TypeAnnotation::String => write!(f, "str"),
-			TypeAnnotation::Bool => write!(f, "bool"),
-			TypeAnnotation::Duration => write!(f, "duration"),
-			TypeAnnotation::Json => write!(f, "Json"),
-			TypeAnnotation::MutJson => write!(f, "MutJson"),
-			TypeAnnotation::Optional(t) => write!(f, "{}?", t),
-			TypeAnnotation::Array(t) => write!(f, "Array<{}>", t),
-			TypeAnnotation::MutArray(t) => write!(f, "MutArray<{}>", t),
-			TypeAnnotation::Map(t) => write!(f, "Map<{}>", t),
-			TypeAnnotation::MutMap(t) => write!(f, "MutMap<{}>", t),
-			TypeAnnotation::Set(t) => write!(f, "Set<{}>", t),
-			TypeAnnotation::MutSet(t) => write!(f, "MutSet<{}>", t),
-			TypeAnnotation::Function(t) => write!(f, "{}", t),
-			TypeAnnotation::UserDefined(user_defined_type) => write!(f, "{}", user_defined_type),
+			TypeAnnotationKind::Number => write!(f, "num"),
+			TypeAnnotationKind::String => write!(f, "str"),
+			TypeAnnotationKind::Bool => write!(f, "bool"),
+			TypeAnnotationKind::Duration => write!(f, "duration"),
+			TypeAnnotationKind::Json => write!(f, "Json"),
+			TypeAnnotationKind::MutJson => write!(f, "MutJson"),
+			TypeAnnotationKind::Optional(t) => write!(f, "{}?", t),
+			TypeAnnotationKind::Array(t) => write!(f, "Array<{}>", t),
+			TypeAnnotationKind::MutArray(t) => write!(f, "MutArray<{}>", t),
+			TypeAnnotationKind::Map(t) => write!(f, "Map<{}>", t),
+			TypeAnnotationKind::MutMap(t) => write!(f, "MutMap<{}>", t),
+			TypeAnnotationKind::Set(t) => write!(f, "Set<{}>", t),
+			TypeAnnotationKind::MutSet(t) => write!(f, "MutSet<{}>", t),
+			TypeAnnotationKind::Function(t) => write!(f, "{}", t),
+			TypeAnnotationKind::UserDefined(user_defined_type) => write!(f, "{}", user_defined_type),
 		}
+	}
+}
+
+impl Display for TypeAnnotation {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		std::fmt::Display::fmt(&self.kind, f)
 	}
 }
 
@@ -198,11 +210,15 @@ pub struct FunctionSignature {
 
 impl FunctionSignature {
 	pub fn to_type_annotation(&self) -> TypeAnnotation {
-		TypeAnnotation::Function(FunctionTypeAnnotation {
-			param_types: self.parameters.iter().map(|p| p.type_annotation.clone()).collect(),
-			return_type: self.return_type.clone(),
-			phase: self.phase,
-		})
+		TypeAnnotation {
+			kind: TypeAnnotationKind::Function(FunctionTypeAnnotation {
+				param_types: self.parameters.iter().map(|p| p.type_annotation.clone()).collect(),
+				return_type: self.return_type.clone(),
+				phase: self.phase,
+			}),
+			// TODO
+			span: Default::default(),
+		}
 	}
 }
 
@@ -611,7 +627,12 @@ impl Display for Reference {
 				write!(f, "{}.{}", obj_str, property.name)
 			}
 			Reference::TypeMember { type_, property } => {
-				write!(f, "{}.{}", TypeAnnotation::UserDefined(type_.clone()), property.name)
+				write!(
+					f,
+					"{}.{}",
+					TypeAnnotationKind::UserDefined(type_.clone()),
+					property.name
+				)
 			}
 		}
 	}

--- a/libs/wingc/src/fold.rs
+++ b/libs/wingc/src/fold.rs
@@ -2,7 +2,7 @@ use crate::ast::{
 	ArgList, CatchBlock, Class, ClassField, ElifBlock, Expr, ExprKind, FunctionBody, FunctionDefinition,
 	FunctionParameter, FunctionSignature, FunctionTypeAnnotation, Initializer, Interface, InterpolatedString,
 	InterpolatedStringPart, Literal, Reference, Scope, Stmt, StmtKind, StructField, Symbol, TypeAnnotation,
-	UserDefinedType,
+	TypeAnnotationKind, UserDefinedType,
 };
 
 /// Similar to the `visit` module in `wingc` except each method takes ownership of an
@@ -413,26 +413,71 @@ pub fn fold_type_annotation<F>(f: &mut F, node: TypeAnnotation) -> TypeAnnotatio
 where
 	F: Fold + ?Sized,
 {
-	match node {
-		TypeAnnotation::Number => TypeAnnotation::Number,
-		TypeAnnotation::String => TypeAnnotation::String,
-		TypeAnnotation::Bool => TypeAnnotation::Bool,
-		TypeAnnotation::Duration => TypeAnnotation::Duration,
-		TypeAnnotation::Json => TypeAnnotation::Json,
-		TypeAnnotation::MutJson => TypeAnnotation::MutJson,
-		TypeAnnotation::Optional(t) => TypeAnnotation::Optional(Box::new(f.fold_type_annotation(*t))),
-		TypeAnnotation::Array(t) => TypeAnnotation::Array(Box::new(f.fold_type_annotation(*t))),
-		TypeAnnotation::MutArray(t) => TypeAnnotation::MutArray(Box::new(f.fold_type_annotation(*t))),
-		TypeAnnotation::Map(t) => TypeAnnotation::Map(Box::new(f.fold_type_annotation(*t))),
-		TypeAnnotation::MutMap(t) => TypeAnnotation::MutMap(Box::new(f.fold_type_annotation(*t))),
-		TypeAnnotation::Set(t) => TypeAnnotation::Set(Box::new(f.fold_type_annotation(*t))),
-		TypeAnnotation::MutSet(t) => TypeAnnotation::MutSet(Box::new(f.fold_type_annotation(*t))),
-		TypeAnnotation::Function(t) => TypeAnnotation::Function(FunctionTypeAnnotation {
-			param_types: t.param_types.into_iter().map(|t| f.fold_type_annotation(t)).collect(),
-			return_type: t.return_type.map(|t| Box::new(f.fold_type_annotation(*t))),
-			phase: t.phase,
-		}),
-		TypeAnnotation::UserDefined(t) => TypeAnnotation::UserDefined(f.fold_user_defined_type(t)),
+	match node.kind {
+		TypeAnnotationKind::Number => TypeAnnotation {
+			kind: TypeAnnotationKind::Number,
+			span: node.span,
+		},
+		TypeAnnotationKind::String => TypeAnnotation {
+			kind: TypeAnnotationKind::String,
+			span: node.span,
+		},
+		TypeAnnotationKind::Bool => TypeAnnotation {
+			kind: TypeAnnotationKind::Bool,
+			span: node.span,
+		},
+		TypeAnnotationKind::Duration => TypeAnnotation {
+			kind: TypeAnnotationKind::Duration,
+			span: node.span,
+		},
+		TypeAnnotationKind::Json => TypeAnnotation {
+			kind: TypeAnnotationKind::Json,
+			span: node.span,
+		},
+		TypeAnnotationKind::MutJson => TypeAnnotation {
+			kind: TypeAnnotationKind::MutJson,
+			span: node.span,
+		},
+		TypeAnnotationKind::Optional(t) => TypeAnnotation {
+			kind: TypeAnnotationKind::Optional(Box::new(f.fold_type_annotation(*t))),
+			span: node.span,
+		},
+		TypeAnnotationKind::Array(t) => TypeAnnotation {
+			kind: TypeAnnotationKind::Array(Box::new(f.fold_type_annotation(*t))),
+			span: node.span,
+		},
+		TypeAnnotationKind::MutArray(t) => TypeAnnotation {
+			kind: TypeAnnotationKind::MutArray(Box::new(f.fold_type_annotation(*t))),
+			span: node.span,
+		},
+		TypeAnnotationKind::Map(t) => TypeAnnotation {
+			kind: TypeAnnotationKind::Map(Box::new(f.fold_type_annotation(*t))),
+			span: node.span,
+		},
+		TypeAnnotationKind::MutMap(t) => TypeAnnotation {
+			kind: TypeAnnotationKind::MutMap(Box::new(f.fold_type_annotation(*t))),
+			span: node.span,
+		},
+		TypeAnnotationKind::Set(t) => TypeAnnotation {
+			kind: TypeAnnotationKind::Set(Box::new(f.fold_type_annotation(*t))),
+			span: node.span,
+		},
+		TypeAnnotationKind::MutSet(t) => TypeAnnotation {
+			kind: TypeAnnotationKind::MutSet(Box::new(f.fold_type_annotation(*t))),
+			span: node.span,
+		},
+		TypeAnnotationKind::Function(t) => TypeAnnotation {
+			kind: TypeAnnotationKind::Function(FunctionTypeAnnotation {
+				param_types: t.param_types.into_iter().map(|t| f.fold_type_annotation(t)).collect(),
+				return_type: t.return_type.map(|t| Box::new(f.fold_type_annotation(*t))),
+				phase: t.phase,
+			}),
+			span: node.span,
+		},
+		TypeAnnotationKind::UserDefined(t) => TypeAnnotation {
+			kind: TypeAnnotationKind::UserDefined(f.fold_user_defined_type(t)),
+			span: node.span,
+		},
 	}
 }
 

--- a/libs/wingc/src/fold.rs
+++ b/libs/wingc/src/fold.rs
@@ -413,72 +413,29 @@ pub fn fold_type_annotation<F>(f: &mut F, node: TypeAnnotation) -> TypeAnnotatio
 where
 	F: Fold + ?Sized,
 {
-	match node.kind {
-		TypeAnnotationKind::Number => TypeAnnotation {
-			kind: TypeAnnotationKind::Number,
-			span: node.span,
-		},
-		TypeAnnotationKind::String => TypeAnnotation {
-			kind: TypeAnnotationKind::String,
-			span: node.span,
-		},
-		TypeAnnotationKind::Bool => TypeAnnotation {
-			kind: TypeAnnotationKind::Bool,
-			span: node.span,
-		},
-		TypeAnnotationKind::Duration => TypeAnnotation {
-			kind: TypeAnnotationKind::Duration,
-			span: node.span,
-		},
-		TypeAnnotationKind::Json => TypeAnnotation {
-			kind: TypeAnnotationKind::Json,
-			span: node.span,
-		},
-		TypeAnnotationKind::MutJson => TypeAnnotation {
-			kind: TypeAnnotationKind::MutJson,
-			span: node.span,
-		},
-		TypeAnnotationKind::Optional(t) => TypeAnnotation {
-			kind: TypeAnnotationKind::Optional(Box::new(f.fold_type_annotation(*t))),
-			span: node.span,
-		},
-		TypeAnnotationKind::Array(t) => TypeAnnotation {
-			kind: TypeAnnotationKind::Array(Box::new(f.fold_type_annotation(*t))),
-			span: node.span,
-		},
-		TypeAnnotationKind::MutArray(t) => TypeAnnotation {
-			kind: TypeAnnotationKind::MutArray(Box::new(f.fold_type_annotation(*t))),
-			span: node.span,
-		},
-		TypeAnnotationKind::Map(t) => TypeAnnotation {
-			kind: TypeAnnotationKind::Map(Box::new(f.fold_type_annotation(*t))),
-			span: node.span,
-		},
-		TypeAnnotationKind::MutMap(t) => TypeAnnotation {
-			kind: TypeAnnotationKind::MutMap(Box::new(f.fold_type_annotation(*t))),
-			span: node.span,
-		},
-		TypeAnnotationKind::Set(t) => TypeAnnotation {
-			kind: TypeAnnotationKind::Set(Box::new(f.fold_type_annotation(*t))),
-			span: node.span,
-		},
-		TypeAnnotationKind::MutSet(t) => TypeAnnotation {
-			kind: TypeAnnotationKind::MutSet(Box::new(f.fold_type_annotation(*t))),
-			span: node.span,
-		},
-		TypeAnnotationKind::Function(t) => TypeAnnotation {
-			kind: TypeAnnotationKind::Function(FunctionTypeAnnotation {
-				param_types: t.param_types.into_iter().map(|t| f.fold_type_annotation(t)).collect(),
-				return_type: t.return_type.map(|t| Box::new(f.fold_type_annotation(*t))),
-				phase: t.phase,
-			}),
-			span: node.span,
-		},
-		TypeAnnotationKind::UserDefined(t) => TypeAnnotation {
-			kind: TypeAnnotationKind::UserDefined(f.fold_user_defined_type(t)),
-			span: node.span,
-		},
-	}
+	let kind = match node.kind {
+		TypeAnnotationKind::Number => TypeAnnotationKind::Number,
+		TypeAnnotationKind::String => TypeAnnotationKind::String,
+		TypeAnnotationKind::Bool => TypeAnnotationKind::Bool,
+		TypeAnnotationKind::Duration => TypeAnnotationKind::Duration,
+		TypeAnnotationKind::Json => TypeAnnotationKind::Json,
+		TypeAnnotationKind::MutJson => TypeAnnotationKind::MutJson,
+		TypeAnnotationKind::Optional(t) => TypeAnnotationKind::Optional(Box::new(f.fold_type_annotation(*t))),
+		TypeAnnotationKind::Array(t) => TypeAnnotationKind::Array(Box::new(f.fold_type_annotation(*t))),
+		TypeAnnotationKind::MutArray(t) => TypeAnnotationKind::MutArray(Box::new(f.fold_type_annotation(*t))),
+		TypeAnnotationKind::Map(t) => TypeAnnotationKind::Map(Box::new(f.fold_type_annotation(*t))),
+		TypeAnnotationKind::MutMap(t) => TypeAnnotationKind::MutMap(Box::new(f.fold_type_annotation(*t))),
+		TypeAnnotationKind::Set(t) => TypeAnnotationKind::Set(Box::new(f.fold_type_annotation(*t))),
+		TypeAnnotationKind::MutSet(t) => TypeAnnotationKind::MutSet(Box::new(f.fold_type_annotation(*t))),
+		TypeAnnotationKind::Function(t) => TypeAnnotationKind::Function(FunctionTypeAnnotation {
+			param_types: t.param_types.into_iter().map(|t| f.fold_type_annotation(t)).collect(),
+			return_type: t.return_type.map(|t| Box::new(f.fold_type_annotation(*t))),
+			phase: t.phase,
+		}),
+		TypeAnnotationKind::UserDefined(t) => TypeAnnotationKind::UserDefined(f.fold_user_defined_type(t)),
+	};
+
+	TypeAnnotation { kind, span: node.span }
 }
 
 pub fn fold_user_defined_type<F>(f: &mut F, node: UserDefinedType) -> UserDefinedType

--- a/libs/wingc/src/jsify.rs
+++ b/libs/wingc/src/jsify.rs
@@ -19,7 +19,7 @@ use crate::{
 	ast::{
 		ArgList, BinaryOperator, Class as AstClass, ClassField, Expr, ExprKind, FunctionBody, FunctionBodyRef,
 		FunctionDefinition, Initializer, InterpolatedStringPart, Literal, MethodLike, Phase, Reference, Scope, Stmt,
-		StmtKind, Symbol, TypeAnnotation, UnaryOperator, UserDefinedType,
+		StmtKind, Symbol, TypeAnnotationKind, UnaryOperator, UserDefinedType,
 	},
 	debug,
 	diagnostic::{Diagnostic, DiagnosticLevel, Diagnostics},
@@ -188,7 +188,7 @@ impl<'a> JSifier<'a> {
 				self.jsify_expression(object, context) + "." + &symbolize(self, property)
 			}
 			Reference::TypeMember { type_, property } => {
-				self.jsify_type(&TypeAnnotation::UserDefined(type_.clone())) + "." + &symbolize(self, property)
+				self.jsify_type(&TypeAnnotationKind::UserDefined(type_.clone())) + "." + &symbolize(self, property)
 			}
 		}
 	}
@@ -255,9 +255,9 @@ impl<'a> JSifier<'a> {
 		}
 	}
 
-	fn jsify_type(&self, typ: &TypeAnnotation) -> String {
+	fn jsify_type(&self, typ: &TypeAnnotationKind) -> String {
 		match typ {
-			TypeAnnotation::UserDefined(user_defined_type) => self.jsify_user_defined_type(user_defined_type),
+			TypeAnnotationKind::UserDefined(user_defined_type) => self.jsify_user_defined_type(user_defined_type),
 			_ => todo!(),
 		}
 	}
@@ -315,7 +315,7 @@ impl<'a> JSifier<'a> {
 				// user-defined types), we simply instantiate the type directly (maybe in the future we will
 				// allow customizations of user-defined types as well, but for now we don't).
 
-				let ctor = self.jsify_type(class);
+				let ctor = self.jsify_type(&class.kind);
 
 				let scope = if is_resource { Some("this") } else { None };
 

--- a/libs/wingc/src/lsp/completions.rs
+++ b/libs/wingc/src/lsp/completions.rs
@@ -75,9 +75,6 @@ pub fn on_completion(params: lsp_types::CompletionParams) -> CompletionResponse 
 
 		let parent = node_to_complete.parent();
 
-		dbg!(parent);
-		dbg!(scope_visitor.nearest_expr);
-
 		if node_to_complete.kind() == "." {
 			let parent = parent.expect("A dot must have a parent");
 
@@ -100,7 +97,7 @@ pub fn on_completion(params: lsp_types::CompletionParams) -> CompletionResponse 
 						);
 					} else {
 						if let ExprKind::Reference(_) = &nearest_expr.kind {
-							// this is probably a type of some kind
+							// This is probably a type of some kind
 							// just get the entire reference and try to resolve it
 							let wing_source = result.contents.as_bytes();
 							let mut reference_text = parent
@@ -111,14 +108,11 @@ pub fn on_completion(params: lsp_types::CompletionParams) -> CompletionResponse 
 								reference_text.pop();
 							}
 
-							dbg!(&reference_text);
-
 							let found_env = scope_visitor.found_scope.unwrap();
 							let found_env = found_env.env.borrow();
 							let found_env = found_env.as_ref().unwrap();
 							let lookup_thing = found_env.lookup_nested_str(&reference_text, scope_visitor.found_stmt_index);
 
-							dbg!(&lookup_thing);
 							if let Ok(lookup_thing) = lookup_thing {
 								match lookup_thing {
 									SymbolKind::Type(t) => {
@@ -135,19 +129,12 @@ pub fn on_completion(params: lsp_types::CompletionParams) -> CompletionResponse 
 										)
 									}
 									SymbolKind::Namespace(n) => {
-										let completions = get_completions_from_namespace(n);
-										// if let Some(grandparent) = parent.parent() {
-										// 	if grandparent.kind() == "new_expression" {
-										// 		// we only want classes
-										// 		return completions
-										// 			.into_iter()
-										// 			.filter(|c| matches!(c.kind, Some(CompletionItemKind::CLASS)))
-										// 			.collect();
-										// 	}
-										// }
-										return completions;
+										return get_completions_from_namespace(n);
 									}
 								}
+							} else {
+								// This is probably a JSII type that has not been imported yet
+								// TODO Need to map a custom_type to a JSII FQN
 							}
 						}
 					}

--- a/libs/wingc/src/lsp/completions.rs
+++ b/libs/wingc/src/lsp/completions.rs
@@ -3,14 +3,15 @@ use std::cmp::max;
 use lsp_types::{CompletionItem, CompletionItemKind, CompletionResponse, InsertTextFormat};
 use tree_sitter::Point;
 
-use crate::ast::{Expr, ExprKind, Phase, Scope};
+use crate::ast::{Expr, ExprKind, Phase, Scope, TypeAnnotation, TypeAnnotationKind};
 use crate::diagnostic::{WingLocation, WingSpan};
 use crate::lsp::sync::FILES;
 use crate::type_check::symbol_env::StatementIdx;
 use crate::type_check::{
-	ClassLike, Namespace, SymbolKind, Type, Types, UnsafeRef, CLASS_INFLIGHT_INIT_NAME, CLASS_INIT_NAME,
+	resolve_user_defined_type, ClassLike, Namespace, SymbolKind, Type, Types, UnsafeRef, CLASS_INFLIGHT_INIT_NAME,
+	CLASS_INIT_NAME,
 };
-use crate::visit::{visit_expr, Visit};
+use crate::visit::{visit_expr, visit_type_annotation, Visit};
 use crate::wasm_util::{ptr_to_string, string_to_combined_ptr, WASM_RETURN_ERROR};
 
 #[no_mangle]
@@ -32,7 +33,6 @@ pub fn on_completion(params: lsp_types::CompletionParams) -> CompletionResponse 
 		let files = files.borrow();
 		let uri = params.text_document_position.text_document.uri;
 		let result = files.get(&uri).expect("File must be open to get completions");
-		let wing_source = result.contents.as_bytes();
 
 		let types = &result.types;
 		let root_scope = &result.scope;
@@ -75,18 +75,14 @@ pub fn on_completion(params: lsp_types::CompletionParams) -> CompletionResponse 
 
 		let parent = node_to_complete.parent();
 
-		let within_nested_node = if let Some(parent) = parent {
-			node_to_complete.kind() == "."
-				|| parent.kind() == "custom_type"
-				|| parent.kind() == "nested_identifier"
-				|| parent.kind() == "reference"
-		} else {
-			false
-		};
+		dbg!(parent);
+		dbg!(scope_visitor.nearest_expr);
 
-		if within_nested_node {
-			if let Some(nearest_expr) = scope_visitor.nearest_expr {
-				if node_to_complete.kind() == "." {
+		if node_to_complete.kind() == "." {
+			let parent = parent.expect("A dot must have a parent");
+
+			if parent.kind() == "nested_identifier" {
+				if let Some(nearest_expr) = scope_visitor.nearest_expr {
 					let nearest_expression_type = nearest_expr
 						.evaluated_type
 						.borrow()
@@ -102,55 +98,83 @@ pub fn on_completion(params: lsp_types::CompletionParams) -> CompletionResponse 
 								.map(|s| s.env.borrow().as_ref().expect("Scopes must have an environment").phase),
 							true,
 						);
-					}
-				}
-			}
+					} else {
+						if let ExprKind::Reference(_) = &nearest_expr.kind {
+							// this is probably a type of some kind
+							// just get the entire reference and try to resolve it
+							let wing_source = result.contents.as_bytes();
+							let mut reference_text = parent
+								.utf8_text(wing_source)
+								.expect("The referenced text should be available")
+								.to_string();
+							if reference_text.ends_with(".") {
+								reference_text.pop();
+							}
 
-			// check to see if we are inside a reference of some kind (the last series of non-whitespace characters contains a ., starting from the current location)
-			if let Some(sibling) = node_to_complete.prev_named_sibling().or(Some(node_to_complete)) {
-				let sibling_kind = sibling.kind();
-				if sibling_kind == "reference" || sibling_kind == "nested_identifier" || sibling_kind == "identifier" {
-					// collect all the text of the reference
-					let mut text = sibling
-						.utf8_text(wing_source)
-						.expect("The referenced text should be available")
-						.to_string();
-					if text.ends_with(".") {
-						text.pop();
-					}
-					if !text.contains(".") {
-						// Currently, we can only handle references that are just a single identifier
-						// In this code path, we are inside an error state so the type checker never resolved full references
-						let found_scope = scope_visitor.found_scope.expect("Should have found a scope");
-						let found_env = found_scope.env.borrow();
-						let found_env = found_env.as_ref().expect("Scope should have an env");
-						let found_phase = Some(found_env.phase);
-						let found_symbol = root_env
-							.try_lookup(text.as_str(), None)
-							.or_else(|| found_env.try_lookup(text.as_str(), None));
+							dbg!(&reference_text);
 
-						if let Some(found_symbol) = found_symbol {
-							match found_symbol {
-								SymbolKind::Type(t) => {
-									return get_completions_from_type(t, types, found_phase, false);
-								}
-								SymbolKind::Variable(v) => {
-									return get_completions_from_type(&v.type_, types, found_phase, true);
-								}
-								SymbolKind::Namespace(n) => {
-									return get_completions_from_namespace(n);
+							let found_env = scope_visitor.found_scope.unwrap();
+							let found_env = found_env.env.borrow();
+							let found_env = found_env.as_ref().unwrap();
+							let lookup_thing = found_env.lookup_nested_str(&reference_text, scope_visitor.found_stmt_index);
+
+							dbg!(&lookup_thing);
+							if let Ok(lookup_thing) = lookup_thing {
+								match lookup_thing {
+									SymbolKind::Type(t) => {
+										return get_completions_from_type(&t, types, Some(found_env.phase), false);
+									}
+									SymbolKind::Variable(v) => {
+										return get_completions_from_type(
+											&v.type_,
+											types,
+											scope_visitor
+												.found_scope
+												.map(|s| s.env.borrow().as_ref().expect("Scopes must have an environment").phase),
+											false,
+										)
+									}
+									SymbolKind::Namespace(n) => {
+										let completions = get_completions_from_namespace(n);
+										// if let Some(grandparent) = parent.parent() {
+										// 	if grandparent.kind() == "new_expression" {
+										// 		// we only want classes
+										// 		return completions
+										// 			.into_iter()
+										// 			.filter(|c| matches!(c.kind, Some(CompletionItemKind::CLASS)))
+										// 			.collect();
+										// 	}
+										// }
+										return completions;
+									}
 								}
 							}
 						}
 					}
-				} else {
-					// we are inside some sort of a (possibly incomplete) literal expression
-					match sibling_kind {
-						"string" => return get_completions_from_type(&types.string(), types, None, true),
-						"number" => return get_completions_from_type(&types.number(), types, None, true),
-						"boolean" => return get_completions_from_type(&types.bool(), types, None, true),
-						"duration" => return get_completions_from_type(&types.duration(), types, None, true),
-						_ => {}
+				}
+			}
+
+			if parent.kind() == "custom_type" {
+				if let Some(nearest_type_annotation) = scope_visitor.nearest_type_annotation {
+					if let TypeAnnotationKind::UserDefined(udt) = &nearest_type_annotation.kind {
+						if udt.fields.is_empty() {
+							// this is probably a namespace
+							// `resolve_user_defined_type` will fail for namespaces, let's just look it up instead
+							let namespace = root_env.lookup_nested_str(&udt.root.name, scope_visitor.found_stmt_index);
+							if let Ok(namespace) = namespace {
+								if let SymbolKind::Namespace(namespace) = namespace {
+									return get_completions_from_namespace(namespace);
+								}
+							}
+						}
+						let found_env = scope_visitor.found_scope.unwrap();
+						let found_env = found_env.env.borrow();
+						let found_env = found_env.as_ref().unwrap();
+						let type_lookup = resolve_user_defined_type(udt, found_env, scope_visitor.found_stmt_index.unwrap());
+
+						if let Ok(type_lookup) = type_lookup {
+							return get_completions_from_type(&type_lookup, types, Some(found_env.phase), false);
+						}
 					}
 				}
 			}
@@ -394,8 +418,10 @@ pub struct ScopeVisitor<'a> {
 	pub found_stmt_index: Option<usize>,
 	/// The scope that contains the target location
 	pub found_scope: Option<&'a Scope>,
-	/// The nearest expression before (or containing) to the target location
+	/// The nearest expression before (or containing) the target location
 	pub nearest_expr: Option<&'a Expr>,
+	/// The nearest type annotation before (or containing) the target location
+	pub nearest_type_annotation: Option<&'a TypeAnnotation>,
 }
 
 impl<'a> ScopeVisitor<'a> {
@@ -405,6 +431,7 @@ impl<'a> ScopeVisitor<'a> {
 			found_stmt_index: None,
 			nearest_expr: None,
 			found_scope: None,
+			nearest_type_annotation: None,
 		}
 	}
 }
@@ -441,5 +468,13 @@ impl<'a> Visit<'a> for ScopeVisitor<'a> {
 		if !matches!(&node.kind, ExprKind::Reference(_)) {
 			visit_expr(self, node);
 		}
+	}
+
+	fn visit_type_annotation(&mut self, node: &'a TypeAnnotation) {
+		if node.span <= self.location {
+			self.nearest_type_annotation = Some(node);
+		}
+
+		visit_type_annotation(self, node);
 	}
 }

--- a/libs/wingc/src/parser.rs
+++ b/libs/wingc/src/parser.rs
@@ -1006,7 +1006,7 @@ impl<'s> Parser<'s> {
 			"new_expression" => {
 				let class = self.build_type_annotation(&expression_node.child_by_field_name("class").unwrap())?;
 
-				let arg_list = if let Some(args_node) = expression_node.child_by_field_name("args") {
+				let arg_list = if let Ok(args_node) = self.get_child_field(expression_node, "args") {
 					self.build_arg_list(&args_node)
 				} else {
 					Ok(ArgList::new())

--- a/libs/wingc/src/parser.rs
+++ b/libs/wingc/src/parser.rs
@@ -10,7 +10,7 @@ use crate::ast::{
 	ArgList, BinaryOperator, CatchBlock, Class, ClassField, ElifBlock, Expr, ExprKind, FunctionBody, FunctionDefinition,
 	FunctionParameter, FunctionSignature, FunctionTypeAnnotation, Initializer, Interface, InterpolatedString,
 	InterpolatedStringPart, Literal, Phase, Reference, Scope, Stmt, StmtKind, StructField, Symbol, TypeAnnotation,
-	UnaryOperator, UserDefinedType,
+	TypeAnnotationKind, UnaryOperator, UserDefinedType,
 };
 use crate::diagnostic::{Diagnostic, DiagnosticLevel, DiagnosticResult, Diagnostics, WingSpan};
 use crate::WINGSDK_STD_MODULE;
@@ -360,8 +360,8 @@ impl<'s> Parser<'s> {
 		let mut extends = vec![];
 		for super_node in statement_node.children_by_field_name("extends", &mut cursor) {
 			let super_type = self.build_type_annotation(&super_node)?;
-			match super_type {
-				TypeAnnotation::UserDefined(t) => {
+			match super_type.kind {
+				TypeAnnotationKind::UserDefined(t) => {
 					extends.push(t);
 				}
 				_ => {
@@ -546,10 +546,13 @@ impl<'s> Parser<'s> {
 							statements: self.build_scope(&class_element.child_by_field_name("block").unwrap()),
 							signature: FunctionSignature {
 								parameters,
-								return_type: Some(Box::new(TypeAnnotation::UserDefined(UserDefinedType {
-									root: name.clone(),
-									fields: vec![],
-								}))),
+								return_type: Some(Box::new(TypeAnnotation {
+									kind: TypeAnnotationKind::UserDefined(UserDefinedType {
+										root: name.clone(),
+										fields: vec![],
+									}),
+									span: self.node_span(&class_element),
+								})),
 								phase: if is_resource { Phase::Preflight } else { Phase::Inflight },
 							},
 							span: self.node_span(&class_element),
@@ -584,8 +587,8 @@ impl<'s> Parser<'s> {
 
 		let parent = if let Some(parent_node) = statement_node.child_by_field_name("parent") {
 			let parent_type = self.build_type_annotation(&parent_node)?;
-			match parent_type {
-				TypeAnnotation::UserDefined(parent_type) => Some(parent_type),
+			match parent_type.kind {
+				TypeAnnotationKind::UserDefined(parent_type) => Some(parent_type),
 				_ => {
 					self.add_error::<Node>(
 						format!("Parent type must be a user defined type, found {}", parent_type),
@@ -611,8 +614,8 @@ impl<'s> Parser<'s> {
 			}
 
 			let interface_type = self.build_type_annotation(&type_node)?;
-			match interface_type {
-				TypeAnnotation::UserDefined(interface_type) => implements.push(interface_type),
+			match interface_type.kind {
+				TypeAnnotationKind::UserDefined(interface_type) => implements.push(interface_type),
 				_ => {
 					self.add_error::<Node>(
 						format!(
@@ -693,7 +696,11 @@ impl<'s> Parser<'s> {
 				continue;
 			}
 
-			if let Ok(TypeAnnotation::UserDefined(interface_type)) = self.build_udt_annotation(&extend) {
+			if let Ok(TypeAnnotation {
+				kind: TypeAnnotationKind::UserDefined(interface_type),
+				..
+			}) = self.build_udt_annotation(&extend)
+			{
 				extends.push(interface_type);
 			}
 		}
@@ -762,18 +769,34 @@ impl<'s> Parser<'s> {
 	}
 
 	fn build_type_annotation(&self, type_node: &Node) -> DiagnosticResult<TypeAnnotation> {
+		let span = self.node_span(type_node);
 		match type_node.kind() {
 			"builtin_type" => match self.node_text(type_node) {
-				"num" => Ok(TypeAnnotation::Number),
-				"str" => Ok(TypeAnnotation::String),
-				"bool" => Ok(TypeAnnotation::Bool),
-				"duration" => Ok(TypeAnnotation::Duration),
+				"num" => Ok(TypeAnnotation {
+					kind: TypeAnnotationKind::Number,
+					span,
+				}),
+				"str" => Ok(TypeAnnotation {
+					kind: TypeAnnotationKind::String,
+					span,
+				}),
+				"bool" => Ok(TypeAnnotation {
+					kind: TypeAnnotationKind::Bool,
+					span,
+				}),
+				"duration" => Ok(TypeAnnotation {
+					kind: TypeAnnotationKind::Duration,
+					span,
+				}),
 				"ERROR" => self.add_error("Expected builtin type", type_node),
 				other => return self.report_unimplemented_grammar(other, "builtin", type_node),
 			},
 			"optional" => {
 				let inner_type = self.build_type_annotation(&type_node.named_child(0).unwrap()).unwrap();
-				Ok(TypeAnnotation::Optional(Box::new(inner_type)))
+				Ok(TypeAnnotation {
+					kind: TypeAnnotationKind::Optional(Box::new(inner_type)),
+					span,
+				})
 			}
 			"custom_type" => Ok(self.build_udt_annotation(&type_node)?),
 			"function_type" => {
@@ -786,7 +809,7 @@ impl<'s> Parser<'s> {
 				let return_type = type_node
 					.child_by_field_name("return_type")
 					.map(|n| Box::new(self.build_type_annotation(&n).unwrap()));
-				Ok(TypeAnnotation::Function(FunctionTypeAnnotation {
+				let kind = TypeAnnotationKind::Function(FunctionTypeAnnotation {
 					param_types,
 					return_type,
 					phase: if type_node.child_by_field_name("inflight").is_some() {
@@ -794,13 +817,20 @@ impl<'s> Parser<'s> {
 					} else {
 						Phase::Preflight
 					},
-				}))
+				});
+				Ok(TypeAnnotation { kind, span })
 			}
 			"json_container_type" => {
 				let container_type = self.node_text(&type_node);
 				match container_type {
-					"Json" => Ok(TypeAnnotation::Json),
-					"MutJson" => Ok(TypeAnnotation::MutJson),
+					"Json" => Ok(TypeAnnotation {
+						kind: TypeAnnotationKind::Json,
+						span,
+					}),
+					"MutJson" => Ok(TypeAnnotation {
+						kind: TypeAnnotationKind::MutJson,
+						span,
+					}),
 					other => self.add_error(format!("invalid json container type {}", other), &type_node),
 				}
 			}
@@ -808,24 +838,30 @@ impl<'s> Parser<'s> {
 				let container_type = self.node_text(&type_node.child_by_field_name("collection_type").unwrap());
 				let element_type = type_node.child_by_field_name("type_parameter").unwrap();
 				match container_type {
-					"Map" => Ok(TypeAnnotation::Map(Box::new(
-						self.build_type_annotation(&element_type)?,
-					))),
-					"MutMap" => Ok(TypeAnnotation::MutMap(Box::new(
-						self.build_type_annotation(&element_type)?,
-					))),
-					"Array" => Ok(TypeAnnotation::Array(Box::new(
-						self.build_type_annotation(&element_type)?,
-					))),
-					"MutArray" => Ok(TypeAnnotation::MutArray(Box::new(
-						self.build_type_annotation(&element_type)?,
-					))),
-					"Set" => Ok(TypeAnnotation::Set(Box::new(
-						self.build_type_annotation(&element_type)?,
-					))),
-					"MutSet" => Ok(TypeAnnotation::MutSet(Box::new(
-						self.build_type_annotation(&element_type)?,
-					))),
+					"Map" => Ok(TypeAnnotation {
+						kind: TypeAnnotationKind::Map(Box::new(self.build_type_annotation(&element_type)?)),
+						span,
+					}),
+					"MutMap" => Ok(TypeAnnotation {
+						kind: TypeAnnotationKind::MutMap(Box::new(self.build_type_annotation(&element_type)?)),
+						span,
+					}),
+					"Array" => Ok(TypeAnnotation {
+						kind: TypeAnnotationKind::Array(Box::new(self.build_type_annotation(&element_type)?)),
+						span,
+					}),
+					"MutArray" => Ok(TypeAnnotation {
+						kind: TypeAnnotationKind::MutArray(Box::new(self.build_type_annotation(&element_type)?)),
+						span,
+					}),
+					"Set" => Ok(TypeAnnotation {
+						kind: TypeAnnotationKind::Set(Box::new(self.build_type_annotation(&element_type)?)),
+						span,
+					}),
+					"MutSet" => Ok(TypeAnnotation {
+						kind: TypeAnnotationKind::MutSet(Box::new(self.build_type_annotation(&element_type)?)),
+						span,
+					}),
 					"ERROR" => self.add_error("Expected builtin container type", type_node)?,
 					other => self.report_unimplemented_grammar(other, "builtin container type", type_node),
 				}
@@ -896,13 +932,17 @@ impl<'s> Parser<'s> {
 		}
 
 		let mut cursor = nested_node.walk();
-		Ok(TypeAnnotation::UserDefined(UserDefinedType {
+		let kind = TypeAnnotationKind::UserDefined(UserDefinedType {
 			root: self.node_symbol(&nested_node.child_by_field_name("object").unwrap())?,
 			fields: nested_node
 				.children_by_field_name("fields", &mut cursor)
 				.map(|n| self.node_symbol(&n).unwrap())
 				.collect(),
-		}))
+		});
+		Ok(TypeAnnotation {
+			kind,
+			span: self.node_span(&nested_node),
+		})
 	}
 
 	fn build_reference(&self, reference_node: &Node) -> DiagnosticResult<Expr> {
@@ -1208,8 +1248,8 @@ impl<'s> Parser<'s> {
 
 				// Special case: empty {} (which is detected as map by tree-sitter) -
 				// if it is annotated as a Set/MutSet we should treat it as a set literal
-				if let Some(TypeAnnotation::Set(_)) | Some(TypeAnnotation::MutSet(_)) = map_type {
-					if fields.is_empty() {
+				if let Some(TypeAnnotation { kind, .. }) = &map_type {
+					if matches!(kind, TypeAnnotationKind::Set(_) | TypeAnnotationKind::MutSet(_)) && fields.is_empty() {
 						return self.build_set_literal(expression_node);
 					}
 				}

--- a/libs/wingc/src/type_check.rs
+++ b/libs/wingc/src/type_check.rs
@@ -3298,7 +3298,7 @@ pub fn resolve_user_defined_type(
 			} else {
 				let symb = nested_name.last().unwrap();
 				Err(TypeError {
-					message: format!("Expected {} to be a type but it's a {}", symb, _type),
+					message: format!("Expected '{}' to be a type but it's a {}", symb.name, _type),
 					span: symb.span.clone(),
 				})
 			}

--- a/libs/wingc/src/type_check.rs
+++ b/libs/wingc/src/type_check.rs
@@ -1,6 +1,6 @@
 pub(crate) mod jsii_importer;
 pub mod symbol_env;
-use crate::ast::{self, FunctionBodyRef};
+use crate::ast::{self, FunctionBodyRef, TypeAnnotationKind};
 use crate::ast::{
 	ArgList, BinaryOperator, Class as AstClass, Expr, ExprKind, FunctionBody, FunctionParameter,
 	Interface as AstInterface, InterpolatedStringPart, Literal, MethodLike, Phase, Reference, Scope, Stmt, StmtKind,
@@ -1756,18 +1756,18 @@ impl<'a> TypeChecker<'a> {
 	}
 
 	fn resolve_type_annotation(&mut self, annotation: &TypeAnnotation, env: &SymbolEnv) -> TypeRef {
-		match annotation {
-			TypeAnnotation::Number => self.types.number(),
-			TypeAnnotation::String => self.types.string(),
-			TypeAnnotation::Bool => self.types.bool(),
-			TypeAnnotation::Duration => self.types.duration(),
-			TypeAnnotation::Json => self.types.json(),
-			TypeAnnotation::MutJson => self.types.mut_json(),
-			TypeAnnotation::Optional(v) => {
+		match &annotation.kind {
+			TypeAnnotationKind::Number => self.types.number(),
+			TypeAnnotationKind::String => self.types.string(),
+			TypeAnnotationKind::Bool => self.types.bool(),
+			TypeAnnotationKind::Duration => self.types.duration(),
+			TypeAnnotationKind::Json => self.types.json(),
+			TypeAnnotationKind::MutJson => self.types.mut_json(),
+			TypeAnnotationKind::Optional(v) => {
 				let value_type = self.resolve_type_annotation(v, env);
 				self.types.add_type(Type::Optional(value_type))
 			}
-			TypeAnnotation::Function(ast_sig) => {
+			TypeAnnotationKind::Function(ast_sig) => {
 				let mut args = vec![];
 				for arg in ast_sig.param_types.iter() {
 					args.push(self.resolve_type_annotation(arg, env));
@@ -1785,35 +1785,35 @@ impl<'a> TypeChecker<'a> {
 				// TODO: avoid creating a new type for each function_sig resolution
 				self.types.add_type(Type::Function(sig))
 			}
-			TypeAnnotation::UserDefined(user_defined_type) => self
+			TypeAnnotationKind::UserDefined(user_defined_type) => self
 				.resolve_user_defined_type(user_defined_type, env, self.statement_idx)
 				.unwrap_or_else(|e| self.type_error(e)),
-			TypeAnnotation::Array(v) => {
+			TypeAnnotationKind::Array(v) => {
 				let value_type = self.resolve_type_annotation(v, env);
 				// TODO: avoid creating a new type for each array resolution
 				self.types.add_type(Type::Array(value_type))
 			}
-			TypeAnnotation::MutArray(v) => {
+			TypeAnnotationKind::MutArray(v) => {
 				let value_type = self.resolve_type_annotation(v, env);
 				// TODO: avoid creating a new type for each array resolution
 				self.types.add_type(Type::MutArray(value_type))
 			}
-			TypeAnnotation::Set(v) => {
+			TypeAnnotationKind::Set(v) => {
 				let value_type = self.resolve_type_annotation(v, env);
 				// TODO: avoid creating a new type for each set resolution
 				self.types.add_type(Type::Set(value_type))
 			}
-			TypeAnnotation::MutSet(v) => {
+			TypeAnnotationKind::MutSet(v) => {
 				let value_type = self.resolve_type_annotation(v, env);
 				// TODO: avoid creating a new type for each set resolution
 				self.types.add_type(Type::MutSet(value_type))
 			}
-			TypeAnnotation::Map(v) => {
+			TypeAnnotationKind::Map(v) => {
 				let value_type = self.resolve_type_annotation(v, env);
 				// TODO: avoid creating a new type for each map resolution
 				self.types.add_type(Type::Map(value_type))
 			}
-			TypeAnnotation::MutMap(v) => {
+			TypeAnnotationKind::MutMap(v) => {
 				let value_type = self.resolve_type_annotation(v, env);
 				// TODO: avoid creating a new type for each map resolution
 				self.types.add_type(Type::MutMap(value_type))

--- a/libs/wingc/src/visit.rs
+++ b/libs/wingc/src/visit.rs
@@ -1,7 +1,7 @@
 use crate::ast::{
 	ArgList, Class, Expr, ExprKind, FunctionBody, FunctionDefinition, FunctionParameter, FunctionSignature, Initializer,
 	Interface, InterpolatedStringPart, Literal, Reference, Scope, Stmt, StmtKind, Symbol, TypeAnnotation,
-	UserDefinedType,
+	TypeAnnotationKind, UserDefinedType,
 };
 
 /// Visitor pattern inspired by implementation from https://docs.rs/syn/latest/syn/visit/index.html
@@ -422,21 +422,21 @@ pub fn visit_type_annotation<'ast, V>(v: &mut V, node: &'ast TypeAnnotation)
 where
 	V: Visit<'ast> + ?Sized,
 {
-	match node {
-		TypeAnnotation::Number => {}
-		TypeAnnotation::String => {}
-		TypeAnnotation::Bool => {}
-		TypeAnnotation::Duration => {}
-		TypeAnnotation::Json => {}
-		TypeAnnotation::MutJson => {}
-		TypeAnnotation::Optional(t) => v.visit_type_annotation(t),
-		TypeAnnotation::Array(t) => v.visit_type_annotation(t),
-		TypeAnnotation::MutArray(t) => v.visit_type_annotation(t),
-		TypeAnnotation::Map(t) => v.visit_type_annotation(t),
-		TypeAnnotation::MutMap(t) => v.visit_type_annotation(t),
-		TypeAnnotation::Set(t) => v.visit_type_annotation(t),
-		TypeAnnotation::MutSet(t) => v.visit_type_annotation(t),
-		TypeAnnotation::Function(f) => {
+	match &node.kind {
+		TypeAnnotationKind::Number => {}
+		TypeAnnotationKind::String => {}
+		TypeAnnotationKind::Bool => {}
+		TypeAnnotationKind::Duration => {}
+		TypeAnnotationKind::Json => {}
+		TypeAnnotationKind::MutJson => {}
+		TypeAnnotationKind::Optional(t) => v.visit_type_annotation(t),
+		TypeAnnotationKind::Array(t) => v.visit_type_annotation(t),
+		TypeAnnotationKind::MutArray(t) => v.visit_type_annotation(t),
+		TypeAnnotationKind::Map(t) => v.visit_type_annotation(t),
+		TypeAnnotationKind::MutMap(t) => v.visit_type_annotation(t),
+		TypeAnnotationKind::Set(t) => v.visit_type_annotation(t),
+		TypeAnnotationKind::MutSet(t) => v.visit_type_annotation(t),
+		TypeAnnotationKind::Function(f) => {
 			for param in &f.param_types {
 				v.visit_type_annotation(&param);
 			}
@@ -444,7 +444,7 @@ where
 				v.visit_type_annotation(return_type);
 			}
 		}
-		TypeAnnotation::UserDefined(t) => {
+		TypeAnnotationKind::UserDefined(t) => {
 			v.visit_symbol(&t.root);
 			for field in &t.fields {
 				v.visit_symbol(field);

--- a/tools/hangar/__snapshots__/invalid.ts.snap
+++ b/tools/hangar/__snapshots__/invalid.ts.snap
@@ -904,11 +904,11 @@ exports[`sorted_errors_no_span.w > stderr 1`] = `
   |              ^^^ Expected type to be \\"num\\", but got \\"str\\" instead
 
 
-error: Expected b (at ../../../examples/tests/invalid/sorted_errors_no_span.w:3:26) to be a type but it's a variable
+error: Expected 'b' to be a type but it's a variable
   --> ../../../examples/tests/invalid/sorted_errors_no_span.w:3:26
   |
 3 | inflight class c extends b {
-  |                          ^ Expected b (at ../../../examples/tests/invalid/sorted_errors_no_span.w:3:26) to be a type but it's a variable
+  |                          ^ Expected 'b' to be a type but it's a variable
 
 
 error: Inflight class c (at ../../../examples/tests/invalid/sorted_errors_no_span.w:3:16)'s parent \\"any\\" is not a class
@@ -921,11 +921,11 @@ error: Expected type to be \\"num\\", but got \\"str\\" instead
   |              ^^^ Expected type to be \\"num\\", but got \\"str\\" instead
 
 
-error: Expected b (at ../../../examples/tests/invalid/sorted_errors_no_span.w:7:26) to be a type but it's a variable
+error: Expected 'b' to be a type but it's a variable
   --> ../../../examples/tests/invalid/sorted_errors_no_span.w:7:26
   |
 7 | inflight class e extends b {
-  |                          ^ Expected b (at ../../../examples/tests/invalid/sorted_errors_no_span.w:7:26) to be a type but it's a variable
+  |                          ^ Expected 'b' to be a type but it's a variable
 
 
 error: Inflight class e (at ../../../examples/tests/invalid/sorted_errors_no_span.w:7:16)'s parent \\"any\\" is not a class


### PR DESCRIPTION
### Type annotations in `new` expressions
<img width="682" alt="image" src="https://user-images.githubusercontent.com/1237390/234864613-6be47273-0e63-4106-b529-5eba41bcd50c.png">


### Statics members
<img width="763" alt="image" src="https://user-images.githubusercontent.com/1237390/234864460-8847cd5e-f08c-4ef1-b90c-abf4a5bd1150.png">

### Changes

- The grammar now allows new expressions like `new cloud.Bucket`
  - Our parser will still yell at you about it
- Most of the changes here are due to the added TypeAnnotationKind enum and changed TypeAnnotation to a struct that also has a span

## Still does not work
- If the jsii type is not imported, it will not show up in completion
- type annotations in variable assignment/declaration don't work
- new expressions really should only show classes
- probably other stuff

