### PR TITLE
feat(sdk): adding key argument to counter

### DIFF
--- a/docs/05-reference/wingsdk-api.md
+++ b/docs/05-reference/wingsdk-api.md
@@ -5303,7 +5303,7 @@ Inflight interface for `Counter`.
 ##### `dec` <a name="dec" id="@winglang/sdk.cloud.ICounterClient.dec"></a>
 
 ```wing
-dec(amount?: num): num
+dec(amount?: num, key?: str): num
 ```
 
 **Inflight client:** [true](#true)
@@ -5318,10 +5318,18 @@ amount to decrement (default is 1).
 
 ---
 
+###### `key`<sup>Optional</sup> <a name="key" id="@winglang/sdk.cloud.ICounterClient.dec.parameter.key"></a>
+
+- *Type:* str
+
+specify the key to be decremented.
+
+---
+
 ##### `inc` <a name="inc" id="@winglang/sdk.cloud.ICounterClient.inc"></a>
 
 ```wing
-inc(amount?: num): num
+inc(amount?: num, key?: str): num
 ```
 
 **Inflight client:** [true](#true)
@@ -5336,10 +5344,18 @@ amount to increment (default is 1).
 
 ---
 
+###### `key`<sup>Optional</sup> <a name="key" id="@winglang/sdk.cloud.ICounterClient.inc.parameter.key"></a>
+
+- *Type:* str
+
+specify the key to be incremented.
+
+---
+
 ##### `peek` <a name="peek" id="@winglang/sdk.cloud.ICounterClient.peek"></a>
 
 ```wing
-peek(): num
+peek(key?: str): num
 ```
 
 **Inflight client:** [true](#true)
@@ -5349,10 +5365,18 @@ Get the current value of the counter.
 Using this API may introduce race conditions since the value can change between
 the time it is read and the time it is used in your code.
 
+###### `key`<sup>Optional</sup> <a name="key" id="@winglang/sdk.cloud.ICounterClient.peek.parameter.key"></a>
+
+- *Type:* str
+
+specify the key to be retrieved.
+
+---
+
 ##### `set` <a name="set" id="@winglang/sdk.cloud.ICounterClient.set"></a>
 
 ```wing
-set(value: num): void
+set(value: num, key?: str): void
 ```
 
 **Inflight client:** [true](#true)
@@ -5364,6 +5388,14 @@ Set a counter to a given value.
 - *Type:* num
 
 new value.
+
+---
+
+###### `key`<sup>Optional</sup> <a name="key" id="@winglang/sdk.cloud.ICounterClient.set.parameter.key"></a>
+
+- *Type:* str
+
+specify the key to be set.
 
 ---
 

--- a/examples/tests/sdk_tests/counter/dec.w
+++ b/examples/tests/sdk_tests/counter/dec.w
@@ -11,3 +11,14 @@ test "dec" {
   assert(counter.peek() == -2);
   assert(dec2 == 0);
 }
+
+test "key dec" {
+  let key = "my-key";
+  assert(counter.peek(key) == 1);
+  let dec1 = counter.dec(nil, key);
+  assert(counter.peek(key) == 0);
+  assert(dec1 == 1);
+  let dec2 = counter.dec(2, key);
+  assert(counter.peek(key) == -2);
+  assert(dec2 == 0);
+}

--- a/examples/tests/sdk_tests/counter/inc.w
+++ b/examples/tests/sdk_tests/counter/inc.w
@@ -16,3 +16,19 @@ test "inc" {
   let r3 = counter.inc();
   assert(r3 == 12);
 }
+
+test "key inc" {
+  let key = "my-key";
+  assert(counter.peek(key) == 0);
+  let r0 = counter.inc(nil, key);
+  assert(r0 == 0);
+  assert(counter.peek(key) == 1);
+  let r1 = counter.inc(nil, key);
+  assert(r1 == 1);
+  assert(counter.peek(key) == 2);
+  let r2 = counter.inc(10, key);
+  assert(r2 == 2);
+  assert(counter.peek(key) == 12);
+  let r3 = counter.inc(nil, key);
+  assert(r3 == 12);
+}

--- a/examples/tests/sdk_tests/counter/peek.w
+++ b/examples/tests/sdk_tests/counter/peek.w
@@ -8,3 +8,11 @@ test "peek" {
   c.inc();
   assert(c.peek() == 1);
 }
+
+test "key peek" {
+  let key = "my-key";
+  assert(c.peek(key) == 0);
+  assert(c.peek(key) == 0);
+  c.inc(nil, key);
+  assert(c.peek(key) == 1);
+}

--- a/examples/tests/sdk_tests/counter/set.w
+++ b/examples/tests/sdk_tests/counter/set.w
@@ -13,3 +13,16 @@ test "set" {
   counter.set(88);
   assert(counter.peek() == 88);
 }
+
+test "key set" {
+  let key = "my-key";
+  assert(counter.peek(key) == 0);
+  counter.inc(nil, key);
+  assert(counter.peek(key) == 1);
+  counter.inc(nil, key);
+  assert(counter.peek(key) == 2);
+  counter.inc(10, key);
+  assert(counter.peek(key) == 12);
+  counter.set(88, key);
+  assert(counter.peek(key) == 88);
+}

--- a/libs/wingsdk/API.md
+++ b/libs/wingsdk/API.md
@@ -5296,7 +5296,7 @@ Inflight interface for `Counter`.
 ##### `dec` <a name="dec" id="@winglang/sdk.cloud.ICounterClient.dec"></a>
 
 ```wing
-dec(amount?: num): num
+dec(amount?: num, key?: str): num
 ```
 
 **Inflight client:** [true](#true)
@@ -5311,10 +5311,18 @@ amount to decrement (default is 1).
 
 ---
 
+###### `key`<sup>Optional</sup> <a name="key" id="@winglang/sdk.cloud.ICounterClient.dec.parameter.key"></a>
+
+- *Type:* str
+
+specify the key to be decremented.
+
+---
+
 ##### `inc` <a name="inc" id="@winglang/sdk.cloud.ICounterClient.inc"></a>
 
 ```wing
-inc(amount?: num): num
+inc(amount?: num, key?: str): num
 ```
 
 **Inflight client:** [true](#true)
@@ -5329,10 +5337,18 @@ amount to increment (default is 1).
 
 ---
 
+###### `key`<sup>Optional</sup> <a name="key" id="@winglang/sdk.cloud.ICounterClient.inc.parameter.key"></a>
+
+- *Type:* str
+
+specify the key to be incremented.
+
+---
+
 ##### `peek` <a name="peek" id="@winglang/sdk.cloud.ICounterClient.peek"></a>
 
 ```wing
-peek(): num
+peek(key?: str): num
 ```
 
 **Inflight client:** [true](#true)
@@ -5342,10 +5358,18 @@ Get the current value of the counter.
 Using this API may introduce race conditions since the value can change between
 the time it is read and the time it is used in your code.
 
+###### `key`<sup>Optional</sup> <a name="key" id="@winglang/sdk.cloud.ICounterClient.peek.parameter.key"></a>
+
+- *Type:* str
+
+specify the key to be retrieved.
+
+---
+
 ##### `set` <a name="set" id="@winglang/sdk.cloud.ICounterClient.set"></a>
 
 ```wing
-set(value: num): void
+set(value: num, key?: str): void
 ```
 
 **Inflight client:** [true](#true)
@@ -5357,6 +5381,14 @@ Set a counter to a given value.
 - *Type:* num
 
 new value.
+
+---
+
+###### `key`<sup>Optional</sup> <a name="key" id="@winglang/sdk.cloud.ICounterClient.set.parameter.key"></a>
+
+- *Type:* str
+
+specify the key to be set.
 
 ---
 

--- a/libs/wingsdk/src/cloud/counter.ts
+++ b/libs/wingsdk/src/cloud/counter.ts
@@ -65,34 +65,38 @@ export interface ICounterClient {
   /**
    * Increments the counter atomically by a certain amount and returns the previous value.
    * @param amount amount to increment (default is 1).
+   * @param key specify the key to be incremented.
    * @returns the previous value of the counter.
    * @inflight
    */
-  inc(amount?: number): Promise<number>;
+  inc(amount?: number, key?: string): Promise<number>;
 
   /**
    * Decrement the counter, returning the previous value.
    * @param amount amount to decrement (default is 1).
+   * @param key specify the key to be decremented.
    * @returns the previous value of the counter.
    * @inflight
    */
-  dec(amount?: number): Promise<number>;
+  dec(amount?: number, key?: string): Promise<number>;
 
   /**
    * Get the current value of the counter.
    * Using this API may introduce race conditions since the value can change between
    * the time it is read and the time it is used in your code.
+   * @param key specify the key to be retrieved.
    * @returns current value
    * @inflight
    */
-  peek(): Promise<number>;
+  peek(key?: string): Promise<number>;
 
   /**
    * Set a counter to a given value.
    * @param value new value
+   * @param key specify the key to be set.
    * @inflight
    */
-  set(value: number): Promise<void>;
+  set(value: number, key?: string): Promise<void>;
 }
 
 /**

--- a/libs/wingsdk/src/shared-aws/counter.inflight.ts
+++ b/libs/wingsdk/src/shared-aws/counter.inflight.ts
@@ -19,10 +19,10 @@ export class CounterClient implements ICounterClient {
     private readonly client = new DynamoDBClient({})
   ) {}
 
-  public async inc(amount = 1): Promise<number> {
+  public async inc(amount = 1, key = COUNTER_ID): Promise<number> {
     const command = new UpdateItemCommand({
       TableName: this.tableName,
-      Key: { [COUNTER_HASH_KEY]: { S: COUNTER_ID } },
+      Key: { [COUNTER_HASH_KEY]: { S: key } },
       UpdateExpression: `SET ${VALUE_ATTRIBUTE} = if_not_exists(${VALUE_ATTRIBUTE}, :${INITIAL_VALUE_TOKEN}) + :${AMOUNT_TOKEN}`,
       ExpressionAttributeValues: {
         [`:${AMOUNT_TOKEN}`]: { N: `${amount}` },
@@ -41,14 +41,14 @@ export class CounterClient implements ICounterClient {
     return parseInt(newValue) - amount;
   }
 
-  public async dec(amount = 1): Promise<number> {
-    return this.inc(-1 * amount);
+  public async dec(amount = 1, key: string = COUNTER_ID): Promise<number> {
+    return this.inc(-1 * amount, key);
   }
 
-  public async peek(): Promise<number> {
+  public async peek(key: string = COUNTER_ID): Promise<number> {
     const command = new GetItemCommand({
       TableName: this.tableName,
-      Key: { [COUNTER_HASH_KEY]: { S: COUNTER_ID } },
+      Key: { [COUNTER_HASH_KEY]: { S: key } },
     });
 
     const result = await this.client.send(command);
@@ -60,10 +60,10 @@ export class CounterClient implements ICounterClient {
     return parseInt(currentValue);
   }
 
-  public async set(value: number): Promise<void> {
+  public async set(value: number, key: string = COUNTER_ID): Promise<void> {
     const command = new UpdateItemCommand({
       TableName: this.tableName,
-      Key: { [COUNTER_HASH_KEY]: { S: COUNTER_ID } },
+      Key: { [COUNTER_HASH_KEY]: { S: key } },
       UpdateExpression: `SET ${VALUE_ATTRIBUTE} = :${SET_VALUE}`,
       ExpressionAttributeValues: {
         [`:${SET_VALUE}`]: { N: `${value}` },

--- a/libs/wingsdk/src/target-sim/counter.inflight.ts
+++ b/libs/wingsdk/src/target-sim/counter.inflight.ts
@@ -6,14 +6,14 @@ import {
 } from "../testing/simulator";
 
 export class Counter implements ICounterClient, ISimulatorResourceInstance {
-  private value: number;
+  private values: Map<string, number>;
   private readonly context: ISimulatorContext;
 
   public constructor(
     props: CounterSchema["props"],
     context: ISimulatorContext
   ) {
-    this.value = props.initial;
+    this.values = new Map().set("default", props.initial);
     this.context = context;
   }
 
@@ -23,42 +23,58 @@ export class Counter implements ICounterClient, ISimulatorResourceInstance {
 
   public async cleanup(): Promise<void> {}
 
-  public async inc(amount: number = 1): Promise<number> {
+  public async inc(
+    amount: number = 1,
+    key: string = "default"
+  ): Promise<number> {
     return this.context.withTrace({
-      message: `Inc (amount=${amount}).`,
+      message: `Inc (amount=${amount}${
+        key != "default" ? ", key: " + key : ""
+      }).`,
       activity: async () => {
-        const prev = this.value;
-        this.value += amount;
+        const prev = this.values.get(key) ?? 0;
+        this.values.set(key, prev + amount);
         return prev;
       },
     });
   }
 
-  public async dec(amount: number = 1): Promise<number> {
+  public async dec(
+    amount: number = 1,
+    key: string = "default"
+  ): Promise<number> {
+    key;
     return this.context.withTrace({
-      message: `Dec (amount=${amount}).`,
+      message: `Dec (amount=${amount}${
+        key != "default" ? ", key: " + key : ""
+      }).`,
       activity: async () => {
-        const prev = this.value;
-        this.value -= amount;
+        const prev = this.values.get(key) ?? 0;
+        this.values.set(key, prev - amount);
         return prev;
       },
     });
   }
 
-  public async peek(): Promise<number> {
+  public async peek(key: string = "default"): Promise<number> {
     return this.context.withTrace({
-      message: `Peek (value=${this.value}).`,
+      message: `Peek (value=${this.values.get(key) ?? 0}${
+        key != "default" ? ", key: " + key : ""
+      }).`,
       activity: async () => {
-        return this.value;
+        return this.values.get(key) ?? 0;
       },
     });
   }
 
-  public async set(value: number): Promise<void> {
+  public async set(value: number, key: string = "default"): Promise<void> {
+    key;
     return this.context.withTrace({
-      message: `Set (value=${this.value}).`,
+      message: `Set (value=${value}${
+        key != "default" ? ", key: " + key : ""
+      }).`,
       activity: async () => {
-        this.value = value;
+        this.values.set(key, value);
       },
     });
   }

--- a/libs/wingsdk/test/target-awscdk/__snapshots__/counter.test.ts.snap
+++ b/libs/wingsdk/test/target-awscdk/__snapshots__/counter.test.ts.snap
@@ -129,7 +129,7 @@ exports[`dec() policy statement 2`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "d67f1ad8d70bdc743141753dd76cf215a976cb60954be5b3780161a5c928fd88.zip",
+          "S3Key": "ada9f60db84f33648f74416160b449d462b6d301d37bceae8c9c33f8de4360df.zip",
         },
         "Environment": {
           "Variables": {
@@ -367,7 +367,7 @@ exports[`function with a counter binding 2`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "9631c62dc45f49b1227489f95a27865dda3d0d3df6996b64112cd9e9083736b7.zip",
+          "S3Key": "95910cce203152828a8a964ba66578212fceaf84e85896b43e5c50b82ceefe9a.zip",
         },
         "Environment": {
           "Variables": {
@@ -539,7 +539,7 @@ exports[`inc() policy statement 2`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "9631c62dc45f49b1227489f95a27865dda3d0d3df6996b64112cd9e9083736b7.zip",
+          "S3Key": "95910cce203152828a8a964ba66578212fceaf84e85896b43e5c50b82ceefe9a.zip",
         },
         "Environment": {
           "Variables": {
@@ -711,7 +711,7 @@ exports[`peek() policy statement 2`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "4f75f2e0b20ec1cfbe64a239806cfaf061e34d45cb85ca8afdfdae79583b1f65.zip",
+          "S3Key": "97ff682f3d0143b51bd399e486ddd5ec32cbb7f9c4386a2d102f80a630cef6d8.zip",
         },
         "Environment": {
           "Variables": {
@@ -883,7 +883,7 @@ exports[`set() policy statement 2`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "c4746e415c05ffc3a40869598f603b3235d1e0c5d22084ac9273cb7379d0e4bf.zip",
+          "S3Key": "c0b9a06c24cc5b9f5c5c534fd299bbc27b16f2646e7d4ae0b69e055c3beaa6d4.zip",
         },
         "Environment": {
           "Variables": {

--- a/libs/wingsdk/test/target-sim/__snapshots__/counter.test.ts.snap
+++ b/libs/wingsdk/test/target-sim/__snapshots__/counter.test.ts.snap
@@ -236,11 +236,258 @@ exports[`inc 2`] = `
 }
 `;
 
+exports[`key dec 1`] = `
+[
+  "wingsdk.cloud.TestRunner created.",
+  "wingsdk.cloud.Counter created.",
+  "Dec (amount=1, key: my-key).",
+  "Dec (amount=1, key: my-key).",
+  "Dec (amount=10, key: my-key).",
+  "Dec (amount=10, key: my-key).",
+  "wingsdk.cloud.Counter deleted.",
+  "wingsdk.cloud.TestRunner deleted.",
+]
+`;
+
+exports[`key dec 2`] = `
+{
+  "simulator.json": {
+    "resources": [
+      {
+        "attrs": {},
+        "path": "root/cloud.TestRunner",
+        "props": {
+          "tests": {},
+        },
+        "type": "wingsdk.cloud.TestRunner",
+      },
+      {
+        "attrs": {},
+        "path": "root/my_counter",
+        "props": {
+          "initial": 0,
+        },
+        "type": "wingsdk.cloud.Counter",
+      },
+    ],
+    "sdkVersion": "0.0.0",
+  },
+  "tree.json": {
+    "tree": {
+      "children": {
+        "cloud.TestRunner": {
+          "attributes": {
+            "wing:resource:connections": [],
+          },
+          "constructInfo": {
+            "fqn": "constructs.Construct",
+            "version": "10.1.245",
+          },
+          "display": {
+            "description": "A suite of APIs for running tests and collecting results.",
+            "hidden": true,
+            "title": "TestRunner",
+          },
+          "id": "cloud.TestRunner",
+          "path": "root/cloud.TestRunner",
+        },
+        "my_counter": {
+          "attributes": {
+            "wing:resource:connections": [],
+          },
+          "constructInfo": {
+            "fqn": "constructs.Construct",
+            "version": "10.1.245",
+          },
+          "display": {
+            "description": "A distributed atomic counter",
+            "title": "Counter",
+          },
+          "id": "my_counter",
+          "path": "root/my_counter",
+        },
+      },
+      "constructInfo": {
+        "fqn": "constructs.Construct",
+        "version": "10.1.245",
+      },
+      "id": "root",
+      "path": "root",
+    },
+    "version": "tree-0.1",
+  },
+}
+`;
+
+exports[`key inc 1`] = `
+[
+  "wingsdk.cloud.TestRunner created.",
+  "wingsdk.cloud.Counter created.",
+  "Inc (amount=1, key: my-key).",
+  "Inc (amount=1, key: my-key).",
+  "Inc (amount=10, key: my-key).",
+  "Inc (amount=10, key: my-key).",
+  "wingsdk.cloud.Counter deleted.",
+  "wingsdk.cloud.TestRunner deleted.",
+]
+`;
+
+exports[`key inc 2`] = `
+{
+  "simulator.json": {
+    "resources": [
+      {
+        "attrs": {},
+        "path": "root/cloud.TestRunner",
+        "props": {
+          "tests": {},
+        },
+        "type": "wingsdk.cloud.TestRunner",
+      },
+      {
+        "attrs": {},
+        "path": "root/my_counter",
+        "props": {
+          "initial": 0,
+        },
+        "type": "wingsdk.cloud.Counter",
+      },
+    ],
+    "sdkVersion": "0.0.0",
+  },
+  "tree.json": {
+    "tree": {
+      "children": {
+        "cloud.TestRunner": {
+          "attributes": {
+            "wing:resource:connections": [],
+          },
+          "constructInfo": {
+            "fqn": "constructs.Construct",
+            "version": "10.1.245",
+          },
+          "display": {
+            "description": "A suite of APIs for running tests and collecting results.",
+            "hidden": true,
+            "title": "TestRunner",
+          },
+          "id": "cloud.TestRunner",
+          "path": "root/cloud.TestRunner",
+        },
+        "my_counter": {
+          "attributes": {
+            "wing:resource:connections": [],
+          },
+          "constructInfo": {
+            "fqn": "constructs.Construct",
+            "version": "10.1.245",
+          },
+          "display": {
+            "description": "A distributed atomic counter",
+            "title": "Counter",
+          },
+          "id": "my_counter",
+          "path": "root/my_counter",
+        },
+      },
+      "constructInfo": {
+        "fqn": "constructs.Construct",
+        "version": "10.1.245",
+      },
+      "id": "root",
+      "path": "root",
+    },
+    "version": "tree-0.1",
+  },
+}
+`;
+
+exports[`key set to new value 1`] = `
+[
+  "wingsdk.cloud.TestRunner created.",
+  "wingsdk.cloud.Counter created.",
+  "Set (value=5, key: my-key).",
+  "Peek (value=5, key: my-key).",
+  "wingsdk.cloud.Counter deleted.",
+  "wingsdk.cloud.TestRunner deleted.",
+]
+`;
+
+exports[`key set to new value 2`] = `
+{
+  "simulator.json": {
+    "resources": [
+      {
+        "attrs": {},
+        "path": "root/cloud.TestRunner",
+        "props": {
+          "tests": {},
+        },
+        "type": "wingsdk.cloud.TestRunner",
+      },
+      {
+        "attrs": {},
+        "path": "root/my_counter",
+        "props": {
+          "initial": 0,
+        },
+        "type": "wingsdk.cloud.Counter",
+      },
+    ],
+    "sdkVersion": "0.0.0",
+  },
+  "tree.json": {
+    "tree": {
+      "children": {
+        "cloud.TestRunner": {
+          "attributes": {
+            "wing:resource:connections": [],
+          },
+          "constructInfo": {
+            "fqn": "constructs.Construct",
+            "version": "10.1.245",
+          },
+          "display": {
+            "description": "A suite of APIs for running tests and collecting results.",
+            "hidden": true,
+            "title": "TestRunner",
+          },
+          "id": "cloud.TestRunner",
+          "path": "root/cloud.TestRunner",
+        },
+        "my_counter": {
+          "attributes": {
+            "wing:resource:connections": [],
+          },
+          "constructInfo": {
+            "fqn": "constructs.Construct",
+            "version": "10.1.245",
+          },
+          "display": {
+            "description": "A distributed atomic counter",
+            "title": "Counter",
+          },
+          "id": "my_counter",
+          "path": "root/my_counter",
+        },
+      },
+      "constructInfo": {
+        "fqn": "constructs.Construct",
+        "version": "10.1.245",
+      },
+      "id": "root",
+      "path": "root",
+    },
+    "version": "tree-0.1",
+  },
+}
+`;
+
 exports[`set to new value 1`] = `
 [
   "wingsdk.cloud.TestRunner created.",
   "wingsdk.cloud.Counter created.",
-  "Set (value=123).",
+  "Set (value=5).",
   "Peek (value=5).",
   "wingsdk.cloud.Counter deleted.",
   "wingsdk.cloud.TestRunner deleted.",

--- a/libs/wingsdk/test/target-sim/counter.test.ts
+++ b/libs/wingsdk/test/target-sim/counter.test.ts
@@ -57,6 +57,32 @@ test("inc", async () => {
   expect(app.snapshot()).toMatchSnapshot();
 });
 
+test("key inc", async () => {
+  // GIVEN
+  const app = new SimApp();
+  cloud.Counter._newCounter(app, "my_counter");
+
+  const s = await app.startSimulator();
+
+  const client = s.getResource("/my_counter") as ICounterClient;
+
+  const value0 = await client.inc(1, "my-key");
+  expect(value0).toEqual(0); // always returns the value before inc (like "i++");
+
+  const value1 = await client.inc(undefined, "my-key");
+  expect(value1).toEqual(1);
+
+  const value2 = await client.inc(10, "my-key");
+  expect(value2).toEqual(1 + 1);
+
+  const value3 = await client.inc(10, "my-key");
+  expect(value3).toEqual(1 + 1 + 10);
+  await s.stop();
+
+  expect(listMessages(s)).toMatchSnapshot();
+  expect(app.snapshot()).toMatchSnapshot();
+});
+
 test("dec", async () => {
   // GIVEN
   const app = new SimApp();
@@ -79,6 +105,32 @@ test("dec", async () => {
 
   const value3 = await client.dec(10);
   expect(value3).toEqual(123 - 1 - 1 - 10);
+  await s.stop();
+
+  expect(listMessages(s)).toMatchSnapshot();
+  expect(app.snapshot()).toMatchSnapshot();
+});
+
+test("key dec", async () => {
+  // GIVEN
+  const app = new SimApp();
+  cloud.Counter._newCounter(app, "my_counter");
+
+  const s = await app.startSimulator();
+
+  const client = s.getResource("/my_counter") as ICounterClient;
+
+  const value0 = await client.dec(1, "my-key");
+  expect(value0).toEqual(0); // always returns the value before inc (like "i--");
+
+  const value1 = await client.dec(undefined, "my-key");
+  expect(value1).toEqual(-1);
+
+  const value2 = await client.dec(10, "my-key");
+  expect(value2).toEqual(-1 - 1);
+
+  const value3 = await client.dec(10, "my-key");
+  expect(value3).toEqual(-1 - 1 - 10);
   await s.stop();
 
   expect(listMessages(s)).toMatchSnapshot();
@@ -113,6 +165,33 @@ test("peek with initial value", async () => {
   expect(peek).toEqual(123);
 });
 
+test("key peek without value", async () => {
+  // GIVEN
+  const app = new SimApp();
+  cloud.Counter._newCounter(app, "my_counter");
+
+  const s = await app.startSimulator();
+
+  const client = s.getResource("/my_counter") as ICounterClient;
+
+  const peek = await client.peek("my-key");
+  expect(peek).toEqual(0);
+});
+
+test("key peek with value", async () => {
+  // GIVEN
+  const app = new SimApp();
+  cloud.Counter._newCounter(app, "my_counter");
+
+  const s = await app.startSimulator();
+
+  const client = s.getResource("/my_counter") as ICounterClient;
+
+  await client.inc(10, "my-key");
+  const peek = await client.peek("my-key");
+  expect(peek).toEqual(10);
+});
+
 test("set to new value", async () => {
   // GIVEN
   const app = new SimApp();
@@ -126,6 +205,25 @@ test("set to new value", async () => {
 
   await client.set(5);
   const peek = await client.peek();
+  expect(peek).toEqual(5);
+
+  await s.stop();
+
+  expect(listMessages(s)).toMatchSnapshot();
+  expect(app.snapshot()).toMatchSnapshot();
+});
+
+test("key set to new value", async () => {
+  // GIVEN
+  const app = new SimApp();
+  cloud.Counter._newCounter(app, "my_counter");
+
+  const s = await app.startSimulator();
+
+  const client = s.getResource("/my_counter") as ICounterClient;
+
+  await client.set(5, "my-key");
+  const peek = await client.peek("my-key");
   expect(peek).toEqual(5);
 
   await s.stop();

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/counter/dec.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/counter/dec.w_compile_tf-aws.md
@@ -26,6 +26,33 @@ module.exports = function({ counter }) {
 
 ```
 
+## inflight.$Closure2.js
+```js
+module.exports = function({ counter }) {
+  class $Closure2 {
+    constructor({  }) {
+      const $obj = (...args) => this.handle(...args);
+      Object.setPrototypeOf($obj, this);
+      return $obj;
+    }
+    async $inflight_init()  {
+    }
+    async handle()  {
+      const key = "my-key";
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '((await counter.peek(key)) === 1)'`)})(((await counter.peek(key)) === 1))};
+      const dec1 = (await counter.dec(undefined,key));
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '((await counter.peek(key)) === 0)'`)})(((await counter.peek(key)) === 0))};
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '(dec1 === 1)'`)})((dec1 === 1))};
+      const dec2 = (await counter.dec(2,key));
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '((await counter.peek(key)) === (-2))'`)})(((await counter.peek(key)) === (-2)))};
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '(dec2 === 0)'`)})((dec2 === 0))};
+    }
+  }
+  return $Closure2;
+}
+
+```
+
 ## main.tf.json
 ```json
 {
@@ -47,7 +74,7 @@ module.exports = function({ counter }) {
   },
   "output": {
     "WING_TEST_RUNNER_FUNCTION_ARNS": {
-      "value": "[[\"root/Default/Default/test:dec\",\"${aws_lambda_function.root_testdec_Handler_AE114D79.arn}\"]]"
+      "value": "[[\"root/Default/Default/test:dec\",\"${aws_lambda_function.root_testdec_Handler_AE114D79.arn}\"],[\"root/Default/Default/test:key dec\",\"${aws_lambda_function.root_testkeydec_Handler_9A4B0F1C.arn}\"]]"
     }
   },
   "provider": {
@@ -84,6 +111,15 @@ module.exports = function({ counter }) {
           }
         },
         "assume_role_policy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Action\":\"sts:AssumeRole\",\"Principal\":{\"Service\":\"lambda.amazonaws.com\"},\"Effect\":\"Allow\"}]}"
+      },
+      "root_testkeydec_Handler_IamRole_3DB80873": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/Default/test:key dec/Handler/IamRole",
+            "uniqueId": "root_testkeydec_Handler_IamRole_3DB80873"
+          }
+        },
+        "assume_role_policy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Action\":\"sts:AssumeRole\",\"Principal\":{\"Service\":\"lambda.amazonaws.com\"},\"Effect\":\"Allow\"}]}"
       }
     },
     "aws_iam_role_policy": {
@@ -96,6 +132,16 @@ module.exports = function({ counter }) {
         },
         "policy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Action\":[\"dynamodb:UpdateItem\"],\"Resource\":[\"${aws_dynamodb_table.root_cloudCounter_E0AC1263.arn}\"],\"Effect\":\"Allow\"},{\"Action\":[\"dynamodb:GetItem\"],\"Resource\":[\"${aws_dynamodb_table.root_cloudCounter_E0AC1263.arn}\"],\"Effect\":\"Allow\"}]}",
         "role": "${aws_iam_role.root_testdec_Handler_IamRole_3E911C09.name}"
+      },
+      "root_testkeydec_Handler_IamRolePolicy_79928BD4": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/Default/test:key dec/Handler/IamRolePolicy",
+            "uniqueId": "root_testkeydec_Handler_IamRolePolicy_79928BD4"
+          }
+        },
+        "policy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Action\":[\"dynamodb:UpdateItem\"],\"Resource\":[\"${aws_dynamodb_table.root_cloudCounter_E0AC1263.arn}\"],\"Effect\":\"Allow\"},{\"Action\":[\"dynamodb:GetItem\"],\"Resource\":[\"${aws_dynamodb_table.root_cloudCounter_E0AC1263.arn}\"],\"Effect\":\"Allow\"}]}",
+        "role": "${aws_iam_role.root_testkeydec_Handler_IamRole_3DB80873.name}"
       }
     },
     "aws_iam_role_policy_attachment": {
@@ -108,6 +154,16 @@ module.exports = function({ counter }) {
         },
         "policy_arn": "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
         "role": "${aws_iam_role.root_testdec_Handler_IamRole_3E911C09.name}"
+      },
+      "root_testkeydec_Handler_IamRolePolicyAttachment_34AF7C34": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/Default/test:key dec/Handler/IamRolePolicyAttachment",
+            "uniqueId": "root_testkeydec_Handler_IamRolePolicyAttachment_34AF7C34"
+          }
+        },
+        "policy_arn": "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+        "role": "${aws_iam_role.root_testkeydec_Handler_IamRole_3DB80873.name}"
       }
     },
     "aws_lambda_function": {
@@ -137,6 +193,33 @@ module.exports = function({ counter }) {
           "security_group_ids": [],
           "subnet_ids": []
         }
+      },
+      "root_testkeydec_Handler_9A4B0F1C": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/Default/test:key dec/Handler/Default",
+            "uniqueId": "root_testkeydec_Handler_9A4B0F1C"
+          }
+        },
+        "environment": {
+          "variables": {
+            "DYNAMODB_TABLE_NAME_49baa65c": "${aws_dynamodb_table.root_cloudCounter_E0AC1263.name}",
+            "WING_FUNCTION_NAME": "Handler-c8a42d0e",
+            "WING_TARGET": "tf-aws"
+          }
+        },
+        "function_name": "Handler-c8a42d0e",
+        "handler": "index.handler",
+        "publish": true,
+        "role": "${aws_iam_role.root_testkeydec_Handler_IamRole_3DB80873.arn}",
+        "runtime": "nodejs18.x",
+        "s3_bucket": "${aws_s3_bucket.root_Code_02F3C603.bucket}",
+        "s3_key": "${aws_s3_object.root_testkeydec_Handler_S3Object_18419CC9.key}",
+        "timeout": 30,
+        "vpc_config": {
+          "security_group_ids": [],
+          "subnet_ids": []
+        }
       }
     },
     "aws_s3_bucket": {
@@ -156,6 +239,17 @@ module.exports = function({ counter }) {
           "metadata": {
             "path": "root/Default/Default/test:dec/Handler/S3Object",
             "uniqueId": "root_testdec_Handler_S3Object_E6EDF071"
+          }
+        },
+        "bucket": "${aws_s3_bucket.root_Code_02F3C603.bucket}",
+        "key": "<ASSET_KEY>",
+        "source": "<ASSET_SOURCE>"
+      },
+      "root_testkeydec_Handler_S3Object_18419CC9": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/Default/test:key dec/Handler/S3Object",
+            "uniqueId": "root_testkeydec_Handler_S3Object_18419CC9"
           }
         },
         "bucket": "${aws_s3_bucket.root_Code_02F3C603.bucket}",
@@ -214,8 +308,45 @@ class $Root extends $stdlib.std.Resource {
         super._registerBind(host, ops);
       }
     }
+    class $Closure2 extends $stdlib.std.Resource {
+      constructor(scope, id, ) {
+        super(scope, id);
+        this._addInflightOps("handle");
+        this.display.hidden = true;
+      }
+      static _toInflightType(context) {
+        const self_client_path = "././inflight.$Closure2.js";
+        const counter_client = context._lift(counter);
+        return $stdlib.core.NodeJsCode.fromInline(`
+          require("${self_client_path}")({
+            counter: ${counter_client},
+          })
+        `);
+      }
+      _toInflight() {
+        return $stdlib.core.NodeJsCode.fromInline(`
+          (await (async () => {
+            const $Closure2Client = ${$Closure2._toInflightType(this).text};
+            const client = new $Closure2Client({
+            });
+            if (client.$inflight_init) { await client.$inflight_init(); }
+            return client;
+          })())
+        `);
+      }
+      _registerBind(host, ops) {
+        if (ops.includes("$inflight_init")) {
+          $Closure2._registerBindObject(counter, host, []);
+        }
+        if (ops.includes("handle")) {
+          $Closure2._registerBindObject(counter, host, ["dec", "peek"]);
+        }
+        super._registerBind(host, ops);
+      }
+    }
     const counter = this.node.root.newAbstract("@winglang/sdk.cloud.Counter",this,"cloud.Counter",{ initial: 1 });
     this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:dec",new $Closure1(this,"$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:key dec",new $Closure2(this,"$Closure2"));
   }
 }
 class $App extends $AppBase {

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/counter/dec.w_test_sim.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/counter/dec.w_test_sim.md
@@ -2,13 +2,33 @@
 
 ## stdout.log
 ```log
-pass ─ dec.wsim » root/env0/test:dec
+pass ─ dec.wsim » root/env0/test:dec    
+fail ┌ dec.wsim » root/env1/test:key dec
+     │ Error: assertion failed: '((await counter.peek(key)) === 1)'
+     │     at /tmp/wing-bundles-ZC7cEz/index.js:23:23
+     │     at $Closure2.handle (/tmp/wing-bundles-ZC7cEz/index.js:24:15)
+     │     at async exports.handler (/tmp/wing-bundles-ZC7cEz/index.js:65:10)
+     │     at async Object.withTrace (/home/marcio/code/wing/libs/wingsdk/lib/testing/simulator.js:71:38)
+     │     at async TestRunnerClient.runTest (/home/marcio/code/wing/libs/wingsdk/lib/target-sim/test-runner.inflight.js:31:13)
+     │     at async testSimulator (/home/marcio/code/wing/apps/wing/dist/commands/test.js:199:22)
+     │     at async testOne (/home/marcio/code/wing/apps/wing/dist/commands/test.js:114:20)
+     └     at async test (/home/marcio/code/wing/apps/wing/dist/commands/test.js:55:29)
+
+Error: assertion failed: '((await counter.peek(key)) === 1)'
+    at /tmp/wing-bundles-ZC7cEz/index.js:23:23
+    at $Closure2.handle (/tmp/wing-bundles-ZC7cEz/index.js:24:15)
+    at async exports.handler (/tmp/wing-bundles-ZC7cEz/index.js:65:10)
+    at async Object.withTrace (/home/marcio/code/wing/libs/wingsdk/lib/testing/simulator.js:71:38)
+    at async TestRunnerClient.runTest (/home/marcio/code/wing/libs/wingsdk/lib/target-sim/test-runner.inflight.js:31:13)
+    at async testSimulator (/home/marcio/code/wing/apps/wing/dist/commands/test.js:199:22)
+    at async testOne (/home/marcio/code/wing/apps/wing/dist/commands/test.js:114:20)
+    at async test (/home/marcio/code/wing/apps/wing/dist/commands/test.js:55:29)
  
 
 
 
 
-Tests 1 passed (1) 
+Tests 1 failed (1) 
 Duration <DURATION>
 
 ```

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/counter/inc.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/counter/inc.w_compile_tf-aws.md
@@ -31,6 +31,38 @@ module.exports = function({ counter }) {
 
 ```
 
+## inflight.$Closure2.js
+```js
+module.exports = function({ counter }) {
+  class $Closure2 {
+    constructor({  }) {
+      const $obj = (...args) => this.handle(...args);
+      Object.setPrototypeOf($obj, this);
+      return $obj;
+    }
+    async $inflight_init()  {
+    }
+    async handle()  {
+      const key = "my-key";
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '((await counter.peek(key)) === 0)'`)})(((await counter.peek(key)) === 0))};
+      const r0 = (await counter.inc(undefined,key));
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '(r0 === 0)'`)})((r0 === 0))};
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '((await counter.peek(key)) === 1)'`)})(((await counter.peek(key)) === 1))};
+      const r1 = (await counter.inc(undefined,key));
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '(r1 === 1)'`)})((r1 === 1))};
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '((await counter.peek(key)) === 2)'`)})(((await counter.peek(key)) === 2))};
+      const r2 = (await counter.inc(10,key));
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '(r2 === 2)'`)})((r2 === 2))};
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '((await counter.peek(key)) === 12)'`)})(((await counter.peek(key)) === 12))};
+      const r3 = (await counter.inc(undefined,key));
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '(r3 === 12)'`)})((r3 === 12))};
+    }
+  }
+  return $Closure2;
+}
+
+```
+
 ## main.tf.json
 ```json
 {
@@ -52,7 +84,7 @@ module.exports = function({ counter }) {
   },
   "output": {
     "WING_TEST_RUNNER_FUNCTION_ARNS": {
-      "value": "[[\"root/Default/Default/test:inc\",\"${aws_lambda_function.root_testinc_Handler_A10D3F88.arn}\"]]"
+      "value": "[[\"root/Default/Default/test:inc\",\"${aws_lambda_function.root_testinc_Handler_A10D3F88.arn}\"],[\"root/Default/Default/test:key inc\",\"${aws_lambda_function.root_testkeyinc_Handler_81AACB2B.arn}\"]]"
     }
   },
   "provider": {
@@ -89,6 +121,15 @@ module.exports = function({ counter }) {
           }
         },
         "assume_role_policy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Action\":\"sts:AssumeRole\",\"Principal\":{\"Service\":\"lambda.amazonaws.com\"},\"Effect\":\"Allow\"}]}"
+      },
+      "root_testkeyinc_Handler_IamRole_3767E961": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/Default/test:key inc/Handler/IamRole",
+            "uniqueId": "root_testkeyinc_Handler_IamRole_3767E961"
+          }
+        },
+        "assume_role_policy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Action\":\"sts:AssumeRole\",\"Principal\":{\"Service\":\"lambda.amazonaws.com\"},\"Effect\":\"Allow\"}]}"
       }
     },
     "aws_iam_role_policy": {
@@ -101,6 +142,16 @@ module.exports = function({ counter }) {
         },
         "policy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Action\":[\"dynamodb:UpdateItem\"],\"Resource\":[\"${aws_dynamodb_table.root_cloudCounter_E0AC1263.arn}\"],\"Effect\":\"Allow\"},{\"Action\":[\"dynamodb:GetItem\"],\"Resource\":[\"${aws_dynamodb_table.root_cloudCounter_E0AC1263.arn}\"],\"Effect\":\"Allow\"}]}",
         "role": "${aws_iam_role.root_testinc_Handler_IamRole_FADF671C.name}"
+      },
+      "root_testkeyinc_Handler_IamRolePolicy_ABAD8DBA": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/Default/test:key inc/Handler/IamRolePolicy",
+            "uniqueId": "root_testkeyinc_Handler_IamRolePolicy_ABAD8DBA"
+          }
+        },
+        "policy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Action\":[\"dynamodb:UpdateItem\"],\"Resource\":[\"${aws_dynamodb_table.root_cloudCounter_E0AC1263.arn}\"],\"Effect\":\"Allow\"},{\"Action\":[\"dynamodb:GetItem\"],\"Resource\":[\"${aws_dynamodb_table.root_cloudCounter_E0AC1263.arn}\"],\"Effect\":\"Allow\"}]}",
+        "role": "${aws_iam_role.root_testkeyinc_Handler_IamRole_3767E961.name}"
       }
     },
     "aws_iam_role_policy_attachment": {
@@ -113,6 +164,16 @@ module.exports = function({ counter }) {
         },
         "policy_arn": "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
         "role": "${aws_iam_role.root_testinc_Handler_IamRole_FADF671C.name}"
+      },
+      "root_testkeyinc_Handler_IamRolePolicyAttachment_F25A8A4D": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/Default/test:key inc/Handler/IamRolePolicyAttachment",
+            "uniqueId": "root_testkeyinc_Handler_IamRolePolicyAttachment_F25A8A4D"
+          }
+        },
+        "policy_arn": "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+        "role": "${aws_iam_role.root_testkeyinc_Handler_IamRole_3767E961.name}"
       }
     },
     "aws_lambda_function": {
@@ -142,6 +203,33 @@ module.exports = function({ counter }) {
           "security_group_ids": [],
           "subnet_ids": []
         }
+      },
+      "root_testkeyinc_Handler_81AACB2B": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/Default/test:key inc/Handler/Default",
+            "uniqueId": "root_testkeyinc_Handler_81AACB2B"
+          }
+        },
+        "environment": {
+          "variables": {
+            "DYNAMODB_TABLE_NAME_49baa65c": "${aws_dynamodb_table.root_cloudCounter_E0AC1263.name}",
+            "WING_FUNCTION_NAME": "Handler-c87f92b5",
+            "WING_TARGET": "tf-aws"
+          }
+        },
+        "function_name": "Handler-c87f92b5",
+        "handler": "index.handler",
+        "publish": true,
+        "role": "${aws_iam_role.root_testkeyinc_Handler_IamRole_3767E961.arn}",
+        "runtime": "nodejs18.x",
+        "s3_bucket": "${aws_s3_bucket.root_Code_02F3C603.bucket}",
+        "s3_key": "${aws_s3_object.root_testkeyinc_Handler_S3Object_38372573.key}",
+        "timeout": 30,
+        "vpc_config": {
+          "security_group_ids": [],
+          "subnet_ids": []
+        }
       }
     },
     "aws_s3_bucket": {
@@ -161,6 +249,17 @@ module.exports = function({ counter }) {
           "metadata": {
             "path": "root/Default/Default/test:inc/Handler/S3Object",
             "uniqueId": "root_testinc_Handler_S3Object_3A9256BD"
+          }
+        },
+        "bucket": "${aws_s3_bucket.root_Code_02F3C603.bucket}",
+        "key": "<ASSET_KEY>",
+        "source": "<ASSET_SOURCE>"
+      },
+      "root_testkeyinc_Handler_S3Object_38372573": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/Default/test:key inc/Handler/S3Object",
+            "uniqueId": "root_testkeyinc_Handler_S3Object_38372573"
           }
         },
         "bucket": "${aws_s3_bucket.root_Code_02F3C603.bucket}",
@@ -219,8 +318,45 @@ class $Root extends $stdlib.std.Resource {
         super._registerBind(host, ops);
       }
     }
+    class $Closure2 extends $stdlib.std.Resource {
+      constructor(scope, id, ) {
+        super(scope, id);
+        this._addInflightOps("handle");
+        this.display.hidden = true;
+      }
+      static _toInflightType(context) {
+        const self_client_path = "././inflight.$Closure2.js";
+        const counter_client = context._lift(counter);
+        return $stdlib.core.NodeJsCode.fromInline(`
+          require("${self_client_path}")({
+            counter: ${counter_client},
+          })
+        `);
+      }
+      _toInflight() {
+        return $stdlib.core.NodeJsCode.fromInline(`
+          (await (async () => {
+            const $Closure2Client = ${$Closure2._toInflightType(this).text};
+            const client = new $Closure2Client({
+            });
+            if (client.$inflight_init) { await client.$inflight_init(); }
+            return client;
+          })())
+        `);
+      }
+      _registerBind(host, ops) {
+        if (ops.includes("$inflight_init")) {
+          $Closure2._registerBindObject(counter, host, []);
+        }
+        if (ops.includes("handle")) {
+          $Closure2._registerBindObject(counter, host, ["inc", "peek"]);
+        }
+        super._registerBind(host, ops);
+      }
+    }
     const counter = this.node.root.newAbstract("@winglang/sdk.cloud.Counter",this,"cloud.Counter",{ initial: 0 });
     this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:inc",new $Closure1(this,"$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:key inc",new $Closure2(this,"$Closure2"));
   }
 }
 class $App extends $AppBase {

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/counter/inc.w_test_sim.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/counter/inc.w_test_sim.md
@@ -2,7 +2,8 @@
 
 ## stdout.log
 ```log
-pass ─ inc.wsim » root/env0/test:inc
+pass ─ inc.wsim » root/env0/test:inc    
+pass ─ inc.wsim » root/env1/test:key inc
  
 
 

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/counter/peek.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/counter/peek.w_compile_tf-aws.md
@@ -23,6 +23,30 @@ module.exports = function({ c }) {
 
 ```
 
+## inflight.$Closure2.js
+```js
+module.exports = function({ c }) {
+  class $Closure2 {
+    constructor({  }) {
+      const $obj = (...args) => this.handle(...args);
+      Object.setPrototypeOf($obj, this);
+      return $obj;
+    }
+    async $inflight_init()  {
+    }
+    async handle()  {
+      const key = "my-key";
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '((await c.peek(key)) === 0)'`)})(((await c.peek(key)) === 0))};
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '((await c.peek(key)) === 0)'`)})(((await c.peek(key)) === 0))};
+      (await c.inc(undefined,key));
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '((await c.peek(key)) === 1)'`)})(((await c.peek(key)) === 1))};
+    }
+  }
+  return $Closure2;
+}
+
+```
+
 ## main.tf.json
 ```json
 {
@@ -44,7 +68,7 @@ module.exports = function({ c }) {
   },
   "output": {
     "WING_TEST_RUNNER_FUNCTION_ARNS": {
-      "value": "[[\"root/Default/Default/test:peek\",\"${aws_lambda_function.root_testpeek_Handler_C724F76F.arn}\"]]"
+      "value": "[[\"root/Default/Default/test:peek\",\"${aws_lambda_function.root_testpeek_Handler_C724F76F.arn}\"],[\"root/Default/Default/test:key peek\",\"${aws_lambda_function.root_testkeypeek_Handler_61C5F573.arn}\"]]"
     }
   },
   "provider": {
@@ -73,6 +97,15 @@ module.exports = function({ c }) {
       }
     },
     "aws_iam_role": {
+      "root_testkeypeek_Handler_IamRole_B6229A6A": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/Default/test:key peek/Handler/IamRole",
+            "uniqueId": "root_testkeypeek_Handler_IamRole_B6229A6A"
+          }
+        },
+        "assume_role_policy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Action\":\"sts:AssumeRole\",\"Principal\":{\"Service\":\"lambda.amazonaws.com\"},\"Effect\":\"Allow\"}]}"
+      },
       "root_testpeek_Handler_IamRole_4D487D73": {
         "//": {
           "metadata": {
@@ -84,6 +117,16 @@ module.exports = function({ c }) {
       }
     },
     "aws_iam_role_policy": {
+      "root_testkeypeek_Handler_IamRolePolicy_C594AA2A": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/Default/test:key peek/Handler/IamRolePolicy",
+            "uniqueId": "root_testkeypeek_Handler_IamRolePolicy_C594AA2A"
+          }
+        },
+        "policy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Action\":[\"dynamodb:UpdateItem\"],\"Resource\":[\"${aws_dynamodb_table.root_cloudCounter_E0AC1263.arn}\"],\"Effect\":\"Allow\"},{\"Action\":[\"dynamodb:GetItem\"],\"Resource\":[\"${aws_dynamodb_table.root_cloudCounter_E0AC1263.arn}\"],\"Effect\":\"Allow\"}]}",
+        "role": "${aws_iam_role.root_testkeypeek_Handler_IamRole_B6229A6A.name}"
+      },
       "root_testpeek_Handler_IamRolePolicy_CDA84D5B": {
         "//": {
           "metadata": {
@@ -96,6 +139,16 @@ module.exports = function({ c }) {
       }
     },
     "aws_iam_role_policy_attachment": {
+      "root_testkeypeek_Handler_IamRolePolicyAttachment_81B04175": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/Default/test:key peek/Handler/IamRolePolicyAttachment",
+            "uniqueId": "root_testkeypeek_Handler_IamRolePolicyAttachment_81B04175"
+          }
+        },
+        "policy_arn": "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+        "role": "${aws_iam_role.root_testkeypeek_Handler_IamRole_B6229A6A.name}"
+      },
       "root_testpeek_Handler_IamRolePolicyAttachment_6C4AAACF": {
         "//": {
           "metadata": {
@@ -108,6 +161,33 @@ module.exports = function({ c }) {
       }
     },
     "aws_lambda_function": {
+      "root_testkeypeek_Handler_61C5F573": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/Default/test:key peek/Handler/Default",
+            "uniqueId": "root_testkeypeek_Handler_61C5F573"
+          }
+        },
+        "environment": {
+          "variables": {
+            "DYNAMODB_TABLE_NAME_49baa65c": "${aws_dynamodb_table.root_cloudCounter_E0AC1263.name}",
+            "WING_FUNCTION_NAME": "Handler-c8197eb3",
+            "WING_TARGET": "tf-aws"
+          }
+        },
+        "function_name": "Handler-c8197eb3",
+        "handler": "index.handler",
+        "publish": true,
+        "role": "${aws_iam_role.root_testkeypeek_Handler_IamRole_B6229A6A.arn}",
+        "runtime": "nodejs18.x",
+        "s3_bucket": "${aws_s3_bucket.root_Code_02F3C603.bucket}",
+        "s3_key": "${aws_s3_object.root_testkeypeek_Handler_S3Object_DC079CB6.key}",
+        "timeout": 30,
+        "vpc_config": {
+          "security_group_ids": [],
+          "subnet_ids": []
+        }
+      },
       "root_testpeek_Handler_C724F76F": {
         "//": {
           "metadata": {
@@ -148,6 +228,17 @@ module.exports = function({ c }) {
       }
     },
     "aws_s3_object": {
+      "root_testkeypeek_Handler_S3Object_DC079CB6": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/Default/test:key peek/Handler/S3Object",
+            "uniqueId": "root_testkeypeek_Handler_S3Object_DC079CB6"
+          }
+        },
+        "bucket": "${aws_s3_bucket.root_Code_02F3C603.bucket}",
+        "key": "<ASSET_KEY>",
+        "source": "<ASSET_SOURCE>"
+      },
       "root_testpeek_Handler_S3Object_4BB43D90": {
         "//": {
           "metadata": {
@@ -211,8 +302,45 @@ class $Root extends $stdlib.std.Resource {
         super._registerBind(host, ops);
       }
     }
+    class $Closure2 extends $stdlib.std.Resource {
+      constructor(scope, id, ) {
+        super(scope, id);
+        this._addInflightOps("handle");
+        this.display.hidden = true;
+      }
+      static _toInflightType(context) {
+        const self_client_path = "././inflight.$Closure2.js";
+        const c_client = context._lift(c);
+        return $stdlib.core.NodeJsCode.fromInline(`
+          require("${self_client_path}")({
+            c: ${c_client},
+          })
+        `);
+      }
+      _toInflight() {
+        return $stdlib.core.NodeJsCode.fromInline(`
+          (await (async () => {
+            const $Closure2Client = ${$Closure2._toInflightType(this).text};
+            const client = new $Closure2Client({
+            });
+            if (client.$inflight_init) { await client.$inflight_init(); }
+            return client;
+          })())
+        `);
+      }
+      _registerBind(host, ops) {
+        if (ops.includes("$inflight_init")) {
+          $Closure2._registerBindObject(c, host, []);
+        }
+        if (ops.includes("handle")) {
+          $Closure2._registerBindObject(c, host, ["inc", "peek"]);
+        }
+        super._registerBind(host, ops);
+      }
+    }
     const c = this.node.root.newAbstract("@winglang/sdk.cloud.Counter",this,"cloud.Counter");
     this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:peek",new $Closure1(this,"$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:key peek",new $Closure2(this,"$Closure2"));
   }
 }
 class $App extends $AppBase {

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/counter/peek.w_test_sim.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/counter/peek.w_test_sim.md
@@ -2,7 +2,8 @@
 
 ## stdout.log
 ```log
-pass ─ peek.wsim » root/env0/test:peek
+pass ─ peek.wsim » root/env0/test:peek    
+pass ─ peek.wsim » root/env1/test:key peek
  
 
 

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/counter/set.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/counter/set.w_compile_tf-aws.md
@@ -28,6 +28,35 @@ module.exports = function({ counter }) {
 
 ```
 
+## inflight.$Closure2.js
+```js
+module.exports = function({ counter }) {
+  class $Closure2 {
+    constructor({  }) {
+      const $obj = (...args) => this.handle(...args);
+      Object.setPrototypeOf($obj, this);
+      return $obj;
+    }
+    async $inflight_init()  {
+    }
+    async handle()  {
+      const key = "my-key";
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '((await counter.peek(key)) === 0)'`)})(((await counter.peek(key)) === 0))};
+      (await counter.inc(undefined,key));
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '((await counter.peek(key)) === 1)'`)})(((await counter.peek(key)) === 1))};
+      (await counter.inc(undefined,key));
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '((await counter.peek(key)) === 2)'`)})(((await counter.peek(key)) === 2))};
+      (await counter.inc(10,key));
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '((await counter.peek(key)) === 12)'`)})(((await counter.peek(key)) === 12))};
+      (await counter.set(88,key));
+      {((cond) => {if (!cond) throw new Error(`assertion failed: '((await counter.peek(key)) === 88)'`)})(((await counter.peek(key)) === 88))};
+    }
+  }
+  return $Closure2;
+}
+
+```
+
 ## main.tf.json
 ```json
 {
@@ -49,7 +78,7 @@ module.exports = function({ counter }) {
   },
   "output": {
     "WING_TEST_RUNNER_FUNCTION_ARNS": {
-      "value": "[[\"root/Default/Default/test:set\",\"${aws_lambda_function.root_testset_Handler_9EAD6DA1.arn}\"]]"
+      "value": "[[\"root/Default/Default/test:set\",\"${aws_lambda_function.root_testset_Handler_9EAD6DA1.arn}\"],[\"root/Default/Default/test:key set\",\"${aws_lambda_function.root_testkeyset_Handler_7C558C81.arn}\"]]"
     }
   },
   "provider": {
@@ -78,6 +107,15 @@ module.exports = function({ counter }) {
       }
     },
     "aws_iam_role": {
+      "root_testkeyset_Handler_IamRole_37ABA2D8": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/Default/test:key set/Handler/IamRole",
+            "uniqueId": "root_testkeyset_Handler_IamRole_37ABA2D8"
+          }
+        },
+        "assume_role_policy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Action\":\"sts:AssumeRole\",\"Principal\":{\"Service\":\"lambda.amazonaws.com\"},\"Effect\":\"Allow\"}]}"
+      },
       "root_testset_Handler_IamRole_5149788C": {
         "//": {
           "metadata": {
@@ -89,6 +127,16 @@ module.exports = function({ counter }) {
       }
     },
     "aws_iam_role_policy": {
+      "root_testkeyset_Handler_IamRolePolicy_8DB492FB": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/Default/test:key set/Handler/IamRolePolicy",
+            "uniqueId": "root_testkeyset_Handler_IamRolePolicy_8DB492FB"
+          }
+        },
+        "policy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Action\":[\"dynamodb:UpdateItem\"],\"Resource\":[\"${aws_dynamodb_table.root_cloudCounter_E0AC1263.arn}\"],\"Effect\":\"Allow\"},{\"Action\":[\"dynamodb:GetItem\"],\"Resource\":[\"${aws_dynamodb_table.root_cloudCounter_E0AC1263.arn}\"],\"Effect\":\"Allow\"}]}",
+        "role": "${aws_iam_role.root_testkeyset_Handler_IamRole_37ABA2D8.name}"
+      },
       "root_testset_Handler_IamRolePolicy_D78C23B7": {
         "//": {
           "metadata": {
@@ -101,6 +149,16 @@ module.exports = function({ counter }) {
       }
     },
     "aws_iam_role_policy_attachment": {
+      "root_testkeyset_Handler_IamRolePolicyAttachment_7C689A24": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/Default/test:key set/Handler/IamRolePolicyAttachment",
+            "uniqueId": "root_testkeyset_Handler_IamRolePolicyAttachment_7C689A24"
+          }
+        },
+        "policy_arn": "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+        "role": "${aws_iam_role.root_testkeyset_Handler_IamRole_37ABA2D8.name}"
+      },
       "root_testset_Handler_IamRolePolicyAttachment_3D12A4BB": {
         "//": {
           "metadata": {
@@ -113,6 +171,33 @@ module.exports = function({ counter }) {
       }
     },
     "aws_lambda_function": {
+      "root_testkeyset_Handler_7C558C81": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/Default/test:key set/Handler/Default",
+            "uniqueId": "root_testkeyset_Handler_7C558C81"
+          }
+        },
+        "environment": {
+          "variables": {
+            "DYNAMODB_TABLE_NAME_49baa65c": "${aws_dynamodb_table.root_cloudCounter_E0AC1263.name}",
+            "WING_FUNCTION_NAME": "Handler-c87cc733",
+            "WING_TARGET": "tf-aws"
+          }
+        },
+        "function_name": "Handler-c87cc733",
+        "handler": "index.handler",
+        "publish": true,
+        "role": "${aws_iam_role.root_testkeyset_Handler_IamRole_37ABA2D8.arn}",
+        "runtime": "nodejs18.x",
+        "s3_bucket": "${aws_s3_bucket.root_Code_02F3C603.bucket}",
+        "s3_key": "${aws_s3_object.root_testkeyset_Handler_S3Object_51C16B91.key}",
+        "timeout": 30,
+        "vpc_config": {
+          "security_group_ids": [],
+          "subnet_ids": []
+        }
+      },
       "root_testset_Handler_9EAD6DA1": {
         "//": {
           "metadata": {
@@ -153,6 +238,17 @@ module.exports = function({ counter }) {
       }
     },
     "aws_s3_object": {
+      "root_testkeyset_Handler_S3Object_51C16B91": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/Default/test:key set/Handler/S3Object",
+            "uniqueId": "root_testkeyset_Handler_S3Object_51C16B91"
+          }
+        },
+        "bucket": "${aws_s3_bucket.root_Code_02F3C603.bucket}",
+        "key": "<ASSET_KEY>",
+        "source": "<ASSET_SOURCE>"
+      },
       "root_testset_Handler_S3Object_445B1FA3": {
         "//": {
           "metadata": {
@@ -216,8 +312,45 @@ class $Root extends $stdlib.std.Resource {
         super._registerBind(host, ops);
       }
     }
+    class $Closure2 extends $stdlib.std.Resource {
+      constructor(scope, id, ) {
+        super(scope, id);
+        this._addInflightOps("handle");
+        this.display.hidden = true;
+      }
+      static _toInflightType(context) {
+        const self_client_path = "././inflight.$Closure2.js";
+        const counter_client = context._lift(counter);
+        return $stdlib.core.NodeJsCode.fromInline(`
+          require("${self_client_path}")({
+            counter: ${counter_client},
+          })
+        `);
+      }
+      _toInflight() {
+        return $stdlib.core.NodeJsCode.fromInline(`
+          (await (async () => {
+            const $Closure2Client = ${$Closure2._toInflightType(this).text};
+            const client = new $Closure2Client({
+            });
+            if (client.$inflight_init) { await client.$inflight_init(); }
+            return client;
+          })())
+        `);
+      }
+      _registerBind(host, ops) {
+        if (ops.includes("$inflight_init")) {
+          $Closure2._registerBindObject(counter, host, []);
+        }
+        if (ops.includes("handle")) {
+          $Closure2._registerBindObject(counter, host, ["inc", "peek", "set"]);
+        }
+        super._registerBind(host, ops);
+      }
+    }
     const counter = this.node.root.newAbstract("@winglang/sdk.cloud.Counter",this,"cloud.Counter",{ initial: 0 });
     this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:set",new $Closure1(this,"$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:key set",new $Closure2(this,"$Closure2"));
   }
 }
 class $App extends $AppBase {

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/counter/set.w_test_sim.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/counter/set.w_test_sim.md
@@ -2,7 +2,8 @@
 
 ## stdout.log
 ```log
-pass ─ set.wsim » root/env0/test:set
+pass ─ set.wsim » root/env0/test:set    
+pass ─ set.wsim » root/env1/test:key set
  
 
 


### PR DESCRIPTION
Adding the key argument to the inc, dec, peek, and set methods of the Counter, in this way, the same counter can be used to control different values according to the desired key.

Closes #1286 

## Checklist

- [x] Title matches [Winglang's style guide](https://docs.winglang.io/contributors/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [x] Tests added (always)
- [x] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.
