### PR TITLE
fix(compiler): ignore stdlib types referenced inflight

### DIFF
--- a/examples/tests/valid/json_static.w
+++ b/examples/tests/valid/json_static.w
@@ -1,3 +1,5 @@
+bring cloud;
+
 // Get Keys
 let x = Json {a: 123, b: {c: 456, d: 789}};
 let k = Json.keys(x);
@@ -46,6 +48,6 @@ assert(bool.fromJson(jsonOfMany.get("c")));
 
 // Inflight access
 test "Access Json static inflight" {
-  let x = Json.stringify(jj, 2);
-  assert(x == "{\n  \"a\": 123,\n  \"b\": {\n    \"c\": 456,\n    \"d\": 789\n  }\n}");
+  let ss = Json.stringify(jj);
+  assert(ss == "{\"a\":123,\"b\":{\"c\":456,\"d\":789}}");
 }

--- a/examples/tests/valid/json_static.w
+++ b/examples/tests/valid/json_static.w
@@ -43,3 +43,9 @@ let jsonOfMany = Json {a: 123, b: "hello", c: true};
 assert(str.fromJson(jsonOfMany.get("b")) == "hello");
 assert(num.fromJson(jsonOfMany.get("a")) == 123);
 assert(bool.fromJson(jsonOfMany.get("c")));
+
+// Inflight access
+test "Access Json static inflight" {
+  let x = Json.stringify(jj, 2);
+  assert(x == "{\n  \"a\": 123,\n  \"b\": {\n    \"c\": 456,\n    \"d\": 789\n  }\n}");
+}

--- a/libs/wingc/src/jsify.rs
+++ b/libs/wingc/src/jsify.rs
@@ -1729,6 +1729,10 @@ impl<'ast> Visit<'ast> for PreflightTypeRefVisitor<'ast> {
 
 	fn visit_reference(&mut self, node: &'ast Reference) {
 		if let Reference::TypeMember { type_, .. } = node {
+			// Skip standard lib types, for now they are available through the macro outputs on call expressions
+			if type_.root.name == "std" {
+				return;
+			}
 			let type_name = type_.to_string();
 			// Lookup the type in the current env and see where it was defined
 			if let LookupResult::Found(kind, info) = (*self.env).lookup_nested_str(&type_name, None) {

--- a/libs/wingc/src/type_check.rs
+++ b/libs/wingc/src/type_check.rs
@@ -2973,16 +2973,18 @@ impl<'a> TypeChecker<'a> {
 		// `foo.Bar.baz()` case (where `baz()`) is a static method of class `Bar`.
 		if !path.is_empty() {
 			let result = env.lookup_nested(&path.iter().collect_vec(), Some(self.statement_idx));
-			if let LookupResult::Found(symbol_kind, info) = result {
+			if let LookupResult::Found(symbol_kind, _) = result {
 				if let SymbolKind::Namespace(_) = symbol_kind {
-
 					// resolve "Util" as a user defined class within the namespace
 					let root = path.pop().unwrap();
 					path.reverse();
-					path.push(Symbol { name: "Util".to_string(), span: root.span.clone() });
+					path.push(Symbol {
+						name: "Util".to_string(),
+						span: root.span.clone(),
+					});
 
-					let ut = UserDefinedType { 
-						root, 
+					let ut = UserDefinedType {
+						root,
 						fields: path,
 						span: WingSpan::default(),
 					};
@@ -3017,9 +3019,11 @@ impl<'a> TypeChecker<'a> {
 					if let Some(var) = var.as_variable() {
 						var
 					} else {
-
 						self.variable_error(TypeError {
-							message: format!("Expected identifier \"{}\" to be a variable, but it's a {}", symbol.name, var),
+							message: format!(
+								"Expected identifier \"{}\" to be a variable, but it's a {}",
+								symbol.name, var
+							),
 							span: symbol.span.clone(),
 						})
 					}
@@ -3559,4 +3563,3 @@ mod tests {
 		assert!(!str_fn.is_subtype_of(&opt_str_fn));
 	}
 }
-

--- a/tools/hangar/__snapshots__/test_corpus/json_static.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/json_static.w_compile_tf-aws.md
@@ -21,13 +21,101 @@
   },
   "output": {
     "WING_TEST_RUNNER_FUNCTION_ARNS": {
-      "value": "[]"
+      "value": "[[\"root/Default/Default/test:Access Json static inflight\",\"${aws_lambda_function.root_testAccessJsonstaticinflight_Handler_8BBF2CE3.arn}\"]]"
     }
   },
   "provider": {
     "aws": [
       {}
     ]
+  },
+  "resource": {
+    "aws_iam_role": {
+      "root_testAccessJsonstaticinflight_Handler_IamRole_9D202F56": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/Default/test:Access Json static inflight/Handler/IamRole",
+            "uniqueId": "root_testAccessJsonstaticinflight_Handler_IamRole_9D202F56"
+          }
+        },
+        "assume_role_policy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Action\":\"sts:AssumeRole\",\"Principal\":{\"Service\":\"lambda.amazonaws.com\"},\"Effect\":\"Allow\"}]}"
+      }
+    },
+    "aws_iam_role_policy": {
+      "root_testAccessJsonstaticinflight_Handler_IamRolePolicy_06C4DEEC": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/Default/test:Access Json static inflight/Handler/IamRolePolicy",
+            "uniqueId": "root_testAccessJsonstaticinflight_Handler_IamRolePolicy_06C4DEEC"
+          }
+        },
+        "policy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Action\":\"none:null\",\"Resource\":\"*\"}]}",
+        "role": "${aws_iam_role.root_testAccessJsonstaticinflight_Handler_IamRole_9D202F56.name}"
+      }
+    },
+    "aws_iam_role_policy_attachment": {
+      "root_testAccessJsonstaticinflight_Handler_IamRolePolicyAttachment_CF756084": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/Default/test:Access Json static inflight/Handler/IamRolePolicyAttachment",
+            "uniqueId": "root_testAccessJsonstaticinflight_Handler_IamRolePolicyAttachment_CF756084"
+          }
+        },
+        "policy_arn": "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+        "role": "${aws_iam_role.root_testAccessJsonstaticinflight_Handler_IamRole_9D202F56.name}"
+      }
+    },
+    "aws_lambda_function": {
+      "root_testAccessJsonstaticinflight_Handler_8BBF2CE3": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/Default/test:Access Json static inflight/Handler/Default",
+            "uniqueId": "root_testAccessJsonstaticinflight_Handler_8BBF2CE3"
+          }
+        },
+        "environment": {
+          "variables": {
+            "WING_FUNCTION_NAME": "Handler-c8867497"
+          }
+        },
+        "function_name": "Handler-c8867497",
+        "handler": "index.handler",
+        "publish": true,
+        "role": "${aws_iam_role.root_testAccessJsonstaticinflight_Handler_IamRole_9D202F56.arn}",
+        "runtime": "nodejs18.x",
+        "s3_bucket": "${aws_s3_bucket.root_Code_02F3C603.bucket}",
+        "s3_key": "${aws_s3_object.root_testAccessJsonstaticinflight_Handler_S3Object_BE5E17BA.key}",
+        "timeout": 30,
+        "vpc_config": {
+          "security_group_ids": [],
+          "subnet_ids": []
+        }
+      }
+    },
+    "aws_s3_bucket": {
+      "root_Code_02F3C603": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/Code",
+            "uniqueId": "root_Code_02F3C603"
+          }
+        },
+        "bucket_prefix": "code-c84a50b1-"
+      }
+    },
+    "aws_s3_object": {
+      "root_testAccessJsonstaticinflight_Handler_S3Object_BE5E17BA": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/Default/test:Access Json static inflight/Handler/S3Object",
+            "uniqueId": "root_testAccessJsonstaticinflight_Handler_S3Object_BE5E17BA"
+          }
+        },
+        "bucket": "${aws_s3_bucket.root_Code_02F3C603.bucket}",
+        "key": "<ASSET_KEY>",
+        "source": "<ASSET_SOURCE>"
+      }
+    }
   }
 }
 ```
@@ -38,6 +126,7 @@ const $stdlib = require('@winglang/sdk');
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const $AppBase = $stdlib.core.App.for(process.env.WING_TARGET);
+const cloud = require('@winglang/sdk').cloud;
 class $Root extends $stdlib.std.Resource {
   constructor(scope, id) {
     super(scope, id);
@@ -69,6 +158,16 @@ class $Root extends $stdlib.std.Resource {
     {((cond) => {if (!cond) throw new Error(`assertion failed: '(((args) => { if (typeof args !== "string") {throw new Error("unable to parse " + typeof args + " " + args + " as a string")}; return JSON.parse(JSON.stringify(args)) })((jsonOfMany)["b"]) === "hello")'`)})((((args) => { if (typeof args !== "string") {throw new Error("unable to parse " + typeof args + " " + args + " as a string")}; return JSON.parse(JSON.stringify(args)) })((jsonOfMany)["b"]) === "hello"))};
     {((cond) => {if (!cond) throw new Error(`assertion failed: '(((args) => { if (typeof args !== "number") {throw new Error("unable to parse " + typeof args + " " + args + " as a number")}; return JSON.parse(JSON.stringify(args)) })((jsonOfMany)["a"]) === 123)'`)})((((args) => { if (typeof args !== "number") {throw new Error("unable to parse " + typeof args + " " + args + " as a number")}; return JSON.parse(JSON.stringify(args)) })((jsonOfMany)["a"]) === 123))};
     {((cond) => {if (!cond) throw new Error(`assertion failed: '((args) => { if (typeof args !== "boolean") {throw new Error("unable to parse " + typeof args + " " + args + " as a boolean")}; return JSON.parse(JSON.stringify(args)) })((jsonOfMany)["c"])'`)})(((args) => { if (typeof args !== "boolean") {throw new Error("unable to parse " + typeof args + " " + args + " as a boolean")}; return JSON.parse(JSON.stringify(args)) })((jsonOfMany)["c"]))};
+    this.node.root.new("@winglang/sdk.cloud.Test",cloud.Test,this,"test:Access Json static inflight",new $stdlib.core.Inflight(this, "$Inflight1", {
+      code: $stdlib.core.NodeJsCode.fromFile(require.resolve("./proc1/index.js".replace(/\\/g, "/"))),
+      bindings: {
+        jj: {
+          obj: jj,
+          ops: []
+        },
+      }
+    })
+    );
   }
 }
 class $App extends $AppBase {
@@ -87,6 +186,16 @@ class $App extends $AppBase {
   }
 }
 new $App().synth();
+
+```
+
+## proc1/index.js
+```js
+async handle() {
+  const { jj } = this;
+  const ss = ((args) => { return JSON.stringify(args[0], null, args[1]) })([jj]);
+  {((cond) => {if (!cond) throw new Error(`assertion failed: '(ss === "{\"a\":123,\"b\":{\"c\":456,\"d\":789}}")'`)})((ss === "{\"a\":123,\"b\":{\"c\":456,\"d\":789}}"))};
+}
 
 ```
 

--- a/tools/hangar/__snapshots__/test_corpus/json_static.w_test_sim.md
+++ b/tools/hangar/__snapshots__/test_corpus/json_static.w_test_sim.md
@@ -4,6 +4,6 @@
 ```log
 - Compiling to sim...
 ✔ Compiling to sim...
-pass ─ json_static.wsim (no tests)
+pass ─ json_static.wsim » root/env0/test:Access Json static inflight
 ```
 


### PR DESCRIPTION
Ignore stdlib types referenced inflight. They're available through the macro system and it's unclear how to import them anyway.
See #2505 

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.