### PR TITLE
chore(docs): updating contributing docs

### DIFF
--- a/docs/06-contributors/020-development.md
+++ b/docs/06-contributors/020-development.md
@@ -28,6 +28,7 @@ Installation:
 git clone https://github.com/winglang/wing
 cd wing
 npm install
+(cd libs/wingsdk && cdktf get)
 ```
 
 :::note Nx Commands


### PR DESCRIPTION
Wing SDK stopped using prebuilt CDKTF providers from libraries like `@cdktf/provider-aws` and the classes are now generated inside the SDK's `src/.gen` folder. Because of this, you need to run the `cdktf get` command inside `libs/wingsdk` at least once, otherwise you may get import errors saying that the modules do not exist.

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.