### PR TITLE
feat(compiler): add `if let` statements

### DIFF
--- a/examples/tests/invalid/optionals.w
+++ b/examples/tests/invalid/optionals.w
@@ -33,3 +33,8 @@ optionalSub1 ?? new Sub2();
 //               ^ error: Sub2 is not a subtype of Sub1
 optionalSub1 ?? new Super();
 //               ^ error: Super? is not a subtype of Sub1
+
+
+if let x = true {
+//         ^^^^ Expected type to be optional, but got "bool" instead
+}

--- a/examples/tests/valid/optionals.w
+++ b/examples/tests/valid/optionals.w
@@ -23,3 +23,56 @@ inflight class Sub1 extends Super {
 let optionalSup: Super? = new Super();
 let s = optionalSup ?? new Sub();
 assert(s.name == "Super");
+
+struct Name {
+  first: str;
+  last: str?;
+}
+
+let var name: Name? = Name {
+  first: "John",
+  last: "Doe",
+};
+
+// simple tests
+if let n = name {
+  assert(n.first == "John");
+}
+
+name = nil;
+
+if let n = name {
+  assert(false); // should not be reached
+} else {
+  assert(true);
+}
+
+let tryParseName = (fullName: str): Name? => {
+  let parts = fullName.split(" ");
+  if parts.length < 1 {
+    return nil;
+  }
+  return Name {
+    first: parts.at(0),
+    last: parts.at(1),
+  };
+};
+
+
+// Nested if lets
+if let parsedName = tryParseName("Good Name") {
+  assert(parsedName.first == "Good");
+  // check for optional last name
+  if let lastName = parsedName.last {
+    assert(lastName == "Name");
+  } else {
+    assert(false); // Something went wrong
+  }
+}
+
+if let parsedName = tryParseName("BadName") {
+  assert(parsedName.first == "BadName");
+  if let lastName = parsedName.last {
+    assert(false); // No last name should exist
+  }
+}

--- a/libs/tree-sitter-wing/grammar.js
+++ b/libs/tree-sitter-wing/grammar.js
@@ -104,6 +104,7 @@ module.exports = grammar({
         $.break_statement,
         $.continue_statement,
         $.if_statement,
+        $.if_let_statement,
         $.struct_definition,
         $.enum_definition,
         $.try_catch_statement,
@@ -266,6 +267,15 @@ module.exports = grammar({
     break_statement: ($) => seq("break", $._semicolon),
 
     continue_statement: ($) => seq("continue", $._semicolon),
+    
+    if_let_statement: ($) => seq(
+      "if let",
+      field("name", $.identifier),
+      "=",
+      field("value", $.expression),
+      field("block", $.block),
+      optional(seq("else", field("else_block", $.block)))
+    ),
 
     if_statement: ($) =>
       seq(

--- a/libs/wingc/src/ast.rs
+++ b/libs/wingc/src/ast.rs
@@ -431,12 +431,12 @@ pub enum StmtKind {
 		condition: Expr,
 		statements: Scope,
 	},
-  IfLet {
-    condition: Expr,
-    statements: Scope,
-    var_name: Symbol,
-    else_statements: Option<Scope>
-  },
+	IfLet {
+		condition: Expr,
+		statements: Scope,
+		var_name: Symbol,
+		else_statements: Option<Scope>,
+	},
 	If {
 		condition: Expr,
 		statements: Scope,

--- a/libs/wingc/src/ast.rs
+++ b/libs/wingc/src/ast.rs
@@ -431,6 +431,12 @@ pub enum StmtKind {
 		condition: Expr,
 		statements: Scope,
 	},
+  IfLet {
+    condition: Expr,
+    statements: Scope,
+    var_name: Symbol,
+    else_statements: Option<Scope>
+  },
 	If {
 		condition: Expr,
 		statements: Scope,

--- a/libs/wingc/src/fold.rs
+++ b/libs/wingc/src/fold.rs
@@ -109,17 +109,17 @@ where
 			condition: f.fold_expr(condition),
 			statements: f.fold_scope(statements),
 		},
-    StmtKind::IfLet { 
-      condition, 
-      statements, 
-      var_name,
-      else_statements
-    } => StmtKind::IfLet {
-      condition: f.fold_expr(condition),
-      statements: f.fold_scope(statements),
-      var_name: f.fold_symbol(var_name),
-      else_statements: else_statements.map(|statements| f.fold_scope(statements)),
-    },
+		StmtKind::IfLet {
+			condition,
+			statements,
+			var_name,
+			else_statements,
+		} => StmtKind::IfLet {
+			condition: f.fold_expr(condition),
+			statements: f.fold_scope(statements),
+			var_name: f.fold_symbol(var_name),
+			else_statements: else_statements.map(|statements| f.fold_scope(statements)),
+		},
 		StmtKind::If {
 			condition,
 			statements,

--- a/libs/wingc/src/fold.rs
+++ b/libs/wingc/src/fold.rs
@@ -109,6 +109,17 @@ where
 			condition: f.fold_expr(condition),
 			statements: f.fold_scope(statements),
 		},
+    StmtKind::IfLet { 
+      condition, 
+      statements, 
+      var_name,
+      else_statements
+    } => StmtKind::IfLet {
+      condition: f.fold_expr(condition),
+      statements: f.fold_scope(statements),
+      var_name: f.fold_symbol(var_name),
+      else_statements: else_statements.map(|statements| f.fold_scope(statements)),
+    },
 		StmtKind::If {
 			condition,
 			statements,

--- a/libs/wingc/src/jsify.rs
+++ b/libs/wingc/src/jsify.rs
@@ -588,6 +588,26 @@ impl<'a> JSifier<'a> {
 			}
 			StmtKind::Break => CodeMaker::one_line("break;"),
 			StmtKind::Continue => CodeMaker::one_line("continue;"),
+      StmtKind::IfLet { 
+        condition, 
+        statements, 
+        var_name,
+        else_statements
+      } => {
+        let mut code = CodeMaker::default();
+        code.open(format!("if ({}) {{", self.jsify_expression(condition, ctx)));
+        code.line(format!("const {} = {};", self.jsify_symbol(var_name), self.jsify_expression(condition, ctx)));
+        code.add_code(self.jsify_scope_body(statements, ctx));
+        code.close("}");
+
+        if let Some(else_scope) = else_statements {
+					code.open("else {");
+					code.add_code(self.jsify_scope_body(else_scope, ctx));
+					code.close("}");
+				}
+        
+        code
+      }
 			StmtKind::If {
 				condition,
 				statements,

--- a/libs/wingc/src/jsify.rs
+++ b/libs/wingc/src/jsify.rs
@@ -588,26 +588,30 @@ impl<'a> JSifier<'a> {
 			}
 			StmtKind::Break => CodeMaker::one_line("break;"),
 			StmtKind::Continue => CodeMaker::one_line("continue;"),
-      StmtKind::IfLet { 
-        condition, 
-        statements, 
-        var_name,
-        else_statements
-      } => {
-        let mut code = CodeMaker::default();
-        code.open(format!("if ({}) {{", self.jsify_expression(condition, ctx)));
-        code.line(format!("const {} = {};", self.jsify_symbol(var_name), self.jsify_expression(condition, ctx)));
-        code.add_code(self.jsify_scope_body(statements, ctx));
-        code.close("}");
+			StmtKind::IfLet {
+				condition,
+				statements,
+				var_name,
+				else_statements,
+			} => {
+				let mut code = CodeMaker::default();
+				code.open(format!("if ({}) {{", self.jsify_expression(condition, ctx)));
+				code.line(format!(
+					"const {} = {};",
+					self.jsify_symbol(var_name),
+					self.jsify_expression(condition, ctx)
+				));
+				code.add_code(self.jsify_scope_body(statements, ctx));
+				code.close("}");
 
-        if let Some(else_scope) = else_statements {
+				if let Some(else_scope) = else_statements {
 					code.open("else {");
 					code.add_code(self.jsify_scope_body(else_scope, ctx));
 					code.close("}");
 				}
-        
-        code
-      }
+
+				code
+			}
 			StmtKind::If {
 				condition,
 				statements,

--- a/libs/wingc/src/parser.rs
+++ b/libs/wingc/src/parser.rs
@@ -185,6 +185,7 @@ impl<'s> Parser<'s> {
 			"expression_statement" => StmtKind::Expression(self.build_expression(&statement_node.named_child(0).unwrap())?),
 			"block" => StmtKind::Scope(self.build_scope(statement_node)),
 			"if_statement" => self.build_if_statement(statement_node)?,
+      "if_let_statement" => self.build_if_let_statement(statement_node)?,
 			"for_in_loop" => self.build_for_statement(statement_node)?,
 			"while_statement" => self.build_while_statement(statement_node)?,
 			"break_statement" => self.build_break_statement(statement_node)?,
@@ -299,6 +300,23 @@ impl<'s> Parser<'s> {
 		}
 		Ok(StmtKind::Continue)
 	}
+
+  fn build_if_let_statement(&self, statement_node: &Node) -> DiagnosticResult<StmtKind> {
+    let if_block = self.build_scope(&statement_node.child_by_field_name("block").unwrap());
+    let condition = self.build_expression(&statement_node.child_by_field_name("value").unwrap())?;
+    let name = self.node_symbol(&statement_node.child_by_field_name("name").unwrap())?;
+    let else_block = if let Some(else_block) = statement_node.child_by_field_name("else_block") {
+			Some(self.build_scope(&else_block))
+		} else {
+			None
+		};
+    Ok(StmtKind::IfLet {
+      condition: condition,
+      statements: if_block,
+      var_name: name ,
+      else_statements: else_block,
+    })
+  }
 
 	fn build_if_statement(&self, statement_node: &Node) -> DiagnosticResult<StmtKind> {
 		let if_block = self.build_scope(&statement_node.child_by_field_name("block").unwrap());

--- a/libs/wingc/src/parser.rs
+++ b/libs/wingc/src/parser.rs
@@ -185,7 +185,7 @@ impl<'s> Parser<'s> {
 			"expression_statement" => StmtKind::Expression(self.build_expression(&statement_node.named_child(0).unwrap())?),
 			"block" => StmtKind::Scope(self.build_scope(statement_node)),
 			"if_statement" => self.build_if_statement(statement_node)?,
-      "if_let_statement" => self.build_if_let_statement(statement_node)?,
+			"if_let_statement" => self.build_if_let_statement(statement_node)?,
 			"for_in_loop" => self.build_for_statement(statement_node)?,
 			"while_statement" => self.build_while_statement(statement_node)?,
 			"break_statement" => self.build_break_statement(statement_node)?,
@@ -301,22 +301,22 @@ impl<'s> Parser<'s> {
 		Ok(StmtKind::Continue)
 	}
 
-  fn build_if_let_statement(&self, statement_node: &Node) -> DiagnosticResult<StmtKind> {
-    let if_block = self.build_scope(&statement_node.child_by_field_name("block").unwrap());
-    let condition = self.build_expression(&statement_node.child_by_field_name("value").unwrap())?;
-    let name = self.node_symbol(&statement_node.child_by_field_name("name").unwrap())?;
-    let else_block = if let Some(else_block) = statement_node.child_by_field_name("else_block") {
+	fn build_if_let_statement(&self, statement_node: &Node) -> DiagnosticResult<StmtKind> {
+		let if_block = self.build_scope(&statement_node.child_by_field_name("block").unwrap());
+		let condition = self.build_expression(&statement_node.child_by_field_name("value").unwrap())?;
+		let name = self.node_symbol(&statement_node.child_by_field_name("name").unwrap())?;
+		let else_block = if let Some(else_block) = statement_node.child_by_field_name("else_block") {
 			Some(self.build_scope(&else_block))
 		} else {
 			None
 		};
-    Ok(StmtKind::IfLet {
-      condition: condition,
-      statements: if_block,
-      var_name: name ,
-      else_statements: else_block,
-    })
-  }
+		Ok(StmtKind::IfLet {
+			condition: condition,
+			statements: if_block,
+			var_name: name,
+			else_statements: else_block,
+		})
+	}
 
 	fn build_if_statement(&self, statement_node: &Node) -> DiagnosticResult<StmtKind> {
 		let if_block = self.build_scope(&statement_node.child_by_field_name("block").unwrap());

--- a/libs/wingc/src/type_check.rs
+++ b/libs/wingc/src/type_check.rs
@@ -2071,8 +2071,6 @@ impl<'a> TypeChecker<'a> {
 				let cond_type = self.type_check_exp(condition, env);
 				self.validate_type_is_optional(cond_type, condition);
 
-				let mut stmt_env = SymbolEnv::new(Some(env.get_ref()), env.return_type, false, env.phase, stmt.idx);
-
 				// Technically we only allow if let statements to be used with optionals
 				// and above validate_type_is_optional method will attach a diagnostic error if it is not.
 				// However to avoid panics this will allow code to continue if the type is not an optional
@@ -2085,6 +2083,9 @@ impl<'a> TypeChecker<'a> {
 					cond_type
 				};
 
+        let mut stmt_env = SymbolEnv::new(Some(env.get_ref()), env.return_type, false, env.phase, stmt.idx);
+        
+        // Add the variable to if block scope
 				match stmt_env.define(
 					var_name,
 					SymbolKind::make_variable(var_type, false, true, env.phase),
@@ -2098,8 +2099,6 @@ impl<'a> TypeChecker<'a> {
 
 				statements.set_env(stmt_env);
 				self.inner_scopes.push(statements);
-
-				// Add if let variable to environment
 
 				if let Some(else_scope) = else_statements {
 					else_scope.set_env(SymbolEnv::new(

--- a/libs/wingc/src/type_check.rs
+++ b/libs/wingc/src/type_check.rs
@@ -830,6 +830,14 @@ impl TypeRef {
 		}
 	}
 
+  // Returns the type of an optional type, or None if the type is not optional.
+  pub fn optional_type(&self) -> Option<TypeRef> {
+    match **self {
+      Type::Optional(t) => Some(t),
+      _ => None,
+    }
+  }
+
 	/// Returns the item type of a collection type, or None if the type is not a collection.
 	pub fn collection_item_type(&self) -> Option<TypeRef> {
 		match **self {
@@ -1843,6 +1851,18 @@ impl<'a> TypeChecker<'a> {
 		}
 	}
 
+  fn validate_type_is_optional(&mut self, actual_type: TypeRef, span: &impl Spanned) {
+    if !actual_type.is_option() {
+      self.diagnostics.borrow_mut().push(Diagnostic {
+        message: format!(
+          "Expected type to be optional, but got \"{}\" instead",
+          actual_type
+        ),
+        span: Some(span.span()),
+      });
+    }
+  }
+
 	pub fn type_check_scope(&mut self, scope: &Scope) {
 		assert!(self.inner_scopes.is_empty());
 		for statement in scope.statements.iter() {
@@ -2045,6 +2065,60 @@ impl<'a> TypeChecker<'a> {
 				self.inner_scopes.push(statements);
 			}
 			StmtKind::Break | StmtKind::Continue => {}
+      StmtKind::IfLet { 
+        condition,
+        statements,
+        var_name,
+        else_statements
+      } => {
+        let cond_type = self.type_check_exp(condition, env);
+        self.validate_type_is_optional(cond_type, condition);
+
+        let mut stmt_env = SymbolEnv::new (
+          Some(env.get_ref()),
+					env.return_type,
+					false,
+					env.phase,
+					stmt.idx,
+        );
+        
+        // Technically we only allow if let statements to be used with optionals
+        // and above validate_type_is_optional method will attach a diagnostic error if it is not.
+        // However to avoid panics this will allow code to continue if the type is not an optional
+        // and complete the type checking process for additional errors.
+        let var_type = if cond_type.is_option() {
+          cond_type.optional_type().expect("Optional types should always have a type")
+        } else {
+          cond_type
+        };
+
+        match stmt_env.define(
+          var_name,
+          SymbolKind::make_variable(var_type, false, true, env.phase),
+          StatementIdx::Top,
+        ) {
+          Err(type_error) => {
+						self.type_error(type_error);
+					}
+          _ => {}
+        }
+
+        statements.set_env(stmt_env);
+				self.inner_scopes.push(statements);
+
+        // Add if let variable to environment
+
+        if let Some(else_scope) = else_statements {
+					else_scope.set_env(SymbolEnv::new(
+						Some(env.get_ref()),
+						env.return_type,
+						false,
+						env.phase,
+						stmt.idx,
+					));
+					self.inner_scopes.push(else_scope);
+				}
+      }
 			StmtKind::If {
 				condition,
 				statements,

--- a/libs/wingc/src/type_check.rs
+++ b/libs/wingc/src/type_check.rs
@@ -830,13 +830,13 @@ impl TypeRef {
 		}
 	}
 
-  // Returns the type of an optional type, or None if the type is not optional.
-  pub fn optional_type(&self) -> Option<TypeRef> {
-    match **self {
-      Type::Optional(t) => Some(t),
-      _ => None,
-    }
-  }
+	// Returns the type of an optional type, or None if the type is not optional.
+	pub fn optional_type(&self) -> Option<TypeRef> {
+		match **self {
+			Type::Optional(t) => Some(t),
+			_ => None,
+		}
+	}
 
 	/// Returns the item type of a collection type, or None if the type is not a collection.
 	pub fn collection_item_type(&self) -> Option<TypeRef> {
@@ -1851,17 +1851,14 @@ impl<'a> TypeChecker<'a> {
 		}
 	}
 
-  fn validate_type_is_optional(&mut self, actual_type: TypeRef, span: &impl Spanned) {
-    if !actual_type.is_option() {
-      self.diagnostics.borrow_mut().push(Diagnostic {
-        message: format!(
-          "Expected type to be optional, but got \"{}\" instead",
-          actual_type
-        ),
-        span: Some(span.span()),
-      });
-    }
-  }
+	fn validate_type_is_optional(&mut self, actual_type: TypeRef, span: &impl Spanned) {
+		if !actual_type.is_option() {
+			self.diagnostics.borrow_mut().push(Diagnostic {
+				message: format!("Expected type to be optional, but got \"{}\" instead", actual_type),
+				span: Some(span.span()),
+			});
+		}
+	}
 
 	pub fn type_check_scope(&mut self, scope: &Scope) {
 		assert!(self.inner_scopes.is_empty());
@@ -2065,50 +2062,46 @@ impl<'a> TypeChecker<'a> {
 				self.inner_scopes.push(statements);
 			}
 			StmtKind::Break | StmtKind::Continue => {}
-      StmtKind::IfLet { 
-        condition,
-        statements,
-        var_name,
-        else_statements
-      } => {
-        let cond_type = self.type_check_exp(condition, env);
-        self.validate_type_is_optional(cond_type, condition);
+			StmtKind::IfLet {
+				condition,
+				statements,
+				var_name,
+				else_statements,
+			} => {
+				let cond_type = self.type_check_exp(condition, env);
+				self.validate_type_is_optional(cond_type, condition);
 
-        let mut stmt_env = SymbolEnv::new (
-          Some(env.get_ref()),
-					env.return_type,
-					false,
-					env.phase,
-					stmt.idx,
-        );
-        
-        // Technically we only allow if let statements to be used with optionals
-        // and above validate_type_is_optional method will attach a diagnostic error if it is not.
-        // However to avoid panics this will allow code to continue if the type is not an optional
-        // and complete the type checking process for additional errors.
-        let var_type = if cond_type.is_option() {
-          cond_type.optional_type().expect("Optional types should always have a type")
-        } else {
-          cond_type
-        };
+				let mut stmt_env = SymbolEnv::new(Some(env.get_ref()), env.return_type, false, env.phase, stmt.idx);
 
-        match stmt_env.define(
-          var_name,
-          SymbolKind::make_variable(var_type, false, true, env.phase),
-          StatementIdx::Top,
-        ) {
-          Err(type_error) => {
+				// Technically we only allow if let statements to be used with optionals
+				// and above validate_type_is_optional method will attach a diagnostic error if it is not.
+				// However to avoid panics this will allow code to continue if the type is not an optional
+				// and complete the type checking process for additional errors.
+				let var_type = if cond_type.is_option() {
+					cond_type
+						.optional_type()
+						.expect("Optional types should always have a type")
+				} else {
+					cond_type
+				};
+
+				match stmt_env.define(
+					var_name,
+					SymbolKind::make_variable(var_type, false, true, env.phase),
+					StatementIdx::Top,
+				) {
+					Err(type_error) => {
 						self.type_error(type_error);
 					}
-          _ => {}
-        }
+					_ => {}
+				}
 
-        statements.set_env(stmt_env);
+				statements.set_env(stmt_env);
 				self.inner_scopes.push(statements);
 
-        // Add if let variable to environment
+				// Add if let variable to environment
 
-        if let Some(else_scope) = else_statements {
+				if let Some(else_scope) = else_statements {
 					else_scope.set_env(SymbolEnv::new(
 						Some(env.get_ref()),
 						env.return_type,
@@ -2118,7 +2111,7 @@ impl<'a> TypeChecker<'a> {
 					));
 					self.inner_scopes.push(else_scope);
 				}
-      }
+			}
 			StmtKind::If {
 				condition,
 				statements,

--- a/libs/wingc/src/visit.rs
+++ b/libs/wingc/src/visit.rs
@@ -124,19 +124,19 @@ where
 			v.visit_scope(statements);
 		}
 		StmtKind::Break | StmtKind::Continue => {}
-    StmtKind::IfLet { 
-      condition, 
-      statements,
-      var_name,
-      else_statements
-    } => {
-      v.visit_expr(condition);
-      v.visit_scope(statements);
-      v.visit_symbol(var_name);
-      if let Some(statements) = else_statements {
+		StmtKind::IfLet {
+			condition,
+			statements,
+			var_name,
+			else_statements,
+		} => {
+			v.visit_expr(condition);
+			v.visit_scope(statements);
+			v.visit_symbol(var_name);
+			if let Some(statements) = else_statements {
 				v.visit_scope(statements);
 			}
-    }
+		}
 		StmtKind::If {
 			condition,
 			statements,

--- a/libs/wingc/src/visit.rs
+++ b/libs/wingc/src/visit.rs
@@ -124,6 +124,19 @@ where
 			v.visit_scope(statements);
 		}
 		StmtKind::Break | StmtKind::Continue => {}
+    StmtKind::IfLet { 
+      condition, 
+      statements,
+      var_name,
+      else_statements
+    } => {
+      v.visit_expr(condition);
+      v.visit_scope(statements);
+      v.visit_symbol(var_name);
+      if let Some(statements) = else_statements {
+				v.visit_scope(statements);
+			}
+    }
 		StmtKind::If {
 			condition,
 			statements,

--- a/tools/hangar/__snapshots__/invalid.ts.snap
+++ b/tools/hangar/__snapshots__/invalid.ts.snap
@@ -798,6 +798,13 @@ error: Expected type to be \\"Sub1\\", but got \\"Super\\" instead
 34 | optionalSub1 ?? new Super();
    |                 ^^^^^^^^^^^ Expected type to be \\"Sub1\\", but got \\"Super\\" instead
 
+
+error: Expected type to be optional, but got \\"bool\\" instead
+   --> ../../../examples/tests/invalid/optionals.w:38:12
+   |
+38 | if let x = true {
+   |            ^^^^ Expected type to be optional, but got \\"bool\\" instead
+
 "
 `;
 

--- a/tools/hangar/__snapshots__/test_corpus/optionals.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/optionals.w_compile_tf-aws.md
@@ -69,6 +69,54 @@ class $Root extends $stdlib.std.Resource {
     const optionalSup = new Super();
     const s = (optionalSup ?? new Sub());
     {((cond) => {if (!cond) throw new Error(`assertion failed: '(s.name === "Super")'`)})((s.name === "Super"))};
+    let name = {
+    "first": "John",
+    "last": "Doe",}
+    ;
+    if (name) {
+      const n = name;
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '(n.first === "John")'`)})((n.first === "John"))};
+    }
+    name = undefined;
+    if (name) {
+      const n = name;
+      {((cond) => {if (!cond) throw new Error(`assertion failed: 'false'`)})(false)};
+    }
+    else {
+      {((cond) => {if (!cond) throw new Error(`assertion failed: 'true'`)})(true)};
+    }
+    const tryParseName =  (fullName) =>  {
+      {
+        const parts = (fullName.split(" "));
+        if ((parts.length < 1)) {
+          return undefined;
+        }
+        return {
+        "first": (parts.at(0)),
+        "last": (parts.at(1)),}
+        ;
+      }
+    }
+    ;
+    if ((tryParseName("Good Name"))) {
+      const parsedName = (tryParseName("Good Name"));
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '(parsedName.first === "Good")'`)})((parsedName.first === "Good"))};
+      if (parsedName.last) {
+        const lastName = parsedName.last;
+        {((cond) => {if (!cond) throw new Error(`assertion failed: '(lastName === "Name")'`)})((lastName === "Name"))};
+      }
+      else {
+        {((cond) => {if (!cond) throw new Error(`assertion failed: 'false'`)})(false)};
+      }
+    }
+    if ((tryParseName("BadName"))) {
+      const parsedName = (tryParseName("BadName"));
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '(parsedName.first === "BadName")'`)})((parsedName.first === "BadName"))};
+      if (parsedName.last) {
+        const lastName = parsedName.last;
+        {((cond) => {if (!cond) throw new Error(`assertion failed: 'false'`)})(false)};
+      }
+    }
   }
 }
 class $App extends $AppBase {


### PR DESCRIPTION
Adds support for `if let` statements to be used with optionals.

as described: https://github.com/winglang/wing/issues/436

- [ ] PR title matches [Winglang's style guide](https://docs.winglang.io/contributors/pull_requests#how-are-pull-request-titles-formatted)
- [ ] PR description explains motivation and solution
- [ ] Tests added
- [ ] Docs updated
- [ ] Needs end-to-end tests (`pr/e2e-full` label)

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.