### PR TITLE
fix(vscode): completion - new expr for namespace returns only classes

### DIFF
--- a/docs/06-contributors/020-development.md
+++ b/docs/06-contributors/020-development.md
@@ -242,6 +242,8 @@ npx nx dev vscode-wing
 
 To modify the package.json, make sure to edit `.projenrc.ts` and rebuild.
 
+Tip: if you want to print debug messages in your code while developing, you should use Rust's `dbg!` macro, instead of `print!` or `println!`.
+
 ## 🧹 How do I lint my code?
 
 To lint Rust code, you can run the `lint` target on the `wingc` or `wingii` projects:

--- a/libs/wingc/src/lsp/completions.rs
+++ b/libs/wingc/src/lsp/completions.rs
@@ -152,7 +152,7 @@ pub fn on_completion(params: lsp_types::CompletionParams) -> CompletionResponse 
 								if let SymbolKind::Namespace(namespace) = namespace {
 									let completions = get_completions_from_namespace(namespace);
 									//for namespaces - return only classes
-									if parent.parent().expect("Should have a parent's parent").kind() == "new_expression" {
+									if parent.parent().expect("custom_type must have a parent node").kind() == "new_expression" {
 										return completions
 											.iter()
 											.filter(|c| matches!(c.kind, Some(CompletionItemKind::CLASS)))

--- a/libs/wingc/src/lsp/completions.rs
+++ b/libs/wingc/src/lsp/completions.rs
@@ -150,7 +150,16 @@ pub fn on_completion(params: lsp_types::CompletionParams) -> CompletionResponse 
 							let namespace = root_env.lookup_nested_str(&udt.root.name, scope_visitor.found_stmt_index);
 							if let Ok(namespace) = namespace {
 								if let SymbolKind::Namespace(namespace) = namespace {
-									return get_completions_from_namespace(namespace);
+									//for namespaces - return only classes
+									if parent.parent().expect("Should have a parent's parent").kind() == "new_expression" {
+										return get_completions_from_namespace(namespace)
+											.iter()
+											.filter(|c| matches!(c.kind, Some(CompletionItemKind::CLASS)))
+											.cloned()
+											.collect();
+									} else {
+										return get_completions_from_namespace(namespace);
+									}
 								}
 							}
 						}

--- a/libs/wingc/src/lsp/completions.rs
+++ b/libs/wingc/src/lsp/completions.rs
@@ -150,15 +150,16 @@ pub fn on_completion(params: lsp_types::CompletionParams) -> CompletionResponse 
 							let namespace = root_env.lookup_nested_str(&udt.root.name, scope_visitor.found_stmt_index);
 							if let Ok(namespace) = namespace {
 								if let SymbolKind::Namespace(namespace) = namespace {
+									let completions = get_completions_from_namespace(namespace);
 									//for namespaces - return only classes
 									if parent.parent().expect("Should have a parent's parent").kind() == "new_expression" {
-										return get_completions_from_namespace(namespace)
+										return completions
 											.iter()
 											.filter(|c| matches!(c.kind, Some(CompletionItemKind::CLASS)))
 											.cloned()
 											.collect();
 									} else {
-										return get_completions_from_namespace(namespace);
+										return completions;
 									}
 								}
 							}


### PR DESCRIPTION
Fixes #2387

Added a special case for language completion:
If typing `new` namespace, then completion should show classes only. 
For example:
<img width="746" alt="image" src="https://github.com/winglang/wing/assets/106860404/f4e9c306-6a95-43f6-b97b-d03520caa634">

Also improved the contributors' guide for printing debug messages for the language server.

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.