### PR TITLE
fix(compiler): allow empty json

### DIFF
--- a/examples/tests/valid/json.w
+++ b/examples/tests/valid/json.w
@@ -82,3 +82,50 @@ Json {
   a: Json [1, 2, "world"],
   b: [1, 2, "world"], // Verify the type-checker knows we're still in a Json after handling `a` above
 };
+
+// Empty Jsons
+let empty_json = Json {};
+let empty_json_arr = Json [];
+
+// start mutjson empty
+let empty_mut_json = MutJson {};
+let empty_mut_json_arr = MutJson [];
+
+// then get crazy with it
+empty_mut_json.set("cool", MutJson{a: 1, b: 2});
+empty_mut_json.get("cool").set("a", 3);
+
+empty_mut_json_arr.set_at(0, MutJson{a: 1, b: 2});
+empty_mut_json_arr.get_at(0).set("a", 3);
+
+// Wanna see something nuts?
+let the_tower_of_json = MutJson {
+  a: {},
+  b: {
+    c: {},
+    d: [
+      [
+        [
+          {}
+        ]
+      ],
+    ],
+  },
+  e: {
+    f: {
+      g: {},
+      h: [
+        {},
+        []
+      ]
+    },
+  }
+};
+
+the_tower_of_json.get("e").get("f").get("h").get_at(0).set("a", 1);
+let that_super_nested_value = the_tower_of_json.get("e").get("f").get("h").get_at(0).get("a");
+assert(num.from_json(that_super_nested_value) == 1);
+
+// Unested Json Arrays
+let unested_json_arr = Json [1, 2, 3];
+assert(unested_json_arr.get_at(0) == 1);

--- a/libs/wingc/src/type_check.rs
+++ b/libs/wingc/src/type_check.rs
@@ -1457,8 +1457,12 @@ impl<'a> TypeChecker<'a> {
 					let some_val_type = self.type_check_exp(items.iter().next().unwrap(), env);
 					self.types.add_type(Type::Array(some_val_type))
 				} else {
-					self.expr_error(exp, "Cannot infer type of empty array".to_owned());
-					self.types.add_type(Type::Array(self.types.anything()))
+					if self.in_json > 0 {
+						self.types.add_type(Type::Array(self.types.json()))
+					} else {
+						self.expr_error(exp, "Cannot infer type of empty array".to_owned());
+						self.types.add_type(Type::Array(self.types.anything()))
+					}
 				};
 
 				let element_type = match *container_type {
@@ -1544,8 +1548,12 @@ impl<'a> TypeChecker<'a> {
 					let some_val_type = self.type_check_exp(fields.iter().next().unwrap().1, env);
 					self.types.add_type(Type::Map(some_val_type))
 				} else {
-					self.expr_error(exp, "Cannot infer type of empty map".to_owned());
-					self.types.add_type(Type::Map(self.types.anything()))
+					if self.in_json > 0 {
+						self.types.add_type(Type::Map(self.types.json()))
+					} else {
+						self.expr_error(exp, "Cannot infer type of empty map".to_owned());
+						self.types.add_type(Type::Map(self.types.anything()))
+					}
 				};
 
 				let value_type = match *container_type {

--- a/libs/wingsdk/src/std/json.ts
+++ b/libs/wingsdk/src/std/json.ts
@@ -184,7 +184,7 @@ export class MutJson {
   /**
    * Set element in MutJson Array with a specific key and value
    *
-   * @macro ((obj, args)) => { obj[args[0]] = args[1]; })($self$, [$args$])
+   * @macro ((obj, args) => { obj[args[0]] = args[1]; })($self$, [$args$])
    *
    * @param value The value of the element to set
    */

--- a/tools/hangar/__snapshots__/test_corpus/json.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/json.w_compile_tf-aws.md
@@ -119,6 +119,20 @@ class $Root extends $stdlib.std.Resource {
     {((cond) => {if (!cond) throw new Error(`assertion failed: '((arr)[2] === b)'`)})(((arr)[2] === b))};
     {((cond) => {if (!cond) throw new Error(`assertion failed: '(((arr)[7])[0] === "shut")'`)})((((arr)[7])[0] === "shut"))};
     Object.freeze({"a":[1, 2, "world"],"b":[1, 2, "world"]});
+    const empty_json = Object.freeze({});
+    const empty_json_arr = [];
+    const empty_mut_json = {};
+    const empty_mut_json_arr = [];
+    ((obj, args) => { obj[args[0]] = args[1]; })(empty_mut_json, ["cool",{"a":1,"b":2}]);
+    ((obj, args) => { obj[args[0]] = args[1]; })((empty_mut_json)["cool"], ["a",3]);
+    ((obj, args) => { obj[args[0]] = args[1]; })(empty_mut_json_arr, [0,{"a":1,"b":2}]);
+    ((obj, args) => { obj[args[0]] = args[1]; })((empty_mut_json_arr)[0], ["a",3]);
+    const the_tower_of_json = {"a":{},"b":{"c":{},"d":[[[{}]]]},"e":{"f":{"g":{},"h":[{}, []]}}};
+    ((obj, args) => { obj[args[0]] = args[1]; })(((((the_tower_of_json)["e"])["f"])["h"])[0], ["a",1]);
+    const that_super_nested_value = (((((the_tower_of_json)["e"])["f"])["h"])[0])["a"];
+    {((cond) => {if (!cond) throw new Error(`assertion failed: '(((args) => { if (typeof args !== "number") {throw new Error("unable to parse " + typeof args + " " + args + " as a number")}; return JSON.parse(JSON.stringify(args)) })(that_super_nested_value) === 1)'`)})((((args) => { if (typeof args !== "number") {throw new Error("unable to parse " + typeof args + " " + args + " as a number")}; return JSON.parse(JSON.stringify(args)) })(that_super_nested_value) === 1))};
+    const unested_json_arr = [1, 2, 3];
+    {((cond) => {if (!cond) throw new Error(`assertion failed: '((unested_json_arr)[0] === 1)'`)})(((unested_json_arr)[0] === 1))};
   }
 }
 class $App extends $AppBase {


### PR DESCRIPTION
Closes: https://github.com/winglang/wing/issues/1947

**Misc:**
- Fixed typo in MutJson.set_at() macro

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.