### PR TITLE
fix(compiler): diagnostics missing error messages

### DIFF
--- a/libs/wingc/src/ast.rs
+++ b/libs/wingc/src/ast.rs
@@ -159,12 +159,6 @@ pub struct UserDefinedType {
 	pub span: WingSpan,
 }
 
-impl Spanned for UserDefinedType {
-	fn span(&self) -> WingSpan {
-		self.span.clone()
-	}
-}
-
 impl Display for UserDefinedType {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		let mut name = self.root.name.clone();
@@ -691,6 +685,12 @@ pub trait Spanned {
 	fn span(&self) -> WingSpan;
 }
 
+impl Spanned for WingSpan {
+	fn span(&self) -> WingSpan {
+		self.clone()
+	}
+}
+
 impl Spanned for Stmt {
 	fn span(&self) -> WingSpan {
 		self.span.clone()
@@ -704,6 +704,18 @@ impl Spanned for Expr {
 }
 
 impl Spanned for Symbol {
+	fn span(&self) -> WingSpan {
+		self.span.clone()
+	}
+}
+
+impl Spanned for TypeAnnotation {
+	fn span(&self) -> WingSpan {
+		self.span.clone()
+	}
+}
+
+impl Spanned for UserDefinedType {
 	fn span(&self) -> WingSpan {
 		self.span.clone()
 	}

--- a/libs/wingc/src/diagnostic.rs
+++ b/libs/wingc/src/diagnostic.rs
@@ -6,8 +6,6 @@ use lsp_types::{Position, Range};
 
 use serde::Serialize;
 
-use crate::debug;
-
 pub type FileId = String;
 pub type Diagnostics = Vec<Diagnostic>;
 pub type DiagnosticResult<T> = Result<T, ()>;
@@ -171,12 +169,6 @@ impl Ord for Diagnostic {
 impl PartialOrd for Diagnostic {
 	fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
 		self.span.partial_cmp(&other.span)
-	}
-}
-
-pub fn print_diagnostics(diagnostics: &Diagnostics) {
-	for diagnostic in diagnostics {
-		debug!("{}", diagnostic);
 	}
 }
 

--- a/libs/wingc/src/lib.rs
+++ b/libs/wingc/src/lib.rs
@@ -9,7 +9,7 @@ extern crate lazy_static;
 
 use ast::{Scope, Stmt, Symbol, UtilityFunctions};
 use closure_transform::ClosureTransformer;
-use diagnostic::{print_diagnostics, Diagnostic, Diagnostics};
+use diagnostic::{Diagnostic, Diagnostics};
 use fold::Fold;
 use jsify::JSifier;
 use type_check::symbol_env::StatementIdx;
@@ -305,10 +305,6 @@ pub fn compile(
 	// Validate that every Expr has an evaluated_type
 	let mut tc_assert = TypeCheckAssert;
 	tc_assert.visit_scope(&scope);
-
-	// Print diagnostics
-	print_diagnostics(&parse_diagnostics);
-	print_diagnostics(&type_check_diagnostics);
 
 	// Collect all diagnostics
 	let mut diagnostics = parse_diagnostics;

--- a/libs/wingc/src/type_check.rs
+++ b/libs/wingc/src/type_check.rs
@@ -102,13 +102,6 @@ impl SymbolKind {
 		}
 	}
 
-	pub fn is_reassignable(&self) -> bool {
-		match self {
-			SymbolKind::Variable(VariableInfo { reassignable: true, .. }) => true,
-			_ => false,
-		}
-	}
-
 	fn as_namespace_ref(&self) -> Option<NamespaceRef> {
 		match self {
 			SymbolKind::Namespace(ns) => Some(*ns),
@@ -2497,10 +2490,7 @@ impl<'a> TypeChecker<'a> {
 				for field in fields.iter() {
 					let field_type = self.resolve_type_annotation(&field.member_type, env);
 					if field_type.is_mutable() {
-						self.spanned_error(
-							&field.name,
-							format!("Struct fields must be immutable types, received: {}", field_type),
-						);
+						self.spanned_error(&field.name, "Struct fields must have immutable types");
 					}
 					match struct_env.define(
 						&field.name,
@@ -3606,24 +3596,6 @@ pub fn resolve_user_defined_type(
 	} else {
 		Err(lookup_result_to_type_error(lookup_result, user_defined_type))
 	}
-}
-
-pub fn resolve_user_defined_type_by_fqn(
-	user_defined_type_name: &str,
-	env: &SymbolEnv,
-	statement_idx: usize,
-) -> Result<TypeRef, TypeError> {
-	let mut fields = user_defined_type_name
-		.split('.')
-		.map(|s| Symbol::global(s))
-		.collect_vec();
-	let root = fields.remove(0);
-	let user_defined_type = UserDefinedType {
-		root,
-		fields,
-		span: WingSpan::default(),
-	};
-	resolve_user_defined_type(&user_defined_type, env, statement_idx)
 }
 
 #[cfg(test)]

--- a/tools/hangar/__snapshots__/invalid.ts.snap
+++ b/tools/hangar/__snapshots__/invalid.ts.snap
@@ -447,6 +447,10 @@ error: Expected type to be \\"inflight (str): void\\", but got \\"inflight (num)
 
 
 error: Expected an interface, instead found type \\"Bucket\\"
+   --> ../../../examples/tests/invalid/impl_interface.w:14:14
+   |
+14 | class C impl cloud.Bucket {
+   |              ^^^^^^^^^^^^ Expected an interface, instead found type \\"Bucket\\"
 
 
 error: Class \\"r\\" does not implement method \\"method1\\" of interface \\"I3\\"
@@ -563,6 +567,10 @@ error: Unknown symbol \\"IDontExist\\"
 
 
 error: Expected an interface, instead found type \\"ISomeClass\\"
+   --> ../../../examples/tests/invalid/interface.w:16:34
+   |
+16 | interface ISomeInterface extends ISomeClass {
+   |                                  ^^^^^^^^^^ Expected an interface, instead found type \\"ISomeClass\\"
 
 
 error: Symbol \\"foo\\" already defined in this scope
@@ -1027,6 +1035,10 @@ error: Capturing collection of resources is not supported yet (type is 'Array<Bu
 
 exports[`resource_inflight.w > stderr 1`] = `
 "error: Cannot create preflight class \\"Bucket\\" in inflight phase
+  --> ../../../examples/tests/invalid/resource_inflight.w:4:3
+  |
+4 |   new cloud.Bucket(); // Should fail because we can't create resources inflight
+  |   ^^^^^^^^^^^^^^^^^^ Cannot create preflight class \\"Bucket\\" in inflight phase
 
 "
 `;
@@ -1233,18 +1245,18 @@ error: \\"x\\" is not initialized
    |                  ^^^^^^^^^^ \\"x\\" is not initialized
 
 
-error: struct fields must be immutable got: MutArray<str>
+error: Struct fields must be immutable types, received: MutArray<str>
    --> ../../../examples/tests/invalid/structs.w:20:3
    |
 20 |   f: MutArray<str>;
-   |   ^ struct fields must be immutable got: MutArray<str>
+   |   ^ Struct fields must be immutable types, received: MutArray<str>
 
 
-error: struct fields must be immutable got: Map<Array<MutArray<str>>>
+error: Struct fields must be immutable types, received: Map<Array<MutArray<str>>>
    --> ../../../examples/tests/invalid/structs.w:25:3
    |
 25 |   f: Map<Array<MutArray<str>>>;
-   |   ^ struct fields must be immutable got: Map<Array<MutArray<str>>>
+   |   ^ Struct fields must be immutable types, received: Map<Array<MutArray<str>>>
 
 
 error: Unknown symbol \\"badField\\"
@@ -1262,6 +1274,10 @@ error: Struct \\"Showtime\\" extends \\"Dazzle\\" which introduces a conflicting
 
 
 error: Cannot instantiate type \\"BucketProps\\" because it is not a class
+   --> ../../../examples/tests/invalid/structs.w:47:13
+   |
+47 | let x = new cloud.BucketProps(1);
+   |             ^^^^^^^^^^^^^^^^^ Cannot instantiate type \\"BucketProps\\" because it is not a class
 
 "
 `;

--- a/tools/hangar/__snapshots__/invalid.ts.snap
+++ b/tools/hangar/__snapshots__/invalid.ts.snap
@@ -1245,18 +1245,18 @@ error: \\"x\\" is not initialized
    |                  ^^^^^^^^^^ \\"x\\" is not initialized
 
 
-error: Struct fields must be immutable types, received: MutArray<str>
+error: Struct fields must have immutable types
    --> ../../../examples/tests/invalid/structs.w:20:3
    |
 20 |   f: MutArray<str>;
-   |   ^ Struct fields must be immutable types, received: MutArray<str>
+   |   ^ Struct fields must have immutable types
 
 
-error: Struct fields must be immutable types, received: Map<Array<MutArray<str>>>
+error: Struct fields must have immutable types
    --> ../../../examples/tests/invalid/structs.w:25:3
    |
 25 |   f: Map<Array<MutArray<str>>>;
-   |   ^ Struct fields must be immutable types, received: Map<Array<MutArray<str>>>
+   |   ^ Struct fields must have immutable types
 
 
 error: Unknown symbol \\"badField\\"


### PR DESCRIPTION
Fixes an issue where some type checking diagnostics are generated without spans showing where in your code the error is.

In the process I refactored some of the code for generating error messages. It didn't feel like it was as big of an improvement as I expected so I'm open to reverting if the changes seem counterproductive. There's also this `TypeError` struct I saw which doesn't seem to serve any purpose / it's basically the same as `Diagnostic`, so I was also thinking about removing that, but I wasn't sure so I left it as is.

Misc:
- removed some dead (unused) code

----

- [x] PR title matches [Winglang's style guide](https://docs.winglang.io/contributors/pull_requests#how-are-pull-request-titles-formatted)
- [x] PR description explains motivation and solution
- [x] Tests added
- [x] Docs updated
- [ ] Needs end-to-end tests (`pr/e2e-full` label)

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.