### PR TITLE
fix(compiler): invalid code location in errors when using multibyte chars

### DIFF
--- a/apps/wing/src/commands/compile.ts
+++ b/apps/wing/src/commands/compile.ts
@@ -65,8 +65,8 @@ export async function compile(entrypoint: string, options: CompileOptions): Prom
         if (span !== null && span.file_id) {
           // `span` should only be null if source file couldn't be read etc.
           const source = await fsPromise.readFile(span.file_id, "utf8");
-          const start = offsetFromLineAndColumn(source, span.start.line, span.start.col);
-          const end = offsetFromLineAndColumn(source, span.end.line, span.end.col);
+          const start = byteOffsetFromLineAndColumn(source, span.start.line, span.start.col);
+          const end = byteOffsetFromLineAndColumn(source, span.end.line, span.end.col);
           files.push({ name: span.file_id, source });
           labels.push({
             fileId: span.file_id,
@@ -156,12 +156,16 @@ function annotatePreflightError(error: Error): Error {
   return error;
 }
 
-function offsetFromLineAndColumn(source: string, line: number, column: number) {
+function byteOffsetFromLineAndColumn(source: string, line: number, column: number) {
   const lines = source.split("\n");
   let offset = 0;
   for (let i = 0; i < line; i++) {
     offset += lines[i].length + 1;
   }
   offset += column;
-  return offset;
+
+  // Convert char offset to byte offset
+  const encoder = new TextEncoder();
+  const srouce_bytes = encoder.encode(source.substring(0, offset));
+  return srouce_bytes.length;
 }

--- a/examples/tests/invalid/diags_with_multibyte_chars.w
+++ b/examples/tests/invalid/diags_with_multibyte_chars.w
@@ -1,0 +1,5 @@
+// Here we have some multibyte haiku which we'll use to verify
+// the reported diagnostics point to the correct location (line 4 column 1)
+// 古池や蛙飛び込む水の音
+asdf;
+//^^ Unknown symbol "asdf"

--- a/tools/hangar/__snapshots__/invalid.ts.snap
+++ b/tools/hangar/__snapshots__/invalid.ts.snap
@@ -508,6 +508,24 @@ Duration <DURATION>
 "
 `;
 
+exports[`diags_with_multibyte_chars.w 1`] = `
+"error: Unknown symbol \\"asdf\\"
+  --> ../../../examples/tests/invalid/diags_with_multibyte_chars.w:4:1
+  |
+4 | asdf;
+  | ^^^^ Unknown symbol \\"asdf\\"
+
+
+ 
+
+
+
+
+Tests 1 failed (1) 
+Duration <DURATION>
+"
+`;
+
 exports[`enums.w 1`] = `
 "error: Enum \\"SomeEnum\\" does not contain value \\"FOUR\\"
   --> ../../../examples/tests/invalid/enums.w:5:21


### PR DESCRIPTION
Multi byte chars in the code (mostly in comments) lead to wrong spans being produced for diagnostics:
This test:
```wing
// Here we have some multibyte haiku which we'll use to verify
// the reported diagnostics point to the correct location (line 4 column 1)
// 古池や蛙飛び込む水の音
asdf;
//^^ Unknown symbol "asdf"
```
Produced this wrong output before the fix:
![image](https://github.com/winglang/wing/assets/1160578/6ea76196-877e-4de2-9a97-017f1ba94e33)

We now calculate the byte offset of the diags which is what our diag reporting tool ([codespan-reporting](https://crates.io/crates/codespan-reporting)) expects instead of the character offset.

## Checklist

- [x] Title matches [Winglang's style guide](https://docs.winglang.io/contributors/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [x] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.
