### PR TITLE
fix(compiler): missing environment variable runtime error

### DIFF
--- a/examples/tests/valid/api.w
+++ b/examples/tests/valid/api.w
@@ -1,7 +1,3 @@
-/*\
-skip: true
-\*/
-// TODO: failing due to https://github.com/winglang/wing/issues/2522
 bring cloud;
 
 let api = new cloud.Api();
@@ -27,7 +23,7 @@ api.get("/hello/world", handler);
 
 test "api url" {
   let url = api.url;
-  assert(url.startsWith("http://"));
+  assert(url.startsWith("http"));
 }
 
 // Initialize the API in resource

--- a/examples/tests/valid/api_path_vars.w
+++ b/examples/tests/valid/api_path_vars.w
@@ -1,8 +1,3 @@
-/*\
-skip: true
-\*/
-// TODO: failing due to https://github.com/winglang/wing/issues/2522
-
 bring cloud;
 
 let api = new cloud.Api();

--- a/libs/wingc/src/jsify.rs
+++ b/libs/wingc/src/jsify.rs
@@ -933,17 +933,8 @@ impl<'a> JSifier<'a> {
 		// Get fields to be captured by resource's client
 		let captured_fields = self.get_capturable_field_names(resource_type);
 
-		// Add inflight init's refs
-		// By default all captured fields are needed in the inflight init method
-		let init_refs = BTreeMap::from_iter(captured_fields.iter().map(|f| (format!("this.{f}"), BTreeSet::new())));
-		// Check what's actually used in the init method
-		let init_refs_entry = refs.entry(CLASS_INFLIGHT_INIT_NAME.to_string()).or_default();
-		// Add the init refs to the refs map
-		for (k, v) in init_refs {
-			if !init_refs_entry.contains_key(&k) {
-				init_refs_entry.insert(k, v);
-			}
-		}
+		// Add bindings for the inflight init
+		self.add_inflight_init_refs(&mut refs, &captured_fields, &free_vars);
 
 		// Jsify inflight client
 		let inflight_methods = class
@@ -996,6 +987,7 @@ impl<'a> JSifier<'a> {
 
 		code.add_code(self.jsify_to_inflight_type_method(&class.name, &free_vars, &referenced_preflight_types));
 		code.add_code(self.jsify_toinflight_method(&class.name, &captured_fields));
+
 		// Generate the the class's host binding methods
 		code.add_code(self.jsify_register_bind_method(class, &refs, resource_type, BindMethod::Instance));
 		code.add_code(self.jsify_register_bind_method(class, &refs, resource_type, BindMethod::Type));
@@ -1400,6 +1392,25 @@ impl<'a> JSifier<'a> {
 		bind_method.line(format!("super.{bind_method_name}(host, ops);"));
 		bind_method.close("}");
 		bind_method
+	}
+
+	fn add_inflight_init_refs(
+		&self,
+		refs: &mut BTreeMap<String, BTreeMap<String, BTreeSet<String>>>,
+		captured_fields: &[String],
+		free_vars: &IndexSet<String>,
+	) {
+		let init_refs_entry = refs.entry(CLASS_INFLIGHT_INIT_NAME.to_string()).or_default();
+
+		// All captured fields are needed in the inflight init method
+		for field in captured_fields {
+			init_refs_entry.entry(format!("this.{field}")).or_default();
+		}
+
+		// All free variables are needed in the inflight init method
+		for free_var in free_vars {
+			init_refs_entry.entry(free_var.clone()).or_default();
+		}
 	}
 }
 

--- a/tools/hangar/__snapshots__/test_corpus/add_consumer.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/add_consumer.w_compile_tf-aws.md
@@ -417,6 +417,7 @@ class $Root extends $stdlib.std.Resource {
       }
       _registerBind(host, ops) {
         if (ops.includes("$inflight_init")) {
+          $Inflight1._registerBindObject(c, host, []);
         }
         if (ops.includes("handle")) {
           $Inflight1._registerBindObject(c, host, ["inc"]);
@@ -456,6 +457,9 @@ class $Root extends $stdlib.std.Resource {
       }
       _registerBind(host, ops) {
         if (ops.includes("$inflight_init")) {
+          $Inflight2._registerBindObject(js, host, []);
+          $Inflight2._registerBindObject(predicate, host, []);
+          $Inflight2._registerBindObject(q, host, []);
         }
         if (ops.includes("handle")) {
           $Inflight2._registerBindObject(js, host, ["sleep"]);

--- a/tools/hangar/__snapshots__/test_corpus/api.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/api.w_compile_tf-aws.md
@@ -8,7 +8,7 @@ module.exports = function({ counter }) {
     }
     async handle(request)  {
       {
-        const count = (await counter.inc());
+        const count = (typeof counter.inc === "function" ? await counter.inc() : await counter.inc.handle());
         const bodyResponse = Object.freeze({"count":count});
         const resp = {
         "body": bodyResponse,
@@ -32,7 +32,7 @@ module.exports = function({ api }) {
     async handle()  {
       {
         const url = api.url;
-        {((cond) => {if (!cond) throw new Error(`assertion failed: 'url.startsWith("http://")'`)})(url.startsWith("http://"))};
+        {((cond) => {if (!cond) throw new Error(`assertion failed: 'url.startsWith("http")'`)})(url.startsWith("http"))};
       }
     }
   }
@@ -71,26 +71,6 @@ module.exports = function({  }) {
     }
   }
   return A;
-}
-
-```
-
-## clients/Foo.inflight.js
-```js
-module.exports = function() {
-  class  Foo {
-    constructor({ api }) {
-      this.api = api;
-    }
-    async handle(message)  {
-      {
-        const __parent_this = this;
-        const url = this.api.url;
-        {((cond) => {if (!cond) throw new Error(`assertion failed: 'url.startsWith("http://")'`)})(url.startsWith("http://"))};
-      }
-    }
-  }
-  return Foo;
 }
 
 ```
@@ -337,6 +317,7 @@ module.exports = function() {
         },
         "environment": {
           "variables": {
+            "CLOUD_API_C8B1D888": "${aws_api_gateway_stage.root_A_cloudApi_api_stage_EEF6B12C.invoke_url}",
             "WING_FUNCTION_NAME": "cloud-Api-OnRequest-155b3888-c85af51e"
           }
         },
@@ -388,6 +369,7 @@ module.exports = function() {
         },
         "environment": {
           "variables": {
+            "CLOUD_API_C82DF3A5": "${aws_api_gateway_stage.root_cloudApi_api_stage_57D6284A.invoke_url}",
             "WING_FUNCTION_NAME": "Handler-c8315524"
           }
         },
@@ -497,6 +479,7 @@ class $Root extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
         this._addInflightOps("handle");
+        this.display.hidden = true;
       }
       static _toInflightType(context) {
         const self_client_path = "./clients/$Inflight1.inflight.js".replace(/\\/g, "/");
@@ -520,9 +503,10 @@ class $Root extends $stdlib.std.Resource {
       }
       _registerBind(host, ops) {
         if (ops.includes("$inflight_init")) {
+          $Inflight1._registerBindObject(counter, host, []);
         }
         if (ops.includes("handle")) {
-          this._registerBindObject(counter, host, ["inc"]);
+          $Inflight1._registerBindObject(counter, host, ["inc"]);
         }
         super._registerBind(host, ops);
       }
@@ -531,6 +515,7 @@ class $Root extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
         this._addInflightOps("handle");
+        this.display.hidden = true;
       }
       static _toInflightType(context) {
         const self_client_path = "./clients/$Inflight2.inflight.js".replace(/\\/g, "/");
@@ -554,9 +539,10 @@ class $Root extends $stdlib.std.Resource {
       }
       _registerBind(host, ops) {
         if (ops.includes("$inflight_init")) {
+          $Inflight2._registerBindObject(api, host, []);
         }
         if (ops.includes("handle")) {
-          this._registerBindObject(api.url, host, []);
+          $Inflight2._registerBindObject(api.url, host, []);
         }
         super._registerBind(host, ops);
       }
@@ -570,6 +556,7 @@ class $Root extends $stdlib.std.Resource {
           constructor(scope, id, ) {
             super(scope, id);
             this._addInflightOps("handle");
+            this.display.hidden = true;
           }
           static _toInflightType(context) {
             const self_client_path = "./clients/$Inflight3.inflight.js".replace(/\\/g, "/");
@@ -593,9 +580,10 @@ class $Root extends $stdlib.std.Resource {
           }
           _registerBind(host, ops) {
             if (ops.includes("$inflight_init")) {
+              $Inflight3._registerBindObject(__parent_this, host, []);
             }
             if (ops.includes("handle")) {
-              this._registerBindObject(__parent_this.api.url, host, []);
+              $Inflight3._registerBindObject(__parent_this.api.url, host, []);
             }
             super._registerBind(host, ops);
           }
@@ -624,7 +612,7 @@ class $Root extends $stdlib.std.Resource {
       }
       _registerBind(host, ops) {
         if (ops.includes("$inflight_init")) {
-          this._registerBindObject(this.api, host, []);
+          A._registerBindObject(this.api, host, []);
         }
         super._registerBind(host, ops);
       }
@@ -653,21 +641,6 @@ class $App extends $AppBase {
   }
 }
 new $App().synth();
-
-```
-
-## proc1/index.js
-```js
-async handle(request) {
-  const { counter } = this;
-  const count = (await counter.inc());
-  const bodyResponse = Object.freeze({"count":count});
-  const resp = {
-  "body": bodyResponse,
-  "status": 200,}
-  ;
-  return resp;
-}
 
 ```
 

--- a/tools/hangar/__snapshots__/test_corpus/api_path_vars.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/api_path_vars.w_compile_tf-aws.md
@@ -2,7 +2,7 @@
 
 ## clients/$Inflight1.inflight.js
 ```js
-module.exports = function() {
+module.exports = function({  }) {
   class  $Inflight1 {
     constructor({  }) {
     }
@@ -22,14 +22,14 @@ module.exports = function() {
 
 ## clients/$Inflight2.inflight.js
 ```js
-module.exports = function({ api, f }) {
+module.exports = function({ f, api }) {
   class  $Inflight2 {
     constructor({  }) {
     }
     async handle()  {
       {
         const username = "tsuf";
-        const res = (await f.get(`${api.url}/users/${username}`));
+        const res = (typeof f.get === "function" ? await f.get(`${api.url}/users/${username}`) : await f.get.handle(`${api.url}/users/${username}`));
         {((cond) => {if (!cond) throw new Error(`assertion failed: '((res)["status"] === 200)'`)})(((res)["status"] === 200))};
         {((cond) => {if (!cond) throw new Error(`assertion failed: '(((res)["body"])["user"] === username)'`)})((((res)["body"])["user"] === username))};
       }
@@ -238,12 +238,8 @@ module.exports = function({  }) {
         },
         "environment": {
           "variables": {
-<<<<<<< HEAD
-            "WING_FUNCTION_NAME": "test-c8b6eece"
-=======
             "CLOUD_API_C82DF3A5": "${aws_api_gateway_stage.root_cloudApi_api_stage_57D6284A.invoke_url}",
             "WING_FUNCTION_NAME": "Handler-c8f4f2a1"
->>>>>>> main
           }
         },
         "function_name": "Handler-c8f4f2a1",
@@ -360,13 +356,20 @@ class $Root extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
         this._addInflightOps("handle");
+        this.display.hidden = true;
       }
-      _toInflight() {
+      static _toInflightType(context) {
         const self_client_path = "./clients/$Inflight1.inflight.js".replace(/\\/g, "/");
         return $stdlib.core.NodeJsCode.fromInline(`
+          require("${self_client_path}")({
+          })
+        `);
+      }
+      _toInflight() {
+        return $stdlib.core.NodeJsCode.fromInline(`
           (await (async () => {
-            const $Inflight1 = require("${self_client_path}")({});
-            const client = new $Inflight1({
+            const $Inflight1Client = ${$Inflight1._toInflightType(this).text};
+            const client = new $Inflight1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
             return client;
@@ -385,18 +388,24 @@ class $Root extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
         this._addInflightOps("handle");
+        this.display.hidden = true;
+      }
+      static _toInflightType(context) {
+        const self_client_path = "./clients/$Inflight2.inflight.js".replace(/\\/g, "/");
+        const f_client = context._lift(f);
+        const api_client = context._lift(api);
+        return $stdlib.core.NodeJsCode.fromInline(`
+          require("${self_client_path}")({
+            f: ${f_client},
+            api: ${api_client},
+          })
+        `);
       }
       _toInflight() {
-        const api_client = this._lift(api);
-        const f_client = this._lift(f);
-        const self_client_path = "./clients/$Inflight2.inflight.js".replace(/\\/g, "/");
         return $stdlib.core.NodeJsCode.fromInline(`
           (await (async () => {
-            const $Inflight2 = require("${self_client_path}")({
-              api: ${api_client},
-              f: ${f_client},
-            });
-            const client = new $Inflight2({
+            const $Inflight2Client = ${$Inflight2._toInflightType(this).text};
+            const client = new $Inflight2Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
             return client;
@@ -405,10 +414,12 @@ class $Root extends $stdlib.std.Resource {
       }
       _registerBind(host, ops) {
         if (ops.includes("$inflight_init")) {
+          $Inflight2._registerBindObject(api, host, []);
+          $Inflight2._registerBindObject(f, host, []);
         }
         if (ops.includes("handle")) {
-          this._registerBindObject(api.url, host, []);
-          this._registerBindObject(f, host, ["get"]);
+          $Inflight2._registerBindObject(api.url, host, []);
+          $Inflight2._registerBindObject(f, host, ["get"]);
         }
         super._registerBind(host, ops);
       }
@@ -417,24 +428,7 @@ class $Root extends $stdlib.std.Resource {
     const handler = new $Inflight1(this,"$Inflight1");
     (api.get("/users/{name}",handler));
     const f = new Fetch(this,"Fetch");
-<<<<<<< HEAD
-    this.node.root.newAbstract("@winglang/sdk.cloud.Function",this,"test",new $Inflight2(this,"$Inflight2"));
-=======
-    this.node.root.new("@winglang/sdk.cloud.Test",cloud.Test,this,"test:test",new $stdlib.core.Inflight(this, "$Inflight2", {
-      code: $stdlib.core.NodeJsCode.fromFile(require.resolve("./proc2/index.js".replace(/\\/g, "/"))),
-      bindings: {
-        api: {
-          obj: api,
-          ops: []
-        },
-        f: {
-          obj: f,
-          ops: ["get"]
-        },
-      }
-    })
-    );
->>>>>>> main
+    this.node.root.new("@winglang/sdk.cloud.Test",cloud.Test,this,"test:test",new $Inflight2(this,"$Inflight2"));
   }
 }
 class $App extends $AppBase {
@@ -453,31 +447,6 @@ class $App extends $AppBase {
   }
 }
 new $App().synth();
-
-```
-
-## proc1/index.js
-```js
-async handle(req) {
-  const {  } = this;
-  const vars = (req.vars ?? Object.freeze({"name":""}));
-  return {
-  "body": Object.freeze({"user":(vars)["name"]}),
-  "status": 200,}
-  ;
-}
-
-```
-
-## proc2/index.js
-```js
-async handle() {
-  const { api, f } = this;
-  const username = "tsuf";
-  const res = (await f.get(`${api.url}/users/${username}`));
-  {((cond) => {if (!cond) throw new Error(`assertion failed: '((res)["status"] === 200)'`)})(((res)["status"] === 200))};
-  {((cond) => {if (!cond) throw new Error(`assertion failed: '(((res)["body"])["user"] === username)'`)})((((res)["body"])["user"] === username))};
-}
 
 ```
 

--- a/tools/hangar/__snapshots__/test_corpus/approx_size.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/approx_size.w_compile_tf-aws.md
@@ -189,6 +189,7 @@ class $Root extends $stdlib.std.Resource {
       }
       _registerBind(host, ops) {
         if (ops.includes("$inflight_init")) {
+          $Inflight1._registerBindObject(q, host, []);
         }
         if (ops.includes("handle")) {
           $Inflight1._registerBindObject(q, host, ["approxSize", "push"]);

--- a/tools/hangar/__snapshots__/test_corpus/asynchronous_model_implicit_await_in_functions.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/asynchronous_model_implicit_await_in_functions.w_compile_tf-aws.md
@@ -301,6 +301,7 @@ class $Root extends $stdlib.std.Resource {
       }
       _registerBind(host, ops) {
         if (ops.includes("$inflight_init")) {
+          $Inflight2._registerBindObject(strToStr, host, []);
         }
         if (ops.includes("handle")) {
           $Inflight2._registerBindObject(strToStr, host, ["invoke"]);

--- a/tools/hangar/__snapshots__/test_corpus/bring_jsii.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/bring_jsii.w_compile_tf-aws.md
@@ -176,6 +176,7 @@ class $Root extends $stdlib.std.Resource {
       }
       _registerBind(host, ops) {
         if (ops.includes("$inflight_init")) {
+          $Inflight1._registerBindObject(greeting, host, []);
         }
         if (ops.includes("handle")) {
           $Inflight1._registerBindObject(greeting, host, []);

--- a/tools/hangar/__snapshots__/test_corpus/bring_jsii_path.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/bring_jsii_path.w_compile_tf-aws.md
@@ -176,6 +176,7 @@ class $Root extends $stdlib.std.Resource {
       }
       _registerBind(host, ops) {
         if (ops.includes("$inflight_init")) {
+          $Inflight1._registerBindObject(greeting, host, []);
         }
         if (ops.includes("handle")) {
           $Inflight1._registerBindObject(greeting, host, []);

--- a/tools/hangar/__snapshots__/test_corpus/bucket_events.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/bucket_events.w_compile_tf-aws.md
@@ -1441,6 +1441,7 @@ class $Root extends $stdlib.std.Resource {
       }
       _registerBind(host, ops) {
         if (ops.includes("$inflight_init")) {
+          $Inflight4._registerBindObject(other, host, []);
         }
         if (ops.includes("handle")) {
           $Inflight4._registerBindObject(other, host, ["put"]);
@@ -1508,6 +1509,7 @@ class $Root extends $stdlib.std.Resource {
       }
       _registerBind(host, ops) {
         if (ops.includes("$inflight_init")) {
+          $Inflight6._registerBindObject(b, host, []);
         }
         if (ops.includes("handle")) {
           $Inflight6._registerBindObject(b, host, ["delete", "put"]);

--- a/tools/hangar/__snapshots__/test_corpus/bucket_keys.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/bucket_keys.w_compile_tf-aws.md
@@ -230,6 +230,7 @@ class $Root extends $stdlib.std.Resource {
       }
       _registerBind(host, ops) {
         if (ops.includes("$inflight_init")) {
+          $Inflight1._registerBindObject(b, host, []);
         }
         if (ops.includes("handle")) {
           $Inflight1._registerBindObject(b, host, ["list", "put"]);

--- a/tools/hangar/__snapshots__/test_corpus/calling_inflight_variants.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/calling_inflight_variants.w_compile_tf-aws.md
@@ -308,6 +308,7 @@ class $Root extends $stdlib.std.Resource {
       }
       _registerBind(host, ops) {
         if (ops.includes("$inflight_init")) {
+          $Inflight2._registerBindObject(foo, host, []);
         }
         if (ops.includes("handle")) {
           $Inflight2._registerBindObject(foo, host, ["callFn"]);

--- a/tools/hangar/__snapshots__/test_corpus/capture_containers.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/capture_containers.w_compile_tf-aws.md
@@ -191,6 +191,11 @@ class $Root extends $stdlib.std.Resource {
       }
       _registerBind(host, ops) {
         if (ops.includes("$inflight_init")) {
+          $Inflight1._registerBindObject(arr, host, []);
+          $Inflight1._registerBindObject(arrOfMap, host, []);
+          $Inflight1._registerBindObject(j, host, []);
+          $Inflight1._registerBindObject(myMap, host, []);
+          $Inflight1._registerBindObject(mySet, host, []);
         }
         if (ops.includes("handle")) {
           $Inflight1._registerBindObject(arr, host, ["at", "length"]);

--- a/tools/hangar/__snapshots__/test_corpus/capture_in_binary.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/capture_in_binary.w_compile_tf-aws.md
@@ -224,6 +224,8 @@ class $Root extends $stdlib.std.Resource {
       }
       _registerBind(host, ops) {
         if (ops.includes("$inflight_init")) {
+          $Inflight1._registerBindObject(b, host, []);
+          $Inflight1._registerBindObject(x, host, []);
         }
         if (ops.includes("handle")) {
           $Inflight1._registerBindObject(b, host, ["get", "put"]);

--- a/tools/hangar/__snapshots__/test_corpus/capture_primitives.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/capture_primitives.w_compile_tf-aws.md
@@ -197,6 +197,11 @@ class $Root extends $stdlib.std.Resource {
       }
       _registerBind(host, ops) {
         if (ops.includes("$inflight_init")) {
+          $Inflight1._registerBindObject(myBool, host, []);
+          $Inflight1._registerBindObject(myDur, host, []);
+          $Inflight1._registerBindObject(myNum, host, []);
+          $Inflight1._registerBindObject(mySecondBool, host, []);
+          $Inflight1._registerBindObject(myStr, host, []);
         }
         if (ops.includes("handle")) {
           $Inflight1._registerBindObject(myBool, host, []);

--- a/tools/hangar/__snapshots__/test_corpus/capture_resource_and_data.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/capture_resource_and_data.w_compile_tf-aws.md
@@ -239,6 +239,9 @@ class $Root extends $stdlib.std.Resource {
       }
       _registerBind(host, ops) {
         if (ops.includes("$inflight_init")) {
+          $Inflight1._registerBindObject(data, host, []);
+          $Inflight1._registerBindObject(queue, host, []);
+          $Inflight1._registerBindObject(res, host, []);
         }
         if (ops.includes("handle")) {
           $Inflight1._registerBindObject(data, host, ["size"]);

--- a/tools/hangar/__snapshots__/test_corpus/capture_resource_with_no_inflight.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/capture_resource_with_no_inflight.w_compile_tf-aws.md
@@ -221,6 +221,7 @@ class $Root extends $stdlib.std.Resource {
       }
       _registerBind(host, ops) {
         if (ops.includes("$inflight_init")) {
+          $Inflight1._registerBindObject(a, host, []);
         }
         if (ops.includes("handle")) {
           $Inflight1._registerBindObject(a.field, host, []);

--- a/tools/hangar/__snapshots__/test_corpus/captures.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/captures.w_compile_tf-aws.md
@@ -498,6 +498,9 @@ class $Root extends $stdlib.std.Resource {
       }
       _registerBind(host, ops) {
         if (ops.includes("$inflight_init")) {
+          $Inflight1._registerBindObject(bucket1, host, []);
+          $Inflight1._registerBindObject(bucket2, host, []);
+          $Inflight1._registerBindObject(bucket3, host, []);
         }
         if (ops.includes("handle")) {
           $Inflight1._registerBindObject(bucket1, host, ["list", "publicUrl", "put"]);

--- a/tools/hangar/__snapshots__/test_corpus/class.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/class.w_compile_tf-aws.md
@@ -422,6 +422,7 @@ class $Root extends $stdlib.std.Resource {
       }
       _registerBind(host, ops) {
         if (ops.includes("$inflight_init")) {
+          $Inflight1._registerBindObject(c5, host, []);
         }
         if (ops.includes("handle")) {
           $Inflight1._registerBindObject(c5, host, ["set", "x", "y"]);

--- a/tools/hangar/__snapshots__/test_corpus/dec.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/dec.w_compile_tf-aws.md
@@ -201,6 +201,7 @@ class $Root extends $stdlib.std.Resource {
       }
       _registerBind(host, ops) {
         if (ops.includes("$inflight_init")) {
+          $Inflight1._registerBindObject(counter, host, []);
         }
         if (ops.includes("handle")) {
           $Inflight1._registerBindObject(counter, host, ["dec", "peek"]);

--- a/tools/hangar/__snapshots__/test_corpus/doubler.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/doubler.w_compile_tf-aws.md
@@ -405,6 +405,7 @@ class $Root extends $stdlib.std.Resource {
             }
             _registerBind(host, ops) {
               if (ops.includes("$inflight_init")) {
+                $Inflight2._registerBindObject(handler, host, []);
               }
               if (ops.includes("handle")) {
                 $Inflight2._registerBindObject(handler, host, ["handle"]);
@@ -499,6 +500,7 @@ class $Root extends $stdlib.std.Resource {
       }
       _registerBind(host, ops) {
         if (ops.includes("$inflight_init")) {
+          $Inflight4._registerBindObject(f, host, []);
         }
         if (ops.includes("handle")) {
           $Inflight4._registerBindObject(f, host, ["invoke"]);

--- a/tools/hangar/__snapshots__/test_corpus/events.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/events.w_compile_tf-aws.md
@@ -979,6 +979,7 @@ class $Root extends $stdlib.std.Resource {
       }
       _registerBind(host, ops) {
         if (ops.includes("$inflight_init")) {
+          $Inflight1._registerBindObject(counter, host, []);
         }
         if (ops.includes("handle")) {
           $Inflight1._registerBindObject(counter, host, ["inc"]);
@@ -1014,6 +1015,7 @@ class $Root extends $stdlib.std.Resource {
       }
       _registerBind(host, ops) {
         if (ops.includes("$inflight_init")) {
+          $Inflight2._registerBindObject(counter, host, []);
         }
         if (ops.includes("handle")) {
           $Inflight2._registerBindObject(counter, host, ["inc"]);
@@ -1049,6 +1051,7 @@ class $Root extends $stdlib.std.Resource {
       }
       _registerBind(host, ops) {
         if (ops.includes("$inflight_init")) {
+          $Inflight3._registerBindObject(counter, host, []);
         }
         if (ops.includes("handle")) {
           $Inflight3._registerBindObject(counter, host, ["inc"]);
@@ -1084,6 +1087,7 @@ class $Root extends $stdlib.std.Resource {
       }
       _registerBind(host, ops) {
         if (ops.includes("$inflight_init")) {
+          $Inflight4._registerBindObject(counter, host, []);
         }
         if (ops.includes("handle")) {
           $Inflight4._registerBindObject(counter, host, ["inc"]);
@@ -1121,6 +1125,8 @@ class $Root extends $stdlib.std.Resource {
       }
       _registerBind(host, ops) {
         if (ops.includes("$inflight_init")) {
+          $Inflight5._registerBindObject(b, host, []);
+          $Inflight5._registerBindObject(counter, host, []);
         }
         if (ops.includes("handle")) {
           $Inflight5._registerBindObject(b, host, ["delete", "put"]);

--- a/tools/hangar/__snapshots__/test_corpus/exists.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/exists.w_compile_tf-aws.md
@@ -226,6 +226,7 @@ class $Root extends $stdlib.std.Resource {
       }
       _registerBind(host, ops) {
         if (ops.includes("$inflight_init")) {
+          $Inflight1._registerBindObject(b, host, []);
         }
         if (ops.includes("handle")) {
           $Inflight1._registerBindObject(b, host, ["delete", "exists", "put"]);

--- a/tools/hangar/__snapshots__/test_corpus/extern_implementation.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/extern_implementation.w_compile_tf-aws.md
@@ -340,6 +340,7 @@ class $Root extends $stdlib.std.Resource {
       }
       _registerBind(host, ops) {
         if (ops.includes("$inflight_init")) {
+          $Inflight1._registerBindObject(f, host, []);
         }
         if (ops.includes("handle")) {
           $Inflight1._registerBindObject(f, host, ["call"]);
@@ -375,6 +376,7 @@ class $Root extends $stdlib.std.Resource {
       }
       _registerBind(host, ops) {
         if (ops.includes("$inflight_init")) {
+          $Inflight2._registerBindObject(f, host, []);
         }
         if (ops.includes("handle")) {
           $Inflight2._registerBindObject(f, host, ["print"]);

--- a/tools/hangar/__snapshots__/test_corpus/file_counter.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/file_counter.w_compile_tf-aws.md
@@ -269,6 +269,8 @@ class $Root extends $stdlib.std.Resource {
       }
       _registerBind(host, ops) {
         if (ops.includes("$inflight_init")) {
+          $Inflight1._registerBindObject(bucket, host, []);
+          $Inflight1._registerBindObject(counter, host, []);
         }
         if (ops.includes("handle")) {
           $Inflight1._registerBindObject(bucket, host, ["put"]);

--- a/tools/hangar/__snapshots__/test_corpus/hello.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/hello.w_compile_tf-aws.md
@@ -244,6 +244,7 @@ class $Root extends $stdlib.std.Resource {
       }
       _registerBind(host, ops) {
         if (ops.includes("$inflight_init")) {
+          $Inflight1._registerBindObject(bucket, host, []);
         }
         if (ops.includes("handle")) {
           $Inflight1._registerBindObject(bucket, host, ["put"]);

--- a/tools/hangar/__snapshots__/test_corpus/impl_interface.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/impl_interface.w_compile_tf-aws.md
@@ -173,6 +173,7 @@ class $Root extends $stdlib.std.Resource {
       }
       _registerBind(host, ops) {
         if (ops.includes("$inflight_init")) {
+          $Inflight1._registerBindObject(x, host, []);
         }
         if (ops.includes("handle")) {
           $Inflight1._registerBindObject(x, host, ["handle"]);

--- a/tools/hangar/__snapshots__/test_corpus/inc.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/inc.w_compile_tf-aws.md
@@ -206,6 +206,7 @@ class $Root extends $stdlib.std.Resource {
       }
       _registerBind(host, ops) {
         if (ops.includes("$inflight_init")) {
+          $Inflight1._registerBindObject(counter, host, []);
         }
         if (ops.includes("handle")) {
           $Inflight1._registerBindObject(counter, host, ["inc", "peek"]);

--- a/tools/hangar/__snapshots__/test_corpus/inflight_class_inside_inflight_closure.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/inflight_class_inside_inflight_closure.w_compile_tf-aws.md
@@ -338,6 +338,7 @@ class $Root extends $stdlib.std.Resource {
             }
             _registerBind(host, ops) {
               if (ops.includes("$inflight_init")) {
+                $Inflight1._registerBindObject(__parent_this, host, []);
               }
               if (ops.includes("handle")) {
                 $Inflight1._registerBindObject(__parent_this.b, host, ["put"]);
@@ -404,6 +405,7 @@ class $Root extends $stdlib.std.Resource {
       }
       _registerBind(host, ops) {
         if (ops.includes("$inflight_init")) {
+          $Inflight2._registerBindObject(f, host, []);
         }
         if (ops.includes("handle")) {
           $Inflight2._registerBindObject(f, host, ["invoke"]);

--- a/tools/hangar/__snapshots__/test_corpus/inflights_calling_inflights.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/inflights_calling_inflights.w_compile_tf-aws.md
@@ -445,6 +445,7 @@ class $Root extends $stdlib.std.Resource {
       }
       _registerBind(host, ops) {
         if (ops.includes("$inflight_init")) {
+          $Inflight1._registerBindObject(globalBucket, host, []);
         }
         if (ops.includes("handle")) {
           $Inflight1._registerBindObject(globalBucket, host, ["put"]);
@@ -480,6 +481,7 @@ class $Root extends $stdlib.std.Resource {
       }
       _registerBind(host, ops) {
         if (ops.includes("$inflight_init")) {
+          $Inflight2._registerBindObject(storeInBucket, host, []);
         }
         if (ops.includes("handle")) {
           $Inflight2._registerBindObject(storeInBucket, host, ["handle"]);
@@ -517,6 +519,8 @@ class $Root extends $stdlib.std.Resource {
       }
       _registerBind(host, ops) {
         if (ops.includes("$inflight_init")) {
+          $Inflight3._registerBindObject(func1, host, []);
+          $Inflight3._registerBindObject(globalBucket, host, []);
         }
         if (ops.includes("handle")) {
           $Inflight3._registerBindObject(func1, host, ["invoke"]);
@@ -558,6 +562,7 @@ class $Root extends $stdlib.std.Resource {
           }
           _registerBind(host, ops) {
             if (ops.includes("$inflight_init")) {
+              $Inflight4._registerBindObject(globalBucket, host, []);
             }
             if (ops.includes("handle")) {
               $Inflight4._registerBindObject(globalBucket, host, ["list"]);
@@ -625,6 +630,7 @@ class $Root extends $stdlib.std.Resource {
       }
       _registerBind(host, ops) {
         if (ops.includes("$inflight_init")) {
+          $Inflight5._registerBindObject(x, host, []);
         }
         if (ops.includes("handle")) {
           $Inflight5._registerBindObject(x, host, ["foo"]);

--- a/tools/hangar/__snapshots__/test_corpus/initial.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/initial.w_compile_tf-aws.md
@@ -395,6 +395,7 @@ class $Root extends $stdlib.std.Resource {
       }
       _registerBind(host, ops) {
         if (ops.includes("$inflight_init")) {
+          $Inflight1._registerBindObject(counterA, host, []);
         }
         if (ops.includes("handle")) {
           $Inflight1._registerBindObject(counterA, host, ["peek"]);
@@ -430,6 +431,7 @@ class $Root extends $stdlib.std.Resource {
       }
       _registerBind(host, ops) {
         if (ops.includes("$inflight_init")) {
+          $Inflight2._registerBindObject(counterB, host, []);
         }
         if (ops.includes("handle")) {
           $Inflight2._registerBindObject(counterB, host, ["peek"]);
@@ -465,6 +467,7 @@ class $Root extends $stdlib.std.Resource {
       }
       _registerBind(host, ops) {
         if (ops.includes("$inflight_init")) {
+          $Inflight3._registerBindObject(counterC, host, []);
         }
         if (ops.includes("handle")) {
           $Inflight3._registerBindObject(counterC, host, ["peek"]);

--- a/tools/hangar/__snapshots__/test_corpus/invoke.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/invoke.w_compile_tf-aws.md
@@ -259,6 +259,7 @@ class $Root extends $stdlib.std.Resource {
       }
       _registerBind(host, ops) {
         if (ops.includes("$inflight_init")) {
+          $Inflight1._registerBindObject(payload, host, []);
         }
         if (ops.includes("handle")) {
           $Inflight1._registerBindObject(payload, host, []);
@@ -296,6 +297,8 @@ class $Root extends $stdlib.std.Resource {
       }
       _registerBind(host, ops) {
         if (ops.includes("$inflight_init")) {
+          $Inflight2._registerBindObject(f, host, []);
+          $Inflight2._registerBindObject(payload, host, []);
         }
         if (ops.includes("handle")) {
           $Inflight2._registerBindObject(f, host, ["invoke"]);

--- a/tools/hangar/__snapshots__/test_corpus/json_bucket.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/json_bucket.w_compile_tf-aws.md
@@ -309,6 +309,8 @@ class $Root extends $stdlib.std.Resource {
       }
       _registerBind(host, ops) {
         if (ops.includes("$inflight_init")) {
+          $Inflight1._registerBindObject(b, host, []);
+          $Inflight1._registerBindObject(fileName, host, []);
         }
         if (ops.includes("handle")) {
           $Inflight1._registerBindObject(b, host, ["getJson"]);
@@ -351,6 +353,10 @@ class $Root extends $stdlib.std.Resource {
       }
       _registerBind(host, ops) {
         if (ops.includes("$inflight_init")) {
+          $Inflight2._registerBindObject(b, host, []);
+          $Inflight2._registerBindObject(fileName, host, []);
+          $Inflight2._registerBindObject(getJson, host, []);
+          $Inflight2._registerBindObject(j, host, []);
         }
         if (ops.includes("handle")) {
           $Inflight2._registerBindObject(b, host, ["putJson"]);

--- a/tools/hangar/__snapshots__/test_corpus/json_static.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/json_static.w_compile_tf-aws.md
@@ -176,6 +176,7 @@ class $Root extends $stdlib.std.Resource {
       }
       _registerBind(host, ops) {
         if (ops.includes("$inflight_init")) {
+          $Inflight1._registerBindObject(jj, host, []);
         }
         if (ops.includes("handle")) {
           $Inflight1._registerBindObject(jj, host, []);

--- a/tools/hangar/__snapshots__/test_corpus/list.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/list.w_compile_tf-aws.md
@@ -208,6 +208,7 @@ class $Root extends $stdlib.std.Resource {
       }
       _registerBind(host, ops) {
         if (ops.includes("$inflight_init")) {
+          $Inflight1._registerBindObject(table, host, []);
         }
         if (ops.includes("handle")) {
           $Inflight1._registerBindObject(table, host, ["insert", "list"]);

--- a/tools/hangar/__snapshots__/test_corpus/nil.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/nil.w_compile_tf-aws.md
@@ -340,6 +340,7 @@ class $Root extends $stdlib.std.Resource {
       }
       _registerBind(host, ops) {
         if (ops.includes("$inflight_init")) {
+          $Inflight1._registerBindObject(foo, host, []);
         }
         if (ops.includes("handle")) {
           $Inflight1._registerBindObject(foo, host, ["returnNil"]);
@@ -375,6 +376,7 @@ class $Root extends $stdlib.std.Resource {
       }
       _registerBind(host, ops) {
         if (ops.includes("$inflight_init")) {
+          $Inflight2._registerBindObject(foo, host, []);
         }
         if (ops.includes("handle")) {
           $Inflight2._registerBindObject(foo, host, ["getOptionalValue", "setOptionalValue"]);

--- a/tools/hangar/__snapshots__/test_corpus/on_message.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/on_message.w_compile_tf-aws.md
@@ -541,6 +541,7 @@ class $Root extends $stdlib.std.Resource {
       }
       _registerBind(host, ops) {
         if (ops.includes("$inflight_init")) {
+          $Inflight1._registerBindObject(c, host, []);
         }
         if (ops.includes("handle")) {
           $Inflight1._registerBindObject(c, host, ["inc"]);
@@ -576,6 +577,7 @@ class $Root extends $stdlib.std.Resource {
       }
       _registerBind(host, ops) {
         if (ops.includes("$inflight_init")) {
+          $Inflight2._registerBindObject(c, host, []);
         }
         if (ops.includes("handle")) {
           $Inflight2._registerBindObject(c, host, ["inc"]);
@@ -615,6 +617,8 @@ class $Root extends $stdlib.std.Resource {
       }
       _registerBind(host, ops) {
         if (ops.includes("$inflight_init")) {
+          $Inflight3._registerBindObject(predicate, host, []);
+          $Inflight3._registerBindObject(t, host, []);
         }
         if (ops.includes("handle")) {
           $Inflight3._registerBindObject(TestHelper, host, ["sleep"]);

--- a/tools/hangar/__snapshots__/test_corpus/peek.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/peek.w_compile_tf-aws.md
@@ -198,6 +198,7 @@ class $Root extends $stdlib.std.Resource {
       }
       _registerBind(host, ops) {
         if (ops.includes("$inflight_init")) {
+          $Inflight1._registerBindObject(c, host, []);
         }
         if (ops.includes("handle")) {
           $Inflight1._registerBindObject(c, host, ["inc", "peek"]);

--- a/tools/hangar/__snapshots__/test_corpus/pop.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/pop.w_compile_tf-aws.md
@@ -198,6 +198,8 @@ class $Root extends $stdlib.std.Resource {
       }
       _registerBind(host, ops) {
         if (ops.includes("$inflight_init")) {
+          $Inflight1._registerBindObject(NIL, host, []);
+          $Inflight1._registerBindObject(q, host, []);
         }
         if (ops.includes("handle")) {
           $Inflight1._registerBindObject(NIL, host, []);

--- a/tools/hangar/__snapshots__/test_corpus/purge.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/purge.w_compile_tf-aws.md
@@ -192,6 +192,7 @@ class $Root extends $stdlib.std.Resource {
       }
       _registerBind(host, ops) {
         if (ops.includes("$inflight_init")) {
+          $Inflight1._registerBindObject(q, host, []);
         }
         if (ops.includes("handle")) {
           $Inflight1._registerBindObject(q, host, ["approxSize", "purge", "push"]);

--- a/tools/hangar/__snapshots__/test_corpus/put.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/put.w_compile_tf-aws.md
@@ -232,6 +232,7 @@ class $Root extends $stdlib.std.Resource {
       }
       _registerBind(host, ops) {
         if (ops.includes("$inflight_init")) {
+          $Inflight1._registerBindObject(b, host, []);
         }
         if (ops.includes("handle")) {
           $Inflight1._registerBindObject(b, host, ["delete", "get", "list", "put"]);

--- a/tools/hangar/__snapshots__/test_corpus/put_json.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/put_json.w_compile_tf-aws.md
@@ -235,6 +235,7 @@ class $Root extends $stdlib.std.Resource {
       }
       _registerBind(host, ops) {
         if (ops.includes("$inflight_init")) {
+          $Inflight1._registerBindObject(b, host, []);
         }
         if (ops.includes("handle")) {
           $Inflight1._registerBindObject(b, host, ["delete", "getJson", "list", "putJson"]);

--- a/tools/hangar/__snapshots__/test_corpus/redis.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/redis.w_compile_tf-aws.md
@@ -507,6 +507,8 @@ class $Root extends $stdlib.std.Resource {
       }
       _registerBind(host, ops) {
         if (ops.includes("$inflight_init")) {
+          $Inflight1._registerBindObject(r, host, []);
+          $Inflight1._registerBindObject(r2, host, []);
         }
         if (ops.includes("handle")) {
           $Inflight1._registerBindObject(r, host, ["rawClient"]);

--- a/tools/hangar/__snapshots__/test_corpus/reset.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/reset.w_compile_tf-aws.md
@@ -205,6 +205,7 @@ class $Root extends $stdlib.std.Resource {
       }
       _registerBind(host, ops) {
         if (ops.includes("$inflight_init")) {
+          $Inflight1._registerBindObject(counter, host, []);
         }
         if (ops.includes("handle")) {
           $Inflight1._registerBindObject(counter, host, ["inc", "peek", "reset"]);

--- a/tools/hangar/__snapshots__/test_corpus/resource.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/resource.w_compile_tf-aws.md
@@ -422,7 +422,12 @@ module.exports = function({  }) {
         },
         "environment": {
           "variables": {
+            "BUCKET_NAME_584271ad": "${aws_s3_bucket.root_BigPublisher_b2_48CEFEE6.bucket}",
+            "BUCKET_NAME_584271ad_IS_PUBLIC": "false",
+            "BUCKET_NAME_7ef741f5": "${aws_s3_bucket.root_BigPublisher_cloudBucket_7AC8CA7E.bucket}",
+            "BUCKET_NAME_7ef741f5_IS_PUBLIC": "false",
             "QUEUE_URL_b0ba884c": "${aws_sqs_queue.root_BigPublisher_cloudQueue_0E439190.url}",
+            "TOPIC_ARN_eb0072ec": "${aws_sns_topic.root_BigPublisher_cloudTopic_B7FD0C9E.arn}",
             "WING_FUNCTION_NAME": "b2-on_create-OnMessage-d05c64b5-c85f4411"
           }
         },
@@ -448,8 +453,12 @@ module.exports = function({  }) {
         },
         "environment": {
           "variables": {
+            "BUCKET_NAME_584271ad": "${aws_s3_bucket.root_BigPublisher_b2_48CEFEE6.bucket}",
+            "BUCKET_NAME_584271ad_IS_PUBLIC": "false",
             "BUCKET_NAME_7ef741f5": "${aws_s3_bucket.root_BigPublisher_cloudBucket_7AC8CA7E.bucket}",
             "BUCKET_NAME_7ef741f5_IS_PUBLIC": "false",
+            "QUEUE_URL_b0ba884c": "${aws_sqs_queue.root_BigPublisher_cloudQueue_0E439190.url}",
+            "TOPIC_ARN_eb0072ec": "${aws_sns_topic.root_BigPublisher_cloudTopic_B7FD0C9E.arn}",
             "WING_FUNCTION_NAME": "cloud-Queue-AddConsumer-fe215853-c89a66f3"
           }
         },
@@ -475,8 +484,12 @@ module.exports = function({  }) {
         },
         "environment": {
           "variables": {
+            "BUCKET_NAME_584271ad": "${aws_s3_bucket.root_BigPublisher_b2_48CEFEE6.bucket}",
+            "BUCKET_NAME_584271ad_IS_PUBLIC": "false",
             "BUCKET_NAME_7ef741f5": "${aws_s3_bucket.root_BigPublisher_cloudBucket_7AC8CA7E.bucket}",
             "BUCKET_NAME_7ef741f5_IS_PUBLIC": "false",
+            "QUEUE_URL_b0ba884c": "${aws_sqs_queue.root_BigPublisher_cloudQueue_0E439190.url}",
+            "TOPIC_ARN_eb0072ec": "${aws_sns_topic.root_BigPublisher_cloudTopic_B7FD0C9E.arn}",
             "WING_FUNCTION_NAME": "cloud-Topic-OnMessage-c351460f-c82610b4"
           }
         },
@@ -1019,6 +1032,8 @@ class $Root extends $stdlib.std.Resource {
       }
       _registerBind(host, ops) {
         if (ops.includes("$inflight_init")) {
+          $Inflight1._registerBindObject(bucket, host, []);
+          $Inflight1._registerBindObject(res, host, []);
         }
         if (ops.includes("handle")) {
           $Inflight1._registerBindObject(bucket, host, ["list"]);
@@ -1065,6 +1080,7 @@ class $Root extends $stdlib.std.Resource {
           }
           _registerBind(host, ops) {
             if (ops.includes("$inflight_init")) {
+              $Inflight2._registerBindObject(__parent_this, host, []);
             }
             if (ops.includes("handle")) {
               $Inflight2._registerBindObject(__parent_this.b, host, ["put"]);
@@ -1101,6 +1117,7 @@ class $Root extends $stdlib.std.Resource {
           }
           _registerBind(host, ops) {
             if (ops.includes("$inflight_init")) {
+              $Inflight3._registerBindObject(__parent_this, host, []);
             }
             if (ops.includes("handle")) {
               $Inflight3._registerBindObject(__parent_this.b, host, ["put"]);
@@ -1137,6 +1154,7 @@ class $Root extends $stdlib.std.Resource {
           }
           _registerBind(host, ops) {
             if (ops.includes("$inflight_init")) {
+              $Inflight4._registerBindObject(__parent_this, host, []);
             }
             if (ops.includes("handle")) {
               $Inflight4._registerBindObject(__parent_this.q, host, ["push"]);
@@ -1218,6 +1236,7 @@ class $Root extends $stdlib.std.Resource {
       }
       _registerBind(host, ops) {
         if (ops.includes("$inflight_init")) {
+          $Inflight5._registerBindObject(bigOlPublisher, host, []);
         }
         if (ops.includes("handle")) {
           $Inflight5._registerBindObject(bigOlPublisher, host, ["getObjectCount", "publish"]);

--- a/tools/hangar/__snapshots__/test_corpus/resource_as_inflight_literal.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/resource_as_inflight_literal.w_compile_tf-aws.md
@@ -291,6 +291,7 @@ class $Root extends $stdlib.std.Resource {
       }
       _registerBind(host, ops) {
         if (ops.includes("$inflight_init")) {
+          $Inflight1._registerBindObject(fn, host, []);
         }
         if (ops.includes("handle")) {
           $Inflight1._registerBindObject(fn, host, ["invoke"]);

--- a/tools/hangar/__snapshots__/test_corpus/resource_captures.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/resource_captures.w_compile_tf-aws.md
@@ -699,6 +699,7 @@ class $Root extends $stdlib.std.Resource {
       }
       _registerBind(host, ops) {
         if (ops.includes("$inflight_init")) {
+          $Inflight1._registerBindObject(r, host, []);
         }
         if (ops.includes("handle")) {
           $Inflight1._registerBindObject(r, host, ["testCaptureCollectionsOfData", "testCaptureOptional", "testCapturePrimitives", "testCaptureResource", "testExpressionRecursive", "testExternal", "testInflightField", "testNestedInflightField", "testNestedResource", "testNoCapture", "testUserDefinedResource"]);

--- a/tools/hangar/__snapshots__/test_corpus/resource_captures_globals.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/resource_captures_globals.w_compile_tf-aws.md
@@ -232,7 +232,7 @@ module.exports = function({ globalCounter, $parentThis }) {
             "uniqueId": "root_MyResource_cloudTopicOnMessagef10eb240_IamRolePolicy_389E9A62"
           }
         },
-        "policy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Action\":[\"dynamodb:UpdateItem\"],\"Resource\":[\"${aws_dynamodb_table.root_cloudCounter_E0AC1263.arn}\"],\"Effect\":\"Allow\"},{\"Action\":[\"dynamodb:UpdateItem\"],\"Resource\":[\"${aws_dynamodb_table.root_MyResource_cloudCounter_B6FF7B6A.arn}\"],\"Effect\":\"Allow\"}]}",
+        "policy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Action\":[\"dynamodb:UpdateItem\"],\"Resource\":[\"${aws_dynamodb_table.root_cloudCounter_E0AC1263.arn}\"],\"Effect\":\"Allow\"},{\"Action\":[\"dynamodb:GetItem\"],\"Resource\":[\"${aws_dynamodb_table.root_cloudCounter_E0AC1263.arn}\"],\"Effect\":\"Allow\"},{\"Action\":[\"dynamodb:UpdateItem\"],\"Resource\":[\"${aws_dynamodb_table.root_MyResource_cloudCounter_B6FF7B6A.arn}\"],\"Effect\":\"Allow\"}]}",
         "role": "${aws_iam_role.root_MyResource_cloudTopicOnMessagef10eb240_IamRole_4BDB9A54.name}"
       },
       "root_testaccesscloudresourcethroughstaticmethodsonly_Handler_IamRolePolicy_2AD210AF": {
@@ -298,8 +298,13 @@ module.exports = function({ globalCounter, $parentThis }) {
         },
         "environment": {
           "variables": {
+            "BUCKET_NAME_ae5b06c6": "${aws_s3_bucket.root_Another_First_cloudBucket_B4A67079.bucket}",
+            "BUCKET_NAME_ae5b06c6_IS_PUBLIC": "false",
+            "BUCKET_NAME_d755b447": "${aws_s3_bucket.root_cloudBucket_4F3C4F53.bucket}",
+            "BUCKET_NAME_d755b447_IS_PUBLIC": "false",
             "DYNAMODB_TABLE_NAME_49baa65c": "${aws_dynamodb_table.root_cloudCounter_E0AC1263.name}",
             "DYNAMODB_TABLE_NAME_5afed199": "${aws_dynamodb_table.root_MyResource_cloudCounter_B6FF7B6A.name}",
+            "TOPIC_ARN_53de52bf": "${aws_sns_topic.root_MyResource_cloudTopic_F71B23B1.arn}",
             "WING_FUNCTION_NAME": "cloud-Topic-OnMessage-f10eb240-c8df2c86"
           }
         },
@@ -676,6 +681,8 @@ class $Root extends $stdlib.std.Resource {
           }
           _registerBind(host, ops) {
             if (ops.includes("$inflight_init")) {
+              R._registerBindObject($parentThis, host, []);
+              R._registerBindObject(globalCounter, host, []);
             }
             if (ops.includes("handle")) {
               R._registerBindObject($parentThis.localCounter, host, ["inc"]);
@@ -728,6 +735,14 @@ class $Root extends $stdlib.std.Resource {
       }
       _registerBind(host, ops) {
         if (ops.includes("$inflight_init")) {
+          MyResource._registerBindObject(globalAnother, host, []);
+          MyResource._registerBindObject(globalArrayOfStr, host, []);
+          MyResource._registerBindObject(globalBool, host, []);
+          MyResource._registerBindObject(globalBucket, host, []);
+          MyResource._registerBindObject(globalMapOfNum, host, []);
+          MyResource._registerBindObject(globalNum, host, []);
+          MyResource._registerBindObject(globalSetOfStr, host, []);
+          MyResource._registerBindObject(globalStr, host, []);
           MyResource._registerBindObject(this.localCounter, host, []);
           MyResource._registerBindObject(this.localTopic, host, []);
         }
@@ -776,6 +791,7 @@ class $Root extends $stdlib.std.Resource {
       }
       _registerBind(host, ops) {
         if (ops.includes("$inflight_init")) {
+          $Inflight1._registerBindObject(res, host, []);
         }
         if (ops.includes("handle")) {
           $Inflight1._registerBindObject(res, host, ["myPut"]);

--- a/tools/hangar/__snapshots__/test_corpus/std_string.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/std_string.w_compile_tf-aws.md
@@ -179,6 +179,8 @@ class $Root extends $stdlib.std.Resource {
       }
       _registerBind(host, ops) {
         if (ops.includes("$inflight_init")) {
+          $Inflight1._registerBindObject(s1, host, []);
+          $Inflight1._registerBindObject(s2, host, []);
         }
         if (ops.includes("handle")) {
           $Inflight1._registerBindObject(s1, host, []);

--- a/tools/hangar/__snapshots__/test_corpus/symbol_shadow.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/symbol_shadow.w_compile_tf-aws.md
@@ -440,6 +440,7 @@ class $Root extends $stdlib.std.Resource {
           }
           _registerBind(host, ops) {
             if (ops.includes("$inflight_init")) {
+              $Inflight2._registerBindObject(s, host, []);
             }
             if (ops.includes("handle")) {
               $Inflight2._registerBindObject(s, host, []);
@@ -501,6 +502,7 @@ class $Root extends $stdlib.std.Resource {
       }
       _registerBind(host, ops) {
         if (ops.includes("$inflight_init")) {
+          $Inflight3._registerBindObject(s, host, []);
         }
         if (ops.includes("handle")) {
           $Inflight3._registerBindObject(s, host, []);
@@ -572,6 +574,7 @@ class $Root extends $stdlib.std.Resource {
         }
         _registerBind(host, ops) {
           if (ops.includes("$inflight_init")) {
+            $Inflight1._registerBindObject(s, host, []);
           }
           if (ops.includes("handle")) {
             $Inflight1._registerBindObject(s, host, []);

--- a/tools/hangar/__snapshots__/test_corpus/test_bucket.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/test_bucket.w_compile_tf-aws.md
@@ -307,6 +307,7 @@ class $Root extends $stdlib.std.Resource {
       }
       _registerBind(host, ops) {
         if (ops.includes("$inflight_init")) {
+          $Inflight1._registerBindObject(b, host, []);
         }
         if (ops.includes("handle")) {
           $Inflight1._registerBindObject(b, host, ["list", "put"]);
@@ -342,6 +343,7 @@ class $Root extends $stdlib.std.Resource {
       }
       _registerBind(host, ops) {
         if (ops.includes("$inflight_init")) {
+          $Inflight2._registerBindObject(b, host, []);
         }
         if (ops.includes("handle")) {
           $Inflight2._registerBindObject(b, host, ["get", "put"]);

--- a/tools/hangar/__snapshots__/test_corpus/website_with_api.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/website_with_api.w_compile_tf-aws.md
@@ -625,6 +625,7 @@ class $Root extends $stdlib.std.Resource {
       }
       _registerBind(host, ops) {
         if (ops.includes("$inflight_init")) {
+          $Inflight1._registerBindObject(usersTable, host, []);
         }
         if (ops.includes("handle")) {
           $Inflight1._registerBindObject(usersTable, host, ["list"]);
@@ -660,6 +661,7 @@ class $Root extends $stdlib.std.Resource {
       }
       _registerBind(host, ops) {
         if (ops.includes("$inflight_init")) {
+          $Inflight2._registerBindObject(usersTable, host, []);
         }
         if (ops.includes("handle")) {
           $Inflight2._registerBindObject(usersTable, host, ["insert"]);

--- a/tools/hangar/__snapshots__/tree_json.ts.snap
+++ b/tools/hangar/__snapshots__/tree_json.ts.snap
@@ -1041,12 +1041,6 @@ exports[`tree.json for an app with many resources 1`] = `
                             {
                               "direction": "outbound",
                               "implicit": false,
-                              "relationship": "list",
-                              "resource": "root/Default/Default/cloud.Bucket",
-                            },
-                            {
-                              "direction": "outbound",
-                              "implicit": false,
                               "relationship": "dec",
                               "resource": "root/Default/Default/Bar/Foo/cloud.Counter",
                             },
@@ -1055,6 +1049,12 @@ exports[`tree.json for an app with many resources 1`] = `
                               "implicit": false,
                               "relationship": "inc",
                               "resource": "root/Default/Default/Bar/Foo/cloud.Counter",
+                            },
+                            {
+                              "direction": "outbound",
+                              "implicit": false,
+                              "relationship": "list",
+                              "resource": "root/Default/Default/cloud.Bucket",
                             },
                             {
                               "direction": "outbound",


### PR DESCRIPTION
Fixes #1966
Fixes #2082

Addresses a bug in the compiler that resulted in "missing environment variable" errors appearing in some situations where inflight functions were created inside of class constructors.

Take the following example:

```js
class MyProcessor {
  b: cloud.Bucket;
  q: cloud.Queue;

  init() {
    this.q = new cloud.Queue();
    this.b = new cloud.Bucket();

    this.q.addConsumer(inflight (message: str) => {
      log("processing ${message}..");
      this.b.put("file.txt", message);
    });
  }
}
```

`this.q.addConsumer` creates a `cloud.Function` resource to run the inflight code. That cloud resource was originally receiving the minimal permissions needed to call the "put" method on "this.b". This caused an issue because in the current way the compiler generates inflight code, it is bundling and instantiating the entire client of "this" - i.e. the inflight client of MyProcessor.

This causes issues because the inflight client code of MyProcessor is a JavaScript class that looks like this:

```js
  class MyProcessor {
    constructor({ b, q }) {
      this.b = b;
      this.q = q;
    }
  }
```

... and declaring `q` requires instantiating a `cloud.Queue` client, which requires these extra environment variables.

The current fix I've added is to grant "inflight init" permissions to the entirety of `this` despite the fact that only the child (`this.b`) is used.

In the future we might want to generate inflight code differently so only `this.b` has to be bundled, but I think it might require more work.

- [x] PR title matches [Winglang's style guide](https://docs.winglang.io/contributors/pull_requests#how-are-pull-request-titles-formatted)
- [x] PR description explains motivation and solution
- [x] Tests added
- [x] Docs updated
- [ ] Needs end-to-end tests (`pr/e2e-full` label)

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.