### PR TITLE
fix(vscode): language server cannot recover from panics

### DIFF
--- a/apps/wing/src/commands/lsp.ts
+++ b/apps/wing/src/commands/lsp.ts
@@ -3,6 +3,7 @@ import {
   InitializeParams,
   TextDocumentSyncKind,
   InitializeResult,
+  DiagnosticSeverity,
 } from "vscode-languageserver/node";
 
 import * as wingCompiler from "../wingc";
@@ -34,9 +35,27 @@ export async function run_server() {
         return JSON.parse(result);
       }
     } catch (e) {
-      connection.window.showErrorMessage(
-        `Wing language server crashed and will resume when changes are made. See logs for details.`
-      );
+      // set status in ide
+      connection.sendDiagnostics({
+        uri: args.textDocument.uri,
+        diagnostics: [
+          {
+            severity: DiagnosticSeverity.Error,
+            message: `Wing language server crashed and will resume when changes are made. See logs for details.`,
+            source: "Wing",
+            range: {
+              start: {
+                line: 0,
+                character: 0,
+              },
+              end: {
+                line: 0,
+                character: 0,
+              },
+            },
+          },
+        ],
+      });
 
       badState = true;
       return null;

--- a/apps/wing/src/commands/lsp.ts
+++ b/apps/wing/src/commands/lsp.ts
@@ -3,25 +3,47 @@ import {
   InitializeParams,
   TextDocumentSyncKind,
   InitializeResult,
-  CompletionItem,
-  DocumentSymbol,
-  Hover,
-  LocationLink,
 } from "vscode-languageserver/node";
 
 import * as wingCompiler from "../wingc";
 
 export async function run_server() {
-  const wingc = await wingCompiler.load({
+  let wingc = await wingCompiler.load({
     imports: {
       env: {
         send_notification,
       },
     },
   });
+  let badState = false;
+
+  const callWing = (func: wingCompiler.WingCompilerFunction, args: any): any | null => {
+    if (badState) {
+      return null;
+    }
+
+    try {
+      const result = wingCompiler.invoke(wingc, func, JSON.stringify(args));
+      if (typeof result === "number") {
+        if (result === 0) {
+          return null;
+        } else {
+          return result;
+        }
+      } else {
+        return JSON.parse(result);
+      }
+    } catch (e) {
+      connection.window.showErrorMessage(
+        `Wing language server crashed and will resume when changes are made. See logs for details.`
+      );
+
+      badState = true;
+      return null;
+    }
+  };
 
   let connection = createConnection(process.stdin, process.stdout);
-
   connection.onInitialize((_params: InitializeParams) => {
     const result: InitializeResult = {
       capabilities: {
@@ -38,44 +60,44 @@ export async function run_server() {
   });
 
   connection.onDidOpenTextDocument(async (params) => {
-    const string = JSON.stringify(params);
-    wingCompiler.invoke(wingc, "wingc_on_did_open_text_document", string);
+    if (badState) {
+      wingc = await wingCompiler.load({
+        imports: {
+          env: {
+            send_notification,
+          },
+        },
+      });
+      badState = false;
+    }
+
+    callWing("wingc_on_did_open_text_document", params);
   });
   connection.onDidChangeTextDocument(async (params) => {
-    const string = JSON.stringify(params);
-    wingCompiler.invoke(wingc, "wingc_on_did_change_text_document", string);
+    if (badState) {
+      wingc = await wingCompiler.load({
+        imports: {
+          env: {
+            send_notification,
+          },
+        },
+      });
+      badState = false;
+    }
+
+    callWing("wingc_on_did_change_text_document", params);
   });
   connection.onCompletion(async (params) => {
-    const result = wingCompiler.invoke(
-      wingc,
-      "wingc_on_completion",
-      JSON.stringify(params)
-    ) as string;
-    return JSON.parse(result) as CompletionItem[];
+    return callWing("wingc_on_completion", params);
   });
   connection.onDefinition(async (params) => {
-    const result = wingCompiler.invoke(wingc, "wingc_on_goto_definition", JSON.stringify(params));
-    if (result == 0) {
-      return null;
-    } else {
-      return JSON.parse(result as string) as LocationLink[];
-    }
+    return callWing("wingc_on_goto_definition", params);
   });
   connection.onDocumentSymbol(async (params) => {
-    const result = wingCompiler.invoke(wingc, "wingc_on_document_symbol", JSON.stringify(params));
-    if (result == 0) {
-      return null;
-    } else {
-      return JSON.parse(result as string) as DocumentSymbol[];
-    }
+    return callWing("wingc_on_document_symbol", params);
   });
   connection.onHover(async (params) => {
-    const result = wingCompiler.invoke(wingc, "wingc_on_hover", JSON.stringify(params));
-    if (result == 0) {
-      return null;
-    } else {
-      return JSON.parse(result as string) as Hover;
-    }
+    return callWing("wingc_on_hover", params);
   });
 
   /**

--- a/libs/wingc/src/jsify.rs
+++ b/libs/wingc/src/jsify.rs
@@ -1215,7 +1215,7 @@ impl<'a> JSifier<'a> {
 
 		// if this class has a "handle" method, we are going to turn it into a callable function
 		// so that instances of this class can also be called like regular functions
-		if inflight_methods.iter().find(|(name, _)| name.name == HANDLE_METHOD_NAME).is_some() {
+		if inflight_methods.iter().any(|(name, _)| name.name == HANDLE_METHOD_NAME) {
 			class_code.line(format!("const $obj = (...args) => this.{HANDLE_METHOD_NAME}(...args);"));
 			class_code.line("Object.setPrototypeOf($obj, this);");
 			class_code.line("return $obj;");

--- a/libs/wingc/src/type_check.rs
+++ b/libs/wingc/src/type_check.rs
@@ -1213,6 +1213,7 @@ impl<'a> TypeChecker<'a> {
 				Literal::Boolean(_) => self.types.bool(),
 			},
 			ExprKind::Binary { op, left, right } => {
+				panic!("TEST");
 				let ltype = self.type_check_exp(left, env);
 				let rtype = self.type_check_exp(right, env);
 
@@ -3321,7 +3322,7 @@ impl<'a> TypeChecker<'a> {
 		instance_type: UnsafeRef<Type>,
 		property: &Symbol,
 		env: &SymbolEnv,
-		object: &Box<Expr>,
+		object: &Expr,
 	) -> VariableInfo {
 		match *instance_type {
 			Type::Optional(t) => self.resolve_variable_from_instance_type(t, property, env, object),

--- a/libs/wingc/src/type_check.rs
+++ b/libs/wingc/src/type_check.rs
@@ -1213,7 +1213,6 @@ impl<'a> TypeChecker<'a> {
 				Literal::Boolean(_) => self.types.bool(),
 			},
 			ExprKind::Binary { op, left, right } => {
-				panic!("TEST");
 				let ltype = self.type_check_exp(left, env);
 				let rtype = self.type_check_exp(right, env);
 


### PR DESCRIPTION
Normally when the language server panics, the whole thing crashes and you need to restart your editor. This adds a built-in mechanism to avoid exiting completely. It instead lets you know and waits until the wing file is changed before trying again.

The method is pretty naive and effectively resets the entire wasm memory. I did this because the thread local storage has a poisoned refcell and I couldn't figure out how to clear it. I think a full reset is avoidable but this current solution is ok.

## Checklist

- [x] Title matches [Winglang's style guide](https://docs.winglang.io/contributors/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [ ] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.
