### PR TITLE
fix: preopen tmp folder

### DIFF
--- a/apps/wing/src/wingc.ts
+++ b/apps/wing/src/wingc.ts
@@ -114,7 +114,8 @@ export async function load(options: WingCompilerLoadOptions) {
       const fullPath = `/${file}`;
       if (
         !file.startsWith(".") &&
-        (await fs.promises.lstat(fullPath)).isDirectory()
+        // include directories and symlinks to directories
+        (await fs.promises.stat(fullPath)).isDirectory()
       ) {
         try {
           await fs.promises.access(fullPath, fs.constants.R_OK | fs.constants.F_OK);


### PR DESCRIPTION
Preopen symbolic links to directories to open`/tmp`

Fixes #2321 

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.