### PR TITLE
chore: fix `tree-sitter-wing` hanging on some scripts

### DIFF
--- a/libs/tree-sitter-wing/package.json
+++ b/libs/tree-sitter-wing/package.json
@@ -19,15 +19,15 @@
     "nan": "^2.12.1"
   },
   "scripts": {
-    "test": "npx tree-sitter-cli test",
-    "test:update": "npx tree-sitter-cli test --update",
-    "test:watch": "npx nodemon --watch grammar.js --watch src/scanner.c --exec \"npm run test\"",
-    "build": "npx tree-sitter-cli generate",
-    "build:watch": "npx nodemon --watch grammar.js --watch src/scanner.c --exec \"npm run build\"",
-    "build:wasm": "npm run build && npx tree-sitter-cli build-wasm --docker",
-    "playground": "npm run build:wasm && npx tree-sitter-cli playground",
-    "playground:quiet": "npm run build:wasm && npx tree-sitter-cli playground -q",
-    "playground:watch": "npx nodemon --watch grammar.js --watch src/scanner.c --exec \"npm run playground:quiet\""
+    "test": "npx -y tree-sitter-cli test",
+    "test:update": "npx -y tree-sitter-cli test --update",
+    "test:watch": "npx -y nodemon --watch grammar.js --watch src/scanner.c --exec \"npm run test\"",
+    "build": "npx -y tree-sitter-cli generate",
+    "build:watch": "npx -y nodemon --watch grammar.js --watch src/scanner.c --exec \"npm run build\"",
+    "build:wasm": "npm run build && npx -y tree-sitter-cli build-wasm --docker",
+    "playground": "npm run build:wasm && npx -y tree-sitter-cli playground",
+    "playground:quiet": "npm run build:wasm && npx -y tree-sitter-cli playground -q",
+    "playground:watch": "npx -y nodemon --watch grammar.js --watch src/scanner.c --exec \"npm run playground:quiet\""
   },
   "volta": {
     "node": "18.12.1",


### PR DESCRIPTION
Adds `-y` parameter to `npx` so it installs `tree-sitter-cli` automatically.