### PR TITLE
fix(sdk): counter inflight client is bundled with excess code

### DIFF
--- a/docs/04-reference/wingsdk-api.md
+++ b/docs/04-reference/wingsdk-api.md
@@ -3097,92 +3097,6 @@ to parse boolean from.
 
 
 
-### CounterClientBase <a name="CounterClientBase" id="@winglang/sdk.cloud.CounterClientBase"></a>
-
-- *Implements:* <a href="#@winglang/sdk.cloud.ICounterClient">ICounterClient</a>
-
-Functionality shared between all `CounterClient` implementations regardless of the target.
-
-#### Initializers <a name="Initializers" id="@winglang/sdk.cloud.CounterClientBase.Initializer"></a>
-
-```wing
-bring cloud;
-
-new cloud.CounterClientBase()
-```
-
-| **Name** | **Type** | **Description** |
-| --- | --- | --- |
-
----
-
-#### Methods <a name="Methods" id="Methods"></a>
-
-| **Name** | **Description** |
-| --- | --- |
-| <code><a href="#@winglang/sdk.cloud.CounterClientBase.dec">dec</a></code> | Decrement the counter, returning the previous value. |
-| <code><a href="#@winglang/sdk.cloud.CounterClientBase.inc">inc</a></code> | Increments the counter atomically by a certain amount and returns the previous value. |
-| <code><a href="#@winglang/sdk.cloud.CounterClientBase.peek">peek</a></code> | Get the current value of the counter. |
-| <code><a href="#@winglang/sdk.cloud.CounterClientBase.reset">reset</a></code> | Reset a counter to a given value. |
-
----
-
-##### `dec` <a name="dec" id="@winglang/sdk.cloud.CounterClientBase.dec"></a>
-
-```wing
-dec(amount?: num): num
-```
-
-Decrement the counter, returning the previous value.
-
-###### `amount`<sup>Optional</sup> <a name="amount" id="@winglang/sdk.cloud.CounterClientBase.dec.parameter.amount"></a>
-
-- *Type:* num
-
----
-
-##### `inc` <a name="inc" id="@winglang/sdk.cloud.CounterClientBase.inc"></a>
-
-```wing
-inc(amount?: num): num
-```
-
-Increments the counter atomically by a certain amount and returns the previous value.
-
-###### `amount`<sup>Optional</sup> <a name="amount" id="@winglang/sdk.cloud.CounterClientBase.inc.parameter.amount"></a>
-
-- *Type:* num
-
----
-
-##### `peek` <a name="peek" id="@winglang/sdk.cloud.CounterClientBase.peek"></a>
-
-```wing
-peek(): num
-```
-
-Get the current value of the counter.
-
-Using this API may introduce race conditions since the value can change between
-the time it is read and the time it is used in your code.
-
-##### `reset` <a name="reset" id="@winglang/sdk.cloud.CounterClientBase.reset"></a>
-
-```wing
-reset(value?: num): void
-```
-
-Reset a counter to a given value.
-
-###### `value`<sup>Optional</sup> <a name="value" id="@winglang/sdk.cloud.CounterClientBase.reset.parameter.value"></a>
-
-- *Type:* num
-
----
-
-
-
-
 ### Display <a name="Display" id="@winglang/sdk.std.Display"></a>
 
 Information on how to display a resource in the UI.
@@ -5163,7 +5077,7 @@ Function that will be called when an event notification is fired.
 
 ### ICounterClient <a name="ICounterClient" id="@winglang/sdk.cloud.ICounterClient"></a>
 
-- *Implemented By:* <a href="#@winglang/sdk.cloud.CounterClientBase">CounterClientBase</a>, <a href="#@winglang/sdk.cloud.ICounterClient">ICounterClient</a>
+- *Implemented By:* <a href="#@winglang/sdk.cloud.ICounterClient">ICounterClient</a>
 
 Inflight interface for `Counter`.
 

--- a/libs/wingsdk/API.md
+++ b/libs/wingsdk/API.md
@@ -3090,92 +3090,6 @@ to parse boolean from.
 
 
 
-### CounterClientBase <a name="CounterClientBase" id="@winglang/sdk.cloud.CounterClientBase"></a>
-
-- *Implements:* <a href="#@winglang/sdk.cloud.ICounterClient">ICounterClient</a>
-
-Functionality shared between all `CounterClient` implementations regardless of the target.
-
-#### Initializers <a name="Initializers" id="@winglang/sdk.cloud.CounterClientBase.Initializer"></a>
-
-```wing
-bring cloud;
-
-new cloud.CounterClientBase()
-```
-
-| **Name** | **Type** | **Description** |
-| --- | --- | --- |
-
----
-
-#### Methods <a name="Methods" id="Methods"></a>
-
-| **Name** | **Description** |
-| --- | --- |
-| <code><a href="#@winglang/sdk.cloud.CounterClientBase.dec">dec</a></code> | Decrement the counter, returning the previous value. |
-| <code><a href="#@winglang/sdk.cloud.CounterClientBase.inc">inc</a></code> | Increments the counter atomically by a certain amount and returns the previous value. |
-| <code><a href="#@winglang/sdk.cloud.CounterClientBase.peek">peek</a></code> | Get the current value of the counter. |
-| <code><a href="#@winglang/sdk.cloud.CounterClientBase.reset">reset</a></code> | Reset a counter to a given value. |
-
----
-
-##### `dec` <a name="dec" id="@winglang/sdk.cloud.CounterClientBase.dec"></a>
-
-```wing
-dec(amount?: num): num
-```
-
-Decrement the counter, returning the previous value.
-
-###### `amount`<sup>Optional</sup> <a name="amount" id="@winglang/sdk.cloud.CounterClientBase.dec.parameter.amount"></a>
-
-- *Type:* num
-
----
-
-##### `inc` <a name="inc" id="@winglang/sdk.cloud.CounterClientBase.inc"></a>
-
-```wing
-inc(amount?: num): num
-```
-
-Increments the counter atomically by a certain amount and returns the previous value.
-
-###### `amount`<sup>Optional</sup> <a name="amount" id="@winglang/sdk.cloud.CounterClientBase.inc.parameter.amount"></a>
-
-- *Type:* num
-
----
-
-##### `peek` <a name="peek" id="@winglang/sdk.cloud.CounterClientBase.peek"></a>
-
-```wing
-peek(): num
-```
-
-Get the current value of the counter.
-
-Using this API may introduce race conditions since the value can change between
-the time it is read and the time it is used in your code.
-
-##### `reset` <a name="reset" id="@winglang/sdk.cloud.CounterClientBase.reset"></a>
-
-```wing
-reset(value?: num): void
-```
-
-Reset a counter to a given value.
-
-###### `value`<sup>Optional</sup> <a name="value" id="@winglang/sdk.cloud.CounterClientBase.reset.parameter.value"></a>
-
-- *Type:* num
-
----
-
-
-
-
 ### Display <a name="Display" id="@winglang/sdk.std.Display"></a>
 
 Information on how to display a resource in the UI.
@@ -5156,7 +5070,7 @@ Function that will be called when an event notification is fired.
 
 ### ICounterClient <a name="ICounterClient" id="@winglang/sdk.cloud.ICounterClient"></a>
 
-- *Implemented By:* <a href="#@winglang/sdk.cloud.CounterClientBase">CounterClientBase</a>, <a href="#@winglang/sdk.cloud.ICounterClient">ICounterClient</a>
+- *Implemented By:* <a href="#@winglang/sdk.cloud.ICounterClient">ICounterClient</a>
 
 Inflight interface for `Counter`.
 

--- a/libs/wingsdk/src/cloud/counter.ts
+++ b/libs/wingsdk/src/cloud/counter.ts
@@ -96,26 +96,6 @@ export interface ICounterClient {
 }
 
 /**
- * Functionality shared between all `CounterClient` implementations regardless of the target.
- */
-export abstract class CounterClientBase implements ICounterClient {
-  inc(amount?: number): Promise<number> {
-    amount;
-    throw new Error("Method not implemented.");
-  }
-  dec(amount?: number): Promise<number> {
-    return this.inc(-1 * (amount ?? 1));
-  }
-  peek(): Promise<number> {
-    throw new Error("Method not implemented.");
-  }
-  reset(value?: number): Promise<void> {
-    value;
-    throw new Error("Method not implemented.");
-  }
-}
-
-/**
  * List of inflight operations available for `Counter`.
  * @internal
  */

--- a/libs/wingsdk/src/shared-aws/counter.inflight.ts
+++ b/libs/wingsdk/src/shared-aws/counter.inflight.ts
@@ -4,7 +4,7 @@ import {
   DynamoDBClient,
 } from "@aws-sdk/client-dynamodb";
 import { COUNTER_HASH_KEY } from "./commons";
-import { CounterClientBase } from "../cloud";
+import type { ICounterClient } from "../cloud";
 
 const AMOUNT_TOKEN = "amount";
 const INITIAL_VALUE_TOKEN = "initial";
@@ -12,14 +12,12 @@ const COUNTER_ID = "counter";
 const VALUE_ATTRIBUTE = "counter_value";
 const RESET_VALUE = "reset_value";
 
-export class CounterClient extends CounterClientBase {
+export class CounterClient implements ICounterClient {
   constructor(
     private readonly tableName: string,
     private readonly initial: number = 0,
     private readonly client = new DynamoDBClient({})
-  ) {
-    super();
-  }
+  ) {}
 
   public async inc(amount = 1): Promise<number> {
     const command = new UpdateItemCommand({
@@ -41,6 +39,10 @@ export class CounterClient extends CounterClientBase {
 
     // return the old value
     return parseInt(newValue) - amount;
+  }
+
+  public async dec(amount = 1): Promise<number> {
+    return this.inc(-1 * amount);
   }
 
   public async peek(): Promise<number> {

--- a/libs/wingsdk/test/target-awscdk/__snapshots__/counter.test.ts.snap
+++ b/libs/wingsdk/test/target-awscdk/__snapshots__/counter.test.ts.snap
@@ -119,7 +119,7 @@ exports[`dec() policy statement 2`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "a27ab5de974c5d509753690aed1bc5bf059d171ec24069cb3ed820e5dd175ac5.zip",
+          "S3Key": "22b0a4eb2d63f0d60c9f3c9d8e3aa9042ecce68f227d50ead7166c1b7ad47138.zip",
         },
         "Environment": {
           "Variables": {
@@ -347,7 +347,7 @@ exports[`function with a counter binding 2`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "00825c7ccf1769bf73f5622844bf5368592a51f04addb0f8ff3c4288a2bd203d.zip",
+          "S3Key": "80483b762bdbc9cf248861e74b656824400b4556cd6680e7319461708a4b36e9.zip",
         },
         "Environment": {
           "Variables": {
@@ -514,7 +514,7 @@ exports[`inc() policy statement 2`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "00825c7ccf1769bf73f5622844bf5368592a51f04addb0f8ff3c4288a2bd203d.zip",
+          "S3Key": "80483b762bdbc9cf248861e74b656824400b4556cd6680e7319461708a4b36e9.zip",
         },
         "Environment": {
           "Variables": {
@@ -681,7 +681,7 @@ exports[`peek() policy statement 2`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "20fe78b1bbfd701e361eebc5a02ae4816d8aa89114749ae398101187282fc432.zip",
+          "S3Key": "0230363fe4a3edf2424cc347df4465d9d2f4f920d6e0a8885d6a589ff8c51f30.zip",
         },
         "Environment": {
           "Variables": {
@@ -848,7 +848,7 @@ exports[`reset() policy statement 2`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "3a2985004e700f8ee059b020ac4a41158f1bf0da0f43d2c780329ff465d1f2bd.zip",
+          "S3Key": "4fa9ba32ca72a89dd3f0f3b098c7b6470797e64dee35e181d0ad6ac61be23052.zip",
         },
         "Environment": {
           "Variables": {


### PR DESCRIPTION
I noticed some tests using the counter resource were updating even on pull requests where no relevant changes were made. After looking into the code that was bundled into lambda functions, it looked like many other parts of the SDK were getting bundled due to how we are organizing and importing different classes/interfaces.

As a simple fix, I've removed the `CounterClientBase` since it wasn't saving us that many lines of code.

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.