### PR TITLE
fix(docs): disable js minimization in docusaurus to display code samples properly

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -8,14 +8,21 @@ module.exports = {
   themeConfig: {
     // ...
   },
-  configureWebpack: {
-    module: {
-      rules: [
-        {
-          test: /\.(w|js|ts|tf)$/,
-          use: 'file-loader',
-        },
-      ],
-    },
+  configureWebpack: (config, isServer, utils) => {
+    const { getCacheLoader } = utils;
+    return {
+      module: {
+        rules: [
+          {
+            test: /\.(w|js|ts|tf)$/,
+            use: 'file-loader',
+          },
+        ],
+      },
+      optimization: {
+        ...config.optimization,
+        minimize: false, // Disables JavaScript minification
+      },
+    };
   },
 };


### PR DESCRIPTION


*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.