### PR TITLE
feat(compiler): error message when class extends itself

### DIFF
--- a/examples/tests/invalid/class.w
+++ b/examples/tests/invalid/class.w
@@ -74,3 +74,7 @@ struct S1 {}
 class C8 extends S1 {
                //^^ Preflight class C8's parent is not a class
 }
+
+class C11 extends C11 {
+                //^^^ Class cannot extend itself
+}

--- a/libs/wingc/src/type_check.rs
+++ b/libs/wingc/src/type_check.rs
@@ -3492,8 +3492,13 @@ impl<'a> TypeChecker<'a> {
 				return (None, None);
 			}
 		}
-		// Safety: we return early if parent_udt is None
+		// Safety: we return from the function above so parent_udt cannot be None
 		let parent_udt = parent_udt.unwrap();
+
+		if &parent_udt.root == name && parent_udt.fields.is_empty() {
+			self.spanned_error(parent_udt, format!("Class cannot extend itself"));
+			return (None, None);
+		}
 
 		let parent_type = self.resolve_user_defined_type(parent_udt, env, stmt.idx);
 		let parent_type = match parent_type {

--- a/tools/hangar/__snapshots__/invalid.ts.snap
+++ b/tools/hangar/__snapshots__/invalid.ts.snap
@@ -257,6 +257,13 @@ error: Preflight class C8's parent \\"S1\\" is not a class
    |                  ^^ Preflight class C8's parent \\"S1\\" is not a class
 
 
+error: Class cannot extend itself
+   --> ../../../examples/tests/invalid/class.w:78:19
+   |
+78 | class C11 extends C11 {
+   |                   ^^^ Class cannot extend itself
+
+
 error: Expected type to be \\"num\\", but got \\"str\\" instead
    --> ../../../examples/tests/invalid/class.w:31:14
    |


### PR DESCRIPTION
I wrote this small enhancement just to try out writing a compiler PR using recently added GitHub codespaces. It worked pretty well, just took some time to run all of the hangar tests.

## Checklist

- [x] Title matches [Winglang's style guide](https://docs.winglang.io/contributors/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [x] Tests added (always)
- [x] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.
