### PR TITLE
fix(compiler): preflight objects cannot reference free variables inflight

### DIFF
--- a/examples/tests/invalid/inflight_ref_resource_sub_method.w
+++ b/examples/tests/invalid/inflight_ref_resource_sub_method.w
@@ -1,5 +1,7 @@
 bring cloud;
 
+let global_queue = new cloud.Queue();
+
 class Another {
   my_queue: cloud.Queue;
 
@@ -10,6 +12,10 @@ class Another {
   inflight inflight_returns_resource(): cloud.Queue {
     return this.my_queue;
 //              ^^^^^^^^ Cannot qualify which operations are performed on class "this.my_queue"
+  }
+
+  inflight inflight_returns_resource2(): cloud.Queue {
+    return global_queue;
   }
 }
 
@@ -23,6 +29,9 @@ class Test {
   inflight test() {
     let q = this.another.inflight_returns_resource();
     q.push("push!");
+
+    let q2 = this.another.inflight_returns_resource2();
+    q2.push("push!");
   }
 }
 

--- a/examples/tests/invalid/inflight_ref_resource_sub_method.w
+++ b/examples/tests/invalid/inflight_ref_resource_sub_method.w
@@ -16,6 +16,7 @@ class Another {
 
   inflight inflight_returns_resource2(): cloud.Queue {
     return global_queue;
+//         ^^^^^^^^^^^^ Cannot qualify which operations are performed on class "global_queue"
   }
 }
 

--- a/examples/tests/invalid/inflight_ref_unknown_op.w
+++ b/examples/tests/invalid/inflight_ref_unknown_op.w
@@ -1,5 +1,7 @@
 bring cloud;
 
+let global_b = new cloud.Bucket();
+
 class Test {
   b: cloud.Bucket;
 
@@ -9,8 +11,12 @@ class Test {
 
   inflight test() {
     let x = this.b;
-//               ^ Cannot qualify which operations are performed on resource
+//               ^ Cannot qualify which operations are performed on object
     x.put("hello", "world");
+
+    let y = global_b;
+//          ^ Cannot qualify which operations are performed on object
+    y.put("boom", "shakalaka");
   }
 }
 

--- a/examples/tests/valid/resource_captures_globals.w
+++ b/examples/tests/valid/resource_captures_globals.w
@@ -39,9 +39,25 @@ class Another {
 let global_another = new Another();
 
 class MyResource {
-  init() {}
+  local_topic: cloud.Topic;
+  local_counter: cloud.Counter;
+  init() {
+    this.local_topic = new cloud.Topic();
+    this.local_counter = new cloud.Counter();
+    let $parent_this = this;
+
+    class R impl cloud.ITopicOnMessageHandler {
+      init() {}
+      inflight handle() {
+        global_counter.inc();
+        $parent_this.local_counter.inc();
+      }
+    }
+    this.local_topic.on_message(new R());
+  }
 
   inflight my_put() {
+    this.local_topic.publish("hello");
     global_bucket.put("key", "value");
     assert(global_str == "hello");
     assert(global_bool == true);

--- a/examples/tests/valid/resource_captures_globals.w
+++ b/examples/tests/valid/resource_captures_globals.w
@@ -1,0 +1,62 @@
+bring cloud;
+
+let global_bucket = new cloud.Bucket();
+let global_counter = new cloud.Counter();
+let global_str = "hello";
+let global_bool = true;
+let global_num = 42;
+let global_array_of_str = ["hello", "world"];
+let global_map_of_num = Map<num>{ "a": -5, "b": 2 };
+let global_set_of_str = Set<str>{ "a", "b" };
+
+class First {
+  my_resource: cloud.Bucket;
+
+  init() {
+    this.my_resource = new cloud.Bucket();
+  }
+}
+
+class Another {
+  my_field: str;
+  first: First;
+
+  init () {
+    this.my_field = "hello!";
+    this.first = new First();
+  }
+
+  inflight init() {
+    assert(global_counter.peek() == 0);
+  }
+
+  inflight my_method(): num {
+    global_counter.inc();
+    return global_counter.peek();
+  }
+}
+
+let global_another = new Another();
+
+class MyResource {
+  init() {}
+
+  inflight my_put() {
+    global_bucket.put("key", "value");
+    assert(global_str == "hello");
+    assert(global_bool == true);
+    assert(global_num == 42);
+    assert(global_array_of_str.at(0) == "hello");
+    assert(global_map_of_num.get("a") == -5);
+    assert(global_set_of_str.has("a"));
+    assert(global_another.my_field == "hello!");
+    global_another.first.my_resource.put("key", "value");
+    assert(global_another.my_method() > 0);
+  }
+}
+
+let res = new MyResource();
+
+new cloud.Function(inflight () => {
+  res.my_put();
+}) as "test";

--- a/libs/wingc/src/ast.rs
+++ b/libs/wingc/src/ast.rs
@@ -23,6 +23,12 @@ impl Symbol {
 			span: Default::default(),
 		}
 	}
+
+	/// Returns true if the symbols refer to the same name AND location in the source code.
+	/// Use `eq` to compare symbols only by name.
+	pub fn same(&self, other: &Self) -> bool {
+		self.name == other.name && self.span == other.span
+	}
 }
 
 impl Ord for Symbol {

--- a/libs/wingc/src/ast.rs
+++ b/libs/wingc/src/ast.rs
@@ -347,6 +347,18 @@ pub enum UtilityFunctions {
 	Assert,
 }
 
+impl UtilityFunctions {
+	/// Returns all utility functions.
+	pub fn all() -> Vec<UtilityFunctions> {
+		vec![
+			UtilityFunctions::Log,
+			UtilityFunctions::Panic,
+			UtilityFunctions::Throw,
+			UtilityFunctions::Assert,
+		]
+	}
+}
+
 impl Display for UtilityFunctions {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		match self {

--- a/libs/wingc/src/jsify.rs
+++ b/libs/wingc/src/jsify.rs
@@ -1513,6 +1513,12 @@ impl<'ast> Visit<'ast> for FieldReferenceVisitor<'ast> {
 		let binding = parts.iter().collect::<Vec<_>>();
 		let qualification = binding.split_at(index).1.iter();
 
+		let fmt = |x: Iter<&Component>| x.map(|f| f.text.to_string()).collect_vec();
+		let mut key = fmt(capture.iter()).join(".");
+		if is_field_reference {
+			key = format!("this.{}", key);
+		}
+
 		// if our last captured component is a resource and we don't have
 		// a qualification for it, it's currently an error.
 		if let Some(c) = capture.last() {
@@ -1523,9 +1529,9 @@ impl<'ast> Visit<'ast> for FieldReferenceVisitor<'ast> {
 							level: DiagnosticLevel::Error,
 							message: format!(
 								"Unable to qualify which operations are performed on '{}' of type '{}'. This is not supported yet.",
-								c.text, v.type_,
+								key, v.type_,
 							),
-							span: Some(c.symbol.span.clone()),
+							span: Some(node.span.clone()),
 						});
 
 						return;
@@ -1534,11 +1540,6 @@ impl<'ast> Visit<'ast> for FieldReferenceVisitor<'ast> {
 			}
 		}
 
-		let fmt = |x: Iter<&Component>| x.map(|f| f.text.to_string()).collect_vec();
-		let mut key = fmt(capture.iter()).join(".");
-		if is_field_reference {
-			key = format!("this.{}", key);
-		}
 		let ops = fmt(qualification);
 
 		self.references.entry(key).or_default().extend(ops);

--- a/libs/wingc/src/jsify.rs
+++ b/libs/wingc/src/jsify.rs
@@ -19,7 +19,7 @@ use crate::{
 	ast::{
 		ArgList, BinaryOperator, Class as AstClass, ClassField, Expr, ExprKind, FunctionBody, FunctionBodyRef,
 		FunctionDefinition, Initializer, InterpolatedStringPart, Literal, MethodLike, Phase, Reference, Scope, Stmt,
-		StmtKind, Symbol, TypeAnnotationKind, UnaryOperator, UserDefinedType,
+		StmtKind, Symbol, TypeAnnotationKind, UnaryOperator, UserDefinedType, UtilityFunctions,
 	},
 	debug,
 	diagnostic::{Diagnostic, DiagnosticLevel, Diagnostics},
@@ -970,11 +970,17 @@ impl<'a> JSifier<'a> {
 		// Lookup the resource type
 		let resource_type = env.lookup(&class.name, None).unwrap().as_type().unwrap();
 
-		// Get all references between inflight methods and preflight fields
-		let mut refs = self.find_inflight_references(class);
+		// Find all free variables in the resource, and return a list of their symbols
+		let free_vars = self.find_free_vars(class);
+
+		// Get all references between inflight methods and preflight values
+		let mut refs = self.find_inflight_references(class, &free_vars);
+
+		// After calling find_inflight_references, we don't really need the exact symbols anymore, only their names
+		let free_vars: BTreeSet<String> = free_vars.iter().map(|s| s.name.clone()).into_iter().collect();
 
 		// Get fields to be captured by resource's client
-		let captured_fields = self.get_captures(resource_type);
+		let captured_fields = self.get_capturable_field_names(resource_type);
 
 		// Add inflight init's refs
 		// By default all captured fields are needed in the inflight init method
@@ -993,15 +999,15 @@ impl<'a> JSifier<'a> {
 			.methods
 			.iter()
 			.filter(|(_, m)| m.signature.phase == Phase::Inflight)
-			.collect::<Vec<_>>();
-		self.jsify_resource_client(env, &class, &captured_fields, &inflight_methods, context);
+			.collect_vec();
+		self.jsify_resource_client(env, &class, &captured_fields, &inflight_methods, &free_vars, context);
 
 		// Get all preflight methods to be jsified to the preflight class
 		let preflight_methods = class
 			.methods
 			.iter()
 			.filter(|(_, m)| m.signature.phase != Phase::Inflight)
-			.collect::<Vec<_>>();
+			.collect_vec();
 
 		let mut code = CodeMaker::default();
 
@@ -1023,7 +1029,7 @@ impl<'a> JSifier<'a> {
 			code.add_code(self.jsify_function(Some(&n.name), m, context));
 		}
 
-		code.add_code(self.jsify_toinflight_method(&class.name, &captured_fields));
+		code.add_code(self.jsify_toinflight_method(&class.name, &captured_fields, &free_vars));
 
 		let mut bind_method = CodeMaker::default();
 		bind_method.open("_registerBind(host, ops) {");
@@ -1088,13 +1094,19 @@ impl<'a> JSifier<'a> {
 		code
 	}
 
-	fn jsify_toinflight_method(&mut self, resource_name: &Symbol, captured_fields: &[String]) -> CodeMaker {
+	fn jsify_toinflight_method(
+		&mut self,
+		resource_name: &Symbol,
+		captured_fields: &[String],
+		free_inflight_variables: &BTreeSet<String>,
+	) -> CodeMaker {
 		let client_path = Self::js_resolve_path(&format!("{}/{}.inflight.js", INFLIGHT_CLIENTS_DIR, resource_name.name));
 
 		let mut code = CodeMaker::default();
 
 		code.open("_toInflight() {");
 
+		// create an inflight client for each "child" object
 		for inner_member_name in captured_fields {
 			code.line(format!(
 				"const {}_client = this._lift(this.{});",
@@ -1102,16 +1114,27 @@ impl<'a> JSifier<'a> {
 			));
 		}
 
+		// create an inflight client for each object that is captured from the environment
+		for var_name in free_inflight_variables {
+			code.line(format!("const {var_name}_client = this._lift({var_name});",));
+		}
+
 		code.line(format!("const self_client_path = {client_path};"));
 
 		code.open(format!("return {STDLIB}.core.NodeJsCode.fromInline(`"));
 
 		code.open("(await (async () => {");
+		code.line("const mod = require(\"${{self_client_path}}\")");
 
-		code.open(format!(
-			"const tmp = new (require(\"${{self_client_path}}\")).{}({{",
-			resource_name.name
-		));
+		code.open("mod.setupGlobals({");
+
+		for var_name in free_inflight_variables {
+			code.line(format!("{var_name}: ${{{var_name}_client}},"));
+		}
+
+		code.close("});");
+
+		code.open(format!("const client = new mod.{}({{", resource_name.name));
 
 		for inner_member_name in captured_fields {
 			code.line(format!("{}: ${{{}_client}},", inner_member_name, inner_member_name));
@@ -1120,9 +1143,9 @@ impl<'a> JSifier<'a> {
 		code.close("});");
 
 		code.line(format!(
-			"if (tmp.{CLASS_INFLIGHT_INIT_NAME}) {{ await tmp.{CLASS_INFLIGHT_INIT_NAME}(); }}"
+			"if (client.{CLASS_INFLIGHT_INIT_NAME}) {{ await client.{CLASS_INFLIGHT_INIT_NAME}(); }}"
 		));
-		code.line("return tmp;");
+		code.line("return client;");
 
 		code.close("})())");
 
@@ -1139,13 +1162,14 @@ impl<'a> JSifier<'a> {
 		resource: &AstClass,
 		captured_fields: &[String],
 		inflight_methods: &[&(Symbol, FunctionDefinition)],
+		free_variables: &BTreeSet<String>,
 		context: &JSifyContext,
 	) {
 		// Handle parent class: Need to call super and pass its captured fields (we assume the parent client is already written)
 		let mut parent_captures = vec![];
 		if let Some(parent) = &resource.parent {
 			let parent_type = resolve_user_defined_type(parent, env, 0).unwrap();
-			parent_captures.extend(self.get_captures(parent_type));
+			parent_captures.extend(self.get_capturable_field_names(parent_type));
 		}
 
 		// Get the fields that are captured by this resource but not by its parent, they will be initialized in the generated constructor
@@ -1215,6 +1239,16 @@ impl<'a> JSifier<'a> {
 		// export all classes from this file
 		code.line(format!("exports.{name} = {name};"));
 
+		// Add a function that can be used to inject free variables
+		for var in free_variables {
+			code.line(format!("let {};", var));
+		}
+		code.open("exports.setupGlobals = function(globals) {");
+		for var in free_variables {
+			code.line(format!("{} = globals[\"{}\"];", var, var));
+		}
+		code.close("};");
+
 		let clients_dir = format!("{}/clients", self.out_dir.to_string_lossy());
 		fs::create_dir_all(&clients_dir).expect("Creating inflight clients");
 		let client_file_name = format!("{name}.inflight.js");
@@ -1257,6 +1291,7 @@ impl<'a> JSifier<'a> {
 	fn find_inflight_references(
 		&mut self,
 		resource_class: &AstClass,
+		free_vars: &[Symbol],
 	) -> BTreeMap<String, BTreeMap<String, BTreeSet<String>>> {
 		let inflight_methods = resource_class
 			.methods
@@ -1267,7 +1302,7 @@ impl<'a> JSifier<'a> {
 
 		for (method_name, function_def) in inflight_methods {
 			// visit statements of method and find all references to fields ("this.xxx")
-			let visitor = FieldReferenceVisitor::new(&function_def);
+			let visitor = FieldReferenceVisitor::new(&function_def, free_vars);
 			let (refs, find_diags) = visitor.find_refs();
 
 			self.diagnostics.extend(find_diags);
@@ -1278,7 +1313,7 @@ impl<'a> JSifier<'a> {
 
 		// Also add field rerferences from the inflight initializer
 		if let Some(inflight_init) = &resource_class.inflight_initializer {
-			let visitor = FieldReferenceVisitor::new(inflight_init);
+			let visitor = FieldReferenceVisitor::new(inflight_init, free_vars);
 			let (refs, find_diags) = visitor.find_refs();
 
 			self.diagnostics.extend(find_diags);
@@ -1290,7 +1325,7 @@ impl<'a> JSifier<'a> {
 	}
 
 	// Get the type and capture info for fields that are captured in the client of the given resource
-	fn get_captures(&self, resource_type: TypeRef) -> Vec<String> {
+	fn get_capturable_field_names(&self, resource_type: TypeRef) -> Vec<String> {
 		resource_type
 			.as_resource()
 			.unwrap()
@@ -1303,6 +1338,18 @@ impl<'a> JSifier<'a> {
 			})
 			.map(|(name, ..)| name)
 			.collect_vec()
+	}
+
+	fn find_free_vars(&self, class: &AstClass) -> Vec<Symbol> {
+		let mut scanner = FreeVariableScanner::new(vec![
+			Symbol::global(UtilityFunctions::Log.to_string()),
+			Symbol::global(UtilityFunctions::Assert.to_string()),
+			Symbol::global(UtilityFunctions::Throw.to_string()),
+			Symbol::global(UtilityFunctions::Panic.to_string()),
+			Symbol::global("this".to_string()),
+		]);
+		scanner.visit_class(class);
+		scanner.free_vars
 	}
 }
 
@@ -1323,15 +1370,21 @@ struct FieldReferenceVisitor<'a> {
 	/// The resource type's symbol env (used to resolve field types)
 	function_def: &'a FunctionDefinition,
 
+	/// A list of free variables preloaded into the visitor. Whenever the visitor encounters a
+	/// reference to a free variable, it will be added to list of references since the
+	/// resource needs to bind to it.
+	free_vars: &'a [Symbol],
+
 	diagnostics: Diagnostics,
 }
 
 impl<'a> FieldReferenceVisitor<'a> {
-	pub fn new(function_def: &'a FunctionDefinition) -> Self {
+	pub fn new(function_def: &'a FunctionDefinition, free_vars: &'a [Symbol]) -> Self {
 		Self {
 			references: BTreeMap::new(),
-			diagnostics: Diagnostics::new(),
 			function_def,
+			free_vars,
+			diagnostics: Diagnostics::new(),
 		}
 	}
 
@@ -1345,19 +1398,29 @@ impl<'a> FieldReferenceVisitor<'a> {
 
 impl<'ast> Visit<'ast> for FieldReferenceVisitor<'ast> {
 	fn visit_expr(&mut self, node: &'ast Expr) {
-		let parts = Self::analyze_expr(node);
+		let parts = self.analyze_expr(node);
 
 		let is_field_reference = match parts.first() {
 			Some(first) => first.text == "this" && parts.len() > 1,
 			None => false,
 		};
 
-		if !is_field_reference {
+		let is_free_var = match parts.first() {
+			Some(first) => self.free_vars.iter().any(|v| v.same(&first.symbol)),
+			None => false,
+		};
+
+		if !is_field_reference && !is_free_var {
 			visit::visit_expr(self, node);
 			return;
 		}
 
-		let mut index = 1; // we know i[0] is "this" and that we have at least 2 parts
+		let mut index = if is_field_reference {
+			// we know i[0] is "this" and that we have at least 2 parts
+			1
+		} else {
+			0
+		};
 
 		// iterate over the components of the expression and determine
 		// what are we capturing from preflight.
@@ -1468,7 +1531,10 @@ impl<'ast> Visit<'ast> for FieldReferenceVisitor<'ast> {
 		}
 
 		let fmt = |x: Iter<&Component>| x.map(|f| f.text.to_string()).collect_vec();
-		let key = format!("this.{}", fmt(capture.iter()).join("."));
+		let mut key = fmt(capture.iter()).join(".");
+		if is_field_reference {
+			key = format!("this.{}", key);
+		}
 		let ops = fmt(qualification);
 
 		self.references.entry(key).or_default().extend(ops);
@@ -1479,6 +1545,7 @@ impl<'ast> Visit<'ast> for FieldReferenceVisitor<'ast> {
 
 struct Component<'a> {
 	expr: &'a Expr,
+	symbol: Symbol,
 	text: String,
 	variable: Option<VariableInfo>,
 }
@@ -1490,13 +1557,25 @@ impl Display for Component<'_> {
 }
 
 impl<'a> FieldReferenceVisitor<'a> {
-	fn analyze_expr(node: &'a Expr) -> Vec<Component> {
+	fn analyze_expr(&self, node: &'a Expr) -> Vec<Component> {
 		match &node.kind {
 			ExprKind::Reference(Reference::Identifier(x)) => {
+				let scope = match &self.function_def.body {
+					FunctionBody::Statements(scope) => scope,
+					FunctionBody::External(_) => panic!("unexpected expression inside body of extern functions"),
+				};
+				let env = scope.env.borrow();
+				let env = env.as_ref().expect("scope should have an env");
+				let var = env
+					.lookup(&x, None)
+					.expect("covered by type checking")
+					.as_variable()
+					.expect("reference to a non-variable");
 				return vec![Component {
 					expr: node,
+					symbol: x.clone(),
 					text: x.name.to_string(),
-					variable: None,
+					variable: Some(var),
 				}];
 			}
 
@@ -1534,15 +1613,175 @@ impl<'a> FieldReferenceVisitor<'a> {
 
 				let prop = vec![Component {
 					expr: node,
+					symbol: property.clone(),
 					variable: var,
 					text: property.name.to_string(),
 				}];
 
-				let obj = Self::analyze_expr(&object);
+				let obj = self.analyze_expr(&object);
 				return [obj, prop].concat();
 			}
 
 			_ => vec![],
+		}
+	}
+}
+
+struct FreeVariableScanner {
+	bound_vars: Vec<Symbol>,
+	free_vars: Vec<Symbol>,
+}
+
+impl FreeVariableScanner {
+	pub fn new(globals: Vec<Symbol>) -> Self {
+		Self {
+			bound_vars: globals,
+			free_vars: Vec::new(),
+		}
+	}
+}
+
+impl Visit<'_> for FreeVariableScanner {
+	fn visit_reference(&mut self, node: &Reference) {
+		if let Reference::Identifier(ref x) = node {
+			// check if there is already a bound variable with the same name
+			if !self.bound_vars.contains(x) {
+				self.free_vars.push(x.clone());
+			}
+		};
+
+		return visit::visit_reference(self, node);
+	}
+
+	// invariant: adds net zero bound variables
+	fn visit_scope(&mut self, scope: &Scope) {
+		let old_bound_vars = self.bound_vars.clone();
+		visit::visit_scope(self, scope);
+		// remove the bound variables that were introduced in this scope
+		self.bound_vars = old_bound_vars;
+	}
+
+	fn visit_stmt(&mut self, stmt: &Stmt) {
+		match &stmt.kind {
+			// this statement introduces bound variables!
+			StmtKind::Bring {
+				module_name,
+				identifier,
+			} => {
+				self.visit_symbol(&module_name);
+
+				// bring cloud;
+				if !(module_name.name.starts_with('"') && module_name.name.ends_with('"')) {
+					// add `cloud` to the list of bound variables
+					self.bound_vars.push(module_name.clone());
+				}
+
+				// bring "foo" as bar;
+				if let Some(ref id) = identifier {
+					self.visit_symbol(&id);
+
+					// add `bar` to the list of bound variables
+					self.bound_vars.push(id.clone());
+				}
+			}
+			// this statement introduces bound variables!
+			StmtKind::VariableDef {
+				reassignable: _,
+				var_name,
+				initial_value,
+				type_,
+			} => {
+				self.visit_symbol(&var_name);
+				self.visit_expr(&initial_value);
+				if let Some(type_) = type_ {
+					self.visit_type_annotation(&type_);
+				}
+				self.bound_vars.push(var_name.clone());
+			}
+			// invariant: adds net zero bound variables
+			StmtKind::ForLoop {
+				iterator,
+				iterable,
+				statements,
+			} => {
+				self.visit_symbol(&iterator);
+				self.visit_expr(&iterable);
+				self.bound_vars.push(iterator.clone());
+				self.visit_scope(&statements);
+				self.bound_vars.pop();
+			}
+			// invariant: adds net zero bound variables
+			StmtKind::TryCatch {
+				try_statements,
+				catch_block,
+				finally_statements,
+			} => {
+				self.visit_scope(&try_statements);
+
+				if let Some(cb) = catch_block {
+					if let Some(ref var) = cb.exception_var {
+						self.visit_symbol(&var);
+						self.bound_vars.push(var.clone());
+					}
+					self.visit_scope(&cb.statements);
+					if cb.exception_var.is_some() {
+						self.bound_vars.pop();
+					}
+				}
+
+				if let Some(ref finally_statements) = finally_statements {
+					self.visit_scope(&finally_statements);
+				}
+			}
+
+			_ => return visit::visit_stmt(self, stmt),
+		};
+	}
+
+	// invariant: adds net zero bound variables
+	fn visit_constructor(&mut self, node: &Initializer) {
+		let Initializer {
+			signature,
+			statements,
+			span: _,
+		} = node;
+
+		for param in &signature.parameters {
+			self.bound_vars.push(param.name.clone());
+		}
+
+		self.visit_scope(statements);
+
+		for _ in &signature.parameters {
+			self.bound_vars.pop();
+		}
+	}
+
+	// invariant: adds net zero bound variables
+	fn visit_function_definition(&mut self, node: &FunctionDefinition) {
+		let FunctionDefinition {
+			signature,
+			body,
+			captures: _,
+			is_static: _,
+			span: _,
+		} = node;
+
+		for param in &signature.parameters {
+			self.bound_vars.push(param.name.clone());
+		}
+
+		self.visit_function_signature(signature);
+
+		let _new_body = match body {
+			FunctionBody::Statements(statements) => {
+				self.visit_scope(statements);
+			}
+			FunctionBody::External(_) => {}
+		};
+
+		for _ in &signature.parameters {
+			self.bound_vars.pop();
 		}
 	}
 }

--- a/libs/wingc/src/jsify.rs
+++ b/libs/wingc/src/jsify.rs
@@ -701,7 +701,7 @@ impl<'a> JSifier<'a> {
 
 				code.line(format!("return {};", name));
 
-				code.close("})({}));".to_string());
+				code.close("})({}));");
 				code
 			}
 			StmtKind::TryCatch {
@@ -1041,7 +1041,7 @@ impl<'a> JSifier<'a> {
 			}
 			bind_method.close("}");
 		}
-		bind_method.line("super._registerBind(host, ops);".to_string());
+		bind_method.line("super._registerBind(host, ops);");
 		bind_method.close("}");
 
 		code.add_code(bind_method);
@@ -1245,14 +1245,15 @@ impl<'a> JSifier<'a> {
 
 		// export the main class from this file
 		let mut code = CodeMaker::default();
-		code.open("module.exports = function($globals) {".to_string());
 		if free_variables.len() > 0 {
 			let free_variables_str = free_variables.iter().join(", ");
-			code.line(format!("const {{ {free_variables_str} }} = $globals;"));
+			code.open(format!("module.exports = function({{ {free_variables_str} }}) {{"));
+		} else {
+			code.open("module.exports = function() {");
 		}
 		code.add_code(class_code);
 		code.line(format!("return {name};"));
-		code.close("}".to_string());
+		code.close("}");
 
 		let clients_dir = format!("{}/clients", self.out_dir.to_string_lossy());
 		fs::create_dir_all(&clients_dir).expect("Creating inflight clients");

--- a/libs/wingc/src/jsify.rs
+++ b/libs/wingc/src/jsify.rs
@@ -1522,10 +1522,10 @@ impl<'ast> Visit<'ast> for FieldReferenceVisitor<'ast> {
 						self.diagnostics.push(Diagnostic {
 							level: DiagnosticLevel::Error,
 							message: format!(
-								"Unable to qualify which operations are performed on 'this.{}' of type '{}'. This is not supported yet.",
+								"Unable to qualify which operations are performed on '{}' of type '{}'. This is not supported yet.",
 								c.text, v.type_,
 							),
-							span: Some(c.expr.span.clone()),
+							span: Some(c.symbol.span.clone()),
 						});
 
 						return;

--- a/tools/hangar/__snapshots__/invalid.ts.snap
+++ b/tools/hangar/__snapshots__/invalid.ts.snap
@@ -402,18 +402,18 @@ exports[`inflight_in_class.w > stderr 1`] = `
 `;
 
 exports[`inflight_ref_explicit_ops.w > stderr 1`] = `
-"error: Unable to qualify which operations are performed on 'my_queue' of type 'Queue'. This is not supported yet.
-   --> ../../../examples/tests/invalid/inflight_ref_explicit_ops.w:13:17
+"error: Unable to qualify which operations are performed on 'this.my_queue' of type 'Queue'. This is not supported yet.
+   --> ../../../examples/tests/invalid/inflight_ref_explicit_ops.w:13:12
    |
 13 |     return this.my_queue;
-   |                 ^^^^^^^^ Unable to qualify which operations are performed on 'my_queue' of type 'Queue'. This is not supported yet.
+   |            ^^^^^^^^^^^^^ Unable to qualify which operations are performed on 'this.my_queue' of type 'Queue'. This is not supported yet.
 
 
-error: Unable to qualify which operations are performed on 'b' of type 'Bucket'. This is not supported yet.
-   --> ../../../examples/tests/invalid/inflight_ref_explicit_ops.w:34:18
+error: Unable to qualify which operations are performed on 'this.b' of type 'Bucket'. This is not supported yet.
+   --> ../../../examples/tests/invalid/inflight_ref_explicit_ops.w:34:13
    |
 34 |     let x = this.b;
-   |                  ^ Unable to qualify which operations are performed on 'b' of type 'Bucket'. This is not supported yet.
+   |             ^^^^^^ Unable to qualify which operations are performed on 'this.b' of type 'Bucket'. This is not supported yet.
 
 
 error: Capturing collection of resources is not supported yet (type is 'Array<Bucket>')
@@ -426,11 +426,11 @@ error: Capturing collection of resources is not supported yet (type is 'Array<Bu
 `;
 
 exports[`inflight_ref_resource_sub_method.w > stderr 1`] = `
-"error: Unable to qualify which operations are performed on 'my_queue' of type 'Queue'. This is not supported yet.
-   --> ../../../examples/tests/invalid/inflight_ref_resource_sub_method.w:13:17
+"error: Unable to qualify which operations are performed on 'this.my_queue' of type 'Queue'. This is not supported yet.
+   --> ../../../examples/tests/invalid/inflight_ref_resource_sub_method.w:13:12
    |
 13 |     return this.my_queue;
-   |                 ^^^^^^^^ Unable to qualify which operations are performed on 'my_queue' of type 'Queue'. This is not supported yet.
+   |            ^^^^^^^^^^^^^ Unable to qualify which operations are performed on 'this.my_queue' of type 'Queue'. This is not supported yet.
 
 
 error: Unable to qualify which operations are performed on 'global_queue' of type 'Queue'. This is not supported yet.
@@ -443,11 +443,11 @@ error: Unable to qualify which operations are performed on 'global_queue' of typ
 `;
 
 exports[`inflight_ref_unknown_op.w > stderr 1`] = `
-"error: Unable to qualify which operations are performed on 'b' of type 'Bucket'. This is not supported yet.
-   --> ../../../examples/tests/invalid/inflight_ref_unknown_op.w:13:18
+"error: Unable to qualify which operations are performed on 'this.b' of type 'Bucket'. This is not supported yet.
+   --> ../../../examples/tests/invalid/inflight_ref_unknown_op.w:13:13
    |
 13 |     let x = this.b;
-   |                  ^ Unable to qualify which operations are performed on 'b' of type 'Bucket'. This is not supported yet.
+   |             ^^^^^^ Unable to qualify which operations are performed on 'this.b' of type 'Bucket'. This is not supported yet.
 
 
 error: Unable to qualify which operations are performed on 'global_b' of type 'Bucket'. This is not supported yet.
@@ -857,11 +857,11 @@ error: Cannot capture field 'mut_array' with non-capturable type 'MutArray<str>'
    |         ^^^^^^^^^^^^^^ Cannot capture field 'mut_array' with non-capturable type 'MutArray<str>'
 
 
-error: Unable to qualify which operations are performed on 'bucket' of type 'Bucket'. This is not supported yet.
-   --> ../../../examples/tests/invalid/resource_captures.w:22:18
+error: Unable to qualify which operations are performed on 'this.bucket' of type 'Bucket'. This is not supported yet.
+   --> ../../../examples/tests/invalid/resource_captures.w:22:13
    |
 22 |     let b = this.bucket;
-   |                  ^^^^^^ Unable to qualify which operations are performed on 'bucket' of type 'Bucket'. This is not supported yet.
+   |             ^^^^^^^^^^^ Unable to qualify which operations are performed on 'this.bucket' of type 'Bucket'. This is not supported yet.
 
 
 error: Capturing collection of resources is not supported yet (type is 'Array<Bucket>')

--- a/tools/hangar/__snapshots__/invalid.ts.snap
+++ b/tools/hangar/__snapshots__/invalid.ts.snap
@@ -402,18 +402,18 @@ exports[`inflight_in_class.w > stderr 1`] = `
 `;
 
 exports[`inflight_ref_explicit_ops.w > stderr 1`] = `
-"error: Unable to qualify which operations are performed on 'this.my_queue' of type 'Queue'. This is not supported yet.
-   --> ../../../examples/tests/invalid/inflight_ref_explicit_ops.w:13:12
+"error: Unable to qualify which operations are performed on 'my_queue' of type 'Queue'. This is not supported yet.
+   --> ../../../examples/tests/invalid/inflight_ref_explicit_ops.w:13:17
    |
 13 |     return this.my_queue;
-   |            ^^^^^^^^^^^^^ Unable to qualify which operations are performed on 'this.my_queue' of type 'Queue'. This is not supported yet.
+   |                 ^^^^^^^^ Unable to qualify which operations are performed on 'my_queue' of type 'Queue'. This is not supported yet.
 
 
-error: Unable to qualify which operations are performed on 'this.b' of type 'Bucket'. This is not supported yet.
-   --> ../../../examples/tests/invalid/inflight_ref_explicit_ops.w:34:13
+error: Unable to qualify which operations are performed on 'b' of type 'Bucket'. This is not supported yet.
+   --> ../../../examples/tests/invalid/inflight_ref_explicit_ops.w:34:18
    |
 34 |     let x = this.b;
-   |             ^^^^^^ Unable to qualify which operations are performed on 'this.b' of type 'Bucket'. This is not supported yet.
+   |                  ^ Unable to qualify which operations are performed on 'b' of type 'Bucket'. This is not supported yet.
 
 
 error: Capturing collection of resources is not supported yet (type is 'Array<Bucket>')
@@ -426,21 +426,35 @@ error: Capturing collection of resources is not supported yet (type is 'Array<Bu
 `;
 
 exports[`inflight_ref_resource_sub_method.w > stderr 1`] = `
-"error: Unable to qualify which operations are performed on 'this.my_queue' of type 'Queue'. This is not supported yet.
-   --> ../../../examples/tests/invalid/inflight_ref_resource_sub_method.w:11:12
+"error: Unable to qualify which operations are performed on 'my_queue' of type 'Queue'. This is not supported yet.
+   --> ../../../examples/tests/invalid/inflight_ref_resource_sub_method.w:13:17
    |
-11 |     return this.my_queue;
-   |            ^^^^^^^^^^^^^ Unable to qualify which operations are performed on 'this.my_queue' of type 'Queue'. This is not supported yet.
+13 |     return this.my_queue;
+   |                 ^^^^^^^^ Unable to qualify which operations are performed on 'my_queue' of type 'Queue'. This is not supported yet.
+
+
+error: Unable to qualify which operations are performed on 'global_queue' of type 'Queue'. This is not supported yet.
+   --> ../../../examples/tests/invalid/inflight_ref_resource_sub_method.w:18:12
+   |
+18 |     return global_queue;
+   |            ^^^^^^^^^^^^ Unable to qualify which operations are performed on 'global_queue' of type 'Queue'. This is not supported yet.
 
 "
 `;
 
 exports[`inflight_ref_unknown_op.w > stderr 1`] = `
-"error: Unable to qualify which operations are performed on 'this.b' of type 'Bucket'. This is not supported yet.
-   --> ../../../examples/tests/invalid/inflight_ref_unknown_op.w:11:13
+"error: Unable to qualify which operations are performed on 'b' of type 'Bucket'. This is not supported yet.
+   --> ../../../examples/tests/invalid/inflight_ref_unknown_op.w:13:18
    |
-11 |     let x = this.b;
-   |             ^^^^^^ Unable to qualify which operations are performed on 'this.b' of type 'Bucket'. This is not supported yet.
+13 |     let x = this.b;
+   |                  ^ Unable to qualify which operations are performed on 'b' of type 'Bucket'. This is not supported yet.
+
+
+error: Unable to qualify which operations are performed on 'global_b' of type 'Bucket'. This is not supported yet.
+   --> ../../../examples/tests/invalid/inflight_ref_unknown_op.w:17:13
+   |
+17 |     let y = global_b;
+   |             ^^^^^^^^ Unable to qualify which operations are performed on 'global_b' of type 'Bucket'. This is not supported yet.
 
 "
 `;
@@ -843,11 +857,11 @@ error: Cannot capture field 'mut_array' with non-capturable type 'MutArray<str>'
    |         ^^^^^^^^^^^^^^ Cannot capture field 'mut_array' with non-capturable type 'MutArray<str>'
 
 
-error: Unable to qualify which operations are performed on 'this.bucket' of type 'Bucket'. This is not supported yet.
-   --> ../../../examples/tests/invalid/resource_captures.w:22:13
+error: Unable to qualify which operations are performed on 'bucket' of type 'Bucket'. This is not supported yet.
+   --> ../../../examples/tests/invalid/resource_captures.w:22:18
    |
 22 |     let b = this.bucket;
-   |             ^^^^^^^^^^^ Unable to qualify which operations are performed on 'this.bucket' of type 'Bucket'. This is not supported yet.
+   |                  ^^^^^^ Unable to qualify which operations are performed on 'bucket' of type 'Bucket'. This is not supported yet.
 
 
 error: Capturing collection of resources is not supported yet (type is 'Array<Bucket>')

--- a/tools/hangar/__snapshots__/test_corpus/api.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/api.w_compile_tf-aws.md
@@ -2,7 +2,7 @@
 
 ## clients/Foo.inflight.js
 ```js
-module.exports = function($globals) {
+module.exports = function() {
   class  Foo {
     constructor({ api, stateful }) {
       this.api = api;

--- a/tools/hangar/__snapshots__/test_corpus/api.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/api.w_compile_tf-aws.md
@@ -15,6 +15,8 @@ class  Foo {
   }
 }
 exports.Foo = Foo;
+exports.setupGlobals = function(globals) {
+};
 
 ```
 
@@ -315,12 +317,13 @@ class $Root extends $stdlib.std.Resource {
         const self_client_path = "./clients/Foo.inflight.js".replace(/\\/g, "/");
         return $stdlib.core.NodeJsCode.fromInline(`
           (await (async () => {
-            const tmp = new (require("${self_client_path}")).Foo({
+            const mod = require("${self_client_path}")
+            const client = new mod.Foo({
               api: ${api_client},
               stateful: ${stateful_client},
             });
-            if (tmp.$inflight_init) { await tmp.$inflight_init(); }
-            return tmp;
+            if (client.$inflight_init) { await client.$inflight_init(); }
+            return client;
           })())
         `);
       }

--- a/tools/hangar/__snapshots__/test_corpus/api.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/api.w_compile_tf-aws.md
@@ -2,21 +2,21 @@
 
 ## clients/Foo.inflight.js
 ```js
-class  Foo {
-  constructor({ api, stateful }) {
-    this.api = api;
-    this.stateful = stateful;
-  }
-  async handle(message)  {
-    {
-      const url = this.api.url;
-      {((cond) => {if (!cond) throw new Error(`assertion failed: 'url.startsWith("http://")'`)})(url.startsWith("http://"))};
+module.exports = function($globals) {
+  class  Foo {
+    constructor({ api, stateful }) {
+      this.api = api;
+      this.stateful = stateful;
+    }
+    async handle(message)  {
+      {
+        const url = this.api.url;
+        {((cond) => {if (!cond) throw new Error(`assertion failed: 'url.startsWith("http://")'`)})(url.startsWith("http://"))};
+      }
     }
   }
+  return Foo;
 }
-exports.Foo = Foo;
-exports.setupGlobals = function(globals) {
-};
 
 ```
 
@@ -317,8 +317,8 @@ class $Root extends $stdlib.std.Resource {
         const self_client_path = "./clients/Foo.inflight.js".replace(/\\/g, "/");
         return $stdlib.core.NodeJsCode.fromInline(`
           (await (async () => {
-            const mod = require("${self_client_path}")
-            const client = new mod.Foo({
+            const Foo = require("${self_client_path}")({});
+            const client = new Foo({
               api: ${api_client},
               stateful: ${stateful_client},
             });

--- a/tools/hangar/__snapshots__/test_corpus/api_path_vars.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/api_path_vars.w_compile_tf-aws.md
@@ -11,6 +11,8 @@ class  Fetch {
   }
 }
 exports.Fetch = Fetch;
+exports.setupGlobals = function(globals) {
+};
 
 ```
 
@@ -289,11 +291,12 @@ class $Root extends $stdlib.std.Resource {
         const self_client_path = "./clients/Fetch.inflight.js".replace(/\\/g, "/");
         return $stdlib.core.NodeJsCode.fromInline(`
           (await (async () => {
-            const tmp = new (require("${self_client_path}")).Fetch({
+            const mod = require("${self_client_path}")
+            const client = new mod.Fetch({
               stateful: ${stateful_client},
             });
-            if (tmp.$inflight_init) { await tmp.$inflight_init(); }
-            return tmp;
+            if (client.$inflight_init) { await client.$inflight_init(); }
+            return client;
           })())
         `);
       }

--- a/tools/hangar/__snapshots__/test_corpus/api_path_vars.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/api_path_vars.w_compile_tf-aws.md
@@ -2,7 +2,7 @@
 
 ## clients/Fetch.inflight.js
 ```js
-module.exports = function($globals) {
+module.exports = function() {
   class  Fetch {
     constructor({ stateful }) {
       this.stateful = stateful;

--- a/tools/hangar/__snapshots__/test_corpus/api_path_vars.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/api_path_vars.w_compile_tf-aws.md
@@ -2,17 +2,17 @@
 
 ## clients/Fetch.inflight.js
 ```js
-class  Fetch {
-  constructor({ stateful }) {
-    this.stateful = stateful;
+module.exports = function($globals) {
+  class  Fetch {
+    constructor({ stateful }) {
+      this.stateful = stateful;
+    }
+    async get(url)  {
+      return (require("<ABSOLUTE_PATH>/api_path_vars.js")["get"])(url)
+    }
   }
-  async get(url)  {
-    return (require("<ABSOLUTE_PATH>/api_path_vars.js")["get"])(url)
-  }
+  return Fetch;
 }
-exports.Fetch = Fetch;
-exports.setupGlobals = function(globals) {
-};
 
 ```
 
@@ -291,8 +291,8 @@ class $Root extends $stdlib.std.Resource {
         const self_client_path = "./clients/Fetch.inflight.js".replace(/\\/g, "/");
         return $stdlib.core.NodeJsCode.fromInline(`
           (await (async () => {
-            const mod = require("${self_client_path}")
-            const client = new mod.Fetch({
+            const Fetch = require("${self_client_path}")({});
+            const client = new Fetch({
               stateful: ${stateful_client},
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/tools/hangar/__snapshots__/test_corpus/capture_resource_with_no_inflight.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/capture_resource_with_no_inflight.w_compile_tf-aws.md
@@ -2,7 +2,7 @@
 
 ## clients/A.inflight.js
 ```js
-module.exports = function($globals) {
+module.exports = function() {
   class  A {
     constructor({ field, stateful }) {
       this.field = field;

--- a/tools/hangar/__snapshots__/test_corpus/capture_resource_with_no_inflight.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/capture_resource_with_no_inflight.w_compile_tf-aws.md
@@ -9,6 +9,8 @@ class  A {
   }
 }
 exports.A = A;
+exports.setupGlobals = function(globals) {
+};
 
 ```
 
@@ -153,12 +155,13 @@ class $Root extends $stdlib.std.Resource {
         const self_client_path = "./clients/A.inflight.js".replace(/\\/g, "/");
         return $stdlib.core.NodeJsCode.fromInline(`
           (await (async () => {
-            const tmp = new (require("${self_client_path}")).A({
+            const mod = require("${self_client_path}")
+            const client = new mod.A({
               field: ${field_client},
               stateful: ${stateful_client},
             });
-            if (tmp.$inflight_init) { await tmp.$inflight_init(); }
-            return tmp;
+            if (client.$inflight_init) { await client.$inflight_init(); }
+            return client;
           })())
         `);
       }

--- a/tools/hangar/__snapshots__/test_corpus/capture_resource_with_no_inflight.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/capture_resource_with_no_inflight.w_compile_tf-aws.md
@@ -2,15 +2,15 @@
 
 ## clients/A.inflight.js
 ```js
-class  A {
-  constructor({ field, stateful }) {
-    this.field = field;
-    this.stateful = stateful;
+module.exports = function($globals) {
+  class  A {
+    constructor({ field, stateful }) {
+      this.field = field;
+      this.stateful = stateful;
+    }
   }
+  return A;
 }
-exports.A = A;
-exports.setupGlobals = function(globals) {
-};
 
 ```
 
@@ -155,8 +155,8 @@ class $Root extends $stdlib.std.Resource {
         const self_client_path = "./clients/A.inflight.js".replace(/\\/g, "/");
         return $stdlib.core.NodeJsCode.fromInline(`
           (await (async () => {
-            const mod = require("${self_client_path}")
-            const client = new mod.A({
+            const A = require("${self_client_path}")({});
+            const client = new A({
               field: ${field_client},
               stateful: ${stateful_client},
             });

--- a/tools/hangar/__snapshots__/test_corpus/construct-base.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/construct-base.w_compile_tf-aws.md
@@ -8,6 +8,8 @@ class  WingResource {
   }
 }
 exports.WingResource = WingResource;
+exports.setupGlobals = function(globals) {
+};
 
 ```
 
@@ -77,11 +79,12 @@ class $Root extends $stdlib.std.Resource {
         const self_client_path = "./clients/WingResource.inflight.js".replace(/\\/g, "/");
         return $stdlib.core.NodeJsCode.fromInline(`
           (await (async () => {
-            const tmp = new (require("${self_client_path}")).WingResource({
+            const mod = require("${self_client_path}")
+            const client = new mod.WingResource({
               stateful: ${stateful_client},
             });
-            if (tmp.$inflight_init) { await tmp.$inflight_init(); }
-            return tmp;
+            if (client.$inflight_init) { await client.$inflight_init(); }
+            return client;
           })())
         `);
       }

--- a/tools/hangar/__snapshots__/test_corpus/construct-base.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/construct-base.w_compile_tf-aws.md
@@ -2,14 +2,14 @@
 
 ## clients/WingResource.inflight.js
 ```js
-class  WingResource {
-  constructor({ stateful }) {
-    this.stateful = stateful;
+module.exports = function($globals) {
+  class  WingResource {
+    constructor({ stateful }) {
+      this.stateful = stateful;
+    }
   }
+  return WingResource;
 }
-exports.WingResource = WingResource;
-exports.setupGlobals = function(globals) {
-};
 
 ```
 
@@ -79,8 +79,8 @@ class $Root extends $stdlib.std.Resource {
         const self_client_path = "./clients/WingResource.inflight.js".replace(/\\/g, "/");
         return $stdlib.core.NodeJsCode.fromInline(`
           (await (async () => {
-            const mod = require("${self_client_path}")
-            const client = new mod.WingResource({
+            const WingResource = require("${self_client_path}")({});
+            const client = new WingResource({
               stateful: ${stateful_client},
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/tools/hangar/__snapshots__/test_corpus/construct-base.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/construct-base.w_compile_tf-aws.md
@@ -2,7 +2,7 @@
 
 ## clients/WingResource.inflight.js
 ```js
-module.exports = function($globals) {
+module.exports = function() {
   class  WingResource {
     constructor({ stateful }) {
       this.stateful = stateful;

--- a/tools/hangar/__snapshots__/test_corpus/doubler.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/doubler.w_compile_tf-aws.md
@@ -15,6 +15,8 @@ class  Doubler {
   }
 }
 exports.Doubler = Doubler;
+exports.setupGlobals = function(globals) {
+};
 
 ```
 
@@ -72,12 +74,13 @@ class $Root extends $stdlib.std.Resource {
         const self_client_path = "./clients/Doubler.inflight.js".replace(/\\/g, "/");
         return $stdlib.core.NodeJsCode.fromInline(`
           (await (async () => {
-            const tmp = new (require("${self_client_path}")).Doubler({
+            const mod = require("${self_client_path}")
+            const client = new mod.Doubler({
               func: ${func_client},
               stateful: ${stateful_client},
             });
-            if (tmp.$inflight_init) { await tmp.$inflight_init(); }
-            return tmp;
+            if (client.$inflight_init) { await client.$inflight_init(); }
+            return client;
           })())
         `);
       }

--- a/tools/hangar/__snapshots__/test_corpus/doubler.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/doubler.w_compile_tf-aws.md
@@ -2,21 +2,21 @@
 
 ## clients/Doubler.inflight.js
 ```js
-class  Doubler {
-  constructor({ func, stateful }) {
-    this.func = func;
-    this.stateful = stateful;
-  }
-  async invoke(message)  {
-    {
-      (await this.func.handle(message));
-      (await this.func.handle(message));
+module.exports = function($globals) {
+  class  Doubler {
+    constructor({ func, stateful }) {
+      this.func = func;
+      this.stateful = stateful;
+    }
+    async invoke(message)  {
+      {
+        (await this.func.handle(message));
+        (await this.func.handle(message));
+      }
     }
   }
+  return Doubler;
 }
-exports.Doubler = Doubler;
-exports.setupGlobals = function(globals) {
-};
 
 ```
 
@@ -74,8 +74,8 @@ class $Root extends $stdlib.std.Resource {
         const self_client_path = "./clients/Doubler.inflight.js".replace(/\\/g, "/");
         return $stdlib.core.NodeJsCode.fromInline(`
           (await (async () => {
-            const mod = require("${self_client_path}")
-            const client = new mod.Doubler({
+            const Doubler = require("${self_client_path}")({});
+            const client = new Doubler({
               func: ${func_client},
               stateful: ${stateful_client},
             });

--- a/tools/hangar/__snapshots__/test_corpus/doubler.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/doubler.w_compile_tf-aws.md
@@ -2,7 +2,7 @@
 
 ## clients/Doubler.inflight.js
 ```js
-module.exports = function($globals) {
+module.exports = function() {
   class  Doubler {
     constructor({ func, stateful }) {
       this.func = func;

--- a/tools/hangar/__snapshots__/test_corpus/extern_implementation.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/extern_implementation.w_compile_tf-aws.md
@@ -2,34 +2,34 @@
 
 ## clients/Foo.inflight.js
 ```js
-class  Foo {
-  constructor({ stateful }) {
-    this.stateful = stateful;
-  }
-  static async regex_inflight(pattern, text)  {
-    return (require("<ABSOLUTE_PATH>/external_js.js")["regex_inflight"])(pattern, text)
-  }
-  static async get_uuid()  {
-    return (require("<ABSOLUTE_PATH>/external_js.js")["get_uuid"])()
-  }
-  static async get_data()  {
-    return (require("<ABSOLUTE_PATH>/external_js.js")["get_data"])()
-  }
-  async print(msg)  {
-    return (require("<ABSOLUTE_PATH>/external_js.js")["print"])(msg)
-  }
-  async call()  {
-    {
-      {((cond) => {if (!cond) throw new Error(`assertion failed: '(await Foo.regex_inflight("[a-z]+-\\d+","abc-123"))'`)})((await Foo.regex_inflight("[a-z]+-\\d+","abc-123")))};
-      const uuid = (await Foo.get_uuid());
-      {((cond) => {if (!cond) throw new Error(`assertion failed: '(uuid.length === 36)'`)})((uuid.length === 36))};
-      {((cond) => {if (!cond) throw new Error(`assertion failed: '((await Foo.get_data()) === "Cool data!")'`)})(((await Foo.get_data()) === "Cool data!"))};
+module.exports = function($globals) {
+  class  Foo {
+    constructor({ stateful }) {
+      this.stateful = stateful;
+    }
+    static async regex_inflight(pattern, text)  {
+      return (require("<ABSOLUTE_PATH>/external_js.js")["regex_inflight"])(pattern, text)
+    }
+    static async get_uuid()  {
+      return (require("<ABSOLUTE_PATH>/external_js.js")["get_uuid"])()
+    }
+    static async get_data()  {
+      return (require("<ABSOLUTE_PATH>/external_js.js")["get_data"])()
+    }
+    async print(msg)  {
+      return (require("<ABSOLUTE_PATH>/external_js.js")["print"])(msg)
+    }
+    async call()  {
+      {
+        {((cond) => {if (!cond) throw new Error(`assertion failed: '(await Foo.regex_inflight("[a-z]+-\\d+","abc-123"))'`)})((await Foo.regex_inflight("[a-z]+-\\d+","abc-123")))};
+        const uuid = (await Foo.get_uuid());
+        {((cond) => {if (!cond) throw new Error(`assertion failed: '(uuid.length === 36)'`)})((uuid.length === 36))};
+        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await Foo.get_data()) === "Cool data!")'`)})(((await Foo.get_data()) === "Cool data!"))};
+      }
     }
   }
+  return Foo;
 }
-exports.Foo = Foo;
-exports.setupGlobals = function(globals) {
-};
 
 ```
 
@@ -244,8 +244,8 @@ class $Root extends $stdlib.std.Resource {
         const self_client_path = "./clients/Foo.inflight.js".replace(/\\/g, "/");
         return $stdlib.core.NodeJsCode.fromInline(`
           (await (async () => {
-            const mod = require("${self_client_path}")
-            const client = new mod.Foo({
+            const Foo = require("${self_client_path}")({});
+            const client = new Foo({
               stateful: ${stateful_client},
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/tools/hangar/__snapshots__/test_corpus/extern_implementation.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/extern_implementation.w_compile_tf-aws.md
@@ -2,7 +2,7 @@
 
 ## clients/Foo.inflight.js
 ```js
-module.exports = function($globals) {
+module.exports = function() {
   class  Foo {
     constructor({ stateful }) {
       this.stateful = stateful;

--- a/tools/hangar/__snapshots__/test_corpus/extern_implementation.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/extern_implementation.w_compile_tf-aws.md
@@ -28,6 +28,8 @@ class  Foo {
   }
 }
 exports.Foo = Foo;
+exports.setupGlobals = function(globals) {
+};
 
 ```
 
@@ -242,11 +244,12 @@ class $Root extends $stdlib.std.Resource {
         const self_client_path = "./clients/Foo.inflight.js".replace(/\\/g, "/");
         return $stdlib.core.NodeJsCode.fromInline(`
           (await (async () => {
-            const tmp = new (require("${self_client_path}")).Foo({
+            const mod = require("${self_client_path}")
+            const client = new mod.Foo({
               stateful: ${stateful_client},
             });
-            if (tmp.$inflight_init) { await tmp.$inflight_init(); }
-            return tmp;
+            if (client.$inflight_init) { await client.$inflight_init(); }
+            return client;
           })())
         `);
       }

--- a/tools/hangar/__snapshots__/test_corpus/forward_decl.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/forward_decl.w_compile_tf-aws.md
@@ -2,15 +2,15 @@
 
 ## clients/R.inflight.js
 ```js
-class  R {
-  constructor({ f, stateful }) {
-    this.f = f;
-    this.stateful = stateful;
+module.exports = function($globals) {
+  class  R {
+    constructor({ f, stateful }) {
+      this.f = f;
+      this.stateful = stateful;
+    }
   }
+  return R;
 }
-exports.R = R;
-exports.setupGlobals = function(globals) {
-};
 
 ```
 
@@ -76,8 +76,8 @@ class $Root extends $stdlib.std.Resource {
         const self_client_path = "./clients/R.inflight.js".replace(/\\/g, "/");
         return $stdlib.core.NodeJsCode.fromInline(`
           (await (async () => {
-            const mod = require("${self_client_path}")
-            const client = new mod.R({
+            const R = require("${self_client_path}")({});
+            const client = new R({
               f: ${f_client},
               stateful: ${stateful_client},
             });

--- a/tools/hangar/__snapshots__/test_corpus/forward_decl.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/forward_decl.w_compile_tf-aws.md
@@ -9,6 +9,8 @@ class  R {
   }
 }
 exports.R = R;
+exports.setupGlobals = function(globals) {
+};
 
 ```
 
@@ -74,12 +76,13 @@ class $Root extends $stdlib.std.Resource {
         const self_client_path = "./clients/R.inflight.js".replace(/\\/g, "/");
         return $stdlib.core.NodeJsCode.fromInline(`
           (await (async () => {
-            const tmp = new (require("${self_client_path}")).R({
+            const mod = require("${self_client_path}")
+            const client = new mod.R({
               f: ${f_client},
               stateful: ${stateful_client},
             });
-            if (tmp.$inflight_init) { await tmp.$inflight_init(); }
-            return tmp;
+            if (client.$inflight_init) { await client.$inflight_init(); }
+            return client;
           })())
         `);
       }

--- a/tools/hangar/__snapshots__/test_corpus/forward_decl.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/forward_decl.w_compile_tf-aws.md
@@ -2,7 +2,7 @@
 
 ## clients/R.inflight.js
 ```js
-module.exports = function($globals) {
+module.exports = function() {
   class  R {
     constructor({ f, stateful }) {
       this.f = f;

--- a/tools/hangar/__snapshots__/test_corpus/impl_interface.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/impl_interface.w_compile_tf-aws.md
@@ -13,6 +13,8 @@ class  A {
   }
 }
 exports.A = A;
+exports.setupGlobals = function(globals) {
+};
 
 ```
 
@@ -29,6 +31,8 @@ class  Dog {
   }
 }
 exports.Dog = Dog;
+exports.setupGlobals = function(globals) {
+};
 
 ```
 
@@ -45,6 +49,8 @@ class  r {
   }
 }
 exports.r = r;
+exports.setupGlobals = function(globals) {
+};
 
 ```
 
@@ -100,11 +106,12 @@ class $Root extends $stdlib.std.Resource {
         const self_client_path = "./clients/A.inflight.js".replace(/\\/g, "/");
         return $stdlib.core.NodeJsCode.fromInline(`
           (await (async () => {
-            const tmp = new (require("${self_client_path}")).A({
+            const mod = require("${self_client_path}")
+            const client = new mod.A({
               stateful: ${stateful_client},
             });
-            if (tmp.$inflight_init) { await tmp.$inflight_init(); }
-            return tmp;
+            if (client.$inflight_init) { await client.$inflight_init(); }
+            return client;
           })())
         `);
       }
@@ -137,11 +144,12 @@ class $Root extends $stdlib.std.Resource {
         const self_client_path = "./clients/r.inflight.js".replace(/\\/g, "/");
         return $stdlib.core.NodeJsCode.fromInline(`
           (await (async () => {
-            const tmp = new (require("${self_client_path}")).r({
+            const mod = require("${self_client_path}")
+            const client = new mod.r({
               stateful: ${stateful_client},
             });
-            if (tmp.$inflight_init) { await tmp.$inflight_init(); }
-            return tmp;
+            if (client.$inflight_init) { await client.$inflight_init(); }
+            return client;
           })())
         `);
       }
@@ -164,11 +172,12 @@ class $Root extends $stdlib.std.Resource {
         const self_client_path = "./clients/Dog.inflight.js".replace(/\\/g, "/");
         return $stdlib.core.NodeJsCode.fromInline(`
           (await (async () => {
-            const tmp = new (require("${self_client_path}")).Dog({
+            const mod = require("${self_client_path}")
+            const client = new mod.Dog({
               stateful: ${stateful_client},
             });
-            if (tmp.$inflight_init) { await tmp.$inflight_init(); }
-            return tmp;
+            if (client.$inflight_init) { await client.$inflight_init(); }
+            return client;
           })())
         `);
       }

--- a/tools/hangar/__snapshots__/test_corpus/impl_interface.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/impl_interface.w_compile_tf-aws.md
@@ -2,55 +2,55 @@
 
 ## clients/A.inflight.js
 ```js
-class  A {
-  constructor({ stateful }) {
-    this.stateful = stateful;
-  }
-  async handle(msg)  {
-    {
-      return;
+module.exports = function($globals) {
+  class  A {
+    constructor({ stateful }) {
+      this.stateful = stateful;
+    }
+    async handle(msg)  {
+      {
+        return;
+      }
     }
   }
+  return A;
 }
-exports.A = A;
-exports.setupGlobals = function(globals) {
-};
 
 ```
 
 ## clients/Dog.inflight.js
 ```js
-class  Dog {
-  constructor({ stateful }) {
-    this.stateful = stateful;
-  }
-  async eat()  {
-    {
-      return;
+module.exports = function($globals) {
+  class  Dog {
+    constructor({ stateful }) {
+      this.stateful = stateful;
+    }
+    async eat()  {
+      {
+        return;
+      }
     }
   }
+  return Dog;
 }
-exports.Dog = Dog;
-exports.setupGlobals = function(globals) {
-};
 
 ```
 
 ## clients/r.inflight.js
 ```js
-class  r {
-  constructor({ stateful }) {
-    this.stateful = stateful;
-  }
-  async method_2(x)  {
-    {
-      return x;
+module.exports = function($globals) {
+  class  r {
+    constructor({ stateful }) {
+      this.stateful = stateful;
+    }
+    async method_2(x)  {
+      {
+        return x;
+      }
     }
   }
+  return r;
 }
-exports.r = r;
-exports.setupGlobals = function(globals) {
-};
 
 ```
 
@@ -106,8 +106,8 @@ class $Root extends $stdlib.std.Resource {
         const self_client_path = "./clients/A.inflight.js".replace(/\\/g, "/");
         return $stdlib.core.NodeJsCode.fromInline(`
           (await (async () => {
-            const mod = require("${self_client_path}")
-            const client = new mod.A({
+            const A = require("${self_client_path}")({});
+            const client = new A({
               stateful: ${stateful_client},
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -144,8 +144,8 @@ class $Root extends $stdlib.std.Resource {
         const self_client_path = "./clients/r.inflight.js".replace(/\\/g, "/");
         return $stdlib.core.NodeJsCode.fromInline(`
           (await (async () => {
-            const mod = require("${self_client_path}")
-            const client = new mod.r({
+            const r = require("${self_client_path}")({});
+            const client = new r({
               stateful: ${stateful_client},
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -172,8 +172,8 @@ class $Root extends $stdlib.std.Resource {
         const self_client_path = "./clients/Dog.inflight.js".replace(/\\/g, "/");
         return $stdlib.core.NodeJsCode.fromInline(`
           (await (async () => {
-            const mod = require("${self_client_path}")
-            const client = new mod.Dog({
+            const Dog = require("${self_client_path}")({});
+            const client = new Dog({
               stateful: ${stateful_client},
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/tools/hangar/__snapshots__/test_corpus/impl_interface.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/impl_interface.w_compile_tf-aws.md
@@ -2,7 +2,7 @@
 
 ## clients/A.inflight.js
 ```js
-module.exports = function($globals) {
+module.exports = function() {
   class  A {
     constructor({ stateful }) {
       this.stateful = stateful;
@@ -20,7 +20,7 @@ module.exports = function($globals) {
 
 ## clients/Dog.inflight.js
 ```js
-module.exports = function($globals) {
+module.exports = function() {
   class  Dog {
     constructor({ stateful }) {
       this.stateful = stateful;
@@ -38,7 +38,7 @@ module.exports = function($globals) {
 
 ## clients/r.inflight.js
 ```js
-module.exports = function($globals) {
+module.exports = function() {
   class  r {
     constructor({ stateful }) {
       this.stateful = stateful;

--- a/tools/hangar/__snapshots__/test_corpus/json.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/json.w_compile_tf-aws.md
@@ -9,6 +9,8 @@ class  Foo {
   }
 }
 exports.Foo = Foo;
+exports.setupGlobals = function(globals) {
+};
 
 ```
 
@@ -64,12 +66,13 @@ class $Root extends $stdlib.std.Resource {
         const self_client_path = "./clients/Foo.inflight.js".replace(/\\/g, "/");
         return $stdlib.core.NodeJsCode.fromInline(`
           (await (async () => {
-            const tmp = new (require("${self_client_path}")).Foo({
+            const mod = require("${self_client_path}")
+            const client = new mod.Foo({
               _sum_str: ${_sum_str_client},
               stateful: ${stateful_client},
             });
-            if (tmp.$inflight_init) { await tmp.$inflight_init(); }
-            return tmp;
+            if (client.$inflight_init) { await client.$inflight_init(); }
+            return client;
           })())
         `);
       }

--- a/tools/hangar/__snapshots__/test_corpus/json.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/json.w_compile_tf-aws.md
@@ -2,7 +2,7 @@
 
 ## clients/Foo.inflight.js
 ```js
-module.exports = function($globals) {
+module.exports = function() {
   class  Foo {
     constructor({ _sum_str, stateful }) {
       this._sum_str = _sum_str;

--- a/tools/hangar/__snapshots__/test_corpus/json.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/json.w_compile_tf-aws.md
@@ -2,15 +2,15 @@
 
 ## clients/Foo.inflight.js
 ```js
-class  Foo {
-  constructor({ _sum_str, stateful }) {
-    this._sum_str = _sum_str;
-    this.stateful = stateful;
+module.exports = function($globals) {
+  class  Foo {
+    constructor({ _sum_str, stateful }) {
+      this._sum_str = _sum_str;
+      this.stateful = stateful;
+    }
   }
+  return Foo;
 }
-exports.Foo = Foo;
-exports.setupGlobals = function(globals) {
-};
 
 ```
 
@@ -66,8 +66,8 @@ class $Root extends $stdlib.std.Resource {
         const self_client_path = "./clients/Foo.inflight.js".replace(/\\/g, "/");
         return $stdlib.core.NodeJsCode.fromInline(`
           (await (async () => {
-            const mod = require("${self_client_path}")
-            const client = new mod.Foo({
+            const Foo = require("${self_client_path}")({});
+            const client = new Foo({
               _sum_str: ${_sum_str_client},
               stateful: ${stateful_client},
             });

--- a/tools/hangar/__snapshots__/test_corpus/reassignment.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/reassignment.w_compile_tf-aws.md
@@ -2,7 +2,7 @@
 
 ## clients/R.inflight.js
 ```js
-module.exports = function($globals) {
+module.exports = function() {
   class  R {
     constructor({ f1, stateful }) {
       this.f1 = f1;

--- a/tools/hangar/__snapshots__/test_corpus/reassignment.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/reassignment.w_compile_tf-aws.md
@@ -9,6 +9,8 @@ class  R {
   }
 }
 exports.R = R;
+exports.setupGlobals = function(globals) {
+};
 
 ```
 
@@ -72,12 +74,13 @@ class $Root extends $stdlib.std.Resource {
         const self_client_path = "./clients/R.inflight.js".replace(/\\/g, "/");
         return $stdlib.core.NodeJsCode.fromInline(`
           (await (async () => {
-            const tmp = new (require("${self_client_path}")).R({
+            const mod = require("${self_client_path}")
+            const client = new mod.R({
               f1: ${f1_client},
               stateful: ${stateful_client},
             });
-            if (tmp.$inflight_init) { await tmp.$inflight_init(); }
-            return tmp;
+            if (client.$inflight_init) { await client.$inflight_init(); }
+            return client;
           })())
         `);
       }

--- a/tools/hangar/__snapshots__/test_corpus/reassignment.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/reassignment.w_compile_tf-aws.md
@@ -2,15 +2,15 @@
 
 ## clients/R.inflight.js
 ```js
-class  R {
-  constructor({ f1, stateful }) {
-    this.f1 = f1;
-    this.stateful = stateful;
+module.exports = function($globals) {
+  class  R {
+    constructor({ f1, stateful }) {
+      this.f1 = f1;
+      this.stateful = stateful;
+    }
   }
+  return R;
 }
-exports.R = R;
-exports.setupGlobals = function(globals) {
-};
 
 ```
 
@@ -74,8 +74,8 @@ class $Root extends $stdlib.std.Resource {
         const self_client_path = "./clients/R.inflight.js".replace(/\\/g, "/");
         return $stdlib.core.NodeJsCode.fromInline(`
           (await (async () => {
-            const mod = require("${self_client_path}")
-            const client = new mod.R({
+            const R = require("${self_client_path}")({});
+            const client = new R({
               f1: ${f1_client},
               stateful: ${stateful_client},
             });

--- a/tools/hangar/__snapshots__/test_corpus/resource.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/resource.w_compile_tf-aws.md
@@ -18,6 +18,8 @@ class  Bar {
   }
 }
 exports.Bar = Bar;
+exports.setupGlobals = function(globals) {
+};
 
 ```
 
@@ -45,6 +47,8 @@ class  BigPublisher {
   }
 }
 exports.BigPublisher = BigPublisher;
+exports.setupGlobals = function(globals) {
+};
 
 ```
 
@@ -74,6 +78,8 @@ class  Foo {
   }
 }
 exports.Foo = Foo;
+exports.setupGlobals = function(globals) {
+};
 
 ```
 
@@ -774,12 +780,13 @@ class $Root extends $stdlib.std.Resource {
         const self_client_path = "./clients/Foo.inflight.js".replace(/\\/g, "/");
         return $stdlib.core.NodeJsCode.fromInline(`
           (await (async () => {
-            const tmp = new (require("${self_client_path}")).Foo({
+            const mod = require("${self_client_path}")
+            const client = new mod.Foo({
               c: ${c_client},
               stateful: ${stateful_client},
             });
-            if (tmp.$inflight_init) { await tmp.$inflight_init(); }
-            return tmp;
+            if (client.$inflight_init) { await client.$inflight_init(); }
+            return client;
           })())
         `);
       }
@@ -813,14 +820,15 @@ class $Root extends $stdlib.std.Resource {
         const self_client_path = "./clients/Bar.inflight.js".replace(/\\/g, "/");
         return $stdlib.core.NodeJsCode.fromInline(`
           (await (async () => {
-            const tmp = new (require("${self_client_path}")).Bar({
+            const mod = require("${self_client_path}")
+            const client = new mod.Bar({
               b: ${b_client},
               foo: ${foo_client},
               name: ${name_client},
               stateful: ${stateful_client},
             });
-            if (tmp.$inflight_init) { await tmp.$inflight_init(); }
-            return tmp;
+            if (client.$inflight_init) { await client.$inflight_init(); }
+            return client;
           })())
         `);
       }
@@ -886,15 +894,16 @@ class $Root extends $stdlib.std.Resource {
         const self_client_path = "./clients/BigPublisher.inflight.js".replace(/\\/g, "/");
         return $stdlib.core.NodeJsCode.fromInline(`
           (await (async () => {
-            const tmp = new (require("${self_client_path}")).BigPublisher({
+            const mod = require("${self_client_path}")
+            const client = new mod.BigPublisher({
               b: ${b_client},
               b2: ${b2_client},
               q: ${q_client},
               t: ${t_client},
               stateful: ${stateful_client},
             });
-            if (tmp.$inflight_init) { await tmp.$inflight_init(); }
-            return tmp;
+            if (client.$inflight_init) { await client.$inflight_init(); }
+            return client;
           })())
         `);
       }

--- a/tools/hangar/__snapshots__/test_corpus/resource.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/resource.w_compile_tf-aws.md
@@ -2,84 +2,84 @@
 
 ## clients/Bar.inflight.js
 ```js
-class  Bar {
-  constructor({ b, foo, name, stateful }) {
-    this.b = b;
-    this.foo = foo;
-    this.name = name;
-    this.stateful = stateful;
-  }
-  async my_method()  {
-    {
-      (await this.foo.foo_inc());
-      (await this.b.put("foo",`counter is: ${(await this.foo.foo_get())}`));
-      return (await this.b.get("foo"));
+module.exports = function($globals) {
+  class  Bar {
+    constructor({ b, foo, name, stateful }) {
+      this.b = b;
+      this.foo = foo;
+      this.name = name;
+      this.stateful = stateful;
+    }
+    async my_method()  {
+      {
+        (await this.foo.foo_inc());
+        (await this.b.put("foo",`counter is: ${(await this.foo.foo_get())}`));
+        return (await this.b.get("foo"));
+      }
     }
   }
+  return Bar;
 }
-exports.Bar = Bar;
-exports.setupGlobals = function(globals) {
-};
 
 ```
 
 ## clients/BigPublisher.inflight.js
 ```js
-class  BigPublisher {
-  constructor({ b, b2, q, t, stateful }) {
-    this.b = b;
-    this.b2 = b2;
-    this.q = q;
-    this.t = t;
-    this.stateful = stateful;
-  }
-  async publish(s)  {
-    {
-      (await this.t.publish(s));
-      (await this.q.push(s));
-      (await this.b2.put("foo",s));
+module.exports = function($globals) {
+  class  BigPublisher {
+    constructor({ b, b2, q, t, stateful }) {
+      this.b = b;
+      this.b2 = b2;
+      this.q = q;
+      this.t = t;
+      this.stateful = stateful;
+    }
+    async publish(s)  {
+      {
+        (await this.t.publish(s));
+        (await this.q.push(s));
+        (await this.b2.put("foo",s));
+      }
+    }
+    async getObjectCount()  {
+      {
+        return (await this.b.list()).length;
+      }
     }
   }
-  async getObjectCount()  {
-    {
-      return (await this.b.list()).length;
-    }
-  }
+  return BigPublisher;
 }
-exports.BigPublisher = BigPublisher;
-exports.setupGlobals = function(globals) {
-};
 
 ```
 
 ## clients/Foo.inflight.js
 ```js
-class  Foo {
-  constructor({ c, stateful }) {
-    this.c = c;
-    this.stateful = stateful;
-  }
-  async $inflight_init()  {
-    {
-      this.inflight_field = 123;
-      (await this.c.inc(110));
-      (await this.c.dec(10));
+module.exports = function($globals) {
+  class  Foo {
+    constructor({ c, stateful }) {
+      this.c = c;
+      this.stateful = stateful;
+    }
+    async $inflight_init()  {
+      {
+        this.inflight_field = 123;
+        (await this.c.inc(110));
+        (await this.c.dec(10));
+      }
+    }
+    async foo_inc()  {
+      {
+        (await this.c.inc());
+      }
+    }
+    async foo_get()  {
+      {
+        return (await this.c.peek());
+      }
     }
   }
-  async foo_inc()  {
-    {
-      (await this.c.inc());
-    }
-  }
-  async foo_get()  {
-    {
-      return (await this.c.peek());
-    }
-  }
+  return Foo;
 }
-exports.Foo = Foo;
-exports.setupGlobals = function(globals) {
-};
 
 ```
 
@@ -780,8 +780,8 @@ class $Root extends $stdlib.std.Resource {
         const self_client_path = "./clients/Foo.inflight.js".replace(/\\/g, "/");
         return $stdlib.core.NodeJsCode.fromInline(`
           (await (async () => {
-            const mod = require("${self_client_path}")
-            const client = new mod.Foo({
+            const Foo = require("${self_client_path}")({});
+            const client = new Foo({
               c: ${c_client},
               stateful: ${stateful_client},
             });
@@ -820,8 +820,8 @@ class $Root extends $stdlib.std.Resource {
         const self_client_path = "./clients/Bar.inflight.js".replace(/\\/g, "/");
         return $stdlib.core.NodeJsCode.fromInline(`
           (await (async () => {
-            const mod = require("${self_client_path}")
-            const client = new mod.Bar({
+            const Bar = require("${self_client_path}")({});
+            const client = new Bar({
               b: ${b_client},
               foo: ${foo_client},
               name: ${name_client},
@@ -894,8 +894,8 @@ class $Root extends $stdlib.std.Resource {
         const self_client_path = "./clients/BigPublisher.inflight.js".replace(/\\/g, "/");
         return $stdlib.core.NodeJsCode.fromInline(`
           (await (async () => {
-            const mod = require("${self_client_path}")
-            const client = new mod.BigPublisher({
+            const BigPublisher = require("${self_client_path}")({});
+            const client = new BigPublisher({
               b: ${b_client},
               b2: ${b2_client},
               q: ${q_client},

--- a/tools/hangar/__snapshots__/test_corpus/resource.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/resource.w_compile_tf-aws.md
@@ -2,7 +2,7 @@
 
 ## clients/Bar.inflight.js
 ```js
-module.exports = function($globals) {
+module.exports = function() {
   class  Bar {
     constructor({ b, foo, name, stateful }) {
       this.b = b;
@@ -25,7 +25,7 @@ module.exports = function($globals) {
 
 ## clients/BigPublisher.inflight.js
 ```js
-module.exports = function($globals) {
+module.exports = function() {
   class  BigPublisher {
     constructor({ b, b2, q, t, stateful }) {
       this.b = b;
@@ -54,7 +54,7 @@ module.exports = function($globals) {
 
 ## clients/Foo.inflight.js
 ```js
-module.exports = function($globals) {
+module.exports = function() {
   class  Foo {
     constructor({ c, stateful }) {
       this.c = c;

--- a/tools/hangar/__snapshots__/test_corpus/resource_as_inflight_literal.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/resource_as_inflight_literal.w_compile_tf-aws.md
@@ -13,6 +13,8 @@ class  Foo {
   }
 }
 exports.Foo = Foo;
+exports.setupGlobals = function(globals) {
+};
 
 ```
 
@@ -222,11 +224,12 @@ class $Root extends $stdlib.std.Resource {
         const self_client_path = "./clients/Foo.inflight.js".replace(/\\/g, "/");
         return $stdlib.core.NodeJsCode.fromInline(`
           (await (async () => {
-            const tmp = new (require("${self_client_path}")).Foo({
+            const mod = require("${self_client_path}")
+            const client = new mod.Foo({
               stateful: ${stateful_client},
             });
-            if (tmp.$inflight_init) { await tmp.$inflight_init(); }
-            return tmp;
+            if (client.$inflight_init) { await client.$inflight_init(); }
+            return client;
           })())
         `);
       }

--- a/tools/hangar/__snapshots__/test_corpus/resource_as_inflight_literal.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/resource_as_inflight_literal.w_compile_tf-aws.md
@@ -2,7 +2,7 @@
 
 ## clients/Foo.inflight.js
 ```js
-module.exports = function($globals) {
+module.exports = function() {
   class  Foo {
     constructor({ stateful }) {
       this.stateful = stateful;

--- a/tools/hangar/__snapshots__/test_corpus/resource_as_inflight_literal.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/resource_as_inflight_literal.w_compile_tf-aws.md
@@ -2,19 +2,19 @@
 
 ## clients/Foo.inflight.js
 ```js
-class  Foo {
-  constructor({ stateful }) {
-    this.stateful = stateful;
-  }
-  async handle(message)  {
-    {
-      return "hello world!";
+module.exports = function($globals) {
+  class  Foo {
+    constructor({ stateful }) {
+      this.stateful = stateful;
+    }
+    async handle(message)  {
+      {
+        return "hello world!";
+      }
     }
   }
+  return Foo;
 }
-exports.Foo = Foo;
-exports.setupGlobals = function(globals) {
-};
 
 ```
 
@@ -224,8 +224,8 @@ class $Root extends $stdlib.std.Resource {
         const self_client_path = "./clients/Foo.inflight.js".replace(/\\/g, "/");
         return $stdlib.core.NodeJsCode.fromInline(`
           (await (async () => {
-            const mod = require("${self_client_path}")
-            const client = new mod.Foo({
+            const Foo = require("${self_client_path}")({});
+            const client = new Foo({
               stateful: ${stateful_client},
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/tools/hangar/__snapshots__/test_corpus/resource_captures.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/resource_captures.w_compile_tf-aws.md
@@ -20,6 +20,8 @@ class  Another {
   }
 }
 exports.Another = Another;
+exports.setupGlobals = function(globals) {
+};
 
 ```
 
@@ -32,6 +34,8 @@ class  First {
   }
 }
 exports.First = First;
+exports.setupGlobals = function(globals) {
+};
 
 ```
 
@@ -130,6 +134,8 @@ class  MyResource {
   }
 }
 exports.MyResource = MyResource;
+exports.setupGlobals = function(globals) {
+};
 
 ```
 
@@ -433,12 +439,13 @@ class $Root extends $stdlib.std.Resource {
         const self_client_path = "./clients/First.inflight.js".replace(/\\/g, "/");
         return $stdlib.core.NodeJsCode.fromInline(`
           (await (async () => {
-            const tmp = new (require("${self_client_path}")).First({
+            const mod = require("${self_client_path}")
+            const client = new mod.First({
               my_resource: ${my_resource_client},
               stateful: ${stateful_client},
             });
-            if (tmp.$inflight_init) { await tmp.$inflight_init(); }
-            return tmp;
+            if (client.$inflight_init) { await client.$inflight_init(); }
+            return client;
           })())
         `);
       }
@@ -464,13 +471,14 @@ class $Root extends $stdlib.std.Resource {
         const self_client_path = "./clients/Another.inflight.js".replace(/\\/g, "/");
         return $stdlib.core.NodeJsCode.fromInline(`
           (await (async () => {
-            const tmp = new (require("${self_client_path}")).Another({
+            const mod = require("${self_client_path}")
+            const client = new mod.Another({
               first: ${first_client},
               my_field: ${my_field_client},
               stateful: ${stateful_client},
             });
-            if (tmp.$inflight_init) { await tmp.$inflight_init(); }
-            return tmp;
+            if (client.$inflight_init) { await client.$inflight_init(); }
+            return client;
           })())
         `);
       }
@@ -528,7 +536,8 @@ class $Root extends $stdlib.std.Resource {
         const self_client_path = "./clients/MyResource.inflight.js".replace(/\\/g, "/");
         return $stdlib.core.NodeJsCode.fromInline(`
           (await (async () => {
-            const tmp = new (require("${self_client_path}")).MyResource({
+            const mod = require("${self_client_path}")
+            const client = new mod.MyResource({
               another: ${another_client},
               array_of_str: ${array_of_str_client},
               ext_bucket: ${ext_bucket_client},
@@ -544,8 +553,8 @@ class $Root extends $stdlib.std.Resource {
               unused_resource: ${unused_resource_client},
               stateful: ${stateful_client},
             });
-            if (tmp.$inflight_init) { await tmp.$inflight_init(); }
-            return tmp;
+            if (client.$inflight_init) { await client.$inflight_init(); }
+            return client;
           })())
         `);
       }

--- a/tools/hangar/__snapshots__/test_corpus/resource_captures.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/resource_captures.w_compile_tf-aws.md
@@ -2,140 +2,140 @@
 
 ## clients/Another.inflight.js
 ```js
-class  Another {
-  constructor({ first, my_field, stateful }) {
-    this.first = first;
-    this.my_field = my_field;
-    this.stateful = stateful;
-  }
-  async meaning_of_life()  {
-    {
-      return 42;
+module.exports = function($globals) {
+  class  Another {
+    constructor({ first, my_field, stateful }) {
+      this.first = first;
+      this.my_field = my_field;
+      this.stateful = stateful;
+    }
+    async meaning_of_life()  {
+      {
+        return 42;
+      }
+    }
+    async another_func()  {
+      {
+        return "42";
+      }
     }
   }
-  async another_func()  {
-    {
-      return "42";
-    }
-  }
+  return Another;
 }
-exports.Another = Another;
-exports.setupGlobals = function(globals) {
-};
 
 ```
 
 ## clients/First.inflight.js
 ```js
-class  First {
-  constructor({ my_resource, stateful }) {
-    this.my_resource = my_resource;
-    this.stateful = stateful;
+module.exports = function($globals) {
+  class  First {
+    constructor({ my_resource, stateful }) {
+      this.my_resource = my_resource;
+      this.stateful = stateful;
+    }
   }
+  return First;
 }
-exports.First = First;
-exports.setupGlobals = function(globals) {
-};
 
 ```
 
 ## clients/MyResource.inflight.js
 ```js
-class  MyResource {
-  constructor({ another, array_of_str, ext_bucket, ext_num, map_of_num, my_bool, my_num, my_opt_str, my_queue, my_resource, my_str, set_of_str, unused_resource, stateful }) {
-    this.another = another;
-    this.array_of_str = array_of_str;
-    this.ext_bucket = ext_bucket;
-    this.ext_num = ext_num;
-    this.map_of_num = map_of_num;
-    this.my_bool = my_bool;
-    this.my_num = my_num;
-    this.my_opt_str = my_opt_str;
-    this.my_queue = my_queue;
-    this.my_resource = my_resource;
-    this.my_str = my_str;
-    this.set_of_str = set_of_str;
-    this.unused_resource = unused_resource;
-    this.stateful = stateful;
-  }
-  async test_no_capture()  {
-    {
-      const arr = Object.freeze([1, 2, 3]);
-      {((cond) => {if (!cond) throw new Error(`assertion failed: '(arr.length === 3)'`)})((arr.length === 3))};
-      {console.log(`array.len=${arr.length}`)};
+module.exports = function($globals) {
+  class  MyResource {
+    constructor({ another, array_of_str, ext_bucket, ext_num, map_of_num, my_bool, my_num, my_opt_str, my_queue, my_resource, my_str, set_of_str, unused_resource, stateful }) {
+      this.another = another;
+      this.array_of_str = array_of_str;
+      this.ext_bucket = ext_bucket;
+      this.ext_num = ext_num;
+      this.map_of_num = map_of_num;
+      this.my_bool = my_bool;
+      this.my_num = my_num;
+      this.my_opt_str = my_opt_str;
+      this.my_queue = my_queue;
+      this.my_resource = my_resource;
+      this.my_str = my_str;
+      this.set_of_str = set_of_str;
+      this.unused_resource = unused_resource;
+      this.stateful = stateful;
+    }
+    async test_no_capture()  {
+      {
+        const arr = Object.freeze([1, 2, 3]);
+        {((cond) => {if (!cond) throw new Error(`assertion failed: '(arr.length === 3)'`)})((arr.length === 3))};
+        {console.log(`array.len=${arr.length}`)};
+      }
+    }
+    async test_capture_collections_of_data()  {
+      {
+        {((cond) => {if (!cond) throw new Error(`assertion failed: '(this.array_of_str.length === 2)'`)})((this.array_of_str.length === 2))};
+        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await this.array_of_str.at(0)) === "s1")'`)})(((await this.array_of_str.at(0)) === "s1"))};
+        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await this.array_of_str.at(1)) === "s2")'`)})(((await this.array_of_str.at(1)) === "s2"))};
+        {((cond) => {if (!cond) throw new Error(`assertion failed: '((this.map_of_num)["k1"] === 11)'`)})(((this.map_of_num)["k1"] === 11))};
+        {((cond) => {if (!cond) throw new Error(`assertion failed: '((this.map_of_num)["k2"] === 22)'`)})(((this.map_of_num)["k2"] === 22))};
+        {((cond) => {if (!cond) throw new Error(`assertion failed: '(await this.set_of_str.has("s1"))'`)})((await this.set_of_str.has("s1")))};
+        {((cond) => {if (!cond) throw new Error(`assertion failed: '(await this.set_of_str.has("s2"))'`)})((await this.set_of_str.has("s2")))};
+        {((cond) => {if (!cond) throw new Error(`assertion failed: '(!(await this.set_of_str.has("s3")))'`)})((!(await this.set_of_str.has("s3"))))};
+      }
+    }
+    async test_capture_primitives()  {
+      {
+        {((cond) => {if (!cond) throw new Error(`assertion failed: '(this.my_str === "my_string")'`)})((this.my_str === "my_string"))};
+        {((cond) => {if (!cond) throw new Error(`assertion failed: '(this.my_num === 42)'`)})((this.my_num === 42))};
+        {((cond) => {if (!cond) throw new Error(`assertion failed: '(this.my_bool === true)'`)})((this.my_bool === true))};
+      }
+    }
+    async test_capture_optional()  {
+      {
+        {((cond) => {if (!cond) throw new Error(`assertion failed: '((this.my_opt_str ?? "") === "my_opt_string")'`)})(((this.my_opt_str ?? "") === "my_opt_string"))};
+      }
+    }
+    async test_capture_resource()  {
+      {
+        (await this.my_resource.put("f1.txt","f1"));
+        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await this.my_resource.get("f1.txt")) === "f1")'`)})(((await this.my_resource.get("f1.txt")) === "f1"))};
+        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await this.my_resource.list()).length === 1)'`)})(((await this.my_resource.list()).length === 1))};
+      }
+    }
+    async test_nested_preflight_field()  {
+      {
+        {((cond) => {if (!cond) throw new Error(`assertion failed: '(this.another.my_field === "hello!")'`)})((this.another.my_field === "hello!"))};
+        {console.log(`field=${this.another.my_field}`)};
+      }
+    }
+    async test_nested_resource()  {
+      {
+        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await this.another.first.my_resource.list()).length === 0)'`)})(((await this.another.first.my_resource.list()).length === 0))};
+        (await this.another.first.my_resource.put("hello",this.my_str));
+        {console.log(`this.another.first.my_resource:${(await this.another.first.my_resource.get("hello"))}`)};
+      }
+    }
+    async test_expression_recursive()  {
+      {
+        (await this.my_queue.push(this.my_str));
+      }
+    }
+    async test_external()  {
+      {
+        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await this.ext_bucket.list()).length === 0)'`)})(((await this.ext_bucket.list()).length === 0))};
+        {((cond) => {if (!cond) throw new Error(`assertion failed: '(this.ext_num === 12)'`)})((this.ext_num === 12))};
+      }
+    }
+    async test_user_defined_resource()  {
+      {
+        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await this.another.meaning_of_life()) === 42)'`)})(((await this.another.meaning_of_life()) === 42))};
+        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await this.another.another_func()) === "42")'`)})(((await this.another.another_func()) === "42"))};
+      }
+    }
+    async test_inflight_field()  {
+      {
+        this.inflight_field = 123;
+        {((cond) => {if (!cond) throw new Error(`assertion failed: '(this.inflight_field === 123)'`)})((this.inflight_field === 123))};
+      }
     }
   }
-  async test_capture_collections_of_data()  {
-    {
-      {((cond) => {if (!cond) throw new Error(`assertion failed: '(this.array_of_str.length === 2)'`)})((this.array_of_str.length === 2))};
-      {((cond) => {if (!cond) throw new Error(`assertion failed: '((await this.array_of_str.at(0)) === "s1")'`)})(((await this.array_of_str.at(0)) === "s1"))};
-      {((cond) => {if (!cond) throw new Error(`assertion failed: '((await this.array_of_str.at(1)) === "s2")'`)})(((await this.array_of_str.at(1)) === "s2"))};
-      {((cond) => {if (!cond) throw new Error(`assertion failed: '((this.map_of_num)["k1"] === 11)'`)})(((this.map_of_num)["k1"] === 11))};
-      {((cond) => {if (!cond) throw new Error(`assertion failed: '((this.map_of_num)["k2"] === 22)'`)})(((this.map_of_num)["k2"] === 22))};
-      {((cond) => {if (!cond) throw new Error(`assertion failed: '(await this.set_of_str.has("s1"))'`)})((await this.set_of_str.has("s1")))};
-      {((cond) => {if (!cond) throw new Error(`assertion failed: '(await this.set_of_str.has("s2"))'`)})((await this.set_of_str.has("s2")))};
-      {((cond) => {if (!cond) throw new Error(`assertion failed: '(!(await this.set_of_str.has("s3")))'`)})((!(await this.set_of_str.has("s3"))))};
-    }
-  }
-  async test_capture_primitives()  {
-    {
-      {((cond) => {if (!cond) throw new Error(`assertion failed: '(this.my_str === "my_string")'`)})((this.my_str === "my_string"))};
-      {((cond) => {if (!cond) throw new Error(`assertion failed: '(this.my_num === 42)'`)})((this.my_num === 42))};
-      {((cond) => {if (!cond) throw new Error(`assertion failed: '(this.my_bool === true)'`)})((this.my_bool === true))};
-    }
-  }
-  async test_capture_optional()  {
-    {
-      {((cond) => {if (!cond) throw new Error(`assertion failed: '((this.my_opt_str ?? "") === "my_opt_string")'`)})(((this.my_opt_str ?? "") === "my_opt_string"))};
-    }
-  }
-  async test_capture_resource()  {
-    {
-      (await this.my_resource.put("f1.txt","f1"));
-      {((cond) => {if (!cond) throw new Error(`assertion failed: '((await this.my_resource.get("f1.txt")) === "f1")'`)})(((await this.my_resource.get("f1.txt")) === "f1"))};
-      {((cond) => {if (!cond) throw new Error(`assertion failed: '((await this.my_resource.list()).length === 1)'`)})(((await this.my_resource.list()).length === 1))};
-    }
-  }
-  async test_nested_preflight_field()  {
-    {
-      {((cond) => {if (!cond) throw new Error(`assertion failed: '(this.another.my_field === "hello!")'`)})((this.another.my_field === "hello!"))};
-      {console.log(`field=${this.another.my_field}`)};
-    }
-  }
-  async test_nested_resource()  {
-    {
-      {((cond) => {if (!cond) throw new Error(`assertion failed: '((await this.another.first.my_resource.list()).length === 0)'`)})(((await this.another.first.my_resource.list()).length === 0))};
-      (await this.another.first.my_resource.put("hello",this.my_str));
-      {console.log(`this.another.first.my_resource:${(await this.another.first.my_resource.get("hello"))}`)};
-    }
-  }
-  async test_expression_recursive()  {
-    {
-      (await this.my_queue.push(this.my_str));
-    }
-  }
-  async test_external()  {
-    {
-      {((cond) => {if (!cond) throw new Error(`assertion failed: '((await this.ext_bucket.list()).length === 0)'`)})(((await this.ext_bucket.list()).length === 0))};
-      {((cond) => {if (!cond) throw new Error(`assertion failed: '(this.ext_num === 12)'`)})((this.ext_num === 12))};
-    }
-  }
-  async test_user_defined_resource()  {
-    {
-      {((cond) => {if (!cond) throw new Error(`assertion failed: '((await this.another.meaning_of_life()) === 42)'`)})(((await this.another.meaning_of_life()) === 42))};
-      {((cond) => {if (!cond) throw new Error(`assertion failed: '((await this.another.another_func()) === "42")'`)})(((await this.another.another_func()) === "42"))};
-    }
-  }
-  async test_inflight_field()  {
-    {
-      this.inflight_field = 123;
-      {((cond) => {if (!cond) throw new Error(`assertion failed: '(this.inflight_field === 123)'`)})((this.inflight_field === 123))};
-    }
-  }
+  return MyResource;
 }
-exports.MyResource = MyResource;
-exports.setupGlobals = function(globals) {
-};
 
 ```
 
@@ -439,8 +439,8 @@ class $Root extends $stdlib.std.Resource {
         const self_client_path = "./clients/First.inflight.js".replace(/\\/g, "/");
         return $stdlib.core.NodeJsCode.fromInline(`
           (await (async () => {
-            const mod = require("${self_client_path}")
-            const client = new mod.First({
+            const First = require("${self_client_path}")({});
+            const client = new First({
               my_resource: ${my_resource_client},
               stateful: ${stateful_client},
             });
@@ -471,8 +471,8 @@ class $Root extends $stdlib.std.Resource {
         const self_client_path = "./clients/Another.inflight.js".replace(/\\/g, "/");
         return $stdlib.core.NodeJsCode.fromInline(`
           (await (async () => {
-            const mod = require("${self_client_path}")
-            const client = new mod.Another({
+            const Another = require("${self_client_path}")({});
+            const client = new Another({
               first: ${first_client},
               my_field: ${my_field_client},
               stateful: ${stateful_client},
@@ -536,8 +536,8 @@ class $Root extends $stdlib.std.Resource {
         const self_client_path = "./clients/MyResource.inflight.js".replace(/\\/g, "/");
         return $stdlib.core.NodeJsCode.fromInline(`
           (await (async () => {
-            const mod = require("${self_client_path}")
-            const client = new mod.MyResource({
+            const MyResource = require("${self_client_path}")({});
+            const client = new MyResource({
               another: ${another_client},
               array_of_str: ${array_of_str_client},
               ext_bucket: ${ext_bucket_client},

--- a/tools/hangar/__snapshots__/test_corpus/resource_captures.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/resource_captures.w_compile_tf-aws.md
@@ -2,7 +2,7 @@
 
 ## clients/Another.inflight.js
 ```js
-module.exports = function($globals) {
+module.exports = function() {
   class  Another {
     constructor({ first, my_field, stateful }) {
       this.first = first;
@@ -27,7 +27,7 @@ module.exports = function($globals) {
 
 ## clients/First.inflight.js
 ```js
-module.exports = function($globals) {
+module.exports = function() {
   class  First {
     constructor({ my_resource, stateful }) {
       this.my_resource = my_resource;
@@ -41,7 +41,7 @@ module.exports = function($globals) {
 
 ## clients/MyResource.inflight.js
 ```js
-module.exports = function($globals) {
+module.exports = function() {
   class  MyResource {
     constructor({ another, array_of_str, ext_bucket, ext_num, map_of_num, my_bool, my_num, my_opt_str, my_queue, my_resource, my_str, set_of_str, unused_resource, stateful }) {
       this.another = another;

--- a/tools/hangar/__snapshots__/test_corpus/resource_captures_globals.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/resource_captures_globals.w_compile_tf-aws.md
@@ -2,86 +2,93 @@
 
 ## clients/Another.inflight.js
 ```js
-class  Another {
-  constructor({ first, my_field, stateful }) {
-    this.first = first;
-    this.my_field = my_field;
-    this.stateful = stateful;
-  }
-  async $inflight_init()  {
-    {
-      {((cond) => {if (!cond) throw new Error(`assertion failed: '((await global_counter.peek()) === 0)'`)})(((await global_counter.peek()) === 0))};
+module.exports = function($globals) {
+  const { global_counter } = $globals;
+  class  Another {
+    constructor({ first, my_field, stateful }) {
+      this.first = first;
+      this.my_field = my_field;
+      this.stateful = stateful;
+    }
+    async $inflight_init()  {
+      {
+        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await global_counter.peek()) === 0)'`)})(((await global_counter.peek()) === 0))};
+      }
+    }
+    async my_method()  {
+      {
+        (await global_counter.inc());
+        return (await global_counter.peek());
+      }
     }
   }
-  async my_method()  {
-    {
-      (await global_counter.inc());
-      return (await global_counter.peek());
-    }
-  }
+  return Another;
 }
-exports.Another = Another;
-let global_counter;
-exports.setupGlobals = function(globals) {
-  global_counter = globals["global_counter"];
-};
 
 ```
 
 ## clients/First.inflight.js
 ```js
-class  First {
-  constructor({ my_resource, stateful }) {
-    this.my_resource = my_resource;
-    this.stateful = stateful;
+module.exports = function($globals) {
+  class  First {
+    constructor({ my_resource, stateful }) {
+      this.my_resource = my_resource;
+      this.stateful = stateful;
+    }
   }
+  return First;
 }
-exports.First = First;
-exports.setupGlobals = function(globals) {
-};
 
 ```
 
 ## clients/MyResource.inflight.js
 ```js
-class  MyResource {
-  constructor({ stateful }) {
-    this.stateful = stateful;
-  }
-  async my_put()  {
-    {
-      (await global_bucket.put("key","value"));
-      {((cond) => {if (!cond) throw new Error(`assertion failed: '(global_str === "hello")'`)})((global_str === "hello"))};
-      {((cond) => {if (!cond) throw new Error(`assertion failed: '(global_bool === true)'`)})((global_bool === true))};
-      {((cond) => {if (!cond) throw new Error(`assertion failed: '(global_num === 42)'`)})((global_num === 42))};
-      {((cond) => {if (!cond) throw new Error(`assertion failed: '((await global_array_of_str.at(0)) === "hello")'`)})(((await global_array_of_str.at(0)) === "hello"))};
-      {((cond) => {if (!cond) throw new Error(`assertion failed: '((global_map_of_num)["a"] === (-5))'`)})(((global_map_of_num)["a"] === (-5)))};
-      {((cond) => {if (!cond) throw new Error(`assertion failed: '(await global_set_of_str.has("a"))'`)})((await global_set_of_str.has("a")))};
-      {((cond) => {if (!cond) throw new Error(`assertion failed: '(global_another.my_field === "hello!")'`)})((global_another.my_field === "hello!"))};
-      (await global_another.first.my_resource.put("key","value"));
-      {((cond) => {if (!cond) throw new Error(`assertion failed: '((await global_another.my_method()) > 0)'`)})(((await global_another.my_method()) > 0))};
+module.exports = function($globals) {
+  const { global_another, global_array_of_str, global_bool, global_bucket, global_counter, global_map_of_num, global_num, global_set_of_str, global_str } = $globals;
+  class  MyResource {
+    constructor({ local_counter, local_topic, stateful }) {
+      this.local_counter = local_counter;
+      this.local_topic = local_topic;
+      this.stateful = stateful;
+    }
+    async my_put()  {
+      {
+        (await this.local_topic.publish("hello"));
+        (await global_bucket.put("key","value"));
+        {((cond) => {if (!cond) throw new Error(`assertion failed: '(global_str === "hello")'`)})((global_str === "hello"))};
+        {((cond) => {if (!cond) throw new Error(`assertion failed: '(global_bool === true)'`)})((global_bool === true))};
+        {((cond) => {if (!cond) throw new Error(`assertion failed: '(global_num === 42)'`)})((global_num === 42))};
+        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await global_array_of_str.at(0)) === "hello")'`)})(((await global_array_of_str.at(0)) === "hello"))};
+        {((cond) => {if (!cond) throw new Error(`assertion failed: '((global_map_of_num)["a"] === (-5))'`)})(((global_map_of_num)["a"] === (-5)))};
+        {((cond) => {if (!cond) throw new Error(`assertion failed: '(await global_set_of_str.has("a"))'`)})((await global_set_of_str.has("a")))};
+        {((cond) => {if (!cond) throw new Error(`assertion failed: '(global_another.my_field === "hello!")'`)})((global_another.my_field === "hello!"))};
+        (await global_another.first.my_resource.put("key","value"));
+        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await global_another.my_method()) > 0)'`)})(((await global_another.my_method()) > 0))};
+      }
     }
   }
+  return MyResource;
 }
-exports.MyResource = MyResource;
-let global_another;
-let global_array_of_str;
-let global_bool;
-let global_bucket;
-let global_map_of_num;
-let global_num;
-let global_set_of_str;
-let global_str;
-exports.setupGlobals = function(globals) {
-  global_another = globals["global_another"];
-  global_array_of_str = globals["global_array_of_str"];
-  global_bool = globals["global_bool"];
-  global_bucket = globals["global_bucket"];
-  global_map_of_num = globals["global_map_of_num"];
-  global_num = globals["global_num"];
-  global_set_of_str = globals["global_set_of_str"];
-  global_str = globals["global_str"];
-};
+
+```
+
+## clients/R.inflight.js
+```js
+module.exports = function($globals) {
+  const { $parent_this, global_counter } = $globals;
+  class  R {
+    constructor({ stateful }) {
+      this.stateful = stateful;
+    }
+    async handle()  {
+      {
+        (await global_counter.inc());
+        (await $parent_this.local_counter.inc());
+      }
+    }
+  }
+  return R;
+}
 
 ```
 
@@ -116,6 +123,23 @@ exports.setupGlobals = function(globals) {
   },
   "resource": {
     "aws_dynamodb_table": {
+      "root_MyResource_cloudCounter_B6FF7B6A": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/Default/MyResource/cloud.Counter/Default",
+            "uniqueId": "root_MyResource_cloudCounter_B6FF7B6A"
+          }
+        },
+        "attribute": [
+          {
+            "name": "id",
+            "type": "S"
+          }
+        ],
+        "billing_mode": "PAY_PER_REQUEST",
+        "hash_key": "id",
+        "name": "wing-counter-cloud.Counter-c87187fa"
+      },
       "root_cloudCounter_E0AC1263": {
         "//": {
           "metadata": {
@@ -135,6 +159,15 @@ exports.setupGlobals = function(globals) {
       }
     },
     "aws_iam_role": {
+      "root_MyResource_cloudTopicOnMessagef10eb240_IamRole_4BDB9A54": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/Default/MyResource/cloud.Topic-OnMessage-f10eb240/IamRole",
+            "uniqueId": "root_MyResource_cloudTopicOnMessagef10eb240_IamRole_4BDB9A54"
+          }
+        },
+        "assume_role_policy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Action\":\"sts:AssumeRole\",\"Principal\":{\"Service\":\"lambda.amazonaws.com\"},\"Effect\":\"Allow\"}]}"
+      },
       "root_test_IamRole_6CDC2D16": {
         "//": {
           "metadata": {
@@ -146,6 +179,16 @@ exports.setupGlobals = function(globals) {
       }
     },
     "aws_iam_role_policy": {
+      "root_MyResource_cloudTopicOnMessagef10eb240_IamRolePolicy_389E9A62": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/Default/MyResource/cloud.Topic-OnMessage-f10eb240/IamRolePolicy",
+            "uniqueId": "root_MyResource_cloudTopicOnMessagef10eb240_IamRolePolicy_389E9A62"
+          }
+        },
+        "policy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Action\":[\"dynamodb:UpdateItem\"],\"Resource\":[\"${aws_dynamodb_table.root_cloudCounter_E0AC1263.arn}\"],\"Effect\":\"Allow\"},{\"Action\":[\"dynamodb:UpdateItem\"],\"Resource\":[\"${aws_dynamodb_table.root_MyResource_cloudCounter_B6FF7B6A.arn}\"],\"Effect\":\"Allow\"}]}",
+        "role": "${aws_iam_role.root_MyResource_cloudTopicOnMessagef10eb240_IamRole_4BDB9A54.name}"
+      },
       "root_test_IamRolePolicy_474A6820": {
         "//": {
           "metadata": {
@@ -153,11 +196,21 @@ exports.setupGlobals = function(globals) {
             "uniqueId": "root_test_IamRolePolicy_474A6820"
           }
         },
-        "policy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Action\":[\"s3:PutObject*\",\"s3:Abort*\"],\"Resource\":[\"${aws_s3_bucket.root_cloudBucket_4F3C4F53.arn}\",\"${aws_s3_bucket.root_cloudBucket_4F3C4F53.arn}/*\"],\"Effect\":\"Allow\"},{\"Action\":[\"dynamodb:UpdateItem\"],\"Resource\":[\"${aws_dynamodb_table.root_cloudCounter_E0AC1263.arn}\"],\"Effect\":\"Allow\"},{\"Action\":[\"dynamodb:GetItem\"],\"Resource\":[\"${aws_dynamodb_table.root_cloudCounter_E0AC1263.arn}\"],\"Effect\":\"Allow\"},{\"Action\":[\"s3:PutObject*\",\"s3:Abort*\"],\"Resource\":[\"${aws_s3_bucket.root_Another_First_cloudBucket_B4A67079.arn}\",\"${aws_s3_bucket.root_Another_First_cloudBucket_B4A67079.arn}/*\"],\"Effect\":\"Allow\"}]}",
+        "policy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Action\":[\"s3:PutObject*\",\"s3:Abort*\"],\"Resource\":[\"${aws_s3_bucket.root_cloudBucket_4F3C4F53.arn}\",\"${aws_s3_bucket.root_cloudBucket_4F3C4F53.arn}/*\"],\"Effect\":\"Allow\"},{\"Action\":[\"dynamodb:UpdateItem\"],\"Resource\":[\"${aws_dynamodb_table.root_cloudCounter_E0AC1263.arn}\"],\"Effect\":\"Allow\"},{\"Action\":[\"dynamodb:GetItem\"],\"Resource\":[\"${aws_dynamodb_table.root_cloudCounter_E0AC1263.arn}\"],\"Effect\":\"Allow\"},{\"Action\":[\"s3:PutObject*\",\"s3:Abort*\"],\"Resource\":[\"${aws_s3_bucket.root_Another_First_cloudBucket_B4A67079.arn}\",\"${aws_s3_bucket.root_Another_First_cloudBucket_B4A67079.arn}/*\"],\"Effect\":\"Allow\"},{\"Action\":[\"sns:Publish\"],\"Resource\":[\"${aws_sns_topic.root_MyResource_cloudTopic_F71B23B1.arn}\"],\"Effect\":\"Allow\"}]}",
         "role": "${aws_iam_role.root_test_IamRole_6CDC2D16.name}"
       }
     },
     "aws_iam_role_policy_attachment": {
+      "root_MyResource_cloudTopicOnMessagef10eb240_IamRolePolicyAttachment_B9171011": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/Default/MyResource/cloud.Topic-OnMessage-f10eb240/IamRolePolicyAttachment",
+            "uniqueId": "root_MyResource_cloudTopicOnMessagef10eb240_IamRolePolicyAttachment_B9171011"
+          }
+        },
+        "policy_arn": "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+        "role": "${aws_iam_role.root_MyResource_cloudTopicOnMessagef10eb240_IamRole_4BDB9A54.name}"
+      },
       "root_test_IamRolePolicyAttachment_1102A28A": {
         "//": {
           "metadata": {
@@ -170,6 +223,33 @@ exports.setupGlobals = function(globals) {
       }
     },
     "aws_lambda_function": {
+      "root_MyResource_cloudTopicOnMessagef10eb240_AE4B2541": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/Default/MyResource/cloud.Topic-OnMessage-f10eb240/Default",
+            "uniqueId": "root_MyResource_cloudTopicOnMessagef10eb240_AE4B2541"
+          }
+        },
+        "environment": {
+          "variables": {
+            "DYNAMODB_TABLE_NAME_49baa65c": "${aws_dynamodb_table.root_cloudCounter_E0AC1263.name}",
+            "DYNAMODB_TABLE_NAME_5afed199": "${aws_dynamodb_table.root_MyResource_cloudCounter_B6FF7B6A.name}",
+            "WING_FUNCTION_NAME": "cloud-Topic-OnMessage-f10eb240-c8df2c86"
+          }
+        },
+        "function_name": "cloud-Topic-OnMessage-f10eb240-c8df2c86",
+        "handler": "index.handler",
+        "publish": true,
+        "role": "${aws_iam_role.root_MyResource_cloudTopicOnMessagef10eb240_IamRole_4BDB9A54.arn}",
+        "runtime": "nodejs18.x",
+        "s3_bucket": "${aws_s3_bucket.root_Code_02F3C603.bucket}",
+        "s3_key": "${aws_s3_object.root_MyResource_cloudTopicOnMessagef10eb240_S3Object_7458F840.key}",
+        "timeout": 30,
+        "vpc_config": {
+          "security_group_ids": [],
+          "subnet_ids": []
+        }
+      },
       "root_test_AAE85061": {
         "//": {
           "metadata": {
@@ -184,6 +264,8 @@ exports.setupGlobals = function(globals) {
             "BUCKET_NAME_d755b447": "${aws_s3_bucket.root_cloudBucket_4F3C4F53.bucket}",
             "BUCKET_NAME_d755b447_IS_PUBLIC": "false",
             "DYNAMODB_TABLE_NAME_49baa65c": "${aws_dynamodb_table.root_cloudCounter_E0AC1263.name}",
+            "DYNAMODB_TABLE_NAME_5afed199": "${aws_dynamodb_table.root_MyResource_cloudCounter_B6FF7B6A.name}",
+            "TOPIC_ARN_53de52bf": "${aws_sns_topic.root_MyResource_cloudTopic_F71B23B1.arn}",
             "WING_FUNCTION_NAME": "test-c8b6eece"
           }
         },
@@ -199,6 +281,20 @@ exports.setupGlobals = function(globals) {
           "security_group_ids": [],
           "subnet_ids": []
         }
+      }
+    },
+    "aws_lambda_permission": {
+      "root_MyResource_cloudTopicOnMessagef10eb240_InvokePermissionc8f2c43e88c72aa87b4192974983c81bf653de52bf_BEBFCC54": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/Default/MyResource/cloud.Topic-OnMessage-f10eb240/InvokePermission-c8f2c43e88c72aa87b4192974983c81bf653de52bf",
+            "uniqueId": "root_MyResource_cloudTopicOnMessagef10eb240_InvokePermissionc8f2c43e88c72aa87b4192974983c81bf653de52bf_BEBFCC54"
+          }
+        },
+        "action": "lambda:InvokeFunction",
+        "function_name": "${aws_lambda_function.root_MyResource_cloudTopicOnMessagef10eb240_AE4B2541.function_name}",
+        "principal": "sns.amazonaws.com",
+        "source_arn": "${aws_sns_topic.root_MyResource_cloudTopic_F71B23B1.arn}"
       }
     },
     "aws_s3_bucket": {
@@ -295,6 +391,17 @@ exports.setupGlobals = function(globals) {
       }
     },
     "aws_s3_object": {
+      "root_MyResource_cloudTopicOnMessagef10eb240_S3Object_7458F840": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/Default/MyResource/cloud.Topic-OnMessage-f10eb240/S3Object",
+            "uniqueId": "root_MyResource_cloudTopicOnMessagef10eb240_S3Object_7458F840"
+          }
+        },
+        "bucket": "${aws_s3_bucket.root_Code_02F3C603.bucket}",
+        "key": "<ASSET_KEY>",
+        "source": "<ASSET_SOURCE>"
+      },
       "root_test_S3Object_A16CD789": {
         "//": {
           "metadata": {
@@ -305,6 +412,30 @@ exports.setupGlobals = function(globals) {
         "bucket": "${aws_s3_bucket.root_Code_02F3C603.bucket}",
         "key": "<ASSET_KEY>",
         "source": "<ASSET_SOURCE>"
+      }
+    },
+    "aws_sns_topic": {
+      "root_MyResource_cloudTopic_F71B23B1": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/Default/MyResource/cloud.Topic/Default",
+            "uniqueId": "root_MyResource_cloudTopic_F71B23B1"
+          }
+        },
+        "name": "cloud-Topic-c8f2c43e"
+      }
+    },
+    "aws_sns_topic_subscription": {
+      "root_MyResource_cloudTopic_cloudTopicTopicSubscriptionf10eb240_334AAAEE": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/Default/MyResource/cloud.Topic/cloud.Topic-TopicSubscription-f10eb240",
+            "uniqueId": "root_MyResource_cloudTopic_cloudTopicTopicSubscriptionf10eb240_334AAAEE"
+          }
+        },
+        "endpoint": "${aws_lambda_function.root_MyResource_cloudTopicOnMessagef10eb240_AE4B2541.arn}",
+        "protocol": "lambda",
+        "topic_arn": "${aws_sns_topic.root_MyResource_cloudTopic_F71B23B1.arn}"
       }
     }
   }
@@ -332,8 +463,8 @@ class $Root extends $stdlib.std.Resource {
         const self_client_path = "./clients/First.inflight.js".replace(/\\/g, "/");
         return $stdlib.core.NodeJsCode.fromInline(`
           (await (async () => {
-            const mod = require("${self_client_path}")
-            const client = new mod.First({
+            const First = require("${self_client_path}")({});
+            const client = new First({
               my_resource: ${my_resource_client},
               stateful: ${stateful_client},
             });
@@ -365,11 +496,10 @@ class $Root extends $stdlib.std.Resource {
         const self_client_path = "./clients/Another.inflight.js".replace(/\\/g, "/");
         return $stdlib.core.NodeJsCode.fromInline(`
           (await (async () => {
-            const mod = require("${self_client_path}")
-            mod.setupGlobals({
+            const Another = require("${self_client_path}")({
               global_counter: ${global_counter_client},
             });
-            const client = new mod.Another({
+            const client = new Another({
               first: ${first_client},
               my_field: ${my_field_client},
               stateful: ${stateful_client},
@@ -396,13 +526,55 @@ class $Root extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
         this._addInflightOps("my_put");
+        this.local_topic = this.node.root.newAbstract("@winglang/sdk.cloud.Topic",this,"cloud.Topic");
+        this.local_counter = this.node.root.newAbstract("@winglang/sdk.cloud.Counter",this,"cloud.Counter");
+        const $parent_this = this;
+        class R extends $stdlib.std.Resource {
+          constructor(scope, id, ) {
+            super(scope, id);
+            this._addInflightOps("handle");
+          }
+          _toInflight() {
+            const stateful_client = this._lift(this.stateful);
+            const $parent_this_client = this._lift($parent_this);
+            const global_counter_client = this._lift(global_counter);
+            const self_client_path = "./clients/R.inflight.js".replace(/\\/g, "/");
+            return $stdlib.core.NodeJsCode.fromInline(`
+              (await (async () => {
+                const R = require("${self_client_path}")({
+                  $parent_this: ${$parent_this_client},
+                  global_counter: ${global_counter_client},
+                });
+                const client = new R({
+                  stateful: ${stateful_client},
+                });
+                if (client.$inflight_init) { await client.$inflight_init(); }
+                return client;
+              })())
+            `);
+          }
+          _registerBind(host, ops) {
+            if (ops.includes("$inflight_init")) {
+              this._registerBindObject(this.stateful, host, []);
+            }
+            if (ops.includes("handle")) {
+              this._registerBindObject($parent_this.local_counter, host, ["inc"]);
+              this._registerBindObject(global_counter, host, ["inc"]);
+            }
+            super._registerBind(host, ops);
+          }
+        }
+        (this.local_topic.onMessage(new R(this,"R")));
       }
       _toInflight() {
+        const local_counter_client = this._lift(this.local_counter);
+        const local_topic_client = this._lift(this.local_topic);
         const stateful_client = this._lift(this.stateful);
         const global_another_client = this._lift(global_another);
         const global_array_of_str_client = this._lift(global_array_of_str);
         const global_bool_client = this._lift(global_bool);
         const global_bucket_client = this._lift(global_bucket);
+        const global_counter_client = this._lift(global_counter);
         const global_map_of_num_client = this._lift(global_map_of_num);
         const global_num_client = this._lift(global_num);
         const global_set_of_str_client = this._lift(global_set_of_str);
@@ -410,18 +582,20 @@ class $Root extends $stdlib.std.Resource {
         const self_client_path = "./clients/MyResource.inflight.js".replace(/\\/g, "/");
         return $stdlib.core.NodeJsCode.fromInline(`
           (await (async () => {
-            const mod = require("${self_client_path}")
-            mod.setupGlobals({
+            const MyResource = require("${self_client_path}")({
               global_another: ${global_another_client},
               global_array_of_str: ${global_array_of_str_client},
               global_bool: ${global_bool_client},
               global_bucket: ${global_bucket_client},
+              global_counter: ${global_counter_client},
               global_map_of_num: ${global_map_of_num_client},
               global_num: ${global_num_client},
               global_set_of_str: ${global_set_of_str_client},
               global_str: ${global_str_client},
             });
-            const client = new mod.MyResource({
+            const client = new MyResource({
+              local_counter: ${local_counter_client},
+              local_topic: ${local_topic_client},
               stateful: ${stateful_client},
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -431,6 +605,8 @@ class $Root extends $stdlib.std.Resource {
       }
       _registerBind(host, ops) {
         if (ops.includes("$inflight_init")) {
+          this._registerBindObject(this.local_counter, host, []);
+          this._registerBindObject(this.local_topic, host, []);
           this._registerBindObject(this.stateful, host, []);
         }
         if (ops.includes("my_put")) {
@@ -444,6 +620,7 @@ class $Root extends $stdlib.std.Resource {
           this._registerBindObject(global_num, host, []);
           this._registerBindObject(global_set_of_str, host, ["has"]);
           this._registerBindObject(global_str, host, []);
+          this._registerBindObject(this.local_topic, host, ["publish"]);
         }
         super._registerBind(host, ops);
       }

--- a/tools/hangar/__snapshots__/test_corpus/resource_captures_globals.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/resource_captures_globals.w_compile_tf-aws.md
@@ -2,8 +2,7 @@
 
 ## clients/Another.inflight.js
 ```js
-module.exports = function($globals) {
-  const { global_counter } = $globals;
+module.exports = function({ global_counter }) {
   class  Another {
     constructor({ first, my_field, stateful }) {
       this.first = first;
@@ -29,7 +28,7 @@ module.exports = function($globals) {
 
 ## clients/First.inflight.js
 ```js
-module.exports = function($globals) {
+module.exports = function() {
   class  First {
     constructor({ my_resource, stateful }) {
       this.my_resource = my_resource;
@@ -43,8 +42,7 @@ module.exports = function($globals) {
 
 ## clients/MyResource.inflight.js
 ```js
-module.exports = function($globals) {
-  const { global_another, global_array_of_str, global_bool, global_bucket, global_counter, global_map_of_num, global_num, global_set_of_str, global_str } = $globals;
+module.exports = function({ global_another, global_array_of_str, global_bool, global_bucket, global_counter, global_map_of_num, global_num, global_set_of_str, global_str }) {
   class  MyResource {
     constructor({ local_counter, local_topic, stateful }) {
       this.local_counter = local_counter;
@@ -74,8 +72,7 @@ module.exports = function($globals) {
 
 ## clients/R.inflight.js
 ```js
-module.exports = function($globals) {
-  const { $parent_this, global_counter } = $globals;
+module.exports = function({ $parent_this, global_counter }) {
   class  R {
     constructor({ stateful }) {
       this.stateful = stateful;

--- a/tools/hangar/__snapshots__/test_corpus/resource_captures_globals.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/resource_captures_globals.w_compile_tf-aws.md
@@ -1,0 +1,500 @@
+# [resource_captures_globals.w](../../../../examples/tests/valid/resource_captures_globals.w) | compile | tf-aws
+
+## clients/Another.inflight.js
+```js
+class  Another {
+  constructor({ first, my_field, stateful }) {
+    this.first = first;
+    this.my_field = my_field;
+    this.stateful = stateful;
+  }
+  async $inflight_init()  {
+    {
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '((await global_counter.peek()) === 0)'`)})(((await global_counter.peek()) === 0))};
+    }
+  }
+  async my_method()  {
+    {
+      (await global_counter.inc());
+      return (await global_counter.peek());
+    }
+  }
+}
+exports.Another = Another;
+let global_counter;
+exports.setupGlobals = function(globals) {
+  global_counter = globals["global_counter"];
+};
+
+```
+
+## clients/First.inflight.js
+```js
+class  First {
+  constructor({ my_resource, stateful }) {
+    this.my_resource = my_resource;
+    this.stateful = stateful;
+  }
+}
+exports.First = First;
+exports.setupGlobals = function(globals) {
+};
+
+```
+
+## clients/MyResource.inflight.js
+```js
+class  MyResource {
+  constructor({ stateful }) {
+    this.stateful = stateful;
+  }
+  async my_put()  {
+    {
+      (await global_bucket.put("key","value"));
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '(global_str === "hello")'`)})((global_str === "hello"))};
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '(global_bool === true)'`)})((global_bool === true))};
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '(global_num === 42)'`)})((global_num === 42))};
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '((await global_array_of_str.at(0)) === "hello")'`)})(((await global_array_of_str.at(0)) === "hello"))};
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '((global_map_of_num)["a"] === (-5))'`)})(((global_map_of_num)["a"] === (-5)))};
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '(await global_set_of_str.has("a"))'`)})((await global_set_of_str.has("a")))};
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '(global_another.my_field === "hello!")'`)})((global_another.my_field === "hello!"))};
+      (await global_another.first.my_resource.put("key","value"));
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '((await global_another.my_method()) > 0)'`)})(((await global_another.my_method()) > 0))};
+    }
+  }
+}
+exports.MyResource = MyResource;
+let global_another;
+let global_array_of_str;
+let global_bool;
+let global_bucket;
+let global_map_of_num;
+let global_num;
+let global_set_of_str;
+let global_str;
+exports.setupGlobals = function(globals) {
+  global_another = globals["global_another"];
+  global_array_of_str = globals["global_array_of_str"];
+  global_bool = globals["global_bool"];
+  global_bucket = globals["global_bucket"];
+  global_map_of_num = globals["global_map_of_num"];
+  global_num = globals["global_num"];
+  global_set_of_str = globals["global_set_of_str"];
+  global_str = globals["global_str"];
+};
+
+```
+
+## main.tf.json
+```json
+{
+  "//": {
+    "metadata": {
+      "backend": "local",
+      "stackName": "root",
+      "version": "0.15.2"
+    },
+    "outputs": {
+      "root": {
+        "Default": {
+          "cloud.TestRunner": {
+            "TestFunctionArns": "WING_TEST_RUNNER_FUNCTION_ARNS"
+          }
+        }
+      }
+    }
+  },
+  "output": {
+    "WING_TEST_RUNNER_FUNCTION_ARNS": {
+      "value": "[[\"root/Default/Default/test\",\"${aws_lambda_function.root_test_AAE85061.arn}\"]]"
+    }
+  },
+  "provider": {
+    "aws": [
+      {}
+    ]
+  },
+  "resource": {
+    "aws_dynamodb_table": {
+      "root_cloudCounter_E0AC1263": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/Default/cloud.Counter/Default",
+            "uniqueId": "root_cloudCounter_E0AC1263"
+          }
+        },
+        "attribute": [
+          {
+            "name": "id",
+            "type": "S"
+          }
+        ],
+        "billing_mode": "PAY_PER_REQUEST",
+        "hash_key": "id",
+        "name": "wing-counter-cloud.Counter-c866f225"
+      }
+    },
+    "aws_iam_role": {
+      "root_test_IamRole_6CDC2D16": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/Default/test/IamRole",
+            "uniqueId": "root_test_IamRole_6CDC2D16"
+          }
+        },
+        "assume_role_policy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Action\":\"sts:AssumeRole\",\"Principal\":{\"Service\":\"lambda.amazonaws.com\"},\"Effect\":\"Allow\"}]}"
+      }
+    },
+    "aws_iam_role_policy": {
+      "root_test_IamRolePolicy_474A6820": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/Default/test/IamRolePolicy",
+            "uniqueId": "root_test_IamRolePolicy_474A6820"
+          }
+        },
+        "policy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Action\":[\"s3:PutObject*\",\"s3:Abort*\"],\"Resource\":[\"${aws_s3_bucket.root_cloudBucket_4F3C4F53.arn}\",\"${aws_s3_bucket.root_cloudBucket_4F3C4F53.arn}/*\"],\"Effect\":\"Allow\"},{\"Action\":[\"dynamodb:UpdateItem\"],\"Resource\":[\"${aws_dynamodb_table.root_cloudCounter_E0AC1263.arn}\"],\"Effect\":\"Allow\"},{\"Action\":[\"dynamodb:GetItem\"],\"Resource\":[\"${aws_dynamodb_table.root_cloudCounter_E0AC1263.arn}\"],\"Effect\":\"Allow\"},{\"Action\":[\"s3:PutObject*\",\"s3:Abort*\"],\"Resource\":[\"${aws_s3_bucket.root_Another_First_cloudBucket_B4A67079.arn}\",\"${aws_s3_bucket.root_Another_First_cloudBucket_B4A67079.arn}/*\"],\"Effect\":\"Allow\"}]}",
+        "role": "${aws_iam_role.root_test_IamRole_6CDC2D16.name}"
+      }
+    },
+    "aws_iam_role_policy_attachment": {
+      "root_test_IamRolePolicyAttachment_1102A28A": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/Default/test/IamRolePolicyAttachment",
+            "uniqueId": "root_test_IamRolePolicyAttachment_1102A28A"
+          }
+        },
+        "policy_arn": "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+        "role": "${aws_iam_role.root_test_IamRole_6CDC2D16.name}"
+      }
+    },
+    "aws_lambda_function": {
+      "root_test_AAE85061": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/Default/test/Default",
+            "uniqueId": "root_test_AAE85061"
+          }
+        },
+        "environment": {
+          "variables": {
+            "BUCKET_NAME_ae5b06c6": "${aws_s3_bucket.root_Another_First_cloudBucket_B4A67079.bucket}",
+            "BUCKET_NAME_ae5b06c6_IS_PUBLIC": "false",
+            "BUCKET_NAME_d755b447": "${aws_s3_bucket.root_cloudBucket_4F3C4F53.bucket}",
+            "BUCKET_NAME_d755b447_IS_PUBLIC": "false",
+            "DYNAMODB_TABLE_NAME_49baa65c": "${aws_dynamodb_table.root_cloudCounter_E0AC1263.name}",
+            "WING_FUNCTION_NAME": "test-c8b6eece"
+          }
+        },
+        "function_name": "test-c8b6eece",
+        "handler": "index.handler",
+        "publish": true,
+        "role": "${aws_iam_role.root_test_IamRole_6CDC2D16.arn}",
+        "runtime": "nodejs18.x",
+        "s3_bucket": "${aws_s3_bucket.root_Code_02F3C603.bucket}",
+        "s3_key": "${aws_s3_object.root_test_S3Object_A16CD789.key}",
+        "timeout": 30,
+        "vpc_config": {
+          "security_group_ids": [],
+          "subnet_ids": []
+        }
+      }
+    },
+    "aws_s3_bucket": {
+      "root_Another_First_cloudBucket_B4A67079": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/Default/Another/First/cloud.Bucket/Default",
+            "uniqueId": "root_Another_First_cloudBucket_B4A67079"
+          }
+        },
+        "bucket_prefix": "cloud-bucket-c84d72a1-",
+        "force_destroy": false
+      },
+      "root_Code_02F3C603": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/Code",
+            "uniqueId": "root_Code_02F3C603"
+          }
+        },
+        "bucket_prefix": "code-c84a50b1-"
+      },
+      "root_cloudBucket_4F3C4F53": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/Default/cloud.Bucket/Default",
+            "uniqueId": "root_cloudBucket_4F3C4F53"
+          }
+        },
+        "bucket_prefix": "cloud-bucket-c87175e7-",
+        "force_destroy": false
+      }
+    },
+    "aws_s3_bucket_public_access_block": {
+      "root_Another_First_cloudBucket_PublicAccessBlock_E03A84DE": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/Default/Another/First/cloud.Bucket/PublicAccessBlock",
+            "uniqueId": "root_Another_First_cloudBucket_PublicAccessBlock_E03A84DE"
+          }
+        },
+        "block_public_acls": true,
+        "block_public_policy": true,
+        "bucket": "${aws_s3_bucket.root_Another_First_cloudBucket_B4A67079.bucket}",
+        "ignore_public_acls": true,
+        "restrict_public_buckets": true
+      },
+      "root_cloudBucket_PublicAccessBlock_319C1C2E": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/Default/cloud.Bucket/PublicAccessBlock",
+            "uniqueId": "root_cloudBucket_PublicAccessBlock_319C1C2E"
+          }
+        },
+        "block_public_acls": true,
+        "block_public_policy": true,
+        "bucket": "${aws_s3_bucket.root_cloudBucket_4F3C4F53.bucket}",
+        "ignore_public_acls": true,
+        "restrict_public_buckets": true
+      }
+    },
+    "aws_s3_bucket_server_side_encryption_configuration": {
+      "root_Another_First_cloudBucket_Encryption_1049825A": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/Default/Another/First/cloud.Bucket/Encryption",
+            "uniqueId": "root_Another_First_cloudBucket_Encryption_1049825A"
+          }
+        },
+        "bucket": "${aws_s3_bucket.root_Another_First_cloudBucket_B4A67079.bucket}",
+        "rule": [
+          {
+            "apply_server_side_encryption_by_default": {
+              "sse_algorithm": "AES256"
+            }
+          }
+        ]
+      },
+      "root_cloudBucket_Encryption_8ED0CD9C": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/Default/cloud.Bucket/Encryption",
+            "uniqueId": "root_cloudBucket_Encryption_8ED0CD9C"
+          }
+        },
+        "bucket": "${aws_s3_bucket.root_cloudBucket_4F3C4F53.bucket}",
+        "rule": [
+          {
+            "apply_server_side_encryption_by_default": {
+              "sse_algorithm": "AES256"
+            }
+          }
+        ]
+      }
+    },
+    "aws_s3_object": {
+      "root_test_S3Object_A16CD789": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/Default/test/S3Object",
+            "uniqueId": "root_test_S3Object_A16CD789"
+          }
+        },
+        "bucket": "${aws_s3_bucket.root_Code_02F3C603.bucket}",
+        "key": "<ASSET_KEY>",
+        "source": "<ASSET_SOURCE>"
+      }
+    }
+  }
+}
+```
+
+## preflight.js
+```js
+const $stdlib = require('@winglang/sdk');
+const $outdir = process.env.WING_SYNTH_DIR ?? ".";
+const $wing_is_test = process.env.WING_IS_TEST === "true";
+const $AppBase = $stdlib.core.App.for(process.env.WING_TARGET);
+const cloud = require('@winglang/sdk').cloud;
+class $Root extends $stdlib.std.Resource {
+  constructor(scope, id) {
+    super(scope, id);
+    class First extends $stdlib.std.Resource {
+      constructor(scope, id, ) {
+        super(scope, id);
+        this.my_resource = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this,"cloud.Bucket");
+      }
+      _toInflight() {
+        const my_resource_client = this._lift(this.my_resource);
+        const stateful_client = this._lift(this.stateful);
+        const self_client_path = "./clients/First.inflight.js".replace(/\\/g, "/");
+        return $stdlib.core.NodeJsCode.fromInline(`
+          (await (async () => {
+            const mod = require("${self_client_path}")
+            const client = new mod.First({
+              my_resource: ${my_resource_client},
+              stateful: ${stateful_client},
+            });
+            if (client.$inflight_init) { await client.$inflight_init(); }
+            return client;
+          })())
+        `);
+      }
+      _registerBind(host, ops) {
+        if (ops.includes("$inflight_init")) {
+          this._registerBindObject(this.my_resource, host, []);
+          this._registerBindObject(this.stateful, host, []);
+        }
+        super._registerBind(host, ops);
+      }
+    }
+    class Another extends $stdlib.std.Resource {
+      constructor(scope, id, ) {
+        super(scope, id);
+        this._addInflightOps("my_method");
+        this.my_field = "hello!";
+        this.first = new First(this,"First");
+      }
+      _toInflight() {
+        const first_client = this._lift(this.first);
+        const my_field_client = this._lift(this.my_field);
+        const stateful_client = this._lift(this.stateful);
+        const global_counter_client = this._lift(global_counter);
+        const self_client_path = "./clients/Another.inflight.js".replace(/\\/g, "/");
+        return $stdlib.core.NodeJsCode.fromInline(`
+          (await (async () => {
+            const mod = require("${self_client_path}")
+            mod.setupGlobals({
+              global_counter: ${global_counter_client},
+            });
+            const client = new mod.Another({
+              first: ${first_client},
+              my_field: ${my_field_client},
+              stateful: ${stateful_client},
+            });
+            if (client.$inflight_init) { await client.$inflight_init(); }
+            return client;
+          })())
+        `);
+      }
+      _registerBind(host, ops) {
+        if (ops.includes("$inflight_init")) {
+          this._registerBindObject(global_counter, host, ["peek"]);
+          this._registerBindObject(this.first, host, []);
+          this._registerBindObject(this.my_field, host, []);
+          this._registerBindObject(this.stateful, host, []);
+        }
+        if (ops.includes("my_method")) {
+          this._registerBindObject(global_counter, host, ["inc", "peek"]);
+        }
+        super._registerBind(host, ops);
+      }
+    }
+    class MyResource extends $stdlib.std.Resource {
+      constructor(scope, id, ) {
+        super(scope, id);
+        this._addInflightOps("my_put");
+      }
+      _toInflight() {
+        const stateful_client = this._lift(this.stateful);
+        const global_another_client = this._lift(global_another);
+        const global_array_of_str_client = this._lift(global_array_of_str);
+        const global_bool_client = this._lift(global_bool);
+        const global_bucket_client = this._lift(global_bucket);
+        const global_map_of_num_client = this._lift(global_map_of_num);
+        const global_num_client = this._lift(global_num);
+        const global_set_of_str_client = this._lift(global_set_of_str);
+        const global_str_client = this._lift(global_str);
+        const self_client_path = "./clients/MyResource.inflight.js".replace(/\\/g, "/");
+        return $stdlib.core.NodeJsCode.fromInline(`
+          (await (async () => {
+            const mod = require("${self_client_path}")
+            mod.setupGlobals({
+              global_another: ${global_another_client},
+              global_array_of_str: ${global_array_of_str_client},
+              global_bool: ${global_bool_client},
+              global_bucket: ${global_bucket_client},
+              global_map_of_num: ${global_map_of_num_client},
+              global_num: ${global_num_client},
+              global_set_of_str: ${global_set_of_str_client},
+              global_str: ${global_str_client},
+            });
+            const client = new mod.MyResource({
+              stateful: ${stateful_client},
+            });
+            if (client.$inflight_init) { await client.$inflight_init(); }
+            return client;
+          })())
+        `);
+      }
+      _registerBind(host, ops) {
+        if (ops.includes("$inflight_init")) {
+          this._registerBindObject(this.stateful, host, []);
+        }
+        if (ops.includes("my_put")) {
+          this._registerBindObject(global_another, host, ["my_method"]);
+          this._registerBindObject(global_another.first.my_resource, host, ["put"]);
+          this._registerBindObject(global_another.my_field, host, []);
+          this._registerBindObject(global_array_of_str, host, ["at"]);
+          this._registerBindObject(global_bool, host, []);
+          this._registerBindObject(global_bucket, host, ["put"]);
+          this._registerBindObject(global_map_of_num, host, ["get"]);
+          this._registerBindObject(global_num, host, []);
+          this._registerBindObject(global_set_of_str, host, ["has"]);
+          this._registerBindObject(global_str, host, []);
+        }
+        super._registerBind(host, ops);
+      }
+    }
+    const global_bucket = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this,"cloud.Bucket");
+    const global_counter = this.node.root.newAbstract("@winglang/sdk.cloud.Counter",this,"cloud.Counter");
+    const global_str = "hello";
+    const global_bool = true;
+    const global_num = 42;
+    const global_array_of_str = Object.freeze(["hello", "world"]);
+    const global_map_of_num = Object.freeze({"a":(-5),"b":2});
+    const global_set_of_str = Object.freeze(new Set(["a", "b"]));
+    const global_another = new Another(this,"Another");
+    const res = new MyResource(this,"MyResource");
+    this.node.root.newAbstract("@winglang/sdk.cloud.Function",this,"test",new $stdlib.core.Inflight(this, "$Inflight1", {
+      code: $stdlib.core.NodeJsCode.fromFile(require.resolve("./proc1/index.js".replace(/\\/g, "/"))),
+      bindings: {
+        res: {
+          obj: res,
+          ops: ["my_put"]
+        },
+      }
+    })
+    );
+  }
+}
+class $App extends $AppBase {
+  constructor() {
+    super({ outdir: $outdir, name: "resource_captures_globals", plugins: $plugins, isTestEnvironment: $wing_is_test });
+    if ($wing_is_test) {
+      new $Root(this, "env0");
+      const $test_runner = this.testRunner;
+      const $tests = $test_runner.findTests();
+      for (let $i = 1; $i < $tests.length; $i++) {
+        new $Root(this, "env" + $i);
+      }
+    } else {
+      new $Root(this, "Default");
+    }
+  }
+}
+new $App().synth();
+
+```
+
+## proc1/index.js
+```js
+async handle() {
+  const { res } = this;
+  (await res.my_put());
+}
+
+```
+

--- a/tools/hangar/__snapshots__/test_corpus/resource_captures_globals.w_test_sim.md
+++ b/tools/hangar/__snapshots__/test_corpus/resource_captures_globals.w_test_sim.md
@@ -1,0 +1,9 @@
+# [resource_captures_globals.w](../../../../examples/tests/valid/resource_captures_globals.w) | test | sim
+
+## stdout.log
+```log
+- Compiling to sim...
+✔ Compiling to sim...
+pass ─ resource_captures_globals.wsim » root/env0/test
+```
+

--- a/tools/hangar/__snapshots__/test_corpus/static_members.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/static_members.w_compile_tf-aws.md
@@ -2,7 +2,7 @@
 
 ## clients/Foo.inflight.js
 ```js
-module.exports = function($globals) {
+module.exports = function() {
   class  Foo {
     constructor({ instance_field, stateful }) {
       this.instance_field = instance_field;

--- a/tools/hangar/__snapshots__/test_corpus/static_members.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/static_members.w_compile_tf-aws.md
@@ -2,20 +2,20 @@
 
 ## clients/Foo.inflight.js
 ```js
-class  Foo {
-  constructor({ instance_field, stateful }) {
-    this.instance_field = instance_field;
-    this.stateful = stateful;
-  }
-  static async get_123()  {
-    {
-      return 123;
+module.exports = function($globals) {
+  class  Foo {
+    constructor({ instance_field, stateful }) {
+      this.instance_field = instance_field;
+      this.stateful = stateful;
+    }
+    static async get_123()  {
+      {
+        return 123;
+      }
     }
   }
+  return Foo;
 }
-exports.Foo = Foo;
-exports.setupGlobals = function(globals) {
-};
 
 ```
 
@@ -166,8 +166,8 @@ class $Root extends $stdlib.std.Resource {
         const self_client_path = "./clients/Foo.inflight.js".replace(/\\/g, "/");
         return $stdlib.core.NodeJsCode.fromInline(`
           (await (async () => {
-            const mod = require("${self_client_path}")
-            const client = new mod.Foo({
+            const Foo = require("${self_client_path}")({});
+            const client = new Foo({
               instance_field: ${instance_field_client},
               stateful: ${stateful_client},
             });

--- a/tools/hangar/__snapshots__/test_corpus/static_members.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/static_members.w_compile_tf-aws.md
@@ -14,6 +14,8 @@ class  Foo {
   }
 }
 exports.Foo = Foo;
+exports.setupGlobals = function(globals) {
+};
 
 ```
 
@@ -164,12 +166,13 @@ class $Root extends $stdlib.std.Resource {
         const self_client_path = "./clients/Foo.inflight.js".replace(/\\/g, "/");
         return $stdlib.core.NodeJsCode.fromInline(`
           (await (async () => {
-            const tmp = new (require("${self_client_path}")).Foo({
+            const mod = require("${self_client_path}")
+            const client = new mod.Foo({
               instance_field: ${instance_field_client},
               stateful: ${stateful_client},
             });
-            if (tmp.$inflight_init) { await tmp.$inflight_init(); }
-            return tmp;
+            if (client.$inflight_init) { await client.$inflight_init(); }
+            return client;
           })())
         `);
       }

--- a/tools/hangar/__snapshots__/test_corpus/structs.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/structs.w_compile_tf-aws.md
@@ -2,20 +2,20 @@
 
 ## clients/Foo.inflight.js
 ```js
-class  Foo {
-  constructor({ data, stateful }) {
-    this.data = data;
-    this.stateful = stateful;
-  }
-  async get_stuff()  {
-    {
-      return this.data.field0;
+module.exports = function($globals) {
+  class  Foo {
+    constructor({ data, stateful }) {
+      this.data = data;
+      this.stateful = stateful;
+    }
+    async get_stuff()  {
+      {
+        return this.data.field0;
+      }
     }
   }
+  return Foo;
 }
-exports.Foo = Foo;
-exports.setupGlobals = function(globals) {
-};
 
 ```
 
@@ -72,8 +72,8 @@ class $Root extends $stdlib.std.Resource {
         const self_client_path = "./clients/Foo.inflight.js".replace(/\\/g, "/");
         return $stdlib.core.NodeJsCode.fromInline(`
           (await (async () => {
-            const mod = require("${self_client_path}")
-            const client = new mod.Foo({
+            const Foo = require("${self_client_path}")({});
+            const client = new Foo({
               data: ${data_client},
               stateful: ${stateful_client},
             });

--- a/tools/hangar/__snapshots__/test_corpus/structs.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/structs.w_compile_tf-aws.md
@@ -14,6 +14,8 @@ class  Foo {
   }
 }
 exports.Foo = Foo;
+exports.setupGlobals = function(globals) {
+};
 
 ```
 
@@ -70,12 +72,13 @@ class $Root extends $stdlib.std.Resource {
         const self_client_path = "./clients/Foo.inflight.js".replace(/\\/g, "/");
         return $stdlib.core.NodeJsCode.fromInline(`
           (await (async () => {
-            const tmp = new (require("${self_client_path}")).Foo({
+            const mod = require("${self_client_path}")
+            const client = new mod.Foo({
               data: ${data_client},
               stateful: ${stateful_client},
             });
-            if (tmp.$inflight_init) { await tmp.$inflight_init(); }
-            return tmp;
+            if (client.$inflight_init) { await client.$inflight_init(); }
+            return client;
           })())
         `);
       }

--- a/tools/hangar/__snapshots__/test_corpus/structs.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/structs.w_compile_tf-aws.md
@@ -2,7 +2,7 @@
 
 ## clients/Foo.inflight.js
 ```js
-module.exports = function($globals) {
+module.exports = function() {
   class  Foo {
     constructor({ data, stateful }) {
       this.data = data;

--- a/tools/hangar/__snapshots__/test_corpus/symbol_shadow.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/symbol_shadow.w_compile_tf-aws.md
@@ -8,6 +8,8 @@ class  A {
   }
 }
 exports.A = A;
+exports.setupGlobals = function(globals) {
+};
 
 ```
 
@@ -357,11 +359,12 @@ class $Root extends $stdlib.std.Resource {
         const self_client_path = "./clients/A.inflight.js".replace(/\\/g, "/");
         return $stdlib.core.NodeJsCode.fromInline(`
           (await (async () => {
-            const tmp = new (require("${self_client_path}")).A({
+            const mod = require("${self_client_path}")
+            const client = new mod.A({
               stateful: ${stateful_client},
             });
-            if (tmp.$inflight_init) { await tmp.$inflight_init(); }
-            return tmp;
+            if (client.$inflight_init) { await client.$inflight_init(); }
+            return client;
           })())
         `);
       }

--- a/tools/hangar/__snapshots__/test_corpus/symbol_shadow.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/symbol_shadow.w_compile_tf-aws.md
@@ -2,14 +2,14 @@
 
 ## clients/A.inflight.js
 ```js
-class  A {
-  constructor({ stateful }) {
-    this.stateful = stateful;
+module.exports = function($globals) {
+  class  A {
+    constructor({ stateful }) {
+      this.stateful = stateful;
+    }
   }
+  return A;
 }
-exports.A = A;
-exports.setupGlobals = function(globals) {
-};
 
 ```
 
@@ -359,8 +359,8 @@ class $Root extends $stdlib.std.Resource {
         const self_client_path = "./clients/A.inflight.js".replace(/\\/g, "/");
         return $stdlib.core.NodeJsCode.fromInline(`
           (await (async () => {
-            const mod = require("${self_client_path}")
-            const client = new mod.A({
+            const A = require("${self_client_path}")({});
+            const client = new A({
               stateful: ${stateful_client},
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/tools/hangar/__snapshots__/test_corpus/symbol_shadow.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/symbol_shadow.w_compile_tf-aws.md
@@ -2,7 +2,7 @@
 
 ## clients/A.inflight.js
 ```js
-module.exports = function($globals) {
+module.exports = function() {
   class  A {
     constructor({ stateful }) {
       this.stateful = stateful;


### PR DESCRIPTION
Re-roll of #2211 with some modifications so the implementation keeps inflight clients in their own separate files. I went through a couple iterations to get to this point, here were the potential problems I found with them:
- as @eladb called out, inlining inflight clients into `preflight.js` as implemented in #2205 seems like it could be problematic if clients need to reference other inflight clients (for example, to access static methods)
- another idea I had was to put all inflight clients all in a single file (`preflight.js` and `inflight.js` - cute, right?) - the problem with this is that global variables could conflict with each other, and there might be scoping issues if/when the user starts defining resources at places besides the top level of a wing file

original description:

---

This pull request adds support for capturing [free variables](https://en.wikipedia.org/wiki/Free_variables_and_bound_variables) in resource classes, a feature that allows Wing to generate more expressive code for inflight clients. It implements a new visitor, modifies the code generation, and adds a new test case and a snapshot to verify the functionality.

The approach I've taken differs from the solution outlined in #1447. The original issue suggests that we transform free variables into resource fields. I saw some risks with this approach since all usages of the global value inside inflight constructors and inflight methods would also need to be transformed (for example, changing `global_bucket` to `this.global_bucket`), and tracking the list of these mappings so that they only apply to inflight code, and preventing name conflicts, could be tricky.

Instead, this PR augments jsification so that free variables are effectively also emitted as free variables in the JavaScript client code. 

I'm not sure this approach is any better, but it seems to work just as well for a number of cases I've tried.

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.