### PR TITLE
fix: build process cwd is wrong in the console

### DIFF
--- a/libs/wingsdk/src/shared/bundling.ts
+++ b/libs/wingsdk/src/shared/bundling.ts
@@ -1,7 +1,7 @@
 import { spawnSync } from "child_process";
 import * as crypto from "crypto";
 import { mkdirSync, readFileSync, writeFileSync } from "fs";
-import { join } from "path";
+import { join, resolve } from "path";
 import { normalPath } from "./misc";
 
 export interface Bundle {
@@ -17,7 +17,7 @@ export interface Bundle {
  * @returns Bundle information
  */
 export function createBundle(entrypoint: string, outputDir?: string): Bundle {
-  const outdir = outputDir ?? entrypoint + ".bundle";
+  const outdir = resolve(outputDir ?? entrypoint + ".bundle");
   mkdirSync(outdir, { recursive: true });
   const outfile = join(outdir, "index.js");
 
@@ -32,16 +32,16 @@ export function createBundle(entrypoint: string, outputDir?: string): Bundle {
   // To workaround the issue, spawn a new process and invoke esbuild inside it.
 
   let esbuildScript = [
-    `const esbuild = require("${normalPath(
-      require.resolve("esbuild-wasm")
-    )}");`,
+    `const esbuild = require("esbuild-wasm");`,
     `esbuild.buildSync({ bundle: true, entryPoints: ["${normalPath(
-      entrypoint
+      resolve(entrypoint)
     )}"], outfile: "${normalPath(outfile)}", ${nodePathString}
     minify: false, platform: "node", target: "node16", external: ["aws-sdk"],
    });`,
   ].join("\n");
-  let result = spawnSync(process.argv[0], ["-e", esbuildScript]);
+  let result = spawnSync(process.argv[0], ["-e", esbuildScript], {
+    cwd: __dirname,
+  });
   if (result.status !== 0) {
     throw new Error(
       `Failed to bundle function: ${result.stderr.toString("utf-8")}`

--- a/libs/wingsdk/test/target-awscdk/__snapshots__/counter.test.ts.snap
+++ b/libs/wingsdk/test/target-awscdk/__snapshots__/counter.test.ts.snap
@@ -119,7 +119,7 @@ exports[`dec() policy statement 2`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "22b0a4eb2d63f0d60c9f3c9d8e3aa9042ecce68f227d50ead7166c1b7ad47138.zip",
+          "S3Key": "b91c356a9e3d0c6b21a460be695c530ab496d9530bc0fd26db3d6e3c13ec13d1.zip",
         },
         "Environment": {
           "Variables": {
@@ -347,7 +347,7 @@ exports[`function with a counter binding 2`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "80483b762bdbc9cf248861e74b656824400b4556cd6680e7319461708a4b36e9.zip",
+          "S3Key": "bd9aaef5b8f06ebc9b2a142c0e08354edd0429febf6261ad6f7421fb64c393b8.zip",
         },
         "Environment": {
           "Variables": {
@@ -514,7 +514,7 @@ exports[`inc() policy statement 2`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "80483b762bdbc9cf248861e74b656824400b4556cd6680e7319461708a4b36e9.zip",
+          "S3Key": "bd9aaef5b8f06ebc9b2a142c0e08354edd0429febf6261ad6f7421fb64c393b8.zip",
         },
         "Environment": {
           "Variables": {
@@ -681,7 +681,7 @@ exports[`peek() policy statement 2`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "0230363fe4a3edf2424cc347df4465d9d2f4f920d6e0a8885d6a589ff8c51f30.zip",
+          "S3Key": "28532282ee0b537c4c9ec8fcc0678b4fb8ae9dcab3655e7af8d6950a78b7fb55.zip",
         },
         "Environment": {
           "Variables": {
@@ -848,7 +848,7 @@ exports[`reset() policy statement 2`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "4fa9ba32ca72a89dd3f0f3b098c7b6470797e64dee35e181d0ad6ac61be23052.zip",
+          "S3Key": "c560ab42ad5f55c14e110751daa7dc5442edd1146909ef9179b58a2a5f5054e4.zip",
         },
         "Environment": {
           "Variables": {

--- a/libs/wingsdk/test/target-awscdk/__snapshots__/queue.test.ts.snap
+++ b/libs/wingsdk/test/target-awscdk/__snapshots__/queue.test.ts.snap
@@ -76,7 +76,7 @@ exports[`queue with a consumer function 2`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "feb941f4c7974d21accf66792f56ace54050bda25c72bf7c86ac21e241758bd3.zip",
+          "S3Key": "6162c1660855627f90a7b3c9766aab3c78c931f92624035ccd56b1478349e3dd.zip",
         },
         "Handler": "index.handler",
         "Role": {

--- a/libs/wingsdk/test/target-awscdk/__snapshots__/topic.test.ts.snap
+++ b/libs/wingsdk/test/target-awscdk/__snapshots__/topic.test.ts.snap
@@ -96,7 +96,7 @@ exports[`topic with multiple subscribers 3`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "70c96f4eb085d5d4284b479242d4d486d9bda405b98f6fc817ece5ead39f2bf2.zip",
+          "S3Key": "6a598b8ed493136c0a8bc11817a99dcbdac19d959b994266d2fc1efc3fb4c53d.zip",
         },
         "Handler": "index.handler",
         "Role": {
@@ -181,7 +181,7 @@ exports[`topic with multiple subscribers 3`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "15c5f36c8226db19dde5bfd00330127a4accccaa3e12cc960aab9c3de7ad1709.zip",
+          "S3Key": "a6acf7b1f7a5c45f5e745d7b249a7ef23edb786f151f47283c125c4c202613fd.zip",
         },
         "Handler": "index.handler",
         "Role": {
@@ -325,7 +325,7 @@ exports[`topic with subscriber function 2`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "4cb297fb007d66c747b23d2179881c6d2bb17d6f9c074160f22414c1d5c700d0.zip",
+          "S3Key": "630dd3605c813433f32d8d619f15f167b8faf68b78f425d96b2caaa76acd665e.zip",
         },
         "Handler": "index.handler",
         "Role": {


### PR DESCRIPTION
Adds the fix from #2687 but without the error that caused.

The fix to the introduced error is to resolve all relative paths to absolute paths (the outdir path and the entrypoint path).

This time, I built winglang and the sdk locally and installed them globally. See https://github.com/winglang/wing/pull/2703 for a PR that also includes a test for the old problem.