### PR TITLE
fix(compiler): calls and `if let` expressions evaluated twice

### DIFF
--- a/libs/wingc/src/jsify.rs
+++ b/libs/wingc/src/jsify.rs
@@ -407,10 +407,9 @@ impl<'a> JSifier<'a> {
 					}
 				}
 
-				match ctx.phase {
-					Phase::Inflight => format!("(typeof {} === \"function\" ? {}{}({}) : {}{}.handle({}))", expr_string, auto_await, expr_string, arg_string, auto_await, expr_string, arg_string),
-					Phase::Independent | Phase::Preflight => format!("({}{}({}))", auto_await, expr_string, arg_string),
-				}
+				// NOTE: if the expression is a "handle" class, the object itself is callable (see
+				// `jsify_class_inflight` below), so we can just call it as-is.
+				format!("({auto_await}{expr_string}({arg_string}))")
 			}
 			ExprKind::Unary { op, exp } => {
 				let js_exp = self.jsify_expression(exp, ctx);
@@ -620,7 +619,7 @@ impl<'a> JSifier<'a> {
 				// const x = "hello"
 				// {
 				//  const $IF_LET_VALUE = x; <== intermediate variable that expires at the end of the scope
-				//  if (x != undefined) {
+				//  if ($IF_LET_VALUE != undefined) {
 				//    const x = $IF_LET_VALUE;
 				//    log(x);
 				//  }
@@ -634,7 +633,7 @@ impl<'a> JSifier<'a> {
 					if_let_value,
 					self.jsify_expression(value, ctx)
 				));
-				code.open(format!("if ({} != undefined) {{", self.jsify_expression(value, ctx)));
+				code.open(format!("if ({if_let_value} != undefined) {{"));
 				code.line(format!("const {} = {};", var_name, if_let_value));
 				code.add_code(self.jsify_scope_body(statements, ctx));
 				code.close("}");
@@ -685,9 +684,7 @@ impl<'a> JSifier<'a> {
 			)),
 			StmtKind::Scope(scope) => {
 				let mut code = CodeMaker::default();
-				code.open("{");
 				code.add_code(self.jsify_scope_body(scope, ctx));
-				code.close("}");
 				code
 			}
 			StmtKind::Return(exp) => {
@@ -1212,6 +1209,14 @@ impl<'a> JSifier<'a> {
 
 		for name in &my_captures {
 			class_code.line(format!("this.{} = {};", name, name));
+		}
+
+		// if this class has a "handle" method, we are going to turn it into a callable function
+		// so that instances of this class can also be called like regular functions
+		if inflight_methods.iter().find(|(name, _)| name.name == HANDLE_METHOD_NAME).is_some() {
+			class_code.line(format!("const $obj = (...args) => this.{HANDLE_METHOD_NAME}(...args);"));
+			class_code.line("Object.setPrototypeOf($obj, this);");
+			class_code.line("return $obj;");
 		}
 
 		class_code.close("}");

--- a/libs/wingc/src/jsify.rs
+++ b/libs/wingc/src/jsify.rs
@@ -684,7 +684,9 @@ impl<'a> JSifier<'a> {
 			)),
 			StmtKind::Scope(scope) => {
 				let mut code = CodeMaker::default();
+				code.open("{");
 				code.add_code(self.jsify_scope_body(scope, ctx));
+				code.close("}");
 				code
 			}
 			StmtKind::Return(exp) => {
@@ -812,9 +814,7 @@ impl<'a> JSifier<'a> {
 		let body = match &func_def.body() {
 			FunctionBodyRef::Statements(scope) => {
 				let mut code = CodeMaker::default();
-				code.open("{");
 				code.add_code(self.jsify_scope_body(scope, ctx));
-				code.close("}");
 				code
 			}
 			FunctionBodyRef::External(external_spec) => {
@@ -1183,9 +1183,9 @@ impl<'a> JSifier<'a> {
 
 		let name = &resource.name.name;
 		class_code.open(format!(
-			"class {} {name} {{",
+			"class {name}{} {{",
 			if let Some(parent) = &resource.parent {
-				format!("extends {}", self.jsify_user_defined_type(parent))
+				format!(" extends {}", self.jsify_user_defined_type(parent))
 			} else {
 				"".to_string()
 			}

--- a/tools/hangar/__snapshots__/test_corpus/add_consumer.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/add_consumer.w_compile_tf-aws.md
@@ -5,10 +5,13 @@
 module.exports = function({ c }) {
   class  $Inflight1 {
     constructor({  }) {
+      const $obj = (...args) => this.handle(...args);
+      Object.setPrototypeOf($obj, this);
+      return $obj;
     }
     async handle(msg)  {
       {
-        (typeof c.inc === "function" ? await c.inc() : await c.inc.handle());
+        (await c.inc());
       }
     }
   }
@@ -22,21 +25,24 @@ module.exports = function({ c }) {
 module.exports = function({ q, predicate, js }) {
   class  $Inflight2 {
     constructor({  }) {
+      const $obj = (...args) => this.handle(...args);
+      Object.setPrototypeOf($obj, this);
+      return $obj;
     }
     async handle()  {
       {
-        (typeof q.push === "function" ? await q.push("hello") : await q.push.handle("hello"));
-        (typeof q.push === "function" ? await q.push("world") : await q.push.handle("world"));
+        (await q.push("hello"));
+        (await q.push("world"));
         let i = 0;
         while ((i < 600)) {
           i = (i + 1);
-          if ((typeof predicate.test === "function" ? await predicate.test() : await predicate.test.handle())) {
-            {((cond) => {if (!cond) throw new Error(`assertion failed: '(typeof predicate.test === "function" ? await predicate.test() : await predicate.test.handle())'`)})((typeof predicate.test === "function" ? await predicate.test() : await predicate.test.handle()))};
+          if ((await predicate.test())) {
+            {((cond) => {if (!cond) throw new Error(`assertion failed: '(await predicate.test())'`)})((await predicate.test()))};
             return;
           }
-          (typeof js.sleep === "function" ? await js.sleep(100) : await js.sleep.handle(100));
+          (await js.sleep(100));
         }
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '(typeof predicate.test === "function" ? await predicate.test() : await predicate.test.handle())'`)})((typeof predicate.test === "function" ? await predicate.test() : await predicate.test.handle()))};
+        {((cond) => {if (!cond) throw new Error(`assertion failed: '(await predicate.test())'`)})((await predicate.test()))};
       }
     }
   }
@@ -55,7 +61,7 @@ module.exports = function({  }) {
     async test()  {
       {
         const __parent_this = this;
-        return ((typeof this.c.peek === "function" ? await this.c.peek() : await this.c.peek.handle()) === 2);
+        return ((await this.c.peek()) === 2);
       }
     }
   }

--- a/tools/hangar/__snapshots__/test_corpus/add_consumer.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/add_consumer.w_compile_tf-aws.md
@@ -3,16 +3,14 @@
 ## clients/$Inflight1.inflight.js
 ```js
 module.exports = function({ c }) {
-  class  $Inflight1 {
+  class $Inflight1 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
       Object.setPrototypeOf($obj, this);
       return $obj;
     }
     async handle(msg)  {
-      {
-        (await c.inc());
-      }
+      (await c.inc());
     }
   }
   return $Inflight1;
@@ -23,27 +21,25 @@ module.exports = function({ c }) {
 ## clients/$Inflight2.inflight.js
 ```js
 module.exports = function({ q, predicate, js }) {
-  class  $Inflight2 {
+  class $Inflight2 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
       Object.setPrototypeOf($obj, this);
       return $obj;
     }
     async handle()  {
-      {
-        (await q.push("hello"));
-        (await q.push("world"));
-        let i = 0;
-        while ((i < 600)) {
-          i = (i + 1);
-          if ((await predicate.test())) {
-            {((cond) => {if (!cond) throw new Error(`assertion failed: '(await predicate.test())'`)})((await predicate.test()))};
-            return;
-          }
-          (await js.sleep(100));
+      (await q.push("hello"));
+      (await q.push("world"));
+      let i = 0;
+      while ((i < 600)) {
+        i = (i + 1);
+        if ((await predicate.test())) {
+          {((cond) => {if (!cond) throw new Error(`assertion failed: '(await predicate.test())'`)})((await predicate.test()))};
+          return;
         }
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '(await predicate.test())'`)})((await predicate.test()))};
+        (await js.sleep(100));
       }
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '(await predicate.test())'`)})((await predicate.test()))};
     }
   }
   return $Inflight2;
@@ -54,15 +50,13 @@ module.exports = function({ q, predicate, js }) {
 ## clients/Predicate.inflight.js
 ```js
 module.exports = function({  }) {
-  class  Predicate {
+  class Predicate {
     constructor({ c }) {
       this.c = c;
     }
     async test()  {
-      {
-        const __parent_this = this;
-        return ((await this.c.peek()) === 2);
-      }
+      const __parent_this = this;
+      return ((await this.c.peek()) === 2);
     }
   }
   return Predicate;
@@ -73,7 +67,7 @@ module.exports = function({  }) {
 ## clients/TestHelper.inflight.js
 ```js
 module.exports = function({  }) {
-  class  TestHelper {
+  class TestHelper {
     constructor({  }) {
     }
     async sleep(milli)  {

--- a/tools/hangar/__snapshots__/test_corpus/anon_function.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/anon_function.w_compile_tf-aws.md
@@ -42,21 +42,17 @@ class $Root extends $stdlib.std.Resource {
   constructor(scope, id) {
     super(scope, id);
     const myfunc =  (x) =>  {
-      {
-        {console.log(`${x}`)};
-        x = (x + 1);
-        if ((x > 3.14)) {
-          return;
-        }
-        (myfunc(x));
+      {console.log(`${x}`)};
+      x = (x + 1);
+      if ((x > 3.14)) {
+        return;
       }
+      (myfunc(x));
     }
     ;
     (myfunc(1));
     (( (x) =>  {
-      {
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '(x === 1)'`)})((x === 1))};
-      }
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '(x === 1)'`)})((x === 1))};
     }
     )(1));
   }

--- a/tools/hangar/__snapshots__/test_corpus/api.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/api.w_compile_tf-aws.md
@@ -3,22 +3,20 @@
 ## clients/$Inflight1.inflight.js
 ```js
 module.exports = function({ counter }) {
-  class  $Inflight1 {
+  class $Inflight1 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
       Object.setPrototypeOf($obj, this);
       return $obj;
     }
     async handle(request)  {
-      {
-        const count = (await counter.inc());
-        const bodyResponse = Object.freeze({"count":count});
-        const resp = {
-        "body": bodyResponse,
-        "status": 200,}
-        ;
-        return resp;
-      }
+      const count = (await counter.inc());
+      const bodyResponse = Object.freeze({"count":count});
+      const resp = {
+      "body": bodyResponse,
+      "status": 200,}
+      ;
+      return resp;
     }
   }
   return $Inflight1;
@@ -29,17 +27,15 @@ module.exports = function({ counter }) {
 ## clients/$Inflight2.inflight.js
 ```js
 module.exports = function({ api }) {
-  class  $Inflight2 {
+  class $Inflight2 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
       Object.setPrototypeOf($obj, this);
       return $obj;
     }
     async handle()  {
-      {
-        const url = api.url;
-        {((cond) => {if (!cond) throw new Error(`assertion failed: 'url.startsWith("http")'`)})(url.startsWith("http"))};
-      }
+      const url = api.url;
+      {((cond) => {if (!cond) throw new Error(`assertion failed: 'url.startsWith("http")'`)})(url.startsWith("http"))};
     }
   }
   return $Inflight2;
@@ -50,20 +46,18 @@ module.exports = function({ api }) {
 ## clients/$Inflight3.inflight.js
 ```js
 module.exports = function({ __parent_this }) {
-  class  $Inflight3 {
+  class $Inflight3 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
       Object.setPrototypeOf($obj, this);
       return $obj;
     }
     async handle(req)  {
-      {
-        const text = `${__parent_this.api.url}/endpoint2`;
-        return {
-        "status": 200,
-        "body": text,}
-        ;
-      }
+      const text = `${__parent_this.api.url}/endpoint2`;
+      return {
+      "status": 200,
+      "body": text,}
+      ;
     }
   }
   return $Inflight3;
@@ -74,7 +68,7 @@ module.exports = function({ __parent_this }) {
 ## clients/A.inflight.js
 ```js
 module.exports = function({  }) {
-  class  A {
+  class A {
     constructor({ api }) {
       this.api = api;
     }

--- a/tools/hangar/__snapshots__/test_corpus/api.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/api.w_compile_tf-aws.md
@@ -5,10 +5,13 @@
 module.exports = function({ counter }) {
   class  $Inflight1 {
     constructor({  }) {
+      const $obj = (...args) => this.handle(...args);
+      Object.setPrototypeOf($obj, this);
+      return $obj;
     }
     async handle(request)  {
       {
-        const count = (typeof counter.inc === "function" ? await counter.inc() : await counter.inc.handle());
+        const count = (await counter.inc());
         const bodyResponse = Object.freeze({"count":count});
         const resp = {
         "body": bodyResponse,
@@ -28,6 +31,9 @@ module.exports = function({ counter }) {
 module.exports = function({ api }) {
   class  $Inflight2 {
     constructor({  }) {
+      const $obj = (...args) => this.handle(...args);
+      Object.setPrototypeOf($obj, this);
+      return $obj;
     }
     async handle()  {
       {
@@ -46,6 +52,9 @@ module.exports = function({ api }) {
 module.exports = function({ __parent_this }) {
   class  $Inflight3 {
     constructor({  }) {
+      const $obj = (...args) => this.handle(...args);
+      Object.setPrototypeOf($obj, this);
+      return $obj;
     }
     async handle(req)  {
       {

--- a/tools/hangar/__snapshots__/test_corpus/api_path_vars.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/api_path_vars.w_compile_tf-aws.md
@@ -5,6 +5,9 @@
 module.exports = function({  }) {
   class  $Inflight1 {
     constructor({  }) {
+      const $obj = (...args) => this.handle(...args);
+      Object.setPrototypeOf($obj, this);
+      return $obj;
     }
     async handle(req)  {
       {
@@ -25,11 +28,14 @@ module.exports = function({  }) {
 module.exports = function({ f, api }) {
   class  $Inflight2 {
     constructor({  }) {
+      const $obj = (...args) => this.handle(...args);
+      Object.setPrototypeOf($obj, this);
+      return $obj;
     }
     async handle()  {
       {
         const username = "tsuf";
-        const res = (typeof f.get === "function" ? await f.get(`${api.url}/users/${username}`) : await f.get.handle(`${api.url}/users/${username}`));
+        const res = (await f.get(`${api.url}/users/${username}`));
         {((cond) => {if (!cond) throw new Error(`assertion failed: '((res)["status"] === 200)'`)})(((res)["status"] === 200))};
         {((cond) => {if (!cond) throw new Error(`assertion failed: '(((res)["body"])["user"] === username)'`)})((((res)["body"])["user"] === username))};
       }

--- a/tools/hangar/__snapshots__/test_corpus/api_path_vars.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/api_path_vars.w_compile_tf-aws.md
@@ -3,19 +3,17 @@
 ## clients/$Inflight1.inflight.js
 ```js
 module.exports = function({  }) {
-  class  $Inflight1 {
+  class $Inflight1 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
       Object.setPrototypeOf($obj, this);
       return $obj;
     }
     async handle(req)  {
-      {
-        return {
-        "body": Object.freeze({"user":(req.vars)["name"]}),
-        "status": 200,}
-        ;
-      }
+      return {
+      "body": Object.freeze({"user":(req.vars)["name"]}),
+      "status": 200,}
+      ;
     }
   }
   return $Inflight1;
@@ -26,19 +24,17 @@ module.exports = function({  }) {
 ## clients/$Inflight2.inflight.js
 ```js
 module.exports = function({ f, api }) {
-  class  $Inflight2 {
+  class $Inflight2 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
       Object.setPrototypeOf($obj, this);
       return $obj;
     }
     async handle()  {
-      {
-        const username = "tsuf";
-        const res = (await f.get(`${api.url}/users/${username}`));
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((res)["status"] === 200)'`)})(((res)["status"] === 200))};
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '(((res)["body"])["user"] === username)'`)})((((res)["body"])["user"] === username))};
-      }
+      const username = "tsuf";
+      const res = (await f.get(`${api.url}/users/${username}`));
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '((res)["status"] === 200)'`)})(((res)["status"] === 200))};
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '(((res)["body"])["user"] === username)'`)})((((res)["body"])["user"] === username))};
     }
   }
   return $Inflight2;
@@ -49,7 +45,7 @@ module.exports = function({ f, api }) {
 ## clients/Fetch.inflight.js
 ```js
 module.exports = function({  }) {
-  class  Fetch {
+  class Fetch {
     constructor({  }) {
     }
     async get(url)  {

--- a/tools/hangar/__snapshots__/test_corpus/api_valid_path.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/api_valid_path.w_compile_tf-aws.md
@@ -3,19 +3,17 @@
 ## clients/$Inflight1.inflight.js
 ```js
 module.exports = function({  }) {
-  class  $Inflight1 {
+  class $Inflight1 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
       Object.setPrototypeOf($obj, this);
       return $obj;
     }
     async handle(req)  {
-      {
-        return {
-        "body": "ok",
-        "status": 200,}
-        ;
-      }
+      return {
+      "body": "ok",
+      "status": 200,}
+      ;
     }
   }
   return $Inflight1;
@@ -309,32 +307,28 @@ class $Root extends $stdlib.std.Resource {
     const api = this.node.root.newAbstract("@winglang/sdk.cloud.Api",this,"cloud.Api");
     const handler = new $Inflight1(this,"$Inflight1");
     const testInvalidPath =  (path) =>  {
-      {
-        let error = "";
-        const expected = `Invalid path ${path}. Url cannot contain \":\", params contains only alpha-numeric chars or \"_\".`;
-        try {
-          (api.get(path,handler));
-        }
-        catch ($error_e) {
-          const e = $error_e.message;
-          error = e;
-        }
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '(error === expected)'`)})((error === expected))};
+      let error = "";
+      const expected = `Invalid path ${path}. Url cannot contain \":\", params contains only alpha-numeric chars or \"_\".`;
+      try {
+        (api.get(path,handler));
       }
+      catch ($error_e) {
+        const e = $error_e.message;
+        error = e;
+      }
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '(error === expected)'`)})((error === expected))};
     }
     ;
     const testValidPath =  (path) =>  {
-      {
-        let error = "";
-        try {
-          (api.get(path,handler));
-        }
-        catch ($error_e) {
-          const e = $error_e.message;
-          error = e;
-        }
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '(error === "")'`)})((error === ""))};
+      let error = "";
+      try {
+        (api.get(path,handler));
       }
+      catch ($error_e) {
+        const e = $error_e.message;
+        error = e;
+      }
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '(error === "")'`)})((error === ""))};
     }
     ;
     (testInvalidPath("/test/{sup:er/:annoying//path}"));

--- a/tools/hangar/__snapshots__/test_corpus/api_valid_path.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/api_valid_path.w_compile_tf-aws.md
@@ -5,6 +5,9 @@
 module.exports = function({  }) {
   class  $Inflight1 {
     constructor({  }) {
+      const $obj = (...args) => this.handle(...args);
+      Object.setPrototypeOf($obj, this);
+      return $obj;
     }
     async handle(req)  {
       {

--- a/tools/hangar/__snapshots__/test_corpus/approx_size.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/approx_size.w_compile_tf-aws.md
@@ -3,18 +3,16 @@
 ## clients/$Inflight1.inflight.js
 ```js
 module.exports = function({ q }) {
-  class  $Inflight1 {
+  class $Inflight1 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
       Object.setPrototypeOf($obj, this);
       return $obj;
     }
     async handle()  {
-      {
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await q.approxSize()) === 0)'`)})(((await q.approxSize()) === 0))};
-        (await q.push("message"));
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await q.approxSize()) === 1)'`)})(((await q.approxSize()) === 1))};
-      }
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '((await q.approxSize()) === 0)'`)})(((await q.approxSize()) === 0))};
+      (await q.push("message"));
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '((await q.approxSize()) === 1)'`)})(((await q.approxSize()) === 1))};
     }
   }
   return $Inflight1;

--- a/tools/hangar/__snapshots__/test_corpus/approx_size.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/approx_size.w_compile_tf-aws.md
@@ -5,12 +5,15 @@
 module.exports = function({ q }) {
   class  $Inflight1 {
     constructor({  }) {
+      const $obj = (...args) => this.handle(...args);
+      Object.setPrototypeOf($obj, this);
+      return $obj;
     }
     async handle()  {
       {
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((typeof q.approxSize === "function" ? await q.approxSize() : await q.approxSize.handle()) === 0)'`)})(((typeof q.approxSize === "function" ? await q.approxSize() : await q.approxSize.handle()) === 0))};
-        (typeof q.push === "function" ? await q.push("message") : await q.push.handle("message"));
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((typeof q.approxSize === "function" ? await q.approxSize() : await q.approxSize.handle()) === 1)'`)})(((typeof q.approxSize === "function" ? await q.approxSize() : await q.approxSize.handle()) === 1))};
+        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await q.approxSize()) === 0)'`)})(((await q.approxSize()) === 0))};
+        (await q.push("message"));
+        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await q.approxSize()) === 1)'`)})(((await q.approxSize()) === 1))};
       }
     }
   }

--- a/tools/hangar/__snapshots__/test_corpus/asynchronous_model_implicit_await_in_functions.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/asynchronous_model_implicit_await_in_functions.w_compile_tf-aws.md
@@ -3,15 +3,13 @@
 ## clients/$Inflight1.inflight.js
 ```js
 module.exports = function({  }) {
-  class  $Inflight1 {
+  class $Inflight1 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
       Object.setPrototypeOf($obj, this);
       return $obj;
     }
     async handle(s)  {
-      {
-      }
     }
   }
   return $Inflight1;
@@ -22,17 +20,15 @@ module.exports = function({  }) {
 ## clients/$Inflight2.inflight.js
 ```js
 module.exports = function({ strToStr }) {
-  class  $Inflight2 {
+  class $Inflight2 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
       Object.setPrototypeOf($obj, this);
       return $obj;
     }
     async handle(s)  {
-      {
-        (await strToStr.invoke("one"));
-        {console.log((await strToStr.invoke("two")))};
-      }
+      (await strToStr.invoke("one"));
+      {console.log((await strToStr.invoke("two")))};
     }
   }
   return $Inflight2;

--- a/tools/hangar/__snapshots__/test_corpus/asynchronous_model_implicit_await_in_functions.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/asynchronous_model_implicit_await_in_functions.w_compile_tf-aws.md
@@ -5,6 +5,9 @@
 module.exports = function({  }) {
   class  $Inflight1 {
     constructor({  }) {
+      const $obj = (...args) => this.handle(...args);
+      Object.setPrototypeOf($obj, this);
+      return $obj;
     }
     async handle(s)  {
       {
@@ -21,11 +24,14 @@ module.exports = function({  }) {
 module.exports = function({ strToStr }) {
   class  $Inflight2 {
     constructor({  }) {
+      const $obj = (...args) => this.handle(...args);
+      Object.setPrototypeOf($obj, this);
+      return $obj;
     }
     async handle(s)  {
       {
-        (typeof strToStr.invoke === "function" ? await strToStr.invoke("one") : await strToStr.invoke.handle("one"));
-        {console.log((typeof strToStr.invoke === "function" ? await strToStr.invoke("two") : await strToStr.invoke.handle("two")))};
+        (await strToStr.invoke("one"));
+        {console.log((await strToStr.invoke("two")))};
       }
     }
   }

--- a/tools/hangar/__snapshots__/test_corpus/bring_awscdk.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/bring_awscdk.w_compile_tf-aws.md
@@ -3,7 +3,7 @@
 ## clients/CdkDockerImageFunction.inflight.js
 ```js
 module.exports = function({  }) {
-  class  CdkDockerImageFunction {
+  class CdkDockerImageFunction {
     constructor({ function }) {
       this.function = function;
     }

--- a/tools/hangar/__snapshots__/test_corpus/bring_jsii.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/bring_jsii.w_compile_tf-aws.md
@@ -3,16 +3,14 @@
 ## clients/$Inflight1.inflight.js
 ```js
 module.exports = function({ greeting }) {
-  class  $Inflight1 {
+  class $Inflight1 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
       Object.setPrototypeOf($obj, this);
       return $obj;
     }
     async handle()  {
-      {
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '(greeting === "Hello, wingnuts")'`)})((greeting === "Hello, wingnuts"))};
-      }
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '(greeting === "Hello, wingnuts")'`)})((greeting === "Hello, wingnuts"))};
     }
   }
   return $Inflight1;

--- a/tools/hangar/__snapshots__/test_corpus/bring_jsii.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/bring_jsii.w_compile_tf-aws.md
@@ -5,6 +5,9 @@
 module.exports = function({ greeting }) {
   class  $Inflight1 {
     constructor({  }) {
+      const $obj = (...args) => this.handle(...args);
+      Object.setPrototypeOf($obj, this);
+      return $obj;
     }
     async handle()  {
       {

--- a/tools/hangar/__snapshots__/test_corpus/bring_jsii_path.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/bring_jsii_path.w_compile_tf-aws.md
@@ -3,16 +3,14 @@
 ## clients/$Inflight1.inflight.js
 ```js
 module.exports = function({ greeting }) {
-  class  $Inflight1 {
+  class $Inflight1 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
       Object.setPrototypeOf($obj, this);
       return $obj;
     }
     async handle()  {
-      {
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '(greeting === "Hello, wingnuts")'`)})((greeting === "Hello, wingnuts"))};
-      }
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '(greeting === "Hello, wingnuts")'`)})((greeting === "Hello, wingnuts"))};
     }
   }
   return $Inflight1;

--- a/tools/hangar/__snapshots__/test_corpus/bring_jsii_path.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/bring_jsii_path.w_compile_tf-aws.md
@@ -5,6 +5,9 @@
 module.exports = function({ greeting }) {
   class  $Inflight1 {
     constructor({  }) {
+      const $obj = (...args) => this.handle(...args);
+      Object.setPrototypeOf($obj, this);
+      return $obj;
     }
     async handle()  {
       {

--- a/tools/hangar/__snapshots__/test_corpus/bucket_events.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/bucket_events.w_compile_tf-aws.md
@@ -5,6 +5,9 @@
 module.exports = function({  }) {
   class  $Inflight1 {
     constructor({  }) {
+      const $obj = (...args) => this.handle(...args);
+      Object.setPrototypeOf($obj, this);
+      return $obj;
     }
     async handle(key)  {
       {
@@ -22,6 +25,9 @@ module.exports = function({  }) {
 module.exports = function({  }) {
   class  $Inflight2 {
     constructor({  }) {
+      const $obj = (...args) => this.handle(...args);
+      Object.setPrototypeOf($obj, this);
+      return $obj;
     }
     async handle(key)  {
       {
@@ -39,6 +45,9 @@ module.exports = function({  }) {
 module.exports = function({  }) {
   class  $Inflight3 {
     constructor({  }) {
+      const $obj = (...args) => this.handle(...args);
+      Object.setPrototypeOf($obj, this);
+      return $obj;
     }
     async handle(key)  {
       {
@@ -56,11 +65,14 @@ module.exports = function({  }) {
 module.exports = function({ other }) {
   class  $Inflight4 {
     constructor({  }) {
+      const $obj = (...args) => this.handle(...args);
+      Object.setPrototypeOf($obj, this);
+      return $obj;
     }
     async handle(key)  {
       {
         {console.log(`last key ${key}`)};
-        (typeof other.put === "function" ? await other.put("last_operation_key",((args) => { return JSON.stringify(args[0], null, args[1]) })([key])) : await other.put.handle("last_operation_key",((args) => { return JSON.stringify(args[0], null, args[1]) })([key])));
+        (await other.put("last_operation_key",((args) => { return JSON.stringify(args[0], null, args[1]) })([key])));
       }
     }
   }
@@ -74,6 +86,9 @@ module.exports = function({ other }) {
 module.exports = function({  }) {
   class  $Inflight5 {
     constructor({  }) {
+      const $obj = (...args) => this.handle(...args);
+      Object.setPrototypeOf($obj, this);
+      return $obj;
     }
     async handle(key)  {
       {
@@ -91,14 +106,17 @@ module.exports = function({  }) {
 module.exports = function({ b }) {
   class  $Inflight6 {
     constructor({  }) {
+      const $obj = (...args) => this.handle(...args);
+      Object.setPrototypeOf($obj, this);
+      return $obj;
     }
     async handle()  {
       {
-        (typeof b.put === "function" ? await b.put("a","1") : await b.put.handle("a","1"));
-        (typeof b.put === "function" ? await b.put("b","1") : await b.put.handle("b","1"));
-        (typeof b.put === "function" ? await b.put("b","100") : await b.put.handle("b","100"));
-        (typeof b.put === "function" ? await b.put("c","1") : await b.put.handle("c","1"));
-        (typeof b.delete === "function" ? await b.delete("c") : await b.delete.handle("c"));
+        (await b.put("a","1"));
+        (await b.put("b","1"));
+        (await b.put("b","100"));
+        (await b.put("c","1"));
+        (await b.delete("c"));
       }
     }
   }

--- a/tools/hangar/__snapshots__/test_corpus/bucket_events.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/bucket_events.w_compile_tf-aws.md
@@ -3,16 +3,14 @@
 ## clients/$Inflight1.inflight.js
 ```js
 module.exports = function({  }) {
-  class  $Inflight1 {
+  class $Inflight1 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
       Object.setPrototypeOf($obj, this);
       return $obj;
     }
     async handle(key)  {
-      {
-        {console.log(`deleted ${key}`)};
-      }
+      {console.log(`deleted ${key}`)};
     }
   }
   return $Inflight1;
@@ -23,16 +21,14 @@ module.exports = function({  }) {
 ## clients/$Inflight2.inflight.js
 ```js
 module.exports = function({  }) {
-  class  $Inflight2 {
+  class $Inflight2 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
       Object.setPrototypeOf($obj, this);
       return $obj;
     }
     async handle(key)  {
-      {
-        {console.log(`updated ${key}`)};
-      }
+      {console.log(`updated ${key}`)};
     }
   }
   return $Inflight2;
@@ -43,16 +39,14 @@ module.exports = function({  }) {
 ## clients/$Inflight3.inflight.js
 ```js
 module.exports = function({  }) {
-  class  $Inflight3 {
+  class $Inflight3 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
       Object.setPrototypeOf($obj, this);
       return $obj;
     }
     async handle(key)  {
-      {
-        {console.log(`created ${key}`)};
-      }
+      {console.log(`created ${key}`)};
     }
   }
   return $Inflight3;
@@ -63,17 +57,15 @@ module.exports = function({  }) {
 ## clients/$Inflight4.inflight.js
 ```js
 module.exports = function({ other }) {
-  class  $Inflight4 {
+  class $Inflight4 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
       Object.setPrototypeOf($obj, this);
       return $obj;
     }
     async handle(key)  {
-      {
-        {console.log(`last key ${key}`)};
-        (await other.put("last_operation_key",((args) => { return JSON.stringify(args[0], null, args[1]) })([key])));
-      }
+      {console.log(`last key ${key}`)};
+      (await other.put("last_operation_key",((args) => { return JSON.stringify(args[0], null, args[1]) })([key])));
     }
   }
   return $Inflight4;
@@ -84,16 +76,14 @@ module.exports = function({ other }) {
 ## clients/$Inflight5.inflight.js
 ```js
 module.exports = function({  }) {
-  class  $Inflight5 {
+  class $Inflight5 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
       Object.setPrototypeOf($obj, this);
       return $obj;
     }
     async handle(key)  {
-      {
-        {console.log("other bucket event called!")};
-      }
+      {console.log("other bucket event called!")};
     }
   }
   return $Inflight5;
@@ -104,20 +94,18 @@ module.exports = function({  }) {
 ## clients/$Inflight6.inflight.js
 ```js
 module.exports = function({ b }) {
-  class  $Inflight6 {
+  class $Inflight6 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
       Object.setPrototypeOf($obj, this);
       return $obj;
     }
     async handle()  {
-      {
-        (await b.put("a","1"));
-        (await b.put("b","1"));
-        (await b.put("b","100"));
-        (await b.put("c","1"));
-        (await b.delete("c"));
-      }
+      (await b.put("a","1"));
+      (await b.put("b","1"));
+      (await b.put("b","100"));
+      (await b.put("c","1"));
+      (await b.delete("c"));
     }
   }
   return $Inflight6;

--- a/tools/hangar/__snapshots__/test_corpus/bucket_keys.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/bucket_keys.w_compile_tf-aws.md
@@ -5,20 +5,23 @@
 module.exports = function({ b }) {
   class  $Inflight1 {
     constructor({  }) {
+      const $obj = (...args) => this.handle(...args);
+      Object.setPrototypeOf($obj, this);
+      return $obj;
     }
     async handle()  {
       {
-        (typeof b.put === "function" ? await b.put("foo","text") : await b.put.handle("foo","text"));
-        (typeof b.put === "function" ? await b.put("foo/","text") : await b.put.handle("foo/","text"));
-        (typeof b.put === "function" ? await b.put("foo/bar","text") : await b.put.handle("foo/bar","text"));
-        (typeof b.put === "function" ? await b.put("foo/bar/","text") : await b.put.handle("foo/bar/","text"));
-        (typeof b.put === "function" ? await b.put("foo/bar/baz","text") : await b.put.handle("foo/bar/baz","text"));
-        const objs = (typeof b.list === "function" ? await b.list() : await b.list.handle());
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((typeof objs.at === "function" ? await objs.at(0) : await objs.at.handle(0)) === "foo")'`)})(((typeof objs.at === "function" ? await objs.at(0) : await objs.at.handle(0)) === "foo"))};
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((typeof objs.at === "function" ? await objs.at(1) : await objs.at.handle(1)) === "foo/")'`)})(((typeof objs.at === "function" ? await objs.at(1) : await objs.at.handle(1)) === "foo/"))};
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((typeof objs.at === "function" ? await objs.at(2) : await objs.at.handle(2)) === "foo/bar")'`)})(((typeof objs.at === "function" ? await objs.at(2) : await objs.at.handle(2)) === "foo/bar"))};
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((typeof objs.at === "function" ? await objs.at(3) : await objs.at.handle(3)) === "foo/bar/")'`)})(((typeof objs.at === "function" ? await objs.at(3) : await objs.at.handle(3)) === "foo/bar/"))};
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((typeof objs.at === "function" ? await objs.at(4) : await objs.at.handle(4)) === "foo/bar/baz")'`)})(((typeof objs.at === "function" ? await objs.at(4) : await objs.at.handle(4)) === "foo/bar/baz"))};
+        (await b.put("foo","text"));
+        (await b.put("foo/","text"));
+        (await b.put("foo/bar","text"));
+        (await b.put("foo/bar/","text"));
+        (await b.put("foo/bar/baz","text"));
+        const objs = (await b.list());
+        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await objs.at(0)) === "foo")'`)})(((await objs.at(0)) === "foo"))};
+        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await objs.at(1)) === "foo/")'`)})(((await objs.at(1)) === "foo/"))};
+        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await objs.at(2)) === "foo/bar")'`)})(((await objs.at(2)) === "foo/bar"))};
+        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await objs.at(3)) === "foo/bar/")'`)})(((await objs.at(3)) === "foo/bar/"))};
+        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await objs.at(4)) === "foo/bar/baz")'`)})(((await objs.at(4)) === "foo/bar/baz"))};
       }
     }
   }

--- a/tools/hangar/__snapshots__/test_corpus/bucket_keys.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/bucket_keys.w_compile_tf-aws.md
@@ -3,26 +3,24 @@
 ## clients/$Inflight1.inflight.js
 ```js
 module.exports = function({ b }) {
-  class  $Inflight1 {
+  class $Inflight1 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
       Object.setPrototypeOf($obj, this);
       return $obj;
     }
     async handle()  {
-      {
-        (await b.put("foo","text"));
-        (await b.put("foo/","text"));
-        (await b.put("foo/bar","text"));
-        (await b.put("foo/bar/","text"));
-        (await b.put("foo/bar/baz","text"));
-        const objs = (await b.list());
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await objs.at(0)) === "foo")'`)})(((await objs.at(0)) === "foo"))};
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await objs.at(1)) === "foo/")'`)})(((await objs.at(1)) === "foo/"))};
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await objs.at(2)) === "foo/bar")'`)})(((await objs.at(2)) === "foo/bar"))};
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await objs.at(3)) === "foo/bar/")'`)})(((await objs.at(3)) === "foo/bar/"))};
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await objs.at(4)) === "foo/bar/baz")'`)})(((await objs.at(4)) === "foo/bar/baz"))};
-      }
+      (await b.put("foo","text"));
+      (await b.put("foo/","text"));
+      (await b.put("foo/bar","text"));
+      (await b.put("foo/bar/","text"));
+      (await b.put("foo/bar/baz","text"));
+      const objs = (await b.list());
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '((await objs.at(0)) === "foo")'`)})(((await objs.at(0)) === "foo"))};
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '((await objs.at(1)) === "foo/")'`)})(((await objs.at(1)) === "foo/"))};
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '((await objs.at(2)) === "foo/bar")'`)})(((await objs.at(2)) === "foo/bar"))};
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '((await objs.at(3)) === "foo/bar/")'`)})(((await objs.at(3)) === "foo/bar/"))};
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '((await objs.at(4)) === "foo/bar/baz")'`)})(((await objs.at(4)) === "foo/bar/baz"))};
     }
   }
   return $Inflight1;

--- a/tools/hangar/__snapshots__/test_corpus/calling_inflight_variants.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/calling_inflight_variants.w_compile_tf-aws.md
@@ -3,16 +3,14 @@
 ## clients/$Inflight1.inflight.js
 ```js
 module.exports = function({  }) {
-  class  $Inflight1 {
+  class $Inflight1 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
       Object.setPrototypeOf($obj, this);
       return $obj;
     }
     async handle()  {
-      {
-        return 1;
-      }
+      return 1;
     }
   }
   return $Inflight1;
@@ -23,17 +21,15 @@ module.exports = function({  }) {
 ## clients/$Inflight2.inflight.js
 ```js
 module.exports = function({ foo }) {
-  class  $Inflight2 {
+  class $Inflight2 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
       Object.setPrototypeOf($obj, this);
       return $obj;
     }
     async handle()  {
-      {
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await foo.callFn(true)) === 1)'`)})(((await foo.callFn(true)) === 1))};
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await foo.callFn(false)) === 2)'`)})(((await foo.callFn(false)) === 2))};
-      }
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '((await foo.callFn(true)) === 1)'`)})(((await foo.callFn(true)) === 1))};
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '((await foo.callFn(false)) === 2)'`)})(((await foo.callFn(false)) === 2))};
     }
   }
   return $Inflight2;
@@ -44,40 +40,32 @@ module.exports = function({ foo }) {
 ## clients/Foo.inflight.js
 ```js
 module.exports = function({  }) {
-  class  Foo {
+  class Foo {
     constructor({ inflight1 }) {
       this.inflight1 = inflight1;
     }
     async $inflight_init()  {
-      {
-        const __parent_this = this;
-        this.inflight2 = async () =>  {
-          {
-            return 2;
-          }
-        }
-        ;
+      const __parent_this = this;
+      this.inflight2 = async () =>  {
+        return 2;
       }
+      ;
     }
     async makeFn(x)  {
-      {
+      const __parent_this = this;
+      if ((x === true)) {
         const __parent_this = this;
-        if ((x === true)) {
-          const __parent_this = this;
-          return this.inflight1;
-        }
-        else {
-          const __parent_this = this;
-          return this.inflight2;
-        }
+        return this.inflight1;
+      }
+      else {
+        const __parent_this = this;
+        return this.inflight2;
       }
     }
     async callFn(x)  {
-      {
-        const __parent_this = this;
-        const partialFn = (await this.makeFn(x));
-        return (await partialFn());
-      }
+      const __parent_this = this;
+      const partialFn = (await this.makeFn(x));
+      return (await partialFn());
     }
   }
   return Foo;

--- a/tools/hangar/__snapshots__/test_corpus/calling_inflight_variants.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/calling_inflight_variants.w_compile_tf-aws.md
@@ -5,6 +5,9 @@
 module.exports = function({  }) {
   class  $Inflight1 {
     constructor({  }) {
+      const $obj = (...args) => this.handle(...args);
+      Object.setPrototypeOf($obj, this);
+      return $obj;
     }
     async handle()  {
       {
@@ -22,11 +25,14 @@ module.exports = function({  }) {
 module.exports = function({ foo }) {
   class  $Inflight2 {
     constructor({  }) {
+      const $obj = (...args) => this.handle(...args);
+      Object.setPrototypeOf($obj, this);
+      return $obj;
     }
     async handle()  {
       {
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((typeof foo.callFn === "function" ? await foo.callFn(true) : await foo.callFn.handle(true)) === 1)'`)})(((typeof foo.callFn === "function" ? await foo.callFn(true) : await foo.callFn.handle(true)) === 1))};
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((typeof foo.callFn === "function" ? await foo.callFn(false) : await foo.callFn.handle(false)) === 2)'`)})(((typeof foo.callFn === "function" ? await foo.callFn(false) : await foo.callFn.handle(false)) === 2))};
+        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await foo.callFn(true)) === 1)'`)})(((await foo.callFn(true)) === 1))};
+        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await foo.callFn(false)) === 2)'`)})(((await foo.callFn(false)) === 2))};
       }
     }
   }
@@ -69,8 +75,8 @@ module.exports = function({  }) {
     async callFn(x)  {
       {
         const __parent_this = this;
-        const partialFn = (typeof this.makeFn === "function" ? await this.makeFn(x) : await this.makeFn.handle(x));
-        return (typeof partialFn === "function" ? await partialFn() : await partialFn.handle());
+        const partialFn = (await this.makeFn(x));
+        return (await partialFn());
       }
     }
   }

--- a/tools/hangar/__snapshots__/test_corpus/capture_containers.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/capture_containers.w_compile_tf-aws.md
@@ -3,24 +3,22 @@
 ## clients/$Inflight1.inflight.js
 ```js
 module.exports = function({ arr, mySet, myMap, arrOfMap, j }) {
-  class  $Inflight1 {
+  class $Inflight1 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
       Object.setPrototypeOf($obj, this);
       return $obj;
     }
     async handle()  {
-      {
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await arr.at(0)) === "hello")'`)})(((await arr.at(0)) === "hello"))};
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await arr.at(1)) === "world")'`)})(((await arr.at(1)) === "world"))};
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '(arr.length === 2)'`)})((arr.length === 2))};
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '(await mySet.has("my"))'`)})((await mySet.has("my")))};
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '(mySet.size === 2)'`)})((mySet.size === 2))};
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '("world" in (myMap))'`)})(("world" in (myMap)))};
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '(Object.keys(myMap).length === 2)'`)})((Object.keys(myMap).length === 2))};
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '("bang" in ((await arrOfMap.at(0))))'`)})(("bang" in ((await arrOfMap.at(0)))))};
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((j)["b"] === "world")'`)})(((j)["b"] === "world"))};
-      }
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '((await arr.at(0)) === "hello")'`)})(((await arr.at(0)) === "hello"))};
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '((await arr.at(1)) === "world")'`)})(((await arr.at(1)) === "world"))};
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '(arr.length === 2)'`)})((arr.length === 2))};
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '(await mySet.has("my"))'`)})((await mySet.has("my")))};
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '(mySet.size === 2)'`)})((mySet.size === 2))};
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '("world" in (myMap))'`)})(("world" in (myMap)))};
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '(Object.keys(myMap).length === 2)'`)})((Object.keys(myMap).length === 2))};
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '("bang" in ((await arrOfMap.at(0))))'`)})(("bang" in ((await arrOfMap.at(0)))))};
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '((j)["b"] === "world")'`)})(((j)["b"] === "world"))};
     }
   }
   return $Inflight1;

--- a/tools/hangar/__snapshots__/test_corpus/capture_containers.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/capture_containers.w_compile_tf-aws.md
@@ -5,17 +5,20 @@
 module.exports = function({ arr, mySet, myMap, arrOfMap, j }) {
   class  $Inflight1 {
     constructor({  }) {
+      const $obj = (...args) => this.handle(...args);
+      Object.setPrototypeOf($obj, this);
+      return $obj;
     }
     async handle()  {
       {
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((typeof arr.at === "function" ? await arr.at(0) : await arr.at.handle(0)) === "hello")'`)})(((typeof arr.at === "function" ? await arr.at(0) : await arr.at.handle(0)) === "hello"))};
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((typeof arr.at === "function" ? await arr.at(1) : await arr.at.handle(1)) === "world")'`)})(((typeof arr.at === "function" ? await arr.at(1) : await arr.at.handle(1)) === "world"))};
+        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await arr.at(0)) === "hello")'`)})(((await arr.at(0)) === "hello"))};
+        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await arr.at(1)) === "world")'`)})(((await arr.at(1)) === "world"))};
         {((cond) => {if (!cond) throw new Error(`assertion failed: '(arr.length === 2)'`)})((arr.length === 2))};
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '(typeof mySet.has === "function" ? await mySet.has("my") : await mySet.has.handle("my"))'`)})((typeof mySet.has === "function" ? await mySet.has("my") : await mySet.has.handle("my")))};
+        {((cond) => {if (!cond) throw new Error(`assertion failed: '(await mySet.has("my"))'`)})((await mySet.has("my")))};
         {((cond) => {if (!cond) throw new Error(`assertion failed: '(mySet.size === 2)'`)})((mySet.size === 2))};
         {((cond) => {if (!cond) throw new Error(`assertion failed: '("world" in (myMap))'`)})(("world" in (myMap)))};
         {((cond) => {if (!cond) throw new Error(`assertion failed: '(Object.keys(myMap).length === 2)'`)})((Object.keys(myMap).length === 2))};
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '("bang" in ((typeof arrOfMap.at === "function" ? await arrOfMap.at(0) : await arrOfMap.at.handle(0))))'`)})(("bang" in ((typeof arrOfMap.at === "function" ? await arrOfMap.at(0) : await arrOfMap.at.handle(0)))))};
+        {((cond) => {if (!cond) throw new Error(`assertion failed: '("bang" in ((await arrOfMap.at(0))))'`)})(("bang" in ((await arrOfMap.at(0)))))};
         {((cond) => {if (!cond) throw new Error(`assertion failed: '((j)["b"] === "world")'`)})(((j)["b"] === "world"))};
       }
     }

--- a/tools/hangar/__snapshots__/test_corpus/capture_in_binary.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/capture_in_binary.w_compile_tf-aws.md
@@ -5,11 +5,14 @@
 module.exports = function({ b, x }) {
   class  $Inflight1 {
     constructor({  }) {
+      const $obj = (...args) => this.handle(...args);
+      Object.setPrototypeOf($obj, this);
+      return $obj;
     }
     async handle()  {
       {
-        (typeof b.put === "function" ? await b.put("file","foo") : await b.put.handle("file","foo"));
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((typeof b.get === "function" ? await b.get("file") : await b.get.handle("file")) === "foo")'`)})(((typeof b.get === "function" ? await b.get("file") : await b.get.handle("file")) === "foo"))};
+        (await b.put("file","foo"));
+        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await b.get("file")) === "foo")'`)})(((await b.get("file")) === "foo"))};
         {((cond) => {if (!cond) throw new Error(`assertion failed: '(12 === x)'`)})((12 === x))};
       }
     }

--- a/tools/hangar/__snapshots__/test_corpus/capture_in_binary.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/capture_in_binary.w_compile_tf-aws.md
@@ -3,18 +3,16 @@
 ## clients/$Inflight1.inflight.js
 ```js
 module.exports = function({ b, x }) {
-  class  $Inflight1 {
+  class $Inflight1 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
       Object.setPrototypeOf($obj, this);
       return $obj;
     }
     async handle()  {
-      {
-        (await b.put("file","foo"));
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await b.get("file")) === "foo")'`)})(((await b.get("file")) === "foo"))};
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '(12 === x)'`)})((12 === x))};
-      }
+      (await b.put("file","foo"));
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '((await b.get("file")) === "foo")'`)})(((await b.get("file")) === "foo"))};
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '(12 === x)'`)})((12 === x))};
     }
   }
   return $Inflight1;

--- a/tools/hangar/__snapshots__/test_corpus/capture_primitives.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/capture_primitives.w_compile_tf-aws.md
@@ -5,6 +5,9 @@
 module.exports = function({ myStr, myNum, mySecondBool, myBool, myDur }) {
   class  $Inflight1 {
     constructor({  }) {
+      const $obj = (...args) => this.handle(...args);
+      Object.setPrototypeOf($obj, this);
+      return $obj;
     }
     async handle(s)  {
       {
@@ -21,7 +24,7 @@ module.exports = function({ myStr, myNum, mySecondBool, myBool, myDur }) {
         const min = myDur.minutes;
         const sec = myDur.seconds;
         const hr = myDur.hours;
-        const split = (typeof `min=${min} sec=${sec} hr=${hr}`.split === "function" ? await `min=${min} sec=${sec} hr=${hr}`.split(" ") : await `min=${min} sec=${sec} hr=${hr}`.split.handle(" "));
+        const split = (await `min=${min} sec=${sec} hr=${hr}`.split(" "));
         {((cond) => {if (!cond) throw new Error(`assertion failed: '(split.length === 3)'`)})((split.length === 3))};
       }
     }

--- a/tools/hangar/__snapshots__/test_corpus/capture_primitives.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/capture_primitives.w_compile_tf-aws.md
@@ -3,30 +3,28 @@
 ## clients/$Inflight1.inflight.js
 ```js
 module.exports = function({ myStr, myNum, mySecondBool, myBool, myDur }) {
-  class  $Inflight1 {
+  class $Inflight1 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
       Object.setPrototypeOf($obj, this);
       return $obj;
     }
     async handle(s)  {
-      {
-        {console.log(myStr)};
-        const n = myNum;
-        {console.log(`${n}`)};
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '(mySecondBool === false)'`)})((mySecondBool === false))};
-        if (myBool) {
-          {console.log("bool=true")};
-        }
-        else {
-          {console.log("bool=false")};
-        }
-        const min = myDur.minutes;
-        const sec = myDur.seconds;
-        const hr = myDur.hours;
-        const split = (await `min=${min} sec=${sec} hr=${hr}`.split(" "));
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '(split.length === 3)'`)})((split.length === 3))};
+      {console.log(myStr)};
+      const n = myNum;
+      {console.log(`${n}`)};
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '(mySecondBool === false)'`)})((mySecondBool === false))};
+      if (myBool) {
+        {console.log("bool=true")};
       }
+      else {
+        {console.log("bool=false")};
+      }
+      const min = myDur.minutes;
+      const sec = myDur.seconds;
+      const hr = myDur.hours;
+      const split = (await `min=${min} sec=${sec} hr=${hr}`.split(" "));
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '(split.length === 3)'`)})((split.length === 3))};
     }
   }
   return $Inflight1;

--- a/tools/hangar/__snapshots__/test_corpus/capture_resource_and_data.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/capture_resource_and_data.w_compile_tf-aws.md
@@ -5,13 +5,16 @@
 module.exports = function({ data, res, queue }) {
   class  $Inflight1 {
     constructor({  }) {
+      const $obj = (...args) => this.handle(...args);
+      Object.setPrototypeOf($obj, this);
+      return $obj;
     }
     async handle()  {
       {
         {((cond) => {if (!cond) throw new Error(`assertion failed: '(data.size === 3)'`)})((data.size === 3))};
-        (typeof res.put === "function" ? await res.put("file.txt","world") : await res.put.handle("file.txt","world"));
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((typeof res.get === "function" ? await res.get("file.txt") : await res.get.handle("file.txt")) === "world")'`)})(((typeof res.get === "function" ? await res.get("file.txt") : await res.get.handle("file.txt")) === "world"))};
-        (typeof queue.push === "function" ? await queue.push("spirulina") : await queue.push.handle("spirulina"));
+        (await res.put("file.txt","world"));
+        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await res.get("file.txt")) === "world")'`)})(((await res.get("file.txt")) === "world"))};
+        (await queue.push("spirulina"));
       }
     }
   }

--- a/tools/hangar/__snapshots__/test_corpus/capture_resource_and_data.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/capture_resource_and_data.w_compile_tf-aws.md
@@ -3,19 +3,17 @@
 ## clients/$Inflight1.inflight.js
 ```js
 module.exports = function({ data, res, queue }) {
-  class  $Inflight1 {
+  class $Inflight1 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
       Object.setPrototypeOf($obj, this);
       return $obj;
     }
     async handle()  {
-      {
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '(data.size === 3)'`)})((data.size === 3))};
-        (await res.put("file.txt","world"));
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await res.get("file.txt")) === "world")'`)})(((await res.get("file.txt")) === "world"))};
-        (await queue.push("spirulina"));
-      }
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '(data.size === 3)'`)})((data.size === 3))};
+      (await res.put("file.txt","world"));
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '((await res.get("file.txt")) === "world")'`)})(((await res.get("file.txt")) === "world"))};
+      (await queue.push("spirulina"));
     }
   }
   return $Inflight1;

--- a/tools/hangar/__snapshots__/test_corpus/capture_resource_with_no_inflight.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/capture_resource_with_no_inflight.w_compile_tf-aws.md
@@ -3,16 +3,14 @@
 ## clients/$Inflight1.inflight.js
 ```js
 module.exports = function({ a }) {
-  class  $Inflight1 {
+  class $Inflight1 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
       Object.setPrototypeOf($obj, this);
       return $obj;
     }
     async handle()  {
-      {
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '("hey" === a.field)'`)})(("hey" === a.field))};
-      }
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '("hey" === a.field)'`)})(("hey" === a.field))};
     }
   }
   return $Inflight1;
@@ -23,7 +21,7 @@ module.exports = function({ a }) {
 ## clients/A.inflight.js
 ```js
 module.exports = function({  }) {
-  class  A {
+  class A {
     constructor({ field }) {
       this.field = field;
     }

--- a/tools/hangar/__snapshots__/test_corpus/capture_resource_with_no_inflight.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/capture_resource_with_no_inflight.w_compile_tf-aws.md
@@ -5,6 +5,9 @@
 module.exports = function({ a }) {
   class  $Inflight1 {
     constructor({  }) {
+      const $obj = (...args) => this.handle(...args);
+      Object.setPrototypeOf($obj, this);
+      return $obj;
     }
     async handle()  {
       {

--- a/tools/hangar/__snapshots__/test_corpus/captures.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/captures.w_compile_tf-aws.md
@@ -3,29 +3,27 @@
 ## clients/$Inflight1.inflight.js
 ```js
 module.exports = function({ bucket1, bucket2, bucket3 }) {
-  class  $Inflight1 {
+  class $Inflight1 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
       Object.setPrototypeOf($obj, this);
       return $obj;
     }
     async handle(event)  {
-      {
-        (await bucket1.put("file.txt","data"));
-        (await bucket2.get("file.txt"));
-        (await bucket2.get("file2.txt"));
-        (await bucket3.get("file3.txt"));
-        for (const stuff of (await bucket1.list())) {
-          {console.log(stuff)};
-        }
-        {console.log((await bucket2.publicUrl("file.txt")))};
-        try {
-          (await bucket1.publicUrl("file.txt"));
-        }
-        catch ($error_error) {
-          const error = $error_error.message;
-          {console.log(error)};
-        }
+      (await bucket1.put("file.txt","data"));
+      (await bucket2.get("file.txt"));
+      (await bucket2.get("file2.txt"));
+      (await bucket3.get("file3.txt"));
+      for (const stuff of (await bucket1.list())) {
+        {console.log(stuff)};
+      }
+      {console.log((await bucket2.publicUrl("file.txt")))};
+      try {
+        (await bucket1.publicUrl("file.txt"));
+      }
+      catch ($error_error) {
+        const error = $error_error.message;
+        {console.log(error)};
       }
     }
   }

--- a/tools/hangar/__snapshots__/test_corpus/captures.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/captures.w_compile_tf-aws.md
@@ -5,19 +5,22 @@
 module.exports = function({ bucket1, bucket2, bucket3 }) {
   class  $Inflight1 {
     constructor({  }) {
+      const $obj = (...args) => this.handle(...args);
+      Object.setPrototypeOf($obj, this);
+      return $obj;
     }
     async handle(event)  {
       {
-        (typeof bucket1.put === "function" ? await bucket1.put("file.txt","data") : await bucket1.put.handle("file.txt","data"));
-        (typeof bucket2.get === "function" ? await bucket2.get("file.txt") : await bucket2.get.handle("file.txt"));
-        (typeof bucket2.get === "function" ? await bucket2.get("file2.txt") : await bucket2.get.handle("file2.txt"));
-        (typeof bucket3.get === "function" ? await bucket3.get("file3.txt") : await bucket3.get.handle("file3.txt"));
-        for (const stuff of (typeof bucket1.list === "function" ? await bucket1.list() : await bucket1.list.handle())) {
+        (await bucket1.put("file.txt","data"));
+        (await bucket2.get("file.txt"));
+        (await bucket2.get("file2.txt"));
+        (await bucket3.get("file3.txt"));
+        for (const stuff of (await bucket1.list())) {
           {console.log(stuff)};
         }
-        {console.log((typeof bucket2.publicUrl === "function" ? await bucket2.publicUrl("file.txt") : await bucket2.publicUrl.handle("file.txt")))};
+        {console.log((await bucket2.publicUrl("file.txt")))};
         try {
-          (typeof bucket1.publicUrl === "function" ? await bucket1.publicUrl("file.txt") : await bucket1.publicUrl.handle("file.txt"));
+          (await bucket1.publicUrl("file.txt"));
         }
         catch ($error_error) {
           const error = $error_error.message;

--- a/tools/hangar/__snapshots__/test_corpus/class.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/class.w_compile_tf-aws.md
@@ -3,19 +3,17 @@
 ## clients/$Inflight1.inflight.js
 ```js
 module.exports = function({ c5 }) {
-  class  $Inflight1 {
+  class $Inflight1 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
       Object.setPrototypeOf($obj, this);
       return $obj;
     }
     async handle()  {
-      {
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '(c5.x === 123)'`)})((c5.x === 123))};
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '(c5.y === 321)'`)})((c5.y === 321))};
-        (await c5.set(111));
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '(c5.y === 111)'`)})((c5.y === 111))};
-      }
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '(c5.x === 123)'`)})((c5.x === 123))};
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '(c5.y === 321)'`)})((c5.y === 321))};
+      (await c5.set(111));
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '(c5.y === 111)'`)})((c5.y === 111))};
     }
   }
   return $Inflight1;
@@ -26,7 +24,7 @@ module.exports = function({ c5 }) {
 ## clients/C1.inflight.js
 ```js
 module.exports = function({  }) {
-  class  C1 {
+  class C1 {
     constructor({  }) {
     }
   }
@@ -38,7 +36,7 @@ module.exports = function({  }) {
 ## clients/C2.inflight.js
 ```js
 module.exports = function({  }) {
-  class  C2 {
+  class C2 {
     constructor({ x }) {
       this.x = x;
     }
@@ -51,7 +49,7 @@ module.exports = function({  }) {
 ## clients/C3.inflight.js
 ```js
 module.exports = function({  }) {
-  class  C3 {
+  class C3 {
     constructor({ x, y }) {
       this.x = x;
       this.y = y;
@@ -65,7 +63,7 @@ module.exports = function({  }) {
 ## clients/C4.inflight.js
 ```js
 module.exports = function({  }) {
-  class  C4 {
+  class C4 {
     constructor({  }) {
     }
   }
@@ -77,21 +75,17 @@ module.exports = function({  }) {
 ## clients/C5.inflight.js
 ```js
 module.exports = function({  }) {
-  class  C5 {
+  class C5 {
     constructor({  }) {
     }
     async $inflight_init()  {
-      {
-        const __parent_this = this;
-        this.x = 123;
-        this.y = 321;
-      }
+      const __parent_this = this;
+      this.x = 123;
+      this.y = 321;
     }
     async set(b)  {
-      {
-        const __parent_this = this;
-        this.y = b;
-      }
+      const __parent_this = this;
+      this.y = b;
     }
   }
   return C5;
@@ -337,9 +331,7 @@ class $Root extends $stdlib.std.Resource {
         const __parent_this = this;
       }
       static m()  {
-        {
-          return 1;
-        }
+        return 1;
       }
       static _toInflightType(context) {
         const self_client_path = "./clients/C4.inflight.js".replace(/\\/g, "/");

--- a/tools/hangar/__snapshots__/test_corpus/class.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/class.w_compile_tf-aws.md
@@ -5,12 +5,15 @@
 module.exports = function({ c5 }) {
   class  $Inflight1 {
     constructor({  }) {
+      const $obj = (...args) => this.handle(...args);
+      Object.setPrototypeOf($obj, this);
+      return $obj;
     }
     async handle()  {
       {
         {((cond) => {if (!cond) throw new Error(`assertion failed: '(c5.x === 123)'`)})((c5.x === 123))};
         {((cond) => {if (!cond) throw new Error(`assertion failed: '(c5.y === 321)'`)})((c5.y === 321))};
-        (typeof c5.set === "function" ? await c5.set(111) : await c5.set.handle(111));
+        (await c5.set(111));
         {((cond) => {if (!cond) throw new Error(`assertion failed: '(c5.y === 111)'`)})((c5.y === 111))};
       }
     }

--- a/tools/hangar/__snapshots__/test_corpus/construct-base.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/construct-base.w_compile_tf-aws.md
@@ -3,7 +3,7 @@
 ## clients/WingResource.inflight.js
 ```js
 module.exports = function({  }) {
-  class  WingResource {
+  class WingResource {
     constructor({  }) {
     }
   }
@@ -99,15 +99,11 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     const getPath =  (c) =>  {
-      {
-        return c.node.path;
-      }
+      return c.node.path;
     }
     ;
     const getDisplayName =  (r) =>  {
-      {
-        return r.display.title;
-      }
+      return r.display.title;
     }
     ;
     const q = this.node.root.new("@cdktf/provider-aws.sqsQueue.SqsQueue",aws.sqsQueue.SqsQueue,this,"aws.sqsQueue.SqsQueue");

--- a/tools/hangar/__snapshots__/test_corpus/dec.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/dec.w_compile_tf-aws.md
@@ -5,15 +5,18 @@
 module.exports = function({ counter }) {
   class  $Inflight1 {
     constructor({  }) {
+      const $obj = (...args) => this.handle(...args);
+      Object.setPrototypeOf($obj, this);
+      return $obj;
     }
     async handle()  {
       {
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((typeof counter.peek === "function" ? await counter.peek() : await counter.peek.handle()) === 1)'`)})(((typeof counter.peek === "function" ? await counter.peek() : await counter.peek.handle()) === 1))};
-        const dec1 = (typeof counter.dec === "function" ? await counter.dec() : await counter.dec.handle());
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((typeof counter.peek === "function" ? await counter.peek() : await counter.peek.handle()) === 0)'`)})(((typeof counter.peek === "function" ? await counter.peek() : await counter.peek.handle()) === 0))};
+        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await counter.peek()) === 1)'`)})(((await counter.peek()) === 1))};
+        const dec1 = (await counter.dec());
+        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await counter.peek()) === 0)'`)})(((await counter.peek()) === 0))};
         {((cond) => {if (!cond) throw new Error(`assertion failed: '(dec1 === 1)'`)})((dec1 === 1))};
-        const dec2 = (typeof counter.dec === "function" ? await counter.dec(2) : await counter.dec.handle(2));
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((typeof counter.peek === "function" ? await counter.peek() : await counter.peek.handle()) === (-2))'`)})(((typeof counter.peek === "function" ? await counter.peek() : await counter.peek.handle()) === (-2)))};
+        const dec2 = (await counter.dec(2));
+        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await counter.peek()) === (-2))'`)})(((await counter.peek()) === (-2)))};
         {((cond) => {if (!cond) throw new Error(`assertion failed: '(dec2 === 0)'`)})((dec2 === 0))};
       }
     }

--- a/tools/hangar/__snapshots__/test_corpus/dec.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/dec.w_compile_tf-aws.md
@@ -3,22 +3,20 @@
 ## clients/$Inflight1.inflight.js
 ```js
 module.exports = function({ counter }) {
-  class  $Inflight1 {
+  class $Inflight1 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
       Object.setPrototypeOf($obj, this);
       return $obj;
     }
     async handle()  {
-      {
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await counter.peek()) === 1)'`)})(((await counter.peek()) === 1))};
-        const dec1 = (await counter.dec());
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await counter.peek()) === 0)'`)})(((await counter.peek()) === 0))};
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '(dec1 === 1)'`)})((dec1 === 1))};
-        const dec2 = (await counter.dec(2));
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await counter.peek()) === (-2))'`)})(((await counter.peek()) === (-2)))};
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '(dec2 === 0)'`)})((dec2 === 0))};
-      }
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '((await counter.peek()) === 1)'`)})(((await counter.peek()) === 1))};
+      const dec1 = (await counter.dec());
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '((await counter.peek()) === 0)'`)})(((await counter.peek()) === 0))};
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '(dec1 === 1)'`)})((dec1 === 1))};
+      const dec2 = (await counter.dec(2));
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '((await counter.peek()) === (-2))'`)})(((await counter.peek()) === (-2)))};
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '(dec2 === 0)'`)})((dec2 === 0))};
     }
   }
   return $Inflight1;

--- a/tools/hangar/__snapshots__/test_corpus/doubler.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/doubler.w_compile_tf-aws.md
@@ -5,6 +5,9 @@
 module.exports = function({  }) {
   class  $Inflight1 {
     constructor({  }) {
+      const $obj = (...args) => this.handle(...args);
+      Object.setPrototypeOf($obj, this);
+      return $obj;
     }
     async handle(m)  {
       {
@@ -22,12 +25,15 @@ module.exports = function({  }) {
 module.exports = function({ handler }) {
   class  $Inflight2 {
     constructor({  }) {
+      const $obj = (...args) => this.handle(...args);
+      Object.setPrototypeOf($obj, this);
+      return $obj;
     }
     async handle(x)  {
       {
         const xStr = ((args) => { if (isNaN(args)) {throw new Error("unable to parse \"" + args + "\" as a number")}; return parseInt(args) })(x);
-        const y = (typeof handler === "function" ? await handler(xStr) : await handler.handle(xStr));
-        const z = (typeof handler === "function" ? await handler(y) : await handler.handle(y));
+        const y = (await handler(xStr));
+        const z = (await handler(y));
         return ((args) => { return JSON.stringify(args[0], null, args[1]) })([z]);
       }
     }
@@ -42,6 +48,9 @@ module.exports = function({ handler }) {
 module.exports = function({  }) {
   class  $Inflight3 {
     constructor({  }) {
+      const $obj = (...args) => this.handle(...args);
+      Object.setPrototypeOf($obj, this);
+      return $obj;
     }
     async handle(x)  {
       {
@@ -59,10 +68,13 @@ module.exports = function({  }) {
 module.exports = function({ f }) {
   class  $Inflight4 {
     constructor({  }) {
+      const $obj = (...args) => this.handle(...args);
+      Object.setPrototypeOf($obj, this);
+      return $obj;
     }
     async handle()  {
       {
-        const result = (typeof f.invoke === "function" ? await f.invoke("2") : await f.invoke.handle("2"));
+        const result = (await f.invoke("2"));
         {((cond) => {if (!cond) throw new Error(`assertion failed: '(result === "8")'`)})((result === "8"))};
       }
     }
@@ -82,8 +94,8 @@ module.exports = function({  }) {
     async invoke(message)  {
       {
         const __parent_this = this;
-        (typeof this.func.handle === "function" ? await this.func.handle(message) : await this.func.handle.handle(message));
-        (typeof this.func.handle === "function" ? await this.func.handle(message) : await this.func.handle.handle(message));
+        (await this.func.handle(message));
+        (await this.func.handle(message));
       }
     }
   }

--- a/tools/hangar/__snapshots__/test_corpus/doubler.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/doubler.w_compile_tf-aws.md
@@ -3,16 +3,14 @@
 ## clients/$Inflight1.inflight.js
 ```js
 module.exports = function({  }) {
-  class  $Inflight1 {
+  class $Inflight1 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
       Object.setPrototypeOf($obj, this);
       return $obj;
     }
     async handle(m)  {
-      {
-        return `Hello ${m}!`;
-      }
+      return `Hello ${m}!`;
     }
   }
   return $Inflight1;
@@ -23,19 +21,17 @@ module.exports = function({  }) {
 ## clients/$Inflight2.inflight.js
 ```js
 module.exports = function({ handler }) {
-  class  $Inflight2 {
+  class $Inflight2 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
       Object.setPrototypeOf($obj, this);
       return $obj;
     }
     async handle(x)  {
-      {
-        const xStr = ((args) => { if (isNaN(args)) {throw new Error("unable to parse \"" + args + "\" as a number")}; return parseInt(args) })(x);
-        const y = (await handler(xStr));
-        const z = (await handler(y));
-        return ((args) => { return JSON.stringify(args[0], null, args[1]) })([z]);
-      }
+      const xStr = ((args) => { if (isNaN(args)) {throw new Error("unable to parse \"" + args + "\" as a number")}; return parseInt(args) })(x);
+      const y = (await handler(xStr));
+      const z = (await handler(y));
+      return ((args) => { return JSON.stringify(args[0], null, args[1]) })([z]);
     }
   }
   return $Inflight2;
@@ -46,16 +42,14 @@ module.exports = function({ handler }) {
 ## clients/$Inflight3.inflight.js
 ```js
 module.exports = function({  }) {
-  class  $Inflight3 {
+  class $Inflight3 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
       Object.setPrototypeOf($obj, this);
       return $obj;
     }
     async handle(x)  {
-      {
-        return (x * 2);
-      }
+      return (x * 2);
     }
   }
   return $Inflight3;
@@ -66,17 +60,15 @@ module.exports = function({  }) {
 ## clients/$Inflight4.inflight.js
 ```js
 module.exports = function({ f }) {
-  class  $Inflight4 {
+  class $Inflight4 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
       Object.setPrototypeOf($obj, this);
       return $obj;
     }
     async handle()  {
-      {
-        const result = (await f.invoke("2"));
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '(result === "8")'`)})((result === "8"))};
-      }
+      const result = (await f.invoke("2"));
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '(result === "8")'`)})((result === "8"))};
     }
   }
   return $Inflight4;
@@ -87,16 +79,14 @@ module.exports = function({ f }) {
 ## clients/Doubler.inflight.js
 ```js
 module.exports = function({  }) {
-  class  Doubler {
+  class Doubler {
     constructor({ func }) {
       this.func = func;
     }
     async invoke(message)  {
-      {
-        const __parent_this = this;
-        (await this.func.handle(message));
-        (await this.func.handle(message));
-      }
+      const __parent_this = this;
+      (await this.func.handle(message));
+      (await this.func.handle(message));
     }
   }
   return Doubler;
@@ -107,7 +97,7 @@ module.exports = function({  }) {
 ## clients/Doubler2.inflight.js
 ```js
 module.exports = function({  }) {
-  class  Doubler2 {
+  class Doubler2 {
     constructor({  }) {
     }
   }
@@ -387,46 +377,44 @@ class $Root extends $stdlib.std.Resource {
         const __parent_this = this;
       }
        makeFunc(handler)  {
-        {
-          const __parent_this = this;
-          class $Inflight2 extends $stdlib.std.Resource {
-            constructor(scope, id, ) {
-              super(scope, id);
-              this._addInflightOps("handle");
-              this.display.hidden = true;
-            }
-            static _toInflightType(context) {
-              const self_client_path = "./clients/$Inflight2.inflight.js".replace(/\\/g, "/");
-              const handler_client = context._lift(handler);
-              return $stdlib.core.NodeJsCode.fromInline(`
-                require("${self_client_path}")({
-                  handler: ${handler_client},
-                })
-              `);
-            }
-            _toInflight() {
-              return $stdlib.core.NodeJsCode.fromInline(`
-                (await (async () => {
-                  const $Inflight2Client = ${$Inflight2._toInflightType(this).text};
-                  const client = new $Inflight2Client({
-                  });
-                  if (client.$inflight_init) { await client.$inflight_init(); }
-                  return client;
-                })())
-              `);
-            }
-            _registerBind(host, ops) {
-              if (ops.includes("$inflight_init")) {
-                $Inflight2._registerBindObject(handler, host, []);
-              }
-              if (ops.includes("handle")) {
-                $Inflight2._registerBindObject(handler, host, ["handle"]);
-              }
-              super._registerBind(host, ops);
-            }
+        const __parent_this = this;
+        class $Inflight2 extends $stdlib.std.Resource {
+          constructor(scope, id, ) {
+            super(scope, id);
+            this._addInflightOps("handle");
+            this.display.hidden = true;
           }
-          return this.node.root.newAbstract("@winglang/sdk.cloud.Function",this,"cloud.Function",new $Inflight2(this,"$Inflight2"));
+          static _toInflightType(context) {
+            const self_client_path = "./clients/$Inflight2.inflight.js".replace(/\\/g, "/");
+            const handler_client = context._lift(handler);
+            return $stdlib.core.NodeJsCode.fromInline(`
+              require("${self_client_path}")({
+                handler: ${handler_client},
+              })
+            `);
+          }
+          _toInflight() {
+            return $stdlib.core.NodeJsCode.fromInline(`
+              (await (async () => {
+                const $Inflight2Client = ${$Inflight2._toInflightType(this).text};
+                const client = new $Inflight2Client({
+                });
+                if (client.$inflight_init) { await client.$inflight_init(); }
+                return client;
+              })())
+            `);
+          }
+          _registerBind(host, ops) {
+            if (ops.includes("$inflight_init")) {
+              $Inflight2._registerBindObject(handler, host, []);
+            }
+            if (ops.includes("handle")) {
+              $Inflight2._registerBindObject(handler, host, ["handle"]);
+            }
+            super._registerBind(host, ops);
+          }
         }
+        return this.node.root.newAbstract("@winglang/sdk.cloud.Function",this,"cloud.Function",new $Inflight2(this,"$Inflight2"));
       }
       static _toInflightType(context) {
         const self_client_path = "./clients/Doubler2.inflight.js".replace(/\\/g, "/");

--- a/tools/hangar/__snapshots__/test_corpus/events.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/events.w_compile_tf-aws.md
@@ -3,16 +3,14 @@
 ## clients/$Inflight1.inflight.js
 ```js
 module.exports = function({ counter }) {
-  class  $Inflight1 {
+  class $Inflight1 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
       Object.setPrototypeOf($obj, this);
       return $obj;
     }
     async handle(key)  {
-      {
-        (await counter.inc());
-      }
+      (await counter.inc());
     }
   }
   return $Inflight1;
@@ -23,16 +21,14 @@ module.exports = function({ counter }) {
 ## clients/$Inflight2.inflight.js
 ```js
 module.exports = function({ counter }) {
-  class  $Inflight2 {
+  class $Inflight2 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
       Object.setPrototypeOf($obj, this);
       return $obj;
     }
     async handle(key)  {
-      {
-        (await counter.inc());
-      }
+      (await counter.inc());
     }
   }
   return $Inflight2;
@@ -43,16 +39,14 @@ module.exports = function({ counter }) {
 ## clients/$Inflight3.inflight.js
 ```js
 module.exports = function({ counter }) {
-  class  $Inflight3 {
+  class $Inflight3 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
       Object.setPrototypeOf($obj, this);
       return $obj;
     }
     async handle(key)  {
-      {
-        (await counter.inc());
-      }
+      (await counter.inc());
     }
   }
   return $Inflight3;
@@ -63,16 +57,14 @@ module.exports = function({ counter }) {
 ## clients/$Inflight4.inflight.js
 ```js
 module.exports = function({ counter }) {
-  class  $Inflight4 {
+  class $Inflight4 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
       Object.setPrototypeOf($obj, this);
       return $obj;
     }
     async handle(key)  {
-      {
-        (await counter.inc());
-      }
+      (await counter.inc());
     }
   }
   return $Inflight4;
@@ -83,49 +75,43 @@ module.exports = function({ counter }) {
 ## clients/$Inflight5.inflight.js
 ```js
 module.exports = function({ counter, b }) {
-  class  $Inflight5 {
+  class $Inflight5 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
       Object.setPrototypeOf($obj, this);
       return $obj;
     }
     async handle()  {
-      {
-        class Predicate {
-          constructor(counterVal)  {
-            this.counterVal = counterVal;
-          }
-          counterVal;
-          static async sleep(ms)  {
-            return (require("<ABSOLUTE_PATH>/sleep.js")["sleep"])(ms)
-          }
-          async assertion()  {
-            {
-              return ((await counter.peek()) === this.counterVal);
-            }
-          }
-          async testAssertion()  {
-            {
-              let i = 0;
-              while ((i < 12)) {
-                i = (i + 1);
-                if ((await this.assertion())) {
-                  {((cond) => {if (!cond) throw new Error(`assertion failed: '(await this.assertion())'`)})((await this.assertion()))};
-                  return;
-                }
-                (await Predicate.sleep((1000 * 10)));
-              }
-              {((cond) => {if (!cond) throw new Error(`assertion failed: '(await this.assertion())'`)})((await this.assertion()))};
-            }
-          }
+      class Predicate {
+        constructor(counterVal)  {
+          this.counterVal = counterVal;
         }
-        (await b.put("a","1"));
-        (await b.put("b","1"));
-        (await b.put("c","1"));
-        (await b.put("b","100"));
-        (await b.delete("c"));
-        (await new Predicate(10).testAssertion());
+        counterVal;
+        static async sleep(ms)  {
+          return (require("<ABSOLUTE_PATH>/sleep.js")["sleep"])(ms)
+        }
+        async assertion()  {
+          return ((await counter.peek()) === this.counterVal);
+        }
+        async testAssertion()  {
+          let i = 0;
+          while ((i < 12)) {
+            i = (i + 1);
+            if ((await this.assertion())) {
+              {((cond) => {if (!cond) throw new Error(`assertion failed: '(await this.assertion())'`)})((await this.assertion()))};
+              return;
+            }
+            (await Predicate.sleep((1000 * 10)));
+          }
+          {((cond) => {if (!cond) throw new Error(`assertion failed: '(await this.assertion())'`)})((await this.assertion()))};
+        }
       }
+      (await b.put("a","1"));
+      (await b.put("b","1"));
+      (await b.put("c","1"));
+      (await b.put("b","100"));
+      (await b.delete("c"));
+      (await new Predicate(10).testAssertion());
     }
   }
   return $Inflight5;

--- a/tools/hangar/__snapshots__/test_corpus/events.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/events.w_compile_tf-aws.md
@@ -5,10 +5,13 @@
 module.exports = function({ counter }) {
   class  $Inflight1 {
     constructor({  }) {
+      const $obj = (...args) => this.handle(...args);
+      Object.setPrototypeOf($obj, this);
+      return $obj;
     }
     async handle(key)  {
       {
-        (typeof counter.inc === "function" ? await counter.inc() : await counter.inc.handle());
+        (await counter.inc());
       }
     }
   }
@@ -22,10 +25,13 @@ module.exports = function({ counter }) {
 module.exports = function({ counter }) {
   class  $Inflight2 {
     constructor({  }) {
+      const $obj = (...args) => this.handle(...args);
+      Object.setPrototypeOf($obj, this);
+      return $obj;
     }
     async handle(key)  {
       {
-        (typeof counter.inc === "function" ? await counter.inc() : await counter.inc.handle());
+        (await counter.inc());
       }
     }
   }
@@ -39,10 +45,13 @@ module.exports = function({ counter }) {
 module.exports = function({ counter }) {
   class  $Inflight3 {
     constructor({  }) {
+      const $obj = (...args) => this.handle(...args);
+      Object.setPrototypeOf($obj, this);
+      return $obj;
     }
     async handle(key)  {
       {
-        (typeof counter.inc === "function" ? await counter.inc() : await counter.inc.handle());
+        (await counter.inc());
       }
     }
   }
@@ -56,10 +65,13 @@ module.exports = function({ counter }) {
 module.exports = function({ counter }) {
   class  $Inflight4 {
     constructor({  }) {
+      const $obj = (...args) => this.handle(...args);
+      Object.setPrototypeOf($obj, this);
+      return $obj;
     }
     async handle(key)  {
       {
-        (typeof counter.inc === "function" ? await counter.inc() : await counter.inc.handle());
+        (await counter.inc());
       }
     }
   }
@@ -73,6 +85,9 @@ module.exports = function({ counter }) {
 module.exports = function({ counter, b }) {
   class  $Inflight5 {
     constructor({  }) {
+      const $obj = (...args) => this.handle(...args);
+      Object.setPrototypeOf($obj, this);
+      return $obj;
     }
     async handle()  {
       {
@@ -86,7 +101,7 @@ module.exports = function({ counter, b }) {
           }
           async assertion()  {
             {
-              return ((typeof counter.peek === "function" ? await counter.peek() : await counter.peek.handle()) === this.counterVal);
+              return ((await counter.peek()) === this.counterVal);
             }
           }
           async testAssertion()  {
@@ -94,22 +109,22 @@ module.exports = function({ counter, b }) {
               let i = 0;
               while ((i < 12)) {
                 i = (i + 1);
-                if ((typeof this.assertion === "function" ? await this.assertion() : await this.assertion.handle())) {
-                  {((cond) => {if (!cond) throw new Error(`assertion failed: '(typeof this.assertion === "function" ? await this.assertion() : await this.assertion.handle())'`)})((typeof this.assertion === "function" ? await this.assertion() : await this.assertion.handle()))};
+                if ((await this.assertion())) {
+                  {((cond) => {if (!cond) throw new Error(`assertion failed: '(await this.assertion())'`)})((await this.assertion()))};
                   return;
                 }
-                (typeof Predicate.sleep === "function" ? await Predicate.sleep((1000 * 10)) : await Predicate.sleep.handle((1000 * 10)));
+                (await Predicate.sleep((1000 * 10)));
               }
-              {((cond) => {if (!cond) throw new Error(`assertion failed: '(typeof this.assertion === "function" ? await this.assertion() : await this.assertion.handle())'`)})((typeof this.assertion === "function" ? await this.assertion() : await this.assertion.handle()))};
+              {((cond) => {if (!cond) throw new Error(`assertion failed: '(await this.assertion())'`)})((await this.assertion()))};
             }
           }
         }
-        (typeof b.put === "function" ? await b.put("a","1") : await b.put.handle("a","1"));
-        (typeof b.put === "function" ? await b.put("b","1") : await b.put.handle("b","1"));
-        (typeof b.put === "function" ? await b.put("c","1") : await b.put.handle("c","1"));
-        (typeof b.put === "function" ? await b.put("b","100") : await b.put.handle("b","100"));
-        (typeof b.delete === "function" ? await b.delete("c") : await b.delete.handle("c"));
-        (typeof new Predicate(10).testAssertion === "function" ? await new Predicate(10).testAssertion() : await new Predicate(10).testAssertion.handle());
+        (await b.put("a","1"));
+        (await b.put("b","1"));
+        (await b.put("c","1"));
+        (await b.put("b","100"));
+        (await b.delete("c"));
+        (await new Predicate(10).testAssertion());
       }
     }
   }

--- a/tools/hangar/__snapshots__/test_corpus/exists.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/exists.w_compile_tf-aws.md
@@ -3,22 +3,20 @@
 ## clients/$Inflight1.inflight.js
 ```js
 module.exports = function({ b }) {
-  class  $Inflight1 {
+  class $Inflight1 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
       Object.setPrototypeOf($obj, this);
       return $obj;
     }
     async handle()  {
-      {
-        (await b.put("test1.txt","Foo"));
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '(await b.exists("test1.txt"))'`)})((await b.exists("test1.txt")))};
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '(!(await b.exists("test2.txt")))'`)})((!(await b.exists("test2.txt"))))};
-        (await b.put("test2.txt","Bar"));
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '(await b.exists("test2.txt"))'`)})((await b.exists("test2.txt")))};
-        (await b.delete("test1.txt"));
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '(!(await b.exists("test1.txt")))'`)})((!(await b.exists("test1.txt"))))};
-      }
+      (await b.put("test1.txt","Foo"));
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '(await b.exists("test1.txt"))'`)})((await b.exists("test1.txt")))};
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '(!(await b.exists("test2.txt")))'`)})((!(await b.exists("test2.txt"))))};
+      (await b.put("test2.txt","Bar"));
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '(await b.exists("test2.txt"))'`)})((await b.exists("test2.txt")))};
+      (await b.delete("test1.txt"));
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '(!(await b.exists("test1.txt")))'`)})((!(await b.exists("test1.txt"))))};
     }
   }
   return $Inflight1;

--- a/tools/hangar/__snapshots__/test_corpus/exists.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/exists.w_compile_tf-aws.md
@@ -5,16 +5,19 @@
 module.exports = function({ b }) {
   class  $Inflight1 {
     constructor({  }) {
+      const $obj = (...args) => this.handle(...args);
+      Object.setPrototypeOf($obj, this);
+      return $obj;
     }
     async handle()  {
       {
-        (typeof b.put === "function" ? await b.put("test1.txt","Foo") : await b.put.handle("test1.txt","Foo"));
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '(typeof b.exists === "function" ? await b.exists("test1.txt") : await b.exists.handle("test1.txt"))'`)})((typeof b.exists === "function" ? await b.exists("test1.txt") : await b.exists.handle("test1.txt")))};
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '(!(typeof b.exists === "function" ? await b.exists("test2.txt") : await b.exists.handle("test2.txt")))'`)})((!(typeof b.exists === "function" ? await b.exists("test2.txt") : await b.exists.handle("test2.txt"))))};
-        (typeof b.put === "function" ? await b.put("test2.txt","Bar") : await b.put.handle("test2.txt","Bar"));
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '(typeof b.exists === "function" ? await b.exists("test2.txt") : await b.exists.handle("test2.txt"))'`)})((typeof b.exists === "function" ? await b.exists("test2.txt") : await b.exists.handle("test2.txt")))};
-        (typeof b.delete === "function" ? await b.delete("test1.txt") : await b.delete.handle("test1.txt"));
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '(!(typeof b.exists === "function" ? await b.exists("test1.txt") : await b.exists.handle("test1.txt")))'`)})((!(typeof b.exists === "function" ? await b.exists("test1.txt") : await b.exists.handle("test1.txt"))))};
+        (await b.put("test1.txt","Foo"));
+        {((cond) => {if (!cond) throw new Error(`assertion failed: '(await b.exists("test1.txt"))'`)})((await b.exists("test1.txt")))};
+        {((cond) => {if (!cond) throw new Error(`assertion failed: '(!(await b.exists("test2.txt")))'`)})((!(await b.exists("test2.txt"))))};
+        (await b.put("test2.txt","Bar"));
+        {((cond) => {if (!cond) throw new Error(`assertion failed: '(await b.exists("test2.txt"))'`)})((await b.exists("test2.txt")))};
+        (await b.delete("test1.txt"));
+        {((cond) => {if (!cond) throw new Error(`assertion failed: '(!(await b.exists("test1.txt")))'`)})((!(await b.exists("test1.txt"))))};
       }
     }
   }

--- a/tools/hangar/__snapshots__/test_corpus/extern_implementation.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/extern_implementation.w_compile_tf-aws.md
@@ -5,10 +5,13 @@
 module.exports = function({ f }) {
   class  $Inflight1 {
     constructor({  }) {
+      const $obj = (...args) => this.handle(...args);
+      Object.setPrototypeOf($obj, this);
+      return $obj;
     }
     async handle()  {
       {
-        (typeof f.call === "function" ? await f.call() : await f.call.handle());
+        (await f.call());
       }
     }
   }
@@ -22,10 +25,13 @@ module.exports = function({ f }) {
 module.exports = function({ f }) {
   class  $Inflight2 {
     constructor({  }) {
+      const $obj = (...args) => this.handle(...args);
+      Object.setPrototypeOf($obj, this);
+      return $obj;
     }
     async handle()  {
       {
-        (typeof f.print === "function" ? await f.print("hey there") : await f.print.handle("hey there"));
+        (await f.print("hey there"));
       }
     }
   }
@@ -55,10 +61,10 @@ module.exports = function({  }) {
     async call()  {
       {
         const __parent_this = this;
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '(typeof Foo.regexInflight === "function" ? await Foo.regexInflight("[a-z]+-\\d+","abc-123") : await Foo.regexInflight.handle("[a-z]+-\\d+","abc-123"))'`)})((typeof Foo.regexInflight === "function" ? await Foo.regexInflight("[a-z]+-\\d+","abc-123") : await Foo.regexInflight.handle("[a-z]+-\\d+","abc-123")))};
-        const uuid = (typeof Foo.getUuid === "function" ? await Foo.getUuid() : await Foo.getUuid.handle());
+        {((cond) => {if (!cond) throw new Error(`assertion failed: '(await Foo.regexInflight("[a-z]+-\\d+","abc-123"))'`)})((await Foo.regexInflight("[a-z]+-\\d+","abc-123")))};
+        const uuid = (await Foo.getUuid());
         {((cond) => {if (!cond) throw new Error(`assertion failed: '(uuid.length === 36)'`)})((uuid.length === 36))};
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((typeof Foo.getData === "function" ? await Foo.getData() : await Foo.getData.handle()) === "Cool data!")'`)})(((typeof Foo.getData === "function" ? await Foo.getData() : await Foo.getData.handle()) === "Cool data!"))};
+        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await Foo.getData()) === "Cool data!")'`)})(((await Foo.getData()) === "Cool data!"))};
       }
     }
   }

--- a/tools/hangar/__snapshots__/test_corpus/extern_implementation.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/extern_implementation.w_compile_tf-aws.md
@@ -3,16 +3,14 @@
 ## clients/$Inflight1.inflight.js
 ```js
 module.exports = function({ f }) {
-  class  $Inflight1 {
+  class $Inflight1 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
       Object.setPrototypeOf($obj, this);
       return $obj;
     }
     async handle()  {
-      {
-        (await f.call());
-      }
+      (await f.call());
     }
   }
   return $Inflight1;
@@ -23,16 +21,14 @@ module.exports = function({ f }) {
 ## clients/$Inflight2.inflight.js
 ```js
 module.exports = function({ f }) {
-  class  $Inflight2 {
+  class $Inflight2 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
       Object.setPrototypeOf($obj, this);
       return $obj;
     }
     async handle()  {
-      {
-        (await f.print("hey there"));
-      }
+      (await f.print("hey there"));
     }
   }
   return $Inflight2;
@@ -43,7 +39,7 @@ module.exports = function({ f }) {
 ## clients/Foo.inflight.js
 ```js
 module.exports = function({  }) {
-  class  Foo {
+  class Foo {
     constructor({  }) {
     }
     static async regexInflight(pattern, text)  {
@@ -59,13 +55,11 @@ module.exports = function({  }) {
       return (require("<ABSOLUTE_PATH>/external_js.js")["print"])(msg)
     }
     async call()  {
-      {
-        const __parent_this = this;
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '(await Foo.regexInflight("[a-z]+-\\d+","abc-123"))'`)})((await Foo.regexInflight("[a-z]+-\\d+","abc-123")))};
-        const uuid = (await Foo.getUuid());
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '(uuid.length === 36)'`)})((uuid.length === 36))};
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await Foo.getData()) === "Cool data!")'`)})(((await Foo.getData()) === "Cool data!"))};
-      }
+      const __parent_this = this;
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '(await Foo.regexInflight("[a-z]+-\\d+","abc-123"))'`)})((await Foo.regexInflight("[a-z]+-\\d+","abc-123")))};
+      const uuid = (await Foo.getUuid());
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '(uuid.length === 36)'`)})((uuid.length === 36))};
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '((await Foo.getData()) === "Cool data!")'`)})(((await Foo.getData()) === "Cool data!"))};
     }
   }
   return Foo;

--- a/tools/hangar/__snapshots__/test_corpus/file_counter.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/file_counter.w_compile_tf-aws.md
@@ -3,18 +3,16 @@
 ## clients/$Inflight1.inflight.js
 ```js
 module.exports = function({ counter, bucket }) {
-  class  $Inflight1 {
+  class $Inflight1 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
       Object.setPrototypeOf($obj, this);
       return $obj;
     }
     async handle(body)  {
-      {
-        const next = (await counter.inc());
-        const key = `myfile-${"hi"}.txt`;
-        (await bucket.put(key,body));
-      }
+      const next = (await counter.inc());
+      const key = `myfile-${"hi"}.txt`;
+      (await bucket.put(key,body));
     }
   }
   return $Inflight1;

--- a/tools/hangar/__snapshots__/test_corpus/file_counter.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/file_counter.w_compile_tf-aws.md
@@ -5,12 +5,15 @@
 module.exports = function({ counter, bucket }) {
   class  $Inflight1 {
     constructor({  }) {
+      const $obj = (...args) => this.handle(...args);
+      Object.setPrototypeOf($obj, this);
+      return $obj;
     }
     async handle(body)  {
       {
-        const next = (typeof counter.inc === "function" ? await counter.inc() : await counter.inc.handle());
+        const next = (await counter.inc());
         const key = `myfile-${"hi"}.txt`;
-        (typeof bucket.put === "function" ? await bucket.put(key,body) : await bucket.put.handle(key,body));
+        (await bucket.put(key,body));
       }
     }
   }

--- a/tools/hangar/__snapshots__/test_corpus/for_loop.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/for_loop.w_compile_tf-aws.md
@@ -5,6 +5,9 @@
 module.exports = function({  }) {
   class  $Inflight1 {
     constructor({  }) {
+      const $obj = (...args) => this.handle(...args);
+      Object.setPrototypeOf($obj, this);
+      return $obj;
     }
     async handle(event)  {
       {

--- a/tools/hangar/__snapshots__/test_corpus/for_loop.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/for_loop.w_compile_tf-aws.md
@@ -3,19 +3,17 @@
 ## clients/$Inflight1.inflight.js
 ```js
 module.exports = function({  }) {
-  class  $Inflight1 {
+  class $Inflight1 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
       Object.setPrototypeOf($obj, this);
       return $obj;
     }
     async handle(event)  {
-      {
-        for (const x of ((s,e,i) => { function* iterator(start,end,inclusive) { let i = start; let limit = inclusive ? ((end < start) ? end - 1 : end + 1) : end; while (i < limit) yield i++; while (i > limit) yield i--; }; return iterator(s,e,i); })(0,10,false)) {
-          {((cond) => {if (!cond) throw new Error(`assertion failed: '(x <= 0)'`)})((x <= 0))};
-          {((cond) => {if (!cond) throw new Error(`assertion failed: '(x > 10)'`)})((x > 10))};
-          {console.log(`${x}`)};
-        }
+      for (const x of ((s,e,i) => { function* iterator(start,end,inclusive) { let i = start; let limit = inclusive ? ((end < start) ? end - 1 : end + 1) : end; while (i < limit) yield i++; while (i > limit) yield i--; }; return iterator(s,e,i); })(0,10,false)) {
+        {((cond) => {if (!cond) throw new Error(`assertion failed: '(x <= 0)'`)})((x <= 0))};
+        {((cond) => {if (!cond) throw new Error(`assertion failed: '(x > 10)'`)})((x > 10))};
+        {console.log(`${x}`)};
       }
     }
   }
@@ -27,16 +25,14 @@ module.exports = function({  }) {
 ## clients/Foo.inflight.js
 ```js
 module.exports = function({  }) {
-  class  Foo {
+  class Foo {
     constructor({  }) {
     }
     async hello()  {
-      {
+      const __parent_this = this;
+      for (const p of Object.freeze(["hello"])) {
         const __parent_this = this;
-        for (const p of Object.freeze(["hello"])) {
-          const __parent_this = this;
-          {console.log(p)};
-        }
+        {console.log(p)};
       }
     }
   }

--- a/tools/hangar/__snapshots__/test_corpus/forward_decl.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/forward_decl.w_compile_tf-aws.md
@@ -3,7 +3,7 @@
 ## clients/R.inflight.js
 ```js
 module.exports = function({  }) {
-  class  R {
+  class R {
     constructor({ f }) {
       this.f = f;
     }
@@ -61,17 +61,13 @@ class $Root extends $stdlib.std.Resource {
         this.f = "Hello World!!!";
       }
        method2()  {
-        {
-          const __parent_this = this;
-          (this.method1());
-          {console.log(`${this.f}`)};
-          (this.method2());
-        }
+        const __parent_this = this;
+        (this.method1());
+        {console.log(`${this.f}`)};
+        (this.method2());
       }
        method1()  {
-        {
-          const __parent_this = this;
-        }
+        const __parent_this = this;
       }
       static _toInflightType(context) {
         const self_client_path = "./clients/R.inflight.js".replace(/\\/g, "/");

--- a/tools/hangar/__snapshots__/test_corpus/hello.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/hello.w_compile_tf-aws.md
@@ -5,10 +5,13 @@
 module.exports = function({ bucket }) {
   class  $Inflight1 {
     constructor({  }) {
+      const $obj = (...args) => this.handle(...args);
+      Object.setPrototypeOf($obj, this);
+      return $obj;
     }
     async handle(message)  {
       {
-        (typeof bucket.put === "function" ? await bucket.put("wing.txt",`Hello, ${message}`) : await bucket.put.handle("wing.txt",`Hello, ${message}`));
+        (await bucket.put("wing.txt",`Hello, ${message}`));
       }
     }
   }

--- a/tools/hangar/__snapshots__/test_corpus/hello.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/hello.w_compile_tf-aws.md
@@ -3,16 +3,14 @@
 ## clients/$Inflight1.inflight.js
 ```js
 module.exports = function({ bucket }) {
-  class  $Inflight1 {
+  class $Inflight1 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
       Object.setPrototypeOf($obj, this);
       return $obj;
     }
     async handle(message)  {
-      {
-        (await bucket.put("wing.txt",`Hello, ${message}`));
-      }
+      (await bucket.put("wing.txt",`Hello, ${message}`));
     }
   }
   return $Inflight1;

--- a/tools/hangar/__snapshots__/test_corpus/identical_inflights.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/identical_inflights.w_compile_tf-aws.md
@@ -5,6 +5,9 @@
 module.exports = function({  }) {
   class  $Inflight1 {
     constructor({  }) {
+      const $obj = (...args) => this.handle(...args);
+      Object.setPrototypeOf($obj, this);
+      return $obj;
     }
     async handle()  {
       {
@@ -21,6 +24,9 @@ module.exports = function({  }) {
 module.exports = function({  }) {
   class  $Inflight2 {
     constructor({  }) {
+      const $obj = (...args) => this.handle(...args);
+      Object.setPrototypeOf($obj, this);
+      return $obj;
     }
     async handle()  {
       {

--- a/tools/hangar/__snapshots__/test_corpus/identical_inflights.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/identical_inflights.w_compile_tf-aws.md
@@ -3,15 +3,13 @@
 ## clients/$Inflight1.inflight.js
 ```js
 module.exports = function({  }) {
-  class  $Inflight1 {
+  class $Inflight1 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
       Object.setPrototypeOf($obj, this);
       return $obj;
     }
     async handle()  {
-      {
-      }
     }
   }
   return $Inflight1;
@@ -22,15 +20,13 @@ module.exports = function({  }) {
 ## clients/$Inflight2.inflight.js
 ```js
 module.exports = function({  }) {
-  class  $Inflight2 {
+  class $Inflight2 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
       Object.setPrototypeOf($obj, this);
       return $obj;
     }
     async handle()  {
-      {
-      }
     }
   }
   return $Inflight2;

--- a/tools/hangar/__snapshots__/test_corpus/impl_interface.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/impl_interface.w_compile_tf-aws.md
@@ -3,16 +3,14 @@
 ## clients/$Inflight1.inflight.js
 ```js
 module.exports = function({ x }) {
-  class  $Inflight1 {
+  class $Inflight1 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
       Object.setPrototypeOf($obj, this);
       return $obj;
     }
     async handle()  {
-      {
-        (await x.handle("hello world!"));
-      }
+      (await x.handle("hello world!"));
     }
   }
   return $Inflight1;
@@ -23,17 +21,15 @@ module.exports = function({ x }) {
 ## clients/A.inflight.js
 ```js
 module.exports = function({  }) {
-  class  A {
+  class A {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
       Object.setPrototypeOf($obj, this);
       return $obj;
     }
     async handle(msg)  {
-      {
-        const __parent_this = this;
-        return;
-      }
+      const __parent_this = this;
+      return;
     }
   }
   return A;
@@ -44,14 +40,12 @@ module.exports = function({  }) {
 ## clients/Dog.inflight.js
 ```js
 module.exports = function({  }) {
-  class  Dog {
+  class Dog {
     constructor({  }) {
     }
     async eat()  {
-      {
-        const __parent_this = this;
-        return;
-      }
+      const __parent_this = this;
+      return;
     }
   }
   return Dog;
@@ -62,14 +56,12 @@ module.exports = function({  }) {
 ## clients/r.inflight.js
 ```js
 module.exports = function({  }) {
-  class  r {
+  class r {
     constructor({  }) {
     }
     async method2(x)  {
-      {
-        const __parent_this = this;
-        return x;
-      }
+      const __parent_this = this;
+      return x;
     }
   }
   return r;
@@ -194,16 +186,12 @@ class $Root extends $stdlib.std.Resource {
         const __parent_this = this;
       }
        method1(x)  {
-        {
-          const __parent_this = this;
-          return x;
-        }
+        const __parent_this = this;
+        return x;
       }
        method3(x)  {
-        {
-          const __parent_this = this;
-          return x;
-        }
+        const __parent_this = this;
+        return x;
       }
       static _toInflightType(context) {
         const self_client_path = "./clients/r.inflight.js".replace(/\\/g, "/");

--- a/tools/hangar/__snapshots__/test_corpus/impl_interface.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/impl_interface.w_compile_tf-aws.md
@@ -5,10 +5,13 @@
 module.exports = function({ x }) {
   class  $Inflight1 {
     constructor({  }) {
+      const $obj = (...args) => this.handle(...args);
+      Object.setPrototypeOf($obj, this);
+      return $obj;
     }
     async handle()  {
       {
-        (typeof x.handle === "function" ? await x.handle("hello world!") : await x.handle.handle("hello world!"));
+        (await x.handle("hello world!"));
       }
     }
   }
@@ -22,6 +25,9 @@ module.exports = function({ x }) {
 module.exports = function({  }) {
   class  A {
     constructor({  }) {
+      const $obj = (...args) => this.handle(...args);
+      Object.setPrototypeOf($obj, this);
+      return $obj;
     }
     async handle(msg)  {
       {

--- a/tools/hangar/__snapshots__/test_corpus/inc.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/inc.w_compile_tf-aws.md
@@ -3,27 +3,25 @@
 ## clients/$Inflight1.inflight.js
 ```js
 module.exports = function({ counter }) {
-  class  $Inflight1 {
+  class $Inflight1 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
       Object.setPrototypeOf($obj, this);
       return $obj;
     }
     async handle()  {
-      {
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await counter.peek()) === 0)'`)})(((await counter.peek()) === 0))};
-        const r0 = (await counter.inc());
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '(r0 === 0)'`)})((r0 === 0))};
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await counter.peek()) === 1)'`)})(((await counter.peek()) === 1))};
-        const r1 = (await counter.inc());
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '(r1 === 1)'`)})((r1 === 1))};
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await counter.peek()) === 2)'`)})(((await counter.peek()) === 2))};
-        const r2 = (await counter.inc(10));
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '(r2 === 2)'`)})((r2 === 2))};
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await counter.peek()) === 12)'`)})(((await counter.peek()) === 12))};
-        const r3 = (await counter.inc());
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '(r3 === 12)'`)})((r3 === 12))};
-      }
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '((await counter.peek()) === 0)'`)})(((await counter.peek()) === 0))};
+      const r0 = (await counter.inc());
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '(r0 === 0)'`)})((r0 === 0))};
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '((await counter.peek()) === 1)'`)})(((await counter.peek()) === 1))};
+      const r1 = (await counter.inc());
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '(r1 === 1)'`)})((r1 === 1))};
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '((await counter.peek()) === 2)'`)})(((await counter.peek()) === 2))};
+      const r2 = (await counter.inc(10));
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '(r2 === 2)'`)})((r2 === 2))};
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '((await counter.peek()) === 12)'`)})(((await counter.peek()) === 12))};
+      const r3 = (await counter.inc());
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '(r3 === 12)'`)})((r3 === 12))};
     }
   }
   return $Inflight1;

--- a/tools/hangar/__snapshots__/test_corpus/inc.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/inc.w_compile_tf-aws.md
@@ -5,20 +5,23 @@
 module.exports = function({ counter }) {
   class  $Inflight1 {
     constructor({  }) {
+      const $obj = (...args) => this.handle(...args);
+      Object.setPrototypeOf($obj, this);
+      return $obj;
     }
     async handle()  {
       {
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((typeof counter.peek === "function" ? await counter.peek() : await counter.peek.handle()) === 0)'`)})(((typeof counter.peek === "function" ? await counter.peek() : await counter.peek.handle()) === 0))};
-        const r0 = (typeof counter.inc === "function" ? await counter.inc() : await counter.inc.handle());
+        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await counter.peek()) === 0)'`)})(((await counter.peek()) === 0))};
+        const r0 = (await counter.inc());
         {((cond) => {if (!cond) throw new Error(`assertion failed: '(r0 === 0)'`)})((r0 === 0))};
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((typeof counter.peek === "function" ? await counter.peek() : await counter.peek.handle()) === 1)'`)})(((typeof counter.peek === "function" ? await counter.peek() : await counter.peek.handle()) === 1))};
-        const r1 = (typeof counter.inc === "function" ? await counter.inc() : await counter.inc.handle());
+        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await counter.peek()) === 1)'`)})(((await counter.peek()) === 1))};
+        const r1 = (await counter.inc());
         {((cond) => {if (!cond) throw new Error(`assertion failed: '(r1 === 1)'`)})((r1 === 1))};
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((typeof counter.peek === "function" ? await counter.peek() : await counter.peek.handle()) === 2)'`)})(((typeof counter.peek === "function" ? await counter.peek() : await counter.peek.handle()) === 2))};
-        const r2 = (typeof counter.inc === "function" ? await counter.inc(10) : await counter.inc.handle(10));
+        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await counter.peek()) === 2)'`)})(((await counter.peek()) === 2))};
+        const r2 = (await counter.inc(10));
         {((cond) => {if (!cond) throw new Error(`assertion failed: '(r2 === 2)'`)})((r2 === 2))};
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((typeof counter.peek === "function" ? await counter.peek() : await counter.peek.handle()) === 12)'`)})(((typeof counter.peek === "function" ? await counter.peek() : await counter.peek.handle()) === 12))};
-        const r3 = (typeof counter.inc === "function" ? await counter.inc() : await counter.inc.handle());
+        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await counter.peek()) === 12)'`)})(((await counter.peek()) === 12))};
+        const r3 = (await counter.inc());
         {((cond) => {if (!cond) throw new Error(`assertion failed: '(r3 === 12)'`)})((r3 === 12))};
       }
     }

--- a/tools/hangar/__snapshots__/test_corpus/inflight-subscribers.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/inflight-subscribers.w_compile_tf-aws.md
@@ -5,6 +5,9 @@
 module.exports = function({  }) {
   class  $Inflight1 {
     constructor({  }) {
+      const $obj = (...args) => this.handle(...args);
+      Object.setPrototypeOf($obj, this);
+      return $obj;
     }
     async handle()  {
       {
@@ -22,6 +25,9 @@ module.exports = function({  }) {
 module.exports = function({  }) {
   class  $Inflight2 {
     constructor({  }) {
+      const $obj = (...args) => this.handle(...args);
+      Object.setPrototypeOf($obj, this);
+      return $obj;
     }
     async handle()  {
       {

--- a/tools/hangar/__snapshots__/test_corpus/inflight-subscribers.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/inflight-subscribers.w_compile_tf-aws.md
@@ -3,16 +3,14 @@
 ## clients/$Inflight1.inflight.js
 ```js
 module.exports = function({  }) {
-  class  $Inflight1 {
+  class $Inflight1 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
       Object.setPrototypeOf($obj, this);
       return $obj;
     }
     async handle()  {
-      {
-        {console.log("hello, world")};
-      }
+      {console.log("hello, world")};
     }
   }
   return $Inflight1;
@@ -23,16 +21,14 @@ module.exports = function({  }) {
 ## clients/$Inflight2.inflight.js
 ```js
 module.exports = function({  }) {
-  class  $Inflight2 {
+  class $Inflight2 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
       Object.setPrototypeOf($obj, this);
       return $obj;
     }
     async handle()  {
-      {
-        {console.log("hello, world")};
-      }
+      {console.log("hello, world")};
     }
   }
   return $Inflight2;

--- a/tools/hangar/__snapshots__/test_corpus/inflight_class_inside_inflight_closure.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/inflight_class_inside_inflight_closure.w_compile_tf-aws.md
@@ -3,29 +3,25 @@
 ## clients/$Inflight1.inflight.js
 ```js
 module.exports = function({ __parent_this }) {
-  class  $Inflight1 {
+  class $Inflight1 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
       Object.setPrototypeOf($obj, this);
       return $obj;
     }
     async handle(payload)  {
-      {
-        (await __parent_this.b.put("k","v"));
-        class InflightClass {
-          constructor()  {
-            this.field = "value";
-          }
-          field;
-          async method()  {
-            {
-              {((cond) => {if (!cond) throw new Error(`assertion failed: '(this.field === "value")'`)})((this.field === "value"))};
-            }
-          }
+      (await __parent_this.b.put("k","v"));
+      class InflightClass {
+        constructor()  {
+          this.field = "value";
         }
-        const c = new InflightClass();
-        (await c.method());
+        field;
+        async method()  {
+          {((cond) => {if (!cond) throw new Error(`assertion failed: '(this.field === "value")'`)})((this.field === "value"))};
+        }
       }
+      const c = new InflightClass();
+      (await c.method());
     }
   }
   return $Inflight1;
@@ -36,16 +32,14 @@ module.exports = function({ __parent_this }) {
 ## clients/$Inflight2.inflight.js
 ```js
 module.exports = function({ f }) {
-  class  $Inflight2 {
+  class $Inflight2 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
       Object.setPrototypeOf($obj, this);
       return $obj;
     }
     async handle()  {
-      {
-        (await f.invoke("text"));
-      }
+      (await f.invoke("text"));
     }
   }
   return $Inflight2;
@@ -56,7 +50,7 @@ module.exports = function({ f }) {
 ## clients/PreflightClass.inflight.js
 ```js
 module.exports = function({  }) {
-  class  PreflightClass {
+  class PreflightClass {
     constructor({ b }) {
       this.b = b;
     }
@@ -314,47 +308,45 @@ class $Root extends $stdlib.std.Resource {
         this.b = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this,"cloud.Bucket");
       }
        preflight_method()  {
-        {
-          const __parent_this = this;
-          class $Inflight1 extends $stdlib.std.Resource {
-            constructor(scope, id, ) {
-              super(scope, id);
-              this._addInflightOps("handle");
-              this.display.hidden = true;
-            }
-            static _toInflightType(context) {
-              const self_client_path = "./clients/$Inflight1.inflight.js".replace(/\\/g, "/");
-              const __parent_this_client = context._lift(__parent_this);
-              return $stdlib.core.NodeJsCode.fromInline(`
-                require("${self_client_path}")({
-                  __parent_this: ${__parent_this_client},
-                })
-              `);
-            }
-            _toInflight() {
-              return $stdlib.core.NodeJsCode.fromInline(`
-                (await (async () => {
-                  const $Inflight1Client = ${$Inflight1._toInflightType(this).text};
-                  const client = new $Inflight1Client({
-                  });
-                  if (client.$inflight_init) { await client.$inflight_init(); }
-                  return client;
-                })())
-              `);
-            }
-            _registerBind(host, ops) {
-              if (ops.includes("$inflight_init")) {
-                $Inflight1._registerBindObject(__parent_this, host, []);
-              }
-              if (ops.includes("handle")) {
-                $Inflight1._registerBindObject(__parent_this.b, host, ["put"]);
-              }
-              super._registerBind(host, ops);
-            }
+        const __parent_this = this;
+        class $Inflight1 extends $stdlib.std.Resource {
+          constructor(scope, id, ) {
+            super(scope, id);
+            this._addInflightOps("handle");
+            this.display.hidden = true;
           }
-          const inflight_closure = new $Inflight1(this,"$Inflight1");
-          return this.node.root.newAbstract("@winglang/sdk.cloud.Function",this,"cloud.Function",inflight_closure);
+          static _toInflightType(context) {
+            const self_client_path = "./clients/$Inflight1.inflight.js".replace(/\\/g, "/");
+            const __parent_this_client = context._lift(__parent_this);
+            return $stdlib.core.NodeJsCode.fromInline(`
+              require("${self_client_path}")({
+                __parent_this: ${__parent_this_client},
+              })
+            `);
+          }
+          _toInflight() {
+            return $stdlib.core.NodeJsCode.fromInline(`
+              (await (async () => {
+                const $Inflight1Client = ${$Inflight1._toInflightType(this).text};
+                const client = new $Inflight1Client({
+                });
+                if (client.$inflight_init) { await client.$inflight_init(); }
+                return client;
+              })())
+            `);
+          }
+          _registerBind(host, ops) {
+            if (ops.includes("$inflight_init")) {
+              $Inflight1._registerBindObject(__parent_this, host, []);
+            }
+            if (ops.includes("handle")) {
+              $Inflight1._registerBindObject(__parent_this.b, host, ["put"]);
+            }
+            super._registerBind(host, ops);
+          }
         }
+        const inflight_closure = new $Inflight1(this,"$Inflight1");
+        return this.node.root.newAbstract("@winglang/sdk.cloud.Function",this,"cloud.Function",inflight_closure);
       }
       static _toInflightType(context) {
         const self_client_path = "./clients/PreflightClass.inflight.js".replace(/\\/g, "/");

--- a/tools/hangar/__snapshots__/test_corpus/inflight_class_inside_inflight_closure.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/inflight_class_inside_inflight_closure.w_compile_tf-aws.md
@@ -5,10 +5,13 @@
 module.exports = function({ __parent_this }) {
   class  $Inflight1 {
     constructor({  }) {
+      const $obj = (...args) => this.handle(...args);
+      Object.setPrototypeOf($obj, this);
+      return $obj;
     }
     async handle(payload)  {
       {
-        (typeof __parent_this.b.put === "function" ? await __parent_this.b.put("k","v") : await __parent_this.b.put.handle("k","v"));
+        (await __parent_this.b.put("k","v"));
         class InflightClass {
           constructor()  {
             this.field = "value";
@@ -21,7 +24,7 @@ module.exports = function({ __parent_this }) {
           }
         }
         const c = new InflightClass();
-        (typeof c.method === "function" ? await c.method() : await c.method.handle());
+        (await c.method());
       }
     }
   }
@@ -35,10 +38,13 @@ module.exports = function({ __parent_this }) {
 module.exports = function({ f }) {
   class  $Inflight2 {
     constructor({  }) {
+      const $obj = (...args) => this.handle(...args);
+      Object.setPrototypeOf($obj, this);
+      return $obj;
     }
     async handle()  {
       {
-        (typeof f.invoke === "function" ? await f.invoke("text") : await f.invoke.handle("text"));
+        (await f.invoke("text"));
       }
     }
   }

--- a/tools/hangar/__snapshots__/test_corpus/inflight_concat.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/inflight_concat.w_compile_tf-aws.md
@@ -3,15 +3,13 @@
 ## clients/R.inflight.js
 ```js
 module.exports = function({  }) {
-  class  R {
+  class R {
     constructor({ s1 }) {
       this.s1 = s1;
     }
     async foo()  {
-      {
-        const __parent_this = this;
-        {console.log((await this.s1.concat(" world")))};
-      }
+      const __parent_this = this;
+      {console.log((await this.s1.concat(" world")))};
     }
   }
   return R;

--- a/tools/hangar/__snapshots__/test_corpus/inflight_concat.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/inflight_concat.w_compile_tf-aws.md
@@ -10,7 +10,7 @@ module.exports = function({  }) {
     async foo()  {
       {
         const __parent_this = this;
-        {console.log((typeof this.s1.concat === "function" ? await this.s1.concat(" world") : await this.s1.concat.handle(" world")))};
+        {console.log((await this.s1.concat(" world")))};
       }
     }
   }

--- a/tools/hangar/__snapshots__/test_corpus/inflights_calling_inflights.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/inflights_calling_inflights.w_compile_tf-aws.md
@@ -5,10 +5,13 @@
 module.exports = function({ globalBucket }) {
   class  $Inflight1 {
     constructor({  }) {
+      const $obj = (...args) => this.handle(...args);
+      Object.setPrototypeOf($obj, this);
+      return $obj;
     }
     async handle(event, file)  {
       {
-        (typeof globalBucket.put === "function" ? await globalBucket.put(file,event) : await globalBucket.put.handle(file,event));
+        (await globalBucket.put(file,event));
       }
     }
   }
@@ -22,10 +25,13 @@ module.exports = function({ globalBucket }) {
 module.exports = function({ storeInBucket }) {
   class  $Inflight2 {
     constructor({  }) {
+      const $obj = (...args) => this.handle(...args);
+      Object.setPrototypeOf($obj, this);
+      return $obj;
     }
     async handle(event)  {
       {
-        (typeof storeInBucket === "function" ? await storeInBucket(event,"file1") : await storeInBucket.handle(event,"file1"));
+        (await storeInBucket(event,"file1"));
       }
     }
   }
@@ -39,11 +45,14 @@ module.exports = function({ storeInBucket }) {
 module.exports = function({ func1, globalBucket }) {
   class  $Inflight3 {
     constructor({  }) {
+      const $obj = (...args) => this.handle(...args);
+      Object.setPrototypeOf($obj, this);
+      return $obj;
     }
     async handle()  {
       {
-        (typeof func1.invoke === "function" ? await func1.invoke("hi1") : await func1.invoke.handle("hi1"));
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((typeof globalBucket.get === "function" ? await globalBucket.get("file1") : await globalBucket.get.handle("file1")) === "hi1")'`)})(((typeof globalBucket.get === "function" ? await globalBucket.get("file1") : await globalBucket.get.handle("file1")) === "hi1"))};
+        (await func1.invoke("hi1"));
+        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await globalBucket.get("file1")) === "hi1")'`)})(((await globalBucket.get("file1")) === "hi1"))};
       }
     }
   }
@@ -57,10 +66,13 @@ module.exports = function({ func1, globalBucket }) {
 module.exports = function({ globalBucket }) {
   class  $Inflight4 {
     constructor({  }) {
+      const $obj = (...args) => this.handle(...args);
+      Object.setPrototypeOf($obj, this);
+      return $obj;
     }
     async handle(s)  {
       {
-        (typeof globalBucket.list === "function" ? await globalBucket.list() : await globalBucket.list.handle());
+        (await globalBucket.list());
         return "hello";
       }
     }
@@ -75,10 +87,13 @@ module.exports = function({ globalBucket }) {
 module.exports = function({ x }) {
   class  $Inflight5 {
     constructor({  }) {
+      const $obj = (...args) => this.handle(...args);
+      Object.setPrototypeOf($obj, this);
+      return $obj;
     }
     async handle()  {
       {
-        const val = (typeof x.foo === "function" ? await x.foo() : await x.foo.handle());
+        const val = (await x.foo());
         {((cond) => {if (!cond) throw new Error(`assertion failed: '(val === "hello")'`)})((val === "hello"))};
       }
     }
@@ -98,7 +113,7 @@ module.exports = function({  }) {
     async foo()  {
       {
         const __parent_this = this;
-        return (typeof this.closure === "function" ? await this.closure("anything") : await this.closure.handle("anything"));
+        return (await this.closure("anything"));
       }
     }
   }

--- a/tools/hangar/__snapshots__/test_corpus/inflights_calling_inflights.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/inflights_calling_inflights.w_compile_tf-aws.md
@@ -3,16 +3,14 @@
 ## clients/$Inflight1.inflight.js
 ```js
 module.exports = function({ globalBucket }) {
-  class  $Inflight1 {
+  class $Inflight1 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
       Object.setPrototypeOf($obj, this);
       return $obj;
     }
     async handle(event, file)  {
-      {
-        (await globalBucket.put(file,event));
-      }
+      (await globalBucket.put(file,event));
     }
   }
   return $Inflight1;
@@ -23,16 +21,14 @@ module.exports = function({ globalBucket }) {
 ## clients/$Inflight2.inflight.js
 ```js
 module.exports = function({ storeInBucket }) {
-  class  $Inflight2 {
+  class $Inflight2 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
       Object.setPrototypeOf($obj, this);
       return $obj;
     }
     async handle(event)  {
-      {
-        (await storeInBucket(event,"file1"));
-      }
+      (await storeInBucket(event,"file1"));
     }
   }
   return $Inflight2;
@@ -43,17 +39,15 @@ module.exports = function({ storeInBucket }) {
 ## clients/$Inflight3.inflight.js
 ```js
 module.exports = function({ func1, globalBucket }) {
-  class  $Inflight3 {
+  class $Inflight3 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
       Object.setPrototypeOf($obj, this);
       return $obj;
     }
     async handle()  {
-      {
-        (await func1.invoke("hi1"));
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await globalBucket.get("file1")) === "hi1")'`)})(((await globalBucket.get("file1")) === "hi1"))};
-      }
+      (await func1.invoke("hi1"));
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '((await globalBucket.get("file1")) === "hi1")'`)})(((await globalBucket.get("file1")) === "hi1"))};
     }
   }
   return $Inflight3;
@@ -64,17 +58,15 @@ module.exports = function({ func1, globalBucket }) {
 ## clients/$Inflight4.inflight.js
 ```js
 module.exports = function({ globalBucket }) {
-  class  $Inflight4 {
+  class $Inflight4 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
       Object.setPrototypeOf($obj, this);
       return $obj;
     }
     async handle(s)  {
-      {
-        (await globalBucket.list());
-        return "hello";
-      }
+      (await globalBucket.list());
+      return "hello";
     }
   }
   return $Inflight4;
@@ -85,17 +77,15 @@ module.exports = function({ globalBucket }) {
 ## clients/$Inflight5.inflight.js
 ```js
 module.exports = function({ x }) {
-  class  $Inflight5 {
+  class $Inflight5 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
       Object.setPrototypeOf($obj, this);
       return $obj;
     }
     async handle()  {
-      {
-        const val = (await x.foo());
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '(val === "hello")'`)})((val === "hello"))};
-      }
+      const val = (await x.foo());
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '(val === "hello")'`)})((val === "hello"))};
     }
   }
   return $Inflight5;
@@ -106,15 +96,13 @@ module.exports = function({ x }) {
 ## clients/MyResource.inflight.js
 ```js
 module.exports = function({  }) {
-  class  MyResource {
+  class MyResource {
     constructor({ closure }) {
       this.closure = closure;
     }
     async foo()  {
-      {
-        const __parent_this = this;
-        return (await this.closure("anything"));
-      }
+      const __parent_this = this;
+      return (await this.closure("anything"));
     }
   }
   return MyResource;

--- a/tools/hangar/__snapshots__/test_corpus/initial.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/initial.w_compile_tf-aws.md
@@ -3,16 +3,14 @@
 ## clients/$Inflight1.inflight.js
 ```js
 module.exports = function({ counterA }) {
-  class  $Inflight1 {
+  class $Inflight1 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
       Object.setPrototypeOf($obj, this);
       return $obj;
     }
     async handle()  {
-      {
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await counterA.peek()) === 0)'`)})(((await counterA.peek()) === 0))};
-      }
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '((await counterA.peek()) === 0)'`)})(((await counterA.peek()) === 0))};
     }
   }
   return $Inflight1;
@@ -23,16 +21,14 @@ module.exports = function({ counterA }) {
 ## clients/$Inflight2.inflight.js
 ```js
 module.exports = function({ counterB }) {
-  class  $Inflight2 {
+  class $Inflight2 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
       Object.setPrototypeOf($obj, this);
       return $obj;
     }
     async handle()  {
-      {
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await counterB.peek()) === 500)'`)})(((await counterB.peek()) === 500))};
-      }
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '((await counterB.peek()) === 500)'`)})(((await counterB.peek()) === 500))};
     }
   }
   return $Inflight2;
@@ -43,16 +39,14 @@ module.exports = function({ counterB }) {
 ## clients/$Inflight3.inflight.js
 ```js
 module.exports = function({ counterC }) {
-  class  $Inflight3 {
+  class $Inflight3 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
       Object.setPrototypeOf($obj, this);
       return $obj;
     }
     async handle()  {
-      {
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await counterC.peek()) === (-198))'`)})(((await counterC.peek()) === (-198)))};
-      }
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '((await counterC.peek()) === (-198))'`)})(((await counterC.peek()) === (-198)))};
     }
   }
   return $Inflight3;

--- a/tools/hangar/__snapshots__/test_corpus/initial.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/initial.w_compile_tf-aws.md
@@ -5,10 +5,13 @@
 module.exports = function({ counterA }) {
   class  $Inflight1 {
     constructor({  }) {
+      const $obj = (...args) => this.handle(...args);
+      Object.setPrototypeOf($obj, this);
+      return $obj;
     }
     async handle()  {
       {
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((typeof counterA.peek === "function" ? await counterA.peek() : await counterA.peek.handle()) === 0)'`)})(((typeof counterA.peek === "function" ? await counterA.peek() : await counterA.peek.handle()) === 0))};
+        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await counterA.peek()) === 0)'`)})(((await counterA.peek()) === 0))};
       }
     }
   }
@@ -22,10 +25,13 @@ module.exports = function({ counterA }) {
 module.exports = function({ counterB }) {
   class  $Inflight2 {
     constructor({  }) {
+      const $obj = (...args) => this.handle(...args);
+      Object.setPrototypeOf($obj, this);
+      return $obj;
     }
     async handle()  {
       {
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((typeof counterB.peek === "function" ? await counterB.peek() : await counterB.peek.handle()) === 500)'`)})(((typeof counterB.peek === "function" ? await counterB.peek() : await counterB.peek.handle()) === 500))};
+        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await counterB.peek()) === 500)'`)})(((await counterB.peek()) === 500))};
       }
     }
   }
@@ -39,10 +45,13 @@ module.exports = function({ counterB }) {
 module.exports = function({ counterC }) {
   class  $Inflight3 {
     constructor({  }) {
+      const $obj = (...args) => this.handle(...args);
+      Object.setPrototypeOf($obj, this);
+      return $obj;
     }
     async handle()  {
       {
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((typeof counterC.peek === "function" ? await counterC.peek() : await counterC.peek.handle()) === (-198))'`)})(((typeof counterC.peek === "function" ? await counterC.peek() : await counterC.peek.handle()) === (-198)))};
+        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await counterC.peek()) === (-198))'`)})(((await counterC.peek()) === (-198)))};
       }
     }
   }

--- a/tools/hangar/__snapshots__/test_corpus/invoke.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/invoke.w_compile_tf-aws.md
@@ -5,6 +5,9 @@
 module.exports = function({ payload }) {
   class  $Inflight1 {
     constructor({  }) {
+      const $obj = (...args) => this.handle(...args);
+      Object.setPrototypeOf($obj, this);
+      return $obj;
     }
     async handle()  {
       {
@@ -22,10 +25,13 @@ module.exports = function({ payload }) {
 module.exports = function({ f, payload }) {
   class  $Inflight2 {
     constructor({  }) {
+      const $obj = (...args) => this.handle(...args);
+      Object.setPrototypeOf($obj, this);
+      return $obj;
     }
     async handle()  {
       {
-        const x = (typeof f.invoke === "function" ? await f.invoke("") : await f.invoke.handle(""));
+        const x = (await f.invoke(""));
         {((cond) => {if (!cond) throw new Error(`assertion failed: '(x === payload)'`)})((x === payload))};
       }
     }

--- a/tools/hangar/__snapshots__/test_corpus/invoke.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/invoke.w_compile_tf-aws.md
@@ -3,16 +3,14 @@
 ## clients/$Inflight1.inflight.js
 ```js
 module.exports = function({ payload }) {
-  class  $Inflight1 {
+  class $Inflight1 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
       Object.setPrototypeOf($obj, this);
       return $obj;
     }
     async handle()  {
-      {
-        return payload;
-      }
+      return payload;
     }
   }
   return $Inflight1;
@@ -23,17 +21,15 @@ module.exports = function({ payload }) {
 ## clients/$Inflight2.inflight.js
 ```js
 module.exports = function({ f, payload }) {
-  class  $Inflight2 {
+  class $Inflight2 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
       Object.setPrototypeOf($obj, this);
       return $obj;
     }
     async handle()  {
-      {
-        const x = (await f.invoke(""));
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '(x === payload)'`)})((x === payload))};
-      }
+      const x = (await f.invoke(""));
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '(x === payload)'`)})((x === payload))};
     }
   }
   return $Inflight2;

--- a/tools/hangar/__snapshots__/test_corpus/json.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/json.w_compile_tf-aws.md
@@ -3,7 +3,7 @@
 ## clients/Foo.inflight.js
 ```js
 module.exports = function({  }) {
-  class  Foo {
+  class Foo {
     constructor({ SumStr }) {
       this.SumStr = SumStr;
     }
@@ -100,9 +100,7 @@ class $Root extends $stdlib.std.Resource {
     const jj1 = Object.freeze({"foo":someNumber});
     const jj2 = [someNumber, {"bar":someNumber}];
     const getStr =  () =>  {
-      {
-        return "hello";
-      }
+      return "hello";
     }
     ;
     const jj3 = (getStr());

--- a/tools/hangar/__snapshots__/test_corpus/json_bucket.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/json_bucket.w_compile_tf-aws.md
@@ -5,10 +5,13 @@
 module.exports = function({ b, fileName }) {
   class  $Inflight1 {
     constructor({  }) {
+      const $obj = (...args) => this.handle(...args);
+      Object.setPrototypeOf($obj, this);
+      return $obj;
     }
     async handle(msg)  {
       {
-        const x = (typeof b.getJson === "function" ? await b.getJson(fileName) : await b.getJson.handle(fileName));
+        const x = (await b.getJson(fileName));
         {((cond) => {if (!cond) throw new Error(`assertion failed: '(((((x)["persons"])[0])["fears"])[1] === "failure")'`)})((((((x)["persons"])[0])["fears"])[1] === "failure"))};
       }
     }
@@ -23,11 +26,14 @@ module.exports = function({ b, fileName }) {
 module.exports = function({ b, fileName, j, getJson }) {
   class  $Inflight2 {
     constructor({  }) {
+      const $obj = (...args) => this.handle(...args);
+      Object.setPrototypeOf($obj, this);
+      return $obj;
     }
     async handle()  {
       {
-        (typeof b.putJson === "function" ? await b.putJson(fileName,j) : await b.putJson.handle(fileName,j));
-        (typeof getJson.invoke === "function" ? await getJson.invoke("") : await getJson.invoke.handle(""));
+        (await b.putJson(fileName,j));
+        (await getJson.invoke(""));
       }
     }
   }

--- a/tools/hangar/__snapshots__/test_corpus/json_bucket.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/json_bucket.w_compile_tf-aws.md
@@ -3,17 +3,15 @@
 ## clients/$Inflight1.inflight.js
 ```js
 module.exports = function({ b, fileName }) {
-  class  $Inflight1 {
+  class $Inflight1 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
       Object.setPrototypeOf($obj, this);
       return $obj;
     }
     async handle(msg)  {
-      {
-        const x = (await b.getJson(fileName));
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '(((((x)["persons"])[0])["fears"])[1] === "failure")'`)})((((((x)["persons"])[0])["fears"])[1] === "failure"))};
-      }
+      const x = (await b.getJson(fileName));
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '(((((x)["persons"])[0])["fears"])[1] === "failure")'`)})((((((x)["persons"])[0])["fears"])[1] === "failure"))};
     }
   }
   return $Inflight1;
@@ -24,17 +22,15 @@ module.exports = function({ b, fileName }) {
 ## clients/$Inflight2.inflight.js
 ```js
 module.exports = function({ b, fileName, j, getJson }) {
-  class  $Inflight2 {
+  class $Inflight2 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
       Object.setPrototypeOf($obj, this);
       return $obj;
     }
     async handle()  {
-      {
-        (await b.putJson(fileName,j));
-        (await getJson.invoke(""));
-      }
+      (await b.putJson(fileName,j));
+      (await getJson.invoke(""));
     }
   }
   return $Inflight2;

--- a/tools/hangar/__snapshots__/test_corpus/json_static.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/json_static.w_compile_tf-aws.md
@@ -5,6 +5,9 @@
 module.exports = function({ jj }) {
   class  $Inflight1 {
     constructor({  }) {
+      const $obj = (...args) => this.handle(...args);
+      Object.setPrototypeOf($obj, this);
+      return $obj;
     }
     async handle()  {
       {

--- a/tools/hangar/__snapshots__/test_corpus/json_static.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/json_static.w_compile_tf-aws.md
@@ -3,17 +3,15 @@
 ## clients/$Inflight1.inflight.js
 ```js
 module.exports = function({ jj }) {
-  class  $Inflight1 {
+  class $Inflight1 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
       Object.setPrototypeOf($obj, this);
       return $obj;
     }
     async handle()  {
-      {
-        const ss = ((args) => { return JSON.stringify(args[0], null, args[1]) })([jj]);
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '(ss === "{\"a\":123,\"b\":{\"c\":456,\"d\":789}}")'`)})((ss === "{\"a\":123,\"b\":{\"c\":456,\"d\":789}}"))};
-      }
+      const ss = ((args) => { return JSON.stringify(args[0], null, args[1]) })([jj]);
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '(ss === "{\"a\":123,\"b\":{\"c\":456,\"d\":789}}")'`)})((ss === "{\"a\":123,\"b\":{\"c\":456,\"d\":789}}"))};
     }
   }
   return $Inflight1;

--- a/tools/hangar/__snapshots__/test_corpus/list.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/list.w_compile_tf-aws.md
@@ -3,27 +3,25 @@
 ## clients/$Inflight1.inflight.js
 ```js
 module.exports = function({ table }) {
-  class  $Inflight1 {
+  class $Inflight1 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
       Object.setPrototypeOf($obj, this);
       return $obj;
     }
     async handle()  {
-      {
-        (await table.insert("eyal",Object.freeze({"gender":"male"})));
-        (await table.insert("revital",Object.freeze({"gender":"female"})));
-        const unorderded = {};
-        for (const u of (await table.list())) {
-          ((obj, args) => { obj[args[0]] = args[1]; })(unorderded, [((args) => { if (typeof args !== "string") {throw new Error("unable to parse " + typeof args + " " + args + " as a string")}; return JSON.parse(JSON.stringify(args)) })((u)["name"]),u]);
-        }
-        const revital = (unorderded)["revital"];
-        const eyal = (unorderded)["eyal"];
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '("eyal" === ((args) => { if (typeof args !== "string") {throw new Error("unable to parse " + typeof args + " " + args + " as a string")}; return JSON.parse(JSON.stringify(args)) })((eyal)["name"]))'`)})(("eyal" === ((args) => { if (typeof args !== "string") {throw new Error("unable to parse " + typeof args + " " + args + " as a string")}; return JSON.parse(JSON.stringify(args)) })((eyal)["name"])))};
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '("male" === ((args) => { if (typeof args !== "string") {throw new Error("unable to parse " + typeof args + " " + args + " as a string")}; return JSON.parse(JSON.stringify(args)) })((eyal)["gender"]))'`)})(("male" === ((args) => { if (typeof args !== "string") {throw new Error("unable to parse " + typeof args + " " + args + " as a string")}; return JSON.parse(JSON.stringify(args)) })((eyal)["gender"])))};
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '("revital" === ((args) => { if (typeof args !== "string") {throw new Error("unable to parse " + typeof args + " " + args + " as a string")}; return JSON.parse(JSON.stringify(args)) })((revital)["name"]))'`)})(("revital" === ((args) => { if (typeof args !== "string") {throw new Error("unable to parse " + typeof args + " " + args + " as a string")}; return JSON.parse(JSON.stringify(args)) })((revital)["name"])))};
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '("female" === ((args) => { if (typeof args !== "string") {throw new Error("unable to parse " + typeof args + " " + args + " as a string")}; return JSON.parse(JSON.stringify(args)) })((revital)["gender"]))'`)})(("female" === ((args) => { if (typeof args !== "string") {throw new Error("unable to parse " + typeof args + " " + args + " as a string")}; return JSON.parse(JSON.stringify(args)) })((revital)["gender"])))};
+      (await table.insert("eyal",Object.freeze({"gender":"male"})));
+      (await table.insert("revital",Object.freeze({"gender":"female"})));
+      const unorderded = {};
+      for (const u of (await table.list())) {
+        ((obj, args) => { obj[args[0]] = args[1]; })(unorderded, [((args) => { if (typeof args !== "string") {throw new Error("unable to parse " + typeof args + " " + args + " as a string")}; return JSON.parse(JSON.stringify(args)) })((u)["name"]),u]);
       }
+      const revital = (unorderded)["revital"];
+      const eyal = (unorderded)["eyal"];
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '("eyal" === ((args) => { if (typeof args !== "string") {throw new Error("unable to parse " + typeof args + " " + args + " as a string")}; return JSON.parse(JSON.stringify(args)) })((eyal)["name"]))'`)})(("eyal" === ((args) => { if (typeof args !== "string") {throw new Error("unable to parse " + typeof args + " " + args + " as a string")}; return JSON.parse(JSON.stringify(args)) })((eyal)["name"])))};
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '("male" === ((args) => { if (typeof args !== "string") {throw new Error("unable to parse " + typeof args + " " + args + " as a string")}; return JSON.parse(JSON.stringify(args)) })((eyal)["gender"]))'`)})(("male" === ((args) => { if (typeof args !== "string") {throw new Error("unable to parse " + typeof args + " " + args + " as a string")}; return JSON.parse(JSON.stringify(args)) })((eyal)["gender"])))};
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '("revital" === ((args) => { if (typeof args !== "string") {throw new Error("unable to parse " + typeof args + " " + args + " as a string")}; return JSON.parse(JSON.stringify(args)) })((revital)["name"]))'`)})(("revital" === ((args) => { if (typeof args !== "string") {throw new Error("unable to parse " + typeof args + " " + args + " as a string")}; return JSON.parse(JSON.stringify(args)) })((revital)["name"])))};
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '("female" === ((args) => { if (typeof args !== "string") {throw new Error("unable to parse " + typeof args + " " + args + " as a string")}; return JSON.parse(JSON.stringify(args)) })((revital)["gender"]))'`)})(("female" === ((args) => { if (typeof args !== "string") {throw new Error("unable to parse " + typeof args + " " + args + " as a string")}; return JSON.parse(JSON.stringify(args)) })((revital)["gender"])))};
     }
   }
   return $Inflight1;

--- a/tools/hangar/__snapshots__/test_corpus/list.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/list.w_compile_tf-aws.md
@@ -5,13 +5,16 @@
 module.exports = function({ table }) {
   class  $Inflight1 {
     constructor({  }) {
+      const $obj = (...args) => this.handle(...args);
+      Object.setPrototypeOf($obj, this);
+      return $obj;
     }
     async handle()  {
       {
-        (typeof table.insert === "function" ? await table.insert("eyal",Object.freeze({"gender":"male"})) : await table.insert.handle("eyal",Object.freeze({"gender":"male"})));
-        (typeof table.insert === "function" ? await table.insert("revital",Object.freeze({"gender":"female"})) : await table.insert.handle("revital",Object.freeze({"gender":"female"})));
+        (await table.insert("eyal",Object.freeze({"gender":"male"})));
+        (await table.insert("revital",Object.freeze({"gender":"female"})));
         const unorderded = {};
-        for (const u of (typeof table.list === "function" ? await table.list() : await table.list.handle())) {
+        for (const u of (await table.list())) {
           ((obj, args) => { obj[args[0]] = args[1]; })(unorderded, [((args) => { if (typeof args !== "string") {throw new Error("unable to parse " + typeof args + " " + args + " as a string")}; return JSON.parse(JSON.stringify(args)) })((u)["name"]),u]);
         }
         const revital = (unorderded)["revital"];

--- a/tools/hangar/__snapshots__/test_corpus/nil.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/nil.w_compile_tf-aws.md
@@ -5,11 +5,14 @@
 module.exports = function({ foo }) {
   class  $Inflight1 {
     constructor({  }) {
+      const $obj = (...args) => this.handle(...args);
+      Object.setPrototypeOf($obj, this);
+      return $obj;
     }
     async handle()  {
       {
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((((typeof foo.returnNil === "function" ? await foo.returnNil(true) : await foo.returnNil.handle(true))) != null) === true)'`)})(((((typeof foo.returnNil === "function" ? await foo.returnNil(true) : await foo.returnNil.handle(true))) != null) === true))};
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((((typeof foo.returnNil === "function" ? await foo.returnNil(false) : await foo.returnNil.handle(false))) != null) === false)'`)})(((((typeof foo.returnNil === "function" ? await foo.returnNil(false) : await foo.returnNil.handle(false))) != null) === false))};
+        {((cond) => {if (!cond) throw new Error(`assertion failed: '((((await foo.returnNil(true))) != null) === true)'`)})(((((await foo.returnNil(true))) != null) === true))};
+        {((cond) => {if (!cond) throw new Error(`assertion failed: '((((await foo.returnNil(false))) != null) === false)'`)})(((((await foo.returnNil(false))) != null) === false))};
       }
     }
   }
@@ -23,16 +26,19 @@ module.exports = function({ foo }) {
 module.exports = function({ foo }) {
   class  $Inflight2 {
     constructor({  }) {
+      const $obj = (...args) => this.handle(...args);
+      Object.setPrototypeOf($obj, this);
+      return $obj;
     }
     async handle()  {
       {
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((((typeof foo.getOptionalValue === "function" ? await foo.getOptionalValue() : await foo.getOptionalValue.handle())) != null) === false)'`)})(((((typeof foo.getOptionalValue === "function" ? await foo.getOptionalValue() : await foo.getOptionalValue.handle())) != null) === false))};
-        (typeof foo.setOptionalValue === "function" ? await foo.setOptionalValue("hello") : await foo.setOptionalValue.handle("hello"));
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((((typeof foo.getOptionalValue === "function" ? await foo.getOptionalValue() : await foo.getOptionalValue.handle())) != null) === true)'`)})(((((typeof foo.getOptionalValue === "function" ? await foo.getOptionalValue() : await foo.getOptionalValue.handle())) != null) === true))};
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((typeof foo.getOptionalValue === "function" ? await foo.getOptionalValue() : await foo.getOptionalValue.handle()) !== undefined)'`)})(((typeof foo.getOptionalValue === "function" ? await foo.getOptionalValue() : await foo.getOptionalValue.handle()) !== undefined))};
-        (typeof foo.setOptionalValue === "function" ? await foo.setOptionalValue(undefined) : await foo.setOptionalValue.handle(undefined));
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((((typeof foo.getOptionalValue === "function" ? await foo.getOptionalValue() : await foo.getOptionalValue.handle())) != null) === false)'`)})(((((typeof foo.getOptionalValue === "function" ? await foo.getOptionalValue() : await foo.getOptionalValue.handle())) != null) === false))};
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((typeof foo.getOptionalValue === "function" ? await foo.getOptionalValue() : await foo.getOptionalValue.handle()) === undefined)'`)})(((typeof foo.getOptionalValue === "function" ? await foo.getOptionalValue() : await foo.getOptionalValue.handle()) === undefined))};
+        {((cond) => {if (!cond) throw new Error(`assertion failed: '((((await foo.getOptionalValue())) != null) === false)'`)})(((((await foo.getOptionalValue())) != null) === false))};
+        (await foo.setOptionalValue("hello"));
+        {((cond) => {if (!cond) throw new Error(`assertion failed: '((((await foo.getOptionalValue())) != null) === true)'`)})(((((await foo.getOptionalValue())) != null) === true))};
+        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await foo.getOptionalValue()) !== undefined)'`)})(((await foo.getOptionalValue()) !== undefined))};
+        (await foo.setOptionalValue(undefined));
+        {((cond) => {if (!cond) throw new Error(`assertion failed: '((((await foo.getOptionalValue())) != null) === false)'`)})(((((await foo.getOptionalValue())) != null) === false))};
+        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await foo.getOptionalValue()) === undefined)'`)})(((await foo.getOptionalValue()) === undefined))};
       }
     }
   }

--- a/tools/hangar/__snapshots__/test_corpus/nil.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/nil.w_compile_tf-aws.md
@@ -3,17 +3,15 @@
 ## clients/$Inflight1.inflight.js
 ```js
 module.exports = function({ foo }) {
-  class  $Inflight1 {
+  class $Inflight1 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
       Object.setPrototypeOf($obj, this);
       return $obj;
     }
     async handle()  {
-      {
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((((await foo.returnNil(true))) != null) === true)'`)})(((((await foo.returnNil(true))) != null) === true))};
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((((await foo.returnNil(false))) != null) === false)'`)})(((((await foo.returnNil(false))) != null) === false))};
-      }
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '((((await foo.returnNil(true))) != null) === true)'`)})(((((await foo.returnNil(true))) != null) === true))};
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '((((await foo.returnNil(false))) != null) === false)'`)})(((((await foo.returnNil(false))) != null) === false))};
     }
   }
   return $Inflight1;
@@ -24,22 +22,20 @@ module.exports = function({ foo }) {
 ## clients/$Inflight2.inflight.js
 ```js
 module.exports = function({ foo }) {
-  class  $Inflight2 {
+  class $Inflight2 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
       Object.setPrototypeOf($obj, this);
       return $obj;
     }
     async handle()  {
-      {
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((((await foo.getOptionalValue())) != null) === false)'`)})(((((await foo.getOptionalValue())) != null) === false))};
-        (await foo.setOptionalValue("hello"));
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((((await foo.getOptionalValue())) != null) === true)'`)})(((((await foo.getOptionalValue())) != null) === true))};
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await foo.getOptionalValue()) !== undefined)'`)})(((await foo.getOptionalValue()) !== undefined))};
-        (await foo.setOptionalValue(undefined));
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((((await foo.getOptionalValue())) != null) === false)'`)})(((((await foo.getOptionalValue())) != null) === false))};
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await foo.getOptionalValue()) === undefined)'`)})(((await foo.getOptionalValue()) === undefined))};
-      }
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '((((await foo.getOptionalValue())) != null) === false)'`)})(((((await foo.getOptionalValue())) != null) === false))};
+      (await foo.setOptionalValue("hello"));
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '((((await foo.getOptionalValue())) != null) === true)'`)})(((((await foo.getOptionalValue())) != null) === true))};
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '((await foo.getOptionalValue()) !== undefined)'`)})(((await foo.getOptionalValue()) !== undefined))};
+      (await foo.setOptionalValue(undefined));
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '((((await foo.getOptionalValue())) != null) === false)'`)})(((((await foo.getOptionalValue())) != null) === false))};
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '((await foo.getOptionalValue()) === undefined)'`)})(((await foo.getOptionalValue()) === undefined))};
     }
   }
   return $Inflight2;
@@ -50,36 +46,28 @@ module.exports = function({ foo }) {
 ## clients/Foo.inflight.js
 ```js
 module.exports = function({  }) {
-  class  Foo {
+  class Foo {
     constructor({  }) {
     }
     async $inflight_init()  {
-      {
-        const __parent_this = this;
-        this.optionalVar = undefined;
-      }
+      const __parent_this = this;
+      this.optionalVar = undefined;
     }
     async returnNil(t)  {
-      {
+      const __parent_this = this;
+      if (t) {
         const __parent_this = this;
-        if (t) {
-          const __parent_this = this;
-          return "hello";
-        }
-        return undefined;
+        return "hello";
       }
+      return undefined;
     }
     async setOptionalValue(msg)  {
-      {
-        const __parent_this = this;
-        this.optionalVar = msg;
-      }
+      const __parent_this = this;
+      this.optionalVar = msg;
     }
     async getOptionalValue()  {
-      {
-        const __parent_this = this;
-        return this.optionalVar;
-      }
+      const __parent_this = this;
+      return this.optionalVar;
     }
   }
   return Foo;

--- a/tools/hangar/__snapshots__/test_corpus/on_message.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/on_message.w_compile_tf-aws.md
@@ -5,10 +5,13 @@
 module.exports = function({ c }) {
   class  $Inflight1 {
     constructor({  }) {
+      const $obj = (...args) => this.handle(...args);
+      Object.setPrototypeOf($obj, this);
+      return $obj;
     }
     async handle()  {
       {
-        (typeof c.inc === "function" ? await c.inc() : await c.inc.handle());
+        (await c.inc());
       }
     }
   }
@@ -22,10 +25,13 @@ module.exports = function({ c }) {
 module.exports = function({ c }) {
   class  $Inflight2 {
     constructor({  }) {
+      const $obj = (...args) => this.handle(...args);
+      Object.setPrototypeOf($obj, this);
+      return $obj;
     }
     async handle()  {
       {
-        (typeof c.inc === "function" ? await c.inc() : await c.inc.handle());
+        (await c.inc());
       }
     }
   }
@@ -39,22 +45,25 @@ module.exports = function({ c }) {
 module.exports = function({ t, predicate, TestHelper }) {
   class  $Inflight3 {
     constructor({  }) {
+      const $obj = (...args) => this.handle(...args);
+      Object.setPrototypeOf($obj, this);
+      return $obj;
     }
     async handle()  {
       {
         for (const i of ((s,e,i) => { function* iterator(start,end,inclusive) { let i = start; let limit = inclusive ? ((end < start) ? end - 1 : end + 1) : end; while (i < limit) yield i++; while (i > limit) yield i--; }; return iterator(s,e,i); })(0,5,false)) {
-          (typeof t.publish === "function" ? await t.publish("msg") : await t.publish.handle("msg"));
+          (await t.publish("msg"));
         }
         let i = 0;
         while ((i < 600)) {
           i = (i + 1);
-          if ((typeof predicate.test === "function" ? await predicate.test() : await predicate.test.handle())) {
-            {((cond) => {if (!cond) throw new Error(`assertion failed: '(typeof predicate.test === "function" ? await predicate.test() : await predicate.test.handle())'`)})((typeof predicate.test === "function" ? await predicate.test() : await predicate.test.handle()))};
+          if ((await predicate.test())) {
+            {((cond) => {if (!cond) throw new Error(`assertion failed: '(await predicate.test())'`)})((await predicate.test()))};
             return;
           }
-          (typeof TestHelper.sleep === "function" ? await TestHelper.sleep(100) : await TestHelper.sleep.handle(100));
+          (await TestHelper.sleep(100));
         }
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '(typeof predicate.test === "function" ? await predicate.test() : await predicate.test.handle())'`)})((typeof predicate.test === "function" ? await predicate.test() : await predicate.test.handle()))};
+        {((cond) => {if (!cond) throw new Error(`assertion failed: '(await predicate.test())'`)})((await predicate.test()))};
       }
     }
   }
@@ -73,7 +82,7 @@ module.exports = function({  }) {
     async test()  {
       {
         const __parent_this = this;
-        return ((typeof this.c.peek === "function" ? await this.c.peek() : await this.c.peek.handle()) === 10);
+        return ((await this.c.peek()) === 10);
       }
     }
   }

--- a/tools/hangar/__snapshots__/test_corpus/on_message.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/on_message.w_compile_tf-aws.md
@@ -3,16 +3,14 @@
 ## clients/$Inflight1.inflight.js
 ```js
 module.exports = function({ c }) {
-  class  $Inflight1 {
+  class $Inflight1 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
       Object.setPrototypeOf($obj, this);
       return $obj;
     }
     async handle()  {
-      {
-        (await c.inc());
-      }
+      (await c.inc());
     }
   }
   return $Inflight1;
@@ -23,16 +21,14 @@ module.exports = function({ c }) {
 ## clients/$Inflight2.inflight.js
 ```js
 module.exports = function({ c }) {
-  class  $Inflight2 {
+  class $Inflight2 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
       Object.setPrototypeOf($obj, this);
       return $obj;
     }
     async handle()  {
-      {
-        (await c.inc());
-      }
+      (await c.inc());
     }
   }
   return $Inflight2;
@@ -43,28 +39,26 @@ module.exports = function({ c }) {
 ## clients/$Inflight3.inflight.js
 ```js
 module.exports = function({ t, predicate, TestHelper }) {
-  class  $Inflight3 {
+  class $Inflight3 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
       Object.setPrototypeOf($obj, this);
       return $obj;
     }
     async handle()  {
-      {
-        for (const i of ((s,e,i) => { function* iterator(start,end,inclusive) { let i = start; let limit = inclusive ? ((end < start) ? end - 1 : end + 1) : end; while (i < limit) yield i++; while (i > limit) yield i--; }; return iterator(s,e,i); })(0,5,false)) {
-          (await t.publish("msg"));
-        }
-        let i = 0;
-        while ((i < 600)) {
-          i = (i + 1);
-          if ((await predicate.test())) {
-            {((cond) => {if (!cond) throw new Error(`assertion failed: '(await predicate.test())'`)})((await predicate.test()))};
-            return;
-          }
-          (await TestHelper.sleep(100));
-        }
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '(await predicate.test())'`)})((await predicate.test()))};
+      for (const i of ((s,e,i) => { function* iterator(start,end,inclusive) { let i = start; let limit = inclusive ? ((end < start) ? end - 1 : end + 1) : end; while (i < limit) yield i++; while (i > limit) yield i--; }; return iterator(s,e,i); })(0,5,false)) {
+        (await t.publish("msg"));
       }
+      let i = 0;
+      while ((i < 600)) {
+        i = (i + 1);
+        if ((await predicate.test())) {
+          {((cond) => {if (!cond) throw new Error(`assertion failed: '(await predicate.test())'`)})((await predicate.test()))};
+          return;
+        }
+        (await TestHelper.sleep(100));
+      }
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '(await predicate.test())'`)})((await predicate.test()))};
     }
   }
   return $Inflight3;
@@ -75,15 +69,13 @@ module.exports = function({ t, predicate, TestHelper }) {
 ## clients/Predicate.inflight.js
 ```js
 module.exports = function({  }) {
-  class  Predicate {
+  class Predicate {
     constructor({ c }) {
       this.c = c;
     }
     async test()  {
-      {
-        const __parent_this = this;
-        return ((await this.c.peek()) === 10);
-      }
+      const __parent_this = this;
+      return ((await this.c.peek()) === 10);
     }
   }
   return Predicate;
@@ -94,7 +86,7 @@ module.exports = function({  }) {
 ## clients/TestHelper.inflight.js
 ```js
 module.exports = function({  }) {
-  class  TestHelper {
+  class TestHelper {
     constructor({  }) {
     }
     static async sleep(milli)  {

--- a/tools/hangar/__snapshots__/test_corpus/optionals.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/optionals.w_compile_tf-aws.md
@@ -3,7 +3,7 @@
 ## clients/Node.inflight.js
 ```js
 module.exports = function({  }) {
-  class  Node {
+  class Node {
     constructor({ left, right, value }) {
       this.left = left;
       this.right = right;
@@ -148,16 +148,14 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     const tryParseName =  (fullName) =>  {
-      {
-        const parts = (fullName.split(" "));
-        if ((parts.length < 1)) {
-          return undefined;
-        }
-        return {
-        "first": (parts.at(0)),
-        "last": (parts.at(1)),}
-        ;
+      const parts = (fullName.split(" "));
+      if ((parts.length < 1)) {
+        return undefined;
       }
+      return {
+      "first": (parts.at(0)),
+      "last": (parts.at(1)),}
+      ;
     }
     ;
     {
@@ -223,15 +221,13 @@ class $Root extends $stdlib.std.Resource {
     }
     const fun =  (a) =>  {
       {
-        {
-          const $IF_LET_VALUE = a;
-          if ($IF_LET_VALUE != undefined) {
-            const y = $IF_LET_VALUE;
-            return y;
-          }
-          else {
-            return "default";
-          }
+        const $IF_LET_VALUE = a;
+        if ($IF_LET_VALUE != undefined) {
+          const y = $IF_LET_VALUE;
+          return y;
+        }
+        else {
+          return "default";
         }
       }
     }

--- a/tools/hangar/__snapshots__/test_corpus/optionals.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/optionals.w_compile_tf-aws.md
@@ -131,7 +131,7 @@ class $Root extends $stdlib.std.Resource {
     ;
     {
       const $IF_LET_VALUE = name;
-      if (name != undefined) {
+      if ($IF_LET_VALUE != undefined) {
         const n = $IF_LET_VALUE;
         {((cond) => {if (!cond) throw new Error(`assertion failed: '(n.first === "John")'`)})((n.first === "John"))};
       }
@@ -139,7 +139,7 @@ class $Root extends $stdlib.std.Resource {
     name = undefined;
     {
       const $IF_LET_VALUE = name;
-      if (name != undefined) {
+      if ($IF_LET_VALUE != undefined) {
         const n = $IF_LET_VALUE;
         {((cond) => {if (!cond) throw new Error(`assertion failed: 'false'`)})(false)};
       }
@@ -162,12 +162,12 @@ class $Root extends $stdlib.std.Resource {
     ;
     {
       const $IF_LET_VALUE = (tryParseName("Good Name"));
-      if ((tryParseName("Good Name")) != undefined) {
+      if ($IF_LET_VALUE != undefined) {
         const parsedName = $IF_LET_VALUE;
         {((cond) => {if (!cond) throw new Error(`assertion failed: '(parsedName.first === "Good")'`)})((parsedName.first === "Good"))};
         {
           const $IF_LET_VALUE = parsedName.last;
-          if (parsedName.last != undefined) {
+          if ($IF_LET_VALUE != undefined) {
             const lastName = $IF_LET_VALUE;
             {((cond) => {if (!cond) throw new Error(`assertion failed: '(lastName === "Name")'`)})((lastName === "Name"))};
           }
@@ -179,12 +179,12 @@ class $Root extends $stdlib.std.Resource {
     }
     {
       const $IF_LET_VALUE = (tryParseName("BadName"));
-      if ((tryParseName("BadName")) != undefined) {
+      if ($IF_LET_VALUE != undefined) {
         const parsedName = $IF_LET_VALUE;
         {((cond) => {if (!cond) throw new Error(`assertion failed: '(parsedName.first === "BadName")'`)})((parsedName.first === "BadName"))};
         {
           const $IF_LET_VALUE = parsedName.last;
-          if (parsedName.last != undefined) {
+          if ($IF_LET_VALUE != undefined) {
             const lastName = $IF_LET_VALUE;
             {((cond) => {if (!cond) throw new Error(`assertion failed: 'false'`)})(false)};
           }
@@ -194,7 +194,7 @@ class $Root extends $stdlib.std.Resource {
     const falsy = false;
     {
       const $IF_LET_VALUE = falsy;
-      if (falsy != undefined) {
+      if ($IF_LET_VALUE != undefined) {
         const f = $IF_LET_VALUE;
         {((cond) => {if (!cond) throw new Error(`assertion failed: '(f === false)'`)})((f === false))};
       }
@@ -205,13 +205,13 @@ class $Root extends $stdlib.std.Resource {
     const shadow = "root";
     {
       const $IF_LET_VALUE = shadow;
-      if (shadow != undefined) {
+      if ($IF_LET_VALUE != undefined) {
         const shadow = $IF_LET_VALUE;
         {((cond) => {if (!cond) throw new Error(`assertion failed: '(shadow === "root")'`)})((shadow === "root"))};
         const shadow1 = "nested";
         {
           const $IF_LET_VALUE = shadow1;
-          if (shadow1 != undefined) {
+          if ($IF_LET_VALUE != undefined) {
             const shadow1 = $IF_LET_VALUE;
             {((cond) => {if (!cond) throw new Error(`assertion failed: '(shadow1 === "nested")'`)})((shadow1 === "nested"))};
           }
@@ -225,7 +225,7 @@ class $Root extends $stdlib.std.Resource {
       {
         {
           const $IF_LET_VALUE = a;
-          if (a != undefined) {
+          if ($IF_LET_VALUE != undefined) {
             const y = $IF_LET_VALUE;
             return y;
           }
@@ -245,7 +245,7 @@ class $Root extends $stdlib.std.Resource {
     {((cond) => {if (!cond) throw new Error(`assertion failed: '(notThere === undefined)'`)})((notThere === undefined))};
     {
       const $IF_LET_VALUE = tree.left.left;
-      if (tree.left.left != undefined) {
+      if ($IF_LET_VALUE != undefined) {
         const o = $IF_LET_VALUE;
         {((cond) => {if (!cond) throw new Error(`assertion failed: '(o.value === 1)'`)})((o.value === 1))};
       }

--- a/tools/hangar/__snapshots__/test_corpus/peek.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/peek.w_compile_tf-aws.md
@@ -5,13 +5,16 @@
 module.exports = function({ c }) {
   class  $Inflight1 {
     constructor({  }) {
+      const $obj = (...args) => this.handle(...args);
+      Object.setPrototypeOf($obj, this);
+      return $obj;
     }
     async handle()  {
       {
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((typeof c.peek === "function" ? await c.peek() : await c.peek.handle()) === 0)'`)})(((typeof c.peek === "function" ? await c.peek() : await c.peek.handle()) === 0))};
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((typeof c.peek === "function" ? await c.peek() : await c.peek.handle()) === 0)'`)})(((typeof c.peek === "function" ? await c.peek() : await c.peek.handle()) === 0))};
-        (typeof c.inc === "function" ? await c.inc() : await c.inc.handle());
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((typeof c.peek === "function" ? await c.peek() : await c.peek.handle()) === 1)'`)})(((typeof c.peek === "function" ? await c.peek() : await c.peek.handle()) === 1))};
+        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await c.peek()) === 0)'`)})(((await c.peek()) === 0))};
+        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await c.peek()) === 0)'`)})(((await c.peek()) === 0))};
+        (await c.inc());
+        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await c.peek()) === 1)'`)})(((await c.peek()) === 1))};
       }
     }
   }

--- a/tools/hangar/__snapshots__/test_corpus/peek.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/peek.w_compile_tf-aws.md
@@ -3,19 +3,17 @@
 ## clients/$Inflight1.inflight.js
 ```js
 module.exports = function({ c }) {
-  class  $Inflight1 {
+  class $Inflight1 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
       Object.setPrototypeOf($obj, this);
       return $obj;
     }
     async handle()  {
-      {
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await c.peek()) === 0)'`)})(((await c.peek()) === 0))};
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await c.peek()) === 0)'`)})(((await c.peek()) === 0))};
-        (await c.inc());
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await c.peek()) === 1)'`)})(((await c.peek()) === 1))};
-      }
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '((await c.peek()) === 0)'`)})(((await c.peek()) === 0))};
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '((await c.peek()) === 0)'`)})(((await c.peek()) === 0))};
+      (await c.inc());
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '((await c.peek()) === 1)'`)})(((await c.peek()) === 1))};
     }
   }
   return $Inflight1;

--- a/tools/hangar/__snapshots__/test_corpus/pop.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/pop.w_compile_tf-aws.md
@@ -5,16 +5,19 @@
 module.exports = function({ q, NIL }) {
   class  $Inflight1 {
     constructor({  }) {
+      const $obj = (...args) => this.handle(...args);
+      Object.setPrototypeOf($obj, this);
+      return $obj;
     }
     async handle()  {
       {
         const msgs = Object.freeze(["Foo", "Bar"]);
         for (const msg of msgs) {
-          (typeof q.push === "function" ? await q.push(msg) : await q.push.handle(msg));
+          (await q.push(msg));
         }
-        const first = ((typeof q.pop === "function" ? await q.pop() : await q.pop.handle()) ?? NIL);
-        const second = ((typeof q.pop === "function" ? await q.pop() : await q.pop.handle()) ?? NIL);
-        const third = ((typeof q.pop === "function" ? await q.pop() : await q.pop.handle()) ?? NIL);
+        const first = ((await q.pop()) ?? NIL);
+        const second = ((await q.pop()) ?? NIL);
+        const third = ((await q.pop()) ?? NIL);
         {((cond) => {if (!cond) throw new Error(`assertion failed: 'msgs.includes(first)'`)})(msgs.includes(first))};
         {((cond) => {if (!cond) throw new Error(`assertion failed: 'msgs.includes(second)'`)})(msgs.includes(second))};
         {((cond) => {if (!cond) throw new Error(`assertion failed: '(third === NIL)'`)})((third === NIL))};

--- a/tools/hangar/__snapshots__/test_corpus/pop.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/pop.w_compile_tf-aws.md
@@ -3,25 +3,23 @@
 ## clients/$Inflight1.inflight.js
 ```js
 module.exports = function({ q, NIL }) {
-  class  $Inflight1 {
+  class $Inflight1 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
       Object.setPrototypeOf($obj, this);
       return $obj;
     }
     async handle()  {
-      {
-        const msgs = Object.freeze(["Foo", "Bar"]);
-        for (const msg of msgs) {
-          (await q.push(msg));
-        }
-        const first = ((await q.pop()) ?? NIL);
-        const second = ((await q.pop()) ?? NIL);
-        const third = ((await q.pop()) ?? NIL);
-        {((cond) => {if (!cond) throw new Error(`assertion failed: 'msgs.includes(first)'`)})(msgs.includes(first))};
-        {((cond) => {if (!cond) throw new Error(`assertion failed: 'msgs.includes(second)'`)})(msgs.includes(second))};
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '(third === NIL)'`)})((third === NIL))};
+      const msgs = Object.freeze(["Foo", "Bar"]);
+      for (const msg of msgs) {
+        (await q.push(msg));
       }
+      const first = ((await q.pop()) ?? NIL);
+      const second = ((await q.pop()) ?? NIL);
+      const third = ((await q.pop()) ?? NIL);
+      {((cond) => {if (!cond) throw new Error(`assertion failed: 'msgs.includes(first)'`)})(msgs.includes(first))};
+      {((cond) => {if (!cond) throw new Error(`assertion failed: 'msgs.includes(second)'`)})(msgs.includes(second))};
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '(third === NIL)'`)})((third === NIL))};
     }
   }
   return $Inflight1;

--- a/tools/hangar/__snapshots__/test_corpus/primitive_methods.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/primitive_methods.w_compile_tf-aws.md
@@ -44,8 +44,6 @@ class $Root extends $stdlib.std.Resource {
     const dur = $stdlib.std.Duration.fromSeconds(60);
     const dur2 = $stdlib.std.Duration.fromSeconds(600);
     const f =  (d) =>  {
-      {
-      }
     }
     ;
     const stringy = `${dur.minutes}:${dur.seconds}`;

--- a/tools/hangar/__snapshots__/test_corpus/print.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/print.w_compile_tf-aws.md
@@ -5,6 +5,9 @@
 module.exports = function({  }) {
   class  $Inflight1 {
     constructor({  }) {
+      const $obj = (...args) => this.handle(...args);
+      Object.setPrototypeOf($obj, this);
+      return $obj;
     }
     async handle()  {
       {
@@ -23,6 +26,9 @@ module.exports = function({  }) {
 module.exports = function({  }) {
   class  $Inflight2 {
     constructor({  }) {
+      const $obj = (...args) => this.handle(...args);
+      Object.setPrototypeOf($obj, this);
+      return $obj;
     }
     async handle()  {
       {

--- a/tools/hangar/__snapshots__/test_corpus/print.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/print.w_compile_tf-aws.md
@@ -3,17 +3,15 @@
 ## clients/$Inflight1.inflight.js
 ```js
 module.exports = function({  }) {
-  class  $Inflight1 {
+  class $Inflight1 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
       Object.setPrototypeOf($obj, this);
       return $obj;
     }
     async handle()  {
-      {
-        {console.log("inflight log 1.1")};
-        {console.log("inflight log 1.2")};
-      }
+      {console.log("inflight log 1.1")};
+      {console.log("inflight log 1.2")};
     }
   }
   return $Inflight1;
@@ -24,17 +22,15 @@ module.exports = function({  }) {
 ## clients/$Inflight2.inflight.js
 ```js
 module.exports = function({  }) {
-  class  $Inflight2 {
+  class $Inflight2 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
       Object.setPrototypeOf($obj, this);
       return $obj;
     }
     async handle()  {
-      {
-        {console.log("inflight log 2.1")};
-        {console.log("inflight log 2.2")};
-      }
+      {console.log("inflight log 2.1")};
+      {console.log("inflight log 2.2")};
     }
   }
   return $Inflight2;

--- a/tools/hangar/__snapshots__/test_corpus/purge.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/purge.w_compile_tf-aws.md
@@ -5,15 +5,18 @@
 module.exports = function({ q }) {
   class  $Inflight1 {
     constructor({  }) {
+      const $obj = (...args) => this.handle(...args);
+      Object.setPrototypeOf($obj, this);
+      return $obj;
     }
     async handle()  {
       {
-        (typeof q.push === "function" ? await q.push("foo") : await q.push.handle("foo"));
-        (typeof q.push === "function" ? await q.push("bar") : await q.push.handle("bar"));
-        (typeof q.push === "function" ? await q.push("baz") : await q.push.handle("baz"));
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((typeof q.approxSize === "function" ? await q.approxSize() : await q.approxSize.handle()) === 3)'`)})(((typeof q.approxSize === "function" ? await q.approxSize() : await q.approxSize.handle()) === 3))};
-        (typeof q.purge === "function" ? await q.purge() : await q.purge.handle());
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((typeof q.approxSize === "function" ? await q.approxSize() : await q.approxSize.handle()) === 0)'`)})(((typeof q.approxSize === "function" ? await q.approxSize() : await q.approxSize.handle()) === 0))};
+        (await q.push("foo"));
+        (await q.push("bar"));
+        (await q.push("baz"));
+        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await q.approxSize()) === 3)'`)})(((await q.approxSize()) === 3))};
+        (await q.purge());
+        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await q.approxSize()) === 0)'`)})(((await q.approxSize()) === 0))};
       }
     }
   }

--- a/tools/hangar/__snapshots__/test_corpus/purge.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/purge.w_compile_tf-aws.md
@@ -3,21 +3,19 @@
 ## clients/$Inflight1.inflight.js
 ```js
 module.exports = function({ q }) {
-  class  $Inflight1 {
+  class $Inflight1 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
       Object.setPrototypeOf($obj, this);
       return $obj;
     }
     async handle()  {
-      {
-        (await q.push("foo"));
-        (await q.push("bar"));
-        (await q.push("baz"));
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await q.approxSize()) === 3)'`)})(((await q.approxSize()) === 3))};
-        (await q.purge());
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await q.approxSize()) === 0)'`)})(((await q.approxSize()) === 0))};
-      }
+      (await q.push("foo"));
+      (await q.push("bar"));
+      (await q.push("baz"));
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '((await q.approxSize()) === 3)'`)})(((await q.approxSize()) === 3))};
+      (await q.purge());
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '((await q.approxSize()) === 0)'`)})(((await q.approxSize()) === 0))};
     }
   }
   return $Inflight1;

--- a/tools/hangar/__snapshots__/test_corpus/put.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/put.w_compile_tf-aws.md
@@ -3,28 +3,26 @@
 ## clients/$Inflight1.inflight.js
 ```js
 module.exports = function({ b }) {
-  class  $Inflight1 {
+  class $Inflight1 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
       Object.setPrototypeOf($obj, this);
       return $obj;
     }
     async handle()  {
-      {
-        (await b.put("test1.txt","Foo"));
-        (await b.put("test2.txt","Bar"));
-        const first = (await b.get("test1.txt"));
-        const second = (await b.get("test2.txt"));
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '(first === "Foo")'`)})((first === "Foo"))};
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '(second === "Bar")'`)})((second === "Bar"))};
-        (await b.delete("test1.txt"));
-        const files = (await b.list());
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '(files.includes("test1.txt") === false)'`)})((files.includes("test1.txt") === false))};
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '(files.includes("test2.txt") === true)'`)})((files.includes("test2.txt") === true))};
-        (await b.put("test2.txt","Baz"));
-        const third = (await b.get("test2.txt"));
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '(third === "Baz")'`)})((third === "Baz"))};
-      }
+      (await b.put("test1.txt","Foo"));
+      (await b.put("test2.txt","Bar"));
+      const first = (await b.get("test1.txt"));
+      const second = (await b.get("test2.txt"));
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '(first === "Foo")'`)})((first === "Foo"))};
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '(second === "Bar")'`)})((second === "Bar"))};
+      (await b.delete("test1.txt"));
+      const files = (await b.list());
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '(files.includes("test1.txt") === false)'`)})((files.includes("test1.txt") === false))};
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '(files.includes("test2.txt") === true)'`)})((files.includes("test2.txt") === true))};
+      (await b.put("test2.txt","Baz"));
+      const third = (await b.get("test2.txt"));
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '(third === "Baz")'`)})((third === "Baz"))};
     }
   }
   return $Inflight1;

--- a/tools/hangar/__snapshots__/test_corpus/put.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/put.w_compile_tf-aws.md
@@ -5,21 +5,24 @@
 module.exports = function({ b }) {
   class  $Inflight1 {
     constructor({  }) {
+      const $obj = (...args) => this.handle(...args);
+      Object.setPrototypeOf($obj, this);
+      return $obj;
     }
     async handle()  {
       {
-        (typeof b.put === "function" ? await b.put("test1.txt","Foo") : await b.put.handle("test1.txt","Foo"));
-        (typeof b.put === "function" ? await b.put("test2.txt","Bar") : await b.put.handle("test2.txt","Bar"));
-        const first = (typeof b.get === "function" ? await b.get("test1.txt") : await b.get.handle("test1.txt"));
-        const second = (typeof b.get === "function" ? await b.get("test2.txt") : await b.get.handle("test2.txt"));
+        (await b.put("test1.txt","Foo"));
+        (await b.put("test2.txt","Bar"));
+        const first = (await b.get("test1.txt"));
+        const second = (await b.get("test2.txt"));
         {((cond) => {if (!cond) throw new Error(`assertion failed: '(first === "Foo")'`)})((first === "Foo"))};
         {((cond) => {if (!cond) throw new Error(`assertion failed: '(second === "Bar")'`)})((second === "Bar"))};
-        (typeof b.delete === "function" ? await b.delete("test1.txt") : await b.delete.handle("test1.txt"));
-        const files = (typeof b.list === "function" ? await b.list() : await b.list.handle());
+        (await b.delete("test1.txt"));
+        const files = (await b.list());
         {((cond) => {if (!cond) throw new Error(`assertion failed: '(files.includes("test1.txt") === false)'`)})((files.includes("test1.txt") === false))};
         {((cond) => {if (!cond) throw new Error(`assertion failed: '(files.includes("test2.txt") === true)'`)})((files.includes("test2.txt") === true))};
-        (typeof b.put === "function" ? await b.put("test2.txt","Baz") : await b.put.handle("test2.txt","Baz"));
-        const third = (typeof b.get === "function" ? await b.get("test2.txt") : await b.get.handle("test2.txt"));
+        (await b.put("test2.txt","Baz"));
+        const third = (await b.get("test2.txt"));
         {((cond) => {if (!cond) throw new Error(`assertion failed: '(third === "Baz")'`)})((third === "Baz"))};
       }
     }

--- a/tools/hangar/__snapshots__/test_corpus/put_json.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/put_json.w_compile_tf-aws.md
@@ -5,23 +5,26 @@
 module.exports = function({ b }) {
   class  $Inflight1 {
     constructor({  }) {
+      const $obj = (...args) => this.handle(...args);
+      Object.setPrototypeOf($obj, this);
+      return $obj;
     }
     async handle()  {
       {
         const jsonObj1 = Object.freeze({"test":"test1"});
         const jsonObj2 = Object.freeze({"test":"test2"});
-        (typeof b.putJson === "function" ? await b.putJson("test1.txt",jsonObj1) : await b.putJson.handle("test1.txt",jsonObj1));
-        (typeof b.putJson === "function" ? await b.putJson("test2.txt",jsonObj2) : await b.putJson.handle("test2.txt",jsonObj2));
-        const testJson1 = (typeof b.getJson === "function" ? await b.getJson("test1.txt") : await b.getJson.handle("test1.txt"));
-        const testJson2 = (typeof b.getJson === "function" ? await b.getJson("test2.txt") : await b.getJson.handle("test2.txt"));
+        (await b.putJson("test1.txt",jsonObj1));
+        (await b.putJson("test2.txt",jsonObj2));
+        const testJson1 = (await b.getJson("test1.txt"));
+        const testJson2 = (await b.getJson("test2.txt"));
         {((cond) => {if (!cond) throw new Error(`assertion failed: '((testJson1)["test"] === (jsonObj1)["test"])'`)})(((testJson1)["test"] === (jsonObj1)["test"]))};
         {((cond) => {if (!cond) throw new Error(`assertion failed: '((testJson2)["test"] === (jsonObj2)["test"])'`)})(((testJson2)["test"] === (jsonObj2)["test"]))};
         const jsonObj3 = Object.freeze({"test":"test3"});
-        (typeof b.putJson === "function" ? await b.putJson("test3.txt",jsonObj3) : await b.putJson.handle("test3.txt",jsonObj3));
-        const testJson3 = (typeof b.getJson === "function" ? await b.getJson("test3.txt") : await b.getJson.handle("test3.txt"));
+        (await b.putJson("test3.txt",jsonObj3));
+        const testJson3 = (await b.getJson("test3.txt"));
         {((cond) => {if (!cond) throw new Error(`assertion failed: '((testJson3)["test"] === (jsonObj3)["test"])'`)})(((testJson3)["test"] === (jsonObj3)["test"]))};
-        (typeof b.delete === "function" ? await b.delete("test1.txt") : await b.delete.handle("test1.txt"));
-        const files = (typeof b.list === "function" ? await b.list() : await b.list.handle());
+        (await b.delete("test1.txt"));
+        const files = (await b.list());
         {((cond) => {if (!cond) throw new Error(`assertion failed: '(files.includes("test1.txt") === false)'`)})((files.includes("test1.txt") === false))};
         {((cond) => {if (!cond) throw new Error(`assertion failed: '(files.includes("test2.txt") === true)'`)})((files.includes("test2.txt") === true))};
       }

--- a/tools/hangar/__snapshots__/test_corpus/put_json.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/put_json.w_compile_tf-aws.md
@@ -3,31 +3,29 @@
 ## clients/$Inflight1.inflight.js
 ```js
 module.exports = function({ b }) {
-  class  $Inflight1 {
+  class $Inflight1 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
       Object.setPrototypeOf($obj, this);
       return $obj;
     }
     async handle()  {
-      {
-        const jsonObj1 = Object.freeze({"test":"test1"});
-        const jsonObj2 = Object.freeze({"test":"test2"});
-        (await b.putJson("test1.txt",jsonObj1));
-        (await b.putJson("test2.txt",jsonObj2));
-        const testJson1 = (await b.getJson("test1.txt"));
-        const testJson2 = (await b.getJson("test2.txt"));
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((testJson1)["test"] === (jsonObj1)["test"])'`)})(((testJson1)["test"] === (jsonObj1)["test"]))};
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((testJson2)["test"] === (jsonObj2)["test"])'`)})(((testJson2)["test"] === (jsonObj2)["test"]))};
-        const jsonObj3 = Object.freeze({"test":"test3"});
-        (await b.putJson("test3.txt",jsonObj3));
-        const testJson3 = (await b.getJson("test3.txt"));
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((testJson3)["test"] === (jsonObj3)["test"])'`)})(((testJson3)["test"] === (jsonObj3)["test"]))};
-        (await b.delete("test1.txt"));
-        const files = (await b.list());
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '(files.includes("test1.txt") === false)'`)})((files.includes("test1.txt") === false))};
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '(files.includes("test2.txt") === true)'`)})((files.includes("test2.txt") === true))};
-      }
+      const jsonObj1 = Object.freeze({"test":"test1"});
+      const jsonObj2 = Object.freeze({"test":"test2"});
+      (await b.putJson("test1.txt",jsonObj1));
+      (await b.putJson("test2.txt",jsonObj2));
+      const testJson1 = (await b.getJson("test1.txt"));
+      const testJson2 = (await b.getJson("test2.txt"));
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '((testJson1)["test"] === (jsonObj1)["test"])'`)})(((testJson1)["test"] === (jsonObj1)["test"]))};
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '((testJson2)["test"] === (jsonObj2)["test"])'`)})(((testJson2)["test"] === (jsonObj2)["test"]))};
+      const jsonObj3 = Object.freeze({"test":"test3"});
+      (await b.putJson("test3.txt",jsonObj3));
+      const testJson3 = (await b.getJson("test3.txt"));
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '((testJson3)["test"] === (jsonObj3)["test"])'`)})(((testJson3)["test"] === (jsonObj3)["test"]))};
+      (await b.delete("test1.txt"));
+      const files = (await b.list());
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '(files.includes("test1.txt") === false)'`)})((files.includes("test1.txt") === false))};
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '(files.includes("test2.txt") === true)'`)})((files.includes("test2.txt") === true))};
     }
   }
   return $Inflight1;

--- a/tools/hangar/__snapshots__/test_corpus/reassignment.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/reassignment.w_compile_tf-aws.md
@@ -3,7 +3,7 @@
 ## clients/R.inflight.js
 ```js
 module.exports = function({  }) {
-  class  R {
+  class R {
     constructor({ f1 }) {
       this.f1 = f1;
     }
@@ -65,10 +65,8 @@ class $Root extends $stdlib.std.Resource {
         }
       }
        inc()  {
-        {
-          const __parent_this = this;
-          this.f = (this.f + 1);
-        }
+        const __parent_this = this;
+        this.f = (this.f + 1);
       }
       static _toInflightType(context) {
         const self_client_path = "./clients/R.inflight.js".replace(/\\/g, "/");
@@ -105,10 +103,8 @@ class $Root extends $stdlib.std.Resource {
     (r.inc());
     {((cond) => {if (!cond) throw new Error(`assertion failed: '(r.f === 2)'`)})((r.f === 2))};
     const f =  (arg) =>  {
-      {
-        arg = 0;
-        return arg;
-      }
+      arg = 0;
+      return arg;
     }
     ;
     const y = 1;

--- a/tools/hangar/__snapshots__/test_corpus/redis.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/redis.w_compile_tf-aws.md
@@ -5,15 +5,18 @@
 module.exports = function({ r, r2 }) {
   class  $Inflight1 {
     constructor({  }) {
+      const $obj = (...args) => this.handle(...args);
+      Object.setPrototypeOf($obj, this);
+      return $obj;
     }
     async handle()  {
       {
-        const connection = (typeof r.rawClient === "function" ? await r.rawClient() : await r.rawClient.handle());
-        (typeof connection.set === "function" ? await connection.set("wing","does redis") : await connection.set.handle("wing","does redis"));
-        const value = (typeof connection.get === "function" ? await connection.get("wing") : await connection.get.handle("wing"));
+        const connection = (await r.rawClient());
+        (await connection.set("wing","does redis"));
+        const value = (await connection.get("wing"));
         {((cond) => {if (!cond) throw new Error(`assertion failed: '(value === "does redis")'`)})((value === "does redis"))};
-        (typeof r2.set === "function" ? await r2.set("wing","does redis again") : await r2.set.handle("wing","does redis again"));
-        const value2 = (typeof r2.get === "function" ? await r2.get("wing") : await r2.get.handle("wing"));
+        (await r2.set("wing","does redis again"));
+        const value2 = (await r2.get("wing"));
         {((cond) => {if (!cond) throw new Error(`assertion failed: '(value2 === "does redis again")'`)})((value2 === "does redis again"))};
       }
     }

--- a/tools/hangar/__snapshots__/test_corpus/redis.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/redis.w_compile_tf-aws.md
@@ -3,22 +3,20 @@
 ## clients/$Inflight1.inflight.js
 ```js
 module.exports = function({ r, r2 }) {
-  class  $Inflight1 {
+  class $Inflight1 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
       Object.setPrototypeOf($obj, this);
       return $obj;
     }
     async handle()  {
-      {
-        const connection = (await r.rawClient());
-        (await connection.set("wing","does redis"));
-        const value = (await connection.get("wing"));
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '(value === "does redis")'`)})((value === "does redis"))};
-        (await r2.set("wing","does redis again"));
-        const value2 = (await r2.get("wing"));
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '(value2 === "does redis again")'`)})((value2 === "does redis again"))};
-      }
+      const connection = (await r.rawClient());
+      (await connection.set("wing","does redis"));
+      const value = (await connection.get("wing"));
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '(value === "does redis")'`)})((value === "does redis"))};
+      (await r2.set("wing","does redis again"));
+      const value2 = (await r2.get("wing"));
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '(value2 === "does redis again")'`)})((value2 === "does redis again"))};
     }
   }
   return $Inflight1;

--- a/tools/hangar/__snapshots__/test_corpus/reset.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/reset.w_compile_tf-aws.md
@@ -5,20 +5,23 @@
 module.exports = function({ counter }) {
   class  $Inflight1 {
     constructor({  }) {
+      const $obj = (...args) => this.handle(...args);
+      Object.setPrototypeOf($obj, this);
+      return $obj;
     }
     async handle()  {
       {
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((typeof counter.peek === "function" ? await counter.peek() : await counter.peek.handle()) === 0)'`)})(((typeof counter.peek === "function" ? await counter.peek() : await counter.peek.handle()) === 0))};
-        (typeof counter.inc === "function" ? await counter.inc() : await counter.inc.handle());
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((typeof counter.peek === "function" ? await counter.peek() : await counter.peek.handle()) === 1)'`)})(((typeof counter.peek === "function" ? await counter.peek() : await counter.peek.handle()) === 1))};
-        (typeof counter.inc === "function" ? await counter.inc() : await counter.inc.handle());
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((typeof counter.peek === "function" ? await counter.peek() : await counter.peek.handle()) === 2)'`)})(((typeof counter.peek === "function" ? await counter.peek() : await counter.peek.handle()) === 2))};
-        (typeof counter.inc === "function" ? await counter.inc(10) : await counter.inc.handle(10));
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((typeof counter.peek === "function" ? await counter.peek() : await counter.peek.handle()) === 12)'`)})(((typeof counter.peek === "function" ? await counter.peek() : await counter.peek.handle()) === 12))};
-        (typeof counter.reset === "function" ? await counter.reset() : await counter.reset.handle());
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((typeof counter.peek === "function" ? await counter.peek() : await counter.peek.handle()) === 0)'`)})(((typeof counter.peek === "function" ? await counter.peek() : await counter.peek.handle()) === 0))};
-        (typeof counter.reset === "function" ? await counter.reset(88) : await counter.reset.handle(88));
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((typeof counter.peek === "function" ? await counter.peek() : await counter.peek.handle()) === 88)'`)})(((typeof counter.peek === "function" ? await counter.peek() : await counter.peek.handle()) === 88))};
+        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await counter.peek()) === 0)'`)})(((await counter.peek()) === 0))};
+        (await counter.inc());
+        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await counter.peek()) === 1)'`)})(((await counter.peek()) === 1))};
+        (await counter.inc());
+        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await counter.peek()) === 2)'`)})(((await counter.peek()) === 2))};
+        (await counter.inc(10));
+        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await counter.peek()) === 12)'`)})(((await counter.peek()) === 12))};
+        (await counter.reset());
+        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await counter.peek()) === 0)'`)})(((await counter.peek()) === 0))};
+        (await counter.reset(88));
+        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await counter.peek()) === 88)'`)})(((await counter.peek()) === 88))};
       }
     }
   }

--- a/tools/hangar/__snapshots__/test_corpus/reset.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/reset.w_compile_tf-aws.md
@@ -3,26 +3,24 @@
 ## clients/$Inflight1.inflight.js
 ```js
 module.exports = function({ counter }) {
-  class  $Inflight1 {
+  class $Inflight1 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
       Object.setPrototypeOf($obj, this);
       return $obj;
     }
     async handle()  {
-      {
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await counter.peek()) === 0)'`)})(((await counter.peek()) === 0))};
-        (await counter.inc());
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await counter.peek()) === 1)'`)})(((await counter.peek()) === 1))};
-        (await counter.inc());
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await counter.peek()) === 2)'`)})(((await counter.peek()) === 2))};
-        (await counter.inc(10));
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await counter.peek()) === 12)'`)})(((await counter.peek()) === 12))};
-        (await counter.reset());
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await counter.peek()) === 0)'`)})(((await counter.peek()) === 0))};
-        (await counter.reset(88));
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await counter.peek()) === 88)'`)})(((await counter.peek()) === 88))};
-      }
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '((await counter.peek()) === 0)'`)})(((await counter.peek()) === 0))};
+      (await counter.inc());
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '((await counter.peek()) === 1)'`)})(((await counter.peek()) === 1))};
+      (await counter.inc());
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '((await counter.peek()) === 2)'`)})(((await counter.peek()) === 2))};
+      (await counter.inc(10));
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '((await counter.peek()) === 12)'`)})(((await counter.peek()) === 12))};
+      (await counter.reset());
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '((await counter.peek()) === 0)'`)})(((await counter.peek()) === 0))};
+      (await counter.reset(88));
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '((await counter.peek()) === 88)'`)})(((await counter.peek()) === 88))};
     }
   }
   return $Inflight1;

--- a/tools/hangar/__snapshots__/test_corpus/resource.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/resource.w_compile_tf-aws.md
@@ -3,20 +3,18 @@
 ## clients/$Inflight1.inflight.js
 ```js
 module.exports = function({ res, bucket }) {
-  class  $Inflight1 {
+  class $Inflight1 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
       Object.setPrototypeOf($obj, this);
       return $obj;
     }
     async handle()  {
-      {
-        const s = (await res.myMethod());
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '(s === "counter is: 101")'`)})((s === "counter is: 101"))};
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await bucket.list()).length === 1)'`)})(((await bucket.list()).length === 1))};
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '(res.foo.inflightField === 123)'`)})((res.foo.inflightField === 123))};
-        (await res.testTypeAccess());
-      }
+      const s = (await res.myMethod());
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '(s === "counter is: 101")'`)})((s === "counter is: 101"))};
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '((await bucket.list()).length === 1)'`)})(((await bucket.list()).length === 1))};
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '(res.foo.inflightField === 123)'`)})((res.foo.inflightField === 123))};
+      (await res.testTypeAccess());
     }
   }
   return $Inflight1;
@@ -27,16 +25,14 @@ module.exports = function({ res, bucket }) {
 ## clients/$Inflight2.inflight.js
 ```js
 module.exports = function({ __parent_this }) {
-  class  $Inflight2 {
+  class $Inflight2 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
       Object.setPrototypeOf($obj, this);
       return $obj;
     }
     async handle()  {
-      {
-        (await __parent_this.b.put("foo1.txt","bar"));
-      }
+      (await __parent_this.b.put("foo1.txt","bar"));
     }
   }
   return $Inflight2;
@@ -47,16 +43,14 @@ module.exports = function({ __parent_this }) {
 ## clients/$Inflight3.inflight.js
 ```js
 module.exports = function({ __parent_this }) {
-  class  $Inflight3 {
+  class $Inflight3 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
       Object.setPrototypeOf($obj, this);
       return $obj;
     }
     async handle()  {
-      {
-        (await __parent_this.b.put("foo2.txt","bar"));
-      }
+      (await __parent_this.b.put("foo2.txt","bar"));
     }
   }
   return $Inflight3;
@@ -67,16 +61,14 @@ module.exports = function({ __parent_this }) {
 ## clients/$Inflight4.inflight.js
 ```js
 module.exports = function({ __parent_this }) {
-  class  $Inflight4 {
+  class $Inflight4 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
       Object.setPrototypeOf($obj, this);
       return $obj;
     }
     async handle()  {
-      {
-        (await __parent_this.q.push("foo"));
-      }
+      (await __parent_this.q.push("foo"));
     }
   }
   return $Inflight4;
@@ -87,17 +79,15 @@ module.exports = function({ __parent_this }) {
 ## clients/$Inflight5.inflight.js
 ```js
 module.exports = function({ bigOlPublisher }) {
-  class  $Inflight5 {
+  class $Inflight5 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
       Object.setPrototypeOf($obj, this);
       return $obj;
     }
     async handle()  {
-      {
-        (await bigOlPublisher.publish("foo"));
-        const count = (await bigOlPublisher.getObjectCount());
-      }
+      (await bigOlPublisher.publish("foo"));
+      const count = (await bigOlPublisher.getObjectCount());
     }
   }
   return $Inflight5;
@@ -108,7 +98,7 @@ module.exports = function({ bigOlPublisher }) {
 ## clients/Bar.inflight.js
 ```js
 module.exports = function({ Foo, MyEnum }) {
-  class  Bar {
+  class Bar {
     constructor({ b, e, foo, name }) {
       this.b = b;
       this.e = e;
@@ -116,28 +106,22 @@ module.exports = function({ Foo, MyEnum }) {
       this.name = name;
     }
     static async barStatic()  {
-      {
-        return "bar static";
-      }
+      return "bar static";
     }
     async myMethod()  {
-      {
-        const __parent_this = this;
-        (await this.foo.fooInc());
-        const s = (await Foo.fooStatic());
-        (await this.b.put("foo",`counter is: ${(await this.foo.fooGet())}`));
-        return (await this.b.get("foo"));
-      }
+      const __parent_this = this;
+      (await this.foo.fooInc());
+      const s = (await Foo.fooStatic());
+      (await this.b.put("foo",`counter is: ${(await this.foo.fooGet())}`));
+      return (await this.b.get("foo"));
     }
     async testTypeAccess()  {
-      {
+      const __parent_this = this;
+      if (true) {
         const __parent_this = this;
-        if (true) {
-          const __parent_this = this;
-          {((cond) => {if (!cond) throw new Error(`assertion failed: '((await Bar.barStatic()) === "bar static")'`)})(((await Bar.barStatic()) === "bar static"))};
-          {((cond) => {if (!cond) throw new Error(`assertion failed: '((await Foo.fooStatic()) === "foo static")'`)})(((await Foo.fooStatic()) === "foo static"))};
-          {((cond) => {if (!cond) throw new Error(`assertion failed: '(this.e === MyEnum.B)'`)})((this.e === MyEnum.B))};
-        }
+        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await Bar.barStatic()) === "bar static")'`)})(((await Bar.barStatic()) === "bar static"))};
+        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await Foo.fooStatic()) === "foo static")'`)})(((await Foo.fooStatic()) === "foo static"))};
+        {((cond) => {if (!cond) throw new Error(`assertion failed: '(this.e === MyEnum.B)'`)})((this.e === MyEnum.B))};
       }
     }
   }
@@ -149,7 +133,7 @@ module.exports = function({ Foo, MyEnum }) {
 ## clients/BigPublisher.inflight.js
 ```js
 module.exports = function({  }) {
-  class  BigPublisher {
+  class BigPublisher {
     constructor({ b, b2, q, t }) {
       this.b = b;
       this.b2 = b2;
@@ -157,18 +141,14 @@ module.exports = function({  }) {
       this.t = t;
     }
     async publish(s)  {
-      {
-        const __parent_this = this;
-        (await this.t.publish(s));
-        (await this.q.push(s));
-        (await this.b2.put("foo",s));
-      }
+      const __parent_this = this;
+      (await this.t.publish(s));
+      (await this.q.push(s));
+      (await this.b2.put("foo",s));
     }
     async getObjectCount()  {
-      {
-        const __parent_this = this;
-        return (await this.b.list()).length;
-      }
+      const __parent_this = this;
+      return (await this.b.list()).length;
     }
   }
   return BigPublisher;
@@ -179,34 +159,26 @@ module.exports = function({  }) {
 ## clients/Foo.inflight.js
 ```js
 module.exports = function({  }) {
-  class  Foo {
+  class Foo {
     constructor({ c }) {
       this.c = c;
     }
     async $inflight_init()  {
-      {
-        const __parent_this = this;
-        this.inflightField = 123;
-        (await this.c.inc(110));
-        (await this.c.dec(10));
-      }
+      const __parent_this = this;
+      this.inflightField = 123;
+      (await this.c.inc(110));
+      (await this.c.dec(10));
     }
     async fooInc()  {
-      {
-        const __parent_this = this;
-        (await this.c.inc());
-      }
+      const __parent_this = this;
+      (await this.c.inc());
     }
     async fooGet()  {
-      {
-        const __parent_this = this;
-        return (await this.c.peek());
-      }
+      const __parent_this = this;
+      return (await this.c.peek());
     }
     static async fooStatic()  {
-      {
-        return "foo static";
-      }
+      return "foo static";
     }
   }
   return Foo;

--- a/tools/hangar/__snapshots__/test_corpus/resource.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/resource.w_compile_tf-aws.md
@@ -5,14 +5,17 @@
 module.exports = function({ res, bucket }) {
   class  $Inflight1 {
     constructor({  }) {
+      const $obj = (...args) => this.handle(...args);
+      Object.setPrototypeOf($obj, this);
+      return $obj;
     }
     async handle()  {
       {
-        const s = (typeof res.myMethod === "function" ? await res.myMethod() : await res.myMethod.handle());
+        const s = (await res.myMethod());
         {((cond) => {if (!cond) throw new Error(`assertion failed: '(s === "counter is: 101")'`)})((s === "counter is: 101"))};
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((typeof bucket.list === "function" ? await bucket.list() : await bucket.list.handle()).length === 1)'`)})(((typeof bucket.list === "function" ? await bucket.list() : await bucket.list.handle()).length === 1))};
+        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await bucket.list()).length === 1)'`)})(((await bucket.list()).length === 1))};
         {((cond) => {if (!cond) throw new Error(`assertion failed: '(res.foo.inflightField === 123)'`)})((res.foo.inflightField === 123))};
-        (typeof res.testTypeAccess === "function" ? await res.testTypeAccess() : await res.testTypeAccess.handle());
+        (await res.testTypeAccess());
       }
     }
   }
@@ -26,10 +29,13 @@ module.exports = function({ res, bucket }) {
 module.exports = function({ __parent_this }) {
   class  $Inflight2 {
     constructor({  }) {
+      const $obj = (...args) => this.handle(...args);
+      Object.setPrototypeOf($obj, this);
+      return $obj;
     }
     async handle()  {
       {
-        (typeof __parent_this.b.put === "function" ? await __parent_this.b.put("foo1.txt","bar") : await __parent_this.b.put.handle("foo1.txt","bar"));
+        (await __parent_this.b.put("foo1.txt","bar"));
       }
     }
   }
@@ -43,10 +49,13 @@ module.exports = function({ __parent_this }) {
 module.exports = function({ __parent_this }) {
   class  $Inflight3 {
     constructor({  }) {
+      const $obj = (...args) => this.handle(...args);
+      Object.setPrototypeOf($obj, this);
+      return $obj;
     }
     async handle()  {
       {
-        (typeof __parent_this.b.put === "function" ? await __parent_this.b.put("foo2.txt","bar") : await __parent_this.b.put.handle("foo2.txt","bar"));
+        (await __parent_this.b.put("foo2.txt","bar"));
       }
     }
   }
@@ -60,10 +69,13 @@ module.exports = function({ __parent_this }) {
 module.exports = function({ __parent_this }) {
   class  $Inflight4 {
     constructor({  }) {
+      const $obj = (...args) => this.handle(...args);
+      Object.setPrototypeOf($obj, this);
+      return $obj;
     }
     async handle()  {
       {
-        (typeof __parent_this.q.push === "function" ? await __parent_this.q.push("foo") : await __parent_this.q.push.handle("foo"));
+        (await __parent_this.q.push("foo"));
       }
     }
   }
@@ -77,11 +89,14 @@ module.exports = function({ __parent_this }) {
 module.exports = function({ bigOlPublisher }) {
   class  $Inflight5 {
     constructor({  }) {
+      const $obj = (...args) => this.handle(...args);
+      Object.setPrototypeOf($obj, this);
+      return $obj;
     }
     async handle()  {
       {
-        (typeof bigOlPublisher.publish === "function" ? await bigOlPublisher.publish("foo") : await bigOlPublisher.publish.handle("foo"));
-        const count = (typeof bigOlPublisher.getObjectCount === "function" ? await bigOlPublisher.getObjectCount() : await bigOlPublisher.getObjectCount.handle());
+        (await bigOlPublisher.publish("foo"));
+        const count = (await bigOlPublisher.getObjectCount());
       }
     }
   }
@@ -108,10 +123,10 @@ module.exports = function({ Foo, MyEnum }) {
     async myMethod()  {
       {
         const __parent_this = this;
-        (typeof this.foo.fooInc === "function" ? await this.foo.fooInc() : await this.foo.fooInc.handle());
-        const s = (typeof Foo.fooStatic === "function" ? await Foo.fooStatic() : await Foo.fooStatic.handle());
-        (typeof this.b.put === "function" ? await this.b.put("foo",`counter is: ${(typeof this.foo.fooGet === "function" ? await this.foo.fooGet() : await this.foo.fooGet.handle())}`) : await this.b.put.handle("foo",`counter is: ${(typeof this.foo.fooGet === "function" ? await this.foo.fooGet() : await this.foo.fooGet.handle())}`));
-        return (typeof this.b.get === "function" ? await this.b.get("foo") : await this.b.get.handle("foo"));
+        (await this.foo.fooInc());
+        const s = (await Foo.fooStatic());
+        (await this.b.put("foo",`counter is: ${(await this.foo.fooGet())}`));
+        return (await this.b.get("foo"));
       }
     }
     async testTypeAccess()  {
@@ -119,8 +134,8 @@ module.exports = function({ Foo, MyEnum }) {
         const __parent_this = this;
         if (true) {
           const __parent_this = this;
-          {((cond) => {if (!cond) throw new Error(`assertion failed: '((typeof Bar.barStatic === "function" ? await Bar.barStatic() : await Bar.barStatic.handle()) === "bar static")'`)})(((typeof Bar.barStatic === "function" ? await Bar.barStatic() : await Bar.barStatic.handle()) === "bar static"))};
-          {((cond) => {if (!cond) throw new Error(`assertion failed: '((typeof Foo.fooStatic === "function" ? await Foo.fooStatic() : await Foo.fooStatic.handle()) === "foo static")'`)})(((typeof Foo.fooStatic === "function" ? await Foo.fooStatic() : await Foo.fooStatic.handle()) === "foo static"))};
+          {((cond) => {if (!cond) throw new Error(`assertion failed: '((await Bar.barStatic()) === "bar static")'`)})(((await Bar.barStatic()) === "bar static"))};
+          {((cond) => {if (!cond) throw new Error(`assertion failed: '((await Foo.fooStatic()) === "foo static")'`)})(((await Foo.fooStatic()) === "foo static"))};
           {((cond) => {if (!cond) throw new Error(`assertion failed: '(this.e === MyEnum.B)'`)})((this.e === MyEnum.B))};
         }
       }
@@ -144,15 +159,15 @@ module.exports = function({  }) {
     async publish(s)  {
       {
         const __parent_this = this;
-        (typeof this.t.publish === "function" ? await this.t.publish(s) : await this.t.publish.handle(s));
-        (typeof this.q.push === "function" ? await this.q.push(s) : await this.q.push.handle(s));
-        (typeof this.b2.put === "function" ? await this.b2.put("foo",s) : await this.b2.put.handle("foo",s));
+        (await this.t.publish(s));
+        (await this.q.push(s));
+        (await this.b2.put("foo",s));
       }
     }
     async getObjectCount()  {
       {
         const __parent_this = this;
-        return (typeof this.b.list === "function" ? await this.b.list() : await this.b.list.handle()).length;
+        return (await this.b.list()).length;
       }
     }
   }
@@ -172,20 +187,20 @@ module.exports = function({  }) {
       {
         const __parent_this = this;
         this.inflightField = 123;
-        (typeof this.c.inc === "function" ? await this.c.inc(110) : await this.c.inc.handle(110));
-        (typeof this.c.dec === "function" ? await this.c.dec(10) : await this.c.dec.handle(10));
+        (await this.c.inc(110));
+        (await this.c.dec(10));
       }
     }
     async fooInc()  {
       {
         const __parent_this = this;
-        (typeof this.c.inc === "function" ? await this.c.inc() : await this.c.inc.handle());
+        (await this.c.inc());
       }
     }
     async fooGet()  {
       {
         const __parent_this = this;
-        return (typeof this.c.peek === "function" ? await this.c.peek() : await this.c.peek.handle());
+        return (await this.c.peek());
       }
     }
     static async fooStatic()  {

--- a/tools/hangar/__snapshots__/test_corpus/resource_as_inflight_literal.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/resource_as_inflight_literal.w_compile_tf-aws.md
@@ -5,10 +5,13 @@
 module.exports = function({ fn }) {
   class  $Inflight1 {
     constructor({  }) {
+      const $obj = (...args) => this.handle(...args);
+      Object.setPrototypeOf($obj, this);
+      return $obj;
     }
     async handle()  {
       {
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((typeof fn.invoke === "function" ? await fn.invoke("test") : await fn.invoke.handle("test")) === "hello world!")'`)})(((typeof fn.invoke === "function" ? await fn.invoke("test") : await fn.invoke.handle("test")) === "hello world!"))};
+        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await fn.invoke("test")) === "hello world!")'`)})(((await fn.invoke("test")) === "hello world!"))};
       }
     }
   }
@@ -22,6 +25,9 @@ module.exports = function({ fn }) {
 module.exports = function({  }) {
   class  Foo {
     constructor({  }) {
+      const $obj = (...args) => this.handle(...args);
+      Object.setPrototypeOf($obj, this);
+      return $obj;
     }
     async handle(message)  {
       {

--- a/tools/hangar/__snapshots__/test_corpus/resource_as_inflight_literal.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/resource_as_inflight_literal.w_compile_tf-aws.md
@@ -3,16 +3,14 @@
 ## clients/$Inflight1.inflight.js
 ```js
 module.exports = function({ fn }) {
-  class  $Inflight1 {
+  class $Inflight1 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
       Object.setPrototypeOf($obj, this);
       return $obj;
     }
     async handle()  {
-      {
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await fn.invoke("test")) === "hello world!")'`)})(((await fn.invoke("test")) === "hello world!"))};
-      }
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '((await fn.invoke("test")) === "hello world!")'`)})(((await fn.invoke("test")) === "hello world!"))};
     }
   }
   return $Inflight1;
@@ -23,17 +21,15 @@ module.exports = function({ fn }) {
 ## clients/Foo.inflight.js
 ```js
 module.exports = function({  }) {
-  class  Foo {
+  class Foo {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
       Object.setPrototypeOf($obj, this);
       return $obj;
     }
     async handle(message)  {
-      {
-        const __parent_this = this;
-        return "hello world!";
-      }
+      const __parent_this = this;
+      return "hello world!";
     }
   }
   return Foo;

--- a/tools/hangar/__snapshots__/test_corpus/resource_captures.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/resource_captures.w_compile_tf-aws.md
@@ -3,26 +3,24 @@
 ## clients/$Inflight1.inflight.js
 ```js
 module.exports = function({ r }) {
-  class  $Inflight1 {
+  class $Inflight1 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
       Object.setPrototypeOf($obj, this);
       return $obj;
     }
     async handle()  {
-      {
-        (await r.testNoCapture());
-        (await r.testCaptureCollectionsOfData());
-        (await r.testCapturePrimitives());
-        (await r.testCaptureOptional());
-        (await r.testCaptureResource());
-        (await r.testNestedInflightField());
-        (await r.testNestedResource());
-        (await r.testExpressionRecursive());
-        (await r.testExternal());
-        (await r.testUserDefinedResource());
-        (await r.testInflightField());
-      }
+      (await r.testNoCapture());
+      (await r.testCaptureCollectionsOfData());
+      (await r.testCapturePrimitives());
+      (await r.testCaptureOptional());
+      (await r.testCaptureResource());
+      (await r.testNestedInflightField());
+      (await r.testNestedResource());
+      (await r.testExpressionRecursive());
+      (await r.testExternal());
+      (await r.testUserDefinedResource());
+      (await r.testInflightField());
     }
   }
   return $Inflight1;
@@ -33,22 +31,18 @@ module.exports = function({ r }) {
 ## clients/Another.inflight.js
 ```js
 module.exports = function({  }) {
-  class  Another {
+  class Another {
     constructor({ first, myField }) {
       this.first = first;
       this.myField = myField;
     }
     async meaningOfLife()  {
-      {
-        const __parent_this = this;
-        return 42;
-      }
+      const __parent_this = this;
+      return 42;
     }
     async anotherFunc()  {
-      {
-        const __parent_this = this;
-        return "42";
-      }
+      const __parent_this = this;
+      return "42";
     }
   }
   return Another;
@@ -59,7 +53,7 @@ module.exports = function({  }) {
 ## clients/First.inflight.js
 ```js
 module.exports = function({  }) {
-  class  First {
+  class First {
     constructor({ myResource }) {
       this.myResource = myResource;
     }
@@ -72,7 +66,7 @@ module.exports = function({  }) {
 ## clients/MyResource.inflight.js
 ```js
 module.exports = function({  }) {
-  class  MyResource {
+  class MyResource {
     constructor({ another, arrayOfStr, extBucket, extNum, mapOfNum, myBool, myNum, myOptStr, myQueue, myResource, myStr, setOfStr, unusedResource }) {
       this.another = another;
       this.arrayOfStr = arrayOfStr;
@@ -89,94 +83,70 @@ module.exports = function({  }) {
       this.unusedResource = unusedResource;
     }
     async $inflight_init()  {
-      {
-        const __parent_this = this;
-        this.inflightField = 123;
-      }
+      const __parent_this = this;
+      this.inflightField = 123;
     }
     async testNoCapture()  {
-      {
-        const __parent_this = this;
-        const arr = Object.freeze([1, 2, 3]);
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '(arr.length === 3)'`)})((arr.length === 3))};
-        {console.log(`array.len=${arr.length}`)};
-      }
+      const __parent_this = this;
+      const arr = Object.freeze([1, 2, 3]);
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '(arr.length === 3)'`)})((arr.length === 3))};
+      {console.log(`array.len=${arr.length}`)};
     }
     async testCaptureCollectionsOfData()  {
-      {
-        const __parent_this = this;
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '(this.arrayOfStr.length === 2)'`)})((this.arrayOfStr.length === 2))};
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await this.arrayOfStr.at(0)) === "s1")'`)})(((await this.arrayOfStr.at(0)) === "s1"))};
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await this.arrayOfStr.at(1)) === "s2")'`)})(((await this.arrayOfStr.at(1)) === "s2"))};
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((this.mapOfNum)["k1"] === 11)'`)})(((this.mapOfNum)["k1"] === 11))};
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((this.mapOfNum)["k2"] === 22)'`)})(((this.mapOfNum)["k2"] === 22))};
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '(await this.setOfStr.has("s1"))'`)})((await this.setOfStr.has("s1")))};
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '(await this.setOfStr.has("s2"))'`)})((await this.setOfStr.has("s2")))};
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '(!(await this.setOfStr.has("s3")))'`)})((!(await this.setOfStr.has("s3"))))};
-      }
+      const __parent_this = this;
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '(this.arrayOfStr.length === 2)'`)})((this.arrayOfStr.length === 2))};
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '((await this.arrayOfStr.at(0)) === "s1")'`)})(((await this.arrayOfStr.at(0)) === "s1"))};
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '((await this.arrayOfStr.at(1)) === "s2")'`)})(((await this.arrayOfStr.at(1)) === "s2"))};
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '((this.mapOfNum)["k1"] === 11)'`)})(((this.mapOfNum)["k1"] === 11))};
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '((this.mapOfNum)["k2"] === 22)'`)})(((this.mapOfNum)["k2"] === 22))};
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '(await this.setOfStr.has("s1"))'`)})((await this.setOfStr.has("s1")))};
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '(await this.setOfStr.has("s2"))'`)})((await this.setOfStr.has("s2")))};
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '(!(await this.setOfStr.has("s3")))'`)})((!(await this.setOfStr.has("s3"))))};
     }
     async testCapturePrimitives()  {
-      {
-        const __parent_this = this;
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '(this.myStr === "myString")'`)})((this.myStr === "myString"))};
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '(this.myNum === 42)'`)})((this.myNum === 42))};
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '(this.myBool === true)'`)})((this.myBool === true))};
-      }
+      const __parent_this = this;
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '(this.myStr === "myString")'`)})((this.myStr === "myString"))};
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '(this.myNum === 42)'`)})((this.myNum === 42))};
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '(this.myBool === true)'`)})((this.myBool === true))};
     }
     async testCaptureOptional()  {
-      {
-        const __parent_this = this;
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((this.myOptStr ?? "") === "myOptString")'`)})(((this.myOptStr ?? "") === "myOptString"))};
-      }
+      const __parent_this = this;
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '((this.myOptStr ?? "") === "myOptString")'`)})(((this.myOptStr ?? "") === "myOptString"))};
     }
     async testCaptureResource()  {
-      {
-        const __parent_this = this;
-        (await this.myResource.put("f1.txt","f1"));
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await this.myResource.get("f1.txt")) === "f1")'`)})(((await this.myResource.get("f1.txt")) === "f1"))};
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await this.myResource.list()).length === 1)'`)})(((await this.myResource.list()).length === 1))};
-      }
+      const __parent_this = this;
+      (await this.myResource.put("f1.txt","f1"));
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '((await this.myResource.get("f1.txt")) === "f1")'`)})(((await this.myResource.get("f1.txt")) === "f1"))};
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '((await this.myResource.list()).length === 1)'`)})(((await this.myResource.list()).length === 1))};
     }
     async testNestedInflightField()  {
-      {
-        const __parent_this = this;
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '(this.another.myField === "hello!")'`)})((this.another.myField === "hello!"))};
-        {console.log(`field=${this.another.myField}`)};
-      }
+      const __parent_this = this;
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '(this.another.myField === "hello!")'`)})((this.another.myField === "hello!"))};
+      {console.log(`field=${this.another.myField}`)};
     }
     async testNestedResource()  {
-      {
-        const __parent_this = this;
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await this.another.first.myResource.list()).length === 0)'`)})(((await this.another.first.myResource.list()).length === 0))};
-        (await this.another.first.myResource.put("hello",this.myStr));
-        {console.log(`this.another.first.myResource:${(await this.another.first.myResource.get("hello"))}`)};
-      }
+      const __parent_this = this;
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '((await this.another.first.myResource.list()).length === 0)'`)})(((await this.another.first.myResource.list()).length === 0))};
+      (await this.another.first.myResource.put("hello",this.myStr));
+      {console.log(`this.another.first.myResource:${(await this.another.first.myResource.get("hello"))}`)};
     }
     async testExpressionRecursive()  {
-      {
-        const __parent_this = this;
-        (await this.myQueue.push(this.myStr));
-      }
+      const __parent_this = this;
+      (await this.myQueue.push(this.myStr));
     }
     async testExternal()  {
-      {
-        const __parent_this = this;
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await this.extBucket.list()).length === 0)'`)})(((await this.extBucket.list()).length === 0))};
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '(this.extNum === 12)'`)})((this.extNum === 12))};
-      }
+      const __parent_this = this;
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '((await this.extBucket.list()).length === 0)'`)})(((await this.extBucket.list()).length === 0))};
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '(this.extNum === 12)'`)})((this.extNum === 12))};
     }
     async testUserDefinedResource()  {
-      {
-        const __parent_this = this;
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await this.another.meaningOfLife()) === 42)'`)})(((await this.another.meaningOfLife()) === 42))};
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await this.another.anotherFunc()) === "42")'`)})(((await this.another.anotherFunc()) === "42"))};
-      }
+      const __parent_this = this;
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '((await this.another.meaningOfLife()) === 42)'`)})(((await this.another.meaningOfLife()) === 42))};
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '((await this.another.anotherFunc()) === "42")'`)})(((await this.another.anotherFunc()) === "42"))};
     }
     async testInflightField()  {
-      {
-        const __parent_this = this;
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '(this.inflightField === 123)'`)})((this.inflightField === 123))};
-      }
+      const __parent_this = this;
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '(this.inflightField === 123)'`)})((this.inflightField === 123))};
     }
   }
   return MyResource;
@@ -568,10 +538,8 @@ class $Root extends $stdlib.std.Resource {
         this.unusedResource = this.node.root.newAbstract("@winglang/sdk.cloud.Counter",this,"cloud.Counter");
       }
        helloPreflight()  {
-        {
-          const __parent_this = this;
-          return this.another;
-        }
+        const __parent_this = this;
+        return this.another;
       }
       static _toInflightType(context) {
         const self_client_path = "./clients/MyResource.inflight.js".replace(/\\/g, "/");

--- a/tools/hangar/__snapshots__/test_corpus/resource_captures.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/resource_captures.w_compile_tf-aws.md
@@ -5,20 +5,23 @@
 module.exports = function({ r }) {
   class  $Inflight1 {
     constructor({  }) {
+      const $obj = (...args) => this.handle(...args);
+      Object.setPrototypeOf($obj, this);
+      return $obj;
     }
     async handle()  {
       {
-        (typeof r.testNoCapture === "function" ? await r.testNoCapture() : await r.testNoCapture.handle());
-        (typeof r.testCaptureCollectionsOfData === "function" ? await r.testCaptureCollectionsOfData() : await r.testCaptureCollectionsOfData.handle());
-        (typeof r.testCapturePrimitives === "function" ? await r.testCapturePrimitives() : await r.testCapturePrimitives.handle());
-        (typeof r.testCaptureOptional === "function" ? await r.testCaptureOptional() : await r.testCaptureOptional.handle());
-        (typeof r.testCaptureResource === "function" ? await r.testCaptureResource() : await r.testCaptureResource.handle());
-        (typeof r.testNestedInflightField === "function" ? await r.testNestedInflightField() : await r.testNestedInflightField.handle());
-        (typeof r.testNestedResource === "function" ? await r.testNestedResource() : await r.testNestedResource.handle());
-        (typeof r.testExpressionRecursive === "function" ? await r.testExpressionRecursive() : await r.testExpressionRecursive.handle());
-        (typeof r.testExternal === "function" ? await r.testExternal() : await r.testExternal.handle());
-        (typeof r.testUserDefinedResource === "function" ? await r.testUserDefinedResource() : await r.testUserDefinedResource.handle());
-        (typeof r.testInflightField === "function" ? await r.testInflightField() : await r.testInflightField.handle());
+        (await r.testNoCapture());
+        (await r.testCaptureCollectionsOfData());
+        (await r.testCapturePrimitives());
+        (await r.testCaptureOptional());
+        (await r.testCaptureResource());
+        (await r.testNestedInflightField());
+        (await r.testNestedResource());
+        (await r.testExpressionRecursive());
+        (await r.testExternal());
+        (await r.testUserDefinedResource());
+        (await r.testInflightField());
       }
     }
   }
@@ -103,13 +106,13 @@ module.exports = function({  }) {
       {
         const __parent_this = this;
         {((cond) => {if (!cond) throw new Error(`assertion failed: '(this.arrayOfStr.length === 2)'`)})((this.arrayOfStr.length === 2))};
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((typeof this.arrayOfStr.at === "function" ? await this.arrayOfStr.at(0) : await this.arrayOfStr.at.handle(0)) === "s1")'`)})(((typeof this.arrayOfStr.at === "function" ? await this.arrayOfStr.at(0) : await this.arrayOfStr.at.handle(0)) === "s1"))};
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((typeof this.arrayOfStr.at === "function" ? await this.arrayOfStr.at(1) : await this.arrayOfStr.at.handle(1)) === "s2")'`)})(((typeof this.arrayOfStr.at === "function" ? await this.arrayOfStr.at(1) : await this.arrayOfStr.at.handle(1)) === "s2"))};
+        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await this.arrayOfStr.at(0)) === "s1")'`)})(((await this.arrayOfStr.at(0)) === "s1"))};
+        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await this.arrayOfStr.at(1)) === "s2")'`)})(((await this.arrayOfStr.at(1)) === "s2"))};
         {((cond) => {if (!cond) throw new Error(`assertion failed: '((this.mapOfNum)["k1"] === 11)'`)})(((this.mapOfNum)["k1"] === 11))};
         {((cond) => {if (!cond) throw new Error(`assertion failed: '((this.mapOfNum)["k2"] === 22)'`)})(((this.mapOfNum)["k2"] === 22))};
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '(typeof this.setOfStr.has === "function" ? await this.setOfStr.has("s1") : await this.setOfStr.has.handle("s1"))'`)})((typeof this.setOfStr.has === "function" ? await this.setOfStr.has("s1") : await this.setOfStr.has.handle("s1")))};
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '(typeof this.setOfStr.has === "function" ? await this.setOfStr.has("s2") : await this.setOfStr.has.handle("s2"))'`)})((typeof this.setOfStr.has === "function" ? await this.setOfStr.has("s2") : await this.setOfStr.has.handle("s2")))};
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '(!(typeof this.setOfStr.has === "function" ? await this.setOfStr.has("s3") : await this.setOfStr.has.handle("s3")))'`)})((!(typeof this.setOfStr.has === "function" ? await this.setOfStr.has("s3") : await this.setOfStr.has.handle("s3"))))};
+        {((cond) => {if (!cond) throw new Error(`assertion failed: '(await this.setOfStr.has("s1"))'`)})((await this.setOfStr.has("s1")))};
+        {((cond) => {if (!cond) throw new Error(`assertion failed: '(await this.setOfStr.has("s2"))'`)})((await this.setOfStr.has("s2")))};
+        {((cond) => {if (!cond) throw new Error(`assertion failed: '(!(await this.setOfStr.has("s3")))'`)})((!(await this.setOfStr.has("s3"))))};
       }
     }
     async testCapturePrimitives()  {
@@ -129,9 +132,9 @@ module.exports = function({  }) {
     async testCaptureResource()  {
       {
         const __parent_this = this;
-        (typeof this.myResource.put === "function" ? await this.myResource.put("f1.txt","f1") : await this.myResource.put.handle("f1.txt","f1"));
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((typeof this.myResource.get === "function" ? await this.myResource.get("f1.txt") : await this.myResource.get.handle("f1.txt")) === "f1")'`)})(((typeof this.myResource.get === "function" ? await this.myResource.get("f1.txt") : await this.myResource.get.handle("f1.txt")) === "f1"))};
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((typeof this.myResource.list === "function" ? await this.myResource.list() : await this.myResource.list.handle()).length === 1)'`)})(((typeof this.myResource.list === "function" ? await this.myResource.list() : await this.myResource.list.handle()).length === 1))};
+        (await this.myResource.put("f1.txt","f1"));
+        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await this.myResource.get("f1.txt")) === "f1")'`)})(((await this.myResource.get("f1.txt")) === "f1"))};
+        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await this.myResource.list()).length === 1)'`)})(((await this.myResource.list()).length === 1))};
       }
     }
     async testNestedInflightField()  {
@@ -144,29 +147,29 @@ module.exports = function({  }) {
     async testNestedResource()  {
       {
         const __parent_this = this;
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((typeof this.another.first.myResource.list === "function" ? await this.another.first.myResource.list() : await this.another.first.myResource.list.handle()).length === 0)'`)})(((typeof this.another.first.myResource.list === "function" ? await this.another.first.myResource.list() : await this.another.first.myResource.list.handle()).length === 0))};
-        (typeof this.another.first.myResource.put === "function" ? await this.another.first.myResource.put("hello",this.myStr) : await this.another.first.myResource.put.handle("hello",this.myStr));
-        {console.log(`this.another.first.myResource:${(typeof this.another.first.myResource.get === "function" ? await this.another.first.myResource.get("hello") : await this.another.first.myResource.get.handle("hello"))}`)};
+        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await this.another.first.myResource.list()).length === 0)'`)})(((await this.another.first.myResource.list()).length === 0))};
+        (await this.another.first.myResource.put("hello",this.myStr));
+        {console.log(`this.another.first.myResource:${(await this.another.first.myResource.get("hello"))}`)};
       }
     }
     async testExpressionRecursive()  {
       {
         const __parent_this = this;
-        (typeof this.myQueue.push === "function" ? await this.myQueue.push(this.myStr) : await this.myQueue.push.handle(this.myStr));
+        (await this.myQueue.push(this.myStr));
       }
     }
     async testExternal()  {
       {
         const __parent_this = this;
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((typeof this.extBucket.list === "function" ? await this.extBucket.list() : await this.extBucket.list.handle()).length === 0)'`)})(((typeof this.extBucket.list === "function" ? await this.extBucket.list() : await this.extBucket.list.handle()).length === 0))};
+        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await this.extBucket.list()).length === 0)'`)})(((await this.extBucket.list()).length === 0))};
         {((cond) => {if (!cond) throw new Error(`assertion failed: '(this.extNum === 12)'`)})((this.extNum === 12))};
       }
     }
     async testUserDefinedResource()  {
       {
         const __parent_this = this;
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((typeof this.another.meaningOfLife === "function" ? await this.another.meaningOfLife() : await this.another.meaningOfLife.handle()) === 42)'`)})(((typeof this.another.meaningOfLife === "function" ? await this.another.meaningOfLife() : await this.another.meaningOfLife.handle()) === 42))};
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((typeof this.another.anotherFunc === "function" ? await this.another.anotherFunc() : await this.another.anotherFunc.handle()) === "42")'`)})(((typeof this.another.anotherFunc === "function" ? await this.another.anotherFunc() : await this.another.anotherFunc.handle()) === "42"))};
+        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await this.another.meaningOfLife()) === 42)'`)})(((await this.another.meaningOfLife()) === 42))};
+        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await this.another.anotherFunc()) === "42")'`)})(((await this.another.anotherFunc()) === "42"))};
       }
     }
     async testInflightField()  {

--- a/tools/hangar/__snapshots__/test_corpus/resource_captures_globals.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/resource_captures_globals.w_compile_tf-aws.md
@@ -5,10 +5,13 @@
 module.exports = function({ res }) {
   class  $Inflight1 {
     constructor({  }) {
+      const $obj = (...args) => this.handle(...args);
+      Object.setPrototypeOf($obj, this);
+      return $obj;
     }
     async handle()  {
       {
-        (typeof res.myPut === "function" ? await res.myPut() : await res.myPut.handle());
+        (await res.myPut());
       }
     }
   }
@@ -22,10 +25,13 @@ module.exports = function({ res }) {
 module.exports = function({ Another }) {
   class  $Inflight2 {
     constructor({  }) {
+      const $obj = (...args) => this.handle(...args);
+      Object.setPrototypeOf($obj, this);
+      return $obj;
     }
     async handle()  {
       {
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((typeof Another.myStaticMethod === "function" ? await Another.myStaticMethod() : await Another.myStaticMethod.handle()) === 0)'`)})(((typeof Another.myStaticMethod === "function" ? await Another.myStaticMethod() : await Another.myStaticMethod.handle()) === 0))};
+        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await Another.myStaticMethod()) === 0)'`)})(((await Another.myStaticMethod()) === 0))};
       }
     }
   }
@@ -45,19 +51,19 @@ module.exports = function({ globalCounter }) {
     async $inflight_init()  {
       {
         const __parent_this = this;
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((typeof globalCounter.peek === "function" ? await globalCounter.peek() : await globalCounter.peek.handle()) === 0)'`)})(((typeof globalCounter.peek === "function" ? await globalCounter.peek() : await globalCounter.peek.handle()) === 0))};
+        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await globalCounter.peek()) === 0)'`)})(((await globalCounter.peek()) === 0))};
       }
     }
     async myMethod()  {
       {
         const __parent_this = this;
-        (typeof globalCounter.inc === "function" ? await globalCounter.inc() : await globalCounter.inc.handle());
-        return (typeof globalCounter.peek === "function" ? await globalCounter.peek() : await globalCounter.peek.handle());
+        (await globalCounter.inc());
+        return (await globalCounter.peek());
       }
     }
     static async myStaticMethod()  {
       {
-        return (typeof globalCounter.peek === "function" ? await globalCounter.peek() : await globalCounter.peek.handle());
+        return (await globalCounter.peek());
       }
     }
   }
@@ -90,18 +96,18 @@ module.exports = function({ globalBucket, globalStr, globalBool, globalNum, glob
     async myPut()  {
       {
         const __parent_this = this;
-        (typeof this.localTopic.publish === "function" ? await this.localTopic.publish("hello") : await this.localTopic.publish.handle("hello"));
-        (typeof globalBucket.put === "function" ? await globalBucket.put("key","value") : await globalBucket.put.handle("key","value"));
+        (await this.localTopic.publish("hello"));
+        (await globalBucket.put("key","value"));
         {((cond) => {if (!cond) throw new Error(`assertion failed: '(globalStr === "hello")'`)})((globalStr === "hello"))};
         {((cond) => {if (!cond) throw new Error(`assertion failed: '(globalBool === true)'`)})((globalBool === true))};
         {((cond) => {if (!cond) throw new Error(`assertion failed: '(globalNum === 42)'`)})((globalNum === 42))};
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((typeof globalArrayOfStr.at === "function" ? await globalArrayOfStr.at(0) : await globalArrayOfStr.at.handle(0)) === "hello")'`)})(((typeof globalArrayOfStr.at === "function" ? await globalArrayOfStr.at(0) : await globalArrayOfStr.at.handle(0)) === "hello"))};
+        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await globalArrayOfStr.at(0)) === "hello")'`)})(((await globalArrayOfStr.at(0)) === "hello"))};
         {((cond) => {if (!cond) throw new Error(`assertion failed: '((globalMapOfNum)["a"] === (-5))'`)})(((globalMapOfNum)["a"] === (-5)))};
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '(typeof globalSetOfStr.has === "function" ? await globalSetOfStr.has("a") : await globalSetOfStr.has.handle("a"))'`)})((typeof globalSetOfStr.has === "function" ? await globalSetOfStr.has("a") : await globalSetOfStr.has.handle("a")))};
+        {((cond) => {if (!cond) throw new Error(`assertion failed: '(await globalSetOfStr.has("a"))'`)})((await globalSetOfStr.has("a")))};
         {((cond) => {if (!cond) throw new Error(`assertion failed: '(globalAnother.myField === "hello!")'`)})((globalAnother.myField === "hello!"))};
-        (typeof globalAnother.first.myResource.put === "function" ? await globalAnother.first.myResource.put("key","value") : await globalAnother.first.myResource.put.handle("key","value"));
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((typeof globalAnother.myMethod === "function" ? await globalAnother.myMethod() : await globalAnother.myMethod.handle()) > 0)'`)})(((typeof globalAnother.myMethod === "function" ? await globalAnother.myMethod() : await globalAnother.myMethod.handle()) > 0))};
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((typeof Another.myStaticMethod === "function" ? await Another.myStaticMethod() : await Another.myStaticMethod.handle()) > 0)'`)})(((typeof Another.myStaticMethod === "function" ? await Another.myStaticMethod() : await Another.myStaticMethod.handle()) > 0))};
+        (await globalAnother.first.myResource.put("key","value"));
+        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await globalAnother.myMethod()) > 0)'`)})(((await globalAnother.myMethod()) > 0))};
+        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await Another.myStaticMethod()) > 0)'`)})(((await Another.myStaticMethod()) > 0))};
       }
     }
   }
@@ -115,12 +121,15 @@ module.exports = function({ globalBucket, globalStr, globalBool, globalNum, glob
 module.exports = function({ globalCounter, $parentThis }) {
   class  R {
     constructor({  }) {
+      const $obj = (...args) => this.handle(...args);
+      Object.setPrototypeOf($obj, this);
+      return $obj;
     }
     async handle()  {
       {
         const __parent_this = this;
-        (typeof globalCounter.inc === "function" ? await globalCounter.inc() : await globalCounter.inc.handle());
-        (typeof $parentThis.localCounter.inc === "function" ? await $parentThis.localCounter.inc() : await $parentThis.localCounter.inc.handle());
+        (await globalCounter.inc());
+        (await $parentThis.localCounter.inc());
       }
     }
   }

--- a/tools/hangar/__snapshots__/test_corpus/resource_captures_globals.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/resource_captures_globals.w_compile_tf-aws.md
@@ -3,16 +3,14 @@
 ## clients/$Inflight1.inflight.js
 ```js
 module.exports = function({ res }) {
-  class  $Inflight1 {
+  class $Inflight1 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
       Object.setPrototypeOf($obj, this);
       return $obj;
     }
     async handle()  {
-      {
-        (await res.myPut());
-      }
+      (await res.myPut());
     }
   }
   return $Inflight1;
@@ -23,16 +21,14 @@ module.exports = function({ res }) {
 ## clients/$Inflight2.inflight.js
 ```js
 module.exports = function({ Another }) {
-  class  $Inflight2 {
+  class $Inflight2 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
       Object.setPrototypeOf($obj, this);
       return $obj;
     }
     async handle()  {
-      {
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await Another.myStaticMethod()) === 0)'`)})(((await Another.myStaticMethod()) === 0))};
-      }
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '((await Another.myStaticMethod()) === 0)'`)})(((await Another.myStaticMethod()) === 0))};
     }
   }
   return $Inflight2;
@@ -43,28 +39,22 @@ module.exports = function({ Another }) {
 ## clients/Another.inflight.js
 ```js
 module.exports = function({ globalCounter }) {
-  class  Another {
+  class Another {
     constructor({ first, myField }) {
       this.first = first;
       this.myField = myField;
     }
     async $inflight_init()  {
-      {
-        const __parent_this = this;
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await globalCounter.peek()) === 0)'`)})(((await globalCounter.peek()) === 0))};
-      }
+      const __parent_this = this;
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '((await globalCounter.peek()) === 0)'`)})(((await globalCounter.peek()) === 0))};
     }
     async myMethod()  {
-      {
-        const __parent_this = this;
-        (await globalCounter.inc());
-        return (await globalCounter.peek());
-      }
+      const __parent_this = this;
+      (await globalCounter.inc());
+      return (await globalCounter.peek());
     }
     static async myStaticMethod()  {
-      {
-        return (await globalCounter.peek());
-      }
+      return (await globalCounter.peek());
     }
   }
   return Another;
@@ -75,7 +65,7 @@ module.exports = function({ globalCounter }) {
 ## clients/First.inflight.js
 ```js
 module.exports = function({  }) {
-  class  First {
+  class First {
     constructor({ myResource }) {
       this.myResource = myResource;
     }
@@ -88,27 +78,25 @@ module.exports = function({  }) {
 ## clients/MyResource.inflight.js
 ```js
 module.exports = function({ globalBucket, globalStr, globalBool, globalNum, globalArrayOfStr, globalMapOfNum, globalSetOfStr, globalAnother, Another }) {
-  class  MyResource {
+  class MyResource {
     constructor({ localCounter, localTopic }) {
       this.localCounter = localCounter;
       this.localTopic = localTopic;
     }
     async myPut()  {
-      {
-        const __parent_this = this;
-        (await this.localTopic.publish("hello"));
-        (await globalBucket.put("key","value"));
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '(globalStr === "hello")'`)})((globalStr === "hello"))};
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '(globalBool === true)'`)})((globalBool === true))};
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '(globalNum === 42)'`)})((globalNum === 42))};
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await globalArrayOfStr.at(0)) === "hello")'`)})(((await globalArrayOfStr.at(0)) === "hello"))};
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((globalMapOfNum)["a"] === (-5))'`)})(((globalMapOfNum)["a"] === (-5)))};
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '(await globalSetOfStr.has("a"))'`)})((await globalSetOfStr.has("a")))};
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '(globalAnother.myField === "hello!")'`)})((globalAnother.myField === "hello!"))};
-        (await globalAnother.first.myResource.put("key","value"));
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await globalAnother.myMethod()) > 0)'`)})(((await globalAnother.myMethod()) > 0))};
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await Another.myStaticMethod()) > 0)'`)})(((await Another.myStaticMethod()) > 0))};
-      }
+      const __parent_this = this;
+      (await this.localTopic.publish("hello"));
+      (await globalBucket.put("key","value"));
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '(globalStr === "hello")'`)})((globalStr === "hello"))};
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '(globalBool === true)'`)})((globalBool === true))};
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '(globalNum === 42)'`)})((globalNum === 42))};
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '((await globalArrayOfStr.at(0)) === "hello")'`)})(((await globalArrayOfStr.at(0)) === "hello"))};
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '((globalMapOfNum)["a"] === (-5))'`)})(((globalMapOfNum)["a"] === (-5)))};
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '(await globalSetOfStr.has("a"))'`)})((await globalSetOfStr.has("a")))};
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '(globalAnother.myField === "hello!")'`)})((globalAnother.myField === "hello!"))};
+      (await globalAnother.first.myResource.put("key","value"));
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '((await globalAnother.myMethod()) > 0)'`)})(((await globalAnother.myMethod()) > 0))};
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '((await Another.myStaticMethod()) > 0)'`)})(((await Another.myStaticMethod()) > 0))};
     }
   }
   return MyResource;
@@ -119,18 +107,16 @@ module.exports = function({ globalBucket, globalStr, globalBool, globalNum, glob
 ## clients/R.inflight.js
 ```js
 module.exports = function({ globalCounter, $parentThis }) {
-  class  R {
+  class R {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
       Object.setPrototypeOf($obj, this);
       return $obj;
     }
     async handle()  {
-      {
-        const __parent_this = this;
-        (await globalCounter.inc());
-        (await $parentThis.localCounter.inc());
-      }
+      const __parent_this = this;
+      (await globalCounter.inc());
+      (await $parentThis.localCounter.inc());
     }
   }
   return R;

--- a/tools/hangar/__snapshots__/test_corpus/statements_if.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/statements_if.w_compile_tf-aws.md
@@ -3,33 +3,31 @@
 ## clients/$Inflight1.inflight.js
 ```js
 module.exports = function({  }) {
-  class  $Inflight1 {
+  class $Inflight1 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
       Object.setPrototypeOf($obj, this);
       return $obj;
     }
     async handle()  {
-      {
-        if (true) {
-          const x = 2;
-          if ((true && ((x + 2) === 4))) {
-            if ((true && ((x + 3) === 4))) {
-              {((cond) => {if (!cond) throw new Error(`assertion failed: 'false'`)})(false)};
-            }
-            else if ((true && ((x + 3) === 6))) {
-              {((cond) => {if (!cond) throw new Error(`assertion failed: 'false'`)})(false)};
-            }
-            else if ((false || ((x + 3) === 5))) {
-              {((cond) => {if (!cond) throw new Error(`assertion failed: 'true'`)})(true)};
-            }
-            else {
-              {((cond) => {if (!cond) throw new Error(`assertion failed: 'false'`)})(false)};
-            }
+      if (true) {
+        const x = 2;
+        if ((true && ((x + 2) === 4))) {
+          if ((true && ((x + 3) === 4))) {
+            {((cond) => {if (!cond) throw new Error(`assertion failed: 'false'`)})(false)};
+          }
+          else if ((true && ((x + 3) === 6))) {
+            {((cond) => {if (!cond) throw new Error(`assertion failed: 'false'`)})(false)};
+          }
+          else if ((false || ((x + 3) === 5))) {
+            {((cond) => {if (!cond) throw new Error(`assertion failed: 'true'`)})(true)};
           }
           else {
             {((cond) => {if (!cond) throw new Error(`assertion failed: 'false'`)})(false)};
           }
+        }
+        else {
+          {((cond) => {if (!cond) throw new Error(`assertion failed: 'false'`)})(false)};
         }
       }
     }

--- a/tools/hangar/__snapshots__/test_corpus/statements_if.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/statements_if.w_compile_tf-aws.md
@@ -5,6 +5,9 @@
 module.exports = function({  }) {
   class  $Inflight1 {
     constructor({  }) {
+      const $obj = (...args) => this.handle(...args);
+      Object.setPrototypeOf($obj, this);
+      return $obj;
     }
     async handle()  {
       {

--- a/tools/hangar/__snapshots__/test_corpus/static_members.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/static_members.w_compile_tf-aws.md
@@ -5,6 +5,9 @@
 module.exports = function({  }) {
   class  $Inflight1 {
     constructor({  }) {
+      const $obj = (...args) => this.handle(...args);
+      Object.setPrototypeOf($obj, this);
+      return $obj;
     }
     async handle()  {
       {
@@ -23,8 +26,8 @@ module.exports = function({  }) {
           }
         }
         const inflightClass = new InflightClass();
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((typeof inflightClass.inflightMethod === "function" ? await inflightClass.inflightMethod() : await inflightClass.inflightMethod.handle()) === "Inflight method")'`)})(((typeof inflightClass.inflightMethod === "function" ? await inflightClass.inflightMethod() : await inflightClass.inflightMethod.handle()) === "Inflight method"))};
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((typeof InflightClass.staticInflightMethod === "function" ? await InflightClass.staticInflightMethod() : await InflightClass.staticInflightMethod.handle()) === "Static inflight method")'`)})(((typeof InflightClass.staticInflightMethod === "function" ? await InflightClass.staticInflightMethod() : await InflightClass.staticInflightMethod.handle()) === "Static inflight method"))};
+        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await inflightClass.inflightMethod()) === "Inflight method")'`)})(((await inflightClass.inflightMethod()) === "Inflight method"))};
+        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await InflightClass.staticInflightMethod()) === "Static inflight method")'`)})(((await InflightClass.staticInflightMethod()) === "Static inflight method"))};
       }
     }
   }

--- a/tools/hangar/__snapshots__/test_corpus/static_members.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/static_members.w_compile_tf-aws.md
@@ -3,32 +3,26 @@
 ## clients/$Inflight1.inflight.js
 ```js
 module.exports = function({  }) {
-  class  $Inflight1 {
+  class $Inflight1 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
       Object.setPrototypeOf($obj, this);
       return $obj;
     }
     async handle()  {
-      {
-        class InflightClass {
-          constructor()  {
-          }
-          async inflightMethod()  {
-            {
-              return "Inflight method";
-            }
-          }
-          static async staticInflightMethod()  {
-            {
-              return "Static inflight method";
-            }
-          }
+      class InflightClass {
+        constructor()  {
         }
-        const inflightClass = new InflightClass();
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await inflightClass.inflightMethod()) === "Inflight method")'`)})(((await inflightClass.inflightMethod()) === "Inflight method"))};
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await InflightClass.staticInflightMethod()) === "Static inflight method")'`)})(((await InflightClass.staticInflightMethod()) === "Static inflight method"))};
+        async inflightMethod()  {
+          return "Inflight method";
+        }
+        static async staticInflightMethod()  {
+          return "Static inflight method";
+        }
       }
+      const inflightClass = new InflightClass();
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '((await inflightClass.inflightMethod()) === "Inflight method")'`)})(((await inflightClass.inflightMethod()) === "Inflight method"))};
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '((await InflightClass.staticInflightMethod()) === "Static inflight method")'`)})(((await InflightClass.staticInflightMethod()) === "Static inflight method"))};
     }
   }
   return $Inflight1;
@@ -39,14 +33,12 @@ module.exports = function({  }) {
 ## clients/Foo.inflight.js
 ```js
 module.exports = function({  }) {
-  class  Foo {
+  class Foo {
     constructor({ instanceField }) {
       this.instanceField = instanceField;
     }
     static async get123()  {
-      {
-        return 123;
-      }
+      return 123;
     }
   }
   return Foo;
@@ -192,9 +184,7 @@ class $Root extends $stdlib.std.Resource {
         this.instanceField = 100;
       }
       static m()  {
-        {
-          return 99;
-        }
+        return 99;
       }
       static _toInflightType(context) {
         const self_client_path = "./clients/Foo.inflight.js".replace(/\\/g, "/");

--- a/tools/hangar/__snapshots__/test_corpus/std_string.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/std_string.w_compile_tf-aws.md
@@ -5,12 +5,15 @@
 module.exports = function({ s1, s2 }) {
   class  $Inflight1 {
     constructor({  }) {
+      const $obj = (...args) => this.handle(...args);
+      Object.setPrototypeOf($obj, this);
+      return $obj;
     }
     async handle()  {
       {
         {console.log(`index of \"s\" in s1 is ${s1.indexOf("s")}`)};
-        {console.log((typeof (typeof s1.split === "function" ? await s1.split(" ") : await s1.split.handle(" ")).at === "function" ? await (typeof s1.split === "function" ? await s1.split(" ") : await s1.split.handle(" ")).at(1) : await (typeof s1.split === "function" ? await s1.split(" ") : await s1.split.handle(" ")).at.handle(1)))};
-        {console.log((typeof s1.concat === "function" ? await s1.concat(s2) : await s1.concat.handle(s2)))};
+        {console.log((await (await s1.split(" ")).at(1)))};
+        {console.log((await s1.concat(s2)))};
       }
     }
   }

--- a/tools/hangar/__snapshots__/test_corpus/std_string.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/std_string.w_compile_tf-aws.md
@@ -3,18 +3,16 @@
 ## clients/$Inflight1.inflight.js
 ```js
 module.exports = function({ s1, s2 }) {
-  class  $Inflight1 {
+  class $Inflight1 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
       Object.setPrototypeOf($obj, this);
       return $obj;
     }
     async handle()  {
-      {
-        {console.log(`index of \"s\" in s1 is ${s1.indexOf("s")}`)};
-        {console.log((await (await s1.split(" ")).at(1)))};
-        {console.log((await s1.concat(s2)))};
-      }
+      {console.log(`index of \"s\" in s1 is ${s1.indexOf("s")}`)};
+      {console.log((await (await s1.split(" ")).at(1)))};
+      {console.log((await s1.concat(s2)))};
     }
   }
   return $Inflight1;

--- a/tools/hangar/__snapshots__/test_corpus/structs.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/structs.w_compile_tf-aws.md
@@ -3,15 +3,13 @@
 ## clients/Foo.inflight.js
 ```js
 module.exports = function({  }) {
-  class  Foo {
+  class Foo {
     constructor({ data }) {
       this.data = data;
     }
     async getStuff()  {
-      {
-        const __parent_this = this;
-        return this.data.field0;
-      }
+      const __parent_this = this;
+      return this.data.field0;
     }
   }
   return Foo;

--- a/tools/hangar/__snapshots__/test_corpus/symbol_shadow.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/symbol_shadow.w_compile_tf-aws.md
@@ -3,16 +3,14 @@
 ## clients/$Inflight1.inflight.js
 ```js
 module.exports = function({ s }) {
-  class  $Inflight1 {
+  class $Inflight1 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
       Object.setPrototypeOf($obj, this);
       return $obj;
     }
     async handle()  {
-      {
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '(s === "inner")'`)})((s === "inner"))};
-      }
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '(s === "inner")'`)})((s === "inner"))};
     }
   }
   return $Inflight1;
@@ -23,16 +21,14 @@ module.exports = function({ s }) {
 ## clients/$Inflight2.inflight.js
 ```js
 module.exports = function({ s }) {
-  class  $Inflight2 {
+  class $Inflight2 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
       Object.setPrototypeOf($obj, this);
       return $obj;
     }
     async handle()  {
-      {
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '(s === "inResource")'`)})((s === "inResource"))};
-      }
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '(s === "inResource")'`)})((s === "inResource"))};
     }
   }
   return $Inflight2;
@@ -43,16 +39,14 @@ module.exports = function({ s }) {
 ## clients/$Inflight3.inflight.js
 ```js
 module.exports = function({ s }) {
-  class  $Inflight3 {
+  class $Inflight3 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
       Object.setPrototypeOf($obj, this);
       return $obj;
     }
     async handle()  {
-      {
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '(s === "top")'`)})((s === "top"))};
-      }
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '(s === "top")'`)})((s === "top"))};
     }
   }
   return $Inflight3;
@@ -63,17 +57,15 @@ module.exports = function({ s }) {
 ## clients/$Inflight4.inflight.js
 ```js
 module.exports = function({  }) {
-  class  $Inflight4 {
+  class $Inflight4 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
       Object.setPrototypeOf($obj, this);
       return $obj;
     }
     async handle()  {
-      {
-        const s = "insideInflight";
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '(s === "insideInflight")'`)})((s === "insideInflight"))};
-      }
+      const s = "insideInflight";
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '(s === "insideInflight")'`)})((s === "insideInflight"))};
     }
   }
   return $Inflight4;
@@ -84,7 +76,7 @@ module.exports = function({  }) {
 ## clients/A.inflight.js
 ```js
 module.exports = function({  }) {
-  class  A {
+  class A {
     constructor({  }) {
     }
   }

--- a/tools/hangar/__snapshots__/test_corpus/symbol_shadow.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/symbol_shadow.w_compile_tf-aws.md
@@ -5,6 +5,9 @@
 module.exports = function({ s }) {
   class  $Inflight1 {
     constructor({  }) {
+      const $obj = (...args) => this.handle(...args);
+      Object.setPrototypeOf($obj, this);
+      return $obj;
     }
     async handle()  {
       {
@@ -22,6 +25,9 @@ module.exports = function({ s }) {
 module.exports = function({ s }) {
   class  $Inflight2 {
     constructor({  }) {
+      const $obj = (...args) => this.handle(...args);
+      Object.setPrototypeOf($obj, this);
+      return $obj;
     }
     async handle()  {
       {
@@ -39,6 +45,9 @@ module.exports = function({ s }) {
 module.exports = function({ s }) {
   class  $Inflight3 {
     constructor({  }) {
+      const $obj = (...args) => this.handle(...args);
+      Object.setPrototypeOf($obj, this);
+      return $obj;
     }
     async handle()  {
       {
@@ -56,6 +65,9 @@ module.exports = function({ s }) {
 module.exports = function({  }) {
   class  $Inflight4 {
     constructor({  }) {
+      const $obj = (...args) => this.handle(...args);
+      Object.setPrototypeOf($obj, this);
+      return $obj;
     }
     async handle()  {
       {

--- a/tools/hangar/__snapshots__/test_corpus/test_bucket.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/test_bucket.w_compile_tf-aws.md
@@ -3,18 +3,16 @@
 ## clients/$Inflight1.inflight.js
 ```js
 module.exports = function({ b }) {
-  class  $Inflight1 {
+  class $Inflight1 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
       Object.setPrototypeOf($obj, this);
       return $obj;
     }
     async handle()  {
-      {
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await b.list()).length === 0)'`)})(((await b.list()).length === 0))};
-        (await b.put("hello.txt","world"));
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await b.list()).length === 1)'`)})(((await b.list()).length === 1))};
-      }
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '((await b.list()).length === 0)'`)})(((await b.list()).length === 0))};
+      (await b.put("hello.txt","world"));
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '((await b.list()).length === 1)'`)})(((await b.list()).length === 1))};
     }
   }
   return $Inflight1;
@@ -25,17 +23,15 @@ module.exports = function({ b }) {
 ## clients/$Inflight2.inflight.js
 ```js
 module.exports = function({ b }) {
-  class  $Inflight2 {
+  class $Inflight2 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
       Object.setPrototypeOf($obj, this);
       return $obj;
     }
     async handle()  {
-      {
-        (await b.put("hello.txt","world"));
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await b.get("hello.txt")) === "world")'`)})(((await b.get("hello.txt")) === "world"))};
-      }
+      (await b.put("hello.txt","world"));
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '((await b.get("hello.txt")) === "world")'`)})(((await b.get("hello.txt")) === "world"))};
     }
   }
   return $Inflight2;

--- a/tools/hangar/__snapshots__/test_corpus/test_bucket.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/test_bucket.w_compile_tf-aws.md
@@ -5,12 +5,15 @@
 module.exports = function({ b }) {
   class  $Inflight1 {
     constructor({  }) {
+      const $obj = (...args) => this.handle(...args);
+      Object.setPrototypeOf($obj, this);
+      return $obj;
     }
     async handle()  {
       {
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((typeof b.list === "function" ? await b.list() : await b.list.handle()).length === 0)'`)})(((typeof b.list === "function" ? await b.list() : await b.list.handle()).length === 0))};
-        (typeof b.put === "function" ? await b.put("hello.txt","world") : await b.put.handle("hello.txt","world"));
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((typeof b.list === "function" ? await b.list() : await b.list.handle()).length === 1)'`)})(((typeof b.list === "function" ? await b.list() : await b.list.handle()).length === 1))};
+        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await b.list()).length === 0)'`)})(((await b.list()).length === 0))};
+        (await b.put("hello.txt","world"));
+        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await b.list()).length === 1)'`)})(((await b.list()).length === 1))};
       }
     }
   }
@@ -24,11 +27,14 @@ module.exports = function({ b }) {
 module.exports = function({ b }) {
   class  $Inflight2 {
     constructor({  }) {
+      const $obj = (...args) => this.handle(...args);
+      Object.setPrototypeOf($obj, this);
+      return $obj;
     }
     async handle()  {
       {
-        (typeof b.put === "function" ? await b.put("hello.txt","world") : await b.put.handle("hello.txt","world"));
-        {((cond) => {if (!cond) throw new Error(`assertion failed: '((typeof b.get === "function" ? await b.get("hello.txt") : await b.get.handle("hello.txt")) === "world")'`)})(((typeof b.get === "function" ? await b.get("hello.txt") : await b.get.handle("hello.txt")) === "world"))};
+        (await b.put("hello.txt","world"));
+        {((cond) => {if (!cond) throw new Error(`assertion failed: '((await b.get("hello.txt")) === "world")'`)})(((await b.get("hello.txt")) === "world"))};
       }
     }
   }

--- a/tools/hangar/__snapshots__/test_corpus/try_catch.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/try_catch.w_compile_tf-aws.md
@@ -86,61 +86,49 @@ class $Root extends $stdlib.std.Resource {
     }
     {((cond) => {if (!cond) throw new Error(`assertion failed: '(x === "finally with no catch and no exception")'`)})((x === "finally with no catch and no exception"))};
     {((cond) => {if (!cond) throw new Error(`assertion failed: '((( () =>  {
-      {
-        try {
-        }
-        finally {
-          return 1;
-        }
+      try {
+      }
+      finally {
+        return 1;
       }
     }
     )()) === 1)'`)})(((( () =>  {
-      {
-        try {
-        }
-        finally {
-          return 1;
-        }
+      try {
+      }
+      finally {
+        return 1;
       }
     }
     )()) === 1))};
     {((cond) => {if (!cond) throw new Error(`assertion failed: '((( () =>  {
-      {
-        try {
-          {((msg) => {throw new Error(msg)})("")};
-        }
-        catch {
-          return 2;
-        }
+      try {
+        {((msg) => {throw new Error(msg)})("")};
+      }
+      catch {
+        return 2;
       }
     }
     )()) === 2)'`)})(((( () =>  {
-      {
-        try {
-          {((msg) => {throw new Error(msg)})("")};
-        }
-        catch {
-          return 2;
-        }
+      try {
+        {((msg) => {throw new Error(msg)})("")};
+      }
+      catch {
+        return 2;
       }
     }
     )()) === 2))};
     {((cond) => {if (!cond) throw new Error(`assertion failed: '((( () =>  {
-      {
-        try {
-          return 3;
-        }
-        finally {
-        }
+      try {
+        return 3;
+      }
+      finally {
       }
     }
     )()) === 3)'`)})(((( () =>  {
-      {
-        try {
-          return 3;
-        }
-        finally {
-        }
+      try {
+        return 3;
+      }
+      finally {
       }
     }
     )()) === 3))};

--- a/tools/hangar/__snapshots__/test_corpus/website_with_api.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/website_with_api.w_compile_tf-aws.md
@@ -5,11 +5,14 @@
 module.exports = function({ usersTable }) {
   class  $Inflight1 {
     constructor({  }) {
+      const $obj = (...args) => this.handle(...args);
+      Object.setPrototypeOf($obj, this);
+      return $obj;
     }
     async handle(req)  {
       {
         return {
-        "body": Object.freeze({"users":(typeof usersTable.list === "function" ? await usersTable.list() : await usersTable.list.handle())}),
+        "body": Object.freeze({"users":(await usersTable.list())}),
         "status": 200,}
         ;
       }
@@ -25,6 +28,9 @@ module.exports = function({ usersTable }) {
 module.exports = function({ usersTable }) {
   class  $Inflight2 {
     constructor({  }) {
+      const $obj = (...args) => this.handle(...args);
+      Object.setPrototypeOf($obj, this);
+      return $obj;
     }
     async handle(req)  {
       {
@@ -35,7 +41,7 @@ module.exports = function({ usersTable }) {
           "status": 400,}
           ;
         }
-        (typeof usersTable.insert === "function" ? await usersTable.insert(((args) => { return JSON.stringify(args[0], null, args[1]) })([(body)["id"]]),body) : await usersTable.insert.handle(((args) => { return JSON.stringify(args[0], null, args[1]) })([(body)["id"]]),body));
+        (await usersTable.insert(((args) => { return JSON.stringify(args[0], null, args[1]) })([(body)["id"]]),body));
         return {
         "body": Object.freeze({"user":(body)["id"]}),
         "status": 201,}
@@ -53,6 +59,9 @@ module.exports = function({ usersTable }) {
 module.exports = function({  }) {
   class  $Inflight3 {
     constructor({  }) {
+      const $obj = (...args) => this.handle(...args);
+      Object.setPrototypeOf($obj, this);
+      return $obj;
     }
     async handle(req)  {
       {

--- a/tools/hangar/__snapshots__/test_corpus/website_with_api.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/website_with_api.w_compile_tf-aws.md
@@ -3,19 +3,17 @@
 ## clients/$Inflight1.inflight.js
 ```js
 module.exports = function({ usersTable }) {
-  class  $Inflight1 {
+  class $Inflight1 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
       Object.setPrototypeOf($obj, this);
       return $obj;
     }
     async handle(req)  {
-      {
-        return {
-        "body": Object.freeze({"users":(await usersTable.list())}),
-        "status": 200,}
-        ;
-      }
+      return {
+      "body": Object.freeze({"users":(await usersTable.list())}),
+      "status": 200,}
+      ;
     }
   }
   return $Inflight1;
@@ -26,27 +24,25 @@ module.exports = function({ usersTable }) {
 ## clients/$Inflight2.inflight.js
 ```js
 module.exports = function({ usersTable }) {
-  class  $Inflight2 {
+  class $Inflight2 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
       Object.setPrototypeOf($obj, this);
       return $obj;
     }
     async handle(req)  {
-      {
-        const body = (req.body ?? Object.freeze({"name":"","age":"","id":""}));
-        if (((((body)["name"] === "") || ((body)["age"] === "")) || ((body)["id"] === ""))) {
-          return {
-          "body": Object.freeze({"error":"incomplete details"}),
-          "status": 400,}
-          ;
-        }
-        (await usersTable.insert(((args) => { return JSON.stringify(args[0], null, args[1]) })([(body)["id"]]),body));
+      const body = (req.body ?? Object.freeze({"name":"","age":"","id":""}));
+      if (((((body)["name"] === "") || ((body)["age"] === "")) || ((body)["id"] === ""))) {
         return {
-        "body": Object.freeze({"user":(body)["id"]}),
-        "status": 201,}
+        "body": Object.freeze({"error":"incomplete details"}),
+        "status": 400,}
         ;
       }
+      (await usersTable.insert(((args) => { return JSON.stringify(args[0], null, args[1]) })([(body)["id"]]),body));
+      return {
+      "body": Object.freeze({"user":(body)["id"]}),
+      "status": 201,}
+      ;
     }
   }
   return $Inflight2;
@@ -57,19 +53,17 @@ module.exports = function({ usersTable }) {
 ## clients/$Inflight3.inflight.js
 ```js
 module.exports = function({  }) {
-  class  $Inflight3 {
+  class $Inflight3 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
       Object.setPrototypeOf($obj, this);
       return $obj;
     }
     async handle(req)  {
-      {
-        return {
-        "headers": Object.freeze({"Access-Control-Allow-Headers":"Content-Type","Access-Control-Allow-Origin":"*","Access-Control-Allow-Methods":"OPTIONS,POST,GET"}),
-        "status": 204,}
-        ;
-      }
+      return {
+      "headers": Object.freeze({"Access-Control-Allow-Headers":"Content-Type","Access-Control-Allow-Origin":"*","Access-Control-Allow-Methods":"OPTIONS,POST,GET"}),
+      "status": 204,}
+      ;
     }
   }
   return $Inflight3;

--- a/tools/hangar/__snapshots__/test_corpus/while_loop_await.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/while_loop_await.w_compile_tf-aws.md
@@ -5,6 +5,9 @@
 module.exports = function({  }) {
   class  $Inflight1 {
     constructor({  }) {
+      const $obj = (...args) => this.handle(...args);
+      Object.setPrototypeOf($obj, this);
+      return $obj;
     }
     async handle(body)  {
       {
@@ -15,7 +18,7 @@ module.exports = function({  }) {
           }
         }
         ;
-        while (((typeof iterator === "function" ? await iterator(i) : await iterator.handle(i)) < 3)) {
+        while (((await iterator(i)) < 3)) {
           {console.log(`${i}`)};
         }
       }

--- a/tools/hangar/__snapshots__/test_corpus/while_loop_await.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/while_loop_await.w_compile_tf-aws.md
@@ -3,24 +3,20 @@
 ## clients/$Inflight1.inflight.js
 ```js
 module.exports = function({  }) {
-  class  $Inflight1 {
+  class $Inflight1 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
       Object.setPrototypeOf($obj, this);
       return $obj;
     }
     async handle(body)  {
-      {
-        const i = 0;
-        const iterator = async (j) =>  {
-          {
-            return (j + 1);
-          }
-        }
-        ;
-        while (((await iterator(i)) < 3)) {
-          {console.log(`${i}`)};
-        }
+      const i = 0;
+      const iterator = async (j) =>  {
+        return (j + 1);
+      }
+      ;
+      while (((await iterator(i)) < 3)) {
+        {console.log(`${i}`)};
       }
     }
   }


### PR DESCRIPTION
When jsifying call and `if let` expressions we generate code that uses the original expression multiple times. If this expression is e.g. a call or a `new` statement, there could be side effects to the fact that it gets called.

To fix the function call case, I've changed the strategy taken in #2580. Instead of testing whether an object is a function or an object with a `handle` method, we are now returning a "function proxy" from the constructor of the generated handle class inflight. This technique allows the returned object to behave both as a function and as an object:

```js
class MyHandler {
  constructor() {
    const $obj = (...args) => this.handle(...args);
    Object.setPrototypeOf($obj, this);
    return this;
  }

  handle() {
    console.log("hi");
  }
}

const f = new MyHandler();
f(); // prints "hi"
f.handle(); prints "hi"
```

This cleans up *a lot* of boilerplate from the call sites because now they don't care if an object a normal function or a handle function. Neat!

The `if let` fix was easier: basically just use the `$IF_LET_VALUE` variable inside the condition instead of replicating the expression. This resolves #2713

## Misc

Took the opportunity to clean the js output a little:
1. Remove redundant whitespace between `class` and it's name in inflight clients.
2. Remove the redundant `{`, `}` within class methods.

## Checklist

- [x] Title matches [Winglang's style guide](https://docs.winglang.io/contributors/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [x] Tests added (always)
- [x] Docs updated (only required for features)
- [x] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.
