### PR TITLE
chore(sdk)!: remove stateful field

### DIFF
--- a/docs/04-reference/wingsdk-api.md
+++ b/docs/04-reference/wingsdk-api.md
@@ -311,7 +311,6 @@ Options for the route.
 | --- | --- | --- |
 | <code><a href="#@winglang/sdk.cloud.Api.property.node">node</a></code> | <code>constructs.Node</code> | The tree node. |
 | <code><a href="#@winglang/sdk.cloud.Api.property.display">display</a></code> | <code><a href="#@winglang/sdk.std.Display">Display</a></code> | Information on how to display a resource in the UI. |
-| <code><a href="#@winglang/sdk.cloud.Api.property.stateful">stateful</a></code> | <code>bool</code> | Whether a resource is stateful, i.e. it stores information that is not defined by your application. |
 | <code><a href="#@winglang/sdk.cloud.Api.property.url">url</a></code> | <code>str</code> | The base URL of the API endpoint. |
 
 ---
@@ -337,22 +336,6 @@ display: Display;
 - *Type:* <a href="#@winglang/sdk.std.Display">Display</a>
 
 Information on how to display a resource in the UI.
-
----
-
-##### `stateful`<sup>Required</sup> <a name="stateful" id="@winglang/sdk.cloud.Api.property.stateful"></a>
-
-```wing
-stateful: bool;
-```
-
-- *Type:* bool
-
-Whether a resource is stateful, i.e. it stores information that is not defined by your application.
-
-A non-stateful resource does not remember information about past
-transactions or events, and can typically be replaced by a cloud provider
-with a fresh copy without any consequences.
 
 ---
 
@@ -517,7 +500,6 @@ Run an inflight whenever a file is updated in the bucket.
 | --- | --- | --- |
 | <code><a href="#@winglang/sdk.cloud.Bucket.property.node">node</a></code> | <code>constructs.Node</code> | The tree node. |
 | <code><a href="#@winglang/sdk.cloud.Bucket.property.display">display</a></code> | <code><a href="#@winglang/sdk.std.Display">Display</a></code> | Information on how to display a resource in the UI. |
-| <code><a href="#@winglang/sdk.cloud.Bucket.property.stateful">stateful</a></code> | <code>bool</code> | Whether a resource is stateful, i.e. it stores information that is not defined by your application. |
 
 ---
 
@@ -542,22 +524,6 @@ display: Display;
 - *Type:* <a href="#@winglang/sdk.std.Display">Display</a>
 
 Information on how to display a resource in the UI.
-
----
-
-##### `stateful`<sup>Required</sup> <a name="stateful" id="@winglang/sdk.cloud.Bucket.property.stateful"></a>
-
-```wing
-stateful: bool;
-```
-
-- *Type:* bool
-
-Whether a resource is stateful, i.e. it stores information that is not defined by your application.
-
-A non-stateful resource does not remember information about past
-transactions or events, and can typically be replaced by a cloud provider
-with a fresh copy without any consequences.
 
 ---
 
@@ -596,7 +562,6 @@ new cloud.Counter(props?: CounterProps)
 | --- | --- | --- |
 | <code><a href="#@winglang/sdk.cloud.Counter.property.node">node</a></code> | <code>constructs.Node</code> | The tree node. |
 | <code><a href="#@winglang/sdk.cloud.Counter.property.display">display</a></code> | <code><a href="#@winglang/sdk.std.Display">Display</a></code> | Information on how to display a resource in the UI. |
-| <code><a href="#@winglang/sdk.cloud.Counter.property.stateful">stateful</a></code> | <code>bool</code> | Whether a resource is stateful, i.e. it stores information that is not defined by your application. |
 | <code><a href="#@winglang/sdk.cloud.Counter.property.initial">initial</a></code> | <code>num</code> | The initial value of the counter. |
 
 ---
@@ -622,22 +587,6 @@ display: Display;
 - *Type:* <a href="#@winglang/sdk.std.Display">Display</a>
 
 Information on how to display a resource in the UI.
-
----
-
-##### `stateful`<sup>Required</sup> <a name="stateful" id="@winglang/sdk.cloud.Counter.property.stateful"></a>
-
-```wing
-stateful: bool;
-```
-
-- *Type:* bool
-
-Whether a resource is stateful, i.e. it stores information that is not defined by your application.
-
-A non-stateful resource does not remember information about past
-transactions or events, and can typically be replaced by a cloud provider
-with a fresh copy without any consequences.
 
 ---
 
@@ -724,7 +673,6 @@ Add an environment variable to the function.
 | --- | --- | --- |
 | <code><a href="#@winglang/sdk.cloud.Function.property.node">node</a></code> | <code>constructs.Node</code> | The tree node. |
 | <code><a href="#@winglang/sdk.cloud.Function.property.display">display</a></code> | <code><a href="#@winglang/sdk.std.Display">Display</a></code> | Information on how to display a resource in the UI. |
-| <code><a href="#@winglang/sdk.cloud.Function.property.stateful">stateful</a></code> | <code>bool</code> | Whether a resource is stateful, i.e. it stores information that is not defined by your application. |
 | <code><a href="#@winglang/sdk.cloud.Function.property.env">env</a></code> | <code>MutMap&lt;str&gt;</code> | Returns the set of environment variables for this function. |
 
 ---
@@ -750,22 +698,6 @@ display: Display;
 - *Type:* <a href="#@winglang/sdk.std.Display">Display</a>
 
 Information on how to display a resource in the UI.
-
----
-
-##### `stateful`<sup>Required</sup> <a name="stateful" id="@winglang/sdk.cloud.Function.property.stateful"></a>
-
-```wing
-stateful: bool;
-```
-
-- *Type:* bool
-
-Whether a resource is stateful, i.e. it stores information that is not defined by your application.
-
-A non-stateful resource does not remember information about past
-transactions or events, and can typically be replaced by a cloud provider
-with a fresh copy without any consequences.
 
 ---
 
@@ -843,7 +775,6 @@ Create a function to consume messages from this queue.
 | --- | --- | --- |
 | <code><a href="#@winglang/sdk.cloud.Queue.property.node">node</a></code> | <code>constructs.Node</code> | The tree node. |
 | <code><a href="#@winglang/sdk.cloud.Queue.property.display">display</a></code> | <code><a href="#@winglang/sdk.std.Display">Display</a></code> | Information on how to display a resource in the UI. |
-| <code><a href="#@winglang/sdk.cloud.Queue.property.stateful">stateful</a></code> | <code>bool</code> | Whether a resource is stateful, i.e. it stores information that is not defined by your application. |
 
 ---
 
@@ -868,22 +799,6 @@ display: Display;
 - *Type:* <a href="#@winglang/sdk.std.Display">Display</a>
 
 Information on how to display a resource in the UI.
-
----
-
-##### `stateful`<sup>Required</sup> <a name="stateful" id="@winglang/sdk.cloud.Queue.property.stateful"></a>
-
-```wing
-stateful: bool;
-```
-
-- *Type:* bool
-
-Whether a resource is stateful, i.e. it stores information that is not defined by your application.
-
-A non-stateful resource does not remember information about past
-transactions or events, and can typically be replaced by a cloud provider
-with a fresh copy without any consequences.
 
 ---
 
@@ -915,7 +830,6 @@ new std.Resource()
 | --- | --- | --- |
 | <code><a href="#@winglang/sdk.std.Resource.property.node">node</a></code> | <code>constructs.Node</code> | The tree node. |
 | <code><a href="#@winglang/sdk.std.Resource.property.display">display</a></code> | <code><a href="#@winglang/sdk.std.Display">Display</a></code> | Information on how to display a resource in the UI. |
-| <code><a href="#@winglang/sdk.std.Resource.property.stateful">stateful</a></code> | <code>bool</code> | Whether a resource is stateful, i.e. it stores information that is not defined by your application. |
 
 ---
 
@@ -940,22 +854,6 @@ display: Display;
 - *Type:* <a href="#@winglang/sdk.std.Display">Display</a>
 
 Information on how to display a resource in the UI.
-
----
-
-##### `stateful`<sup>Required</sup> <a name="stateful" id="@winglang/sdk.std.Resource.property.stateful"></a>
-
-```wing
-stateful: bool;
-```
-
-- *Type:* bool
-
-Whether a resource is stateful, i.e. it stores information that is not defined by your application.
-
-A non-stateful resource does not remember information about past
-transactions or events, and can typically be replaced by a cloud provider
-with a fresh copy without any consequences.
 
 ---
 
@@ -1021,7 +919,6 @@ Create a function that runs when receiving the scheduled event.
 | --- | --- | --- |
 | <code><a href="#@winglang/sdk.cloud.Schedule.property.node">node</a></code> | <code>constructs.Node</code> | The tree node. |
 | <code><a href="#@winglang/sdk.cloud.Schedule.property.display">display</a></code> | <code><a href="#@winglang/sdk.std.Display">Display</a></code> | Information on how to display a resource in the UI. |
-| <code><a href="#@winglang/sdk.cloud.Schedule.property.stateful">stateful</a></code> | <code>bool</code> | Whether a resource is stateful, i.e. it stores information that is not defined by your application. |
 
 ---
 
@@ -1046,22 +943,6 @@ display: Display;
 - *Type:* <a href="#@winglang/sdk.std.Display">Display</a>
 
 Information on how to display a resource in the UI.
-
----
-
-##### `stateful`<sup>Required</sup> <a name="stateful" id="@winglang/sdk.cloud.Schedule.property.stateful"></a>
-
-```wing
-stateful: bool;
-```
-
-- *Type:* bool
-
-Whether a resource is stateful, i.e. it stores information that is not defined by your application.
-
-A non-stateful resource does not remember information about past
-transactions or events, and can typically be replaced by a cloud provider
-with a fresh copy without any consequences.
 
 ---
 
@@ -1100,7 +981,6 @@ new cloud.Secret(props?: SecretProps)
 | --- | --- | --- |
 | <code><a href="#@winglang/sdk.cloud.Secret.property.node">node</a></code> | <code>constructs.Node</code> | The tree node. |
 | <code><a href="#@winglang/sdk.cloud.Secret.property.display">display</a></code> | <code><a href="#@winglang/sdk.std.Display">Display</a></code> | Information on how to display a resource in the UI. |
-| <code><a href="#@winglang/sdk.cloud.Secret.property.stateful">stateful</a></code> | <code>bool</code> | Whether a resource is stateful, i.e. it stores information that is not defined by your application. |
 
 ---
 
@@ -1125,22 +1005,6 @@ display: Display;
 - *Type:* <a href="#@winglang/sdk.std.Display">Display</a>
 
 Information on how to display a resource in the UI.
-
----
-
-##### `stateful`<sup>Required</sup> <a name="stateful" id="@winglang/sdk.cloud.Secret.property.stateful"></a>
-
-```wing
-stateful: bool;
-```
-
-- *Type:* bool
-
-Whether a resource is stateful, i.e. it stores information that is not defined by your application.
-
-A non-stateful resource does not remember information about past
-transactions or events, and can typically be replaced by a cloud provider
-with a fresh copy without any consequences.
 
 ---
 
@@ -1179,7 +1043,6 @@ new cloud.Table(props: TableProps)
 | --- | --- | --- |
 | <code><a href="#@winglang/sdk.cloud.Table.property.node">node</a></code> | <code>constructs.Node</code> | The tree node. |
 | <code><a href="#@winglang/sdk.cloud.Table.property.display">display</a></code> | <code><a href="#@winglang/sdk.std.Display">Display</a></code> | Information on how to display a resource in the UI. |
-| <code><a href="#@winglang/sdk.cloud.Table.property.stateful">stateful</a></code> | <code>bool</code> | Whether a resource is stateful, i.e. it stores information that is not defined by your application. |
 | <code><a href="#@winglang/sdk.cloud.Table.property.columns">columns</a></code> | <code>MutMap&lt;<a href="#@winglang/sdk.cloud.ColumnType">ColumnType</a>&gt;</code> | Table columns. |
 | <code><a href="#@winglang/sdk.cloud.Table.property.name">name</a></code> | <code>str</code> | Table name. |
 | <code><a href="#@winglang/sdk.cloud.Table.property.primaryKey">primary_key</a></code> | <code>str</code> | Table primary key name. |
@@ -1207,22 +1070,6 @@ display: Display;
 - *Type:* <a href="#@winglang/sdk.std.Display">Display</a>
 
 Information on how to display a resource in the UI.
-
----
-
-##### `stateful`<sup>Required</sup> <a name="stateful" id="@winglang/sdk.cloud.Table.property.stateful"></a>
-
-```wing
-stateful: bool;
-```
-
-- *Type:* bool
-
-Whether a resource is stateful, i.e. it stores information that is not defined by your application.
-
-A non-stateful resource does not remember information about past
-transactions or events, and can typically be replaced by a cloud provider
-with a fresh copy without any consequences.
 
 ---
 
@@ -1341,7 +1188,6 @@ A construct.
 | --- | --- | --- |
 | <code><a href="#@winglang/sdk.cloud.TestRunner.property.node">node</a></code> | <code>constructs.Node</code> | The tree node. |
 | <code><a href="#@winglang/sdk.cloud.TestRunner.property.display">display</a></code> | <code><a href="#@winglang/sdk.std.Display">Display</a></code> | Information on how to display a resource in the UI. |
-| <code><a href="#@winglang/sdk.cloud.TestRunner.property.stateful">stateful</a></code> | <code>bool</code> | Whether a resource is stateful, i.e. it stores information that is not defined by your application. |
 
 ---
 
@@ -1366,22 +1212,6 @@ display: Display;
 - *Type:* <a href="#@winglang/sdk.std.Display">Display</a>
 
 Information on how to display a resource in the UI.
-
----
-
-##### `stateful`<sup>Required</sup> <a name="stateful" id="@winglang/sdk.cloud.TestRunner.property.stateful"></a>
-
-```wing
-stateful: bool;
-```
-
-- *Type:* bool
-
-Whether a resource is stateful, i.e. it stores information that is not defined by your application.
-
-A non-stateful resource does not remember information about past
-transactions or events, and can typically be replaced by a cloud provider
-with a fresh copy without any consequences.
 
 ---
 
@@ -1447,7 +1277,6 @@ Run an inflight whenever an message is published to the topic.
 | --- | --- | --- |
 | <code><a href="#@winglang/sdk.cloud.Topic.property.node">node</a></code> | <code>constructs.Node</code> | The tree node. |
 | <code><a href="#@winglang/sdk.cloud.Topic.property.display">display</a></code> | <code><a href="#@winglang/sdk.std.Display">Display</a></code> | Information on how to display a resource in the UI. |
-| <code><a href="#@winglang/sdk.cloud.Topic.property.stateful">stateful</a></code> | <code>bool</code> | Whether a resource is stateful, i.e. it stores information that is not defined by your application. |
 
 ---
 
@@ -1472,22 +1301,6 @@ display: Display;
 - *Type:* <a href="#@winglang/sdk.std.Display">Display</a>
 
 Information on how to display a resource in the UI.
-
----
-
-##### `stateful`<sup>Required</sup> <a name="stateful" id="@winglang/sdk.cloud.Topic.property.stateful"></a>
-
-```wing
-stateful: bool;
-```
-
-- *Type:* bool
-
-Whether a resource is stateful, i.e. it stores information that is not defined by your application.
-
-A non-stateful resource does not remember information about past
-transactions or events, and can typically be replaced by a cloud provider
-with a fresh copy without any consequences.
 
 ---
 

--- a/libs/wingsdk/API.md
+++ b/libs/wingsdk/API.md
@@ -304,7 +304,6 @@ Options for the route.
 | --- | --- | --- |
 | <code><a href="#@winglang/sdk.cloud.Api.property.node">node</a></code> | <code>constructs.Node</code> | The tree node. |
 | <code><a href="#@winglang/sdk.cloud.Api.property.display">display</a></code> | <code><a href="#@winglang/sdk.std.Display">Display</a></code> | Information on how to display a resource in the UI. |
-| <code><a href="#@winglang/sdk.cloud.Api.property.stateful">stateful</a></code> | <code>bool</code> | Whether a resource is stateful, i.e. it stores information that is not defined by your application. |
 | <code><a href="#@winglang/sdk.cloud.Api.property.url">url</a></code> | <code>str</code> | The base URL of the API endpoint. |
 
 ---
@@ -330,22 +329,6 @@ display: Display;
 - *Type:* <a href="#@winglang/sdk.std.Display">Display</a>
 
 Information on how to display a resource in the UI.
-
----
-
-##### `stateful`<sup>Required</sup> <a name="stateful" id="@winglang/sdk.cloud.Api.property.stateful"></a>
-
-```wing
-stateful: bool;
-```
-
-- *Type:* bool
-
-Whether a resource is stateful, i.e. it stores information that is not defined by your application.
-
-A non-stateful resource does not remember information about past
-transactions or events, and can typically be replaced by a cloud provider
-with a fresh copy without any consequences.
 
 ---
 
@@ -510,7 +493,6 @@ Run an inflight whenever a file is updated in the bucket.
 | --- | --- | --- |
 | <code><a href="#@winglang/sdk.cloud.Bucket.property.node">node</a></code> | <code>constructs.Node</code> | The tree node. |
 | <code><a href="#@winglang/sdk.cloud.Bucket.property.display">display</a></code> | <code><a href="#@winglang/sdk.std.Display">Display</a></code> | Information on how to display a resource in the UI. |
-| <code><a href="#@winglang/sdk.cloud.Bucket.property.stateful">stateful</a></code> | <code>bool</code> | Whether a resource is stateful, i.e. it stores information that is not defined by your application. |
 
 ---
 
@@ -535,22 +517,6 @@ display: Display;
 - *Type:* <a href="#@winglang/sdk.std.Display">Display</a>
 
 Information on how to display a resource in the UI.
-
----
-
-##### `stateful`<sup>Required</sup> <a name="stateful" id="@winglang/sdk.cloud.Bucket.property.stateful"></a>
-
-```wing
-stateful: bool;
-```
-
-- *Type:* bool
-
-Whether a resource is stateful, i.e. it stores information that is not defined by your application.
-
-A non-stateful resource does not remember information about past
-transactions or events, and can typically be replaced by a cloud provider
-with a fresh copy without any consequences.
 
 ---
 
@@ -589,7 +555,6 @@ new cloud.Counter(props?: CounterProps)
 | --- | --- | --- |
 | <code><a href="#@winglang/sdk.cloud.Counter.property.node">node</a></code> | <code>constructs.Node</code> | The tree node. |
 | <code><a href="#@winglang/sdk.cloud.Counter.property.display">display</a></code> | <code><a href="#@winglang/sdk.std.Display">Display</a></code> | Information on how to display a resource in the UI. |
-| <code><a href="#@winglang/sdk.cloud.Counter.property.stateful">stateful</a></code> | <code>bool</code> | Whether a resource is stateful, i.e. it stores information that is not defined by your application. |
 | <code><a href="#@winglang/sdk.cloud.Counter.property.initial">initial</a></code> | <code>num</code> | The initial value of the counter. |
 
 ---
@@ -615,22 +580,6 @@ display: Display;
 - *Type:* <a href="#@winglang/sdk.std.Display">Display</a>
 
 Information on how to display a resource in the UI.
-
----
-
-##### `stateful`<sup>Required</sup> <a name="stateful" id="@winglang/sdk.cloud.Counter.property.stateful"></a>
-
-```wing
-stateful: bool;
-```
-
-- *Type:* bool
-
-Whether a resource is stateful, i.e. it stores information that is not defined by your application.
-
-A non-stateful resource does not remember information about past
-transactions or events, and can typically be replaced by a cloud provider
-with a fresh copy without any consequences.
 
 ---
 
@@ -717,7 +666,6 @@ Add an environment variable to the function.
 | --- | --- | --- |
 | <code><a href="#@winglang/sdk.cloud.Function.property.node">node</a></code> | <code>constructs.Node</code> | The tree node. |
 | <code><a href="#@winglang/sdk.cloud.Function.property.display">display</a></code> | <code><a href="#@winglang/sdk.std.Display">Display</a></code> | Information on how to display a resource in the UI. |
-| <code><a href="#@winglang/sdk.cloud.Function.property.stateful">stateful</a></code> | <code>bool</code> | Whether a resource is stateful, i.e. it stores information that is not defined by your application. |
 | <code><a href="#@winglang/sdk.cloud.Function.property.env">env</a></code> | <code>MutMap&lt;str&gt;</code> | Returns the set of environment variables for this function. |
 
 ---
@@ -743,22 +691,6 @@ display: Display;
 - *Type:* <a href="#@winglang/sdk.std.Display">Display</a>
 
 Information on how to display a resource in the UI.
-
----
-
-##### `stateful`<sup>Required</sup> <a name="stateful" id="@winglang/sdk.cloud.Function.property.stateful"></a>
-
-```wing
-stateful: bool;
-```
-
-- *Type:* bool
-
-Whether a resource is stateful, i.e. it stores information that is not defined by your application.
-
-A non-stateful resource does not remember information about past
-transactions or events, and can typically be replaced by a cloud provider
-with a fresh copy without any consequences.
 
 ---
 
@@ -836,7 +768,6 @@ Create a function to consume messages from this queue.
 | --- | --- | --- |
 | <code><a href="#@winglang/sdk.cloud.Queue.property.node">node</a></code> | <code>constructs.Node</code> | The tree node. |
 | <code><a href="#@winglang/sdk.cloud.Queue.property.display">display</a></code> | <code><a href="#@winglang/sdk.std.Display">Display</a></code> | Information on how to display a resource in the UI. |
-| <code><a href="#@winglang/sdk.cloud.Queue.property.stateful">stateful</a></code> | <code>bool</code> | Whether a resource is stateful, i.e. it stores information that is not defined by your application. |
 
 ---
 
@@ -861,22 +792,6 @@ display: Display;
 - *Type:* <a href="#@winglang/sdk.std.Display">Display</a>
 
 Information on how to display a resource in the UI.
-
----
-
-##### `stateful`<sup>Required</sup> <a name="stateful" id="@winglang/sdk.cloud.Queue.property.stateful"></a>
-
-```wing
-stateful: bool;
-```
-
-- *Type:* bool
-
-Whether a resource is stateful, i.e. it stores information that is not defined by your application.
-
-A non-stateful resource does not remember information about past
-transactions or events, and can typically be replaced by a cloud provider
-with a fresh copy without any consequences.
 
 ---
 
@@ -908,7 +823,6 @@ new std.Resource()
 | --- | --- | --- |
 | <code><a href="#@winglang/sdk.std.Resource.property.node">node</a></code> | <code>constructs.Node</code> | The tree node. |
 | <code><a href="#@winglang/sdk.std.Resource.property.display">display</a></code> | <code><a href="#@winglang/sdk.std.Display">Display</a></code> | Information on how to display a resource in the UI. |
-| <code><a href="#@winglang/sdk.std.Resource.property.stateful">stateful</a></code> | <code>bool</code> | Whether a resource is stateful, i.e. it stores information that is not defined by your application. |
 
 ---
 
@@ -933,22 +847,6 @@ display: Display;
 - *Type:* <a href="#@winglang/sdk.std.Display">Display</a>
 
 Information on how to display a resource in the UI.
-
----
-
-##### `stateful`<sup>Required</sup> <a name="stateful" id="@winglang/sdk.std.Resource.property.stateful"></a>
-
-```wing
-stateful: bool;
-```
-
-- *Type:* bool
-
-Whether a resource is stateful, i.e. it stores information that is not defined by your application.
-
-A non-stateful resource does not remember information about past
-transactions or events, and can typically be replaced by a cloud provider
-with a fresh copy without any consequences.
 
 ---
 
@@ -1014,7 +912,6 @@ Create a function that runs when receiving the scheduled event.
 | --- | --- | --- |
 | <code><a href="#@winglang/sdk.cloud.Schedule.property.node">node</a></code> | <code>constructs.Node</code> | The tree node. |
 | <code><a href="#@winglang/sdk.cloud.Schedule.property.display">display</a></code> | <code><a href="#@winglang/sdk.std.Display">Display</a></code> | Information on how to display a resource in the UI. |
-| <code><a href="#@winglang/sdk.cloud.Schedule.property.stateful">stateful</a></code> | <code>bool</code> | Whether a resource is stateful, i.e. it stores information that is not defined by your application. |
 
 ---
 
@@ -1039,22 +936,6 @@ display: Display;
 - *Type:* <a href="#@winglang/sdk.std.Display">Display</a>
 
 Information on how to display a resource in the UI.
-
----
-
-##### `stateful`<sup>Required</sup> <a name="stateful" id="@winglang/sdk.cloud.Schedule.property.stateful"></a>
-
-```wing
-stateful: bool;
-```
-
-- *Type:* bool
-
-Whether a resource is stateful, i.e. it stores information that is not defined by your application.
-
-A non-stateful resource does not remember information about past
-transactions or events, and can typically be replaced by a cloud provider
-with a fresh copy without any consequences.
 
 ---
 
@@ -1093,7 +974,6 @@ new cloud.Secret(props?: SecretProps)
 | --- | --- | --- |
 | <code><a href="#@winglang/sdk.cloud.Secret.property.node">node</a></code> | <code>constructs.Node</code> | The tree node. |
 | <code><a href="#@winglang/sdk.cloud.Secret.property.display">display</a></code> | <code><a href="#@winglang/sdk.std.Display">Display</a></code> | Information on how to display a resource in the UI. |
-| <code><a href="#@winglang/sdk.cloud.Secret.property.stateful">stateful</a></code> | <code>bool</code> | Whether a resource is stateful, i.e. it stores information that is not defined by your application. |
 
 ---
 
@@ -1118,22 +998,6 @@ display: Display;
 - *Type:* <a href="#@winglang/sdk.std.Display">Display</a>
 
 Information on how to display a resource in the UI.
-
----
-
-##### `stateful`<sup>Required</sup> <a name="stateful" id="@winglang/sdk.cloud.Secret.property.stateful"></a>
-
-```wing
-stateful: bool;
-```
-
-- *Type:* bool
-
-Whether a resource is stateful, i.e. it stores information that is not defined by your application.
-
-A non-stateful resource does not remember information about past
-transactions or events, and can typically be replaced by a cloud provider
-with a fresh copy without any consequences.
 
 ---
 
@@ -1172,7 +1036,6 @@ new cloud.Table(props: TableProps)
 | --- | --- | --- |
 | <code><a href="#@winglang/sdk.cloud.Table.property.node">node</a></code> | <code>constructs.Node</code> | The tree node. |
 | <code><a href="#@winglang/sdk.cloud.Table.property.display">display</a></code> | <code><a href="#@winglang/sdk.std.Display">Display</a></code> | Information on how to display a resource in the UI. |
-| <code><a href="#@winglang/sdk.cloud.Table.property.stateful">stateful</a></code> | <code>bool</code> | Whether a resource is stateful, i.e. it stores information that is not defined by your application. |
 | <code><a href="#@winglang/sdk.cloud.Table.property.columns">columns</a></code> | <code>MutMap&lt;<a href="#@winglang/sdk.cloud.ColumnType">ColumnType</a>&gt;</code> | Table columns. |
 | <code><a href="#@winglang/sdk.cloud.Table.property.name">name</a></code> | <code>str</code> | Table name. |
 | <code><a href="#@winglang/sdk.cloud.Table.property.primaryKey">primary_key</a></code> | <code>str</code> | Table primary key name. |
@@ -1200,22 +1063,6 @@ display: Display;
 - *Type:* <a href="#@winglang/sdk.std.Display">Display</a>
 
 Information on how to display a resource in the UI.
-
----
-
-##### `stateful`<sup>Required</sup> <a name="stateful" id="@winglang/sdk.cloud.Table.property.stateful"></a>
-
-```wing
-stateful: bool;
-```
-
-- *Type:* bool
-
-Whether a resource is stateful, i.e. it stores information that is not defined by your application.
-
-A non-stateful resource does not remember information about past
-transactions or events, and can typically be replaced by a cloud provider
-with a fresh copy without any consequences.
 
 ---
 
@@ -1334,7 +1181,6 @@ A construct.
 | --- | --- | --- |
 | <code><a href="#@winglang/sdk.cloud.TestRunner.property.node">node</a></code> | <code>constructs.Node</code> | The tree node. |
 | <code><a href="#@winglang/sdk.cloud.TestRunner.property.display">display</a></code> | <code><a href="#@winglang/sdk.std.Display">Display</a></code> | Information on how to display a resource in the UI. |
-| <code><a href="#@winglang/sdk.cloud.TestRunner.property.stateful">stateful</a></code> | <code>bool</code> | Whether a resource is stateful, i.e. it stores information that is not defined by your application. |
 
 ---
 
@@ -1359,22 +1205,6 @@ display: Display;
 - *Type:* <a href="#@winglang/sdk.std.Display">Display</a>
 
 Information on how to display a resource in the UI.
-
----
-
-##### `stateful`<sup>Required</sup> <a name="stateful" id="@winglang/sdk.cloud.TestRunner.property.stateful"></a>
-
-```wing
-stateful: bool;
-```
-
-- *Type:* bool
-
-Whether a resource is stateful, i.e. it stores information that is not defined by your application.
-
-A non-stateful resource does not remember information about past
-transactions or events, and can typically be replaced by a cloud provider
-with a fresh copy without any consequences.
 
 ---
 
@@ -1440,7 +1270,6 @@ Run an inflight whenever an message is published to the topic.
 | --- | --- | --- |
 | <code><a href="#@winglang/sdk.cloud.Topic.property.node">node</a></code> | <code>constructs.Node</code> | The tree node. |
 | <code><a href="#@winglang/sdk.cloud.Topic.property.display">display</a></code> | <code><a href="#@winglang/sdk.std.Display">Display</a></code> | Information on how to display a resource in the UI. |
-| <code><a href="#@winglang/sdk.cloud.Topic.property.stateful">stateful</a></code> | <code>bool</code> | Whether a resource is stateful, i.e. it stores information that is not defined by your application. |
 
 ---
 
@@ -1465,22 +1294,6 @@ display: Display;
 - *Type:* <a href="#@winglang/sdk.std.Display">Display</a>
 
 Information on how to display a resource in the UI.
-
----
-
-##### `stateful`<sup>Required</sup> <a name="stateful" id="@winglang/sdk.cloud.Topic.property.stateful"></a>
-
-```wing
-stateful: bool;
-```
-
-- *Type:* bool
-
-Whether a resource is stateful, i.e. it stores information that is not defined by your application.
-
-A non-stateful resource does not remember information about past
-transactions or events, and can typically be replaced by a cloud provider
-with a fresh copy without any consequences.
 
 ---
 

--- a/libs/wingsdk/src/cloud/api.ts
+++ b/libs/wingsdk/src/cloud/api.ts
@@ -43,8 +43,6 @@ export abstract class Api extends Resource {
     return App.of(scope).newAbstract(API_FQN, scope, id, props);
   }
 
-  public readonly stateful = true;
-
   /**
    * The base URL of the API endpoint.
    */

--- a/libs/wingsdk/src/cloud/bucket.ts
+++ b/libs/wingsdk/src/cloud/bucket.ts
@@ -41,7 +41,6 @@ export abstract class Bucket extends Resource {
 
   /** @internal */
   protected readonly _topics = new Map<BucketEventType, Topic>();
-  public readonly stateful = true;
 
   constructor(scope: Construct, id: string, props: BucketProps = {}) {
     super(scope, id);

--- a/libs/wingsdk/src/cloud/counter.ts
+++ b/libs/wingsdk/src/cloud/counter.ts
@@ -36,8 +36,6 @@ export abstract class Counter extends Resource {
     return App.of(scope).newAbstract(COUNTER_FQN, scope, id, props);
   }
 
-  public readonly stateful = true;
-
   /**
    * The initial value of the counter.
    */

--- a/libs/wingsdk/src/cloud/function.ts
+++ b/libs/wingsdk/src/cloud/function.ts
@@ -57,8 +57,6 @@ export abstract class Function extends Resource implements IInflightHost {
 
   private readonly _env: Record<string, string> = {};
 
-  public readonly stateful = false;
-
   /**
    * The path to the entrypoint source code of the function.
    */

--- a/libs/wingsdk/src/cloud/queue.ts
+++ b/libs/wingsdk/src/cloud/queue.ts
@@ -50,7 +50,6 @@ export abstract class Queue extends Resource {
     return App.of(scope).newAbstract(QUEUE_FQN, scope, id, props);
   }
 
-  public readonly stateful = true;
   constructor(scope: Construct, id: string, props: QueueProps = {}) {
     super(scope, id);
 

--- a/libs/wingsdk/src/cloud/schedule.ts
+++ b/libs/wingsdk/src/cloud/schedule.ts
@@ -47,7 +47,6 @@ export abstract class Schedule extends Resource {
     return App.of(scope).newAbstract(SCHEDULE_FQN, scope, id, props);
   }
 
-  public readonly stateful = true;
   constructor(scope: Construct, id: string, props: ScheduleProps = {}) {
     super(scope, id);
 

--- a/libs/wingsdk/src/cloud/secret.ts
+++ b/libs/wingsdk/src/cloud/secret.ts
@@ -42,8 +42,6 @@ export abstract class Secret extends Resource {
     return App.of(scope).newAbstract(SECRET_FQN, scope, id, props);
   }
 
-  public readonly stateful = true;
-
   constructor(scope: Construct, id: string, props: SecretProps = {}) {
     super(scope, id);
 

--- a/libs/wingsdk/src/cloud/table.ts
+++ b/libs/wingsdk/src/cloud/table.ts
@@ -76,7 +76,6 @@ export abstract class Table extends Resource {
    */
   public readonly columns: { [key: string]: ColumnType };
 
-  public readonly stateful = true;
   constructor(scope: Construct, id: string, props: TableProps) {
     super(scope, id);
 

--- a/libs/wingsdk/src/cloud/test-runner.ts
+++ b/libs/wingsdk/src/cloud/test-runner.ts
@@ -42,8 +42,6 @@ export abstract class TestRunner extends Resource {
     return regex.test(c.node.path);
   }
 
-  public readonly stateful = false;
-
   constructor(scope: Construct, id: string, props: TestRunnerProps = {}) {
     super(scope, id);
 

--- a/libs/wingsdk/src/cloud/topic.ts
+++ b/libs/wingsdk/src/cloud/topic.ts
@@ -29,8 +29,6 @@ export abstract class Topic extends Resource {
     return App.of(scope).newAbstract(TOPIC_FQN, scope, id, props);
   }
 
-  public readonly stateful = true;
-
   constructor(scope: Construct, id: string, props: TopicProps = {}) {
     super(scope, id);
 

--- a/libs/wingsdk/src/core/attributes.ts
+++ b/libs/wingsdk/src/core/attributes.ts
@@ -1,2 +1,1 @@
-export const WING_ATTRIBUTE_RESOURCE_STATEFUL = "wing:resource:stateful";
 export const WING_ATTRIBUTE_RESOURCE_CONNECTIONS = "wing:resource:connections";

--- a/libs/wingsdk/src/core/internal.ts
+++ b/libs/wingsdk/src/core/internal.ts
@@ -23,8 +23,6 @@ export function makeHandler(
 
   // implements IFunctionHandler
   class Handler extends Resource {
-    public readonly stateful = false;
-
     constructor() {
       super(scope, id);
 

--- a/libs/wingsdk/src/redis/redis.ts
+++ b/libs/wingsdk/src/redis/redis.ts
@@ -22,8 +22,6 @@ export abstract class Redis extends Resource {
     return App.of(scope).newAbstract(REDIS_FQN, scope, id);
   }
 
-  public readonly stateful = false; // TODO: redis persistence
-
   constructor(scope: Construct, id: string) {
     super(scope, id);
 

--- a/libs/wingsdk/src/std/resource.ts
+++ b/libs/wingsdk/src/std/resource.ts
@@ -1,9 +1,6 @@
 import { Construct, IConstruct } from "constructs";
 import { Duration } from ".";
-import {
-  WING_ATTRIBUTE_RESOURCE_CONNECTIONS,
-  WING_ATTRIBUTE_RESOURCE_STATEFUL,
-} from "../core/attributes";
+import { WING_ATTRIBUTE_RESOURCE_CONNECTIONS } from "../core/attributes";
 import { Code } from "../core/inflight";
 import { serializeImmutableData } from "../core/internal";
 import { IInspectable, TreeInspector } from "../core/tree";
@@ -134,16 +131,6 @@ export abstract class Resource extends Construct implements IResource {
    * Information on how to display a resource in the UI.
    */
   public readonly display = new Display();
-
-  /**
-   * Whether a resource is stateful, i.e. it stores information that is not
-   * defined by your application.
-   *
-   * A non-stateful resource does not remember information about past
-   * transactions or events, and can typically be replaced by a cloud provider
-   * with a fresh copy without any consequences.
-   */
-  public readonly stateful: boolean = false;
 
   /**
    * Record that this resource supports the given inflight operation.
@@ -317,7 +304,6 @@ export abstract class Resource extends Construct implements IResource {
    * @internal
    */
   public _inspect(inspector: TreeInspector): void {
-    inspector.addAttribute(WING_ATTRIBUTE_RESOURCE_STATEFUL, this.stateful);
     inspector.addAttribute(
       WING_ATTRIBUTE_RESOURCE_CONNECTIONS,
       this._connections.map((conn) => ({

--- a/libs/wingsdk/src/target-sim/event-mapping.ts
+++ b/libs/wingsdk/src/target-sim/event-mapping.ts
@@ -45,7 +45,6 @@ export interface EventMappingProps {
  * @inflight `@winglang/sdk.sim.EventMapping`
  */
 export class EventMapping extends Resource implements ISimulatorResource {
-  public readonly stateful = true;
   private readonly _eventProps: EventMappingProps;
 
   constructor(scope: Construct, id: string, props: EventMappingProps) {

--- a/libs/wingsdk/src/utils/convert.ts
+++ b/libs/wingsdk/src/utils/convert.ts
@@ -19,7 +19,6 @@ export function convertBetweenHandlers(
   newHandlerClientClassName: string
 ): IResource {
   class NewHandler extends Resource {
-    public readonly stateful = false;
     private readonly handler: IResource;
 
     constructor(theScope: Construct, theId: string, handler: IResource) {

--- a/libs/wingsdk/test/core/__snapshots__/connections.test.ts.snap
+++ b/libs/wingsdk/test/core/__snapshots__/connections.test.ts.snap
@@ -56,7 +56,6 @@ return class Handler {
         "Handler": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -73,7 +72,6 @@ return class Handler {
         "cloud.TestRunner": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -97,7 +95,6 @@ return class Handler {
                 "resource": "root/my_function",
               },
             ],
-            "wing:resource:stateful": true,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -120,7 +117,6 @@ return class Handler {
                 "resource": "root/my_bucket",
               },
             ],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",

--- a/libs/wingsdk/test/target-sim/__snapshots__/api.test.ts.snap
+++ b/libs/wingsdk/test/target-sim/__snapshots__/api.test.ts.snap
@@ -87,7 +87,6 @@ return class Handler {
         "Handler": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -104,7 +103,6 @@ return class Handler {
         "cloud.TestRunner": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -128,13 +126,11 @@ return class Handler {
                 "resource": "root/my_api/OnRequestHandler-e645076f",
               },
             ],
-            "wing:resource:stateful": true,
           },
           "children": {
             "ApiEventMapping-e645076f": {
               "attributes": {
                 "wing:resource:connections": [],
-                "wing:resource:stateful": true,
               },
               "constructInfo": {
                 "fqn": "constructs.Construct",
@@ -156,7 +152,6 @@ return class Handler {
                     "resource": "root/my_api",
                   },
                 ],
-                "wing:resource:stateful": false,
               },
               "constructInfo": {
                 "fqn": "constructs.Construct",
@@ -281,7 +276,6 @@ return class Handler {
         "Handler": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -298,7 +292,6 @@ return class Handler {
         "cloud.TestRunner": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -322,13 +315,11 @@ return class Handler {
                 "resource": "root/my_api/OnRequestHandler-e645076f",
               },
             ],
-            "wing:resource:stateful": true,
           },
           "children": {
             "ApiEventMapping-e645076f": {
               "attributes": {
                 "wing:resource:connections": [],
-                "wing:resource:stateful": true,
               },
               "constructInfo": {
                 "fqn": "constructs.Construct",
@@ -350,7 +341,6 @@ return class Handler {
                     "resource": "root/my_api",
                   },
                 ],
-                "wing:resource:stateful": false,
               },
               "constructInfo": {
                 "fqn": "constructs.Construct",
@@ -475,7 +465,6 @@ return class Handler {
         "Handler": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -492,7 +481,6 @@ return class Handler {
         "cloud.TestRunner": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -516,13 +504,11 @@ return class Handler {
                 "resource": "root/my_api/OnRequestHandler-e645076f",
               },
             ],
-            "wing:resource:stateful": true,
           },
           "children": {
             "ApiEventMapping-e645076f": {
               "attributes": {
                 "wing:resource:connections": [],
-                "wing:resource:stateful": true,
               },
               "constructInfo": {
                 "fqn": "constructs.Construct",
@@ -544,7 +530,6 @@ return class Handler {
                     "resource": "root/my_api",
                   },
                 ],
-                "wing:resource:stateful": false,
               },
               "constructInfo": {
                 "fqn": "constructs.Construct",
@@ -711,7 +696,6 @@ return class Handler {
         "Handler": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -728,7 +712,6 @@ return class Handler {
         "cloud.TestRunner": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -788,13 +771,11 @@ return class Handler {
                 "resource": "root/my_api/OnRequestHandler-e645076f",
               },
             ],
-            "wing:resource:stateful": true,
           },
           "children": {
             "ApiEventMapping-e645076f": {
               "attributes": {
                 "wing:resource:connections": [],
-                "wing:resource:stateful": true,
               },
               "constructInfo": {
                 "fqn": "constructs.Construct",
@@ -852,7 +833,6 @@ return class Handler {
                     "resource": "root/my_api",
                   },
                 ],
-                "wing:resource:stateful": false,
               },
               "constructInfo": {
                 "fqn": "constructs.Construct",
@@ -963,7 +943,6 @@ return class Handler {
         "Handler": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -980,7 +959,6 @@ return class Handler {
         "cloud.TestRunner": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -1004,13 +982,11 @@ return class Handler {
                 "resource": "root/my_api/OnRequestHandler-e645076f",
               },
             ],
-            "wing:resource:stateful": true,
           },
           "children": {
             "ApiEventMapping-e645076f": {
               "attributes": {
                 "wing:resource:connections": [],
-                "wing:resource:stateful": true,
               },
               "constructInfo": {
                 "fqn": "constructs.Construct",
@@ -1032,7 +1008,6 @@ return class Handler {
                     "resource": "root/my_api",
                   },
                 ],
-                "wing:resource:stateful": false,
               },
               "constructInfo": {
                 "fqn": "constructs.Construct",
@@ -1206,7 +1181,6 @@ return class Handler {
         "Handler1": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -1223,7 +1197,6 @@ return class Handler {
         "Handler2": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -1240,7 +1213,6 @@ return class Handler {
         "cloud.TestRunner": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -1270,13 +1242,11 @@ return class Handler {
                 "resource": "root/my_api/OnRequestHandler-f6d90a7f",
               },
             ],
-            "wing:resource:stateful": true,
           },
           "children": {
             "ApiEventMapping-7c48a9f0": {
               "attributes": {
                 "wing:resource:connections": [],
-                "wing:resource:stateful": true,
               },
               "constructInfo": {
                 "fqn": "constructs.Construct",
@@ -1291,7 +1261,6 @@ return class Handler {
             "ApiEventMapping-f6d90a7f": {
               "attributes": {
                 "wing:resource:connections": [],
-                "wing:resource:stateful": true,
               },
               "constructInfo": {
                 "fqn": "constructs.Construct",
@@ -1313,7 +1282,6 @@ return class Handler {
                     "resource": "root/my_api",
                   },
                 ],
-                "wing:resource:stateful": false,
               },
               "constructInfo": {
                 "fqn": "constructs.Construct",
@@ -1336,7 +1304,6 @@ return class Handler {
                     "resource": "root/my_api",
                   },
                 ],
-                "wing:resource:stateful": false,
               },
               "constructInfo": {
                 "fqn": "constructs.Construct",
@@ -1510,7 +1477,6 @@ return class Handler {
         "Handler1": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -1527,7 +1493,6 @@ return class Handler {
         "Handler2": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -1544,7 +1509,6 @@ return class Handler {
         "cloud.TestRunner": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -1574,13 +1538,11 @@ return class Handler {
                 "resource": "root/my_api/OnRequestHandler-f6d90a7f",
               },
             ],
-            "wing:resource:stateful": true,
           },
           "children": {
             "ApiEventMapping-7c48a9f0": {
               "attributes": {
                 "wing:resource:connections": [],
-                "wing:resource:stateful": true,
               },
               "constructInfo": {
                 "fqn": "constructs.Construct",
@@ -1595,7 +1557,6 @@ return class Handler {
             "ApiEventMapping-f6d90a7f": {
               "attributes": {
                 "wing:resource:connections": [],
-                "wing:resource:stateful": true,
               },
               "constructInfo": {
                 "fqn": "constructs.Construct",
@@ -1617,7 +1578,6 @@ return class Handler {
                     "resource": "root/my_api",
                   },
                 ],
-                "wing:resource:stateful": false,
               },
               "constructInfo": {
                 "fqn": "constructs.Construct",
@@ -1640,7 +1600,6 @@ return class Handler {
                     "resource": "root/my_api",
                   },
                 ],
-                "wing:resource:stateful": false,
               },
               "constructInfo": {
                 "fqn": "constructs.Construct",
@@ -1765,7 +1724,6 @@ return class Handler {
         "Handler": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -1782,7 +1740,6 @@ return class Handler {
         "cloud.TestRunner": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -1806,13 +1763,11 @@ return class Handler {
                 "resource": "root/my_api/OnRequestHandler-e645076f",
               },
             ],
-            "wing:resource:stateful": true,
           },
           "children": {
             "ApiEventMapping-e645076f": {
               "attributes": {
                 "wing:resource:connections": [],
-                "wing:resource:stateful": true,
               },
               "constructInfo": {
                 "fqn": "constructs.Construct",
@@ -1834,7 +1789,6 @@ return class Handler {
                     "resource": "root/my_api",
                   },
                 ],
-                "wing:resource:stateful": false,
               },
               "constructInfo": {
                 "fqn": "constructs.Construct",
@@ -1959,7 +1913,6 @@ return class Handler {
         "Handler": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -1976,7 +1929,6 @@ return class Handler {
         "cloud.TestRunner": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -2000,13 +1952,11 @@ return class Handler {
                 "resource": "root/my_api/OnRequestHandler-e645076f",
               },
             ],
-            "wing:resource:stateful": true,
           },
           "children": {
             "ApiEventMapping-e645076f": {
               "attributes": {
                 "wing:resource:connections": [],
-                "wing:resource:stateful": true,
               },
               "constructInfo": {
                 "fqn": "constructs.Construct",
@@ -2028,7 +1978,6 @@ return class Handler {
                     "resource": "root/my_api",
                   },
                 ],
-                "wing:resource:stateful": false,
               },
               "constructInfo": {
                 "fqn": "constructs.Construct",
@@ -2153,7 +2102,6 @@ return class Handler {
         "Handler": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -2170,7 +2118,6 @@ return class Handler {
         "cloud.TestRunner": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -2194,13 +2141,11 @@ return class Handler {
                 "resource": "root/my_api/OnRequestHandler-e645076f",
               },
             ],
-            "wing:resource:stateful": true,
           },
           "children": {
             "ApiEventMapping-e645076f": {
               "attributes": {
                 "wing:resource:connections": [],
-                "wing:resource:stateful": true,
               },
               "constructInfo": {
                 "fqn": "constructs.Construct",
@@ -2222,7 +2167,6 @@ return class Handler {
                     "resource": "root/my_api",
                   },
                 ],
-                "wing:resource:stateful": false,
               },
               "constructInfo": {
                 "fqn": "constructs.Construct",
@@ -2347,7 +2291,6 @@ return class Handler {
         "Handler": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -2364,7 +2307,6 @@ return class Handler {
         "cloud.TestRunner": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -2388,13 +2330,11 @@ return class Handler {
                 "resource": "root/my_api/OnRequestHandler-e645076f",
               },
             ],
-            "wing:resource:stateful": true,
           },
           "children": {
             "ApiEventMapping-e645076f": {
               "attributes": {
                 "wing:resource:connections": [],
-                "wing:resource:stateful": true,
               },
               "constructInfo": {
                 "fqn": "constructs.Construct",
@@ -2416,7 +2356,6 @@ return class Handler {
                     "resource": "root/my_api",
                   },
                 ],
-                "wing:resource:stateful": false,
               },
               "constructInfo": {
                 "fqn": "constructs.Construct",
@@ -2481,7 +2420,6 @@ exports[`create an api 1`] = `
         "cloud.TestRunner": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -2498,7 +2436,6 @@ exports[`create an api 1`] = `
         "my_api": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": true,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",

--- a/libs/wingsdk/test/target-sim/__snapshots__/bucket.test.ts.snap
+++ b/libs/wingsdk/test/target-sim/__snapshots__/bucket.test.ts.snap
@@ -73,7 +73,6 @@ exports[`can add object in preflight 2`] = `
         "cloud.TestRunner": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -90,7 +89,6 @@ exports[`can add object in preflight 2`] = `
         "my_bucket": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": true,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -147,7 +145,6 @@ exports[`create a bucket 1`] = `
         "cloud.TestRunner": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -164,7 +161,6 @@ exports[`create a bucket 1`] = `
         "my_bucket": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": true,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -231,7 +227,6 @@ exports[`get invalid object throws an error 2`] = `
         "cloud.TestRunner": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -248,7 +243,6 @@ exports[`get invalid object throws an error 2`] = `
         "my_bucket": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": true,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -362,7 +356,6 @@ exports[`put json objects from bucket 2`] = `
         "cloud.TestRunner": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -379,7 +372,6 @@ exports[`put json objects from bucket 2`] = `
         "my_bucket": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": true,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",

--- a/libs/wingsdk/test/target-sim/__snapshots__/counter.test.ts.snap
+++ b/libs/wingsdk/test/target-sim/__snapshots__/counter.test.ts.snap
@@ -29,7 +29,6 @@ exports[`create a counter 1`] = `
         "cloud.TestRunner": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -46,7 +45,6 @@ exports[`create a counter 1`] = `
         "my_counter": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": true,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -114,7 +112,6 @@ exports[`dec 2`] = `
         "cloud.TestRunner": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -131,7 +128,6 @@ exports[`dec 2`] = `
         "my_counter": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": true,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -199,7 +195,6 @@ exports[`inc 2`] = `
         "cloud.TestRunner": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -216,7 +211,6 @@ exports[`inc 2`] = `
         "my_counter": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": true,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -282,7 +276,6 @@ exports[`reset with initial value 2`] = `
         "cloud.TestRunner": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -299,7 +292,6 @@ exports[`reset with initial value 2`] = `
         "my_counter": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": true,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -365,7 +357,6 @@ exports[`reset without initial value 2`] = `
         "cloud.TestRunner": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -382,7 +373,6 @@ exports[`reset without initial value 2`] = `
         "my_counter": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": true,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",

--- a/libs/wingsdk/test/target-sim/__snapshots__/file-counter.test.ts.snap
+++ b/libs/wingsdk/test/target-sim/__snapshots__/file-counter.test.ts.snap
@@ -115,7 +115,6 @@ bucket: (function(env) {
                     "resource": "root/HelloWorld/Queue-AddConsumer-401ee792",
                   },
                 ],
-                "wing:resource:stateful": true,
               },
               "constructInfo": {
                 "fqn": "constructs.Construct",
@@ -138,7 +137,6 @@ bucket: (function(env) {
                     "resource": "root/HelloWorld/Queue-AddConsumer-401ee792",
                   },
                 ],
-                "wing:resource:stateful": true,
               },
               "constructInfo": {
                 "fqn": "constructs.Construct",
@@ -161,7 +159,6 @@ bucket: (function(env) {
                     "resource": "root/HelloWorld/Queue-AddConsumer-401ee792",
                   },
                 ],
-                "wing:resource:stateful": false,
               },
               "constructInfo": {
                 "fqn": "constructs.Construct",
@@ -185,13 +182,11 @@ bucket: (function(env) {
                     "resource": "root/HelloWorld/Queue-AddConsumer-401ee792",
                   },
                 ],
-                "wing:resource:stateful": true,
               },
               "children": {
                 "Queue-QueueEventMapping-401ee792": {
                   "attributes": {
                     "wing:resource:connections": [],
-                    "wing:resource:stateful": true,
                   },
                   "constructInfo": {
                     "fqn": "constructs.Construct",
@@ -243,7 +238,6 @@ bucket: (function(env) {
                     "resource": "root/HelloWorld/Queue",
                   },
                 ],
-                "wing:resource:stateful": false,
               },
               "constructInfo": {
                 "fqn": "constructs.Construct",
@@ -259,7 +253,6 @@ bucket: (function(env) {
             "Queue-AddConsumerHandler-401ee792": {
               "attributes": {
                 "wing:resource:connections": [],
-                "wing:resource:stateful": false,
               },
               "constructInfo": {
                 "fqn": "constructs.Construct",
@@ -282,7 +275,6 @@ bucket: (function(env) {
         "cloud.TestRunner": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",

--- a/libs/wingsdk/test/target-sim/__snapshots__/function.test.ts.snap
+++ b/libs/wingsdk/test/target-sim/__snapshots__/function.test.ts.snap
@@ -61,7 +61,6 @@ async handle(event) {
         "Handler": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -78,7 +77,6 @@ async handle(event) {
         "cloud.TestRunner": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -95,7 +93,6 @@ async handle(event) {
         "my_function": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -190,7 +187,6 @@ async handle(event) {
         "Handler": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -207,7 +203,6 @@ async handle(event) {
         "cloud.TestRunner": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -224,7 +219,6 @@ async handle(event) {
         "my_function": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -319,7 +313,6 @@ async handle(event) {
         "Handler": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -336,7 +329,6 @@ async handle(event) {
         "cloud.TestRunner": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -353,7 +345,6 @@ async handle(event) {
         "my_function": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -450,7 +441,6 @@ async handle(event) {
         "Handler": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -467,7 +457,6 @@ async handle(event) {
         "cloud.TestRunner": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -484,7 +473,6 @@ async handle(event) {
         "my_function": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -569,7 +557,6 @@ async handle() {
         "Handler": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -586,7 +573,6 @@ async handle() {
         "cloud.TestRunner": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -603,7 +589,6 @@ async handle() {
         "my_function": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",

--- a/libs/wingsdk/test/target-sim/__snapshots__/immutable-capture.test.ts.snap
+++ b/libs/wingsdk/test/target-sim/__snapshots__/immutable-capture.test.ts.snap
@@ -51,7 +51,6 @@ my_capture: [\\"hello\\",\\"dude\\"]
         "Function": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -67,7 +66,6 @@ my_capture: [\\"hello\\",\\"dude\\"]
         "cloud.TestRunner": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -84,7 +82,6 @@ my_capture: [\\"hello\\",\\"dude\\"]
         "foo": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -200,7 +197,6 @@ my_buckets: [(function(env) {
         "B1": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": true,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -216,7 +212,6 @@ my_buckets: [(function(env) {
         "B2": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": true,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -232,7 +227,6 @@ my_buckets: [(function(env) {
         "Function": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -248,7 +242,6 @@ my_buckets: [(function(env) {
         "cloud.TestRunner": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -265,7 +258,6 @@ my_buckets: [(function(env) {
         "foo": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -343,7 +335,6 @@ my_array: [{seconds: 600,minutes: 10,hours: 0.16666666666666666,},{seconds: 1200
         "Function": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -359,7 +350,6 @@ my_array: [{seconds: 600,minutes: 10,hours: 0.16666666666666666,},{seconds: 1200
         "cloud.TestRunner": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -376,7 +366,6 @@ my_array: [{seconds: 600,minutes: 10,hours: 0.16666666666666666,},{seconds: 1200
         "foo": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -453,7 +442,6 @@ my_array: [new Map([[\\"foo\\",1],[\\"bar\\",2]]),new Map([[\\"foo\\",3],[\\"bar
         "Function": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -469,7 +457,6 @@ my_array: [new Map([[\\"foo\\",1],[\\"bar\\",2]]),new Map([[\\"foo\\",3],[\\"bar
         "cloud.TestRunner": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -486,7 +473,6 @@ my_array: [new Map([[\\"foo\\",1],[\\"bar\\",2]]),new Map([[\\"foo\\",3],[\\"bar
         "foo": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -562,7 +548,6 @@ my_capture: false
         "Function": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -578,7 +563,6 @@ my_capture: false
         "cloud.TestRunner": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -595,7 +579,6 @@ my_capture: false
         "foo": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -673,7 +656,6 @@ my_capture: {seconds: 7200,minutes: 120,hours: 2,}
         "Function": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -689,7 +671,6 @@ my_capture: {seconds: 7200,minutes: 120,hours: 2,}
         "cloud.TestRunner": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -706,7 +687,6 @@ my_capture: {seconds: 7200,minutes: 120,hours: 2,}
         "foo": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -786,7 +766,6 @@ my_capture: new Map([[\\"foo\\",123],[\\"bar\\",456]])
         "Function": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -802,7 +781,6 @@ my_capture: new Map([[\\"foo\\",123],[\\"bar\\",456]])
         "cloud.TestRunner": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -819,7 +797,6 @@ my_capture: new Map([[\\"foo\\",123],[\\"bar\\",456]])
         "foo": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -901,7 +878,6 @@ my_map: new Map([[\\"foo\\",[1,2]],[\\"bar\\",[3,4]]])
         "Function": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -917,7 +893,6 @@ my_map: new Map([[\\"foo\\",[1,2]],[\\"bar\\",[3,4]]])
         "cloud.TestRunner": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -934,7 +909,6 @@ my_map: new Map([[\\"foo\\",[1,2]],[\\"bar\\",[3,4]]])
         "foo": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -1013,7 +987,6 @@ my_map: new Map([[\\"foo\\",[{seconds: 600,minutes: 10,hours: 0.1666666666666666
         "Function": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -1029,7 +1002,6 @@ my_map: new Map([[\\"foo\\",[{seconds: 600,minutes: 10,hours: 0.1666666666666666
         "cloud.TestRunner": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -1046,7 +1018,6 @@ my_map: new Map([[\\"foo\\",[{seconds: 600,minutes: 10,hours: 0.1666666666666666
         "foo": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -1159,7 +1130,6 @@ my_map: new Map([[\\"foo\\",(function(env) {
         "B1": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": true,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -1175,7 +1145,6 @@ my_map: new Map([[\\"foo\\",(function(env) {
         "B2": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": true,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -1191,7 +1160,6 @@ my_map: new Map([[\\"foo\\",(function(env) {
         "Function": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -1207,7 +1175,6 @@ my_map: new Map([[\\"foo\\",(function(env) {
         "cloud.TestRunner": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -1224,7 +1191,6 @@ my_map: new Map([[\\"foo\\",(function(env) {
         "foo": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -1300,7 +1266,6 @@ my_capture: 123
         "Function": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -1316,7 +1281,6 @@ my_capture: 123
         "cloud.TestRunner": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -1333,7 +1297,6 @@ my_capture: 123
         "foo": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -1412,7 +1375,6 @@ my_capture: new Set([\\"boom\\",\\"bam\\",\\"bang\\"])
         "Function": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -1428,7 +1390,6 @@ my_capture: new Set([\\"boom\\",\\"bam\\",\\"bang\\"])
         "cloud.TestRunner": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -1445,7 +1406,6 @@ my_capture: new Set([\\"boom\\",\\"bam\\",\\"bang\\"])
         "foo": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -1523,7 +1483,6 @@ my_set: new Set([{seconds: 600,minutes: 10,hours: 0.16666666666666666,},{seconds
         "Function": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -1539,7 +1498,6 @@ my_set: new Set([{seconds: 600,minutes: 10,hours: 0.16666666666666666,},{seconds
         "cloud.TestRunner": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -1556,7 +1514,6 @@ my_set: new Set([{seconds: 600,minutes: 10,hours: 0.16666666666666666,},{seconds
         "foo": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -1633,7 +1590,6 @@ my_capture: \\"bam bam bam\\"
         "Function": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -1649,7 +1605,6 @@ my_capture: \\"bam bam bam\\"
         "cloud.TestRunner": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -1666,7 +1621,6 @@ my_capture: \\"bam bam bam\\"
         "foo": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -1745,7 +1699,6 @@ my_capture: {hello: \\"dude\\",world: \\"cup\\",foo: \\"bar\\",}
         "Function": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -1761,7 +1714,6 @@ my_capture: {hello: \\"dude\\",world: \\"cup\\",foo: \\"bar\\",}
         "cloud.TestRunner": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -1778,7 +1730,6 @@ my_capture: {hello: \\"dude\\",world: \\"cup\\",foo: \\"bar\\",}
         "foo": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -1857,7 +1808,6 @@ my_struct: {foo: new Map([[\\"foo\\",1],[\\"bar\\",2]]),bar: new Map([[\\"foo\\"
         "Function": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -1873,7 +1823,6 @@ my_struct: {foo: new Map([[\\"foo\\",1],[\\"bar\\",2]]),bar: new Map([[\\"foo\\"
         "cloud.TestRunner": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -1890,7 +1839,6 @@ my_struct: {foo: new Map([[\\"foo\\",1],[\\"bar\\",2]]),bar: new Map([[\\"foo\\"
         "foo": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -2059,7 +2007,6 @@ my_struct: {bucky: (function(env) {
         "B1": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": true,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -2075,7 +2022,6 @@ my_struct: {bucky: (function(env) {
         "B2": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": true,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -2091,7 +2037,6 @@ my_struct: {bucky: (function(env) {
         "B3": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": true,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -2107,7 +2052,6 @@ my_struct: {bucky: (function(env) {
         "B4": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": true,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -2123,7 +2067,6 @@ my_struct: {bucky: (function(env) {
         "B5": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": true,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -2139,7 +2082,6 @@ my_struct: {bucky: (function(env) {
         "Function": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -2155,7 +2097,6 @@ my_struct: {bucky: (function(env) {
         "cloud.TestRunner": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -2172,7 +2113,6 @@ my_struct: {bucky: (function(env) {
         "foo": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",

--- a/libs/wingsdk/test/target-sim/__snapshots__/queue.test.ts.snap
+++ b/libs/wingsdk/test/target-sim/__snapshots__/queue.test.ts.snap
@@ -31,7 +31,6 @@ exports[`create a queue 1`] = `
         "cloud.TestRunner": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -48,7 +47,6 @@ exports[`create a queue 1`] = `
         "my_queue": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": true,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -171,7 +169,6 @@ async handle(message) {
                 "resource": "root/my_queue-AddConsumer-e645076f",
               },
             ],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -188,7 +185,6 @@ async handle(message) {
         "cloud.TestRunner": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -212,13 +208,11 @@ async handle(message) {
                 "resource": "root/my_queue-AddConsumer-e645076f",
               },
             ],
-            "wing:resource:stateful": true,
           },
           "children": {
             "my_queue-QueueEventMapping-e645076f": {
               "attributes": {
                 "wing:resource:connections": [],
-                "wing:resource:stateful": true,
               },
               "constructInfo": {
                 "fqn": "constructs.Construct",
@@ -258,7 +252,6 @@ async handle(message) {
                 "resource": "root/my_queue",
               },
             ],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -274,7 +267,6 @@ async handle(message) {
         "my_queue-AddConsumerHandler-e645076f": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -396,7 +388,6 @@ async handle(message) {
                 "resource": "root/my_queue-AddConsumer-e645076f",
               },
             ],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -413,7 +404,6 @@ async handle(message) {
         "cloud.TestRunner": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -437,13 +427,11 @@ async handle(message) {
                 "resource": "root/my_queue-AddConsumer-e645076f",
               },
             ],
-            "wing:resource:stateful": true,
           },
           "children": {
             "my_queue-QueueEventMapping-e645076f": {
               "attributes": {
                 "wing:resource:connections": [],
-                "wing:resource:stateful": true,
               },
               "constructInfo": {
                 "fqn": "constructs.Construct",
@@ -483,7 +471,6 @@ async handle(message) {
                 "resource": "root/my_queue",
               },
             ],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -499,7 +486,6 @@ async handle(message) {
         "my_queue-AddConsumerHandler-e645076f": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -625,7 +611,6 @@ async handle(message) {
                 "resource": "root/my_queue-AddConsumer-e645076f",
               },
             ],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -642,7 +627,6 @@ async handle(message) {
         "cloud.TestRunner": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -666,13 +650,11 @@ async handle(message) {
                 "resource": "root/my_queue-AddConsumer-e645076f",
               },
             ],
-            "wing:resource:stateful": true,
           },
           "children": {
             "my_queue-QueueEventMapping-e645076f": {
               "attributes": {
                 "wing:resource:connections": [],
-                "wing:resource:stateful": true,
               },
               "constructInfo": {
                 "fqn": "constructs.Construct",
@@ -712,7 +694,6 @@ async handle(message) {
                 "resource": "root/my_queue",
               },
             ],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -728,7 +709,6 @@ async handle(message) {
         "my_queue-AddConsumerHandler-e645076f": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -798,7 +778,6 @@ exports[`queue batch size of 2, purge the queue 2`] = `
         "cloud.TestRunner": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -815,7 +794,6 @@ exports[`queue batch size of 2, purge the queue 2`] = `
         "my_queue": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": true,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -945,7 +923,6 @@ async handle(message) {
                 "resource": "root/my_queue-AddConsumer-e645076f",
               },
             ],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -962,7 +939,6 @@ async handle(message) {
         "cloud.TestRunner": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -986,13 +962,11 @@ async handle(message) {
                 "resource": "root/my_queue-AddConsumer-e645076f",
               },
             ],
-            "wing:resource:stateful": true,
           },
           "children": {
             "my_queue-QueueEventMapping-e645076f": {
               "attributes": {
                 "wing:resource:connections": [],
-                "wing:resource:stateful": true,
               },
               "constructInfo": {
                 "fqn": "constructs.Construct",
@@ -1032,7 +1006,6 @@ async handle(message) {
                 "resource": "root/my_queue",
               },
             ],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -1048,7 +1021,6 @@ async handle(message) {
         "my_queue-AddConsumerHandler-e645076f": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -1172,7 +1144,6 @@ async handle(message) {
                 "resource": "root/my_queue-AddConsumer-e645076f",
               },
             ],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -1189,7 +1160,6 @@ async handle(message) {
         "cloud.TestRunner": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -1213,13 +1183,11 @@ async handle(message) {
                 "resource": "root/my_queue-AddConsumer-e645076f",
               },
             ],
-            "wing:resource:stateful": true,
           },
           "children": {
             "my_queue-QueueEventMapping-e645076f": {
               "attributes": {
                 "wing:resource:connections": [],
-                "wing:resource:stateful": true,
               },
               "constructInfo": {
                 "fqn": "constructs.Construct",
@@ -1259,7 +1227,6 @@ async handle(message) {
                 "resource": "root/my_queue",
               },
             ],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -1275,7 +1242,6 @@ async handle(message) {
         "my_queue-AddConsumerHandler-e645076f": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",

--- a/libs/wingsdk/test/target-sim/__snapshots__/redis.test.ts.snap
+++ b/libs/wingsdk/test/target-sim/__snapshots__/redis.test.ts.snap
@@ -27,7 +27,6 @@ exports[`create a Redis resource 1`] = `
         "cloud.TestRunner": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -44,7 +43,6 @@ exports[`create a Redis resource 1`] = `
         "my_redis": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",

--- a/libs/wingsdk/test/target-sim/__snapshots__/schedule.test.ts.snap
+++ b/libs/wingsdk/test/target-sim/__snapshots__/schedule.test.ts.snap
@@ -29,7 +29,6 @@ exports[`create a schedule 1`] = `
         "cloud.TestRunner": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -46,7 +45,6 @@ exports[`create a schedule 1`] = `
         "my_schedule": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": true,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -146,7 +144,6 @@ console.log(\\"Hello from schedule!\\");
                 "resource": "root/my_schedule-OnTick-e645076f",
               },
             ],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -163,7 +160,6 @@ console.log(\\"Hello from schedule!\\");
         "cloud.TestRunner": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -187,13 +183,11 @@ console.log(\\"Hello from schedule!\\");
                 "resource": "root/my_schedule-OnTick-e645076f",
               },
             ],
-            "wing:resource:stateful": true,
           },
           "children": {
             "my_schedule-OnTickMapping-e645076f": {
               "attributes": {
                 "wing:resource:connections": [],
-                "wing:resource:stateful": true,
               },
               "constructInfo": {
                 "fqn": "constructs.Construct",
@@ -233,7 +227,6 @@ console.log(\\"Hello from schedule!\\");
                 "resource": "root/my_schedule",
               },
             ],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -249,7 +242,6 @@ console.log(\\"Hello from schedule!\\");
         "my_scheduleOnTickHandlere645076f": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -348,7 +340,6 @@ console.log(\\"Hello from schedule!\\");
                 "resource": "root/my_schedule-OnTick-e645076f",
               },
             ],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -365,7 +356,6 @@ console.log(\\"Hello from schedule!\\");
         "cloud.TestRunner": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -389,13 +379,11 @@ console.log(\\"Hello from schedule!\\");
                 "resource": "root/my_schedule-OnTick-e645076f",
               },
             ],
-            "wing:resource:stateful": true,
           },
           "children": {
             "my_schedule-OnTickMapping-e645076f": {
               "attributes": {
                 "wing:resource:connections": [],
-                "wing:resource:stateful": true,
               },
               "constructInfo": {
                 "fqn": "constructs.Construct",
@@ -435,7 +423,6 @@ console.log(\\"Hello from schedule!\\");
                 "resource": "root/my_schedule",
               },
             ],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -451,7 +438,6 @@ console.log(\\"Hello from schedule!\\");
         "my_scheduleOnTickHandlere645076f": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -550,7 +536,6 @@ console.log(\\"Hello from schedule!\\");
                 "resource": "root/my_schedule-OnTick-e645076f",
               },
             ],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -567,7 +552,6 @@ console.log(\\"Hello from schedule!\\");
         "cloud.TestRunner": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -591,13 +575,11 @@ console.log(\\"Hello from schedule!\\");
                 "resource": "root/my_schedule-OnTick-e645076f",
               },
             ],
-            "wing:resource:stateful": true,
           },
           "children": {
             "my_schedule-OnTickMapping-e645076f": {
               "attributes": {
                 "wing:resource:connections": [],
-                "wing:resource:stateful": true,
               },
               "constructInfo": {
                 "fqn": "constructs.Construct",
@@ -637,7 +619,6 @@ console.log(\\"Hello from schedule!\\");
                 "resource": "root/my_schedule",
               },
             ],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -653,7 +634,6 @@ console.log(\\"Hello from schedule!\\");
         "my_scheduleOnTickHandlere645076f": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",

--- a/libs/wingsdk/test/target-sim/__snapshots__/secret.test.ts.snap
+++ b/libs/wingsdk/test/target-sim/__snapshots__/secret.test.ts.snap
@@ -29,7 +29,6 @@ exports[`create a secret 1`] = `
         "cloud.TestRunner": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -46,7 +45,6 @@ exports[`create a secret 1`] = `
         "my_secret": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": true,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",

--- a/libs/wingsdk/test/target-sim/__snapshots__/table.test.ts.snap
+++ b/libs/wingsdk/test/target-sim/__snapshots__/table.test.ts.snap
@@ -34,7 +34,6 @@ exports[`create a table 1`] = `
         "cloud.TestRunner": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -51,7 +50,6 @@ exports[`create a table 1`] = `
         "my_table": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": true,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -123,7 +121,6 @@ exports[`get row 2`] = `
         "cloud.TestRunner": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -140,7 +137,6 @@ exports[`get row 2`] = `
         "my_table": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": true,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -211,7 +207,6 @@ exports[`insert row 2`] = `
         "cloud.TestRunner": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -228,7 +223,6 @@ exports[`insert row 2`] = `
         "my_table": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": true,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -302,7 +296,6 @@ exports[`list table 2`] = `
         "cloud.TestRunner": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -319,7 +312,6 @@ exports[`list table 2`] = `
         "my_table": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": true,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -394,7 +386,6 @@ exports[`update row 2`] = `
         "cloud.TestRunner": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -411,7 +402,6 @@ exports[`update row 2`] = `
         "my_table": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": true,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",

--- a/libs/wingsdk/test/target-sim/__snapshots__/topic.test.ts.snap
+++ b/libs/wingsdk/test/target-sim/__snapshots__/topic.test.ts.snap
@@ -27,7 +27,6 @@ exports[`create a topic 1`] = `
         "cloud.TestRunner": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": false,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",
@@ -44,7 +43,6 @@ exports[`create a topic 1`] = `
         "my_topic": {
           "attributes": {
             "wing:resource:connections": [],
-            "wing:resource:stateful": true,
           },
           "constructInfo": {
             "fqn": "constructs.Construct",

--- a/libs/wingsdk/test/target-sim/bucket.test.ts
+++ b/libs/wingsdk/test/target-sim/bucket.test.ts
@@ -10,7 +10,6 @@ class InflightBucketEventHandler
   extends Inflight
   implements IBucketEventHandler
 {
-  public stateful: boolean;
   constructor(scope: Construct, id: string) {
     super(scope, id, { code: NodeJsCode.fromInline("null") });
   }

--- a/libs/wingsdk/test/target-tf-aws/__snapshots__/bucket.test.ts.snap
+++ b/libs/wingsdk/test/target-tf-aws/__snapshots__/bucket.test.ts.snap
@@ -55,7 +55,6 @@ exports[`bucket is public 2`] = `
               "cloud.TestRunner": {
                 "attributes": {
                   "wing:resource:connections": [],
-                  "wing:resource:stateful": false,
                 },
                 "children": {
                   "TestFunctionArns": {
@@ -82,7 +81,6 @@ exports[`bucket is public 2`] = `
               "my_bucket": {
                 "attributes": {
                   "wing:resource:connections": [],
-                  "wing:resource:stateful": true,
                 },
                 "children": {
                   "Default": {
@@ -207,7 +205,6 @@ exports[`bucket prefix must be lowercase 2`] = `
               "The-Uncanny.Bucket": {
                 "attributes": {
                   "wing:resource:connections": [],
-                  "wing:resource:stateful": true,
                 },
                 "children": {
                   "Default": {
@@ -257,7 +254,6 @@ exports[`bucket prefix must be lowercase 2`] = `
               "cloud.TestRunner": {
                 "attributes": {
                   "wing:resource:connections": [],
-                  "wing:resource:stateful": false,
                 },
                 "children": {
                   "TestFunctionArns": {
@@ -375,7 +371,6 @@ exports[`bucket prefix valid 2`] = `
               "cloud.TestRunner": {
                 "attributes": {
                   "wing:resource:connections": [],
-                  "wing:resource:stateful": false,
                 },
                 "children": {
                   "TestFunctionArns": {
@@ -402,7 +397,6 @@ exports[`bucket prefix valid 2`] = `
               "the-uncanny.bucket": {
                 "attributes": {
                   "wing:resource:connections": [],
-                  "wing:resource:stateful": true,
                 },
                 "children": {
                   "Default": {
@@ -630,7 +624,6 @@ exports[`bucket with onCreate method 2`] = `
               "cloud.TestRunner": {
                 "attributes": {
                   "wing:resource:connections": [],
-                  "wing:resource:stateful": false,
                 },
                 "children": {
                   "TestFunctionArns": {
@@ -664,7 +657,6 @@ exports[`bucket with onCreate method 2`] = `
                       "resource": "root/Default/my_bucket/my_bucket-on_create-OnMessage-2c90a36b",
                     },
                   ],
-                  "wing:resource:stateful": false,
                 },
                 "constructInfo": {
                   "fqn": "constructs.Construct",
@@ -688,7 +680,6 @@ exports[`bucket with onCreate method 2`] = `
                       "resource": "root/Default/my_bucket/my_bucket-on_create",
                     },
                   ],
-                  "wing:resource:stateful": true,
                 },
                 "children": {
                   "Default": {
@@ -739,7 +730,6 @@ exports[`bucket with onCreate method 2`] = `
                           "resource": "root/Default/my_bucket/my_bucket-on_create-OnMessage-2c90a36b",
                         },
                       ],
-                      "wing:resource:stateful": true,
                     },
                     "children": {
                       "Default": {
@@ -800,7 +790,6 @@ exports[`bucket with onCreate method 2`] = `
                           "resource": "root/Default/my_bucket/my_bucket-on_create",
                         },
                       ],
-                      "wing:resource:stateful": false,
                     },
                     "children": {
                       "Asset": {
@@ -874,7 +863,6 @@ exports[`bucket with onCreate method 2`] = `
                   "my_bucket-on_create-OnMessageHandler-2c90a36b": {
                     "attributes": {
                       "wing:resource:connections": [],
-                      "wing:resource:stateful": false,
                     },
                     "constructInfo": {
                       "fqn": "constructs.Construct",
@@ -908,7 +896,6 @@ exports[`bucket with onCreate method 2`] = `
                       "resource": "root/Default/my_bucket/my_bucket-on_create-OnMessage-2c90a36b",
                     },
                   ],
-                  "wing:resource:stateful": false,
                 },
                 "constructInfo": {
                   "fqn": "constructs.Construct",
@@ -1109,7 +1096,6 @@ exports[`bucket with onDelete method 2`] = `
               "cloud.TestRunner": {
                 "attributes": {
                   "wing:resource:connections": [],
-                  "wing:resource:stateful": false,
                 },
                 "children": {
                   "TestFunctionArns": {
@@ -1143,7 +1129,6 @@ exports[`bucket with onDelete method 2`] = `
                       "resource": "root/Default/my_bucket/my_bucket-on_delete-OnMessage-f22c8a47",
                     },
                   ],
-                  "wing:resource:stateful": false,
                 },
                 "constructInfo": {
                   "fqn": "constructs.Construct",
@@ -1167,7 +1152,6 @@ exports[`bucket with onDelete method 2`] = `
                       "resource": "root/Default/my_bucket/my_bucket-on_delete",
                     },
                   ],
-                  "wing:resource:stateful": true,
                 },
                 "children": {
                   "Default": {
@@ -1218,7 +1202,6 @@ exports[`bucket with onDelete method 2`] = `
                           "resource": "root/Default/my_bucket/my_bucket-on_delete-OnMessage-f22c8a47",
                         },
                       ],
-                      "wing:resource:stateful": true,
                     },
                     "children": {
                       "Default": {
@@ -1279,7 +1262,6 @@ exports[`bucket with onDelete method 2`] = `
                           "resource": "root/Default/my_bucket/my_bucket-on_delete",
                         },
                       ],
-                      "wing:resource:stateful": false,
                     },
                     "children": {
                       "Asset": {
@@ -1353,7 +1335,6 @@ exports[`bucket with onDelete method 2`] = `
                   "my_bucket-on_delete-OnMessageHandler-f22c8a47": {
                     "attributes": {
                       "wing:resource:connections": [],
-                      "wing:resource:stateful": false,
                     },
                     "constructInfo": {
                       "fqn": "constructs.Construct",
@@ -1387,7 +1368,6 @@ exports[`bucket with onDelete method 2`] = `
                       "resource": "root/Default/my_bucket/my_bucket-on_delete-OnMessage-f22c8a47",
                     },
                   ],
-                  "wing:resource:stateful": false,
                 },
                 "constructInfo": {
                   "fqn": "constructs.Construct",
@@ -1722,7 +1702,6 @@ exports[`bucket with onEvent method 2`] = `
               "cloud.TestRunner": {
                 "attributes": {
                   "wing:resource:connections": [],
-                  "wing:resource:stateful": false,
                 },
                 "children": {
                   "TestFunctionArns": {
@@ -1768,7 +1747,6 @@ exports[`bucket with onEvent method 2`] = `
                       "resource": "root/Default/my_bucket/my_bucket-on_delete-OnMessage-f22c8a47",
                     },
                   ],
-                  "wing:resource:stateful": false,
                 },
                 "constructInfo": {
                   "fqn": "constructs.Construct",
@@ -1804,7 +1782,6 @@ exports[`bucket with onEvent method 2`] = `
                       "resource": "root/Default/my_bucket/my_bucket-on_delete",
                     },
                   ],
-                  "wing:resource:stateful": true,
                 },
                 "children": {
                   "Default": {
@@ -1871,7 +1848,6 @@ exports[`bucket with onEvent method 2`] = `
                           "resource": "root/Default/my_bucket/my_bucket-on_create-OnMessage-2c90a36b",
                         },
                       ],
-                      "wing:resource:stateful": true,
                     },
                     "children": {
                       "Default": {
@@ -1932,7 +1908,6 @@ exports[`bucket with onEvent method 2`] = `
                           "resource": "root/Default/my_bucket/my_bucket-on_create",
                         },
                       ],
-                      "wing:resource:stateful": false,
                     },
                     "children": {
                       "Asset": {
@@ -2006,7 +1981,6 @@ exports[`bucket with onEvent method 2`] = `
                   "my_bucket-on_create-OnMessageHandler-2c90a36b": {
                     "attributes": {
                       "wing:resource:connections": [],
-                      "wing:resource:stateful": false,
                     },
                     "constructInfo": {
                       "fqn": "constructs.Construct",
@@ -2034,7 +2008,6 @@ exports[`bucket with onEvent method 2`] = `
                           "resource": "root/Default/my_bucket/my_bucket-on_delete-OnMessage-f22c8a47",
                         },
                       ],
-                      "wing:resource:stateful": true,
                     },
                     "children": {
                       "Default": {
@@ -2095,7 +2068,6 @@ exports[`bucket with onEvent method 2`] = `
                           "resource": "root/Default/my_bucket/my_bucket-on_delete",
                         },
                       ],
-                      "wing:resource:stateful": false,
                     },
                     "children": {
                       "Asset": {
@@ -2169,7 +2141,6 @@ exports[`bucket with onEvent method 2`] = `
                   "my_bucket-on_delete-OnMessageHandler-f22c8a47": {
                     "attributes": {
                       "wing:resource:connections": [],
-                      "wing:resource:stateful": false,
                     },
                     "constructInfo": {
                       "fqn": "constructs.Construct",
@@ -2197,7 +2168,6 @@ exports[`bucket with onEvent method 2`] = `
                           "resource": "root/Default/my_bucket/my_bucket-on_update-OnMessage-32b7a290",
                         },
                       ],
-                      "wing:resource:stateful": true,
                     },
                     "children": {
                       "Default": {
@@ -2258,7 +2228,6 @@ exports[`bucket with onEvent method 2`] = `
                           "resource": "root/Default/my_bucket/my_bucket-on_update",
                         },
                       ],
-                      "wing:resource:stateful": false,
                     },
                     "children": {
                       "Asset": {
@@ -2332,7 +2301,6 @@ exports[`bucket with onEvent method 2`] = `
                   "my_bucket-on_update-OnMessageHandler-32b7a290": {
                     "attributes": {
                       "wing:resource:connections": [],
-                      "wing:resource:stateful": false,
                     },
                     "constructInfo": {
                       "fqn": "constructs.Construct",
@@ -2366,7 +2334,6 @@ exports[`bucket with onEvent method 2`] = `
                       "resource": "root/Default/my_bucket/my_bucket-on_create-OnMessage-2c90a36b",
                     },
                   ],
-                  "wing:resource:stateful": false,
                 },
                 "constructInfo": {
                   "fqn": "constructs.Construct",
@@ -2388,7 +2355,6 @@ exports[`bucket with onEvent method 2`] = `
                       "resource": "root/Default/my_bucket/my_bucket-on_delete-OnMessage-f22c8a47",
                     },
                   ],
-                  "wing:resource:stateful": false,
                 },
                 "constructInfo": {
                   "fqn": "constructs.Construct",
@@ -2410,7 +2376,6 @@ exports[`bucket with onEvent method 2`] = `
                       "resource": "root/Default/my_bucket/my_bucket-on_update-OnMessage-32b7a290",
                     },
                   ],
-                  "wing:resource:stateful": false,
                 },
                 "constructInfo": {
                   "fqn": "constructs.Construct",
@@ -2611,7 +2576,6 @@ exports[`bucket with onUpdate method 2`] = `
               "cloud.TestRunner": {
                 "attributes": {
                   "wing:resource:connections": [],
-                  "wing:resource:stateful": false,
                 },
                 "children": {
                   "TestFunctionArns": {
@@ -2645,7 +2609,6 @@ exports[`bucket with onUpdate method 2`] = `
                       "resource": "root/Default/my_bucket/my_bucket-on_update-OnMessage-32b7a290",
                     },
                   ],
-                  "wing:resource:stateful": false,
                 },
                 "constructInfo": {
                   "fqn": "constructs.Construct",
@@ -2669,7 +2632,6 @@ exports[`bucket with onUpdate method 2`] = `
                       "resource": "root/Default/my_bucket/my_bucket-on_update",
                     },
                   ],
-                  "wing:resource:stateful": true,
                 },
                 "children": {
                   "Default": {
@@ -2720,7 +2682,6 @@ exports[`bucket with onUpdate method 2`] = `
                           "resource": "root/Default/my_bucket/my_bucket-on_update-OnMessage-32b7a290",
                         },
                       ],
-                      "wing:resource:stateful": true,
                     },
                     "children": {
                       "Default": {
@@ -2781,7 +2742,6 @@ exports[`bucket with onUpdate method 2`] = `
                           "resource": "root/Default/my_bucket/my_bucket-on_update",
                         },
                       ],
-                      "wing:resource:stateful": false,
                     },
                     "children": {
                       "Asset": {
@@ -2855,7 +2815,6 @@ exports[`bucket with onUpdate method 2`] = `
                   "my_bucket-on_update-OnMessageHandler-32b7a290": {
                     "attributes": {
                       "wing:resource:connections": [],
-                      "wing:resource:stateful": false,
                     },
                     "constructInfo": {
                       "fqn": "constructs.Construct",
@@ -2889,7 +2848,6 @@ exports[`bucket with onUpdate method 2`] = `
                       "resource": "root/Default/my_bucket/my_bucket-on_update-OnMessage-32b7a290",
                     },
                   ],
-                  "wing:resource:stateful": false,
                 },
                 "constructInfo": {
                   "fqn": "constructs.Construct",
@@ -3004,7 +2962,6 @@ exports[`bucket with two preflight objects 2`] = `
               "cloud.TestRunner": {
                 "attributes": {
                   "wing:resource:connections": [],
-                  "wing:resource:stateful": false,
                 },
                 "children": {
                   "TestFunctionArns": {
@@ -3031,7 +2988,6 @@ exports[`bucket with two preflight objects 2`] = `
               "my_bucket": {
                 "attributes": {
                   "wing:resource:connections": [],
-                  "wing:resource:stateful": true,
                 },
                 "children": {
                   "Default": {
@@ -3180,7 +3136,6 @@ exports[`create a bucket 2`] = `
               "cloud.TestRunner": {
                 "attributes": {
                   "wing:resource:connections": [],
-                  "wing:resource:stateful": false,
                 },
                 "children": {
                   "TestFunctionArns": {
@@ -3207,7 +3162,6 @@ exports[`create a bucket 2`] = `
               "my_bucket": {
                 "attributes": {
                   "wing:resource:connections": [],
-                  "wing:resource:stateful": true,
                 },
                 "children": {
                   "Default": {

--- a/libs/wingsdk/test/target-tf-aws/__snapshots__/counter.test.ts.snap
+++ b/libs/wingsdk/test/target-tf-aws/__snapshots__/counter.test.ts.snap
@@ -36,7 +36,6 @@ exports[`counter name valid 2`] = `
               "The.Amazing-Counter_01": {
                 "attributes": {
                   "wing:resource:connections": [],
-                  "wing:resource:stateful": true,
                 },
                 "children": {
                   "Default": {
@@ -70,7 +69,6 @@ exports[`counter name valid 2`] = `
               "cloud.TestRunner": {
                 "attributes": {
                   "wing:resource:connections": [],
-                  "wing:resource:stateful": false,
                 },
                 "children": {
                   "TestFunctionArns": {
@@ -166,7 +164,6 @@ exports[`counter with initial value 2`] = `
               "Counter": {
                 "attributes": {
                   "wing:resource:connections": [],
-                  "wing:resource:stateful": true,
                 },
                 "children": {
                   "Default": {
@@ -200,7 +197,6 @@ exports[`counter with initial value 2`] = `
               "cloud.TestRunner": {
                 "attributes": {
                   "wing:resource:connections": [],
-                  "wing:resource:stateful": false,
                 },
                 "children": {
                   "TestFunctionArns": {
@@ -362,7 +358,6 @@ exports[`dec() policy statement 2`] = `
                       "resource": "root/Default/Function",
                     },
                   ],
-                  "wing:resource:stateful": true,
                 },
                 "children": {
                   "Default": {
@@ -395,7 +390,6 @@ exports[`dec() policy statement 2`] = `
                       "resource": "root/Default/Counter",
                     },
                   ],
-                  "wing:resource:stateful": false,
                 },
                 "children": {
                   "Asset": {
@@ -461,7 +455,6 @@ exports[`dec() policy statement 2`] = `
               "Handler": {
                 "attributes": {
                   "wing:resource:connections": [],
-                  "wing:resource:stateful": false,
                 },
                 "constructInfo": {
                   "fqn": "constructs.Construct",
@@ -486,7 +479,6 @@ exports[`dec() policy statement 2`] = `
               "cloud.TestRunner": {
                 "attributes": {
                   "wing:resource:connections": [],
-                  "wing:resource:stateful": false,
                 },
                 "children": {
                   "TestFunctionArns": {
@@ -691,7 +683,6 @@ exports[`function with a counter binding 3`] = `
                       "resource": "root/Default/Function",
                     },
                   ],
-                  "wing:resource:stateful": true,
                 },
                 "children": {
                   "Default": {
@@ -724,7 +715,6 @@ exports[`function with a counter binding 3`] = `
                       "resource": "root/Default/Counter",
                     },
                   ],
-                  "wing:resource:stateful": false,
                 },
                 "children": {
                   "Asset": {
@@ -790,7 +780,6 @@ exports[`function with a counter binding 3`] = `
               "Handler": {
                 "attributes": {
                   "wing:resource:connections": [],
-                  "wing:resource:stateful": false,
                 },
                 "constructInfo": {
                   "fqn": "constructs.Construct",
@@ -815,7 +804,6 @@ exports[`function with a counter binding 3`] = `
               "cloud.TestRunner": {
                 "attributes": {
                   "wing:resource:connections": [],
-                  "wing:resource:stateful": false,
                 },
                 "children": {
                   "TestFunctionArns": {
@@ -977,7 +965,6 @@ exports[`inc() policy statement 2`] = `
                       "resource": "root/Default/Function",
                     },
                   ],
-                  "wing:resource:stateful": true,
                 },
                 "children": {
                   "Default": {
@@ -1010,7 +997,6 @@ exports[`inc() policy statement 2`] = `
                       "resource": "root/Default/Counter",
                     },
                   ],
-                  "wing:resource:stateful": false,
                 },
                 "children": {
                   "Asset": {
@@ -1076,7 +1062,6 @@ exports[`inc() policy statement 2`] = `
               "Handler": {
                 "attributes": {
                   "wing:resource:connections": [],
-                  "wing:resource:stateful": false,
                 },
                 "constructInfo": {
                   "fqn": "constructs.Construct",
@@ -1101,7 +1086,6 @@ exports[`inc() policy statement 2`] = `
               "cloud.TestRunner": {
                 "attributes": {
                   "wing:resource:connections": [],
-                  "wing:resource:stateful": false,
                 },
                 "children": {
                   "TestFunctionArns": {
@@ -1263,7 +1247,6 @@ exports[`peek() policy statement 2`] = `
                       "resource": "root/Default/Function",
                     },
                   ],
-                  "wing:resource:stateful": true,
                 },
                 "children": {
                   "Default": {
@@ -1296,7 +1279,6 @@ exports[`peek() policy statement 2`] = `
                       "resource": "root/Default/Counter",
                     },
                   ],
-                  "wing:resource:stateful": false,
                 },
                 "children": {
                   "Asset": {
@@ -1362,7 +1344,6 @@ exports[`peek() policy statement 2`] = `
               "Handler": {
                 "attributes": {
                   "wing:resource:connections": [],
-                  "wing:resource:stateful": false,
                 },
                 "constructInfo": {
                   "fqn": "constructs.Construct",
@@ -1387,7 +1368,6 @@ exports[`peek() policy statement 2`] = `
               "cloud.TestRunner": {
                 "attributes": {
                   "wing:resource:connections": [],
-                  "wing:resource:stateful": false,
                 },
                 "children": {
                   "TestFunctionArns": {
@@ -1483,7 +1463,6 @@ exports[`replace invalid character from counter name 2`] = `
               "The*Amazing%Counter@01": {
                 "attributes": {
                   "wing:resource:connections": [],
-                  "wing:resource:stateful": true,
                 },
                 "children": {
                   "Default": {
@@ -1517,7 +1496,6 @@ exports[`replace invalid character from counter name 2`] = `
               "cloud.TestRunner": {
                 "attributes": {
                   "wing:resource:connections": [],
-                  "wing:resource:stateful": false,
                 },
                 "children": {
                   "TestFunctionArns": {
@@ -1679,7 +1657,6 @@ exports[`reset() policy statement 2`] = `
                       "resource": "root/Default/Function",
                     },
                   ],
-                  "wing:resource:stateful": true,
                 },
                 "children": {
                   "Default": {
@@ -1712,7 +1689,6 @@ exports[`reset() policy statement 2`] = `
                       "resource": "root/Default/Counter",
                     },
                   ],
-                  "wing:resource:stateful": false,
                 },
                 "children": {
                   "Asset": {
@@ -1778,7 +1754,6 @@ exports[`reset() policy statement 2`] = `
               "Handler": {
                 "attributes": {
                   "wing:resource:connections": [],
-                  "wing:resource:stateful": false,
                 },
                 "constructInfo": {
                   "fqn": "constructs.Construct",
@@ -1803,7 +1778,6 @@ exports[`reset() policy statement 2`] = `
               "cloud.TestRunner": {
                 "attributes": {
                   "wing:resource:connections": [],
-                  "wing:resource:stateful": false,
                 },
                 "children": {
                   "TestFunctionArns": {

--- a/libs/wingsdk/test/target-tf-aws/__snapshots__/function.test.ts.snap
+++ b/libs/wingsdk/test/target-tf-aws/__snapshots__/function.test.ts.snap
@@ -81,7 +81,6 @@ exports[`basic function 2`] = `
               "Function": {
                 "attributes": {
                   "wing:resource:connections": [],
-                  "wing:resource:stateful": false,
                 },
                 "children": {
                   "Asset": {
@@ -147,7 +146,6 @@ exports[`basic function 2`] = `
               "Handler": {
                 "attributes": {
                   "wing:resource:connections": [],
-                  "wing:resource:stateful": false,
                 },
                 "constructInfo": {
                   "fqn": "constructs.Construct",
@@ -172,7 +170,6 @@ exports[`basic function 2`] = `
               "cloud.TestRunner": {
                 "attributes": {
                   "wing:resource:connections": [],
-                  "wing:resource:stateful": false,
                 },
                 "children": {
                   "TestFunctionArns": {
@@ -315,7 +312,6 @@ exports[`basic function with environment variables 2`] = `
               "Function": {
                 "attributes": {
                   "wing:resource:connections": [],
-                  "wing:resource:stateful": false,
                 },
                 "children": {
                   "Asset": {
@@ -381,7 +377,6 @@ exports[`basic function with environment variables 2`] = `
               "Handler": {
                 "attributes": {
                   "wing:resource:connections": [],
-                  "wing:resource:stateful": false,
                 },
                 "constructInfo": {
                   "fqn": "constructs.Construct",
@@ -406,7 +401,6 @@ exports[`basic function with environment variables 2`] = `
               "cloud.TestRunner": {
                 "attributes": {
                   "wing:resource:connections": [],
-                  "wing:resource:stateful": false,
                 },
                 "children": {
                   "TestFunctionArns": {
@@ -548,7 +542,6 @@ exports[`basic function with memory size specified 2`] = `
               "Function": {
                 "attributes": {
                   "wing:resource:connections": [],
-                  "wing:resource:stateful": false,
                 },
                 "children": {
                   "Asset": {
@@ -614,7 +607,6 @@ exports[`basic function with memory size specified 2`] = `
               "Handler": {
                 "attributes": {
                   "wing:resource:connections": [],
-                  "wing:resource:stateful": false,
                 },
                 "constructInfo": {
                   "fqn": "constructs.Construct",
@@ -639,7 +631,6 @@ exports[`basic function with memory size specified 2`] = `
               "cloud.TestRunner": {
                 "attributes": {
                   "wing:resource:connections": [],
-                  "wing:resource:stateful": false,
                 },
                 "children": {
                   "TestFunctionArns": {
@@ -780,7 +771,6 @@ exports[`basic function with timeout explicitly set 2`] = `
               "Function": {
                 "attributes": {
                   "wing:resource:connections": [],
-                  "wing:resource:stateful": false,
                 },
                 "children": {
                   "Asset": {
@@ -846,7 +836,6 @@ exports[`basic function with timeout explicitly set 2`] = `
               "Handler": {
                 "attributes": {
                   "wing:resource:connections": [],
-                  "wing:resource:stateful": false,
                 },
                 "constructInfo": {
                   "fqn": "constructs.Construct",
@@ -871,7 +860,6 @@ exports[`basic function with timeout explicitly set 2`] = `
               "cloud.TestRunner": {
                 "attributes": {
                   "wing:resource:connections": [],
-                  "wing:resource:stateful": false,
                 },
                 "children": {
                   "TestFunctionArns": {
@@ -1012,7 +1000,6 @@ exports[`function name valid 2`] = `
               "Handler": {
                 "attributes": {
                   "wing:resource:connections": [],
-                  "wing:resource:stateful": false,
                 },
                 "constructInfo": {
                   "fqn": "constructs.Construct",
@@ -1029,7 +1016,6 @@ exports[`function name valid 2`] = `
               "The-Mighty_Function-01": {
                 "attributes": {
                   "wing:resource:connections": [],
-                  "wing:resource:stateful": false,
                 },
                 "children": {
                   "Asset": {
@@ -1103,7 +1089,6 @@ exports[`function name valid 2`] = `
               "cloud.TestRunner": {
                 "attributes": {
                   "wing:resource:connections": [],
-                  "wing:resource:stateful": false,
                 },
                 "children": {
                   "TestFunctionArns": {
@@ -1244,7 +1229,6 @@ exports[`replace invalid character from function name 2`] = `
               "Handler": {
                 "attributes": {
                   "wing:resource:connections": [],
-                  "wing:resource:stateful": false,
                 },
                 "constructInfo": {
                   "fqn": "constructs.Construct",
@@ -1261,7 +1245,6 @@ exports[`replace invalid character from function name 2`] = `
               "The%Mighty$Function": {
                 "attributes": {
                   "wing:resource:connections": [],
-                  "wing:resource:stateful": false,
                 },
                 "children": {
                   "Asset": {
@@ -1335,7 +1318,6 @@ exports[`replace invalid character from function name 2`] = `
               "cloud.TestRunner": {
                 "attributes": {
                   "wing:resource:connections": [],
-                  "wing:resource:stateful": false,
                 },
                 "children": {
                   "TestFunctionArns": {

--- a/libs/wingsdk/test/target-tf-aws/__snapshots__/queue.test.ts.snap
+++ b/libs/wingsdk/test/target-tf-aws/__snapshots__/queue.test.ts.snap
@@ -28,7 +28,6 @@ exports[`default queue behavior 2`] = `
               "Queue": {
                 "attributes": {
                   "wing:resource:connections": [],
-                  "wing:resource:stateful": true,
                 },
                 "children": {
                   "Default": {
@@ -62,7 +61,6 @@ exports[`default queue behavior 2`] = `
               "cloud.TestRunner": {
                 "attributes": {
                   "wing:resource:connections": [],
-                  "wing:resource:stateful": false,
                 },
                 "children": {
                   "TestFunctionArns": {
@@ -150,7 +148,6 @@ exports[`queue name valid 2`] = `
               "The-Incredible_Queue-01": {
                 "attributes": {
                   "wing:resource:connections": [],
-                  "wing:resource:stateful": true,
                 },
                 "children": {
                   "Default": {
@@ -184,7 +181,6 @@ exports[`queue name valid 2`] = `
               "cloud.TestRunner": {
                 "attributes": {
                   "wing:resource:connections": [],
-                  "wing:resource:stateful": false,
                 },
                 "children": {
                   "TestFunctionArns": {
@@ -347,7 +343,6 @@ exports[`queue with a consumer function 3`] = `
                       "resource": "root/Default/Queue-AddConsumer-c5395e41",
                     },
                   ],
-                  "wing:resource:stateful": false,
                 },
                 "constructInfo": {
                   "fqn": "constructs.Construct",
@@ -371,7 +366,6 @@ exports[`queue with a consumer function 3`] = `
                       "resource": "root/Default/Queue-AddConsumer-c5395e41",
                     },
                   ],
-                  "wing:resource:stateful": true,
                 },
                 "children": {
                   "Default": {
@@ -418,7 +412,6 @@ exports[`queue with a consumer function 3`] = `
                       "resource": "root/Default/Queue",
                     },
                   ],
-                  "wing:resource:stateful": false,
                 },
                 "children": {
                   "Asset": {
@@ -484,7 +477,6 @@ exports[`queue with a consumer function 3`] = `
               "Queue-AddConsumerHandler-c5395e41": {
                 "attributes": {
                   "wing:resource:connections": [],
-                  "wing:resource:stateful": false,
                 },
                 "constructInfo": {
                   "fqn": "constructs.Construct",
@@ -507,7 +499,6 @@ exports[`queue with a consumer function 3`] = `
               "cloud.TestRunner": {
                 "attributes": {
                   "wing:resource:connections": [],
-                  "wing:resource:stateful": false,
                 },
                 "children": {
                   "TestFunctionArns": {
@@ -596,7 +587,6 @@ exports[`queue with custom retention 2`] = `
               "Queue": {
                 "attributes": {
                   "wing:resource:connections": [],
-                  "wing:resource:stateful": true,
                 },
                 "children": {
                   "Default": {
@@ -630,7 +620,6 @@ exports[`queue with custom retention 2`] = `
               "cloud.TestRunner": {
                 "attributes": {
                   "wing:resource:connections": [],
-                  "wing:resource:stateful": false,
                 },
                 "children": {
                   "TestFunctionArns": {
@@ -719,7 +708,6 @@ exports[`queue with custom timeout 2`] = `
               "Queue": {
                 "attributes": {
                   "wing:resource:connections": [],
-                  "wing:resource:stateful": true,
                 },
                 "children": {
                   "Default": {
@@ -753,7 +741,6 @@ exports[`queue with custom timeout 2`] = `
               "cloud.TestRunner": {
                 "attributes": {
                   "wing:resource:connections": [],
-                  "wing:resource:stateful": false,
                 },
                 "children": {
                   "TestFunctionArns": {
@@ -841,7 +828,6 @@ exports[`replace invalid character from queue name 2`] = `
               "The*Incredible$Queue": {
                 "attributes": {
                   "wing:resource:connections": [],
-                  "wing:resource:stateful": true,
                 },
                 "children": {
                   "Default": {
@@ -875,7 +861,6 @@ exports[`replace invalid character from queue name 2`] = `
               "cloud.TestRunner": {
                 "attributes": {
                   "wing:resource:connections": [],
-                  "wing:resource:stateful": false,
                 },
                 "children": {
                   "TestFunctionArns": {

--- a/libs/wingsdk/test/target-tf-aws/__snapshots__/schedule.test.ts.snap
+++ b/libs/wingsdk/test/target-tf-aws/__snapshots__/schedule.test.ts.snap
@@ -109,7 +109,6 @@ exports[`schedule behavior with cron 2`] = `
                       "resource": "root/Default/Schedule-OnTick-c5395e41",
                     },
                   ],
-                  "wing:resource:stateful": false,
                 },
                 "constructInfo": {
                   "fqn": "constructs.Construct",
@@ -133,7 +132,6 @@ exports[`schedule behavior with cron 2`] = `
                       "resource": "root/Default/Schedule-OnTick-c5395e41",
                     },
                   ],
-                  "wing:resource:stateful": true,
                 },
                 "children": {
                   "Schedule": {
@@ -180,7 +178,6 @@ exports[`schedule behavior with cron 2`] = `
                       "resource": "root/Default/Schedule",
                     },
                   ],
-                  "wing:resource:stateful": false,
                 },
                 "children": {
                   "Asset": {
@@ -254,7 +251,6 @@ exports[`schedule behavior with cron 2`] = `
               "Schedule-OnTickHandler-c5395e41": {
                 "attributes": {
                   "wing:resource:connections": [],
-                  "wing:resource:stateful": false,
                 },
                 "constructInfo": {
                   "fqn": "constructs.Construct",
@@ -277,7 +273,6 @@ exports[`schedule behavior with cron 2`] = `
               "cloud.TestRunner": {
                 "attributes": {
                   "wing:resource:connections": [],
-                  "wing:resource:stateful": false,
                 },
                 "children": {
                   "TestFunctionArns": {
@@ -446,7 +441,6 @@ exports[`schedule behavior with rate 2`] = `
                       "resource": "root/Default/Schedule-OnTick-c5395e41",
                     },
                   ],
-                  "wing:resource:stateful": false,
                 },
                 "constructInfo": {
                   "fqn": "constructs.Construct",
@@ -470,7 +464,6 @@ exports[`schedule behavior with rate 2`] = `
                       "resource": "root/Default/Schedule-OnTick-c5395e41",
                     },
                   ],
-                  "wing:resource:stateful": true,
                 },
                 "children": {
                   "Schedule": {
@@ -517,7 +510,6 @@ exports[`schedule behavior with rate 2`] = `
                       "resource": "root/Default/Schedule",
                     },
                   ],
-                  "wing:resource:stateful": false,
                 },
                 "children": {
                   "Asset": {
@@ -591,7 +583,6 @@ exports[`schedule behavior with rate 2`] = `
               "Schedule-OnTickHandler-c5395e41": {
                 "attributes": {
                   "wing:resource:connections": [],
-                  "wing:resource:stateful": false,
                 },
                 "constructInfo": {
                   "fqn": "constructs.Construct",
@@ -614,7 +605,6 @@ exports[`schedule behavior with rate 2`] = `
               "cloud.TestRunner": {
                 "attributes": {
                   "wing:resource:connections": [],
-                  "wing:resource:stateful": false,
                 },
                 "children": {
                   "TestFunctionArns": {
@@ -829,7 +819,6 @@ exports[`schedule with two functions 2`] = `
                       "resource": "root/Default/Schedule-OnTick-7b33bcba",
                     },
                   ],
-                  "wing:resource:stateful": false,
                 },
                 "constructInfo": {
                   "fqn": "constructs.Construct",
@@ -853,7 +842,6 @@ exports[`schedule with two functions 2`] = `
                       "resource": "root/Default/Schedule-OnTick-0a615500",
                     },
                   ],
-                  "wing:resource:stateful": false,
                 },
                 "constructInfo": {
                   "fqn": "constructs.Construct",
@@ -883,7 +871,6 @@ exports[`schedule with two functions 2`] = `
                       "resource": "root/Default/Schedule-OnTick-0a615500",
                     },
                   ],
-                  "wing:resource:stateful": true,
                 },
                 "children": {
                   "Schedule": {
@@ -938,7 +925,6 @@ exports[`schedule with two functions 2`] = `
                       "resource": "root/Default/Schedule",
                     },
                   ],
-                  "wing:resource:stateful": false,
                 },
                 "children": {
                   "Asset": {
@@ -1025,7 +1011,6 @@ exports[`schedule with two functions 2`] = `
                       "resource": "root/Default/Schedule",
                     },
                   ],
-                  "wing:resource:stateful": false,
                 },
                 "children": {
                   "Asset": {
@@ -1099,7 +1084,6 @@ exports[`schedule with two functions 2`] = `
               "Schedule-OnTickHandler-0a615500": {
                 "attributes": {
                   "wing:resource:connections": [],
-                  "wing:resource:stateful": false,
                 },
                 "constructInfo": {
                   "fqn": "constructs.Construct",
@@ -1114,7 +1098,6 @@ exports[`schedule with two functions 2`] = `
               "Schedule-OnTickHandler-7b33bcba": {
                 "attributes": {
                   "wing:resource:connections": [],
-                  "wing:resource:stateful": false,
                 },
                 "constructInfo": {
                   "fqn": "constructs.Construct",
@@ -1137,7 +1120,6 @@ exports[`schedule with two functions 2`] = `
               "cloud.TestRunner": {
                 "attributes": {
                   "wing:resource:connections": [],
-                  "wing:resource:stateful": false,
                 },
                 "children": {
                   "TestFunctionArns": {

--- a/libs/wingsdk/test/target-tf-aws/__snapshots__/secret.test.ts.snap
+++ b/libs/wingsdk/test/target-tf-aws/__snapshots__/secret.test.ts.snap
@@ -31,7 +31,6 @@ exports[`default secret behavior 2`] = `
               "Secret": {
                 "attributes": {
                   "wing:resource:connections": [],
-                  "wing:resource:stateful": true,
                 },
                 "children": {
                   "Default": {
@@ -73,7 +72,6 @@ exports[`default secret behavior 2`] = `
               "cloud.TestRunner": {
                 "attributes": {
                   "wing:resource:connections": [],
-                  "wing:resource:stateful": false,
                 },
                 "children": {
                   "TestFunctionArns": {

--- a/libs/wingsdk/test/target-tf-aws/__snapshots__/table.test.ts.snap
+++ b/libs/wingsdk/test/target-tf-aws/__snapshots__/table.test.ts.snap
@@ -146,7 +146,6 @@ exports[`function with a table binding 3`] = `
                       "resource": "root/Default/Table",
                     },
                   ],
-                  "wing:resource:stateful": false,
                 },
                 "children": {
                   "Asset": {
@@ -212,7 +211,6 @@ exports[`function with a table binding 3`] = `
               "Handler": {
                 "attributes": {
                   "wing:resource:connections": [],
-                  "wing:resource:stateful": false,
                 },
                 "constructInfo": {
                   "fqn": "constructs.Construct",
@@ -236,7 +234,6 @@ exports[`function with a table binding 3`] = `
                       "resource": "root/Default/Function",
                     },
                   ],
-                  "wing:resource:stateful": true,
                 },
                 "children": {
                   "Default": {
@@ -270,7 +267,6 @@ exports[`function with a table binding 3`] = `
               "cloud.TestRunner": {
                 "attributes": {
                   "wing:resource:connections": [],
-                  "wing:resource:stateful": false,
                 },
                 "children": {
                   "TestFunctionArns": {

--- a/libs/wingsdk/test/target-tf-aws/__snapshots__/topic.test.ts.snap
+++ b/libs/wingsdk/test/target-tf-aws/__snapshots__/topic.test.ts.snap
@@ -28,7 +28,6 @@ exports[`default topic behavior 2`] = `
               "Topic": {
                 "attributes": {
                   "wing:resource:connections": [],
-                  "wing:resource:stateful": true,
                 },
                 "children": {
                   "Default": {
@@ -62,7 +61,6 @@ exports[`default topic behavior 2`] = `
               "cloud.TestRunner": {
                 "attributes": {
                   "wing:resource:connections": [],
-                  "wing:resource:stateful": false,
                 },
                 "children": {
                   "TestFunctionArns": {
@@ -150,7 +148,6 @@ exports[`replace invalid character from queue name 2`] = `
               "The%Spectacular@Topic": {
                 "attributes": {
                   "wing:resource:connections": [],
-                  "wing:resource:stateful": true,
                 },
                 "children": {
                   "Default": {
@@ -184,7 +181,6 @@ exports[`replace invalid character from queue name 2`] = `
               "cloud.TestRunner": {
                 "attributes": {
                   "wing:resource:connections": [],
-                  "wing:resource:stateful": false,
                 },
                 "children": {
                   "TestFunctionArns": {
@@ -272,7 +268,6 @@ exports[`topic name valid 2`] = `
               "The-Spectacular_Topic-01": {
                 "attributes": {
                   "wing:resource:connections": [],
-                  "wing:resource:stateful": true,
                 },
                 "children": {
                   "Default": {
@@ -306,7 +301,6 @@ exports[`topic name valid 2`] = `
               "cloud.TestRunner": {
                 "attributes": {
                   "wing:resource:connections": [],
-                  "wing:resource:stateful": false,
                 },
                 "children": {
                   "TestFunctionArns": {
@@ -489,7 +483,6 @@ exports[`topic with subscriber function 3`] = `
                       "resource": "root/Default/Topic-OnMessage-c5395e41",
                     },
                   ],
-                  "wing:resource:stateful": false,
                 },
                 "constructInfo": {
                   "fqn": "constructs.Construct",
@@ -513,7 +506,6 @@ exports[`topic with subscriber function 3`] = `
                       "resource": "root/Default/Topic-OnMessage-c5395e41",
                     },
                   ],
-                  "wing:resource:stateful": true,
                 },
                 "children": {
                   "Default": {
@@ -560,7 +552,6 @@ exports[`topic with subscriber function 3`] = `
                       "resource": "root/Default/Topic",
                     },
                   ],
-                  "wing:resource:stateful": false,
                 },
                 "children": {
                   "Asset": {
@@ -634,7 +625,6 @@ exports[`topic with subscriber function 3`] = `
               "Topic-OnMessageHandler-c5395e41": {
                 "attributes": {
                   "wing:resource:connections": [],
-                  "wing:resource:stateful": false,
                 },
                 "constructInfo": {
                   "fqn": "constructs.Construct",
@@ -657,7 +647,6 @@ exports[`topic with subscriber function 3`] = `
               "cloud.TestRunner": {
                 "attributes": {
                   "wing:resource:connections": [],
-                  "wing:resource:stateful": false,
                 },
                 "children": {
                   "TestFunctionArns": {

--- a/libs/wingsdk/test/target-tf-aws/bucket.test.ts
+++ b/libs/wingsdk/test/target-tf-aws/bucket.test.ts
@@ -16,7 +16,6 @@ class InflightBucketEventHandler
   extends Inflight
   implements IBucketEventHandler
 {
-  public stateful: boolean;
   constructor(scope: Construct, id: string) {
     super(scope, id, { code: NodeJsCode.fromInline("null") });
   }

--- a/libs/wingsdk/test/target-tf-azure/__snapshots__/bucket.test.ts.snap
+++ b/libs/wingsdk/test/target-tf-azure/__snapshots__/bucket.test.ts.snap
@@ -64,7 +64,6 @@ exports[`bucket is public 2`] = `
               "my_bucket": {
                 "attributes": {
                   "wing:resource:connections": [],
-                  "wing:resource:stateful": true,
                 },
                 "children": {
                   "Bucket": {
@@ -179,7 +178,6 @@ exports[`bucket name valid 2`] = `
               "The-Uncanny-Bucket": {
                 "attributes": {
                   "wing:resource:connections": [],
-                  "wing:resource:stateful": true,
                 },
                 "children": {
                   "Bucket": {
@@ -326,7 +324,6 @@ exports[`bucket with two preflight objects 2`] = `
               "my_bucket": {
                 "attributes": {
                   "wing:resource:connections": [],
-                  "wing:resource:stateful": true,
                 },
                 "children": {
                   "Blob-file1.txt": {
@@ -465,7 +462,6 @@ exports[`create a bucket 2`] = `
               "my_bucket": {
                 "attributes": {
                   "wing:resource:connections": [],
-                  "wing:resource:stateful": true,
                 },
                 "children": {
                   "Bucket": {
@@ -593,7 +589,6 @@ exports[`create multiple buckets 2`] = `
               "my_bucket": {
                 "attributes": {
                   "wing:resource:connections": [],
-                  "wing:resource:stateful": true,
                 },
                 "children": {
                   "Bucket": {
@@ -619,7 +614,6 @@ exports[`create multiple buckets 2`] = `
               "my_bucket2": {
                 "attributes": {
                   "wing:resource:connections": [],
-                  "wing:resource:stateful": true,
                 },
                 "children": {
                   "Bucket": {

--- a/libs/wingsdk/test/target-tf-azure/__snapshots__/function.test.ts.snap
+++ b/libs/wingsdk/test/target-tf-azure/__snapshots__/function.test.ts.snap
@@ -88,7 +88,6 @@ exports[`basic function 2`] = `
               "Function": {
                 "attributes": {
                   "wing:resource:connections": [],
-                  "wing:resource:stateful": false,
                 },
                 "children": {
                   "Asset": {
@@ -118,7 +117,6 @@ exports[`basic function 2`] = `
                   "FunctionBucket": {
                     "attributes": {
                       "wing:resource:connections": [],
-                      "wing:resource:stateful": true,
                     },
                     "children": {
                       "Bucket": {
@@ -164,7 +162,6 @@ exports[`basic function 2`] = `
               "Handler": {
                 "attributes": {
                   "wing:resource:connections": [],
-                  "wing:resource:stateful": false,
                 },
                 "constructInfo": {
                   "fqn": "constructs.Construct",
@@ -336,7 +333,6 @@ exports[`basic function with environment variables 2`] = `
               "Function": {
                 "attributes": {
                   "wing:resource:connections": [],
-                  "wing:resource:stateful": false,
                 },
                 "children": {
                   "Asset": {
@@ -366,7 +362,6 @@ exports[`basic function with environment variables 2`] = `
                   "FunctionBucket": {
                     "attributes": {
                       "wing:resource:connections": [],
-                      "wing:resource:stateful": true,
                     },
                     "children": {
                       "Bucket": {
@@ -412,7 +407,6 @@ exports[`basic function with environment variables 2`] = `
               "Handler": {
                 "attributes": {
                   "wing:resource:connections": [],
-                  "wing:resource:stateful": false,
                 },
                 "constructInfo": {
                   "fqn": "constructs.Construct",
@@ -582,7 +576,6 @@ exports[`replace invalid character from function name 2`] = `
               "Handler": {
                 "attributes": {
                   "wing:resource:connections": [],
-                  "wing:resource:stateful": false,
                 },
                 "constructInfo": {
                   "fqn": "constructs.Construct",
@@ -631,7 +624,6 @@ exports[`replace invalid character from function name 2`] = `
               "someFunction01": {
                 "attributes": {
                   "wing:resource:connections": [],
-                  "wing:resource:stateful": false,
                 },
                 "children": {
                   "Asset": {
@@ -661,7 +653,6 @@ exports[`replace invalid character from function name 2`] = `
                   "FunctionBucket": {
                     "attributes": {
                       "wing:resource:connections": [],
-                      "wing:resource:stateful": true,
                     },
                     "children": {
                       "Bucket": {

--- a/libs/wingsdk/test/target-tf-azure/bucket.test.ts
+++ b/libs/wingsdk/test/target-tf-azure/bucket.test.ts
@@ -16,7 +16,6 @@ class InflightBucketEventHandler
   extends Inflight
   implements IBucketEventHandler
 {
-  public stateful: boolean;
   constructor(scope: Construct, id: string) {
     super(scope, id, { code: NodeJsCode.fromInline("null") });
   }

--- a/libs/wingsdk/test/target-tf-gcp/__snapshots__/bucket.test.ts.snap
+++ b/libs/wingsdk/test/target-tf-gcp/__snapshots__/bucket.test.ts.snap
@@ -46,7 +46,6 @@ exports[`bucket is public 2`] = `
               "my_bucket": {
                 "attributes": {
                   "wing:resource:connections": [],
-                  "wing:resource:stateful": true,
                 },
                 "children": {
                   "Default": {
@@ -180,7 +179,6 @@ exports[`bucket with two preflight objects 2`] = `
               "my_bucket": {
                 "attributes": {
                   "wing:resource:connections": [],
-                  "wing:resource:stateful": true,
                 },
                 "children": {
                   "Default": {
@@ -310,7 +308,6 @@ exports[`create a bucket 2`] = `
               "my_bucket": {
                 "attributes": {
                   "wing:resource:connections": [],
-                  "wing:resource:stateful": true,
                 },
                 "children": {
                   "Default": {
@@ -433,7 +430,6 @@ exports[`two buckets 2`] = `
               "my_bucket1": {
                 "attributes": {
                   "wing:resource:connections": [],
-                  "wing:resource:stateful": true,
                 },
                 "children": {
                   "Default": {
@@ -467,7 +463,6 @@ exports[`two buckets 2`] = `
               "my_bucket2": {
                 "attributes": {
                   "wing:resource:connections": [],
-                  "wing:resource:stateful": true,
                 },
                 "children": {
                   "Default": {

--- a/libs/wingsdk/test/testing/__snapshots__/simulator.test.ts.snap
+++ b/libs/wingsdk/test/testing/__snapshots__/simulator.test.ts.snap
@@ -7,7 +7,6 @@ exports[`provides raw tree data 1`] = `
       "cloud.TestRunner": {
         "attributes": {
           "wing:resource:connections": [],
-          "wing:resource:stateful": false,
         },
         "constructInfo": {
           "fqn": "constructs.Construct",
@@ -24,7 +23,6 @@ exports[`provides raw tree data 1`] = `
       "test": {
         "attributes": {
           "wing:resource:connections": [],
-          "wing:resource:stateful": false,
         },
         "constructInfo": {
           "fqn": "constructs.Construct",
@@ -40,7 +38,6 @@ exports[`provides raw tree data 1`] = `
       "test.handler": {
         "attributes": {
           "wing:resource:connections": [],
-          "wing:resource:stateful": false,
         },
         "constructInfo": {
           "fqn": "constructs.Construct",

--- a/tools/hangar/__snapshots__/test_corpus/api.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/api.w_compile_tf-aws.md
@@ -4,9 +4,8 @@
 ```js
 module.exports = function() {
   class  A {
-    constructor({ api, stateful }) {
+    constructor({ api }) {
       this.api = api;
-      this.stateful = stateful;
     }
   }
   return A;
@@ -18,9 +17,8 @@ module.exports = function() {
 ```js
 module.exports = function() {
   class  Foo {
-    constructor({ api, stateful }) {
+    constructor({ api }) {
       this.api = api;
-      this.stateful = stateful;
     }
     async handle(message)  {
       {
@@ -442,14 +440,12 @@ class $Root extends $stdlib.std.Resource {
       }
       _toInflight() {
         const api_client = this._lift(this.api);
-        const stateful_client = this._lift(this.stateful);
         const self_client_path = "./clients/Foo.inflight.js".replace(/\\/g, "/");
         return $stdlib.core.NodeJsCode.fromInline(`
           (await (async () => {
             const Foo = require("${self_client_path}")({});
             const client = new Foo({
               api: ${api_client},
-              stateful: ${stateful_client},
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
             return client;
@@ -459,7 +455,6 @@ class $Root extends $stdlib.std.Resource {
       _registerBind(host, ops) {
         if (ops.includes("$inflight_init")) {
           this._registerBindObject(this.api, host, []);
-          this._registerBindObject(this.stateful, host, []);
         }
         if (ops.includes("handle")) {
           this._registerBindObject(this.api.url, host, []);
@@ -484,14 +479,12 @@ class $Root extends $stdlib.std.Resource {
       }
       _toInflight() {
         const api_client = this._lift(this.api);
-        const stateful_client = this._lift(this.stateful);
         const self_client_path = "./clients/A.inflight.js".replace(/\\/g, "/");
         return $stdlib.core.NodeJsCode.fromInline(`
           (await (async () => {
             const A = require("${self_client_path}")({});
             const client = new A({
               api: ${api_client},
-              stateful: ${stateful_client},
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
             return client;
@@ -501,7 +494,6 @@ class $Root extends $stdlib.std.Resource {
       _registerBind(host, ops) {
         if (ops.includes("$inflight_init")) {
           this._registerBindObject(this.api, host, []);
-          this._registerBindObject(this.stateful, host, []);
         }
         super._registerBind(host, ops);
       }

--- a/tools/hangar/__snapshots__/test_corpus/api_path_vars.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/api_path_vars.w_compile_tf-aws.md
@@ -4,8 +4,7 @@
 ```js
 module.exports = function() {
   class  Fetch {
-    constructor({ stateful }) {
-      this.stateful = stateful;
+    constructor({  }) {
     }
     async get(url)  {
       return (require("<ABSOLUTE_PATH>/api_path_vars.js")["get"])(url)
@@ -287,13 +286,11 @@ class $Root extends $stdlib.std.Resource {
         this._addInflightOps("get");
       }
       _toInflight() {
-        const stateful_client = this._lift(this.stateful);
         const self_client_path = "./clients/Fetch.inflight.js".replace(/\\/g, "/");
         return $stdlib.core.NodeJsCode.fromInline(`
           (await (async () => {
             const Fetch = require("${self_client_path}")({});
             const client = new Fetch({
-              stateful: ${stateful_client},
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
             return client;
@@ -302,7 +299,6 @@ class $Root extends $stdlib.std.Resource {
       }
       _registerBind(host, ops) {
         if (ops.includes("$inflight_init")) {
-          this._registerBindObject(this.stateful, host, []);
         }
         if (ops.includes("get")) {
         }

--- a/tools/hangar/__snapshots__/test_corpus/bring_awscdk.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/bring_awscdk.w_compile_tf-aws.md
@@ -4,9 +4,8 @@
 ```js
 module.exports = function() {
   class  CdkDockerImageFunction {
-    constructor({ function, stateful }) {
+    constructor({ function }) {
       this.function = function;
-      this.stateful = stateful;
     }
   }
   return CdkDockerImageFunction;
@@ -65,14 +64,12 @@ class $Root extends $stdlib.std.Resource {
       }
       _toInflight() {
         const function_client = this._lift(this.function);
-        const stateful_client = this._lift(this.stateful);
         const self_client_path = "./clients/CdkDockerImageFunction.inflight.js".replace(/\\/g, "/");
         return $stdlib.core.NodeJsCode.fromInline(`
           (await (async () => {
             const CdkDockerImageFunction = require("${self_client_path}")({});
             const client = new CdkDockerImageFunction({
               function: ${function_client},
-              stateful: ${stateful_client},
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
             return client;
@@ -82,7 +79,6 @@ class $Root extends $stdlib.std.Resource {
       _registerBind(host, ops) {
         if (ops.includes("$inflight_init")) {
           this._registerBindObject(this.function, host, []);
-          this._registerBindObject(this.stateful, host, []);
         }
         super._registerBind(host, ops);
       }

--- a/tools/hangar/__snapshots__/test_corpus/capture_resource_with_no_inflight.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/capture_resource_with_no_inflight.w_compile_tf-aws.md
@@ -4,9 +4,8 @@
 ```js
 module.exports = function() {
   class  A {
-    constructor({ field, stateful }) {
+    constructor({ field }) {
       this.field = field;
-      this.stateful = stateful;
     }
   }
   return A;
@@ -151,14 +150,12 @@ class $Root extends $stdlib.std.Resource {
       }
       _toInflight() {
         const field_client = this._lift(this.field);
-        const stateful_client = this._lift(this.stateful);
         const self_client_path = "./clients/A.inflight.js".replace(/\\/g, "/");
         return $stdlib.core.NodeJsCode.fromInline(`
           (await (async () => {
             const A = require("${self_client_path}")({});
             const client = new A({
               field: ${field_client},
-              stateful: ${stateful_client},
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
             return client;
@@ -168,7 +165,6 @@ class $Root extends $stdlib.std.Resource {
       _registerBind(host, ops) {
         if (ops.includes("$inflight_init")) {
           this._registerBindObject(this.field, host, []);
-          this._registerBindObject(this.stateful, host, []);
         }
         super._registerBind(host, ops);
       }

--- a/tools/hangar/__snapshots__/test_corpus/construct-base.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/construct-base.w_compile_tf-aws.md
@@ -4,8 +4,7 @@
 ```js
 module.exports = function() {
   class  WingResource {
-    constructor({ stateful }) {
-      this.stateful = stateful;
+    constructor({  }) {
     }
   }
   return WingResource;
@@ -75,13 +74,11 @@ class $Root extends $stdlib.std.Resource {
         {console.log(`my id is ${this.node.id}`)};
       }
       _toInflight() {
-        const stateful_client = this._lift(this.stateful);
         const self_client_path = "./clients/WingResource.inflight.js".replace(/\\/g, "/");
         return $stdlib.core.NodeJsCode.fromInline(`
           (await (async () => {
             const WingResource = require("${self_client_path}")({});
             const client = new WingResource({
-              stateful: ${stateful_client},
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
             return client;
@@ -90,7 +87,6 @@ class $Root extends $stdlib.std.Resource {
       }
       _registerBind(host, ops) {
         if (ops.includes("$inflight_init")) {
-          this._registerBindObject(this.stateful, host, []);
         }
         super._registerBind(host, ops);
       }

--- a/tools/hangar/__snapshots__/test_corpus/doubler.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/doubler.w_compile_tf-aws.md
@@ -4,9 +4,8 @@
 ```js
 module.exports = function() {
   class  Doubler {
-    constructor({ func, stateful }) {
+    constructor({ func }) {
       this.func = func;
-      this.stateful = stateful;
     }
     async invoke(message)  {
       {
@@ -70,14 +69,12 @@ class $Root extends $stdlib.std.Resource {
       }
       _toInflight() {
         const func_client = this._lift(this.func);
-        const stateful_client = this._lift(this.stateful);
         const self_client_path = "./clients/Doubler.inflight.js".replace(/\\/g, "/");
         return $stdlib.core.NodeJsCode.fromInline(`
           (await (async () => {
             const Doubler = require("${self_client_path}")({});
             const client = new Doubler({
               func: ${func_client},
-              stateful: ${stateful_client},
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
             return client;
@@ -87,7 +84,6 @@ class $Root extends $stdlib.std.Resource {
       _registerBind(host, ops) {
         if (ops.includes("$inflight_init")) {
           this._registerBindObject(this.func, host, []);
-          this._registerBindObject(this.stateful, host, []);
         }
         if (ops.includes("invoke")) {
           this._registerBindObject(this.func, host, ["handle"]);

--- a/tools/hangar/__snapshots__/test_corpus/extern_implementation.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/extern_implementation.w_compile_tf-aws.md
@@ -4,8 +4,7 @@
 ```js
 module.exports = function() {
   class  Foo {
-    constructor({ stateful }) {
-      this.stateful = stateful;
+    constructor({  }) {
     }
     static async regex_inflight(pattern, text)  {
       return (require("<ABSOLUTE_PATH>/external_js.js")["regex_inflight"])(pattern, text)
@@ -240,13 +239,11 @@ class $Root extends $stdlib.std.Resource {
         return (require("<ABSOLUTE_PATH>/index.js")["v4"])()
       }
       _toInflight() {
-        const stateful_client = this._lift(this.stateful);
         const self_client_path = "./clients/Foo.inflight.js".replace(/\\/g, "/");
         return $stdlib.core.NodeJsCode.fromInline(`
           (await (async () => {
             const Foo = require("${self_client_path}")({});
             const client = new Foo({
-              stateful: ${stateful_client},
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
             return client;
@@ -255,7 +252,6 @@ class $Root extends $stdlib.std.Resource {
       }
       _registerBind(host, ops) {
         if (ops.includes("$inflight_init")) {
-          this._registerBindObject(this.stateful, host, []);
         }
         if (ops.includes("call")) {
         }

--- a/tools/hangar/__snapshots__/test_corpus/forward_decl.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/forward_decl.w_compile_tf-aws.md
@@ -4,9 +4,8 @@
 ```js
 module.exports = function() {
   class  R {
-    constructor({ f, stateful }) {
+    constructor({ f }) {
       this.f = f;
-      this.stateful = stateful;
     }
   }
   return R;
@@ -72,14 +71,12 @@ class $Root extends $stdlib.std.Resource {
       }
       _toInflight() {
         const f_client = this._lift(this.f);
-        const stateful_client = this._lift(this.stateful);
         const self_client_path = "./clients/R.inflight.js".replace(/\\/g, "/");
         return $stdlib.core.NodeJsCode.fromInline(`
           (await (async () => {
             const R = require("${self_client_path}")({});
             const client = new R({
               f: ${f_client},
-              stateful: ${stateful_client},
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
             return client;
@@ -89,7 +86,6 @@ class $Root extends $stdlib.std.Resource {
       _registerBind(host, ops) {
         if (ops.includes("$inflight_init")) {
           this._registerBindObject(this.f, host, []);
-          this._registerBindObject(this.stateful, host, []);
         }
         super._registerBind(host, ops);
       }

--- a/tools/hangar/__snapshots__/test_corpus/impl_interface.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/impl_interface.w_compile_tf-aws.md
@@ -4,8 +4,7 @@
 ```js
 module.exports = function() {
   class  A {
-    constructor({ stateful }) {
-      this.stateful = stateful;
+    constructor({  }) {
     }
     async handle(msg)  {
       {
@@ -22,8 +21,7 @@ module.exports = function() {
 ```js
 module.exports = function() {
   class  Dog {
-    constructor({ stateful }) {
-      this.stateful = stateful;
+    constructor({  }) {
     }
     async eat()  {
       {
@@ -40,8 +38,7 @@ module.exports = function() {
 ```js
 module.exports = function() {
   class  r {
-    constructor({ stateful }) {
-      this.stateful = stateful;
+    constructor({  }) {
     }
     async method_2(x)  {
       {
@@ -102,13 +99,11 @@ class $Root extends $stdlib.std.Resource {
         this._addInflightOps("handle");
       }
       _toInflight() {
-        const stateful_client = this._lift(this.stateful);
         const self_client_path = "./clients/A.inflight.js".replace(/\\/g, "/");
         return $stdlib.core.NodeJsCode.fromInline(`
           (await (async () => {
             const A = require("${self_client_path}")({});
             const client = new A({
-              stateful: ${stateful_client},
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
             return client;
@@ -117,7 +112,6 @@ class $Root extends $stdlib.std.Resource {
       }
       _registerBind(host, ops) {
         if (ops.includes("$inflight_init")) {
-          this._registerBindObject(this.stateful, host, []);
         }
         if (ops.includes("handle")) {
         }
@@ -140,13 +134,11 @@ class $Root extends $stdlib.std.Resource {
         }
       }
       _toInflight() {
-        const stateful_client = this._lift(this.stateful);
         const self_client_path = "./clients/r.inflight.js".replace(/\\/g, "/");
         return $stdlib.core.NodeJsCode.fromInline(`
           (await (async () => {
             const r = require("${self_client_path}")({});
             const client = new r({
-              stateful: ${stateful_client},
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
             return client;
@@ -155,7 +147,6 @@ class $Root extends $stdlib.std.Resource {
       }
       _registerBind(host, ops) {
         if (ops.includes("$inflight_init")) {
-          this._registerBindObject(this.stateful, host, []);
         }
         if (ops.includes("method_2")) {
         }
@@ -168,13 +159,11 @@ class $Root extends $stdlib.std.Resource {
         this._addInflightOps("eat");
       }
       _toInflight() {
-        const stateful_client = this._lift(this.stateful);
         const self_client_path = "./clients/Dog.inflight.js".replace(/\\/g, "/");
         return $stdlib.core.NodeJsCode.fromInline(`
           (await (async () => {
             const Dog = require("${self_client_path}")({});
             const client = new Dog({
-              stateful: ${stateful_client},
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
             return client;
@@ -183,7 +172,6 @@ class $Root extends $stdlib.std.Resource {
       }
       _registerBind(host, ops) {
         if (ops.includes("$inflight_init")) {
-          this._registerBindObject(this.stateful, host, []);
         }
         if (ops.includes("eat")) {
         }

--- a/tools/hangar/__snapshots__/test_corpus/json.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/json.w_compile_tf-aws.md
@@ -4,9 +4,8 @@
 ```js
 module.exports = function() {
   class  Foo {
-    constructor({ _sum_str, stateful }) {
+    constructor({ _sum_str }) {
       this._sum_str = _sum_str;
-      this.stateful = stateful;
     }
   }
   return Foo;
@@ -62,14 +61,12 @@ class $Root extends $stdlib.std.Resource {
       }
       _toInflight() {
         const _sum_str_client = this._lift(this._sum_str);
-        const stateful_client = this._lift(this.stateful);
         const self_client_path = "./clients/Foo.inflight.js".replace(/\\/g, "/");
         return $stdlib.core.NodeJsCode.fromInline(`
           (await (async () => {
             const Foo = require("${self_client_path}")({});
             const client = new Foo({
               _sum_str: ${_sum_str_client},
-              stateful: ${stateful_client},
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
             return client;
@@ -79,7 +76,6 @@ class $Root extends $stdlib.std.Resource {
       _registerBind(host, ops) {
         if (ops.includes("$inflight_init")) {
           this._registerBindObject(this._sum_str, host, []);
-          this._registerBindObject(this.stateful, host, []);
         }
         super._registerBind(host, ops);
       }

--- a/tools/hangar/__snapshots__/test_corpus/reassignment.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/reassignment.w_compile_tf-aws.md
@@ -4,9 +4,8 @@
 ```js
 module.exports = function() {
   class  R {
-    constructor({ f1, stateful }) {
+    constructor({ f1 }) {
       this.f1 = f1;
-      this.stateful = stateful;
     }
   }
   return R;
@@ -70,14 +69,12 @@ class $Root extends $stdlib.std.Resource {
       }
       _toInflight() {
         const f1_client = this._lift(this.f1);
-        const stateful_client = this._lift(this.stateful);
         const self_client_path = "./clients/R.inflight.js".replace(/\\/g, "/");
         return $stdlib.core.NodeJsCode.fromInline(`
           (await (async () => {
             const R = require("${self_client_path}")({});
             const client = new R({
               f1: ${f1_client},
-              stateful: ${stateful_client},
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
             return client;
@@ -87,7 +84,6 @@ class $Root extends $stdlib.std.Resource {
       _registerBind(host, ops) {
         if (ops.includes("$inflight_init")) {
           this._registerBindObject(this.f1, host, []);
-          this._registerBindObject(this.stateful, host, []);
         }
         super._registerBind(host, ops);
       }

--- a/tools/hangar/__snapshots__/test_corpus/resource.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/resource.w_compile_tf-aws.md
@@ -4,11 +4,10 @@
 ```js
 module.exports = function() {
   class  Bar {
-    constructor({ b, foo, name, stateful }) {
+    constructor({ b, foo, name }) {
       this.b = b;
       this.foo = foo;
       this.name = name;
-      this.stateful = stateful;
     }
     async my_method()  {
       {
@@ -27,12 +26,11 @@ module.exports = function() {
 ```js
 module.exports = function() {
   class  BigPublisher {
-    constructor({ b, b2, q, t, stateful }) {
+    constructor({ b, b2, q, t }) {
       this.b = b;
       this.b2 = b2;
       this.q = q;
       this.t = t;
-      this.stateful = stateful;
     }
     async publish(s)  {
       {
@@ -56,9 +54,8 @@ module.exports = function() {
 ```js
 module.exports = function() {
   class  Foo {
-    constructor({ c, stateful }) {
+    constructor({ c }) {
       this.c = c;
-      this.stateful = stateful;
     }
     async $inflight_init()  {
       {
@@ -776,14 +773,12 @@ class $Root extends $stdlib.std.Resource {
       }
       _toInflight() {
         const c_client = this._lift(this.c);
-        const stateful_client = this._lift(this.stateful);
         const self_client_path = "./clients/Foo.inflight.js".replace(/\\/g, "/");
         return $stdlib.core.NodeJsCode.fromInline(`
           (await (async () => {
             const Foo = require("${self_client_path}")({});
             const client = new Foo({
               c: ${c_client},
-              stateful: ${stateful_client},
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
             return client;
@@ -793,7 +788,6 @@ class $Root extends $stdlib.std.Resource {
       _registerBind(host, ops) {
         if (ops.includes("$inflight_init")) {
           this._registerBindObject(this.c, host, ["dec", "inc"]);
-          this._registerBindObject(this.stateful, host, []);
         }
         if (ops.includes("foo_get")) {
           this._registerBindObject(this.c, host, ["peek"]);
@@ -816,7 +810,6 @@ class $Root extends $stdlib.std.Resource {
         const b_client = this._lift(this.b);
         const foo_client = this._lift(this.foo);
         const name_client = this._lift(this.name);
-        const stateful_client = this._lift(this.stateful);
         const self_client_path = "./clients/Bar.inflight.js".replace(/\\/g, "/");
         return $stdlib.core.NodeJsCode.fromInline(`
           (await (async () => {
@@ -825,7 +818,6 @@ class $Root extends $stdlib.std.Resource {
               b: ${b_client},
               foo: ${foo_client},
               name: ${name_client},
-              stateful: ${stateful_client},
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
             return client;
@@ -837,7 +829,6 @@ class $Root extends $stdlib.std.Resource {
           this._registerBindObject(this.b, host, []);
           this._registerBindObject(this.foo, host, []);
           this._registerBindObject(this.name, host, []);
-          this._registerBindObject(this.stateful, host, []);
         }
         if (ops.includes("my_method")) {
           this._registerBindObject(this.b, host, ["get", "put"]);
@@ -890,7 +881,6 @@ class $Root extends $stdlib.std.Resource {
         const b2_client = this._lift(this.b2);
         const q_client = this._lift(this.q);
         const t_client = this._lift(this.t);
-        const stateful_client = this._lift(this.stateful);
         const self_client_path = "./clients/BigPublisher.inflight.js".replace(/\\/g, "/");
         return $stdlib.core.NodeJsCode.fromInline(`
           (await (async () => {
@@ -900,7 +890,6 @@ class $Root extends $stdlib.std.Resource {
               b2: ${b2_client},
               q: ${q_client},
               t: ${t_client},
-              stateful: ${stateful_client},
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
             return client;
@@ -912,7 +901,6 @@ class $Root extends $stdlib.std.Resource {
           this._registerBindObject(this.b, host, []);
           this._registerBindObject(this.b2, host, []);
           this._registerBindObject(this.q, host, []);
-          this._registerBindObject(this.stateful, host, []);
           this._registerBindObject(this.t, host, []);
         }
         if (ops.includes("getObjectCount")) {

--- a/tools/hangar/__snapshots__/test_corpus/resource_as_inflight_literal.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/resource_as_inflight_literal.w_compile_tf-aws.md
@@ -4,8 +4,7 @@
 ```js
 module.exports = function() {
   class  Foo {
-    constructor({ stateful }) {
-      this.stateful = stateful;
+    constructor({  }) {
     }
     async handle(message)  {
       {
@@ -220,13 +219,11 @@ class $Root extends $stdlib.std.Resource {
         this._addInflightOps("handle");
       }
       _toInflight() {
-        const stateful_client = this._lift(this.stateful);
         const self_client_path = "./clients/Foo.inflight.js".replace(/\\/g, "/");
         return $stdlib.core.NodeJsCode.fromInline(`
           (await (async () => {
             const Foo = require("${self_client_path}")({});
             const client = new Foo({
-              stateful: ${stateful_client},
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
             return client;
@@ -235,7 +232,6 @@ class $Root extends $stdlib.std.Resource {
       }
       _registerBind(host, ops) {
         if (ops.includes("$inflight_init")) {
-          this._registerBindObject(this.stateful, host, []);
         }
         if (ops.includes("handle")) {
         }

--- a/tools/hangar/__snapshots__/test_corpus/resource_captures.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/resource_captures.w_compile_tf-aws.md
@@ -4,10 +4,9 @@
 ```js
 module.exports = function() {
   class  Another {
-    constructor({ first, my_field, stateful }) {
+    constructor({ first, my_field }) {
       this.first = first;
       this.my_field = my_field;
-      this.stateful = stateful;
     }
     async meaning_of_life()  {
       {
@@ -29,9 +28,8 @@ module.exports = function() {
 ```js
 module.exports = function() {
   class  First {
-    constructor({ my_resource, stateful }) {
+    constructor({ my_resource }) {
       this.my_resource = my_resource;
-      this.stateful = stateful;
     }
   }
   return First;
@@ -43,7 +41,7 @@ module.exports = function() {
 ```js
 module.exports = function() {
   class  MyResource {
-    constructor({ another, array_of_str, ext_bucket, ext_num, map_of_num, my_bool, my_num, my_opt_str, my_queue, my_resource, my_str, set_of_str, unused_resource, stateful }) {
+    constructor({ another, array_of_str, ext_bucket, ext_num, map_of_num, my_bool, my_num, my_opt_str, my_queue, my_resource, my_str, set_of_str, unused_resource }) {
       this.another = another;
       this.array_of_str = array_of_str;
       this.ext_bucket = ext_bucket;
@@ -57,7 +55,6 @@ module.exports = function() {
       this.my_str = my_str;
       this.set_of_str = set_of_str;
       this.unused_resource = unused_resource;
-      this.stateful = stateful;
     }
     async test_no_capture()  {
       {
@@ -435,14 +432,12 @@ class $Root extends $stdlib.std.Resource {
       }
       _toInflight() {
         const my_resource_client = this._lift(this.my_resource);
-        const stateful_client = this._lift(this.stateful);
         const self_client_path = "./clients/First.inflight.js".replace(/\\/g, "/");
         return $stdlib.core.NodeJsCode.fromInline(`
           (await (async () => {
             const First = require("${self_client_path}")({});
             const client = new First({
               my_resource: ${my_resource_client},
-              stateful: ${stateful_client},
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
             return client;
@@ -452,7 +447,6 @@ class $Root extends $stdlib.std.Resource {
       _registerBind(host, ops) {
         if (ops.includes("$inflight_init")) {
           this._registerBindObject(this.my_resource, host, []);
-          this._registerBindObject(this.stateful, host, []);
         }
         super._registerBind(host, ops);
       }
@@ -467,7 +461,6 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         const first_client = this._lift(this.first);
         const my_field_client = this._lift(this.my_field);
-        const stateful_client = this._lift(this.stateful);
         const self_client_path = "./clients/Another.inflight.js".replace(/\\/g, "/");
         return $stdlib.core.NodeJsCode.fromInline(`
           (await (async () => {
@@ -475,7 +468,6 @@ class $Root extends $stdlib.std.Resource {
             const client = new Another({
               first: ${first_client},
               my_field: ${my_field_client},
-              stateful: ${stateful_client},
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
             return client;
@@ -486,7 +478,6 @@ class $Root extends $stdlib.std.Resource {
         if (ops.includes("$inflight_init")) {
           this._registerBindObject(this.first, host, []);
           this._registerBindObject(this.my_field, host, []);
-          this._registerBindObject(this.stateful, host, []);
         }
         if (ops.includes("another_func")) {
         }
@@ -532,7 +523,6 @@ class $Root extends $stdlib.std.Resource {
         const my_str_client = this._lift(this.my_str);
         const set_of_str_client = this._lift(this.set_of_str);
         const unused_resource_client = this._lift(this.unused_resource);
-        const stateful_client = this._lift(this.stateful);
         const self_client_path = "./clients/MyResource.inflight.js".replace(/\\/g, "/");
         return $stdlib.core.NodeJsCode.fromInline(`
           (await (async () => {
@@ -551,7 +541,6 @@ class $Root extends $stdlib.std.Resource {
               my_str: ${my_str_client},
               set_of_str: ${set_of_str_client},
               unused_resource: ${unused_resource_client},
-              stateful: ${stateful_client},
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
             return client;
@@ -572,7 +561,6 @@ class $Root extends $stdlib.std.Resource {
           this._registerBindObject(this.my_resource, host, []);
           this._registerBindObject(this.my_str, host, []);
           this._registerBindObject(this.set_of_str, host, []);
-          this._registerBindObject(this.stateful, host, []);
           this._registerBindObject(this.unused_resource, host, []);
         }
         if (ops.includes("test_capture_collections_of_data")) {

--- a/tools/hangar/__snapshots__/test_corpus/resource_captures_globals.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/resource_captures_globals.w_compile_tf-aws.md
@@ -4,10 +4,9 @@
 ```js
 module.exports = function({ global_counter }) {
   class  Another {
-    constructor({ first, my_field, stateful }) {
+    constructor({ first, my_field }) {
       this.first = first;
       this.my_field = my_field;
-      this.stateful = stateful;
     }
     async $inflight_init()  {
       {
@@ -30,9 +29,8 @@ module.exports = function({ global_counter }) {
 ```js
 module.exports = function() {
   class  First {
-    constructor({ my_resource, stateful }) {
+    constructor({ my_resource }) {
       this.my_resource = my_resource;
-      this.stateful = stateful;
     }
   }
   return First;
@@ -44,10 +42,9 @@ module.exports = function() {
 ```js
 module.exports = function({ global_another, global_array_of_str, global_bool, global_bucket, global_counter, global_map_of_num, global_num, global_set_of_str, global_str }) {
   class  MyResource {
-    constructor({ local_counter, local_topic, stateful }) {
+    constructor({ local_counter, local_topic }) {
       this.local_counter = local_counter;
       this.local_topic = local_topic;
-      this.stateful = stateful;
     }
     async my_put()  {
       {
@@ -74,8 +71,7 @@ module.exports = function({ global_another, global_array_of_str, global_bool, gl
 ```js
 module.exports = function({ $parent_this, global_counter }) {
   class  R {
-    constructor({ stateful }) {
-      this.stateful = stateful;
+    constructor({  }) {
     }
     async handle()  {
       {
@@ -456,14 +452,12 @@ class $Root extends $stdlib.std.Resource {
       }
       _toInflight() {
         const my_resource_client = this._lift(this.my_resource);
-        const stateful_client = this._lift(this.stateful);
         const self_client_path = "./clients/First.inflight.js".replace(/\\/g, "/");
         return $stdlib.core.NodeJsCode.fromInline(`
           (await (async () => {
             const First = require("${self_client_path}")({});
             const client = new First({
               my_resource: ${my_resource_client},
-              stateful: ${stateful_client},
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
             return client;
@@ -473,7 +467,6 @@ class $Root extends $stdlib.std.Resource {
       _registerBind(host, ops) {
         if (ops.includes("$inflight_init")) {
           this._registerBindObject(this.my_resource, host, []);
-          this._registerBindObject(this.stateful, host, []);
         }
         super._registerBind(host, ops);
       }
@@ -488,7 +481,6 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         const first_client = this._lift(this.first);
         const my_field_client = this._lift(this.my_field);
-        const stateful_client = this._lift(this.stateful);
         const global_counter_client = this._lift(global_counter);
         const self_client_path = "./clients/Another.inflight.js".replace(/\\/g, "/");
         return $stdlib.core.NodeJsCode.fromInline(`
@@ -499,7 +491,6 @@ class $Root extends $stdlib.std.Resource {
             const client = new Another({
               first: ${first_client},
               my_field: ${my_field_client},
-              stateful: ${stateful_client},
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
             return client;
@@ -511,7 +502,6 @@ class $Root extends $stdlib.std.Resource {
           this._registerBindObject(global_counter, host, ["peek"]);
           this._registerBindObject(this.first, host, []);
           this._registerBindObject(this.my_field, host, []);
-          this._registerBindObject(this.stateful, host, []);
         }
         if (ops.includes("my_method")) {
           this._registerBindObject(global_counter, host, ["inc", "peek"]);
@@ -532,7 +522,6 @@ class $Root extends $stdlib.std.Resource {
             this._addInflightOps("handle");
           }
           _toInflight() {
-            const stateful_client = this._lift(this.stateful);
             const $parent_this_client = this._lift($parent_this);
             const global_counter_client = this._lift(global_counter);
             const self_client_path = "./clients/R.inflight.js".replace(/\\/g, "/");
@@ -543,7 +532,6 @@ class $Root extends $stdlib.std.Resource {
                   global_counter: ${global_counter_client},
                 });
                 const client = new R({
-                  stateful: ${stateful_client},
                 });
                 if (client.$inflight_init) { await client.$inflight_init(); }
                 return client;
@@ -552,7 +540,6 @@ class $Root extends $stdlib.std.Resource {
           }
           _registerBind(host, ops) {
             if (ops.includes("$inflight_init")) {
-              this._registerBindObject(this.stateful, host, []);
             }
             if (ops.includes("handle")) {
               this._registerBindObject($parent_this.local_counter, host, ["inc"]);
@@ -566,7 +553,6 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         const local_counter_client = this._lift(this.local_counter);
         const local_topic_client = this._lift(this.local_topic);
-        const stateful_client = this._lift(this.stateful);
         const global_another_client = this._lift(global_another);
         const global_array_of_str_client = this._lift(global_array_of_str);
         const global_bool_client = this._lift(global_bool);
@@ -593,7 +579,6 @@ class $Root extends $stdlib.std.Resource {
             const client = new MyResource({
               local_counter: ${local_counter_client},
               local_topic: ${local_topic_client},
-              stateful: ${stateful_client},
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
             return client;
@@ -604,7 +589,6 @@ class $Root extends $stdlib.std.Resource {
         if (ops.includes("$inflight_init")) {
           this._registerBindObject(this.local_counter, host, []);
           this._registerBindObject(this.local_topic, host, []);
-          this._registerBindObject(this.stateful, host, []);
         }
         if (ops.includes("my_put")) {
           this._registerBindObject(global_another, host, ["my_method"]);

--- a/tools/hangar/__snapshots__/test_corpus/static_members.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/static_members.w_compile_tf-aws.md
@@ -4,9 +4,8 @@
 ```js
 module.exports = function() {
   class  Foo {
-    constructor({ instance_field, stateful }) {
+    constructor({ instance_field }) {
       this.instance_field = instance_field;
-      this.stateful = stateful;
     }
     static async get_123()  {
       {
@@ -162,14 +161,12 @@ class $Root extends $stdlib.std.Resource {
       }
       _toInflight() {
         const instance_field_client = this._lift(this.instance_field);
-        const stateful_client = this._lift(this.stateful);
         const self_client_path = "./clients/Foo.inflight.js".replace(/\\/g, "/");
         return $stdlib.core.NodeJsCode.fromInline(`
           (await (async () => {
             const Foo = require("${self_client_path}")({});
             const client = new Foo({
               instance_field: ${instance_field_client},
-              stateful: ${stateful_client},
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
             return client;
@@ -179,7 +176,6 @@ class $Root extends $stdlib.std.Resource {
       _registerBind(host, ops) {
         if (ops.includes("$inflight_init")) {
           this._registerBindObject(this.instance_field, host, []);
-          this._registerBindObject(this.stateful, host, []);
         }
         if (ops.includes("get_123")) {
         }

--- a/tools/hangar/__snapshots__/test_corpus/structs.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/structs.w_compile_tf-aws.md
@@ -4,9 +4,8 @@
 ```js
 module.exports = function() {
   class  Foo {
-    constructor({ data, stateful }) {
+    constructor({ data }) {
       this.data = data;
-      this.stateful = stateful;
     }
     async get_stuff()  {
       {
@@ -68,14 +67,12 @@ class $Root extends $stdlib.std.Resource {
       }
       _toInflight() {
         const data_client = this._lift(this.data);
-        const stateful_client = this._lift(this.stateful);
         const self_client_path = "./clients/Foo.inflight.js".replace(/\\/g, "/");
         return $stdlib.core.NodeJsCode.fromInline(`
           (await (async () => {
             const Foo = require("${self_client_path}")({});
             const client = new Foo({
               data: ${data_client},
-              stateful: ${stateful_client},
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
             return client;
@@ -85,7 +82,6 @@ class $Root extends $stdlib.std.Resource {
       _registerBind(host, ops) {
         if (ops.includes("$inflight_init")) {
           this._registerBindObject(this.data, host, []);
-          this._registerBindObject(this.stateful, host, []);
         }
         if (ops.includes("get_stuff")) {
           this._registerBindObject(this.data.field0, host, []);

--- a/tools/hangar/__snapshots__/test_corpus/symbol_shadow.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/symbol_shadow.w_compile_tf-aws.md
@@ -4,8 +4,7 @@
 ```js
 module.exports = function() {
   class  A {
-    constructor({ stateful }) {
-      this.stateful = stateful;
+    constructor({  }) {
     }
   }
   return A;
@@ -355,13 +354,11 @@ class $Root extends $stdlib.std.Resource {
         );
       }
       _toInflight() {
-        const stateful_client = this._lift(this.stateful);
         const self_client_path = "./clients/A.inflight.js".replace(/\\/g, "/");
         return $stdlib.core.NodeJsCode.fromInline(`
           (await (async () => {
             const A = require("${self_client_path}")({});
             const client = new A({
-              stateful: ${stateful_client},
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
             return client;
@@ -370,7 +367,6 @@ class $Root extends $stdlib.std.Resource {
       }
       _registerBind(host, ops) {
         if (ops.includes("$inflight_init")) {
-          this._registerBindObject(this.stateful, host, []);
         }
         super._registerBind(host, ops);
       }

--- a/tools/hangar/__snapshots__/tree_json.ts.snap
+++ b/tools/hangar/__snapshots__/tree_json.ts.snap
@@ -19,13 +19,11 @@ exports[`tree.json for an app with many resources 1`] = `
               "Default": {
                 "attributes": {
                   "wing:resource:connections": [],
-                  "wing:resource:stateful": false,
                 },
                 "children": {
                   "$Inflight4": {
                     "attributes": {
                       "wing:resource:connections": [],
-                      "wing:resource:stateful": false,
                     },
                     "constructInfo": {
                       "fqn": "@winglang/sdk.std.Resource",
@@ -42,7 +40,6 @@ exports[`tree.json for an app with many resources 1`] = `
                   "$Inflight5": {
                     "attributes": {
                       "wing:resource:connections": [],
-                      "wing:resource:stateful": false,
                     },
                     "constructInfo": {
                       "fqn": "@winglang/sdk.std.Resource",
@@ -66,7 +63,6 @@ exports[`tree.json for an app with many resources 1`] = `
                           "resource": "root/Default/Default/test",
                         },
                       ],
-                      "wing:resource:stateful": false,
                     },
                     "children": {
                       "Foo": {
@@ -85,7 +81,6 @@ exports[`tree.json for an app with many resources 1`] = `
                               "resource": "root/Default/Default/test",
                             },
                           ],
-                          "wing:resource:stateful": false,
                         },
                         "children": {
                           "cloud.Counter": {
@@ -110,7 +105,6 @@ exports[`tree.json for an app with many resources 1`] = `
                                   "resource": "root/Default/Default/test",
                                 },
                               ],
-                              "wing:resource:stateful": true,
                             },
                             "children": {
                               "Default": {
@@ -201,7 +195,6 @@ exports[`tree.json for an app with many resources 1`] = `
                           "resource": "root/Default/Default/test: dependency cycles",
                         },
                       ],
-                      "wing:resource:stateful": false,
                     },
                     "children": {
                       "$Inflight1": {
@@ -214,7 +207,6 @@ exports[`tree.json for an app with many resources 1`] = `
                               "resource": "root/Default/Default/BigPublisher/cloud.Topic-OnMessage-cb235724",
                             },
                           ],
-                          "wing:resource:stateful": false,
                         },
                         "constructInfo": {
                           "fqn": "@winglang/sdk.std.Resource",
@@ -238,7 +230,6 @@ exports[`tree.json for an app with many resources 1`] = `
                               "resource": "root/Default/Default/BigPublisher/cloud.Queue-AddConsumer-c351460f",
                             },
                           ],
-                          "wing:resource:stateful": false,
                         },
                         "constructInfo": {
                           "fqn": "@winglang/sdk.std.Resource",
@@ -262,7 +253,6 @@ exports[`tree.json for an app with many resources 1`] = `
                               "resource": "root/Default/Default/BigPublisher/b2/b2-on_create-OnMessage-a754ef69",
                             },
                           ],
-                          "wing:resource:stateful": false,
                         },
                         "constructInfo": {
                           "fqn": "@winglang/sdk.std.Resource",
@@ -310,7 +300,6 @@ exports[`tree.json for an app with many resources 1`] = `
                               "resource": "root/Default/Default/test: dependency cycles",
                             },
                           ],
-                          "wing:resource:stateful": true,
                         },
                         "children": {
                           "Default": {
@@ -361,7 +350,6 @@ exports[`tree.json for an app with many resources 1`] = `
                                   "resource": "root/Default/Default/BigPublisher/b2/b2-on_create-OnMessage-a754ef69",
                                 },
                               ],
-                              "wing:resource:stateful": true,
                             },
                             "children": {
                               "Default": {
@@ -458,7 +446,6 @@ exports[`tree.json for an app with many resources 1`] = `
                                   "resource": "root/Default/Default/BigPublisher/b2/b2-on_create",
                                 },
                               ],
-                              "wing:resource:stateful": false,
                             },
                             "children": {
                               "Asset": {
@@ -532,7 +519,6 @@ exports[`tree.json for an app with many resources 1`] = `
                           "b2-on_create-OnMessageHandler-a754ef69": {
                             "attributes": {
                               "wing:resource:connections": [],
-                              "wing:resource:stateful": false,
                             },
                             "constructInfo": {
                               "fqn": "@winglang/sdk.std.Resource",
@@ -566,7 +552,6 @@ exports[`tree.json for an app with many resources 1`] = `
                               "resource": "root/Default/Default/BigPublisher/b2/b2-on_create-OnMessage-a754ef69",
                             },
                           ],
-                          "wing:resource:stateful": false,
                         },
                         "constructInfo": {
                           "fqn": "@winglang/sdk.std.Resource",
@@ -606,7 +591,6 @@ exports[`tree.json for an app with many resources 1`] = `
                               "resource": "root/Default/Default/test: dependency cycles",
                             },
                           ],
-                          "wing:resource:stateful": true,
                         },
                         "children": {
                           "Default": {
@@ -679,7 +663,6 @@ exports[`tree.json for an app with many resources 1`] = `
                               "resource": "root/Default/Default/test: dependency cycles",
                             },
                           ],
-                          "wing:resource:stateful": true,
                         },
                         "children": {
                           "Default": {
@@ -762,7 +745,6 @@ exports[`tree.json for an app with many resources 1`] = `
                               "resource": "root/Default/Default/BigPublisher/cloud.Queue",
                             },
                           ],
-                          "wing:resource:stateful": false,
                         },
                         "children": {
                           "Asset": {
@@ -828,7 +810,6 @@ exports[`tree.json for an app with many resources 1`] = `
                       "cloud.Queue-AddConsumerHandler-c351460f": {
                         "attributes": {
                           "wing:resource:connections": [],
-                          "wing:resource:stateful": false,
                         },
                         "constructInfo": {
                           "fqn": "@winglang/sdk.std.Resource",
@@ -874,7 +855,6 @@ exports[`tree.json for an app with many resources 1`] = `
                               "resource": "root/Default/Default/test: dependency cycles",
                             },
                           ],
-                          "wing:resource:stateful": true,
                         },
                         "children": {
                           "Default": {
@@ -957,7 +937,6 @@ exports[`tree.json for an app with many resources 1`] = `
                               "resource": "root/Default/Default/BigPublisher/cloud.Topic",
                             },
                           ],
-                          "wing:resource:stateful": false,
                         },
                         "children": {
                           "Asset": {
@@ -1031,7 +1010,6 @@ exports[`tree.json for an app with many resources 1`] = `
                       "cloud.Topic-OnMessageHandler-cb235724": {
                         "attributes": {
                           "wing:resource:connections": [],
-                          "wing:resource:stateful": false,
                         },
                         "constructInfo": {
                           "fqn": "@winglang/sdk.std.Resource",
@@ -1097,7 +1075,6 @@ exports[`tree.json for an app with many resources 1`] = `
                           "resource": "root/Default/Default/test",
                         },
                       ],
-                      "wing:resource:stateful": true,
                     },
                     "children": {
                       "Default": {
@@ -1218,7 +1195,6 @@ exports[`tree.json for an app with many resources 1`] = `
                           "resource": "root/Default/Default/Bar",
                         },
                       ],
-                      "wing:resource:stateful": false,
                     },
                     "children": {
                       "Asset": {
@@ -1321,7 +1297,6 @@ exports[`tree.json for an app with many resources 1`] = `
                           "resource": "root/Default/Default/BigPublisher",
                         },
                       ],
-                      "wing:resource:stateful": false,
                     },
                     "children": {
                       "Asset": {
@@ -1403,7 +1378,6 @@ exports[`tree.json for an app with many resources 1`] = `
               "cloud.TestRunner": {
                 "attributes": {
                   "wing:resource:connections": [],
-                  "wing:resource:stateful": false,
                 },
                 "children": {
                   "TestFunctionArns": {


### PR DESCRIPTION
Removes the `stateful` field from resources in the SDK. This field doesn't serve any functional purpose right now, and every now and then folks ask about it since it's a public API that appears in IDE auto-completions. Let's add it back when we have a use case for it.

BREAKING CHANGE: `stateful` field has been removed as a built-in field of preflight objects

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.