### PR TITLE
fix(compiler): type check assertion is ignored

### DIFF
--- a/libs/wingc/src/lib.rs
+++ b/libs/wingc/src/lib.rs
@@ -15,6 +15,7 @@ use fold::Fold;
 use jsify::JSifier;
 use type_check::symbol_env::StatementIdx;
 use type_check::{FunctionSignature, SymbolKind, Type};
+use type_check_assert::TypeCheckAssert;
 use wasm_util::{ptr_to_string, string_to_combined_ptr, WASM_RETURN_ERROR};
 use wingii::type_system::TypeSystem;
 
@@ -40,6 +41,7 @@ pub mod jsify;
 pub mod lsp;
 pub mod parser;
 pub mod type_check;
+mod type_check_assert;
 pub mod visit;
 mod wasm_util;
 
@@ -298,15 +300,11 @@ pub fn compile(
 	let mut jsii_types = TypeSystem::new();
 
 	// Type check everything and build typed symbol environment
-	let type_check_diagnostics = if scope.statements.len() > 0 {
-		type_check(&mut scope, &mut types, &source_path, &mut jsii_types)
-	} else {
-		// empty scope, no type checking needed
-		Diagnostics::new()
-	};
+	let type_check_diagnostics = type_check(&mut scope, &mut types, &source_path, &mut jsii_types);
 
-	// Validate that every Expr has been type checked
-	types.check_all_exprs_type_checked();
+	// Validate that every Expr in the final tree has been type checked
+	let mut tc_assert = TypeCheckAssert::new(&types);
+	tc_assert.check(&scope);
 
 	// Collect all diagnostics
 	let mut diagnostics = parse_diagnostics;

--- a/libs/wingc/src/type_check.rs
+++ b/libs/wingc/src/type_check.rs
@@ -1104,11 +1104,6 @@ impl Types {
 	pub fn get_expr_type(&self, expr: &Expr) -> Option<TypeRef> {
 		self.type_for_expr.get(expr.id).and_then(|t| *t)
 	}
-
-	/// Returns true if all expressions have been type checked.
-	pub fn check_all_exprs_type_checked(&self) -> bool {
-		self.type_for_expr.iter().all(|t| t.is_some())
-	}
 }
 
 pub struct TypeChecker<'a> {

--- a/libs/wingc/src/type_check_assert.rs
+++ b/libs/wingc/src/type_check_assert.rs
@@ -1,0 +1,30 @@
+use crate::{
+	ast::{Expr, Scope},
+	type_check::Types,
+	visit::{self, Visit},
+};
+
+pub struct TypeCheckAssert<'a> {
+	types: &'a Types,
+}
+
+impl<'a> TypeCheckAssert<'a> {
+	pub fn new(types: &'a Types) -> Self {
+		Self { types }
+	}
+
+	pub fn check(&mut self, scope: &Scope) {
+		self.visit_scope(scope);
+	}
+}
+
+impl<'a> Visit<'_> for TypeCheckAssert<'a> {
+	fn visit_expr(&mut self, expr: &Expr) {
+		assert!(
+			self.types.get_expr_type(expr).is_some(),
+			"Expr was not type checked: {:?}",
+			expr,
+		);
+		visit::visit_expr(self, expr);
+	}
+}


### PR DESCRIPTION
I realized I introduced a small bug in my last PR [here](https://github.com/winglang/wing/pull/2860) - inside the main compiler pipeline (inside `compile.rs`) I added a call to `check_all_exprs_type_checked`, but didn't actually check the result. When we do check the result, it claims many AST nodes that are not type checked because it's looking at all `Expr`'s that have ever been created - but the reason for that is that some `Expr`'s nodes get thrown away. For example, in this snippet of Wing code:

```js
enum Foo { A, B }

let a = Foo.A;
```

We initially parse the expression in the last statement as something like

```js
Expr(Ref::InstanceMember(Expr(Ref::Identifier("Foo")), "A"))
```

But it's converted into this during type checking

```js
Expr(Ref::TypeMember(UserDefinedType("Foo"), "A"))
```

So, to fix this I just went back to the old strategy of traversing the final tree.

## Checklist

- [x] Title matches [Winglang's style guide](https://docs.winglang.io/contributors/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [x] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.
