### PR TITLE
chore(docs): some grammar fixes to the language spec

### DIFF
--- a/docs/04-reference/winglang-spec.md
+++ b/docs/04-reference/winglang-spec.md
@@ -9,7 +9,7 @@ keywords: [Wing reference, Wing language, language, Wing language spec, Wing pro
 
 This document is a *specification* of the programming language, and many features
 are still not implemented (see [project board](https://github.com/orgs/winglang/projects/1)).
- 
+
 :::
 
 ## 0. Preface
@@ -39,7 +39,7 @@ the mechanics of the cloud.
 
 - Developer Experience (DX) is priority #1 for Wing.
 - Syntax design aims to be concise and minimal, while being "batteries included"
-- at the same time in terms of tooling and DX.
+  at the same time in terms of tooling and DX.
 - Developers coming from other mainstream cloud languages (C#, Java, and TS)
   should feel right at home.
 - Public facing APIs and syntax are designed to be compatible with JSII. Wing
@@ -76,7 +76,7 @@ import TOCInline from '@theme/TOCInline';
 
 > `any` is only available to JSII imported modules.
 
-User defined explicit "any" is supported iff declared by the user.  
+User defined explicit "any" is supported if declared by the user.  
 Almost all types can be implicitly resolved by the compiler except for "any".  
 "any" must be explicitly declared and annotated.
 
@@ -659,10 +659,10 @@ log("UTC: ${t1.utc.to_iso())}");            // output: 2023-02-09T06:21:03.000Z
 Wing is a statically typed language, so attempting to redefine any of the above
 functions, just like any other "symbol" will result in a compile-time error. 
 
-Above functions can accept variadic arguments of any type except `throw` which
+The above functions can accept variadic arguments of any type except `throw` which
 only accepts one argument and that is the message to be contained in the error.
 
-"panic" is a fatal call by design. If intention is error handling, panic is the
+`panic` is a fatal call by design. If the intention is error handling, panic is the
 last resort. Exceptions are non fatal and should be used instead for effectively
 communicating errors to the user.
 
@@ -700,9 +700,9 @@ communicating errors to the user.
 
 In Wing, we differentiate between code that executes during compilation and code
 that executes after the application has been deployed by referring to them as
-**preflight** and **inflight** code respectively.
+`preflight` and `inflight` code respectively.
 
-The default (and implicit) execution context in Wing is **preflight**. This is
+The default (and implicit) execution context in Wing is `preflight`. This is
 because in cloud applications, the entrypoint is the definition of the app's
 cloud architecture, and not the code that runs within a specific machine within
 this cloud infrastructure.
@@ -793,7 +793,7 @@ is only available once per program and for the entire duration of that program.
 All statics must be defined inline and initialized right away.  
 Statics are not allowed on structs or interfaces.
 
-Statics are both supported in inflight as well as preflight mode of execution.
+Statics are supported in both inflight as well as preflight modes of execution.
 
 A declaration for a static member is a member declaration whose declaration
 specifiers contain the keyword static. The keyword static must appear before
@@ -827,7 +827,7 @@ Visibility inference is done with the following rules:
 
 Accessing fields, members, or structured data is done with `.`.
 
-Visibility modifiers can be applied to members of classes.
+Visibility modifiers can be applied to members of the classes.
 Mixing `protected` and `internal` is not allowed.
 
 [`▲ top`][top]
@@ -1010,7 +1010,7 @@ assert(increment(88) == 89);
 assert(increment(88, 2) == 90);
 ```
 
-Alternatively, using the default value notation can be used to allow an parameter not to be assigned
+Alternatively, using the default value notation can be used to allow a parameter not to be assigned
 when calling the function. Using a default value in the function declaration ensures that `by`
 always has a value so there is no need to unwrap it (this is why its type is `num` and not `num?`):
 
@@ -1101,7 +1101,7 @@ if my_person.address == nil {
 
 #### 1.7.3 Unwrapping using `if let`
 
-The `if let` statement can be used to test if an optional is defined and *unwrap* it into a
+The `if let` statement can be used to test if an optional is defined and *unwrap*s it into a
 non-optional variable defined inside the block:
 
 ```js
@@ -1173,7 +1173,7 @@ All defined symbols are immutable (constant) by default.
 Type casting is generally not allowed unless otherwise specified.
 
 Function arguments and their return type is always required. Function argument
-type is inferred iff a default value is provided.
+type is inferred if a default value is provided.
 
 > ```TS
 > let i = 5;
@@ -1205,7 +1205,7 @@ type is inferred iff a default value is provided.
 
 ### 1.9 Error Handling
 
-Exceptions and `try/catch/finally` is the error mechanism. Mechanics directly
+Exceptions and `try/catch/finally` are the error mechanisms. Mechanics directly
 translate to JavaScript. You can create a new exception with a `throw` call.
 
 In the presence of `try`, both `catch` and `finally` are optional but at least one of them must be present.
@@ -1252,8 +1252,8 @@ expected from a call and it is not being caught.
 
 Wing recommends the following formatting and naming conventions:
 
-- Interface names should start with capital letter "I"
-- Class, struct, and interface names should be TitleCased
+- Interface names should start with capital letter "I".
+- Class, struct, and interface names should be TitleCased.
 - Members of classes, and interfaces cannot share the same TitleCased
   representation as the declaring expression itself.
 - Parentheses are optional in expressions. Any Wing expression can be surrounded
@@ -1323,15 +1323,15 @@ with `inflight` in Wing deliberately to indicate extended functionality.
 
 Main concepts to understand:
 
-- "preflight" implies synchronous execution.
-- `inflight` implies asynchronous execution
+- `preflight` implies synchronous execution.
+- `inflight` implies asynchronous execution.
 
-Contrary to JavaScript, any call to an async function is implicitly awaited. As
+Contrary to JavaScript, any call to an async function is implicitly awaited in Wing. As
 a result, `await` in Wing is a rarely used keyword, since its use is implied by
 the `inflight` keyword. `await` is only used when you want a `defer`ed `Promise`
 to be fulfilled before execution flow continues.
 
-The Wing compiler emits `await`s when encountering `Promise<T>` types as rvalues
+The Wing compiler emits `await`s when encountering `Promise<T>` types as r-values
 in expressions. Use the `defer` keyword to defer the resolution of a promise and
 obtain a `Promise<T>` type instead (a.k.a un`await` what the compiler does).
 
@@ -1341,7 +1341,7 @@ The `Promise<T>` type is not allowed to hold nested promises in `T`.
 
 ### 2.1 bring
 
-"bring" statement can be used to import and reuse code from other Wing files or
+**bring** statement can be used to import and reuse code from other Wing files or
 other JSII supported languages. The statement is detailed in its own section in
 this document: [Module System](#4-module-system).
 
@@ -1446,11 +1446,11 @@ includes for and while loops currently.
 
 > Read [Asynchronous Model](#114-asynchronous-model) section as a prerequisite.
 
-You mostly do not need to use `defer` and `await` keywords in Wing.  
-"defer" prevents the compiler from `await`ing a promise and grabs a reference.  
+You mostly do not need to use **defer** and **await** keywords in Wing.  
+"defer" prevents the compiler from awaiting a promise and grabs a reference.  
 "await" and "Promise" are semantically similar to JavaScript's promises.  
 "await" statement is only valid in `inflight` function declarations.  
-awaiting non promises in Wing is a no-op just like in JavaScript.
+Awaiting non promises in Wing is a no-op just like in JavaScript.
 
 > ```TS
 > // Wing program:
@@ -1492,7 +1492,7 @@ awaiting non promises in Wing is a no-op just like in JavaScript.
 ### 2.6 if
 
 Flow control can be done with `if/elif/else` statements.  
-The `if` statement is optionally followed by `elif` and `else`.  
+The **if** statement is optionally followed by **elif** and **else**.  
 
 > ```TS
 > // Wing program:
@@ -1529,8 +1529,8 @@ The `if` statement is optionally followed by `elif` and `else`.
 
 ### 2.7 for
 
-`for..in` statement is used to iterate over a array or set.  
-Type annotation after an iteratee (left hand side of `in`) is optional.  
+`for..in` statement is used to iterate over an array or a set.  
+Type annotation after an iteratee (left hand side of **in**) is optional.  
 The loop invariant in for loops is implicitly re-assignable (`var`).
 
 > ```TS
@@ -1579,7 +1579,7 @@ The loop invariant in for loops is implicitly re-assignable (`var`).
 
 ### 2.8 while
 
-while statement is used to execute a block of code while a condition is true.  
+**while** statement is used to execute a block of code while a condition is true.  
 
 > ```TS
 > // Wing program:
@@ -1677,11 +1677,11 @@ Structs can inherit from multiple other structs.
 
 ### 3.2 Classes
 
-Similarly to other object-oriented programming languages, Wing uses classes as its first-class
+Similar to other object-oriented programming languages, Wing uses classes as its first-class
 composition pattern. 
 
 Classes consist of fields and methods in any order.  
-The class system is single-dispatch class based object-orientated system.  
+The class system is a single-dispatch class based object-orientated system.  
 Classes are instantiated with the `new` keyword.
 
 Classes are associated with a specific execution phase (preflight or inflight). The phase indicates
@@ -1728,7 +1728,7 @@ initialized to `nil` if omitted, unless the type is `nil?`, which in that case,
 absent initialization is a compile error.
 
 Member function and field access in constructor with the "this" keyword before
-all fields are initialized is invalid and should throw a compile error.
+all fields are initialized is invalid and would throw a compile error.
 
 In other words, the `this` keyword is immutable to its field access operator `.`
 before all the member fields are properly initialized. The behavior is similar
@@ -1786,7 +1786,7 @@ class Boo extends Foo {
 ```
 
 Classes can inherit and extend other classes using the `extends` keyword.  
-Classes can implement interfaces iff the interfaces does not contain `inflight`.
+Classes can implement interfaces if the interfaces do not contain `inflight`.
 You can use the keyword `final` to stop the inheritance chain.
 
 ```TS
@@ -1809,15 +1809,15 @@ By default all methods are virtual. But if you are about to override a method,
 you need to explicitly provide the keyword **override**.  
 Static, private, and internal methods cannot be and are not virtual.  
 
-Statics are not inherited.  
-As a result, statics can be overridden mid hierarchy chain. Access to statics is
-through the class name that originally defined it `<class name>.Foo`.  
+Statics are not inherited. As a result, statics can be overridden mid hierarchy
+chain. Access to statics is through the class name that originally defined it: 
+`<class name>.Foo`.  
 
 Child class must not introduce additional signatures (overloads) for overridden
 (virtual) methods.
 
 Multiple inheritance is invalid and forbidden.  
-Multiple implementations of various interfaces is allowed.  
+Multiple implementations of various interfaces are allowed.  
 Multiple implementations of the same interface is invalid and forbidden.
 
 In methods if return type is missing, `: void` is assumed.
@@ -1867,7 +1867,7 @@ Preflight objects all have a scope and a unique ID. Compiler provides an implici
 and ID for each object, both overrideable by user-defined ones in constructor.
 
 The default for scope is `this`, which means the scope in which the object was
-defined (instantiated). The implicit ID is the type name of the class iff the type
+defined (instantiated). The implicit ID is the type name of the class if the type
 is the only preflight object of this type being used in the current scope. In other words, if
 there are multiple preflight objects of the same type defined in the same scope, they
 must all have an explicit id.
@@ -1903,8 +1903,8 @@ Preflight classes can extend other preflight classes (but not [structs](#31-stru
 all of the implemented methods must be `inflight`.
 
 Declaration of fields of the same name with different phases is not allowed due to requirement of
-having inflight fields of same name being implicitly initialized by the compiler  
-but declaration of methods with different phases is allowed.
+having inflight fields of same name being implicitly initialized by the compiler. But declaration 
+of methods with different phases is allowed.
 
 [`▲ top`][top]
 
@@ -2102,7 +2102,7 @@ f(1, 2, field1: 3, field2: 4);
 
 #### 3.6.4 Variadic Arguments
 
-If the last argument of a function type is the `...args` keyword followed by a
+If the last argument of a function type is the `...args` keyword followed by an
 `Array` type, then the function accepts typed variadic arguments. Expansion of
 variadic arguments is not supported currently and the container of variadic
 arguments is accessible with the `args` key like a normal array instance.
@@ -2111,7 +2111,7 @@ arguments is accessible with the `args` key like a normal array instance.
 let f = (x: num, ...args: Array<num>) => {
   log(x + y + args.len);
 }
-// last arguments are expanded into their struct
+// last arguments are expanded into their array
 f(1, 2, 3, 4, 5, 6, 34..100);
 ```
 
@@ -2121,7 +2121,7 @@ f(1, 2, 3, 4, 5, 6, 34..100);
 
 ### 3.7 Arrays
 
-Arrays are dynamically sized in Wing and are defined with the `[]` syntax.  
+`Array`s are dynamically sized in Wing and are defined with the `[]` syntax.  
 Individual array items are also accessed with the `[]` syntax.  
 Arrays are similar to dynamically sized arrays or vectors in other languages.
 
@@ -2149,11 +2149,11 @@ Arrays are similar to dynamically sized arrays or vectors in other languages.
 
 ### 3.8 Enumeration
 
-Enumeration type (enum) is a type that groups a list of named constant members.
+Enumeration type (`enum`) is a type that groups a list of named constant members.
 Enumeration is defined by writing **enum**, followed by enumeration name and a
 list of comma-separated constants in a {}. Last comma is optional in single line
 definitions but required in multi line definitions.  
-Naming convention for enums is to use "TitleCase" for name ALL_CAPS for members.
+Naming convention for enums is to use "TitleCase" for name and ALL_CAPS for members.
 
 > ```TS
 > enum SomeEnum { ONE, TWO, THREE };
@@ -2286,8 +2286,8 @@ class Rect {
 
 ## 4. Module System
 
-The module system in Wing uses the "bring" expression to reuse code.  
-**bring** expression allows code to "import" functions, classes and variables
+The module system in Wing uses the `bring` expression to reuse code.  
+**bring** expression allow code to "import" functions, classes, and variables
 from other files, to allow reusability.  
 **bring** expression is only allowed at the top of the file before any other
 code. Comments before the first bring expression are valid.
@@ -2314,7 +2314,7 @@ acts like C `#include`s. Symbols collision is fatal in this style of imports.
 
 In preflight, anything with `public` at block scope level is importable.
 This includes functions, classes, structs and interfaces.
-In inflight, the above excluding preflight classes are importable.
+In inflight, all of the above excluding preflight classes are importable.
 Variables are not exportable.
 
 Preflight classes cannot be instantiated in inflight functions. There is no synthesizer inside
@@ -2383,7 +2383,7 @@ exports.make_id = function() {
 Given a method of name X, the compiler will map the method to the JavaScript export with the 
 matching name (without any case conversion).
 
-Initially, we only support specifying `extern` for static methods (either inflight or preflight),
+Initially we only support specifying `extern` for static methods (either inflight or preflight),
 but we will consider adding support for instance methods in the future. In those cases the first
 argument to the method will implicitly be `this`.
 
@@ -2398,9 +2398,9 @@ In the future we will consider adding direct support for `extern "./helpers.ts"`
 ### 5.2.2 Type model
 
 The table below shows the mapping between Wing types and JavaScript types, represented with TypeScript syntax.
-When calling extern function, the arguments are checked against these declared types and the return type is **assumed** to be satisfied by the called function.
+When calling **extern** function, the arguments are checked against these declared types and the return type is **assumed** to be satisfied by the called function.
 
-If [frozen](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/freeze#description), the value is expected to be immutable and will throw if any attempt is made to modify it.
+If [frozen](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/freeze#description), the value is expected to be immutable and will throw an error if any attempt is made to modify it.
 
 | Built-In Wing Type     | JavaScript Type                                                       | Frozen? |
 |------------------------|-----------------------------------------------------------------------|---------|
@@ -2591,11 +2591,11 @@ For the built-in logical NOT operators, the result is `true` if the operand is
 
 For the built-in logical AND operators, the result is `true` if both operands
 are `true`. Otherwise, the result is `false`. This operator is short-circuiting
-if the first operand is `false`, the second operand is not evaluated.
+if the first operand is `false`, and the second operand is not evaluated.
 
 For the built-in logical OR operators, the result is `true` if either the first
 or the second operand (or both) is `true`. This operator is short-circuiting if
-the first operand is `true`, the second operand is not evaluated.
+the first operand is `true`, and the second operand is not evaluated.
 
 Note that bitwise logic operators do not perform short-circuiting.
 


### PR DESCRIPTION
Found few errors while going through the lang spec and so did a lazy proofread. Few grammar fixes, few updates to inconsistent styles etc.
Note: Take  a proper look at lines 2114 and 2403

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.