### PR TITLE
fix(compiler): friendly error message when defining preflight class inflight

### DIFF
--- a/examples/tests/invalid/preflight_class_inflight.w
+++ b/examples/tests/invalid/preflight_class_inflight.w
@@ -1,0 +1,9 @@
+bring cloud;
+
+let handler = inflight () => {
+  class R {
+    init() {}
+  }
+//^ Cannot define a preflight class in inflight scope
+  log("hello world!");
+};

--- a/libs/wingc/src/capture.rs
+++ b/libs/wingc/src/capture.rs
@@ -328,8 +328,10 @@ fn scan_captures_in_inflight_scope(scope: &Scope, diagnostics: &mut Diagnostics)
 	let env_ref = scope.env.borrow();
 	let env = env_ref.as_ref().unwrap();
 
-	// Make sure we're looking for captures only in inflight code
-	assert!(matches!(env.phase, Phase::Inflight));
+	// Early bail-out if we're looking for captures in preflight code - an error will be reported in type checking.
+	if matches!(env.phase, Phase::Preflight) {
+		return res;
+	}
 
 	for s in scope.statements.iter() {
 		match &s.kind {

--- a/libs/wingc/src/type_check.rs
+++ b/libs/wingc/src/type_check.rs
@@ -2124,7 +2124,9 @@ impl<'a> TypeChecker<'a> {
 				inflight_initializer,
 			}) => {
 				// Resources cannot be defined inflight
-				assert!(!*is_resource || env.phase == Phase::Preflight);
+				if *is_resource && env.phase == Phase::Inflight {
+					self.stmt_error(stmt, "Cannot define a preflight class in inflight scope".to_string());
+				}
 
 				// Verify parent is actually a known Class/Resource and get their env
 				let (parent_class, parent_class_env) = if let Some(parent_type) = parent {

--- a/tools/hangar/__snapshots__/invalid.ts.snap
+++ b/tools/hangar/__snapshots__/invalid.ts.snap
@@ -784,6 +784,18 @@ error: Expected type to be \\"Sub1\\", but got \\"Super\\" instead
 "
 `;
 
+exports[`preflight_class_inflight.w > stderr 1`] = `
+"error: Cannot define a preflight class in inflight scope
+  --> ../../../examples/tests/invalid/preflight_class_inflight.w:4:3
+  |  
+4 | /   class R {
+5 | |     init() {}
+6 | |   }
+  | \\\\---^ Cannot define a preflight class in inflight scope
+
+"
+`;
+
 exports[`preflight_from_inflight.w > stderr 1`] = `
 "error: Cannot call into preflight phase while inflight
    --> ../../../examples/tests/invalid/preflight_from_inflight.w:15:5


### PR DESCRIPTION
Fixes #1710.

Copilot summary wasn't great to say the least... (you can see it at the bottom).

This PR makes sure a friendly error message is shown when a preflight class (`class`) is defined in `inflight` scope.


-----------------------------------------------------------------------
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at fb5cbc4</samp>

This pull request fixes two bugs related to preflight and inflight code in `wingc`, the Wing compiler. It prevents the compiler from panicking or asserting when trying to capture variables or resources that are not available in preflight code, and reports an error when defining a preflight class in an inflight scope.

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.