### PR TITLE
feat(sdk): implementing `bucket.exists`

### DIFF
--- a/libs/wingsdk/src/cloud/bucket.ts
+++ b/libs/wingsdk/src/cloud/bucket.ts
@@ -222,6 +222,13 @@ export interface BucketDeleteOptions {
  */
 export interface IBucketClient {
   /**
+   * Check if an object exists in the bucket.
+   * @param key Key of the object.
+   * @inflight
+   */
+  exists(key: string): Promise<boolean>;
+
+  /**
    * Put an object in the bucket.
    * @param key Key of the object.
    * @param body Content of the object we want to store into the bucket.

--- a/libs/wingsdk/src/shared-aws/bucket.inflight.ts
+++ b/libs/wingsdk/src/shared-aws/bucket.inflight.ts
@@ -20,6 +20,16 @@ export class BucketClient implements IBucketClient {
     private readonly s3Client = new S3Client({})
   ) {}
 
+  private async exists(key: string): Promise<boolean> {
+    const command = new ListObjectsV2Command({
+      Bucket: this.bucketName,
+      Prefix: key,
+      MaxKeys: 1,
+    });
+    const resp: ListObjectsV2CommandOutput = await this.s3Client.send(command);
+    return !!resp.Contents && resp.Contents.length > 0;
+  }
+
   public async put(key: string, body: string): Promise<void> {
     const command = new PutObjectCommand({
       Bucket: this.bucketName,
@@ -60,16 +70,6 @@ export class BucketClient implements IBucketClient {
 
   public async getJson(key: string): Promise<Json> {
     return JSON.parse(await this.get(key));
-  }
-
-  private async exists(key: string): Promise<boolean> {
-    const command = new ListObjectsV2Command({
-      Bucket: this.bucketName,
-      Prefix: key,
-      MaxKeys: 1,
-    });
-    const resp: ListObjectsV2CommandOutput = await this.s3Client.send(command);
-    return !!resp.Contents && resp.Contents.length > 0;
   }
 
   private async getLocation(): Promise<string> {

--- a/libs/wingsdk/src/target-sim/bucket.inflight.ts
+++ b/libs/wingsdk/src/target-sim/bucket.inflight.ts
@@ -60,7 +60,7 @@ export class Bucket implements IBucketClient, ISimulatorResourceInstance {
     return topicClient.publish(key);
   }
 
-  private async fileExists(key: string): Promise<boolean> {
+  private async exists(key: string): Promise<boolean> {
     return fs.promises
       .access(join(this.fileDir, key))
       .then(() => true)
@@ -80,7 +80,7 @@ export class Bucket implements IBucketClient, ISimulatorResourceInstance {
     return this.context.withTrace({
       message: `Put Json (key=${key}).`,
       activity: async () => {
-        const actionType: BucketEventType = (await this.fileExists(key))
+        const actionType: BucketEventType = (await this.exists(key))
           ? BucketEventType.UPDATE
           : BucketEventType.CREATE;
 

--- a/libs/wingsdk/src/target-tf-azure/bucket.inflight.ts
+++ b/libs/wingsdk/src/target-tf-azure/bucket.inflight.ts
@@ -35,6 +35,15 @@ export class BucketClient implements IBucketClient {
   }
 
   /**
+   * Check if an object exists in the bucket
+   *
+   * @param key Key of the object
+   */
+  public async exists(key: string): Promise<boolean> {
+    // WIP
+  }
+
+  /**
    * Put object into bucket with given body contents
    *
    * @param key Key of the object


### PR DESCRIPTION
I noticed that, while `bucket.exists` is part of the SDK Spec, it's not currently defined in the `IBucketClient` interface. Despite this, it actually got implemented anyway (sometimes with different name) for some of the targets.

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.