### PR TITLE
fix(cli): fixing cli failure -  cannot find module 'fs-extra'

### DIFF
--- a/apps/wing-playground/package-lock.json
+++ b/apps/wing-playground/package-lock.json
@@ -27501,7 +27501,6 @@
       },
       "devDependencies": {
         "@types/debug": "^4.1.7",
-        "@types/fs-extra": "^11.0.1",
         "@types/node": "^18.11.18",
         "@types/node-persist": "^3.1.3",
         "@types/semver-utils": "^1.1.1",
@@ -38172,26 +38171,9 @@
         "@types/ms": "*"
       }
     },
-    "../wing/node_modules/@types/fs-extra": {
-      "version": "11.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/jsonfile": "*",
-        "@types/node": "*"
-      }
-    },
     "../wing/node_modules/@types/http-cache-semantics": {
       "version": "4.0.1",
       "license": "MIT"
-    },
-    "../wing/node_modules/@types/jsonfile": {
-      "version": "6.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
     },
     "../wing/node_modules/@types/ms": {
       "version": "0.7.31",
@@ -67963,7 +67945,6 @@
       "version": "file:../wing",
       "requires": {
         "@types/debug": "^4.1.7",
-        "@types/fs-extra": "^11.0.1",
         "@types/node": "^18.11.18",
         "@types/node-persist": "^3.1.3",
         "@types/semver-utils": "^1.1.1",
@@ -68045,23 +68026,8 @@
             "@types/ms": "*"
           }
         },
-        "@types/fs-extra": {
-          "version": "11.0.1",
-          "dev": true,
-          "requires": {
-            "@types/jsonfile": "*",
-            "@types/node": "*"
-          }
-        },
         "@types/http-cache-semantics": {
           "version": "4.0.1"
-        },
-        "@types/jsonfile": {
-          "version": "6.1.1",
-          "dev": true,
-          "requires": {
-            "@types/node": "*"
-          }
         },
         "@types/ms": {
           "version": "0.7.31",

--- a/apps/wing/package-lock.json
+++ b/apps/wing/package-lock.json
@@ -29,7 +29,6 @@
       },
       "devDependencies": {
         "@types/debug": "^4.1.7",
-        "@types/fs-extra": "^11.0.1",
         "@types/node": "^18.11.18",
         "@types/node-persist": "^3.1.3",
         "@types/semver-utils": "^1.1.1",
@@ -38495,26 +38494,9 @@
         "@types/ms": "*"
       }
     },
-    "node_modules/@types/fs-extra": {
-      "version": "11.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/jsonfile": "*",
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/http-cache-semantics": {
       "version": "4.0.1",
       "license": "MIT"
-    },
-    "node_modules/@types/jsonfile": {
-      "version": "6.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
     },
     "node_modules/@types/ms": {
       "version": "0.7.31",
@@ -41290,23 +41272,8 @@
         "@types/ms": "*"
       }
     },
-    "@types/fs-extra": {
-      "version": "11.0.1",
-      "dev": true,
-      "requires": {
-        "@types/jsonfile": "*",
-        "@types/node": "*"
-      }
-    },
     "@types/http-cache-semantics": {
       "version": "4.0.1"
-    },
-    "@types/jsonfile": {
-      "version": "6.1.1",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
-      }
     },
     "@types/ms": {
       "version": "0.7.31",

--- a/apps/wing/package.json
+++ b/apps/wing/package.json
@@ -46,7 +46,6 @@
   ],
   "devDependencies": {
     "@types/debug": "^4.1.7",
-    "@types/fs-extra": "^11.0.1",
     "@types/node": "^18.11.18",
     "@types/node-persist": "^3.1.3",
     "@types/semver-utils": "^1.1.1",

--- a/apps/wing/src/commands/test.ts
+++ b/apps/wing/src/commands/test.ts
@@ -9,7 +9,7 @@ import debug from "debug";
 import { promisify } from "util";
 import { generateTmpDir, withSpinner } from "../util";
 import { Target } from "./constants";
-import { rmSync } from "fs-extra";
+import { rmSync } from "fs";
 
 const log = debug("wing:test");
 

--- a/apps/wing/src/util.ts
+++ b/apps/wing/src/util.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, copyFileSync, promises as fsPromise, readFileSync, cpSync } from "fs-extra";
+import { copyFileSync, promises as fsPromise, readFileSync, cpSync } from "fs";
 import ora from "ora";
 import { basename, join, resolve } from "path";
 import { tmpdir } from "os";
@@ -52,7 +52,7 @@ export async function generateTmpDir(sourcePath: string, ...additionalFiles: str
   const sourceFile = basename(sourcePath);
   const file = readFileSync(sourcePath, "utf-8");
   const externs = file.match(/(?<=extern ")[.\\\/A-Za-z0-9_-]+/g) ?? [];
-  const sourceDir = await mkdtemp(join(tmpdir(), "-wing-compile-test"));
+  const sourceDir = await fsPromise.mkdtemp(join(tmpdir(), "-wing-compile-test"));
   const tempWingFile = join(sourceDir, sourceFile);
 
   cpSync(sourcePath, tempWingFile);

--- a/tools/hangar/__snapshots__/test_corpus/purge.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/purge.w_compile_tf-aws.md
@@ -25,6 +25,24 @@ module.exports = function({ q }) {
 
 ```
 
+## clients/TestHelper.inflight.js
+```js
+module.exports = function({  }) {
+  class TestHelper {
+    constructor({  }) {
+    }
+    async $inflight_init()  {
+      const __parent_this = this;
+    }
+    async sleep(milli)  {
+      return (require("<ABSOLUTE_PATH>/sleep.js")["sleep"])(milli)
+    }
+  }
+  return TestHelper;
+}
+
+```
+
 ## main.tf.json
 ```json
 {


### PR DESCRIPTION
fixes: #2789 

* using fs instead of fs-extra in the cli
* creating snapshots and running build

## Checklist

- [x] Title matches [Winglang's style guide](https://docs.winglang.io/contributors/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [ ] Tests added (always)
- [ ] Docs updated (only required for features)
- [x] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.
