### PR TITLE
fix(compiler): fixing windows build - normalize paths

### DIFF
--- a/tools/hangar/__snapshots__/error.ts.snap
+++ b/tools/hangar/__snapshots__/error.ts.snap
@@ -18,7 +18,7 @@ exports[`num_from_str.w > stderr 1`] = `
 ../../../examples/tests/error/target/test/num_from_str.wsim.[REDACTED].tmp/.wing/preflight.js:7
      constructor(scope, id) {
        super(scope, id);
->>     const a = ((args) => { if (isNaN(args)) {throw new Error(\\"unable to parse \\\\\\"\\" + args + \\"\\\\\\" as a number\\")}; return parseInt(args) })(\\"123a\\");
+>>     const a = ((args) => { if (isNaN(args)) {throw new Error(\\"unable to parse /\\"\\" + args + \\"/\\" as a number\\")}; return parseInt(args) })(\\"123a\\");
      }
    }
 "

--- a/tools/hangar/src/error.test.ts
+++ b/tools/hangar/src/error.test.ts
@@ -24,6 +24,8 @@ errorWingFiles.forEach((wingFile) => {
     const stderrSanitized = stderr
       // Remove absolute paths
       .replaceAll(relativeWingFile, relativeWingFile.replaceAll("\\", "/"))
+      // Normalize paths
+      .replaceAll("\\", "/")
       // Normalize line endings
       .replaceAll("\r\n", "\n")
       // Remove random numbers from generated test artifact folder

--- a/tools/hangar/src/error.test.ts
+++ b/tools/hangar/src/error.test.ts
@@ -23,7 +23,6 @@ errorWingFiles.forEach((wingFile) => {
 
     const stderrSanitized = stderr
       // Remove absolute paths
-      .replaceAll(relativeWingFile, relativeWingFile.replaceAll("\\", "/"))
       // Normalize paths
       .replaceAll("\\", "/")
       // Normalize line endings

--- a/tools/hangar/src/misc.test.ts
+++ b/tools/hangar/src/misc.test.ts
@@ -42,8 +42,15 @@ test("unsupported resource in target", async ({ expect }) => {
   `);
 });
 
-// Remove random numbers from generated test artifact folder
-// e.g. "{...}.tfgcp.927822.tmp/{...}" => "{...}.tfgcp.[REDACTED].tmp/{...}"
 function sanitizeErrorMessage(inputString: string): string {
-  return inputString.replaceAll(/\.tfgcp\.\d+\.tmp/g, ".tfgcp.[REDACTED].tmp");
+  let sanitizedString = inputString
+    // Normalize paths
+    .replaceAll("\\", "/")
+    // Normalize line endings
+    .replaceAll("\r\n", "\n")
+    // Remove random numbers from generated test artifact folder
+    // e.g. "{...}.tfgcp.927822.tmp/{...}" => "{...}.tfgcp.[REDACTED].tmp/{...}"
+    .replaceAll(/\.tfgcp\.\d+\.tmp/g, ".tfgcp.[REDACTED].tmp");
+
+  return sanitizedString;
 }


### PR DESCRIPTION
- [x] PR title matches [Winglang's style guide](https://docs.winglang.io/contributors/pull_requests#how-are-pull-request-titles-formatted)
- [x] PR description explains motivation and solution
- [ ] Tests added
- [ ] Docs updated
- [x] Needs end-to-end tests (`pr/e2e-full` label)

Following the merge of #2442 we saw a regression on Windows (see [here](https://github.com/winglang/wing/actions/runs/5077675549/jobs/9121654237)). Fixing the regression by normalizing paths.

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.