### PR TITLE
fix(build): flakey on_tick test

### DIFF
--- a/examples/tests/sdk_tests/schedule/on_tick.w
+++ b/examples/tests/sdk_tests/schedule/on_tick.w
@@ -21,11 +21,15 @@ class Utils {
 
 // std.Test is used setting the timeout property
 new std.Test(inflight () => {
-
+    // counters start at zero
     assert(c1.peek() == 0);
     assert(c2.peek() == 0);
+
+    // wait at least one minute
     Utils.sleep(60 * 1000 * 1.1);
-    assert(c1.peek() == 1);
-    assert(c2.peek() == 1);
+
+    // check that both counters have been incremented
+    assert(c1.peek() >= 1);
+    assert(c2.peek() >= 1);
 
 }, std.TestProps { timeout: 2m }) as "on tick is called both for rate and cron schedules";

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/schedule/on_tick.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/schedule/on_tick.w_compile_tf-aws.md
@@ -55,8 +55,8 @@ module.exports = function({ c1, c2, Utils }) {
       {((cond) => {if (!cond) throw new Error(`assertion failed: '((await c1.peek()) === 0)'`)})(((await c1.peek()) === 0))};
       {((cond) => {if (!cond) throw new Error(`assertion failed: '((await c2.peek()) === 0)'`)})(((await c2.peek()) === 0))};
       (await Utils.sleep(((60 * 1000) * 1.1)));
-      {((cond) => {if (!cond) throw new Error(`assertion failed: '((await c1.peek()) === 1)'`)})(((await c1.peek()) === 1))};
-      {((cond) => {if (!cond) throw new Error(`assertion failed: '((await c2.peek()) === 1)'`)})(((await c2.peek()) === 1))};
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '((await c1.peek()) >= 1)'`)})(((await c1.peek()) >= 1))};
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '((await c2.peek()) >= 1)'`)})(((await c2.peek()) >= 1))};
     }
   }
   return $Closure3;


### PR DESCRIPTION
Since our code is async, sleeping for one minute guarantees we have waited at least that long, but it could be longer depending on CPU scheduling.

## Checklist

- [ ] Title matches [Winglang's style guide](https://docs.winglang.io/contributors/pull_requests#how-are-pull-request-titles-formatted)
- [ ] Description explains motivation and solution
- [ ] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.
