### PR TITLE
fix: generated inflight classes are visible by default in Wing Console

### DIFF
--- a/libs/wingc/src/closure_transform.rs
+++ b/libs/wingc/src/closure_transform.rs
@@ -195,6 +195,10 @@ impl Fold for ClosureTransformer {
 				// we need to set this to false.
 				new_func_def.is_static = false;
 
+				// class_init_body :=
+				// ```
+				// this.display.hidden = true;
+				// ```
 				let class_init_body = vec![Stmt {
 					idx: 0,
 					kind: StmtKind::Assignment {

--- a/tools/hangar/__snapshots__/test_corpus/add_consumer.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/add_consumer.w_compile_tf-aws.md
@@ -393,6 +393,7 @@ class $Root extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
         this._addInflightOps("handle");
+        this.display.hidden = true;
       }
       static _toInflightType(context) {
         const self_client_path = "./clients/$Inflight1.inflight.js".replace(/\\/g, "/");
@@ -427,6 +428,7 @@ class $Root extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
         this._addInflightOps("handle");
+        this.display.hidden = true;
       }
       static _toInflightType(context) {
         const self_client_path = "./clients/$Inflight2.inflight.js".replace(/\\/g, "/");

--- a/tools/hangar/__snapshots__/test_corpus/api_valid_path.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/api_valid_path.w_compile_tf-aws.md
@@ -275,6 +275,7 @@ class $Root extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
         this._addInflightOps("handle");
+        this.display.hidden = true;
       }
       static _toInflightType(context) {
         const self_client_path = "./clients/$Inflight1.inflight.js".replace(/\\/g, "/");

--- a/tools/hangar/__snapshots__/test_corpus/approx_size.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/approx_size.w_compile_tf-aws.md
@@ -165,6 +165,7 @@ class $Root extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
         this._addInflightOps("handle");
+        this.display.hidden = true;
       }
       static _toInflightType(context) {
         const self_client_path = "./clients/$Inflight1.inflight.js".replace(/\\/g, "/");

--- a/tools/hangar/__snapshots__/test_corpus/asynchronous_model_implicit_await_in_functions.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/asynchronous_model_implicit_await_in_functions.w_compile_tf-aws.md
@@ -245,6 +245,7 @@ class $Root extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
         this._addInflightOps("handle");
+        this.display.hidden = true;
       }
       static _toInflightType(context) {
         const self_client_path = "./clients/$Inflight1.inflight.js".replace(/\\/g, "/");
@@ -276,6 +277,7 @@ class $Root extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
         this._addInflightOps("handle");
+        this.display.hidden = true;
       }
       static _toInflightType(context) {
         const self_client_path = "./clients/$Inflight2.inflight.js".replace(/\\/g, "/");

--- a/tools/hangar/__snapshots__/test_corpus/bring_jsii.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/bring_jsii.w_compile_tf-aws.md
@@ -152,6 +152,7 @@ class $Root extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
         this._addInflightOps("handle");
+        this.display.hidden = true;
       }
       static _toInflightType(context) {
         const self_client_path = "./clients/$Inflight1.inflight.js".replace(/\\/g, "/");

--- a/tools/hangar/__snapshots__/test_corpus/bring_jsii_path.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/bring_jsii_path.w_compile_tf-aws.md
@@ -152,6 +152,7 @@ class $Root extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
         this._addInflightOps("handle");
+        this.display.hidden = true;
       }
       static _toInflightType(context) {
         const self_client_path = "./clients/$Inflight1.inflight.js".replace(/\\/g, "/");

--- a/tools/hangar/__snapshots__/test_corpus/bucket_events.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/bucket_events.w_compile_tf-aws.md
@@ -1321,6 +1321,7 @@ class $Root extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
         this._addInflightOps("handle");
+        this.display.hidden = true;
       }
       static _toInflightType(context) {
         const self_client_path = "./clients/$Inflight1.inflight.js".replace(/\\/g, "/");
@@ -1352,6 +1353,7 @@ class $Root extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
         this._addInflightOps("handle");
+        this.display.hidden = true;
       }
       static _toInflightType(context) {
         const self_client_path = "./clients/$Inflight2.inflight.js".replace(/\\/g, "/");
@@ -1383,6 +1385,7 @@ class $Root extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
         this._addInflightOps("handle");
+        this.display.hidden = true;
       }
       static _toInflightType(context) {
         const self_client_path = "./clients/$Inflight3.inflight.js".replace(/\\/g, "/");
@@ -1414,6 +1417,7 @@ class $Root extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
         this._addInflightOps("handle");
+        this.display.hidden = true;
       }
       static _toInflightType(context) {
         const self_client_path = "./clients/$Inflight4.inflight.js".replace(/\\/g, "/");
@@ -1448,6 +1452,7 @@ class $Root extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
         this._addInflightOps("handle");
+        this.display.hidden = true;
       }
       static _toInflightType(context) {
         const self_client_path = "./clients/$Inflight5.inflight.js".replace(/\\/g, "/");
@@ -1479,6 +1484,7 @@ class $Root extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
         this._addInflightOps("handle");
+        this.display.hidden = true;
       }
       static _toInflightType(context) {
         const self_client_path = "./clients/$Inflight6.inflight.js".replace(/\\/g, "/");

--- a/tools/hangar/__snapshots__/test_corpus/bucket_keys.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/bucket_keys.w_compile_tf-aws.md
@@ -206,6 +206,7 @@ class $Root extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
         this._addInflightOps("handle");
+        this.display.hidden = true;
       }
       static _toInflightType(context) {
         const self_client_path = "./clients/$Inflight1.inflight.js".replace(/\\/g, "/");

--- a/tools/hangar/__snapshots__/test_corpus/capture_containers.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/capture_containers.w_compile_tf-aws.md
@@ -159,6 +159,7 @@ class $Root extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
         this._addInflightOps("handle");
+        this.display.hidden = true;
       }
       static _toInflightType(context) {
         const self_client_path = "./clients/$Inflight1.inflight.js".replace(/\\/g, "/");

--- a/tools/hangar/__snapshots__/test_corpus/capture_in_binary.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/capture_in_binary.w_compile_tf-aws.md
@@ -198,6 +198,7 @@ class $Root extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
         this._addInflightOps("handle");
+        this.display.hidden = true;
       }
       static _toInflightType(context) {
         const self_client_path = "./clients/$Inflight1.inflight.js".replace(/\\/g, "/");

--- a/tools/hangar/__snapshots__/test_corpus/capture_primitives.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/capture_primitives.w_compile_tf-aws.md
@@ -165,6 +165,7 @@ class $Root extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
         this._addInflightOps("handle");
+        this.display.hidden = true;
       }
       static _toInflightType(context) {
         const self_client_path = "./clients/$Inflight1.inflight.js".replace(/\\/g, "/");

--- a/tools/hangar/__snapshots__/test_corpus/capture_resource_and_data.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/capture_resource_and_data.w_compile_tf-aws.md
@@ -211,6 +211,7 @@ class $Root extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
         this._addInflightOps("handle");
+        this.display.hidden = true;
       }
       static _toInflightType(context) {
         const self_client_path = "./clients/$Inflight1.inflight.js".replace(/\\/g, "/");

--- a/tools/hangar/__snapshots__/test_corpus/capture_resource_with_no_inflight.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/capture_resource_with_no_inflight.w_compile_tf-aws.md
@@ -197,6 +197,7 @@ class $Root extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
         this._addInflightOps("handle");
+        this.display.hidden = true;
       }
       static _toInflightType(context) {
         const self_client_path = "./clients/$Inflight1.inflight.js".replace(/\\/g, "/");

--- a/tools/hangar/__snapshots__/test_corpus/captures.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/captures.w_compile_tf-aws.md
@@ -470,6 +470,7 @@ class $Root extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
         this._addInflightOps("handle");
+        this.display.hidden = true;
       }
       static _toInflightType(context) {
         const self_client_path = "./clients/$Inflight1.inflight.js".replace(/\\/g, "/");

--- a/tools/hangar/__snapshots__/test_corpus/dec.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/dec.w_compile_tf-aws.md
@@ -177,6 +177,7 @@ class $Root extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
         this._addInflightOps("handle");
+        this.display.hidden = true;
       }
       static _toInflightType(context) {
         const self_client_path = "./clients/$Inflight1.inflight.js".replace(/\\/g, "/");

--- a/tools/hangar/__snapshots__/test_corpus/doubler.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/doubler.w_compile_tf-aws.md
@@ -120,6 +120,7 @@ class $Root extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
         this._addInflightOps("handle");
+        this.display.hidden = true;
       }
       static _toInflightType(context) {
         const self_client_path = "./clients/$Inflight1.inflight.js".replace(/\\/g, "/");

--- a/tools/hangar/__snapshots__/test_corpus/events.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/events.w_compile_tf-aws.md
@@ -955,6 +955,7 @@ class $Root extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
         this._addInflightOps("handle");
+        this.display.hidden = true;
       }
       static _toInflightType(context) {
         const self_client_path = "./clients/$Inflight1.inflight.js".replace(/\\/g, "/");
@@ -989,6 +990,7 @@ class $Root extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
         this._addInflightOps("handle");
+        this.display.hidden = true;
       }
       static _toInflightType(context) {
         const self_client_path = "./clients/$Inflight2.inflight.js".replace(/\\/g, "/");
@@ -1023,6 +1025,7 @@ class $Root extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
         this._addInflightOps("handle");
+        this.display.hidden = true;
       }
       static _toInflightType(context) {
         const self_client_path = "./clients/$Inflight3.inflight.js".replace(/\\/g, "/");
@@ -1057,6 +1060,7 @@ class $Root extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
         this._addInflightOps("handle");
+        this.display.hidden = true;
       }
       static _toInflightType(context) {
         const self_client_path = "./clients/$Inflight4.inflight.js".replace(/\\/g, "/");
@@ -1091,6 +1095,7 @@ class $Root extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
         this._addInflightOps("handle");
+        this.display.hidden = true;
       }
       static _toInflightType(context) {
         const self_client_path = "./clients/$Inflight5.inflight.js".replace(/\\/g, "/");

--- a/tools/hangar/__snapshots__/test_corpus/extern_implementation.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/extern_implementation.w_compile_tf-aws.md
@@ -312,6 +312,7 @@ class $Root extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
         this._addInflightOps("handle");
+        this.display.hidden = true;
       }
       static _toInflightType(context) {
         const self_client_path = "./clients/$Inflight1.inflight.js".replace(/\\/g, "/");
@@ -346,6 +347,7 @@ class $Root extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
         this._addInflightOps("handle");
+        this.display.hidden = true;
       }
       static _toInflightType(context) {
         const self_client_path = "./clients/$Inflight2.inflight.js".replace(/\\/g, "/");

--- a/tools/hangar/__snapshots__/test_corpus/file_counter.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/file_counter.w_compile_tf-aws.md
@@ -243,6 +243,7 @@ class $Root extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
         this._addInflightOps("handle");
+        this.display.hidden = true;
       }
       static _toInflightType(context) {
         const self_client_path = "./clients/$Inflight1.inflight.js".replace(/\\/g, "/");

--- a/tools/hangar/__snapshots__/test_corpus/for_loop.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/for_loop.w_compile_tf-aws.md
@@ -176,6 +176,7 @@ class $Root extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
         this._addInflightOps("handle");
+        this.display.hidden = true;
       }
       static _toInflightType(context) {
         const self_client_path = "./clients/$Inflight1.inflight.js".replace(/\\/g, "/");

--- a/tools/hangar/__snapshots__/test_corpus/hello.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/hello.w_compile_tf-aws.md
@@ -220,6 +220,7 @@ class $Root extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
         this._addInflightOps("handle");
+        this.display.hidden = true;
       }
       static _toInflightType(context) {
         const self_client_path = "./clients/$Inflight1.inflight.js".replace(/\\/g, "/");

--- a/tools/hangar/__snapshots__/test_corpus/identical_inflights.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/identical_inflights.w_compile_tf-aws.md
@@ -77,6 +77,7 @@ class $Root extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
         this._addInflightOps("handle");
+        this.display.hidden = true;
       }
       static _toInflightType(context) {
         const self_client_path = "./clients/$Inflight1.inflight.js".replace(/\\/g, "/");
@@ -108,6 +109,7 @@ class $Root extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
         this._addInflightOps("handle");
+        this.display.hidden = true;
       }
       static _toInflightType(context) {
         const self_client_path = "./clients/$Inflight2.inflight.js".replace(/\\/g, "/");

--- a/tools/hangar/__snapshots__/test_corpus/impl_interface.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/impl_interface.w_compile_tf-aws.md
@@ -149,6 +149,7 @@ class $Root extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
         this._addInflightOps("handle");
+        this.display.hidden = true;
       }
       static _toInflightType(context) {
         const self_client_path = "./clients/$Inflight1.inflight.js".replace(/\\/g, "/");

--- a/tools/hangar/__snapshots__/test_corpus/inc.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/inc.w_compile_tf-aws.md
@@ -182,6 +182,7 @@ class $Root extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
         this._addInflightOps("handle");
+        this.display.hidden = true;
       }
       static _toInflightType(context) {
         const self_client_path = "./clients/$Inflight1.inflight.js".replace(/\\/g, "/");

--- a/tools/hangar/__snapshots__/test_corpus/inflight-subscribers.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/inflight-subscribers.w_compile_tf-aws.md
@@ -295,6 +295,7 @@ class $Root extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
         this._addInflightOps("handle");
+        this.display.hidden = true;
       }
       static _toInflightType(context) {
         const self_client_path = "./clients/$Inflight1.inflight.js".replace(/\\/g, "/");
@@ -326,6 +327,7 @@ class $Root extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
         this._addInflightOps("handle");
+        this.display.hidden = true;
       }
       static _toInflightType(context) {
         const self_client_path = "./clients/$Inflight2.inflight.js".replace(/\\/g, "/");

--- a/tools/hangar/__snapshots__/test_corpus/inflight_class_inside_inflight_closure.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/inflight_class_inside_inflight_closure.w_compile_tf-aws.md
@@ -314,6 +314,7 @@ class $Root extends $stdlib.std.Resource {
             constructor(scope, id, ) {
               super(scope, id);
               this._addInflightOps("handle");
+              this.display.hidden = true;
             }
             static _toInflightType(context) {
               const self_client_path = "./clients/$Inflight1.inflight.js".replace(/\\/g, "/");
@@ -379,6 +380,7 @@ class $Root extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
         this._addInflightOps("handle");
+        this.display.hidden = true;
       }
       static _toInflightType(context) {
         const self_client_path = "./clients/$Inflight2.inflight.js".replace(/\\/g, "/");

--- a/tools/hangar/__snapshots__/test_corpus/initial.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/initial.w_compile_tf-aws.md
@@ -371,6 +371,7 @@ class $Root extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
         this._addInflightOps("handle");
+        this.display.hidden = true;
       }
       static _toInflightType(context) {
         const self_client_path = "./clients/$Inflight1.inflight.js".replace(/\\/g, "/");
@@ -405,6 +406,7 @@ class $Root extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
         this._addInflightOps("handle");
+        this.display.hidden = true;
       }
       static _toInflightType(context) {
         const self_client_path = "./clients/$Inflight2.inflight.js".replace(/\\/g, "/");
@@ -439,6 +441,7 @@ class $Root extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
         this._addInflightOps("handle");
+        this.display.hidden = true;
       }
       static _toInflightType(context) {
         const self_client_path = "./clients/$Inflight3.inflight.js".replace(/\\/g, "/");

--- a/tools/hangar/__snapshots__/test_corpus/invoke.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/invoke.w_compile_tf-aws.md
@@ -235,6 +235,7 @@ class $Root extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
         this._addInflightOps("handle");
+        this.display.hidden = true;
       }
       static _toInflightType(context) {
         const self_client_path = "./clients/$Inflight1.inflight.js".replace(/\\/g, "/");
@@ -269,6 +270,7 @@ class $Root extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
         this._addInflightOps("handle");
+        this.display.hidden = true;
       }
       static _toInflightType(context) {
         const self_client_path = "./clients/$Inflight2.inflight.js".replace(/\\/g, "/");

--- a/tools/hangar/__snapshots__/test_corpus/json_bucket.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/json_bucket.w_compile_tf-aws.md
@@ -283,6 +283,7 @@ class $Root extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
         this._addInflightOps("handle");
+        this.display.hidden = true;
       }
       static _toInflightType(context) {
         const self_client_path = "./clients/$Inflight1.inflight.js".replace(/\\/g, "/");
@@ -320,6 +321,7 @@ class $Root extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
         this._addInflightOps("handle");
+        this.display.hidden = true;
       }
       static _toInflightType(context) {
         const self_client_path = "./clients/$Inflight2.inflight.js".replace(/\\/g, "/");

--- a/tools/hangar/__snapshots__/test_corpus/json_static.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/json_static.w_compile_tf-aws.md
@@ -152,6 +152,7 @@ class $Root extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
         this._addInflightOps("handle");
+        this.display.hidden = true;
       }
       static _toInflightType(context) {
         const self_client_path = "./clients/$Inflight1.inflight.js".replace(/\\/g, "/");

--- a/tools/hangar/__snapshots__/test_corpus/list.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/list.w_compile_tf-aws.md
@@ -184,6 +184,7 @@ class $Root extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
         this._addInflightOps("handle");
+        this.display.hidden = true;
       }
       static _toInflightType(context) {
         const self_client_path = "./clients/$Inflight1.inflight.js".replace(/\\/g, "/");

--- a/tools/hangar/__snapshots__/test_corpus/on_message.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/on_message.w_compile_tf-aws.md
@@ -514,6 +514,7 @@ class $Root extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
         this._addInflightOps("handle");
+        this.display.hidden = true;
       }
       static _toInflightType(context) {
         const self_client_path = "./clients/$Inflight1.inflight.js".replace(/\\/g, "/");
@@ -548,6 +549,7 @@ class $Root extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
         this._addInflightOps("handle");
+        this.display.hidden = true;
       }
       static _toInflightType(context) {
         const self_client_path = "./clients/$Inflight2.inflight.js".replace(/\\/g, "/");
@@ -582,6 +584,7 @@ class $Root extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
         this._addInflightOps("handle");
+        this.display.hidden = true;
       }
       static _toInflightType(context) {
         const self_client_path = "./clients/$Inflight3.inflight.js".replace(/\\/g, "/");

--- a/tools/hangar/__snapshots__/test_corpus/peek.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/peek.w_compile_tf-aws.md
@@ -174,6 +174,7 @@ class $Root extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
         this._addInflightOps("handle");
+        this.display.hidden = true;
       }
       static _toInflightType(context) {
         const self_client_path = "./clients/$Inflight1.inflight.js".replace(/\\/g, "/");

--- a/tools/hangar/__snapshots__/test_corpus/pop.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/pop.w_compile_tf-aws.md
@@ -172,6 +172,7 @@ class $Root extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
         this._addInflightOps("handle");
+        this.display.hidden = true;
       }
       static _toInflightType(context) {
         const self_client_path = "./clients/$Inflight1.inflight.js".replace(/\\/g, "/");

--- a/tools/hangar/__snapshots__/test_corpus/print.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/print.w_compile_tf-aws.md
@@ -235,6 +235,7 @@ class $Root extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
         this._addInflightOps("handle");
+        this.display.hidden = true;
       }
       static _toInflightType(context) {
         const self_client_path = "./clients/$Inflight1.inflight.js".replace(/\\/g, "/");
@@ -266,6 +267,7 @@ class $Root extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
         this._addInflightOps("handle");
+        this.display.hidden = true;
       }
       static _toInflightType(context) {
         const self_client_path = "./clients/$Inflight2.inflight.js".replace(/\\/g, "/");

--- a/tools/hangar/__snapshots__/test_corpus/purge.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/purge.w_compile_tf-aws.md
@@ -168,6 +168,7 @@ class $Root extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
         this._addInflightOps("handle");
+        this.display.hidden = true;
       }
       static _toInflightType(context) {
         const self_client_path = "./clients/$Inflight1.inflight.js".replace(/\\/g, "/");

--- a/tools/hangar/__snapshots__/test_corpus/put.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/put.w_compile_tf-aws.md
@@ -208,6 +208,7 @@ class $Root extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
         this._addInflightOps("handle");
+        this.display.hidden = true;
       }
       static _toInflightType(context) {
         const self_client_path = "./clients/$Inflight1.inflight.js".replace(/\\/g, "/");

--- a/tools/hangar/__snapshots__/test_corpus/put_json.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/put_json.w_compile_tf-aws.md
@@ -211,6 +211,7 @@ class $Root extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
         this._addInflightOps("handle");
+        this.display.hidden = true;
       }
       static _toInflightType(context) {
         const self_client_path = "./clients/$Inflight1.inflight.js".replace(/\\/g, "/");

--- a/tools/hangar/__snapshots__/test_corpus/redis.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/redis.w_compile_tf-aws.md
@@ -481,6 +481,7 @@ class $Root extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
         this._addInflightOps("handle");
+        this.display.hidden = true;
       }
       static _toInflightType(context) {
         const self_client_path = "./clients/$Inflight1.inflight.js".replace(/\\/g, "/");

--- a/tools/hangar/__snapshots__/test_corpus/reset.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/reset.w_compile_tf-aws.md
@@ -181,6 +181,7 @@ class $Root extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
         this._addInflightOps("handle");
+        this.display.hidden = true;
       }
       static _toInflightType(context) {
         const self_client_path = "./clients/$Inflight1.inflight.js".replace(/\\/g, "/");

--- a/tools/hangar/__snapshots__/test_corpus/resource.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/resource.w_compile_tf-aws.md
@@ -984,6 +984,7 @@ class $Root extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
         this._addInflightOps("handle");
+        this.display.hidden = true;
       }
       static _toInflightType(context) {
         const self_client_path = "./clients/$Inflight1.inflight.js".replace(/\\/g, "/");
@@ -1031,6 +1032,7 @@ class $Root extends $stdlib.std.Resource {
           constructor(scope, id, ) {
             super(scope, id);
             this._addInflightOps("handle");
+            this.display.hidden = true;
           }
           static _toInflightType(context) {
             const self_client_path = "./clients/$Inflight2.inflight.js".replace(/\\/g, "/");
@@ -1066,6 +1068,7 @@ class $Root extends $stdlib.std.Resource {
           constructor(scope, id, ) {
             super(scope, id);
             this._addInflightOps("handle");
+            this.display.hidden = true;
           }
           static _toInflightType(context) {
             const self_client_path = "./clients/$Inflight3.inflight.js".replace(/\\/g, "/");
@@ -1101,6 +1104,7 @@ class $Root extends $stdlib.std.Resource {
           constructor(scope, id, ) {
             super(scope, id);
             this._addInflightOps("handle");
+            this.display.hidden = true;
           }
           static _toInflightType(context) {
             const self_client_path = "./clients/$Inflight4.inflight.js".replace(/\\/g, "/");
@@ -1181,6 +1185,7 @@ class $Root extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
         this._addInflightOps("handle");
+        this.display.hidden = true;
       }
       static _toInflightType(context) {
         const self_client_path = "./clients/$Inflight5.inflight.js".replace(/\\/g, "/");

--- a/tools/hangar/__snapshots__/test_corpus/resource_as_inflight_literal.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/resource_as_inflight_literal.w_compile_tf-aws.md
@@ -267,6 +267,7 @@ class $Root extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
         this._addInflightOps("handle");
+        this.display.hidden = true;
       }
       static _toInflightType(context) {
         const self_client_path = "./clients/$Inflight1.inflight.js".replace(/\\/g, "/");

--- a/tools/hangar/__snapshots__/test_corpus/resource_captures.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/resource_captures.w_compile_tf-aws.md
@@ -670,6 +670,7 @@ class $Root extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
         this._addInflightOps("handle");
+        this.display.hidden = true;
       }
       static _toInflightType(context) {
         const self_client_path = "./clients/$Inflight1.inflight.js".replace(/\\/g, "/");

--- a/tools/hangar/__snapshots__/test_corpus/resource_captures_globals.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/resource_captures_globals.w_compile_tf-aws.md
@@ -662,6 +662,7 @@ class $Root extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
         this._addInflightOps("handle");
+        this.display.hidden = true;
       }
       static _toInflightType(context) {
         const self_client_path = "./clients/$Inflight1.inflight.js".replace(/\\/g, "/");

--- a/tools/hangar/__snapshots__/test_corpus/statements_if.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/statements_if.w_compile_tf-aws.md
@@ -170,6 +170,7 @@ class $Root extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
         this._addInflightOps("handle");
+        this.display.hidden = true;
       }
       static _toInflightType(context) {
         const self_client_path = "./clients/$Inflight1.inflight.js".replace(/\\/g, "/");

--- a/tools/hangar/__snapshots__/test_corpus/static_members.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/static_members.w_compile_tf-aws.md
@@ -226,6 +226,7 @@ class $Root extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
         this._addInflightOps("handle");
+        this.display.hidden = true;
       }
       static _toInflightType(context) {
         const self_client_path = "./clients/$Inflight1.inflight.js".replace(/\\/g, "/");

--- a/tools/hangar/__snapshots__/test_corpus/std_string.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/std_string.w_compile_tf-aws.md
@@ -153,6 +153,7 @@ class $Root extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
         this._addInflightOps("handle");
+        this.display.hidden = true;
       }
       static _toInflightType(context) {
         const self_client_path = "./clients/$Inflight1.inflight.js".replace(/\\/g, "/");

--- a/tools/hangar/__snapshots__/test_corpus/symbol_shadow.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/symbol_shadow.w_compile_tf-aws.md
@@ -416,6 +416,7 @@ class $Root extends $stdlib.std.Resource {
           constructor(scope, id, ) {
             super(scope, id);
             this._addInflightOps("handle");
+            this.display.hidden = true;
           }
           static _toInflightType(context) {
             const self_client_path = "./clients/$Inflight2.inflight.js".replace(/\\/g, "/");
@@ -476,6 +477,7 @@ class $Root extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
         this._addInflightOps("handle");
+        this.display.hidden = true;
       }
       static _toInflightType(context) {
         const self_client_path = "./clients/$Inflight3.inflight.js".replace(/\\/g, "/");
@@ -510,6 +512,7 @@ class $Root extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
         this._addInflightOps("handle");
+        this.display.hidden = true;
       }
       static _toInflightType(context) {
         const self_client_path = "./clients/$Inflight4.inflight.js".replace(/\\/g, "/");
@@ -545,6 +548,7 @@ class $Root extends $stdlib.std.Resource {
         constructor(scope, id, ) {
           super(scope, id);
           this._addInflightOps("handle");
+          this.display.hidden = true;
         }
         static _toInflightType(context) {
           const self_client_path = "./clients/$Inflight1.inflight.js".replace(/\\/g, "/");

--- a/tools/hangar/__snapshots__/test_corpus/test_bucket.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/test_bucket.w_compile_tf-aws.md
@@ -283,6 +283,7 @@ class $Root extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
         this._addInflightOps("handle");
+        this.display.hidden = true;
       }
       static _toInflightType(context) {
         const self_client_path = "./clients/$Inflight1.inflight.js".replace(/\\/g, "/");
@@ -317,6 +318,7 @@ class $Root extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
         this._addInflightOps("handle");
+        this.display.hidden = true;
       }
       static _toInflightType(context) {
         const self_client_path = "./clients/$Inflight2.inflight.js".replace(/\\/g, "/");

--- a/tools/hangar/__snapshots__/test_corpus/website_with_api.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/website_with_api.w_compile_tf-aws.md
@@ -601,6 +601,7 @@ class $Root extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
         this._addInflightOps("handle");
+        this.display.hidden = true;
       }
       static _toInflightType(context) {
         const self_client_path = "./clients/$Inflight1.inflight.js".replace(/\\/g, "/");
@@ -635,6 +636,7 @@ class $Root extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
         this._addInflightOps("handle");
+        this.display.hidden = true;
       }
       static _toInflightType(context) {
         const self_client_path = "./clients/$Inflight2.inflight.js".replace(/\\/g, "/");
@@ -669,6 +671,7 @@ class $Root extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
         this._addInflightOps("handle");
+        this.display.hidden = true;
       }
       static _toInflightType(context) {
         const self_client_path = "./clients/$Inflight3.inflight.js".replace(/\\/g, "/");

--- a/tools/hangar/__snapshots__/test_corpus/while_loop_await.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/while_loop_await.w_compile_tf-aws.md
@@ -184,6 +184,7 @@ class $Root extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
         this._addInflightOps("handle");
+        this.display.hidden = true;
       }
       static _toInflightType(context) {
         const self_client_path = "./clients/$Inflight1.inflight.js".replace(/\\/g, "/");

--- a/tools/hangar/__snapshots__/tree_json.ts.snap
+++ b/tools/hangar/__snapshots__/tree_json.ts.snap
@@ -29,6 +29,9 @@ exports[`tree.json for an app with many resources 1`] = `
                       "fqn": "@winglang/sdk.std.Resource",
                       "version": "0.0.0",
                     },
+                    "display": {
+                      "hidden": true,
+                    },
                     "id": "$Inflight1",
                     "path": "root/Default/Default/$Inflight1",
                   },
@@ -39,6 +42,9 @@ exports[`tree.json for an app with many resources 1`] = `
                     "constructInfo": {
                       "fqn": "@winglang/sdk.std.Resource",
                       "version": "0.0.0",
+                    },
+                    "display": {
+                      "hidden": true,
                     },
                     "id": "$Inflight5",
                     "path": "root/Default/Default/$Inflight5",
@@ -178,6 +184,9 @@ exports[`tree.json for an app with many resources 1`] = `
                           "fqn": "@winglang/sdk.std.Resource",
                           "version": "0.0.0",
                         },
+                        "display": {
+                          "hidden": true,
+                        },
                         "id": "$Inflight2",
                         "path": "root/Default/Default/BigPublisher/$Inflight2",
                       },
@@ -196,6 +205,9 @@ exports[`tree.json for an app with many resources 1`] = `
                           "fqn": "@winglang/sdk.std.Resource",
                           "version": "0.0.0",
                         },
+                        "display": {
+                          "hidden": true,
+                        },
                         "id": "$Inflight3",
                         "path": "root/Default/Default/BigPublisher/$Inflight3",
                       },
@@ -213,6 +225,9 @@ exports[`tree.json for an app with many resources 1`] = `
                         "constructInfo": {
                           "fqn": "@winglang/sdk.std.Resource",
                           "version": "0.0.0",
+                        },
+                        "display": {
+                          "hidden": true,
                         },
                         "id": "$Inflight4",
                         "path": "root/Default/Default/BigPublisher/$Inflight4",


### PR DESCRIPTION
Fixes a regression to the Wing Console experience that was brought to my attention by @ainvoner 🙂

#2411 changed our compiler so inflight closures defined in preflight scopes are turned into preflight classes (which are added to the construct tree)  -- however it doesn't make sense to show them in the console by default, since they represent ephemeral pieces of code, and not logical resources or services.

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.