### PR TITLE
feat(cli): show traces in wing tests with --debug

### DIFF
--- a/apps/wing/src/commands/__snapshots__/test.test.ts.snap
+++ b/apps/wing/src/commands/__snapshots__/test.test.ts.snap
@@ -1,6 +1,24 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`printing test reports > resource traces are not shown if debug mode is disabled 1`] = `
+"fail ┌ hello.w » root/env0/test:test
+     │ sleeping for 500 ms
+     └ Error: Object does not exist (key=file.txt)"
+`;
+
 exports[`printing test reports > resource traces are shown if debug mode is active 1`] = `
+"fail ┌ hello.w » root/env0/test:test
+     │ [trace] Push (message=cool).
+     │ sleeping for 500 ms
+     │ [trace] Sending messages (messages=[\\"cool\\"], subscriber=sim-4).
+     │ [trace] Invoke (payload=\\"{\\\\\\"messages\\\\\\":[\\\\\\"cool\\\\\\"]}\\").
+     │ [trace] Subscriber error - returning 1 messages to queue: Missing environment variable: QUEUE_HANDLE_7164aec4
+     │ [trace] Get (key=file.txt).
+     │ [trace] Invoke (payload=\\"\\").
+     └ Error: Object does not exist (key=file.txt)"
+`;
+
+exports[`printing test reports > resource traces are shown if debug mode is enabled 1`] = `
 "fail ┌ hello.w » root/env0/test:test
      │ [trace] Push (message=cool).
      │ sleeping for 500 ms

--- a/apps/wing/src/commands/__snapshots__/test.test.ts.snap
+++ b/apps/wing/src/commands/__snapshots__/test.test.ts.snap
@@ -1,0 +1,13 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`printing test reports > resource traces are shown if debug mode is active 1`] = `
+"fail ┌ hello.w » root/env0/test:test
+     │ [trace] Push (message=cool).
+     │ sleeping for 500 ms
+     │ [trace] Sending messages (messages=[\\"cool\\"], subscriber=sim-4).
+     │ [trace] Invoke (payload=\\"{\\\\\\"messages\\\\\\":[\\\\\\"cool\\\\\\"]}\\").
+     │ [trace] Subscriber error - returning 1 messages to queue: Missing environment variable: QUEUE_HANDLE_7164aec4
+     │ [trace] Get (key=file.txt).
+     │ [trace] Invoke (payload=\\"\\").
+     └ Error: Object does not exist (key=file.txt)"
+`;

--- a/apps/wing/src/commands/__snapshots__/test.test.ts.snap
+++ b/apps/wing/src/commands/__snapshots__/test.test.ts.snap
@@ -6,18 +6,6 @@ exports[`printing test reports > resource traces are not shown if debug mode is 
      └ Error: Object does not exist (key=file.txt)"
 `;
 
-exports[`printing test reports > resource traces are shown if debug mode is active 1`] = `
-"fail ┌ hello.w » root/env0/test:test
-     │ [trace] Push (message=cool).
-     │ sleeping for 500 ms
-     │ [trace] Sending messages (messages=[\\"cool\\"], subscriber=sim-4).
-     │ [trace] Invoke (payload=\\"{\\\\\\"messages\\\\\\":[\\\\\\"cool\\\\\\"]}\\").
-     │ [trace] Subscriber error - returning 1 messages to queue: Missing environment variable: QUEUE_HANDLE_7164aec4
-     │ [trace] Get (key=file.txt).
-     │ [trace] Invoke (payload=\\"\\").
-     └ Error: Object does not exist (key=file.txt)"
-`;
-
 exports[`printing test reports > resource traces are shown if debug mode is enabled 1`] = `
 "fail ┌ hello.w » root/env0/test:test
      │ [trace] Push (message=cool).

--- a/apps/wing/src/commands/test.test.ts
+++ b/apps/wing/src/commands/test.test.ts
@@ -38,10 +38,16 @@ describe("printing test reports", () => {
 
   afterEach(() => {
     chalk.level = defaultChalkLevel;
-    console.error("test", chalk.level);
   });
 
-  test("resource traces are shown if debug mode is active", () => {
+  test("resource traces are not shown if debug mode is disabled", () => {
+    const testReport = renderTestReport("hello.w", EXAMPLE_TEST_RESULTS);
+
+    expect(testReport).toMatchSnapshot();
+    expect(testReport).not.toContain("Push (message=cool)");
+  });
+
+  test("resource traces are shown if debug mode is enabled", () => {
     const oldDebug = process.env.DEBUG;
     process.env.DEBUG = "1";
 

--- a/apps/wing/src/commands/test.test.ts
+++ b/apps/wing/src/commands/test.test.ts
@@ -1,8 +1,10 @@
-import { describe, test, expect } from "vitest";
+import { describe, test, expect, beforeEach, afterEach } from "vitest";
 import { tmpTestFile } from "./compile.test";
-import { checkTerraformStateIsEmpty, terraformInit } from "./test";
+import { checkTerraformStateIsEmpty, renderTestReport, terraformInit } from "./test";
 import { compile } from "./compile";
 import { Target } from "./constants";
+import { TestResult, TraceType } from "@winglang/sdk/lib/cloud";
+import chalk from "chalk";
 
 describe("test command tests", () => {
   test(
@@ -26,3 +28,94 @@ describe("test command tests", () => {
     { timeout: 5 * 60 * 1000 }
   );
 });
+
+const defaultChalkLevel = chalk.level;
+
+describe("printing test reports", () => {
+  beforeEach(() => {
+    chalk.level = 0;
+  });
+
+  afterEach(() => {
+    chalk.level = defaultChalkLevel;
+    console.error("test", chalk.level);
+  });
+
+  test("resource traces are shown if debug mode is active", () => {
+    const oldDebug = process.env.DEBUG;
+    process.env.DEBUG = "1";
+
+    const testReport = renderTestReport("hello.w", EXAMPLE_TEST_RESULTS);
+
+    process.env.DEBUG = oldDebug;
+
+    expect(testReport).toMatchSnapshot();
+    expect(testReport).toContain("Push (message=cool)");
+  });
+});
+
+const EXAMPLE_TEST_RESULTS: Array<TestResult> = [
+  {
+    path: "root/env0/test:test",
+    pass: false,
+    error: "Error: Object does not exist (key=file.txt)",
+    traces: [
+      {
+        data: { message: "Push (message=cool).", status: "success" },
+        type: TraceType.RESOURCE,
+        sourcePath: "root/env0/MyProcessor/cloud.Queue",
+        sourceType: "wingsdk.cloud.Queue",
+        timestamp: "2023-05-15T16:20:46.886Z",
+      },
+      {
+        data: { message: "sleeping for 500 ms" },
+        type: TraceType.LOG,
+        sourcePath: "root/env0/test:test/Handler",
+        sourceType: "wingsdk.cloud.Function",
+        timestamp: "2023-05-15T16:20:46.887Z",
+      },
+      {
+        type: TraceType.RESOURCE,
+        data: { message: 'Sending messages (messages=["cool"], subscriber=sim-4).' },
+        sourcePath: "root/env0/MyProcessor/cloud.Queue",
+        sourceType: "wingsdk.cloud.Queue",
+        timestamp: "2023-05-15T16:20:46.961Z",
+      },
+      {
+        data: {
+          message: 'Invoke (payload="{\\"messages\\":[\\"cool\\"]}").',
+          status: "failure",
+          error: {},
+        },
+        type: TraceType.RESOURCE,
+        sourcePath: "root/env0/MyProcessor/cloud.Queue-AddConsumer-0088483a",
+        sourceType: "wingsdk.cloud.Function",
+        timestamp: "2023-05-15T16:20:46.966Z",
+      },
+      {
+        data: {
+          message:
+            "Subscriber error - returning 1 messages to queue: Missing environment variable: QUEUE_HANDLE_7164aec4",
+        },
+        sourcePath: "root/env0/MyProcessor/cloud.Queue",
+        sourceType: "wingsdk.cloud.Queue",
+        type: TraceType.RESOURCE,
+        timestamp: "2023-05-15T16:20:46.966Z",
+      },
+      {
+        data: { message: "Get (key=file.txt).", status: "failure", error: {} },
+        type: TraceType.RESOURCE,
+        sourcePath: "root/env0/MyProcessor/cloud.Bucket",
+        sourceType: "wingsdk.cloud.Bucket",
+        timestamp: "2023-05-15T16:20:47.388Z",
+      },
+      {
+        data: { message: 'Invoke (payload="").', status: "failure", error: {} },
+        type: TraceType.RESOURCE,
+        sourcePath: "root/env0/test:test/Handler",
+        sourceType: "wingsdk.cloud.Function",
+        timestamp: "2023-05-15T16:20:47.388Z",
+      },
+    ],
+  },
+];

--- a/apps/wing/src/commands/test.ts
+++ b/apps/wing/src/commands/test.ts
@@ -46,12 +46,10 @@ async function testOne(entrypoint: string, options: TestOptions) {
 }
 
 /**
- * Print out a test report to the console.
- * @returns `true` if any tests failed, `false` otherwise.
+ * Render a test report for printing out to the console.
  */
-function printTestReport(entrypoint: string, results: sdk.cloud.TestResult[]): boolean {
-  // print report
-  let hasFailures = false;
+export function renderTestReport(entrypoint: string, results: sdk.cloud.TestResult[]): string {
+  const out = new Array<string>();
 
   // find the longest `path` of all the tests
   const longestPath = results.reduce(
@@ -75,8 +73,14 @@ function printTestReport(entrypoint: string, results: sdk.cloud.TestResult[]): b
     const details = new Array<string>();
 
     // add any log messages that were emitted during the test
-    for (const log of result.traces.filter((t) => t.type == "log")) {
-      details.push(chalk.gray(log.data.message));
+    for (const log of result.traces) {
+      // only show detailed traces if we are in debug mode
+      if (log.type === "resource" && process.env.DEBUG) {
+        details.push(chalk.gray("[trace] " + log.data.message));
+      }
+      if (log.type === "log") {
+        details.push(chalk.gray(log.data.message));
+      }
     }
 
     // if the test failed, add the error message and trace
@@ -109,20 +113,20 @@ function printTestReport(entrypoint: string, results: sdk.cloud.TestResult[]): b
     // okay we are ready to print the test result
 
     // print the primary description of the test
-    console.log(firstRow.join(" "));
+    out.push(firstRow.join(" "));
 
     // print additional rows that are related to this test
     for (let i = 0; i < details.length; i++) {
       const left = i === details.length - 1 ? "└" : "│";
-      console.log(`    ${chalk.gray(` ${left} `)}${details[i]}`);
-    }
-
-    if (!result.pass) {
-      hasFailures = true;
+      out.push(`    ${chalk.gray(` ${left} `)}${details[i]}`);
     }
   }
 
-  return hasFailures;
+  return out.join("\n");
+}
+
+function testResultsContainsFailure(results: sdk.cloud.TestResult[]): boolean {
+  return results.some((r) => !r.pass);
 }
 
 async function testSimulator(synthDir: string) {
@@ -141,8 +145,10 @@ async function testSimulator(synthDir: string) {
 
   await s.stop();
 
-  const hasFailures = printTestReport(synthDir, results);
-  if (hasFailures) {
+  const testReport = renderTestReport(synthDir, results);
+  console.log(testReport);
+
+  if (testResultsContainsFailure(results)) {
     process.exit(1);
   }
 }
@@ -176,9 +182,10 @@ async function testTfAws(synthDir: string): Promise<sdk.cloud.TestResult[]> {
     return results;
   });
 
-  const hasFailures = printTestReport(synthDir, results);
+  const testReport = renderTestReport(synthDir, results);
+  console.log(testReport);
 
-  if (hasFailures) {
+  if (testResultsContainsFailure(results)) {
     console.log("One or more tests failed. Cleaning up resources...");
   }
 


### PR DESCRIPTION
This change introduces the ability to see traces in Wing unit tests by including the `--debug` flag when running `wing test` (or using DEBUG=1).

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.