### PR TITLE
chore: remove volta from ci

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,12 +1,15 @@
 {
   "name": "Wing Development",
 	"image": "mcr.microsoft.com/devcontainers/base:jammy",
-  "postStartCommand": "volta setup && npm install",
+  "postCreateCommand": "npm install -g npm@8.19.3",
+  "updateContentCommand": "npm install",
   "features": {
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "18.12.1"
+    },
     "ghcr.io/devcontainers/features/aws-cli:1": {},
     "ghcr.io/devcontainers/features/terraform:1": {},
     "ghcr.io/devcontainers/features/docker-in-docker:2": {},
-    "ghcr.io/devcontainers-contrib/features/volta:1": {},
     "ghcr.io/devcontainers/features/rust:1": {},
   },
   "hostRequirements": {

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.head.ref || github.ref }}
   cancel-in-progress: true
 
+env:
+  RUST_VERSION: "1.67.1"
+  NODE_VERSION: "18.12.1"
+  NPM_VERSION: "8.19.3"
+
 jobs:
   build:
     name: "Build"
@@ -26,7 +31,6 @@ jobs:
     env:
       # Testing runs out of memory without this
       NODE_OPTIONS: "--max-old-space-size=4096"
-      RUST_VERSION: "1.67.1"
       CARGO_TERM_COLOR: always
     outputs:
       version: ${{ fromJson(steps.changelog.outputs.data).newVersion }}
@@ -38,15 +42,13 @@ jobs:
         with:
           fetch-depth: 0
 
-      # Reads versions from root package.json "volta" section
-      - name: Setup Node/NPM with pinned Volta version
-        uses: volta-cli/action@v4.0.0
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ env.NODE_VERSION }}
 
-      # Forces volta to load node and npm upfront, reducing conflict when running in parallel later
-      - name: Preload Node/NPM
-        run: |
-          node -v
-          npm -v
+      - name: Setup NPM
+        run: npm install -g npm@${{ env.NPM_VERSION }}
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master
@@ -145,15 +147,13 @@ jobs:
       - name: Download Build Artifacts
         uses: actions/download-artifact@v2
 
-      # Reads versions from root package.json "volta" section
-      - name: Setup Node/NPM with pinned Volta version
-        uses: volta-cli/action@v4.0.0
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ env.NODE_VERSION }}
 
-      # Forces volta to load node and npm upfront, reducing conflict when running in parallel later
-      - name: Preload Node/NPM
-        run: |
-          node -v
-          npm -v
+      - name: Setup NPM
+        run: npm install -g npm@${{ env.NPM_VERSION }}
 
       - name: Install Dependencies
         uses: bahmutov/npm-install@v1

--- a/.github/workflows/wingsdk-mutation.yml
+++ b/.github/workflows/wingsdk-mutation.yml
@@ -16,7 +16,8 @@ defaults:
     working-directory: libs/wingsdk
 
 env:
-  CI: "true"
+  NODE_VERSION: "18.12.1"
+  NPM_VERSION: "8.19.3"
 
 jobs:
   mutate:
@@ -39,9 +40,12 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           token: ${{ secrets.MUTATION_TOKEN }}
-      # Reads versions from root package.json "volta" section
-      - name: Setup Node/NPM with pinned Volta version
-        uses: volta-cli/action@v4.0.0
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+      - name: Setup NPM
+        run: npm install -g npm@${{ env.NPM_VERSION }}
       - name: Install dependencies
         if: steps.token-check.outputs.HAS_TOKEN == 'true'
         run: npm ci


### PR DESCRIPTION
Fixes #2590

Volta was causing too many intermittent issues in CI. I kept it in the docs locally because I still think it's really great, but I'm open to removing it from there as well if it's causing enough issues for others. 

Removed from the devcontainer as well, which helps because it let's us use `postCreateCommand` and `updateContentCommand` which will be great if we want to start doing prebuilds. Verified the change locally.

The only real downside of this change is that now the node/npm version is duplicated, but I think the tradeoff is worth it.

## Checklist

- [x] Title matches [Winglang's style guide](https://docs.winglang.io/contributors/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [ ] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.
