### PR TITLE
fix(compiler): optional instance members could be referenced inflight

### DIFF
--- a/examples/tests/valid/optionals.w
+++ b/examples/tests/valid/optionals.w
@@ -1,3 +1,5 @@
+bring cloud;
+
 let x: num? = 4;
 assert(x? == true);
 assert(!x? == false);
@@ -148,3 +150,34 @@ assert(notThere == nil);
 if let o = tree.left?.left {
   assert(o.value == 1);
 }
+
+struct Foo {
+  a: str;
+}
+
+struct Bar {
+  f: Foo?;
+}
+
+let bar: Bar? = Bar {
+  f: Foo {
+    a: "hello"
+  }
+};
+
+let j: Json? = Json {
+  a: {
+    b: "ss"
+  }
+};
+
+let bb: cloud.Bucket? = new cloud.Bucket();
+
+let f = inflight () => {
+  let x = j?.get("a").get("b");
+  assert(x == "ss");
+  let y = bar?.f?.a;
+  assert(y == "hello");
+
+  bb?.put("hello.txt", "world");
+};

--- a/tools/hangar/__snapshots__/test_corpus/optionals.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/optionals.w_compile_tf-aws.md
@@ -1,5 +1,27 @@
 # [optionals.w](../../../../examples/tests/valid/optionals.w) | compile | tf-aws
 
+## clients/$Inflight1.inflight.js
+```js
+module.exports = function({ j, bar, bb }) {
+  class $Inflight1 {
+    constructor({  }) {
+      const $obj = (...args) => this.handle(...args);
+      Object.setPrototypeOf($obj, this);
+      return $obj;
+    }
+    async handle()  {
+      const x = ((j)["a"])["b"];
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '(x === "ss")'`)})((x === "ss"))};
+      const y = bar.f.a;
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '(y === "hello")'`)})((y === "hello"))};
+      (await bb.put("hello.txt","world"));
+    }
+  }
+  return $Inflight1;
+}
+
+```
+
 ## clients/Node.inflight.js
 ```js
 module.exports = function({  }) {
@@ -43,6 +65,53 @@ module.exports = function({  }) {
     "aws": [
       {}
     ]
+  },
+  "resource": {
+    "aws_s3_bucket": {
+      "root_cloudBucket_4F3C4F53": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/Default/cloud.Bucket/Default",
+            "uniqueId": "root_cloudBucket_4F3C4F53"
+          }
+        },
+        "bucket_prefix": "cloud-bucket-c87175e7-",
+        "force_destroy": false
+      }
+    },
+    "aws_s3_bucket_public_access_block": {
+      "root_cloudBucket_PublicAccessBlock_319C1C2E": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/Default/cloud.Bucket/PublicAccessBlock",
+            "uniqueId": "root_cloudBucket_PublicAccessBlock_319C1C2E"
+          }
+        },
+        "block_public_acls": true,
+        "block_public_policy": true,
+        "bucket": "${aws_s3_bucket.root_cloudBucket_4F3C4F53.bucket}",
+        "ignore_public_acls": true,
+        "restrict_public_buckets": true
+      }
+    },
+    "aws_s3_bucket_server_side_encryption_configuration": {
+      "root_cloudBucket_Encryption_8ED0CD9C": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/Default/cloud.Bucket/Encryption",
+            "uniqueId": "root_cloudBucket_Encryption_8ED0CD9C"
+          }
+        },
+        "bucket": "${aws_s3_bucket.root_cloudBucket_4F3C4F53.bucket}",
+        "rule": [
+          {
+            "apply_server_side_encryption_by_default": {
+              "sse_algorithm": "AES256"
+            }
+          }
+        ]
+      }
+    }
   }
 }
 ```
@@ -54,6 +123,7 @@ const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const std = $stdlib.std;
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const $AppBase = $stdlib.core.App.for(process.env.WING_TARGET);
+const cloud = require('@winglang/sdk').cloud;
 class $Root extends $stdlib.std.Resource {
   constructor(scope, id) {
     super(scope, id);
@@ -113,6 +183,50 @@ class $Root extends $stdlib.std.Resource {
           Node._registerBindObject(this.left, host, []);
           Node._registerBindObject(this.right, host, []);
           Node._registerBindObject(this.value, host, []);
+        }
+        super._registerBind(host, ops);
+      }
+    }
+    class $Inflight1 extends $stdlib.std.Resource {
+      constructor(scope, id, ) {
+        super(scope, id);
+        this._addInflightOps("handle");
+        this.display.hidden = true;
+      }
+      static _toInflightType(context) {
+        const self_client_path = "./clients/$Inflight1.inflight.js".replace(/\\/g, "/");
+        const j_client = context._lift(j);
+        const bar_client = context._lift(bar);
+        const bb_client = context._lift(bb);
+        return $stdlib.core.NodeJsCode.fromInline(`
+          require("${self_client_path}")({
+            j: ${j_client},
+            bar: ${bar_client},
+            bb: ${bb_client},
+          })
+        `);
+      }
+      _toInflight() {
+        return $stdlib.core.NodeJsCode.fromInline(`
+          (await (async () => {
+            const $Inflight1Client = ${$Inflight1._toInflightType(this).text};
+            const client = new $Inflight1Client({
+            });
+            if (client.$inflight_init) { await client.$inflight_init(); }
+            return client;
+          })())
+        `);
+      }
+      _registerBind(host, ops) {
+        if (ops.includes("$inflight_init")) {
+          $Inflight1._registerBindObject(bar, host, []);
+          $Inflight1._registerBindObject(bb, host, []);
+          $Inflight1._registerBindObject(j, host, []);
+        }
+        if (ops.includes("handle")) {
+          $Inflight1._registerBindObject(bar.f.a, host, []);
+          $Inflight1._registerBindObject(bb, host, ["put"]);
+          $Inflight1._registerBindObject(j, host, []);
         }
         super._registerBind(host, ops);
       }
@@ -247,6 +361,14 @@ class $Root extends $stdlib.std.Resource {
         {((cond) => {if (!cond) throw new Error(`assertion failed: '(o.value === 1)'`)})((o.value === 1))};
       }
     }
+    const bar = {
+    "f": {
+    "a": "hello",}
+    ,}
+    ;
+    const j = Object.freeze({"a":{"b":"ss"}});
+    const bb = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this,"cloud.Bucket");
+    const f = new $Inflight1(this,"$Inflight1");
   }
 }
 class $App extends $AppBase {


### PR DESCRIPTION
Allows calling optional instance members within an inflight function

## Checklist

- [x] Title matches [Winglang's style guide](https://docs.winglang.io/contributors/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [x] Tests added (always)
- [x] Docs updated (only required for features)
- [x] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.
