### PR TITLE
chore(compiler): remove diagnostic levels and other refactorings

### DIFF
--- a/apps/wing/project.json
+++ b/apps/wing/project.json
@@ -22,7 +22,7 @@
       }
     },
     "test": {
-      "dependsOn": ["build"],
+      "dependsOn": ["copy"],
       "options": {
         "command": "npm run test",
         "cwd": "apps/wing"

--- a/apps/wing/project.json
+++ b/apps/wing/project.json
@@ -22,6 +22,7 @@
       }
     },
     "test": {
+      "dependsOn": ["build"],
       "options": {
         "command": "npm run test",
         "cwd": "apps/wing"

--- a/apps/wing/src/commands/compile.ts
+++ b/apps/wing/src/commands/compile.ts
@@ -8,7 +8,7 @@ import chalk from "chalk";
 import debug from "debug";
 import * as wingCompiler from "../wingc";
 import { copyDir, normalPath } from "../util";
-import { CHARS_ASCII, emitDiagnostic, Severity, File, Label } from "codespan-wasm";
+import { CHARS_ASCII, emitDiagnostic, File, Label } from "codespan-wasm";
 import { existsSync } from "fs";
 import { Target } from "./constants";
 
@@ -144,7 +144,7 @@ export async function compile(entrypoint: string, options: CompileOptions): Prom
     const coloring = chalk.supportsColor ? chalk.supportsColor.hasBasic : false;
 
     for (const error of errors) {
-      const { message, span, level } = error;
+      const { message, span } = error;
       let files: File[] = [];
       let labels: Label[] = [];
 
@@ -167,7 +167,7 @@ export async function compile(entrypoint: string, options: CompileOptions): Prom
         files,
         {
           message,
-          severity: level.toLowerCase() as Severity,
+          severity: "error",
           labels,
         },
         {

--- a/apps/wing/src/wingc.ts
+++ b/apps/wing/src/wingc.ts
@@ -115,7 +115,7 @@ export async function load(options: WingCompilerLoadOptions) {
       if (file.startsWith(".")) {
         continue;
       }
- 
+
       const fullPath = `/${file}`;
       const fileStat = await fs.promises.stat(fullPath);
       if (
@@ -216,7 +216,6 @@ export interface WingDiagnostic {
     };
     file_id: string;
   };
-  level: "Error" | "Warning" | "Note";
 }
 
 /**

--- a/libs/wingc/src/ast.rs
+++ b/libs/wingc/src/ast.rs
@@ -416,7 +416,7 @@ pub enum StmtKind {
 		module_name: Symbol, // Reference?
 		identifier: Option<Symbol>,
 	},
-	VariableDef {
+	Let {
 		reassignable: bool,
 		var_name: Symbol,
 		initial_value: Expr,
@@ -501,7 +501,7 @@ pub enum ExprKind {
 	},
 	Reference(Reference),
 	Call {
-		function: Box<Expr>,
+		callee: Box<Expr>,
 		arg_list: ArgList,
 	},
 	Unary {

--- a/libs/wingc/src/closure_transform.rs
+++ b/libs/wingc/src/closure_transform.rs
@@ -76,7 +76,7 @@ impl Fold for ClosureTransformer {
 			let parent_this_name = Symbol::new(PARENT_THIS_NAME, node.span.clone());
 			let this_name = Symbol::new("this", node.span.clone());
 			let parent_this_def = Stmt {
-				kind: StmtKind::VariableDef {
+				kind: StmtKind::Let {
 					reassignable: false,
 					var_name: parent_this_name,
 					initial_value: Expr {

--- a/libs/wingc/src/diagnostic.rs
+++ b/libs/wingc/src/diagnostic.rs
@@ -147,35 +147,17 @@ impl PartialOrd for WingSpan {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
-pub enum DiagnosticLevel {
-	Error,
-	Warning,
-	Note,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
 pub struct Diagnostic {
 	pub message: String,
 	pub span: Option<WingSpan>,
-	pub level: DiagnosticLevel,
-}
-
-impl Display for DiagnosticLevel {
-	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-		match self {
-			DiagnosticLevel::Error => write!(f, "{}", "Error".bold().red()),
-			DiagnosticLevel::Warning => write!(f, "{}", "Warning".bold().yellow()),
-			DiagnosticLevel::Note => write!(f, "{}", "Note".bold().blue()),
-		}
-	}
 }
 
 impl std::fmt::Display for Diagnostic {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		if let Some(span) = &self.span {
-			write!(f, "{} at {} | {}", self.level, span, self.message.bold().white())
+			write!(f, "Error at {} | {}", span, self.message.bold().white())
 		} else {
-			write!(f, "{} | {}", self.level, self.message.bold().white())
+			write!(f, "Error | {}", self.message.bold().white())
 		}
 	}
 }

--- a/libs/wingc/src/fold.rs
+++ b/libs/wingc/src/fold.rs
@@ -266,11 +266,8 @@ where
 			end: Box::new(f.fold_expr(*end)),
 		},
 		ExprKind::Reference(reference) => ExprKind::Reference(f.fold_reference(reference)),
-		ExprKind::Call {
-			callee: function,
-			arg_list,
-		} => ExprKind::Call {
-			callee: Box::new(f.fold_expr(*function)),
+		ExprKind::Call { callee, arg_list } => ExprKind::Call {
+			callee: Box::new(f.fold_expr(*callee)),
 			arg_list: f.fold_args(arg_list),
 		},
 		ExprKind::Unary { op, exp } => ExprKind::Unary {

--- a/libs/wingc/src/fold.rs
+++ b/libs/wingc/src/fold.rs
@@ -85,12 +85,12 @@ where
 			module_name: f.fold_symbol(module_name),
 			identifier: identifier.map(|id| f.fold_symbol(id)),
 		},
-		StmtKind::VariableDef {
+		StmtKind::Let {
 			reassignable,
 			var_name,
 			initial_value,
 			type_,
-		} => StmtKind::VariableDef {
+		} => StmtKind::Let {
 			reassignable,
 			var_name: f.fold_symbol(var_name),
 			initial_value: f.fold_expr(initial_value),
@@ -266,8 +266,11 @@ where
 			end: Box::new(f.fold_expr(*end)),
 		},
 		ExprKind::Reference(reference) => ExprKind::Reference(f.fold_reference(reference)),
-		ExprKind::Call { function, arg_list } => ExprKind::Call {
-			function: Box::new(f.fold_expr(*function)),
+		ExprKind::Call {
+			callee: function,
+			arg_list,
+		} => ExprKind::Call {
+			callee: Box::new(f.fold_expr(*function)),
 			arg_list: f.fold_args(arg_list),
 		},
 		ExprKind::Unary { op, exp } => ExprKind::Unary {

--- a/libs/wingc/src/jsify.rs
+++ b/libs/wingc/src/jsify.rs
@@ -368,23 +368,23 @@ impl<'a> JSifier<'a> {
 				}
 			}
 			ExprKind::Reference(_ref) => self.jsify_reference(&_ref, ctx),
-			ExprKind::Call { callee: function, arg_list } => {
-				let function_type = function.evaluated_type.borrow().unwrap();
+			ExprKind::Call { callee, arg_list } => {
+				let function_type = callee.evaluated_type.borrow().unwrap();
 				let function_sig = function_type.as_function_sig();
 				assert!(
 					function_sig.is_some() || function_type.is_anything(),
 					"Expected expression to be callable"
 				);
 
-				let expr_string = match &function.kind {
+				let expr_string = match &callee.kind {
 					ExprKind::Reference(reference) => self.jsify_reference(reference, ctx),
-					_ => format!("({})", self.jsify_expression(function, ctx)),
+					_ => format!("({})", self.jsify_expression(callee, ctx)),
 				};
 				let arg_string = self.jsify_arg_list(&arg_list, None, None, ctx);
 
 				if let Some(function_sig) = function_sig {
 					if let Some(js_override) = &function_sig.js_override {
-						let self_string = &match &function.kind {
+						let self_string = &match &callee.kind {
 							// for "loose" macros, e.g. `print()`, $self$ is the global object
 							ExprKind::Reference(Reference::Identifier(_)) => "global".to_string(),
 							ExprKind::Reference(Reference::InstanceMember { object, .. }) => {

--- a/libs/wingc/src/jsify.rs
+++ b/libs/wingc/src/jsify.rs
@@ -1,8 +1,9 @@
 mod codemaker;
+mod free_var_scanner;
 
 use aho_corasick::AhoCorasick;
 use const_format::formatcp;
-use indexmap::{indexmap, indexset, IndexMap, IndexSet};
+use indexmap::{indexmap, IndexMap, IndexSet};
 use itertools::Itertools;
 
 use std::{
@@ -32,7 +33,7 @@ use crate::{
 	MACRO_REPLACE_ARGS, MACRO_REPLACE_SELF, WINGSDK_ASSEMBLY_NAME, WINGSDK_RESOURCE,
 };
 
-use self::codemaker::CodeMaker;
+use self::{codemaker::CodeMaker, free_var_scanner::FreeVariableScanner};
 
 const STDLIB: &str = "$stdlib";
 const STDLIB_CORE_RESOURCE: &str = formatcp!("{}.{}", STDLIB, WINGSDK_RESOURCE);
@@ -1682,107 +1683,5 @@ impl<'ast> Visit<'ast> for PreflightTypeRefVisitor<'ast> {
 				panic!("Unknown symbol: {type_name}, should be covered by type checking");
 			}
 		}
-	}
-}
-
-/// Scans AST nodes for free variables.
-///
-/// A free variable is a variable that is used in the body of a function but not
-/// defined in the function's scope. Here is an example where "x" is a free variable:
-/// ```wing
-/// let x = 5;
-/// let foo = () => {
-///  return x + 3;
-/// }
-/// ```
-///
-/// For more info see https://en.wikipedia.org/wiki/Free_variables_and_bound_variables
-struct FreeVariableScanner {
-	/// A list of all free variables the scanner has found so far.
-	/// This collects the exact symbols (not just the names of variables) since
-	/// this scanner may be used to scan an entire class, and a class may have
-	/// multiple methods. It's possible that in method A, a variable "x" is a
-	/// free variable, but in method B, "x" is a bound variable:
-	/// ```wing
-	/// let x = 5;
-	/// class Foo {
-	///   methodA() {
-	///     return x + 3;
-	///   }
-	///   methodB(x) {
-	///     return x + 3;
-	///   }
-	/// }
-	/// ```
-	free_vars: IndexSet<Symbol>,
-
-	/// The current scopes env during traversal
-	env: Option<SymbolEnvRef>,
-	/// The current statement index
-	statement_index: usize,
-	/// The last symbol we visited
-	last_symb: Symbol,
-}
-
-impl FreeVariableScanner {
-	pub fn new() -> Self {
-		Self {
-			free_vars: indexset![],
-			env: None,
-			statement_index: 0,
-			last_symb: Symbol::global("badger"),
-		}
-	}
-}
-
-impl Visit<'_> for FreeVariableScanner {
-	// invariant: adds zero bound variables
-	fn visit_reference(&mut self, node: &Reference) {
-		if let Reference::Identifier(ref symb) = node {
-			// Skip "this" symbol since it's never a free var even though it refers to a preflight type
-			if symb.name != "this" {
-				// Lookup the reference int the current environment
-				let lookup_result = self
-					.env
-					.as_ref()
-					.unwrap()
-					.lookup(symb, Some(self.statement_index))
-					.expect("covered by type checking");
-
-				// If this reference is a capturable, non-reassignable, preflight
-				// variable then it's a capture
-				if let SymbolKind::Variable(v) = lookup_result {
-					// TODO: if we see a reassignable or non-capturable variable, should we emit an error here or inside analyze_expr?
-					if v.phase == Phase::Preflight {
-						self.free_vars.insert(symb.clone());
-					}
-				}
-			}
-		};
-
-		return visit::visit_reference(self, node);
-	}
-
-	fn visit_scope(&mut self, scope: &Scope) {
-		let curr_env = scope.env.borrow().as_ref().unwrap().get_ref();
-		// Don't look for free vars in non-inflight scopes
-		if curr_env.phase != Phase::Inflight {
-			return;
-		}
-		let old_env = self.env;
-		self.env = Some(curr_env);
-		visit::visit_scope(self, scope);
-		self.env = old_env;
-	}
-
-	fn visit_stmt(&mut self, stmt: &Stmt) {
-		let old_statement_index = self.statement_index;
-		self.statement_index = stmt.idx;
-		visit::visit_stmt(self, stmt);
-		self.statement_index = old_statement_index;
-	}
-
-	fn visit_symbol(&mut self, node: &Symbol) {
-		self.last_symb = node.clone();
 	}
 }

--- a/libs/wingc/src/jsify.rs
+++ b/libs/wingc/src/jsify.rs
@@ -368,7 +368,7 @@ impl<'a> JSifier<'a> {
 				}
 			}
 			ExprKind::Reference(_ref) => self.jsify_reference(&_ref, ctx),
-			ExprKind::Call { function, arg_list } => {
+			ExprKind::Call { callee: function, arg_list } => {
 				let function_type = function.evaluated_type.borrow().unwrap();
 				let function_sig = function_type.as_function_sig();
 				assert!(
@@ -547,7 +547,7 @@ impl<'a> JSifier<'a> {
 					}
 				))
 			}
-			StmtKind::VariableDef {
+			StmtKind::Let {
 				reassignable,
 				var_name,
 				initial_value,

--- a/libs/wingc/src/jsify.rs
+++ b/libs/wingc/src/jsify.rs
@@ -23,7 +23,7 @@ use crate::{
 		StmtKind, Symbol, TypeAnnotationKind, UnaryOperator, UserDefinedType,
 	},
 	debug,
-	diagnostic::{Diagnostic, DiagnosticLevel, Diagnostics},
+	diagnostic::{Diagnostic, Diagnostics},
 	type_check::{
 		resolve_user_defined_type,
 		symbol_env::{LookupResult, SymbolEnv, SymbolEnvRef},
@@ -773,7 +773,6 @@ impl<'a> JSifier<'a> {
 							self.diagnostics.push(Diagnostic {
 								message: format!("Failed to resolve extern \"{external_spec}\": {err}"),
 								span: Some(func_def.span()),
-								level: DiagnosticLevel::Error,
 							});
 							format!("/* unresolved: \"{external_spec}\" */")
 						}
@@ -1420,7 +1419,6 @@ impl<'ast> Visit<'ast> for FieldReferenceVisitor<'ast> {
 			// if the variable is reassignable, bail out
 			if variable.reassignable {
 				self.diagnostics.push(Diagnostic {
-					level: DiagnosticLevel::Error,
 					message: format!("Cannot capture reassignable field '{}'", curr.text),
 					span: Some(curr.expr.span.clone()),
 				});
@@ -1431,7 +1429,6 @@ impl<'ast> Visit<'ast> for FieldReferenceVisitor<'ast> {
 			// if this type is not capturable, bail out
 			if !variable.type_.is_capturable() {
 				self.diagnostics.push(Diagnostic {
-					level: DiagnosticLevel::Error,
 					message: format!(
 						"Cannot capture field '{}' with non-capturable type '{}'",
 						curr.text, variable.type_
@@ -1449,7 +1446,6 @@ impl<'ast> Visit<'ast> for FieldReferenceVisitor<'ast> {
 			if let Some(inner_type) = variable.type_.collection_item_type() {
 				if inner_type.as_resource().is_some() {
 					self.diagnostics.push(Diagnostic {
-						level: DiagnosticLevel::Error,
 						message: format!(
 							"Capturing collection of resources is not supported yet (type is '{}')",
 							variable.type_,
@@ -1497,7 +1493,6 @@ impl<'ast> Visit<'ast> for FieldReferenceVisitor<'ast> {
 				if v.type_.as_resource().is_some() {
 					if qualification.len() == 0 {
 						self.diagnostics.push(Diagnostic {
-							level: DiagnosticLevel::Error,
 							message: format!(
 								"Unable to qualify which operations are performed on '{}' of type '{}'. This is not supported yet.",
 								key, v.type_,

--- a/libs/wingc/src/jsify/free_var_scanner.rs
+++ b/libs/wingc/src/jsify/free_var_scanner.rs
@@ -1,0 +1,109 @@
+use indexmap::{indexset, IndexSet};
+
+use crate::{
+	ast::{Phase, Reference, Scope, Stmt, Symbol},
+	type_check::{symbol_env::SymbolEnvRef, SymbolKind},
+	visit::{self, Visit},
+};
+
+/// Scans AST nodes for free variables.
+///
+/// A free variable is a variable that is used in the body of a function but not
+/// defined in the function's scope. Here is an example where "x" is a free variable:
+/// ```wing
+/// let x = 5;
+/// let foo = () => {
+///  return x + 3;
+/// }
+/// ```
+///
+/// For more info see https://en.wikipedia.org/wiki/Free_variables_and_bound_variables
+pub struct FreeVariableScanner {
+	/// A list of all free variables the scanner has found so far.
+	/// This collects the exact symbols (not just the names of variables) since
+	/// this scanner may be used to scan an entire class, and a class may have
+	/// multiple methods. It's possible that in method A, a variable "x" is a
+	/// free variable, but in method B, "x" is a bound variable:
+	/// ```wing
+	/// let x = 5;
+	/// class Foo {
+	///   methodA() {
+	///     return x + 3;
+	///   }
+	///   methodB(x) {
+	///     return x + 3;
+	///   }
+	/// }
+	/// ```
+	pub free_vars: IndexSet<Symbol>,
+
+	/// The current scopes env during traversal
+	env: Option<SymbolEnvRef>,
+	/// The current statement index
+	statement_index: usize,
+	/// The last symbol we visited
+	last_symb: Symbol,
+}
+
+impl FreeVariableScanner {
+	pub fn new() -> Self {
+		Self {
+			free_vars: indexset![],
+			env: None,
+			statement_index: 0,
+			last_symb: Symbol::global("badger"),
+		}
+	}
+}
+
+impl Visit<'_> for FreeVariableScanner {
+	// invariant: adds zero bound variables
+	fn visit_reference(&mut self, node: &Reference) {
+		if let Reference::Identifier(ref symb) = node {
+			// Skip "this" symbol since it's never a free var even though it refers to a preflight type
+			if symb.name != "this" {
+				// Lookup the reference int the current environment
+				let lookup_result = self
+					.env
+					.as_ref()
+					.unwrap()
+					.lookup(symb, Some(self.statement_index))
+					.expect("covered by type checking");
+
+				// If this reference is a capturable, non-reassignable, preflight
+				// variable then it's a capture
+				if let SymbolKind::Variable(v) = lookup_result {
+					// TODO: if we see a reassignable or non-capturable variable, should we emit an error here or inside analyze_expr?
+					if v.phase == Phase::Preflight {
+						self.free_vars.insert(symb.clone());
+					}
+				}
+			}
+		};
+
+		return visit::visit_reference(self, node);
+	}
+
+	fn visit_scope(&mut self, scope: &Scope) {
+		let curr_env = scope.env.borrow().as_ref().unwrap().get_ref();
+		// Don't look for free vars in non-inflight scopes
+		if curr_env.phase != Phase::Inflight {
+			return;
+		}
+		let old_env = self.env;
+		self.env = Some(curr_env);
+		visit::visit_scope(self, scope);
+		self.env = old_env;
+	}
+
+	fn visit_stmt(&mut self, stmt: &Stmt) {
+		let old_statement_index = self.statement_index;
+		self.statement_index = stmt.idx;
+		visit::visit_stmt(self, stmt);
+		self.statement_index = old_statement_index;
+	}
+
+	fn visit_symbol(&mut self, node: &Symbol) {
+		self.last_symb = node.clone();
+	}
+}

--- a/libs/wingc/src/lib.rs
+++ b/libs/wingc/src/lib.rs
@@ -41,7 +41,6 @@ pub mod lsp;
 pub mod parser;
 pub mod type_check;
 pub mod type_check_assert;
-pub mod type_check_class_fields_init;
 pub mod visit;
 mod wasm_util;
 

--- a/libs/wingc/src/lib.rs
+++ b/libs/wingc/src/lib.rs
@@ -9,7 +9,7 @@ extern crate lazy_static;
 
 use ast::{Scope, Stmt, Symbol, UtilityFunctions};
 use closure_transform::ClosureTransformer;
-use diagnostic::{print_diagnostics, Diagnostic, DiagnosticLevel, Diagnostics};
+use diagnostic::{print_diagnostics, Diagnostic, Diagnostics};
 use fold::Fold;
 use jsify::JSifier;
 use type_check::symbol_env::StatementIdx;
@@ -143,7 +143,6 @@ pub fn parse(source_path: &Path) -> (Scope, Diagnostics) {
 			diagnostics.push(Diagnostic {
 				message: format!("Error reading source file: {}: {:?}", source_path.display(), err),
 				span: None,
-				level: DiagnosticLevel::Error,
 			});
 
 			// Set up a dummy scope to return
@@ -263,7 +262,6 @@ pub fn compile(
 		return Err(vec![Diagnostic {
 			message: format!("Source file cannot be found: {}", source_path.display()),
 			span: None,
-			level: DiagnosticLevel::Error,
 		}]);
 	}
 
@@ -274,7 +272,6 @@ pub fn compile(
 				source_path.display()
 			),
 			span: None,
-			level: DiagnosticLevel::Error,
 		}]);
 	}
 
@@ -317,16 +314,9 @@ pub fn compile(
 	let mut diagnostics = parse_diagnostics;
 	diagnostics.extend(type_check_diagnostics);
 
-	// Filter diagnostics to only errors
-	let errors = diagnostics
-		.iter()
-		.filter(|d| matches!(d.level, DiagnosticLevel::Error))
-		.cloned()
-		.collect::<Vec<_>>();
-
 	// bail out now (before jsification) if there are errors (no point in jsifying)
-	if errors.len() > 0 {
-		return Err(errors);
+	if diagnostics.len() > 0 {
+		return Err(diagnostics);
 	}
 
 	// -- JSIFICATION PHASE --
@@ -348,7 +338,6 @@ pub fn compile(
 			diagnostics.push(Diagnostic {
 				message: format!("Project directory must be absolute: {}", project_dir.display()),
 				span: None,
-				level: DiagnosticLevel::Error,
 			});
 			return Err(diagnostics);
 		}

--- a/libs/wingc/src/lsp/document_symbols.rs
+++ b/libs/wingc/src/lsp/document_symbols.rs
@@ -35,7 +35,7 @@ impl Visit<'_> for DocumentSymbolVisitor {
 						.push(create_document_symbol(symbol, SymbolKind::VARIABLE));
 				}
 			}
-			StmtKind::VariableDef { var_name, .. } => {
+			StmtKind::Let { var_name, .. } => {
 				let symbol = var_name;
 				self
 					.document_symbols

--- a/libs/wingc/src/lsp/notifications.rs
+++ b/libs/wingc/src/lsp/notifications.rs
@@ -1,7 +1,7 @@
 use itertools::Itertools;
 use lsp_types::{Range, Url};
 
-use crate::diagnostic::{DiagnosticLevel, Diagnostics};
+use crate::diagnostic::Diagnostics;
 
 lazy_static! {
 	static ref NOTIFICATION_TYPE_LOG: Vec<u8> = "window/logMessage".to_string().into_bytes();
@@ -43,7 +43,7 @@ pub unsafe fn send_notification(
 pub fn send_diagnostics(uri: &Url, diagnostics: &Diagnostics) {
 	let final_diags = diagnostics
 		.iter()
-		.filter(|item| matches!(item.level, DiagnosticLevel::Error) && item.span.is_some())
+		.filter(|item| item.span.is_some())
 		.map(|item| {
 			let span = item.span.as_ref().unwrap();
 			let start_position = span.start.into();

--- a/libs/wingc/src/parser.rs
+++ b/libs/wingc/src/parser.rs
@@ -12,7 +12,7 @@ use crate::ast::{
 	InterpolatedStringPart, Literal, Phase, Reference, Scope, Stmt, StmtKind, StructField, Symbol, TypeAnnotation,
 	TypeAnnotationKind, UnaryOperator, UserDefinedType,
 };
-use crate::diagnostic::{Diagnostic, DiagnosticLevel, DiagnosticResult, Diagnostics, WingSpan};
+use crate::diagnostic::{Diagnostic, DiagnosticResult, Diagnostics, WingSpan};
 use crate::WINGSDK_STD_MODULE;
 
 pub struct Parser<'a> {
@@ -70,7 +70,6 @@ impl<'s> Parser<'s> {
 		let diag = Diagnostic {
 			message: message.to_string(),
 			span: Some(self.node_span(node)),
-			level: DiagnosticLevel::Error,
 		};
 		// TODO terrible to clone here to avoid move
 		self.diagnostics.borrow_mut().push(diag);
@@ -480,7 +479,6 @@ impl<'s> Parser<'s> {
 					let is_static = class_element.child_by_field_name("static").is_some();
 					if is_static {
 						self.diagnostics.borrow_mut().push(Diagnostic {
-							level: DiagnosticLevel::Error,
 							message: "Static class fields not supported yet, see https://github.com/winglang/wing/issues/1668"
 								.to_string(),
 							span: Some(self.node_span(&class_element)),

--- a/libs/wingc/src/parser.rs
+++ b/libs/wingc/src/parser.rs
@@ -386,7 +386,7 @@ impl<'s> Parser<'s> {
 		} else {
 			None
 		};
-		Ok(StmtKind::VariableDef {
+		Ok(StmtKind::Let {
 			reassignable: statement_node.child_by_field_name("reassignable").is_some(),
 			var_name: self.node_symbol(&statement_node.child_by_field_name("name").unwrap())?,
 			initial_value: self.build_expression(&statement_node.child_by_field_name("value").unwrap())?,
@@ -1196,7 +1196,7 @@ impl<'s> Parser<'s> {
 			"keyword_argument_value" => self.build_expression(&expression_node.named_child(0).unwrap()),
 			"call" => Ok(Expr::new(
 				ExprKind::Call {
-					function: Box::new(self.build_expression(&expression_node.child_by_field_name("caller").unwrap())?),
+					callee: Box::new(self.build_expression(&expression_node.child_by_field_name("caller").unwrap())?),
 					arg_list: self.build_arg_list(&expression_node.child_by_field_name("args").unwrap())?,
 				},
 				expression_span,

--- a/libs/wingc/src/type_check.rs
+++ b/libs/wingc/src/type_check.rs
@@ -8,7 +8,7 @@ use crate::ast::{
 	Interface as AstInterface, InterpolatedStringPart, Literal, MethodLike, Phase, Reference, Scope, Spanned, Stmt,
 	StmtKind, Symbol, TypeAnnotation, UnaryOperator, UserDefinedType,
 };
-use crate::diagnostic::{Diagnostic, DiagnosticLevel, Diagnostics, TypeError, WingSpan};
+use crate::diagnostic::{Diagnostic, Diagnostics, TypeError, WingSpan};
 use crate::{
 	debug, WINGSDK_ARRAY, WINGSDK_ASSEMBLY_NAME, WINGSDK_CLOUD_MODULE, WINGSDK_DURATION, WINGSDK_FS_MODULE, WINGSDK_JSON,
 	WINGSDK_MAP, WINGSDK_MUT_ARRAY, WINGSDK_MUT_JSON, WINGSDK_MUT_MAP, WINGSDK_MUT_SET, WINGSDK_REDIS_MODULE,
@@ -1120,31 +1120,14 @@ impl<'a> TypeChecker<'a> {
 		);
 	}
 
-	// TODO: All calls to this should be removed and we should make sure type checks are done
-	// for unimplemented types
-	pub fn unimplemented_type(&self, type_name: &str) -> Option<Type> {
-		self.diagnostics.borrow_mut().push(Diagnostic {
-			level: DiagnosticLevel::Warning,
-			message: format!("Unimplemented type: {}", type_name),
-			span: None,
-		});
-
-		return Some(Type::Anything);
-	}
-
 	fn general_type_error(&self, message: String) -> TypeRef {
-		self.diagnostics.borrow_mut().push(Diagnostic {
-			level: DiagnosticLevel::Error,
-			message,
-			span: None,
-		});
+		self.diagnostics.borrow_mut().push(Diagnostic { message, span: None });
 
 		self.types.anything()
 	}
 
 	fn resolve_static_error(&self, property: &Symbol, message: String) -> VariableInfo {
 		self.diagnostics.borrow_mut().push(Diagnostic {
-			level: DiagnosticLevel::Error,
 			message,
 			span: Some(property.span.clone()),
 		});
@@ -1158,7 +1141,6 @@ impl<'a> TypeChecker<'a> {
 
 	fn expr_error(&self, expr: &Expr, message: String) -> TypeRef {
 		self.diagnostics.borrow_mut().push(Diagnostic {
-			level: DiagnosticLevel::Error,
 			message,
 			span: Some(expr.span.clone()),
 		});
@@ -1168,7 +1150,6 @@ impl<'a> TypeChecker<'a> {
 
 	fn stmt_error(&self, stmt: &Stmt, message: String) {
 		self.diagnostics.borrow_mut().push(Diagnostic {
-			level: DiagnosticLevel::Error,
 			message,
 			span: Some(stmt.span.clone()),
 		});
@@ -1177,7 +1158,6 @@ impl<'a> TypeChecker<'a> {
 	fn type_error(&self, type_error: TypeError) -> TypeRef {
 		let TypeError { message, span } = type_error;
 		self.diagnostics.borrow_mut().push(Diagnostic {
-			level: DiagnosticLevel::Error,
 			message,
 			span: Some(span),
 		});
@@ -1188,7 +1168,6 @@ impl<'a> TypeChecker<'a> {
 	fn variable_error(&self, type_error: TypeError) -> VariableInfo {
 		let TypeError { message, span } = type_error;
 		self.diagnostics.borrow_mut().push(Diagnostic {
-			level: DiagnosticLevel::Error,
 			message,
 			span: Some(span),
 		});
@@ -1263,7 +1242,6 @@ impl<'a> TypeChecker<'a> {
 									ltype, rtype, self.types.number(), self.types.number(), self.types.string(), self.types.string(),
 								),
 								span: Some(exp.span()),
-								level: DiagnosticLevel::Error,
 							});
 							self.types.anything() // TODO: return error type
 						}
@@ -1814,7 +1792,6 @@ impl<'a> TypeChecker<'a> {
 					)
 				},
 				span: Some(span.span()),
-				level: DiagnosticLevel::Error,
 			});
 			expected_types[0]
 		} else {

--- a/libs/wingc/src/type_check.rs
+++ b/libs/wingc/src/type_check.rs
@@ -1429,12 +1429,9 @@ impl<'a> TypeChecker<'a> {
 				}
 				type_
 			}
-			ExprKind::Call {
-				callee: function,
-				arg_list,
-			} => {
+			ExprKind::Call { callee, arg_list } => {
 				// Resolve the function's reference (either a method in the class's env or a function in the current env)
-				let func_type = self.type_check_exp(function, env);
+				let func_type = self.type_check_exp(callee, env);
 
 				let arg_list_types = self.type_check_arg_list(arg_list, env);
 
@@ -1447,7 +1444,7 @@ impl<'a> TypeChecker<'a> {
 				let func_sig = if let Some(func_sig) = func_type.as_function_sig() {
 					func_sig
 				} else {
-					return self.expr_error(function, "should be a function or method".to_string());
+					return self.expr_error(callee, "should be a function or method".to_string());
 				};
 
 				if !env.phase.can_call_to(&func_sig.phase) {

--- a/libs/wingc/src/type_check.rs
+++ b/libs/wingc/src/type_check.rs
@@ -191,7 +191,6 @@ pub struct Class {
 	implements: Vec<TypeRef>, // Must be a Type::Interface type
 	#[derivative(Debug = "ignore")]
 	pub env: SymbolEnv,
-	pub should_case_convert_jsii: bool,
 	pub fqn: Option<String>,
 	pub is_abstract: bool,
 	pub type_parameters: Option<Vec<TypeRef>>,
@@ -305,7 +304,6 @@ pub struct Struct {
 	extends: Vec<TypeRef>, // Must be a Type::Struct type
 	#[derivative(Debug = "ignore")]
 	pub env: SymbolEnv,
-	pub should_case_convert_jsii: bool,
 }
 
 #[derive(Debug)]
@@ -2205,7 +2203,6 @@ impl<'a> TypeChecker<'a> {
 
 				// Create the resource/class type and add it to the current environment (so class implementation can reference itself)
 				let class_spec = Class {
-					should_case_convert_jsii: false,
 					name: name.clone(),
 					fqn: None,
 					env: dummy_env,
@@ -2469,7 +2466,6 @@ impl<'a> TypeChecker<'a> {
 					name,
 					SymbolKind::Type(self.types.add_type(Type::Struct(Struct {
 						name: name.clone(),
-						should_case_convert_jsii: false,
 						extends: extends_types,
 						env: struct_env,
 					}))),
@@ -2812,7 +2808,6 @@ impl<'a> TypeChecker<'a> {
 			fqn: Some(original_fqn.to_string()),
 			parent: original_type_class.parent,
 			implements: original_type_class.implements.clone(),
-			should_case_convert_jsii: original_type_class.should_case_convert_jsii,
 			is_abstract: original_type_class.is_abstract,
 			type_parameters: Some(type_params),
 		});

--- a/libs/wingc/src/type_check.rs
+++ b/libs/wingc/src/type_check.rs
@@ -1429,7 +1429,10 @@ impl<'a> TypeChecker<'a> {
 				}
 				type_
 			}
-			ExprKind::Call { function, arg_list } => {
+			ExprKind::Call {
+				callee: function,
+				arg_list,
+			} => {
 				// Resolve the function's reference (either a method in the class's env or a function in the current env)
 				let func_type = self.type_check_exp(function, env);
 
@@ -1907,7 +1910,7 @@ impl<'a> TypeChecker<'a> {
 		self.statement_idx = stmt.idx;
 
 		match &stmt.kind {
-			StmtKind::VariableDef {
+			StmtKind::Let {
 				reassignable,
 				var_name,
 				initial_value,

--- a/libs/wingc/src/type_check/class_fields_init.rs
+++ b/libs/wingc/src/type_check/class_fields_init.rs
@@ -3,9 +3,18 @@ use crate::{
 	visit::{self, Visit},
 };
 
-/// Visitor Pattern for listing the variables that are initialized in the class constructor.
+/// Determine a list of all variables that are initialized in a class constructor.
+#[derive(Default)]
 pub struct VisitClassInit {
 	pub fields: Vec<String>,
+}
+
+impl VisitClassInit {
+	pub fn analyze_statements(&mut self, statements: &[Stmt]) {
+		for stmt in statements {
+			self.visit_stmt(stmt);
+		}
+	}
 }
 
 impl Visit<'_> for VisitClassInit {

--- a/libs/wingc/src/type_check/class_fields_init.rs
+++ b/libs/wingc/src/type_check/class_fields_init.rs
@@ -3,7 +3,7 @@ use crate::{
 	visit::{self, Visit},
 };
 
-/// Determine a list of all variables that are initialized in a class constructor.
+/// Determine a list of all fields that are initialized in a class constructor.
 #[derive(Default)]
 pub struct VisitClassInit {
 	pub fields: Vec<String>,

--- a/libs/wingc/src/type_check/jsii_importer.rs
+++ b/libs/wingc/src/type_check/jsii_importer.rs
@@ -332,7 +332,6 @@ impl<'a> JsiiImporter<'a> {
 			true => self.wing_types.add_type(Type::Struct(Struct {
 				name: new_type_symbol.clone(),
 				extends: extends.clone(),
-				should_case_convert_jsii: true,
 				env: SymbolEnv::new(
 					None,
 					self.wing_types.void(),
@@ -628,7 +627,6 @@ impl<'a> JsiiImporter<'a> {
 		};
 
 		let class_spec = Class {
-			should_case_convert_jsii: true,
 			name: new_type_symbol.clone(),
 			env: dummy_env,
 			fqn: Some(jsii_class_fqn.to_string()),

--- a/libs/wingc/src/visit.rs
+++ b/libs/wingc/src/visit.rs
@@ -98,7 +98,7 @@ where
 				v.visit_symbol(identifier);
 			}
 		}
-		StmtKind::VariableDef {
+		StmtKind::Let {
 			reassignable: _,
 			var_name,
 			initial_value,
@@ -286,7 +286,10 @@ where
 		ExprKind::Reference(ref_) => {
 			v.visit_reference(ref_);
 		}
-		ExprKind::Call { function, arg_list } => {
+		ExprKind::Call {
+			callee: function,
+			arg_list,
+		} => {
 			v.visit_expr(function);
 			v.visit_args(arg_list);
 		}

--- a/libs/wingc/src/visit.rs
+++ b/libs/wingc/src/visit.rs
@@ -286,11 +286,8 @@ where
 		ExprKind::Reference(ref_) => {
 			v.visit_reference(ref_);
 		}
-		ExprKind::Call {
-			callee: function,
-			arg_list,
-		} => {
-			v.visit_expr(function);
+		ExprKind::Call { callee, arg_list } => {
+			v.visit_expr(callee);
 			v.visit_args(arg_list);
 		}
 		ExprKind::Unary { op: _, exp } => {


### PR DESCRIPTION
- Remove dead code related to diagnostic levels. Our compiler only produces error diagnostics, so tracking the levels doesn't serve a function right now. Let's add it back when we have a use case for it
- Move FreeVariableScanner and VisitClassInit to their own self-contained modules that can only be accessed by `jsify` and `type_check` respectively.
- Renamed StmtKind::VariableDef to StmtKind::Let and ExprKind::Call.function to ExprKind::Call.callee
- Removed dead code related to case conversion

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.