### PR TITLE
chore(compiler): debug wingc on vscode

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,7 +9,7 @@
       "id": "wingSource",
       "type": "promptString",
       "description": "Wing source path",
-      "default": "${workspaceFolder}/temp/tst.w"
+      "default": "${workspaceFolder}/examples/tests/valid/hello.w"
     }
   ],
   "configurations": [

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -4,6 +4,14 @@
 // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
 {
   "version": "0.2.0",
+  "inputs": [
+    {
+      "id": "wingSource",
+      "type": "promptString",
+      "description": "Wing source path",
+      "default": "${workspaceFolder}/temp/tst.w"
+    }
+  ],
   "configurations": [
     {
       "command": "npx nx wing -- compile -t tf-aws ..${pathSeparator}..${pathSeparator}${relativeFile}",
@@ -42,6 +50,25 @@
         "--disable-extensions",
         "--extensionDevelopmentPath=${workspaceFolder}/apps/vscode-wing"
       ]
-    }
+    },
+    {
+      "name": "Debug Wing Compiler",
+      "type": "lldb",
+      "request": "launch",
+      "cwd": "${workspaceFolder}/libs/wingc",
+      "cargo": {
+        "args": [
+          "build",
+          "--example",
+          "compile"
+        ]
+      },
+      "args": [
+        "${input:wingSource}"
+      ],
+      "sourceLanguages": [
+        "rust"
+      ],
+    },
   ]
 }

--- a/docs/06-contributors/020-development.md
+++ b/docs/06-contributors/020-development.md
@@ -197,6 +197,13 @@ You can show clippy errors in your IDE by installing the [rust-analyzer](https:/
 
 The [insta](https://marketplace.visualstudio.com/items?itemName=mitsuhiko.insta) extension allows you to view snapshots in the tests files.
 
+## How do I debug the Wing compiler on VSCode?
+
+To debug the Rust compiler on VSCode, first you need to install the [CodeLLDB extension](https://marketplace.visualstudio.com/items?itemName=vadimcn.vscode-lldb).<br/>
+Next, you can use the `Debug Wing Compiler` launch configuration available on our [launch.json](https://github.com/winglang/wing/blob/main/.vscode/launch.json).
+
+Hit F5 to start debugging. You'll be prompted to insert the path to the `.w` file you want to debug.<br/>You can use the `${workspaceFolder}/examples/tests/valid/hello.w` file for example.
+
 ## How do I make changes to the Wing grammar?
 
 After making changes to `grammar.js`, run:


### PR DESCRIPTION
@yoav-steinberg added this launch configuration allowing to debug our Rust compiler code (wingc).
I also added a short section in the contributors guide.

Fixes #1104

## Checklist

- [x] Title matches [Winglang's style guide](https://docs.winglang.io/contributors/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [ ] Tests added (always)
- [x] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.
