### PR TITLE
chore(build): increase build timeout

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ concurrency:
 jobs:
   build:
     name: "Build"
-    timeout-minutes: 30
+    timeout-minutes: 45
     runs-on: ubuntu-latest
     env:
       # Testing runs out of memory without this


### PR DESCRIPTION
Increase build timeout by 15 minutes, seems 30mins is not reliably long enough anymore. 

## Checklist

- [x] Title matches [Winglang's style guide](https://docs.winglang.io/contributors/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [x] Tests added (always)
- [x] Docs updated (only required for features)
- [x] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.
