### PR TITLE
fix(docs): 'are' word repetition in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Wing is built by [Elad Ben-Israel](https://github.com/eladb), the guy behind the
 
 ## Why do we think the cloud needs a programming language? 🤔
 
-Cloud applications are are fundamentally different from applications that run on a single machine - 
+Cloud applications are fundamentally different from applications that run on a single machine - 
 they are distributed systems that rely on cloud infrastructure to achieve their goals.
 
 In order to be able to express both infrastructure and application logic in a safe and unified programming model, 


### PR DESCRIPTION
Found in the [why do we think the cloud needs a programming language](https://github.com/winglang/wing#why-do-we-think-the-cloud-needs-a-programming-language-) section



*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.