### PR TITLE
chore(sdk)!: renaming `cloud.Queue` method `addConsumer` to `setConsumer`

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ let queue = new cloud.Queue();
 let counter = new cloud.Counter();
 let bucket = new cloud.Bucket();
 
-queue.addConsumer(inflight (message: str) => {
+queue.setConsumer(inflight (message: str) => {
   let i = counter.inc();
   bucket.put("file-${i}.txt", message);
 });
@@ -62,7 +62,7 @@ queue.addConsumer(inflight (message: str) => {
 `cloud.Queue`, `cloud.Counter` and `cloud.Bucket` are *preflight objects*.
 They represent cloud infrastructure resources. 
 When compiled to a specific cloud provider, such as AWS, a Terraform file will be produced with the provider's implementation
-of these resources. The `queue.addConsumer()` method is a *preflight method* that configures the infrastructure to
+of these resources. The `queue.setConsumer()` method is a *preflight method* that configures the infrastructure to
 invoke a particular *inflight function* for each message in the queue.
 
 **Now comes the cool part:** the code that runs inside the inflight function interacts with the `counter` and the `bucket` objects

--- a/docs/01-welcome.md
+++ b/docs/01-welcome.md
@@ -50,7 +50,7 @@ let queue = new cloud.Queue(timeout: 2m);
 let bucket = new cloud.Bucket();
 let counter = new cloud.Counter(initial: 100);
 
-queue.addConsumer(inflight (body: str): str => {
+queue.setConsumer(inflight (body: str): str => {
   let next = counter.inc();
   let key = "myfile-${next}.txt";
   bucket.put(key, body);

--- a/docs/02-getting-started/03-hello.md
+++ b/docs/02-getting-started/03-hello.md
@@ -26,7 +26,7 @@ bring cloud;
 let bucket = new cloud.Bucket();
 let queue = new cloud.Queue();
 
-queue.addConsumer(inflight (message: str) => {
+queue.setConsumer(inflight (message: str) => {
   bucket.put("wing.txt", "Hello, ${message}");
 });
 ```

--- a/docs/03-concepts/01-resources.md
+++ b/docs/03-concepts/01-resources.md
@@ -31,7 +31,7 @@ class SafeQueue extends cloud.Queue {
   init() {
     let dlq = new cloud.Queue();
 
-    dlq.addConsumer(inflight (m: str) => {
+    dlq.setConsumer(inflight (m: str) => {
       log.error("dead-letter: ${m}");
     });
 

--- a/docs/05-reference/winglang-spec.md
+++ b/docs/05-reference/winglang-spec.md
@@ -2748,7 +2748,7 @@ let filterFn = inflight (event: cloud.QueueEvent) => {
 
 queue = cloud.Queue();
 filter = cloud.Function(filterFn);
-queue.addConsumer(filter);
+queue.setConsumer(filter);
 ```
 
 [`▲ top`][top]

--- a/docs/05-reference/wingsdk-api.md
+++ b/docs/05-reference/wingsdk-api.md
@@ -744,25 +744,25 @@ new cloud.Queue(props?: QueueProps)
 
 | **Name** | **Description** |
 | --- | --- |
-| <code><a href="#@winglang/sdk.cloud.Queue.addConsumer">addConsumer</a></code> | Create a function to consume messages from this queue. |
+| <code><a href="#@winglang/sdk.cloud.Queue.setConsumer">setConsumer</a></code> | Create a function to consume messages from this queue. |
 
 ---
 
-##### `addConsumer` <a name="addConsumer" id="@winglang/sdk.cloud.Queue.addConsumer"></a>
+##### `setConsumer` <a name="setConsumer" id="@winglang/sdk.cloud.Queue.setConsumer"></a>
 
 ```wing
-addConsumer(handler: IQueueAddConsumerHandler, props?: QueueAddConsumerProps): Function
+setConsumer(handler: IQueueAddConsumerHandler, props?: QueueAddConsumerProps): Function
 ```
 
 Create a function to consume messages from this queue.
 
-###### `handler`<sup>Required</sup> <a name="handler" id="@winglang/sdk.cloud.Queue.addConsumer.parameter.handler"></a>
+###### `handler`<sup>Required</sup> <a name="handler" id="@winglang/sdk.cloud.Queue.setConsumer.parameter.handler"></a>
 
 - *Type:* <a href="#@winglang/sdk.cloud.IQueueAddConsumerHandler">IQueueAddConsumerHandler</a>
 
 ---
 
-###### `props`<sup>Optional</sup> <a name="props" id="@winglang/sdk.cloud.Queue.addConsumer.parameter.props"></a>
+###### `props`<sup>Optional</sup> <a name="props" id="@winglang/sdk.cloud.Queue.setConsumer.parameter.props"></a>
 
 - *Type:* <a href="#@winglang/sdk.cloud.QueueAddConsumerProps">QueueAddConsumerProps</a>
 
@@ -2302,7 +2302,7 @@ Whether to cache the value.
 
 ### QueueAddConsumerProps <a name="QueueAddConsumerProps" id="@winglang/sdk.cloud.QueueAddConsumerProps"></a>
 
-Options for Queue.addConsumer.
+Options for Queue.setConsumer.
 
 #### Initializer <a name="Initializer" id="@winglang/sdk.cloud.QueueAddConsumerProps.Initializer"></a>
 
@@ -5524,7 +5524,7 @@ Information on how to display a resource in the UI.
 
 **Inflight client:** [@winglang/sdk.cloud.IQueueAddConsumerHandlerClient](#@winglang/sdk.cloud.IQueueAddConsumerHandlerClient)
 
-Represents a resource with an inflight "handle" method that can be passed to `Queue.addConsumer`.
+Represents a resource with an inflight "handle" method that can be passed to `Queue.setConsumer`.
 
 
 #### Properties <a name="Properties" id="Properties"></a>

--- a/docs/06-contributors/999-rfcs/2023-01-20-wingsdk-spec.md
+++ b/docs/06-contributors/999-rfcs/2023-01-20-wingsdk-spec.md
@@ -448,7 +448,7 @@ resource Queue {
   /**
    * Run an inflight in a cloud function whenever a message is pushed to the queue.
    */
-  addConsumer(fn: inflight (message: Json) => void, opts: QueueAddConsumerProps?): void;
+  setConsumer(fn: inflight (message: Json) => void, opts: QueueAddConsumerProps?): void;
 
   /**
    * Return the approximate message count of the queue.

--- a/docs/07-faq/005-why-a-language.md
+++ b/docs/07-faq/005-why-a-language.md
@@ -22,13 +22,13 @@ let queue = new cloud.Queue();
 let counter = new cloud.Counter();
 let bucket = new cloud.Bucket();
 
-queue.addConsumer(inflight (message: str) => {
+queue.setConsumer(inflight (message: str) => {
   let i = counter.inc();
   bucket.put("file-${i}.txt", message);
 });
 ```
 
-`cloud.Queue`, `cloud.Counter`, and `cloud.Bucket` are *preflight objects*. They represent cloud infrastructure resources. When compiled to a specific cloud provider, such as AWS, a Terraform file will be produced with the provider's implementation of these resources. The `queue.addConsumer()` method is a *preflight method* that configures the infrastructure to invoke a particular *inflight function* for each message in the queue.
+`cloud.Queue`, `cloud.Counter`, and `cloud.Bucket` are *preflight objects*. They represent cloud infrastructure resources. When compiled to a specific cloud provider, such as AWS, a Terraform file will be produced with the provider's implementation of these resources. The `queue.setConsumer()` method is a *preflight method* that configures the infrastructure to invoke a particular *inflight function* for each message in the queue.
 
 **Now comes the cool part**: the code that runs inside the inflight function interacts with the `counter` and the `bucket` objects through their *inflight methods* (`counter.inc()` and `bucket.put()`). These methods can only be called from inflight scopes.
 

--- a/examples/plugins/app.w
+++ b/examples/plugins/app.w
@@ -3,6 +3,6 @@ bring cloud;
 let b = new cloud.Bucket();
 let q = new cloud.Queue();
 
-q.addConsumer(inflight (msg: str) => {
+q.setConsumer(inflight (msg: str) => {
   b.put("file.txt", msg);
 });

--- a/examples/proposed/replayable-queue.w
+++ b/examples/proposed/replayable-queue.w
@@ -14,8 +14,8 @@ class ReplayableQueue {
     this.counter = new cloud.Counter();
   }
 
-  addConsumer(fn: inflight (str): str){
-    this.queue.addConsumer(fn);
+  setConsumer(fn: inflight (str): str){
+    this.queue.setConsumer(fn);
   }
   
   inflight push(m: str) {
@@ -35,10 +35,10 @@ class ReplayableQueue {
 class RemoteControl { 
   init(q: ReplayableQueue){
     let f = inflight (m: str): str => {
-      log("addConsumer got triggered with ${m}");
+      log("setConsumer got triggered with ${m}");
     };
       
-    q.addConsumer(f);
+    q.setConsumer(f);
     
     new cloud.Function(inflight (m: str) => {
       q.push(m);

--- a/examples/tests/invalid/cloud_function_expects_inflight.w
+++ b/examples/tests/invalid/cloud_function_expects_inflight.w
@@ -6,7 +6,7 @@ new cloud.Function((name: str): str => {
 // ^ Expected type to be "inflight (any): any", but got "preflight (str): str" instead
 
 let q = new cloud.Queue();
-q.addConsumer(inflight (x: num) => {
+q.setConsumer(inflight (x: num) => {
                      // ^ "num" doesn't match the expected type "str"
   return;
 });

--- a/examples/tests/invalid/missing_semicolon.w
+++ b/examples/tests/invalid/missing_semicolon.w
@@ -4,12 +4,12 @@ let b = new cloud.Bucket() as "Eyal Keren";
 let q1 = new cloud.Queue() as "q1";
 let q2 = new cloud.Queue() as "q2";
 
-q1.addConsumer(inflight (m:str): str => {
+q1.setConsumer(inflight (m:str): str => {
   b.put("1.txt", "Hello, ${m}"); 
 })
 //^ Expected ';'
 
-q2.addConsumer(inflight (m:str): str => {
+q2.setConsumer(inflight (m:str): str => {
   b.put("2.txt", "Hello, ${m}"); 
 });
 

--- a/examples/tests/sdk_tests/queue/add_consumer.w
+++ b/examples/tests/sdk_tests/queue/add_consumer.w
@@ -21,14 +21,14 @@ class TestHelper {
   extern "../external/sleep.js" inflight sleep(milli: num);
 }
 
-q.addConsumer(inflight (msg: str): str => {
+q.setConsumer(inflight (msg: str): str => {
   c.inc();
 });
 
 let js = new TestHelper();
 
 let predicate = new Predicate(c);
-test "addConsumer" {
+test "setConsumer" {
   q.push("hello");
   q.push("world");
 

--- a/examples/tests/sdk_tests/queue/timeout.w
+++ b/examples/tests/sdk_tests/queue/timeout.w
@@ -13,7 +13,7 @@ class JSHelper {
 
 let js = new JSHelper();
 
-q.addConsumer(inflight () => {
+q.setConsumer(inflight () => {
   js.sleep(2000);
 });
 

--- a/examples/tests/valid/captures.w
+++ b/examples/tests/valid/captures.w
@@ -26,7 +26,7 @@ let handler = inflight (event: str): str => {
   }
 };
 
-queue.addConsumer(handler, batchSize: 5);
+queue.setConsumer(handler, batchSize: 5);
 
 new cloud.Function(
   handler, 

--- a/examples/tests/valid/file_counter.w
+++ b/examples/tests/valid/file_counter.w
@@ -10,4 +10,4 @@ let handler = inflight (body: str /* string arg */): str => {
   bucket.put(key, body);
 };
 
-queue.addConsumer(handler);
+queue.setConsumer(handler);

--- a/examples/tests/valid/hello.w
+++ b/examples/tests/valid/hello.w
@@ -3,6 +3,6 @@ bring cloud;
 let bucket = new cloud.Bucket();
 let queue = new cloud.Queue();
 
-queue.addConsumer(inflight (message: str) => {
+queue.setConsumer(inflight (message: str) => {
   bucket.put("wing.txt", "Hello, ${message}");
 });

--- a/examples/tests/valid/inflight-subscribers.w
+++ b/examples/tests/valid/inflight-subscribers.w
@@ -5,6 +5,6 @@ new cloud.Topic().onMessage(inflight () => {
   log("hello, world");
 }, cloud.TopicOnMessageProps { timeout: 3m });
 
-new cloud.Queue().addConsumer(inflight () => {
+new cloud.Queue().setConsumer(inflight () => {
   log("hello, world");
 }, cloud.QueueAddConsumerProps { timeout: 3m });

--- a/examples/tests/valid/resource.w
+++ b/examples/tests/valid/resource.w
@@ -111,7 +111,7 @@ class BigPublisher {
       this.b.put("foo1.txt", "bar");
     });
 
-    this.q.addConsumer(inflight () => {
+    this.q.setConsumer(inflight () => {
       this.b.put("foo2.txt", "bar");
     });
 

--- a/examples/tests/valid/while_loop_await.w
+++ b/examples/tests/valid/while_loop_await.w
@@ -12,4 +12,4 @@ let handler = inflight (body: str): str => {
     }
 };
 
-queue.addConsumer(handler);
+queue.setConsumer(handler);

--- a/libs/wingsdk/API.md
+++ b/libs/wingsdk/API.md
@@ -737,25 +737,25 @@ new cloud.Queue(props?: QueueProps)
 
 | **Name** | **Description** |
 | --- | --- |
-| <code><a href="#@winglang/sdk.cloud.Queue.addConsumer">addConsumer</a></code> | Create a function to consume messages from this queue. |
+| <code><a href="#@winglang/sdk.cloud.Queue.setConsumer">setConsumer</a></code> | Create a function to consume messages from this queue. |
 
 ---
 
-##### `addConsumer` <a name="addConsumer" id="@winglang/sdk.cloud.Queue.addConsumer"></a>
+##### `setConsumer` <a name="setConsumer" id="@winglang/sdk.cloud.Queue.setConsumer"></a>
 
 ```wing
-addConsumer(handler: IQueueAddConsumerHandler, props?: QueueAddConsumerProps): Function
+setConsumer(handler: IQueueAddConsumerHandler, props?: QueueAddConsumerProps): Function
 ```
 
 Create a function to consume messages from this queue.
 
-###### `handler`<sup>Required</sup> <a name="handler" id="@winglang/sdk.cloud.Queue.addConsumer.parameter.handler"></a>
+###### `handler`<sup>Required</sup> <a name="handler" id="@winglang/sdk.cloud.Queue.setConsumer.parameter.handler"></a>
 
 - *Type:* <a href="#@winglang/sdk.cloud.IQueueAddConsumerHandler">IQueueAddConsumerHandler</a>
 
 ---
 
-###### `props`<sup>Optional</sup> <a name="props" id="@winglang/sdk.cloud.Queue.addConsumer.parameter.props"></a>
+###### `props`<sup>Optional</sup> <a name="props" id="@winglang/sdk.cloud.Queue.setConsumer.parameter.props"></a>
 
 - *Type:* <a href="#@winglang/sdk.cloud.QueueAddConsumerProps">QueueAddConsumerProps</a>
 
@@ -2295,7 +2295,7 @@ Whether to cache the value.
 
 ### QueueAddConsumerProps <a name="QueueAddConsumerProps" id="@winglang/sdk.cloud.QueueAddConsumerProps"></a>
 
-Options for Queue.addConsumer.
+Options for Queue.setConsumer.
 
 #### Initializer <a name="Initializer" id="@winglang/sdk.cloud.QueueAddConsumerProps.Initializer"></a>
 
@@ -5517,7 +5517,7 @@ Information on how to display a resource in the UI.
 
 **Inflight client:** [@winglang/sdk.cloud.IQueueAddConsumerHandlerClient](#@winglang/sdk.cloud.IQueueAddConsumerHandlerClient)
 
-Represents a resource with an inflight "handle" method that can be passed to `Queue.addConsumer`.
+Represents a resource with an inflight "handle" method that can be passed to `Queue.setConsumer`.
 
 
 #### Properties <a name="Properties" id="Properties"></a>

--- a/libs/wingsdk/README.md
+++ b/libs/wingsdk/README.md
@@ -28,7 +28,7 @@ bring cloud;
 
 let queue = new cloud.Queue();
 
-queue.addConsumer(inflight (message) => {
+queue.setConsumer(inflight (message) => {
   log("Hello, ${message}!");
 });
 ```

--- a/libs/wingsdk/src/cloud/queue.ts
+++ b/libs/wingsdk/src/cloud/queue.ts
@@ -69,14 +69,14 @@ export abstract class Queue extends Resource {
   /**
    * Create a function to consume messages from this queue.
    */
-  public abstract addConsumer(
+  public abstract setConsumer(
     handler: IQueueAddConsumerHandler,
     props?: QueueAddConsumerProps
   ): Function;
 }
 
 /**
- * Options for Queue.addConsumer.
+ * Options for Queue.setConsumer.
  */
 export interface QueueAddConsumerProps extends FunctionProps {
   /**
@@ -119,7 +119,7 @@ export interface IQueueClient {
 
 /**
  * Represents a resource with an inflight "handle" method that can be passed to
- * `Queue.addConsumer`.
+ * `Queue.setConsumer`.
  *
  * @inflight `@winglang/sdk.cloud.IQueueAddConsumerHandlerClient`
  */

--- a/libs/wingsdk/src/target-awscdk/queue.ts
+++ b/libs/wingsdk/src/target-awscdk/queue.ts
@@ -37,7 +37,7 @@ export class Queue extends cloud.Queue {
     }
   }
 
-  public addConsumer(
+  public setConsumer(
     inflight: cloud.IQueueAddConsumerHandler,
     props: cloud.QueueAddConsumerProps = {}
   ): cloud.Function {

--- a/libs/wingsdk/src/target-sim/queue.ts
+++ b/libs/wingsdk/src/target-sim/queue.ts
@@ -35,7 +35,7 @@ export class Queue extends cloud.Queue implements ISimulatorResource {
     this.initialMessages.push(...(props.initialMessages ?? []));
   }
 
-  public addConsumer(
+  public setConsumer(
     inflight: cloud.IQueueAddConsumerHandler,
     props: cloud.QueueAddConsumerProps = {}
   ): cloud.Function {

--- a/libs/wingsdk/src/target-tf-aws/queue.ts
+++ b/libs/wingsdk/src/target-tf-aws/queue.ts
@@ -43,7 +43,7 @@ export class Queue extends cloud.Queue {
     }
   }
 
-  public addConsumer(
+  public setConsumer(
     inflight: cloud.IQueueAddConsumerHandler,
     props: cloud.QueueAddConsumerProps = {}
   ): cloud.Function {

--- a/libs/wingsdk/test/target-awscdk/queue.test.ts
+++ b/libs/wingsdk/test/target-awscdk/queue.test.ts
@@ -61,7 +61,7 @@ async handle(event) {
   console.log("Received " + event.name);
 }`
   );
-  const processorFn = queue.addConsumer(processor);
+  const processorFn = queue.setConsumer(processor);
   const output = app.synth();
 
   // THEN

--- a/libs/wingsdk/test/target-sim/file-counter.test.ts
+++ b/libs/wingsdk/test/target-sim/file-counter.test.ts
@@ -36,7 +36,7 @@ test("can create sequential files in a bucket", async () => {
           },
         }
       );
-      queue.addConsumer(processor);
+      queue.setConsumer(processor);
     }
   }
 

--- a/libs/wingsdk/test/target-sim/queue-consumer.test.ts
+++ b/libs/wingsdk/test/target-sim/queue-consumer.test.ts
@@ -36,7 +36,7 @@ test("pushing messages through a queue", async () => {
           console.log("Received " + event);
         }`
       );
-      queue.addConsumer(processor);
+      queue.setConsumer(processor);
     }
   }
 

--- a/libs/wingsdk/test/target-sim/queue.test.ts
+++ b/libs/wingsdk/test/target-sim/queue.test.ts
@@ -44,7 +44,7 @@ test("queue with one subscriber, default batch size of 1", async () => {
   const app = new SimApp();
   const handler = Testing.makeHandler(app, "Handler", INFLIGHT_CODE);
   const queue = cloud.Queue._newQueue(app, "my_queue");
-  queue.addConsumer(handler);
+  queue.setConsumer(handler);
   const s = await app.startSimulator();
 
   const queueClient = s.getResource("/my_queue") as cloud.IQueueClient;
@@ -100,7 +100,7 @@ test("queue with one subscriber, batch size of 5", async () => {
   const queue = cloud.Queue._newQueue(app, "my_queue", {
     initialMessages: ["A", "B", "C", "D", "E", "F"],
   });
-  queue.addConsumer(handler, { batchSize: 5 });
+  queue.setConsumer(handler, { batchSize: 5 });
   const s = await app.startSimulator();
 
   // WHEN
@@ -120,7 +120,7 @@ test("messages are requeued if the function fails after timeout", async () => {
   const queue = cloud.Queue._newQueue(app, "my_queue", {
     timeout: Duration.fromSeconds(1),
   });
-  queue.addConsumer(handler);
+  queue.setConsumer(handler);
   const s = await app.startSimulator();
 
   // warm up the function so timing is more predictable
@@ -156,7 +156,7 @@ test("messages are not requeued if the function fails before timeout", async () 
   const queue = cloud.Queue._newQueue(app, "my_queue", {
     timeout: Duration.fromSeconds(1),
   });
-  queue.addConsumer(handler);
+  queue.setConsumer(handler);
   const s = await app.startSimulator();
 
   // warm up the function so timing is more predictable
@@ -199,7 +199,7 @@ test("messages are not requeued if the function fails after retention timeout", 
     timeout: Duration.fromSeconds(2),
     retentionPeriod: Duration.fromSeconds(1),
   });
-  queue.addConsumer(handler);
+  queue.setConsumer(handler);
   const s = await app.startSimulator();
 
   // warm up the function so timing is more predictable

--- a/libs/wingsdk/test/target-tf-aws/captures.test.ts
+++ b/libs/wingsdk/test/target-tf-aws/captures.test.ts
@@ -202,7 +202,7 @@ test("function with a queue binding", () => {
     "Processor",
     `async handle(event) { console.log("Received" + event); }`
   );
-  queue.addConsumer(processor);
+  queue.setConsumer(processor);
   const output = app.synth();
 
   // THEN

--- a/libs/wingsdk/test/target-tf-aws/queue.test.ts
+++ b/libs/wingsdk/test/target-tf-aws/queue.test.ts
@@ -66,7 +66,7 @@ async handle(event) {
   console.log("Received " + event.name);
 }`
   );
-  const processorFn = queue.addConsumer(processor);
+  const processorFn = queue.setConsumer(processor);
   const output = app.synth();
 
   // THEN

--- a/tools/hangar/__snapshots__/invalid.ts.snap
+++ b/tools/hangar/__snapshots__/invalid.ts.snap
@@ -361,7 +361,7 @@ exports[`cloud_function_expects_inflight.w 1`] = `
 error: Expected type to be \\"IQueueAddConsumerHandler (inflight (str): void)\\", but got \\"$Closure1\\" instead
    --> ../../../examples/tests/invalid/cloud_function_expects_inflight.w:9:15
    |  
- 9 |   q.addConsumer(inflight (x: num) => {
+ 9 |   q.setConsumer(inflight (x: num) => {
    | /---------------^
 10 | |                      // ^ \\"num\\" doesn't match the expected type \\"str\\"
 11 | |   return;

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/queue/add_consumer.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/queue/add_consumer.w_compile_tf-aws.md
@@ -110,7 +110,7 @@ module.exports = function({  }) {
   },
   "output": {
     "WING_TEST_RUNNER_FUNCTION_ARNS": {
-      "value": "[[\"root/Default/Default/test:addConsumer\",\"${aws_lambda_function.root_testaddConsumer_Handler_3B513ABC.arn}\"]]"
+      "value": "[[\"root/Default/Default/test:setConsumer\",\"${aws_lambda_function.root_testaddConsumer_Handler_3B513ABC.arn}\"]]"
     }
   },
   "provider": {
@@ -151,7 +151,7 @@ module.exports = function({  }) {
       "root_testaddConsumer_Handler_IamRole_8E4E4EFE": {
         "//": {
           "metadata": {
-            "path": "root/Default/Default/test:addConsumer/Handler/IamRole",
+            "path": "root/Default/Default/test:setConsumer/Handler/IamRole",
             "uniqueId": "root_testaddConsumer_Handler_IamRole_8E4E4EFE"
           }
         },
@@ -172,7 +172,7 @@ module.exports = function({  }) {
       "root_testaddConsumer_Handler_IamRolePolicy_9DC09BA2": {
         "//": {
           "metadata": {
-            "path": "root/Default/Default/test:addConsumer/Handler/IamRolePolicy",
+            "path": "root/Default/Default/test:setConsumer/Handler/IamRolePolicy",
             "uniqueId": "root_testaddConsumer_Handler_IamRolePolicy_9DC09BA2"
           }
         },
@@ -194,7 +194,7 @@ module.exports = function({  }) {
       "root_testaddConsumer_Handler_IamRolePolicyAttachment_FAA6841D": {
         "//": {
           "metadata": {
-            "path": "root/Default/Default/test:addConsumer/Handler/IamRolePolicyAttachment",
+            "path": "root/Default/Default/test:setConsumer/Handler/IamRolePolicyAttachment",
             "uniqueId": "root_testaddConsumer_Handler_IamRolePolicyAttachment_FAA6841D"
           }
         },
@@ -246,7 +246,7 @@ module.exports = function({  }) {
       "root_testaddConsumer_Handler_3B513ABC": {
         "//": {
           "metadata": {
-            "path": "root/Default/Default/test:addConsumer/Handler/Default",
+            "path": "root/Default/Default/test:setConsumer/Handler/Default",
             "uniqueId": "root_testaddConsumer_Handler_3B513ABC"
           }
         },
@@ -298,7 +298,7 @@ module.exports = function({  }) {
       "root_testaddConsumer_Handler_S3Object_2F78F235": {
         "//": {
           "metadata": {
-            "path": "root/Default/Default/test:addConsumer/Handler/S3Object",
+            "path": "root/Default/Default/test:setConsumer/Handler/S3Object",
             "uniqueId": "root_testaddConsumer_Handler_S3Object_2F78F235"
           }
         },
@@ -484,10 +484,10 @@ class $Root extends $stdlib.std.Resource {
     }
     const q = this.node.root.newAbstract("@winglang/sdk.cloud.Queue",this,"cloud.Queue");
     const c = this.node.root.newAbstract("@winglang/sdk.cloud.Counter",this,"cloud.Counter");
-    (q.addConsumer(new $Closure1(this,"$Closure1")));
+    (q.setConsumer(new $Closure1(this,"$Closure1")));
     const js = new TestHelper(this,"TestHelper");
     const predicate = new Predicate(this,"Predicate",c);
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:addConsumer",new $Closure2(this,"$Closure2"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:setConsumer",new $Closure2(this,"$Closure2"));
   }
 }
 class $App extends $AppBase {

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/queue/add_consumer.w_test_sim.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/queue/add_consumer.w_test_sim.md
@@ -2,7 +2,7 @@
 
 ## stdout.log
 ```log
-pass ─ add_consumer.wsim » root/env0/test:addConsumer
+pass ─ add_consumer.wsim » root/env0/test:setConsumer
  
 
 

--- a/tools/hangar/__snapshots__/test_corpus/valid/captures.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/captures.w_compile_tf-aws.md
@@ -524,7 +524,7 @@ class $Root extends $stdlib.std.Resource {
     const bucket3 = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this,"PrivateBucket",{ public: false });
     const queue = this.node.root.newAbstract("@winglang/sdk.cloud.Queue",this,"cloud.Queue");
     const handler = new $Closure1(this,"$Closure1");
-    (queue.addConsumer(handler,{ batchSize: 5 }));
+    (queue.setConsumer(handler,{ batchSize: 5 }));
     this.node.root.newAbstract("@winglang/sdk.cloud.Function",this,"cloud.Function",handler,{ env: Object.freeze({}) });
     const emptyEnv = Object.freeze({});
     this.node.root.newAbstract("@winglang/sdk.cloud.Function",this,"AnotherFunction",handler,{ env: emptyEnv });

--- a/tools/hangar/__snapshots__/test_corpus/valid/file_counter.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/file_counter.w_compile_tf-aws.md
@@ -288,7 +288,7 @@ class $Root extends $stdlib.std.Resource {
     const counter = this.node.root.newAbstract("@winglang/sdk.cloud.Counter",this,"cloud.Counter",{ initial: 100 });
     const queue = this.node.root.newAbstract("@winglang/sdk.cloud.Queue",this,"cloud.Queue",{ timeout: $stdlib.std.Duration.fromSeconds(10) });
     const handler = new $Closure1(this,"$Closure1");
-    (queue.addConsumer(handler));
+    (queue.setConsumer(handler));
   }
 }
 class $App extends $AppBase {

--- a/tools/hangar/__snapshots__/test_corpus/valid/hello.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/hello.w_compile_tf-aws.md
@@ -259,7 +259,7 @@ class $Root extends $stdlib.std.Resource {
     }
     const bucket = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this,"cloud.Bucket");
     const queue = this.node.root.newAbstract("@winglang/sdk.cloud.Queue",this,"cloud.Queue");
-    (queue.addConsumer(new $Closure1(this,"$Closure1")));
+    (queue.setConsumer(new $Closure1(this,"$Closure1")));
   }
 }
 class $App extends $AppBase {

--- a/tools/hangar/__snapshots__/test_corpus/valid/inflight-subscribers.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/inflight-subscribers.w_compile_tf-aws.md
@@ -367,7 +367,7 @@ class $Root extends $stdlib.std.Resource {
     (this.node.root.newAbstract("@winglang/sdk.cloud.Topic",this,"cloud.Topic").onMessage(new $Closure1(this,"$Closure1"),{
     "timeout": $stdlib.std.Duration.fromSeconds(180),}
     ));
-    (this.node.root.newAbstract("@winglang/sdk.cloud.Queue",this,"cloud.Queue").addConsumer(new $Closure2(this,"$Closure2"),{
+    (this.node.root.newAbstract("@winglang/sdk.cloud.Queue",this,"cloud.Queue").setConsumer(new $Closure2(this,"$Closure2"),{
     "timeout": $stdlib.std.Duration.fromSeconds(180),}
     ));
   }

--- a/tools/hangar/__snapshots__/test_corpus/valid/resource.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/resource.w_compile_tf-aws.md
@@ -1134,7 +1134,7 @@ class $Root extends $stdlib.std.Resource {
             super._registerBind(host, ops);
           }
         }
-        (this.q.addConsumer(new $Closure3(this,"$Closure3")));
+        (this.q.setConsumer(new $Closure3(this,"$Closure3")));
         class $Closure4 extends $stdlib.std.Resource {
           constructor(scope, id, ) {
             super(scope, id);

--- a/tools/hangar/__snapshots__/test_corpus/valid/while_loop_await.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/while_loop_await.w_compile_tf-aws.md
@@ -217,7 +217,7 @@ class $Root extends $stdlib.std.Resource {
     }
     const queue = this.node.root.newAbstract("@winglang/sdk.cloud.Queue",this,"cloud.Queue");
     const handler = new $Closure1(this,"$Closure1");
-    (queue.addConsumer(handler));
+    (queue.setConsumer(handler));
   }
 }
 class $App extends $AppBase {


### PR DESCRIPTION
Closes #2745

## Checklist

- [x] Update code (including wing examples)
- [x] Update docs (getting started guide, etc.)
- [x] Update the sdk spec
- [ ] Before the PR merges - let the Wing Console team (@ainvoner) know that there's a breaking change headed their way

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.
