### PR TITLE
fix(compiler): panic when trying to reference an unknown field

### DIFF
--- a/examples/tests/invalid/unknown_field.w
+++ b/examples/tests/invalid/unknown_field.w
@@ -1,0 +1,2 @@
+std.String.a.b.c.fromJson();
+//         ^ No member "a" in class "String"

--- a/examples/tests/invalid/unknown_submodule.w
+++ b/examples/tests/invalid/unknown_submodule.w
@@ -1,0 +1,4 @@
+std.random.String.fromJson("hello");
+//^Expected identifier "std" to be a variable, but it's a namespace
+
+// TODO: Fix error message (https://github.com/winglang/wing/issues/2876)

--- a/libs/wingc/src/type_check/jsii_importer.rs
+++ b/libs/wingc/src/type_check/jsii_importer.rs
@@ -153,8 +153,6 @@ impl<'a> JsiiImporter<'a> {
 	}
 
 	pub fn import_type(&mut self, type_fqn: &FQN) -> bool {
-		self.setup_namespaces_for(&type_fqn);
-
 		let type_str = type_fqn.as_str();
 
 		// check if type is already imported
@@ -250,13 +248,7 @@ impl<'a> JsiiImporter<'a> {
 			} else {
 				let ns = self.wing_types.add_namespace(Namespace {
 					name: namespace_name.to_string(),
-					env: SymbolEnv::new(
-						Some(parent_ns.env.get_ref()),
-						self.wing_types.void(),
-						false,
-						Phase::Preflight,
-						0,
-					),
+					env: SymbolEnv::new(None, self.wing_types.void(), false, Phase::Preflight, 0),
 				});
 				parent_ns
 					.env
@@ -859,6 +851,9 @@ impl<'a> JsiiImporter<'a> {
 		) {
 			return;
 		}
+
+		// make sure we have a namespace for this type
+		self.setup_namespaces_for(&fqn);
 
 		let mut ns = self
 			.wing_types

--- a/libs/wingc/src/type_check/symbol_env.rs
+++ b/libs/wingc/src/type_check/symbol_env.rs
@@ -238,6 +238,8 @@ impl SymbolEnv {
 			);
 		}
 
+		// we couldn't find the symbol in the current environment, let's look up in the parent
+		// environment.
 		if let Some(ref_annotation([parent_env])) = self.parent {
 			return parent_env.lookup_ext(symbol, not_after_stmt_idx.map(|_| self.statement_idx));
 		}

--- a/tools/hangar/__snapshots__/invalid.ts.snap
+++ b/tools/hangar/__snapshots__/invalid.ts.snap
@@ -1905,6 +1905,42 @@ Duration <DURATION>
 "
 `;
 
+exports[`unknown_field.w 1`] = `
+"error: No member \\"a\\" in class \\"String\\"
+  --> ../../../examples/tests/invalid/unknown_field.w:1:12
+  |
+1 | std.String.a.b.c.fromJson();
+  |            ^ No member \\"a\\" in class \\"String\\"
+
+
+ 
+
+
+
+
+Tests 1 failed (1) 
+Duration <DURATION>
+"
+`;
+
+exports[`unknown_submodule.w 1`] = `
+"error: Expected identifier \\"std\\" to be a variable, but it's a namespace
+  --> ../../../examples/tests/invalid/unknown_submodule.w:1:1
+  |
+1 | std.random.String.fromJson(\\"hello\\");
+  | ^^^ Expected identifier \\"std\\" to be a variable, but it's a namespace
+
+
+ 
+
+
+
+
+Tests 1 failed (1) 
+Duration <DURATION>
+"
+`;
+
 exports[`unknown_symbol.w 1`] = `
 "error: Unknown symbol \\"clod\\"
   --> ../../../examples/tests/invalid/unknown_symbol.w:3:18


### PR DESCRIPTION
Fixes #2602 by avoiding the creation of namespaces blindly, even if a type doesn't exist in that namespace.

Additionally fixes #2877 which was caused by mistakenly associating its symbol environment with the parent submodule, but that's not actually what we want. If I couldn't find `String` in `std.foo`, I don't want to look up string in `std`. The diagnostics emitted in this case is still weird, so I created #2876 to address this.

## Checklist

- [x] Title matches [Winglang's style guide](https://docs.winglang.io/contributors/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [x] Tests added (always)
- [x] Docs updated (only required for features)
- [x] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.
