### PR TITLE
fix(compiler): `bring fs` panics

### DIFF
--- a/docs/04-resources/bucket.md
+++ b/docs/04-resources/bucket.md
@@ -105,7 +105,7 @@ The Google Cloud implementation of `cloud.Bucket` uses [Google Cloud Storage](ht
 
 ## API Reference
 
-The full list of APIs for `cloud.Bucket` is available in the [API Reference](../05-reference/wingsdk-api.md).
+The full list of APIs for `cloud.Secret` is available in the [API Reference](../05-reference/wingsdk-api.md).
 
 
 

--- a/docs/04-resources/bucket.md
+++ b/docs/04-resources/bucket.md
@@ -105,7 +105,7 @@ The Google Cloud implementation of `cloud.Bucket` uses [Google Cloud Storage](ht
 
 ## API Reference
 
-The full list of APIs for `cloud.Secret` is available in the [API Reference](../05-reference/wingsdk-api.md).
+The full list of APIs for `cloud.Bucket` is available in the [API Reference](../05-reference/wingsdk-api.md).
 
 
 

--- a/docs/04-resources/topic.md
+++ b/docs/04-resources/topic.md
@@ -19,7 +19,7 @@ bring cloud;
 let topic = new cloud.Topic();
 ```
 
-### Using a topic
+### Subscribing to a topic
 
 ```js
 bring cloud;
@@ -31,14 +31,15 @@ topic.onMessage(inflight (message: str) => {
 });
 ```
 
-### Using a topic inflight
-The inflight api for a topic allows for publishing messages to the topic.
+### Publishing to a topic
+
+The inflight method `publish` sends a message to all of the topic's subscribers.
 ```js
 bring cloud;
 
 let topic = new cloud.Topic();
 
-inflight() => {
+inflight () => {
   topic.publish("Hello World!");
 };
 ```
@@ -59,12 +60,12 @@ let consumerHandler = inflight(message: str) => {
   log("Doing some work with message: ${message}");
 };
 
-// Now we can use the preflight api of topic to register the consumer handler
+// Now we can use a preflight method of topic to register the consumer handler
 // to be invoked when a message is published to the topic.
 topic.onMessage(consumerHandler);
 
 // Then we define the producer inflight handler
-let publisherHandler = inflight() => {
+let publisherHandler = inflight () => {
   // Here we use the inflight api to publish a message to the topic.
   topic.publish("Here are those launch codes you asked for.");
 };

--- a/examples/tests/invalid/bring.w
+++ b/examples/tests/invalid/bring.w
@@ -4,3 +4,4 @@ bring cloud;
 bring cloud;
 //    ^^^^^ "cloud" is already defined
 bring fs;
+//    ^^^^^ "fs" is not a built-in module

--- a/examples/tests/invalid/bring.w
+++ b/examples/tests/invalid/bring.w
@@ -3,3 +3,4 @@ bring std;
 bring cloud;
 bring cloud;
 //    ^^^^^ "cloud" is already defined
+bring fs;

--- a/libs/wingc/src/lib.rs
+++ b/libs/wingc/src/lib.rs
@@ -47,7 +47,6 @@ mod wasm_util;
 const WINGSDK_ASSEMBLY_NAME: &'static str = "@winglang/sdk";
 
 const WINGSDK_STD_MODULE: &'static str = "std";
-const WINGSDK_FS_MODULE: &'static str = "fs";
 const WINGSDK_REDIS_MODULE: &'static str = "redis";
 const WINGSDK_CLOUD_MODULE: &'static str = "cloud";
 const WINGSDK_UTIL_MODULE: &'static str = "util";

--- a/libs/wingc/src/type_check.rs
+++ b/libs/wingc/src/type_check.rs
@@ -10,9 +10,9 @@ use crate::ast::{
 };
 use crate::diagnostic::{Diagnostic, Diagnostics, TypeError, WingSpan};
 use crate::{
-	debug, WINGSDK_ARRAY, WINGSDK_ASSEMBLY_NAME, WINGSDK_CLOUD_MODULE, WINGSDK_DURATION, WINGSDK_FS_MODULE, WINGSDK_JSON,
-	WINGSDK_MAP, WINGSDK_MUT_ARRAY, WINGSDK_MUT_JSON, WINGSDK_MUT_MAP, WINGSDK_MUT_SET, WINGSDK_REDIS_MODULE,
-	WINGSDK_RESOURCE, WINGSDK_SET, WINGSDK_STD_MODULE, WINGSDK_STRING, WINGSDK_UTIL_MODULE,
+	debug, WINGSDK_ARRAY, WINGSDK_ASSEMBLY_NAME, WINGSDK_CLOUD_MODULE, WINGSDK_DURATION, WINGSDK_JSON, WINGSDK_MAP,
+	WINGSDK_MUT_ARRAY, WINGSDK_MUT_JSON, WINGSDK_MUT_MAP, WINGSDK_MUT_SET, WINGSDK_REDIS_MODULE, WINGSDK_RESOURCE,
+	WINGSDK_SET, WINGSDK_STD_MODULE, WINGSDK_STRING, WINGSDK_UTIL_MODULE,
 };
 use derivative::Derivative;
 use indexmap::{IndexMap, IndexSet};
@@ -2167,9 +2167,9 @@ impl<'a> TypeChecker<'a> {
 						// If the module name is a built-in module, then we use @winglang/sdk as the library name,
 						// and import the module as a namespace. If the user doesn't specify an identifier, then
 						// we use the module name as the identifier.
-						// For example, `bring fs` will import the `fs` namespace from @winglang/sdk and assign it
-						// to an identifier named `fs`.
-						WINGSDK_CLOUD_MODULE | WINGSDK_FS_MODULE | WINGSDK_REDIS_MODULE | WINGSDK_UTIL_MODULE => {
+						// For example, `bring cloud` will import the `cloud` namespace from @winglang/sdk and assign it
+						// to an identifier named `cloud`.
+						WINGSDK_CLOUD_MODULE | WINGSDK_REDIS_MODULE | WINGSDK_UTIL_MODULE => {
 							library_name = WINGSDK_ASSEMBLY_NAME.to_string();
 							namespace_filter = vec![module_name.name.clone()];
 							alias = identifier.as_ref().unwrap_or(&module_name);

--- a/libs/wingsdk/src/cloud/bucket.md
+++ b/libs/wingsdk/src/cloud/bucket.md
@@ -105,7 +105,7 @@ The Google Cloud implementation of `cloud.Bucket` uses [Google Cloud Storage](ht
 
 ## API Reference
 
-The full list of APIs for `cloud.Secret` is available in the [API Reference](../05-reference/wingsdk-api.md).
+The full list of APIs for `cloud.Bucket` is available in the [API Reference](../05-reference/wingsdk-api.md).
 
 
 

--- a/tools/hangar/__snapshots__/invalid.ts.snap
+++ b/tools/hangar/__snapshots__/invalid.ts.snap
@@ -76,6 +76,13 @@ error: \\"cloud\\" is already defined
 4 | bring cloud;
   |       ^^^^^ \\"cloud\\" is already defined
 
+
+error: \\"fs\\" is not a built-in module
+  --> ../../../examples/tests/invalid/bring.w:6:1
+  |
+6 | bring fs;
+  | ^^^^^^^^^ \\"fs\\" is not a built-in module
+
 "
 `;
 


### PR DESCRIPTION
`bring fs;` causes a compiler panic. 
We used to have a built-in `fs` module, which we removed a while ago. The panic happens because of some leftover code resolving this module.

Fixes #2668

## Misc
Also fixed a small typo in Bucket resource documentation.

## Checklist

- [x] Title matches [Winglang's style guide](https://docs.winglang.io/contributors/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [x] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.
