### PR TITLE
chore(repo): cache wasi sdk tarball to reduce repo setup time

### DIFF
--- a/scripts/setup_wasi.sh
+++ b/scripts/setup_wasi.sh
@@ -22,8 +22,17 @@ if ! command -v cargo-wasi &> /dev/null; then
 fi
 
 if [ ! -d $WASI_INSTALL_DIR ]; then
-    WASI_INSTALL_URL="https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-$WASI_VERSION/wasi-sdk-$WASI_VERSION_FULL-$WASI_OS.tar.gz"
-    echo "Installing WASI SDK $WASI_VERSION_FULL to $WASI_INSTALL_DIR..."
-    curl --retry 2 -L $WASI_INSTALL_URL | tar zxf - -C $WASI_INSTALL_PARENT_DIR
-fi
+    WASI_TARBALL="wasi-sdk-$WASI_VERSION_FULL-$WASI_OS.tar.gz"
+    WASI_INSTALL_URL="https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-$WASI_VERSION/$WASI_TARBALL"
+    OUTFILE="/tmp/$WASI_TARBALL"
 
+    echo "Installing WASI SDK $WASI_VERSION_FULL to $WASI_INSTALL_DIR..."
+
+    if [ ! -f $OUTFILE ]; then
+        echo "Downloading WASI SDK $WASI_VERSION_FULL to $OUTFILE..."
+        curl --retry 2 -L $WASI_INSTALL_URL -o $OUTFILE
+    fi
+    
+    echo "Extracting to $WASI_INSTALL_PARENT_DIR..."
+    tar zxf $OUTFILE -C $WASI_INSTALL_PARENT_DIR
+fi


### PR DESCRIPTION
Opportunistically cache the WASI SDK tarball under `/tmp` to avoid having to download it every time.

- [x] PR title matches [Winglang's style guide](https://docs.winglang.io/contributors/pull_requests#how-are-pull-request-titles-formatted)
- [x] PR description explains motivation and solution

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.