### PR TITLE
fix(docs): fixing docsite build

### DIFF
--- a/docs/06-contributors/99-maintainers/10-runbooks/000-runbook-template.md
+++ b/docs/06-contributors/99-maintainers/10-runbooks/000-runbook-template.md
@@ -1,5 +1,5 @@
 ---
-title: [Template] Standard Runbook
+title: "[Template] Standard Runbook"
 id: runbook-template
 keywords: [template, runbook]
 ---
@@ -11,6 +11,7 @@ Short description and relevant issue link(s).
 ### Prerequisites
 
 What is required to follow this runbook? e.g.
+
 - What tools are needed?
 - What permissions are required?
 
@@ -34,5 +35,3 @@ What are the steps to verify that the issue is resolved?
 ### Escalate
 
 What is the escalation path for this scenario? Who should be notified? What are the steps to notify them? What is the severity of this scenario?
-
-


### PR DESCRIPTION
fixing this error: 
<img width="1041" alt="image" src="https://github.com/winglang/wing/assets/39455181/e44cf1f0-5356-4070-bda7-1a75f4984db8">

by quoting special chars on the title.

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.