### PR TITLE
fix(docs): misspelling in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ It includes an assembly of different features that serve that purpose:
 * [JavaScript interoperability](https://docs.winglang.io/reference/spec#5-interoperability).
 * [Distributed computing primitives](https://docs.winglang.io/concepts/inflights).
 * Automatic generation of IAM policies and other cloud mechanics based on intent.
-* Local functional simulaor with a visualization and interaction [console](https://docs.winglang.io/getting-started/installation#wing-console) - used for testing and debugging with instant hot-reloading. 
+* Local functional simulator with a visualization and interaction [console](https://docs.winglang.io/getting-started/installation#wing-console) - used for testing and debugging with instant hot-reloading. 
 * [Native JSON](https://docs.winglang.io/reference/spec#114-json-type) and schema validation support.
 * [Default immutability](https://docs.winglang.io/blog/2023/02/02/good-cognitive-friction#immutable-by-default).
 * [Implicit async](https://docs.winglang.io/reference/spec#113-asynchronous-model), explicit defer.


### PR DESCRIPTION
Correct misspelling of "simulator" in README.md.

## Checklist

- [x] Title matches [Winglang's style guide](https://docs.winglang.io/contributors/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.
