### PR TITLE
chore(compiler): refactoring class field initialization

### DIFF
--- a/libs/wingc/src/lib.rs
+++ b/libs/wingc/src/lib.rs
@@ -40,6 +40,7 @@ pub mod lsp;
 pub mod parser;
 pub mod type_check;
 pub mod type_check_assert;
+pub mod type_check_class_fields_init;
 pub mod utilities;
 pub mod visit;
 mod wasm_util;

--- a/libs/wingc/src/type_check.rs
+++ b/libs/wingc/src/type_check.rs
@@ -7,7 +7,8 @@ use crate::ast::{
 	Symbol, ToSpan, TypeAnnotation, UnaryOperator, UserDefinedType,
 };
 use crate::diagnostic::{Diagnostic, DiagnosticLevel, Diagnostics, TypeError};
-use crate::visit::{self, Visit};
+use crate::type_check_class_fields_init::VisitClassInit;
+use crate::visit::Visit;
 use crate::{
 	debug, WINGSDK_ARRAY, WINGSDK_ASSEMBLY_NAME, WINGSDK_CLOUD_MODULE, WINGSDK_DURATION, WINGSDK_FS_MODULE, WINGSDK_JSON,
 	WINGSDK_MAP, WINGSDK_MUT_ARRAY, WINGSDK_MUT_JSON, WINGSDK_MUT_MAP, WINGSDK_MUT_SET, WINGSDK_REDIS_MODULE,
@@ -28,30 +29,6 @@ use wingii::type_system::TypeSystem;
 
 use self::jsii_importer::JsiiImportSpec;
 use self::symbol_env::SymbolEnvIter;
-
-/// Visitor Pattern for listing the variables that are initialized in the class constructor.
-pub struct VisitClassInit {
-	fields: Vec<String>,
-}
-impl Visit<'_> for VisitClassInit {
-	fn visit_stmt(&mut self, node: &Stmt) {
-		match &node.kind {
-			StmtKind::Assignment { variable, value: _ } => {
-				visit::visit_reference(self, variable);
-			}
-			_ => (),
-		}
-		visit::visit_stmt(self, node);
-	}
-
-	fn visit_reference(&mut self, node: &Reference) {
-		match node {
-			Reference::InstanceMember { property, object: _ } => self.fields.push(property.name.clone()),
-			_ => (),
-		}
-		visit::visit_reference(self, node);
-	}
-}
 
 pub struct UnsafeRef<T>(*const T);
 impl<T> Clone for UnsafeRef<T> {

--- a/libs/wingc/src/type_check_class_fields_init.rs
+++ b/libs/wingc/src/type_check_class_fields_init.rs
@@ -1,0 +1,29 @@
+use crate::{
+	ast::{Reference, Stmt, StmtKind},
+	visit::{self, Visit},
+};
+
+/// Visitor Pattern for listing the variables that are initialized in the class constructor.
+pub struct VisitClassInit {
+	pub fields: Vec<String>,
+}
+
+impl Visit<'_> for VisitClassInit {
+	fn visit_stmt(&mut self, node: &Stmt) {
+		match &node.kind {
+			StmtKind::Assignment { variable, value: _ } => {
+				visit::visit_reference(self, variable);
+			}
+			_ => (),
+		}
+		visit::visit_stmt(self, node);
+	}
+
+	fn visit_reference(&mut self, node: &Reference) {
+		match node {
+			Reference::InstanceMember { property, object: _ } => self.fields.push(property.name.clone()),
+			_ => (),
+		}
+		visit::visit_reference(self, node);
+	}
+}


### PR DESCRIPTION
A little refactoring on "class without an initializer"

I removed the Class Init Visitor from the type_check file to a separate file

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.