### PR TITLE
fix(compiler): add error message for wrong struct instantiation.

### DIFF
--- a/libs/wingc/src/type_check.rs
+++ b/libs/wingc/src/type_check.rs
@@ -1356,33 +1356,40 @@ impl<'a> TypeChecker<'a> {
 
 				// Lookup the class's type in the env
 				let type_ = self.resolve_type_annotation(class, env);
-				let (class_env, class_symbol) = match &*type_ {
-					Type::Class(ref class) => {
-						if class.phase == Phase::Independent || env.phase == class.phase {
-							(&class.env, &class.name)
-						} else {
-							self.spanned_error(
-								exp,
-								format!(
-									"Cannot create {} class \"{}\" in {} phase",
-									class.phase, class.name, env.phase
-								),
-							);
-							return self.types.error();
+				let (class_env, class_symbol) =
+					match &*type_ {
+						Type::Class(ref class) => {
+							if class.phase == Phase::Independent || env.phase == class.phase {
+								(&class.env, &class.name)
+							} else {
+								self.spanned_error(
+									exp,
+									format!(
+										"Cannot create {} class \"{}\" in {} phase",
+										class.phase, class.name, env.phase
+									),
+								);
+								return self.types.error();
+							}
 						}
-					}
-					t => {
-						if matches!(t, Type::Anything) {
-							return self.types.anything();
-						} else {
-							self.spanned_error(
+						t => {
+							if matches!(t, Type::Anything) {
+								return self.types.anything();
+							} else if matches!(t, Type::Struct(_)) {
+								self.spanned_error(
 								class,
-								format!("Cannot instantiate type \"{}\" because it is not a class", type_),
+								format!("Cannot instantiate type \"{}\" because it is a struct and not a class. Use struct instantiation instead.", type_),
 							);
-							return self.types.error();
+								return self.types.error();
+							} else {
+								self.spanned_error(
+									class,
+									format!("Cannot instantiate type \"{}\" because it is not a class", type_),
+								);
+								return self.types.error();
+							}
 						}
-					}
-				};
+					};
 
 				// Type check args against constructor
 				let init_method_name = if env.phase == Phase::Preflight {

--- a/tools/hangar/__snapshots__/invalid.ts.snap
+++ b/tools/hangar/__snapshots__/invalid.ts.snap
@@ -1775,11 +1775,11 @@ error: Struct \\"Showtime\\" extends \\"Dazzle\\" which introduces a conflicting
    |        ^^^^^^^^ Struct \\"Showtime\\" extends \\"Dazzle\\" which introduces a conflicting member \\"a\\" (num != num)
 
 
-error: Cannot instantiate type \\"BucketProps\\" because it is not a class
+error: Cannot instantiate type \\"BucketProps\\" because it is a struct and not a class. Use struct instantiation instead.
    --> ../../../examples/tests/invalid/structs.w:47:13
    |
 47 | let x = new cloud.BucketProps(1);
-   |             ^^^^^^^^^^^^^^^^^ Cannot instantiate type \\"BucketProps\\" because it is not a class
+   |             ^^^^^^^^^^^^^^^^^ Cannot instantiate type \\"BucketProps\\" because it is a struct and not a class. Use struct instantiation instead.
 
 
  


### PR DESCRIPTION
Improves the compiler error message if a struct is instantiated with `new` keyword.

Closes #2695. 

## Checklist

- [x] Title matches [Winglang's style guide](https://docs.winglang.io/contributors/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [x] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.
