### PR TITLE
fix(sdk): updating website permission

### DIFF
--- a/libs/wingsdk/src/target-tf-aws/bucket.ts
+++ b/libs/wingsdk/src/target-tf-aws/bucket.ts
@@ -181,6 +181,13 @@ export function createEncryptedBucket(
   });
 
   if (isPublic) {
+    new S3BucketPublicAccessBlock(scope, "PublicAccessBlock", {
+      bucket: bucket.bucket,
+      blockPublicAcls: false,
+      blockPublicPolicy: false,
+      ignorePublicAcls: false,
+      restrictPublicBuckets: false,
+    });
     const policy = {
       Version: "2012-10-17",
       Statement: [
@@ -195,7 +202,6 @@ export function createEncryptedBucket(
     new S3BucketPolicy(scope, "PublicPolicy", {
       bucket: bucket.bucket,
       policy: JSON.stringify(policy),
-      dependsOn: [bucket],
     });
   } else {
     new S3BucketPublicAccessBlock(scope, "PublicAccessBlock", {

--- a/libs/wingsdk/test/target-tf-aws/__snapshots__/bucket.test.ts.snap
+++ b/libs/wingsdk/test/target-tf-aws/__snapshots__/bucket.test.ts.snap
@@ -17,10 +17,16 @@ exports[`bucket is public 1`] = `
     \\"aws_s3_bucket_policy\\": {
       \\"root_mybucket_PublicPolicy_2A65F5BE\\": {
         \\"bucket\\": \\"\${aws_s3_bucket.root_mybucket_E5DAA363.bucket}\\",
-        \\"depends_on\\": [
-          \\"aws_s3_bucket.root_mybucket_E5DAA363\\"
-        ],
         \\"policy\\": \\"{\\\\\\"Version\\\\\\":\\\\\\"2012-10-17\\\\\\",\\\\\\"Statement\\\\\\":[{\\\\\\"Effect\\\\\\":\\\\\\"Allow\\\\\\",\\\\\\"Principal\\\\\\":\\\\\\"*\\\\\\",\\\\\\"Action\\\\\\":[\\\\\\"s3:GetObject\\\\\\"],\\\\\\"Resource\\\\\\":[\\\\\\"\${aws_s3_bucket.root_mybucket_E5DAA363.arn}/*\\\\\\"]}]}\\"
+      }
+    },
+    \\"aws_s3_bucket_public_access_block\\": {
+      \\"root_mybucket_PublicAccessBlock_3EF88EB3\\": {
+        \\"block_public_acls\\": false,
+        \\"block_public_policy\\": false,
+        \\"bucket\\": \\"\${aws_s3_bucket.root_mybucket_E5DAA363.bucket}\\",
+        \\"ignore_public_acls\\": false,
+        \\"restrict_public_buckets\\": false
       }
     },
     \\"aws_s3_bucket_server_side_encryption_configuration\\": {
@@ -101,6 +107,14 @@ exports[`bucket is public 2`] = `
                     },
                     "id": "Encryption",
                     "path": "root/Default/my_bucket/Encryption",
+                  },
+                  "PublicAccessBlock": {
+                    "constructInfo": {
+                      "fqn": "cdktf.TerraformResource",
+                      "version": "0.15.2",
+                    },
+                    "id": "PublicAccessBlock",
+                    "path": "root/Default/my_bucket/PublicAccessBlock",
                   },
                   "PublicPolicy": {
                     "constructInfo": {
@@ -556,10 +570,16 @@ exports[`bucket with onCreate method 1`] = `
     \\"aws_s3_bucket_policy\\": {
       \\"root_mybucket_PublicPolicy_2A65F5BE\\": {
         \\"bucket\\": \\"\${aws_s3_bucket.root_mybucket_E5DAA363.bucket}\\",
-        \\"depends_on\\": [
-          \\"aws_s3_bucket.root_mybucket_E5DAA363\\"
-        ],
         \\"policy\\": \\"{\\\\\\"Version\\\\\\":\\\\\\"2012-10-17\\\\\\",\\\\\\"Statement\\\\\\":[{\\\\\\"Effect\\\\\\":\\\\\\"Allow\\\\\\",\\\\\\"Principal\\\\\\":\\\\\\"*\\\\\\",\\\\\\"Action\\\\\\":[\\\\\\"s3:GetObject\\\\\\"],\\\\\\"Resource\\\\\\":[\\\\\\"\${aws_s3_bucket.root_mybucket_E5DAA363.arn}/*\\\\\\"]}]}\\"
+      }
+    },
+    \\"aws_s3_bucket_public_access_block\\": {
+      \\"root_mybucket_PublicAccessBlock_3EF88EB3\\": {
+        \\"block_public_acls\\": false,
+        \\"block_public_policy\\": false,
+        \\"bucket\\": \\"\${aws_s3_bucket.root_mybucket_E5DAA363.bucket}\\",
+        \\"ignore_public_acls\\": false,
+        \\"restrict_public_buckets\\": false
       }
     },
     \\"aws_s3_bucket_server_side_encryption_configuration\\": {
@@ -703,6 +723,14 @@ exports[`bucket with onCreate method 2`] = `
                     },
                     "id": "Encryption",
                     "path": "root/Default/my_bucket/Encryption",
+                  },
+                  "PublicAccessBlock": {
+                    "constructInfo": {
+                      "fqn": "cdktf.TerraformResource",
+                      "version": "0.15.2",
+                    },
+                    "id": "PublicAccessBlock",
+                    "path": "root/Default/my_bucket/PublicAccessBlock",
                   },
                   "PublicPolicy": {
                     "constructInfo": {
@@ -1031,10 +1059,16 @@ exports[`bucket with onDelete method 1`] = `
     \\"aws_s3_bucket_policy\\": {
       \\"root_mybucket_PublicPolicy_2A65F5BE\\": {
         \\"bucket\\": \\"\${aws_s3_bucket.root_mybucket_E5DAA363.bucket}\\",
-        \\"depends_on\\": [
-          \\"aws_s3_bucket.root_mybucket_E5DAA363\\"
-        ],
         \\"policy\\": \\"{\\\\\\"Version\\\\\\":\\\\\\"2012-10-17\\\\\\",\\\\\\"Statement\\\\\\":[{\\\\\\"Effect\\\\\\":\\\\\\"Allow\\\\\\",\\\\\\"Principal\\\\\\":\\\\\\"*\\\\\\",\\\\\\"Action\\\\\\":[\\\\\\"s3:GetObject\\\\\\"],\\\\\\"Resource\\\\\\":[\\\\\\"\${aws_s3_bucket.root_mybucket_E5DAA363.arn}/*\\\\\\"]}]}\\"
+      }
+    },
+    \\"aws_s3_bucket_public_access_block\\": {
+      \\"root_mybucket_PublicAccessBlock_3EF88EB3\\": {
+        \\"block_public_acls\\": false,
+        \\"block_public_policy\\": false,
+        \\"bucket\\": \\"\${aws_s3_bucket.root_mybucket_E5DAA363.bucket}\\",
+        \\"ignore_public_acls\\": false,
+        \\"restrict_public_buckets\\": false
       }
     },
     \\"aws_s3_bucket_server_side_encryption_configuration\\": {
@@ -1178,6 +1212,14 @@ exports[`bucket with onDelete method 2`] = `
                     },
                     "id": "Encryption",
                     "path": "root/Default/my_bucket/Encryption",
+                  },
+                  "PublicAccessBlock": {
+                    "constructInfo": {
+                      "fqn": "cdktf.TerraformResource",
+                      "version": "0.15.2",
+                    },
+                    "id": "PublicAccessBlock",
+                    "path": "root/Default/my_bucket/PublicAccessBlock",
                   },
                   "PublicPolicy": {
                     "constructInfo": {
@@ -1606,10 +1648,16 @@ exports[`bucket with onEvent method 1`] = `
     \\"aws_s3_bucket_policy\\": {
       \\"root_mybucket_PublicPolicy_2A65F5BE\\": {
         \\"bucket\\": \\"\${aws_s3_bucket.root_mybucket_E5DAA363.bucket}\\",
-        \\"depends_on\\": [
-          \\"aws_s3_bucket.root_mybucket_E5DAA363\\"
-        ],
         \\"policy\\": \\"{\\\\\\"Version\\\\\\":\\\\\\"2012-10-17\\\\\\",\\\\\\"Statement\\\\\\":[{\\\\\\"Effect\\\\\\":\\\\\\"Allow\\\\\\",\\\\\\"Principal\\\\\\":\\\\\\"*\\\\\\",\\\\\\"Action\\\\\\":[\\\\\\"s3:GetObject\\\\\\"],\\\\\\"Resource\\\\\\":[\\\\\\"\${aws_s3_bucket.root_mybucket_E5DAA363.arn}/*\\\\\\"]}]}\\"
+      }
+    },
+    \\"aws_s3_bucket_public_access_block\\": {
+      \\"root_mybucket_PublicAccessBlock_3EF88EB3\\": {
+        \\"block_public_acls\\": false,
+        \\"block_public_policy\\": false,
+        \\"bucket\\": \\"\${aws_s3_bucket.root_mybucket_E5DAA363.bucket}\\",
+        \\"ignore_public_acls\\": false,
+        \\"restrict_public_buckets\\": false
       }
     },
     \\"aws_s3_bucket_server_side_encryption_configuration\\": {
@@ -1811,6 +1859,14 @@ exports[`bucket with onEvent method 2`] = `
                     },
                     "id": "Encryption",
                     "path": "root/Default/my_bucket/Encryption",
+                  },
+                  "PublicAccessBlock": {
+                    "constructInfo": {
+                      "fqn": "cdktf.TerraformResource",
+                      "version": "0.15.2",
+                    },
+                    "id": "PublicAccessBlock",
+                    "path": "root/Default/my_bucket/PublicAccessBlock",
                   },
                   "PublicPolicy": {
                     "constructInfo": {
@@ -2517,10 +2573,16 @@ exports[`bucket with onUpdate method 1`] = `
     \\"aws_s3_bucket_policy\\": {
       \\"root_mybucket_PublicPolicy_2A65F5BE\\": {
         \\"bucket\\": \\"\${aws_s3_bucket.root_mybucket_E5DAA363.bucket}\\",
-        \\"depends_on\\": [
-          \\"aws_s3_bucket.root_mybucket_E5DAA363\\"
-        ],
         \\"policy\\": \\"{\\\\\\"Version\\\\\\":\\\\\\"2012-10-17\\\\\\",\\\\\\"Statement\\\\\\":[{\\\\\\"Effect\\\\\\":\\\\\\"Allow\\\\\\",\\\\\\"Principal\\\\\\":\\\\\\"*\\\\\\",\\\\\\"Action\\\\\\":[\\\\\\"s3:GetObject\\\\\\"],\\\\\\"Resource\\\\\\":[\\\\\\"\${aws_s3_bucket.root_mybucket_E5DAA363.arn}/*\\\\\\"]}]}\\"
+      }
+    },
+    \\"aws_s3_bucket_public_access_block\\": {
+      \\"root_mybucket_PublicAccessBlock_3EF88EB3\\": {
+        \\"block_public_acls\\": false,
+        \\"block_public_policy\\": false,
+        \\"bucket\\": \\"\${aws_s3_bucket.root_mybucket_E5DAA363.bucket}\\",
+        \\"ignore_public_acls\\": false,
+        \\"restrict_public_buckets\\": false
       }
     },
     \\"aws_s3_bucket_server_side_encryption_configuration\\": {
@@ -2664,6 +2726,14 @@ exports[`bucket with onUpdate method 2`] = `
                     },
                     "id": "Encryption",
                     "path": "root/Default/my_bucket/Encryption",
+                  },
+                  "PublicAccessBlock": {
+                    "constructInfo": {
+                      "fqn": "cdktf.TerraformResource",
+                      "version": "0.15.2",
+                    },
+                    "id": "PublicAccessBlock",
+                    "path": "root/Default/my_bucket/PublicAccessBlock",
                   },
                   "PublicPolicy": {
                     "constructInfo": {
@@ -2927,10 +2997,16 @@ exports[`bucket with two preflight objects 1`] = `
     \\"aws_s3_bucket_policy\\": {
       \\"root_mybucket_PublicPolicy_2A65F5BE\\": {
         \\"bucket\\": \\"\${aws_s3_bucket.root_mybucket_E5DAA363.bucket}\\",
-        \\"depends_on\\": [
-          \\"aws_s3_bucket.root_mybucket_E5DAA363\\"
-        ],
         \\"policy\\": \\"{\\\\\\"Version\\\\\\":\\\\\\"2012-10-17\\\\\\",\\\\\\"Statement\\\\\\":[{\\\\\\"Effect\\\\\\":\\\\\\"Allow\\\\\\",\\\\\\"Principal\\\\\\":\\\\\\"*\\\\\\",\\\\\\"Action\\\\\\":[\\\\\\"s3:GetObject\\\\\\"],\\\\\\"Resource\\\\\\":[\\\\\\"\${aws_s3_bucket.root_mybucket_E5DAA363.arn}/*\\\\\\"]}]}\\"
+      }
+    },
+    \\"aws_s3_bucket_public_access_block\\": {
+      \\"root_mybucket_PublicAccessBlock_3EF88EB3\\": {
+        \\"block_public_acls\\": false,
+        \\"block_public_policy\\": false,
+        \\"bucket\\": \\"\${aws_s3_bucket.root_mybucket_E5DAA363.bucket}\\",
+        \\"ignore_public_acls\\": false,
+        \\"restrict_public_buckets\\": false
       }
     },
     \\"aws_s3_bucket_server_side_encryption_configuration\\": {
@@ -3023,6 +3099,14 @@ exports[`bucket with two preflight objects 2`] = `
                     },
                     "id": "Encryption",
                     "path": "root/Default/my_bucket/Encryption",
+                  },
+                  "PublicAccessBlock": {
+                    "constructInfo": {
+                      "fqn": "cdktf.TerraformResource",
+                      "version": "0.15.2",
+                    },
+                    "id": "PublicAccessBlock",
+                    "path": "root/Default/my_bucket/PublicAccessBlock",
                   },
                   "PublicPolicy": {
                     "constructInfo": {

--- a/libs/wingsdk/test/target-tf-aws/__snapshots__/website.test.ts.snap
+++ b/libs/wingsdk/test/target-tf-aws/__snapshots__/website.test.ts.snap
@@ -61,10 +61,16 @@ exports[`default website behavior 1`] = `
     \\"aws_s3_bucket_policy\\": {
       \\"root_Website_PublicPolicy_F4A65951\\": {
         \\"bucket\\": \\"\${aws_s3_bucket.root_Website_WebsiteBucket_B334706B.bucket}\\",
-        \\"depends_on\\": [
-          \\"aws_s3_bucket.root_Website_WebsiteBucket_B334706B\\"
-        ],
         \\"policy\\": \\"{\\\\\\"Version\\\\\\":\\\\\\"2012-10-17\\\\\\",\\\\\\"Statement\\\\\\":[{\\\\\\"Effect\\\\\\":\\\\\\"Allow\\\\\\",\\\\\\"Principal\\\\\\":\\\\\\"*\\\\\\",\\\\\\"Action\\\\\\":[\\\\\\"s3:GetObject\\\\\\"],\\\\\\"Resource\\\\\\":[\\\\\\"\${aws_s3_bucket.root_Website_WebsiteBucket_B334706B.arn}/*\\\\\\"]}]}\\"
+      }
+    },
+    \\"aws_s3_bucket_public_access_block\\": {
+      \\"root_Website_PublicAccessBlock_1B1D8C0A\\": {
+        \\"block_public_acls\\": false,
+        \\"block_public_policy\\": false,
+        \\"bucket\\": \\"\${aws_s3_bucket.root_Website_WebsiteBucket_B334706B.bucket}\\",
+        \\"ignore_public_acls\\": false,
+        \\"restrict_public_buckets\\": false
       }
     },
     \\"aws_s3_bucket_server_side_encryption_configuration\\": {
@@ -163,6 +169,14 @@ exports[`default website behavior 2`] = `
                     },
                     "id": "File--inner-folder--a.html",
                     "path": "root/Default/Website/File--inner-folder--a.html",
+                  },
+                  "PublicAccessBlock": {
+                    "constructInfo": {
+                      "fqn": "cdktf.TerraformResource",
+                      "version": "0.15.2",
+                    },
+                    "id": "PublicAccessBlock",
+                    "path": "root/Default/Website/PublicAccessBlock",
                   },
                   "PublicPolicy": {
                     "constructInfo": {
@@ -323,10 +337,16 @@ exports[`website with add_json 1`] = `
     \\"aws_s3_bucket_policy\\": {
       \\"root_Website_PublicPolicy_F4A65951\\": {
         \\"bucket\\": \\"\${aws_s3_bucket.root_Website_WebsiteBucket_B334706B.bucket}\\",
-        \\"depends_on\\": [
-          \\"aws_s3_bucket.root_Website_WebsiteBucket_B334706B\\"
-        ],
         \\"policy\\": \\"{\\\\\\"Version\\\\\\":\\\\\\"2012-10-17\\\\\\",\\\\\\"Statement\\\\\\":[{\\\\\\"Effect\\\\\\":\\\\\\"Allow\\\\\\",\\\\\\"Principal\\\\\\":\\\\\\"*\\\\\\",\\\\\\"Action\\\\\\":[\\\\\\"s3:GetObject\\\\\\"],\\\\\\"Resource\\\\\\":[\\\\\\"\${aws_s3_bucket.root_Website_WebsiteBucket_B334706B.arn}/*\\\\\\"]}]}\\"
+      }
+    },
+    \\"aws_s3_bucket_public_access_block\\": {
+      \\"root_Website_PublicAccessBlock_1B1D8C0A\\": {
+        \\"block_public_acls\\": false,
+        \\"block_public_policy\\": false,
+        \\"bucket\\": \\"\${aws_s3_bucket.root_Website_WebsiteBucket_B334706B.bucket}\\",
+        \\"ignore_public_acls\\": false,
+        \\"restrict_public_buckets\\": false
       }
     },
     \\"aws_s3_bucket_server_side_encryption_configuration\\": {
@@ -442,6 +462,14 @@ exports[`website with add_json 2`] = `
                     },
                     "id": "File-config.json",
                     "path": "root/Default/Website/File-config.json",
+                  },
+                  "PublicAccessBlock": {
+                    "constructInfo": {
+                      "fqn": "cdktf.TerraformResource",
+                      "version": "0.15.2",
+                    },
+                    "id": "PublicAccessBlock",
+                    "path": "root/Default/Website/PublicAccessBlock",
                   },
                   "PublicPolicy": {
                     "constructInfo": {

--- a/libs/wingsdk/test/target-tf-aws/bucket.test.ts
+++ b/libs/wingsdk/test/target-tf-aws/bucket.test.ts
@@ -60,6 +60,7 @@ test("bucket is public", () => {
   expect(tfResourcesOf(output)).toEqual([
     "aws_s3_bucket", // main bucket
     "aws_s3_bucket_policy", // resource policy to grant read access to anyone
+    "aws_s3_bucket_public_access_block", // allow public access to an s3 bucket
     "aws_s3_bucket_server_side_encryption_configuration", // server side encryption
   ]);
   expect(tfSanitize(output)).toMatchSnapshot();
@@ -78,6 +79,7 @@ test("bucket with two preflight objects", () => {
   expect(tfResourcesOf(output)).toEqual([
     "aws_s3_bucket", // main bucket
     "aws_s3_bucket_policy", // resource policy to grant read access to anyone
+    "aws_s3_bucket_public_access_block", // allow public access to an s3 bucket
     "aws_s3_bucket_server_side_encryption_configuration", // server side encryption
     "aws_s3_object", // file1.txt
   ]);
@@ -156,6 +158,7 @@ test("bucket with onCreate method", () => {
     "aws_s3_bucket", // main bucket
     "aws_s3_bucket_notification",
     "aws_s3_bucket_policy", // resource policy to grant read access to anyone
+    "aws_s3_bucket_public_access_block", // allow public access to an s3 bucket
     "aws_s3_bucket_server_side_encryption_configuration", // server side encryption
     "aws_s3_object",
     "aws_sns_topic", // topic to subscribe to bucket events
@@ -187,6 +190,7 @@ test("bucket with onDelete method", () => {
     "aws_s3_bucket", // main bucket
     "aws_s3_bucket_notification",
     "aws_s3_bucket_policy", // resource policy to grant read access to anyone
+    "aws_s3_bucket_public_access_block", // allow public access to an s3 bucket
     "aws_s3_bucket_server_side_encryption_configuration", // server side encryption
     "aws_s3_object",
     "aws_sns_topic", // topic to subscribe to bucket events
@@ -218,6 +222,7 @@ test("bucket with onUpdate method", () => {
     "aws_s3_bucket", // main bucket
     "aws_s3_bucket_notification",
     "aws_s3_bucket_policy", // resource policy to grant read access to anyone
+    "aws_s3_bucket_public_access_block", // allow public access to an s3 bucket
     "aws_s3_bucket_server_side_encryption_configuration", // server side encryption
     "aws_s3_object",
     "aws_sns_topic", // topic to subscribe to bucket events
@@ -249,6 +254,7 @@ test("bucket with onEvent method", () => {
     "aws_s3_bucket", // main bucket
     "aws_s3_bucket_notification",
     "aws_s3_bucket_policy", // resource policy to grant read access to anyone
+    "aws_s3_bucket_public_access_block", // allow public access to an s3 bucket
     "aws_s3_bucket_server_side_encryption_configuration", // server side encryption
     "aws_s3_object",
     "aws_sns_topic", // topic to subscribe to bucket events

--- a/libs/wingsdk/test/target-tf-aws/website.test.ts
+++ b/libs/wingsdk/test/target-tf-aws/website.test.ts
@@ -24,6 +24,7 @@ test("default website behavior", () => {
     "aws_cloudfront_distribution",
     "aws_s3_bucket",
     "aws_s3_bucket_policy",
+    "aws_s3_bucket_public_access_block", // allow public access to an s3 bucket
     "aws_s3_bucket_server_side_encryption_configuration",
     "aws_s3_bucket_website_configuration",
     "aws_s3_object",
@@ -70,6 +71,7 @@ test("website with add_json", () => {
     "aws_cloudfront_distribution",
     "aws_s3_bucket",
     "aws_s3_bucket_policy",
+    "aws_s3_bucket_public_access_block", // allow public access to an s3 bucket
     "aws_s3_bucket_server_side_encryption_configuration",
     "aws_s3_bucket_website_configuration",
     "aws_s3_object",

--- a/tools/hangar/__snapshots__/test_corpus/captures.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/captures.w_compile_tf-aws.md
@@ -281,9 +281,6 @@
           }
         },
         "bucket": "${aws_s3_bucket.root_PublicBucket_73AE6C59.bucket}",
-        "depends_on": [
-          "aws_s3_bucket.root_PublicBucket_73AE6C59"
-        ],
         "policy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":\"*\",\"Action\":[\"s3:GetObject\"],\"Resource\":[\"${aws_s3_bucket.root_PublicBucket_73AE6C59.arn}/*\"]}]}"
       }
     },
@@ -300,6 +297,19 @@
         "bucket": "${aws_s3_bucket.root_PrivateBucket_82B4DCC5.bucket}",
         "ignore_public_acls": true,
         "restrict_public_buckets": true
+      },
+      "root_PublicBucket_PublicAccessBlock_A244D6BC": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/Default/PublicBucket/PublicAccessBlock",
+            "uniqueId": "root_PublicBucket_PublicAccessBlock_A244D6BC"
+          }
+        },
+        "block_public_acls": false,
+        "block_public_policy": false,
+        "bucket": "${aws_s3_bucket.root_PublicBucket_73AE6C59.bucket}",
+        "ignore_public_acls": false,
+        "restrict_public_buckets": false
       },
       "root_cloudBucket_PublicAccessBlock_319C1C2E": {
         "//": {

--- a/tools/hangar/__snapshots__/test_corpus/website.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/website.w_compile_tf-aws.md
@@ -101,10 +101,22 @@
           }
         },
         "bucket": "${aws_s3_bucket.root_cloudWebsite_WebsiteBucket_E28E35CE.bucket}",
-        "depends_on": [
-          "aws_s3_bucket.root_cloudWebsite_WebsiteBucket_E28E35CE"
-        ],
         "policy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":\"*\",\"Action\":[\"s3:GetObject\"],\"Resource\":[\"${aws_s3_bucket.root_cloudWebsite_WebsiteBucket_E28E35CE.arn}/*\"]}]}"
+      }
+    },
+    "aws_s3_bucket_public_access_block": {
+      "root_cloudWebsite_PublicAccessBlock_89CD01D0": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/Default/cloud.Website/PublicAccessBlock",
+            "uniqueId": "root_cloudWebsite_PublicAccessBlock_89CD01D0"
+          }
+        },
+        "block_public_acls": false,
+        "block_public_policy": false,
+        "bucket": "${aws_s3_bucket.root_cloudWebsite_WebsiteBucket_E28E35CE.bucket}",
+        "ignore_public_acls": false,
+        "restrict_public_buckets": false
       }
     },
     "aws_s3_bucket_server_side_encryption_configuration": {

--- a/tools/hangar/__snapshots__/test_corpus/website_with_api.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/website_with_api.w_compile_tf-aws.md
@@ -400,10 +400,22 @@
           }
         },
         "bucket": "${aws_s3_bucket.root_cloudWebsite_WebsiteBucket_E28E35CE.bucket}",
-        "depends_on": [
-          "aws_s3_bucket.root_cloudWebsite_WebsiteBucket_E28E35CE"
-        ],
         "policy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":\"*\",\"Action\":[\"s3:GetObject\"],\"Resource\":[\"${aws_s3_bucket.root_cloudWebsite_WebsiteBucket_E28E35CE.arn}/*\"]}]}"
+      }
+    },
+    "aws_s3_bucket_public_access_block": {
+      "root_cloudWebsite_PublicAccessBlock_89CD01D0": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/Default/cloud.Website/PublicAccessBlock",
+            "uniqueId": "root_cloudWebsite_PublicAccessBlock_89CD01D0"
+          }
+        },
+        "block_public_acls": false,
+        "block_public_policy": false,
+        "bucket": "${aws_s3_bucket.root_cloudWebsite_WebsiteBucket_E28E35CE.bucket}",
+        "ignore_public_acls": false,
+        "restrict_public_buckets": false
       }
     },
     "aws_s3_bucket_server_side_encryption_configuration": {


### PR DESCRIPTION
I was testing cloud.Website() and there was a small issue with permissions.
I am uploading the fix, but you can already see the result at this link.

[static website example](https://d24lp7k5o7ycd7.cloudfront.net/index.html)

Another thing is that in AWS it is not possible to know the URL of the website at compile time since the URL is only created when the deployment is completed (and in this case, when CloudFront is finished activating).


*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.