### PR TITLE
fix(vscode): vscode extension doesn't come up when searching 'winglang`

### DIFF
--- a/apps/vscode-wing/.projenrc.ts
+++ b/apps/vscode-wing/.projenrc.ts
@@ -17,7 +17,16 @@ const project = new TypeScriptAppProject({
   bugsUrl: "https://github.com/winglang/wing/issues",
   homepage: "https://winglang.io",
   description: "Wing language support for VSCode",
-  keywords: ["wing", "language", "cloud", "cdk", "infrastructure"],
+  keywords: [
+    "cdk",
+    "cdktf",
+    "cloud",
+    "infrastructure",
+    "language",
+    "terraform",
+    "wing",
+    "winglang",
+  ],
   license: "MIT",
 
   packageManager: NodePackageManager.NPM,

--- a/apps/vscode-wing/package.json
+++ b/apps/vscode-wing/package.json
@@ -53,10 +53,13 @@
   },
   "keywords": [
     "cdk",
+    "cdktf",
     "cloud",
     "infrastructure",
     "language",
-    "wing"
+    "terraform",
+    "wing",
+    "winglang"
   ],
   "engines": {
     "vscode": "^1.70.0"

--- a/libs/wingc/src/lsp/signature.rs
+++ b/libs/wingc/src/lsp/signature.rs
@@ -82,8 +82,8 @@ pub fn on_signature_help(params: lsp_types::SignatureHelpParams) -> Option<Signa
 									let fields = structy
 										.env
 										.iter(true)
-										.map(|f| format!("  {}: {}", f.0, f.1.as_variable().unwrap().type_))
-										.join(",\n");
+										.map(|f| format!("  {}: {};", f.0, f.1.as_variable().unwrap().type_))
+										.join("\n");
 									Some(lsp_types::Documentation::MarkupContent(lsp_types::MarkupContent {
 										kind: lsp_types::MarkupKind::Markdown,
 										value: format!("```wing\nstruct {} {{ \n{}\n}}\n```", structy.name.name, fields),

--- a/libs/wingc/src/lsp/snapshots/signature/named_arg_active.snap
+++ b/libs/wingc/src/lsp/snapshots/signature/named_arg_active.snap
@@ -8,6 +8,6 @@ signatures:
       - label: "1: BucketDeleteOptions?"
         documentation:
           kind: markdown
-          value: "```wing\nstruct BucketDeleteOptions { \n  mustExist: bool?\n}\n```"
+          value: "```wing\nstruct BucketDeleteOptions { \n  mustExist: bool?;\n}\n```"
     activeParameter: 1
 


### PR DESCRIPTION
Fixes #2538

Misc: Also improved the signature text to use proper syntax

## Checklist

- [x] Title matches [Winglang's style guide](https://docs.winglang.io/contributors/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [ ] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.
