### PR TITLE
feat(vscode): show signature help

### DIFF
--- a/apps/wing/src/commands/lsp.ts
+++ b/apps/wing/src/commands/lsp.ts
@@ -7,6 +7,7 @@ import {
   DocumentSymbol,
   Hover,
   LocationLink,
+  SignatureHelp,
 } from "vscode-languageserver/node";
 
 import * as wingCompiler from "../wingc";
@@ -28,6 +29,9 @@ export async function run_server() {
         textDocumentSync: TextDocumentSyncKind.Full,
         completionProvider: {
           triggerCharacters: ["."],
+        },
+        signatureHelpProvider: {
+          triggerCharacters: ["(", ",", ")"],
         },
         hoverProvider: true,
         documentSymbolProvider: true,
@@ -52,6 +56,14 @@ export async function run_server() {
       JSON.stringify(params)
     ) as string;
     return JSON.parse(result) as CompletionItem[];
+  });
+  connection.onSignatureHelp(async (params) => {
+    const result = wingCompiler.invoke(
+      wingc,
+      "wingc_on_signature_help",
+      JSON.stringify(params)
+    ) as string;
+    return JSON.parse(result) as SignatureHelp;
   });
   connection.onDefinition(async (params) => {
     const result = wingCompiler.invoke(wingc, "wingc_on_goto_definition", JSON.stringify(params));

--- a/apps/wing/src/wingc.ts
+++ b/apps/wing/src/wingc.ts
@@ -13,6 +13,7 @@ export type WingCompilerFunction =
   | "wingc_on_did_open_text_document"
   | "wingc_on_did_change_text_document"
   | "wingc_on_completion"
+  | "wingc_on_signature_help"
   | "wingc_on_goto_definition"
   | "wingc_on_document_symbol"
   | "wingc_on_semantic_tokens"

--- a/libs/wingc/src/jsify.rs
+++ b/libs/wingc/src/jsify.rs
@@ -1215,7 +1215,7 @@ impl<'a> JSifier<'a> {
 
 		// if this class has a "handle" method, we are going to turn it into a callable function
 		// so that instances of this class can also be called like regular functions
-		if inflight_methods.iter().find(|(name, _)| name.name == HANDLE_METHOD_NAME).is_some() {
+		if inflight_methods.iter().any(|(name, _)| name.name == HANDLE_METHOD_NAME) {
 			class_code.line(format!("const $obj = (...args) => this.{HANDLE_METHOD_NAME}(...args);"));
 			class_code.line("Object.setPrototypeOf($obj, this);");
 			class_code.line("return $obj;");

--- a/libs/wingc/src/lsp/completions.rs
+++ b/libs/wingc/src/lsp/completions.rs
@@ -272,7 +272,12 @@ fn get_completions_from_type(
 				"MutSet" => "MutableSet",
 				"MutMap" => "MutableMap",
 				"MutArray" => "MutableArray",
-				s => s,
+				"str" => "String",
+				"duration" => "Duration",
+				"json" => "Json",
+				"bool" => "Boolean",
+				"num" => "Number",
+				_ => type_name,
 			};
 			if let LookupResult::Found(std_type, _) = types
 				.libraries

--- a/libs/wingc/src/lsp/completions.rs
+++ b/libs/wingc/src/lsp/completions.rs
@@ -1,6 +1,6 @@
 use std::cmp::max;
 
-use lsp_types::{CompletionItem, CompletionItemKind, CompletionResponse, InsertTextFormat};
+use lsp_types::{Command, CompletionItem, CompletionItemKind, CompletionResponse, InsertTextFormat};
 use tree_sitter::Point;
 
 use crate::ast::{Expr, ExprKind, Phase, Scope, TypeAnnotation, TypeAnnotationKind};
@@ -330,18 +330,27 @@ fn get_completions_from_class(
 			} else {
 				Some(CompletionItemKind::FIELD)
 			};
-			let insert_text = if kind == Some(CompletionItemKind::METHOD) {
-				Some(format!("{}($0)", symbol_data.0))
-			} else {
-				Some(symbol_data.0.to_string())
-			};
+			let is_method = kind == Some(CompletionItemKind::METHOD);
 
 			Some(CompletionItem {
-				insert_text,
+				insert_text: if is_method {
+					Some(format!("{}($0)", symbol_data.0))
+				} else {
+					Some(symbol_data.0.to_string())
+				},
 				label: symbol_data.0,
 				detail: Some(variable.type_.to_string()),
 				kind,
 				insert_text_format: Some(InsertTextFormat::SNIPPET),
+				command: if is_method {
+					Some(Command {
+						title: "triggerParameterHints".to_string(),
+						command: "editor.action.triggerParameterHints".to_string(),
+						arguments: None,
+					})
+				} else {
+					None
+				},
 				..Default::default()
 			})
 		})
@@ -393,17 +402,27 @@ fn format_symbol_kind_as_completion(name: &str, symbol_kind: &SymbolKind) -> Com
 			} else {
 				Some(CompletionItemKind::VARIABLE)
 			};
-			let insert_text = if kind == Some(CompletionItemKind::FUNCTION) {
-				Some(format!("{}($0)", name))
-			} else {
-				Some(name.to_string())
-			};
+			let is_method = kind == Some(CompletionItemKind::FUNCTION);
+
 			CompletionItem {
 				label: name.to_string(),
-				insert_text,
+				insert_text: if is_method {
+					Some(format!("{}($0)", name))
+				} else {
+					Some(name.to_string())
+				},
 				detail: Some(v.type_.to_string()),
 				insert_text_format: Some(InsertTextFormat::SNIPPET),
 				kind,
+				command: if is_method {
+					Some(Command {
+						title: "triggerParameterHints".to_string(),
+						command: "editor.action.triggerParameterHints".to_string(),
+						arguments: None,
+					})
+				} else {
+					None
+				},
 				..Default::default()
 			}
 		}

--- a/libs/wingc/src/lsp/mod.rs
+++ b/libs/wingc/src/lsp/mod.rs
@@ -3,4 +3,5 @@ mod document_symbols;
 mod goto_definition;
 mod hover;
 mod notifications;
+mod signature;
 mod sync;

--- a/libs/wingc/src/lsp/signature.rs
+++ b/libs/wingc/src/lsp/signature.rs
@@ -1,0 +1,132 @@
+use std::cmp::max;
+
+use lsp_types::{ParameterInformation, ParameterLabel, Position, SignatureHelp, SignatureInformation};
+use tree_sitter::Point;
+
+use crate::ast::{Expr, ExprKind};
+use crate::diagnostic::{WingLocation, WingSpan};
+use crate::lsp::sync::FILES;
+
+use crate::visit::{visit_expr, Visit};
+use crate::wasm_util::{ptr_to_string, string_to_combined_ptr, WASM_RETURN_ERROR};
+
+#[no_mangle]
+pub unsafe extern "C" fn wingc_on_signature_help(ptr: u32, len: u32) -> u64 {
+	let parse_string = ptr_to_string(ptr, len);
+	if let Ok(parsed) = serde_json::from_str(&parse_string) {
+		let result = on_signature_help(parsed);
+		let result = serde_json::to_string(&result).unwrap();
+
+		// return result as u64 with ptr and len
+		string_to_combined_ptr(result)
+	} else {
+		WASM_RETURN_ERROR
+	}
+}
+
+pub fn on_signature_help(params: lsp_types::SignatureHelpParams) -> Option<SignatureHelp> {
+	FILES.with(|files| {
+		let files = files.borrow();
+		let uri = params.text_document_position_params.text_document.uri;
+		let result = files.get(&uri).expect("File must be open to get completions");
+
+		let root_scope = &result.scope;
+
+		let point = Point::new(
+			params.text_document_position_params.position.line as usize,
+			max(params.text_document_position_params.position.character as i64, 0) as usize,
+		);
+
+		let file = uri.to_file_path().ok().expect("LSP only works on real filesystems");
+
+		let wing_location = WingLocation {
+			col: point.column as u32,
+			line: point.row as u32,
+		};
+
+		let mut scope_visitor = ScopeVisitor::new(WingSpan {
+			start: wing_location,
+			end: wing_location,
+			file_id: file.to_str().expect("File path must be valid utf8").to_string(),
+		});
+		scope_visitor.visit_scope(root_scope);
+
+		if let Some(expr) = scope_visitor.call_expr {
+			if let ExprKind::Call { callee, arg_list: _ } = &expr.kind {
+				let t = callee.evaluated_type.borrow();
+				let t = t.as_ref().unwrap();
+				let sig = t.as_function_sig().unwrap();
+				let signature_info = SignatureInformation {
+					label: format!(
+						"{}({})",
+						t.to_string(),
+						sig
+							.parameters
+							.iter()
+							.map(|p| p.to_string())
+							.collect::<Vec<String>>()
+							.join(", ")
+					),
+					documentation: None,
+					parameters: Some(
+						sig
+							.parameters
+							.iter()
+							.map(|p| ParameterInformation {
+								label: ParameterLabel::Simple(p.to_string()),
+								documentation: None,
+							})
+							.collect(),
+					),
+					active_parameter: None,
+				};
+
+				return Some(SignatureHelp {
+					signatures: vec![signature_info],
+					active_signature: None,
+					active_parameter: None,
+				});
+			}
+		}
+
+		None
+	})
+}
+
+/// This visitor is used to find the scope
+/// and relevant expression that contains a given location.
+pub struct ScopeVisitor<'a> {
+	/// The target location we're looking for
+	pub location: WingSpan,
+	/// The nearest expression before (or containing) the target location
+	pub call_expr: Option<&'a Expr>,
+}
+
+impl<'a> ScopeVisitor<'a> {
+	pub fn new(location: WingSpan) -> Self {
+		Self {
+			location,
+			call_expr: None,
+		}
+	}
+}
+
+impl<'a> Visit<'a> for ScopeVisitor<'a> {
+	fn visit_expr(&mut self, node: &'a Expr) {
+		// We want to find the nearest expression to our target location
+		// i.e we want the expression that is to the left of it
+		if node.span.contains(&Position {
+			character: self.location.start.col,
+			line: self.location.start.line,
+		}) {
+			match node.kind {
+				ExprKind::Call { .. } | ExprKind::New { .. } => {
+					self.call_expr = Some(node);
+				}
+				_ => {}
+			}
+		}
+
+		visit_expr(self, node);
+	}
+}

--- a/libs/wingc/src/lsp/signature.rs
+++ b/libs/wingc/src/lsp/signature.rs
@@ -195,10 +195,23 @@ mod tests {
 	test_signature!(empty, "", assert!(false));
 
 	test_signature!(
-		single_arg_builtin,
+		second_arg_active,
 		r#"
-let arr1 = MutArray<str>["a", "b", "c"];
-arr1.join()
-	     //^"#,
+bring cloud;
+let bucket = new cloud.Bucket();
+bucket.addObject("key", )
+                     //^
+		"#,
+	);
+
+	test_signature!(
+		named_arg_active,
+		r#"
+bring cloud;
+let bucket = new cloud.Bucket();
+bucket.onEvent(inflight () => {
+	bucket.delete("", );
+                 //^
+});"#,
 	);
 }

--- a/libs/wingc/src/lsp/signature.rs
+++ b/libs/wingc/src/lsp/signature.rs
@@ -1,10 +1,7 @@
-use std::cmp::max;
-
+use itertools::Itertools;
 use lsp_types::{ParameterInformation, ParameterLabel, Position, SignatureHelp, SignatureInformation};
-use tree_sitter::Point;
 
 use crate::ast::{Expr, ExprKind};
-use crate::diagnostic::{WingLocation, WingSpan};
 use crate::lsp::sync::FILES;
 
 use crate::visit::{visit_expr, Visit};
@@ -32,53 +29,73 @@ pub fn on_signature_help(params: lsp_types::SignatureHelpParams) -> Option<Signa
 
 		let root_scope = &result.scope;
 
-		let point = Point::new(
-			params.text_document_position_params.position.line as usize,
-			max(params.text_document_position_params.position.character as i64, 0) as usize,
-		);
-
-		let file = uri.to_file_path().ok().expect("LSP only works on real filesystems");
-
-		let wing_location = WingLocation {
-			col: point.column as u32,
-			line: point.row as u32,
-		};
-
-		let mut scope_visitor = ScopeVisitor::new(WingSpan {
-			start: wing_location,
-			end: wing_location,
-			file_id: file.to_str().expect("File path must be valid utf8").to_string(),
-		});
+		let mut scope_visitor = ScopeVisitor::new(params.text_document_position_params.position);
 		scope_visitor.visit_scope(root_scope);
 
 		if let Some(expr) = scope_visitor.call_expr {
-			if let ExprKind::Call { callee, arg_list: _ } = &expr.kind {
+			if let ExprKind::Call {
+				callee,
+				arg_list: provided_args,
+			} = &expr.kind
+			{
 				let t = callee.evaluated_type.borrow();
-				let t = t.as_ref().unwrap();
-				let sig = t.as_function_sig().unwrap();
+				let t = t.as_ref()?;
+				let sig = t.as_function_sig()?;
+
+				let positional_arg_pos = provided_args
+					.pos_args
+					.iter()
+					.enumerate()
+					.filter(|(_, arg)| params.text_document_position_params.position <= arg.span.end.into())
+					.count();
+				let named_arg_pos = provided_args
+					.named_args
+					.iter()
+					.find(|arg| arg.1.span.contains(&params.text_document_position_params.position));
+
+				let active_parameter = if named_arg_pos.is_some() {
+					sig.parameters.len() - 1
+				} else {
+					provided_args.pos_args.len() - positional_arg_pos
+				};
+
+				let param_text = sig
+					.parameters
+					.iter()
+					.enumerate()
+					.map(|(i, p)| format!("{}: {}", i, p))
+					.join(", ");
+				let label = format!("({}): {}", param_text, sig.return_type);
+
 				let signature_info = SignatureInformation {
-					label: format!(
-						"{}({})",
-						t.to_string(),
-						sig
-							.parameters
-							.iter()
-							.map(|p| p.to_string())
-							.collect::<Vec<String>>()
-							.join(", ")
-					),
+					label,
 					documentation: None,
 					parameters: Some(
 						sig
 							.parameters
 							.iter()
+							.enumerate()
 							.map(|p| ParameterInformation {
-								label: ParameterLabel::Simple(p.to_string()),
-								documentation: None,
+								label: ParameterLabel::Simple(format!("{}: {}", p.0, p.1)),
+								documentation: if let Some(structy) = p.1.maybe_unwrap_option().as_struct() {
+									// print all fields
+									let fields = structy
+										.env
+										.iter(true)
+										.map(|f| format!("  {}: {}", f.0, f.1.as_variable().unwrap().type_))
+										.join(",\n");
+									Some(lsp_types::Documentation::MarkupContent(lsp_types::MarkupContent {
+										kind: lsp_types::MarkupKind::Markdown,
+										value: format!("```wing\nstruct {} {{ \n{}\n}}\n```", structy.name.name, fields),
+									}))
+								} else {
+									None
+								},
 							})
 							.collect(),
 					),
-					active_parameter: None,
+
+					active_parameter: Some(active_parameter as u32),
 				};
 
 				return Some(SignatureHelp {
@@ -97,13 +114,13 @@ pub fn on_signature_help(params: lsp_types::SignatureHelpParams) -> Option<Signa
 /// and relevant expression that contains a given location.
 pub struct ScopeVisitor<'a> {
 	/// The target location we're looking for
-	pub location: WingSpan,
+	pub location: Position,
 	/// The nearest expression before (or containing) the target location
 	pub call_expr: Option<&'a Expr>,
 }
 
 impl<'a> ScopeVisitor<'a> {
-	pub fn new(location: WingSpan) -> Self {
+	pub fn new(location: Position) -> Self {
 		Self {
 			location,
 			call_expr: None,
@@ -115,10 +132,7 @@ impl<'a> Visit<'a> for ScopeVisitor<'a> {
 	fn visit_expr(&mut self, node: &'a Expr) {
 		// We want to find the nearest expression to our target location
 		// i.e we want the expression that is to the left of it
-		if node.span.contains(&Position {
-			character: self.location.start.col,
-			line: self.location.start.line,
-		}) {
+		if node.span.contains(&self.location) {
 			match node.kind {
 				ExprKind::Call { .. } | ExprKind::New { .. } => {
 					self.call_expr = Some(node);
@@ -129,4 +143,62 @@ impl<'a> Visit<'a> for ScopeVisitor<'a> {
 
 		visit_expr(self, node);
 	}
+}
+
+#[cfg(test)]
+mod tests {
+	use crate::lsp::signature::*;
+	use crate::lsp::sync::test_utils::*;
+	use lsp_types::*;
+
+	/// Creates a snapshot test for a given wing program's signature at a given position
+	/// In the wing program, place a comment "//^" into the text where the "^" is pointing to the desired character position
+	///
+	/// First parameter will be the name of the tests, as well as the identifier to use for the list of completion in the asserts (see last parameter)
+	/// Second parameter is the wing code block as a string literal
+	/// After the first two parameters, any additional are optional statements that should be used for asserting on the given completions.
+	///
+	/// Result is a list of [CompletionItem]s
+	macro_rules! test_signature {
+		($name:ident, $code:literal, $($assertion:stmt)*) => {
+			#[test]
+			fn $name() {
+				let text_document_position = load_file_with_contents($code);
+				let sig = on_signature_help(SignatureHelpParams {
+					context: None,
+					text_document_position_params: TextDocumentPositionParams {
+						text_document: text_document_position.text_document.clone(),
+						position: Position {
+							line: text_document_position.position.line,
+							character: text_document_position.position.character,
+						},
+					},
+					work_done_progress_params: Default::default(),
+				});
+
+				if let Some($name) = sig {
+					insta::with_settings!(
+						{
+							prepend_module_to_snapshot => false,
+							omit_expression => true,
+							snapshot_path => "./snapshots/signature",
+						}, {
+							insta::assert_yaml_snapshot!($name);
+						}
+					);
+					$($assertion)*
+				}
+			}
+		};
+	}
+
+	test_signature!(empty, "", assert!(false));
+
+	test_signature!(
+		single_arg_builtin,
+		r#"
+let arr1 = MutArray<str>["a", "b", "c"];
+arr1.join()
+	     //^"#,
+	);
 }

--- a/libs/wingc/src/lsp/snapshots/completions/empty.snap
+++ b/libs/wingc/src/lsp/snapshots/completions/empty.snap
@@ -6,16 +6,25 @@ source: libs/wingc/src/lsp/completions.rs
   detail: "(bool): void"
   insertText: assert($0)
   insertTextFormat: 2
+  command:
+    title: triggerParameterHints
+    command: editor.action.triggerParameterHints
 - label: log
   kind: 3
   detail: "(str): void"
   insertText: log($0)
   insertTextFormat: 2
+  command:
+    title: triggerParameterHints
+    command: editor.action.triggerParameterHints
 - label: panic
   kind: 3
   detail: "(str): void"
   insertText: panic($0)
   insertTextFormat: 2
+  command:
+    title: triggerParameterHints
+    command: editor.action.triggerParameterHints
 - label: std
   kind: 9
   detail: bring std
@@ -24,4 +33,7 @@ source: libs/wingc/src/lsp/completions.rs
   detail: "(str): void"
   insertText: throw($0)
   insertTextFormat: 2
+  command:
+    title: triggerParameterHints
+    command: editor.action.triggerParameterHints
 

--- a/libs/wingc/src/lsp/snapshots/completions/incomplete_if_statement.snap
+++ b/libs/wingc/src/lsp/snapshots/completions/incomplete_if_statement.snap
@@ -6,44 +6,71 @@ source: libs/wingc/src/lsp/completions.rs
   detail: "(): void"
   insertText: clear($0)
   insertTextFormat: 2
+  command:
+    title: triggerParameterHints
+    command: editor.action.triggerParameterHints
 - label: copy
   kind: 2
   detail: "(): ImmutableMap"
   insertText: copy($0)
   insertTextFormat: 2
+  command:
+    title: triggerParameterHints
+    command: editor.action.triggerParameterHints
 - label: delete
   kind: 2
   detail: "(str): bool"
   insertText: delete($0)
   insertTextFormat: 2
+  command:
+    title: triggerParameterHints
+    command: editor.action.triggerParameterHints
 - label: get
   kind: 2
   detail: "(str): T1"
   insertText: get($0)
   insertTextFormat: 2
+  command:
+    title: triggerParameterHints
+    command: editor.action.triggerParameterHints
 - label: has
   kind: 2
   detail: "(str): bool"
   insertText: has($0)
   insertTextFormat: 2
+  command:
+    title: triggerParameterHints
+    command: editor.action.triggerParameterHints
 - label: keys
   kind: 2
   detail: "(): ImmutableArray"
   insertText: keys($0)
   insertTextFormat: 2
+  command:
+    title: triggerParameterHints
+    command: editor.action.triggerParameterHints
 - label: set
   kind: 2
   detail: "(str, T1): void"
   insertText: set($0)
   insertTextFormat: 2
+  command:
+    title: triggerParameterHints
+    command: editor.action.triggerParameterHints
 - label: size
   kind: 2
   detail: "(): num"
   insertText: size($0)
   insertTextFormat: 2
+  command:
+    title: triggerParameterHints
+    command: editor.action.triggerParameterHints
 - label: values
   kind: 2
   detail: "(): ImmutableArray"
   insertText: values($0)
   insertTextFormat: 2
+  command:
+    title: triggerParameterHints
+    command: editor.action.triggerParameterHints
 

--- a/libs/wingc/src/lsp/snapshots/completions/only_show_symbols_in_scope.snap
+++ b/libs/wingc/src/lsp/snapshots/completions/only_show_symbols_in_scope.snap
@@ -11,6 +11,9 @@ source: libs/wingc/src/lsp/completions.rs
   detail: "(bool): void"
   insertText: assert($0)
   insertTextFormat: 2
+  command:
+    title: triggerParameterHints
+    command: editor.action.triggerParameterHints
 - label: b
   kind: 6
   detail: any
@@ -21,11 +24,17 @@ source: libs/wingc/src/lsp/completions.rs
   detail: "(str): void"
   insertText: log($0)
   insertTextFormat: 2
+  command:
+    title: triggerParameterHints
+    command: editor.action.triggerParameterHints
 - label: panic
   kind: 3
   detail: "(str): void"
   insertText: panic($0)
   insertTextFormat: 2
+  command:
+    title: triggerParameterHints
+    command: editor.action.triggerParameterHints
 - label: std
   kind: 9
   detail: bring std
@@ -34,4 +43,7 @@ source: libs/wingc/src/lsp/completions.rs
   detail: "(str): void"
   insertText: throw($0)
   insertTextFormat: 2
+  command:
+    title: triggerParameterHints
+    command: editor.action.triggerParameterHints
 

--- a/libs/wingc/src/lsp/snapshots/completions/static_method_call.snap
+++ b/libs/wingc/src/lsp/snapshots/completions/static_method_call.snap
@@ -6,14 +6,23 @@ source: libs/wingc/src/lsp/completions.rs
   detail: "preflight (): void"
   insertText: hello($0)
   insertTextFormat: 2
+  command:
+    title: triggerParameterHints
+    command: editor.action.triggerParameterHints
 - label: addConnection
   kind: 2
   detail: "preflight (AddConnectionProps): void"
   insertText: addConnection($0)
   insertTextFormat: 2
+  command:
+    title: triggerParameterHints
+    command: editor.action.triggerParameterHints
 - label: isConstruct
   kind: 2
   detail: "preflight (any): bool"
   insertText: isConstruct($0)
   insertTextFormat: 2
+  command:
+    title: triggerParameterHints
+    command: editor.action.triggerParameterHints
 

--- a/libs/wingc/src/lsp/snapshots/signature/named_arg_active.snap
+++ b/libs/wingc/src/lsp/snapshots/signature/named_arg_active.snap
@@ -1,0 +1,13 @@
+---
+source: libs/wingc/src/lsp/signature.rs
+---
+signatures:
+  - label: "(0: str, 1: BucketDeleteOptions?): void"
+    parameters:
+      - label: "0: str"
+      - label: "1: BucketDeleteOptions?"
+        documentation:
+          kind: markdown
+          value: "```wing\nstruct BucketDeleteOptions { \n  mustExist: bool?\n}\n```"
+    activeParameter: 1
+

--- a/libs/wingc/src/lsp/snapshots/signature/second_arg_active.snap
+++ b/libs/wingc/src/lsp/snapshots/signature/second_arg_active.snap
@@ -1,0 +1,10 @@
+---
+source: libs/wingc/src/lsp/signature.rs
+---
+signatures:
+  - label: "(0: str, 1: str): void"
+    parameters:
+      - label: "0: str"
+      - label: "1: str"
+    activeParameter: 1
+

--- a/libs/wingc/src/lsp/snapshots/signature/single_arg_builtin.snap
+++ b/libs/wingc/src/lsp/snapshots/signature/single_arg_builtin.snap
@@ -1,0 +1,9 @@
+---
+source: libs/wingc/src/lsp/signature.rs
+---
+signatures:
+  - label: "(0: str?): str"
+    parameters:
+      - label: "0: str?"
+    activeParameter: 0
+

--- a/libs/wingc/src/type_check.rs
+++ b/libs/wingc/src/type_check.rs
@@ -761,7 +761,7 @@ impl TypeRef {
 		}
 	}
 
-	fn maybe_unwrap_option(&self) -> TypeRef {
+	pub fn maybe_unwrap_option(&self) -> TypeRef {
 		if let Type::Optional(ref t) = **self {
 			*t
 		} else {

--- a/libs/wingc/src/type_check.rs
+++ b/libs/wingc/src/type_check.rs
@@ -3321,7 +3321,7 @@ impl<'a> TypeChecker<'a> {
 		instance_type: UnsafeRef<Type>,
 		property: &Symbol,
 		env: &SymbolEnv,
-		object: &Box<Expr>,
+		object: &Expr,
 	) -> VariableInfo {
 		match *instance_type {
 			Type::Optional(t) => self.resolve_variable_from_instance_type(t, property, env, object),


### PR DESCRIPTION
Closes #2625

First pass, provides some bare-bones functionality. Note this is only for non-constructor function sigs.

https://github.com/winglang/wing/assets/1237390/28be217e-7f80-48e4-9491-a7b9db9ae676

### Misc

- Threw in a fix for missing completions for std lib types. Closes #2711 and Closes #2593

## Missing Features

- https://github.com/winglang/wing/issues/2747 Show help for constructors, slightly non-trivial compared to regular calls
- https://github.com/winglang/wing/issues/2749 Show param names 
- Need to figure out how to show struct expansion help
- Show param docs (partially waiting on https://github.com/winglang/wing/pull/2534)

## Checklist

- [x] Title matches [Winglang's style guide](https://docs.winglang.io/contributors/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [x] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.
