### PR TITLE
fix(sdk): aws test when invoke function that returns null

### DIFF
--- a/libs/wingsdk/src/shared-aws/function.inflight.ts
+++ b/libs/wingsdk/src/shared-aws/function.inflight.ts
@@ -27,7 +27,10 @@ export class FunctionClient implements IFunctionClient {
     if (!response.Payload) {
       return "";
     }
-    const value = JSON.parse(toUtf8(response.Payload));
+    const value =
+      toUtf8(response.Payload) === "null"
+        ? ""
+        : JSON.parse(toUtf8(response.Payload));
     if (typeof value !== "string") {
       throw new Error(
         `function returned value of type ${typeof value}, not string`


### PR DESCRIPTION
The PR #2587 modification fixed tests that were returning strings when executed on AWS, but it created a problem when the function didn't return a value (null). This PR validates this return and returns an empty string in these cases.

## Checklist

- [x] Title matches [Winglang's style guide](https://docs.winglang.io/contributors/pull_requests#how-are-pull-request-titles-formatted)
- [ ] Description explains motivation and solution
- [ ] Tests added (always)
- [ ] Docs updated (only required for features)
- [x] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.
