### PR TITLE
fix(vscode): missing completions for `Json` and other methods on static `std` types

### DIFF
--- a/libs/wingc/src/lsp/completions.rs
+++ b/libs/wingc/src/lsp/completions.rs
@@ -14,7 +14,7 @@ use crate::type_check::{
 };
 use crate::visit::{visit_expr, visit_type_annotation, Visit};
 use crate::wasm_util::{ptr_to_string, string_to_combined_ptr, WASM_RETURN_ERROR};
-use crate::WINGSDK_STD_MODULE;
+use crate::{WINGSDK_ASSEMBLY_NAME, WINGSDK_STD_MODULE};
 
 #[no_mangle]
 pub unsafe extern "C" fn wingc_on_completion(ptr: u32, len: u32) -> u64 {
@@ -94,53 +94,49 @@ pub fn on_completion(params: lsp_types::CompletionParams) -> CompletionResponse 
 								.map(|s| s.env.borrow().as_ref().expect("Scopes must have an environment").phase),
 							true,
 						);
-					} else {
-						if let ExprKind::Reference(_) = &nearest_expr.kind {
-							// This is probably a type of some kind
-							// just get the entire reference and try to resolve it
-							let wing_source = file_data.contents.as_bytes();
-							let mut reference_text = parent
-								.utf8_text(wing_source)
-								.expect("The referenced text should be available")
-								.to_string();
-							if reference_text.ends_with(".") {
-								reference_text.pop();
-							}
+					}
+				}
 
-							let found_env = scope_visitor.found_scope.unwrap();
-							let found_env = found_env.env.borrow();
-							let found_env = found_env.as_ref().unwrap();
-							let lookup_thing = found_env
-								.lookup_nested_str(&reference_text, scope_visitor.found_stmt_index)
-								.ok();
+				// We're likely in a type reference, so let's use the raw text for a lookup
+				let wing_source = file_data.contents.as_bytes();
+				let mut reference_text = parent
+					.utf8_text(wing_source)
+					.expect("The referenced text should be available")
+					.to_string();
+				if reference_text.ends_with(".") {
+					reference_text.pop();
+				}
 
-							if let Some((lookup_thing, _)) = lookup_thing {
-								match lookup_thing {
-									SymbolKind::Type(t) => {
-										return get_completions_from_type(&t, types, Some(found_env.phase), false);
-									}
-									SymbolKind::Variable(v) => {
-										return get_completions_from_type(
-											&v.type_,
-											types,
-											scope_visitor
-												.found_scope
-												.map(|s| s.env.borrow().as_ref().expect("Scopes must have an environment").phase),
-											false,
-										)
-									}
-									SymbolKind::Namespace(n) => {
-										return get_completions_from_namespace(n);
-									}
-								}
-							} else {
-								// No lookup found, let's not provide any completions
-								// TODO This may be a JSII type that has not been imported yet https://github.com/winglang/wing/issues/2639
+				reference_text = add_std_namespace(&reference_text);
 
-								return vec![];
-							}
+				let found_env = scope_visitor.found_scope.unwrap();
+				let found_env = found_env.env.borrow();
+				let found_env = found_env.as_ref().unwrap();
+				let lookup_thing = found_env
+					.lookup_nested_str(&reference_text, scope_visitor.found_stmt_index)
+					.ok();
+
+				if let Some((lookup_thing, _)) = lookup_thing {
+					match lookup_thing {
+						SymbolKind::Type(t) => {
+							return get_completions_from_type(&t, types, Some(found_env.phase), false);
+						}
+						SymbolKind::Variable(v) => {
+							return get_completions_from_type(
+								&v.type_,
+								types,
+								scope_visitor
+									.found_scope
+									.map(|s| s.env.borrow().as_ref().expect("Scopes must have an environment").phase),
+								false,
+							)
+						}
+						SymbolKind::Namespace(n) => {
+							return get_completions_from_namespace(n);
 						}
 					}
+				} else {
+					return vec![];
 				}
 			}
 
@@ -261,43 +257,59 @@ fn get_completions_from_type(
 		| Type::MutMap(_)
 		| Type::Set(_)
 		| Type::MutSet(_) => {
-			// This section of the code is hacky
-			// This is needed because our builtin types have no API
-			// So we have to get the API from the std lib
-			// But the std lib sometimes doesn't have the same names as the builtin types
-			// https://github.com/winglang/wing/issues/1780
-
-			// Additionally, this doesn't handle for generics
 			let type_name = type_.to_string();
-			let type_name = if let Some((prefix, _)) = type_name.split_once("<") {
-				prefix
-			} else {
-				&type_name
-			};
-			let type_name = match type_name {
-				"Set" => "ImmutableSet",
-				"Map" => "ImmutableMap",
-				"Array" => "ImmutableArray",
-				"MutSet" => "MutableSet",
-				"MutMap" => "MutableMap",
-				"MutArray" => "MutableArray",
+			let mut type_name = type_name.as_str();
+
+			// Certain primitive type names differ from how they actually appear in the std namespace
+			// These are unique when used as a type definition, rather than as a type reference when calling a static method
+			type_name = match type_name {
 				"str" => "String",
 				"duration" => "Duration",
-				"json" => "Json",
 				"bool" => "Boolean",
 				"num" => "Number",
 				_ => type_name,
 			};
-			if let LookupResult::Found(std_type, _) = types
-				.libraries
-				.lookup_nested_str(format!("@winglang/sdk.std.{}", type_name).as_str(), None)
-			{
+			let final_type_name = add_std_namespace(type_name);
+			let final_type_name = final_type_name.as_str();
+
+			let fqn = format!("{WINGSDK_ASSEMBLY_NAME}.{final_type_name}");
+			if let LookupResult::Found(std_type, _) = types.libraries.lookup_nested_str(fqn.as_str(), None) {
 				return get_completions_from_type(&std_type.as_type().expect("is type"), types, current_phase, is_instance);
 			} else {
 				vec![]
 			}
 		}
 	}
+}
+
+/// If the given type is from the std namespace, add the implicit `std.` to it
+fn add_std_namespace(type_: &str) -> std::string::String {
+	// This section of the code is hacky
+	// This is needed because our builtin types have no API
+	// So we have to get the API from the std lib
+	// But the std lib sometimes doesn't have the same names as the builtin types
+	// https://github.com/winglang/wing/issues/1780
+
+	// Additionally, this doesn't handle for generics
+	let type_name = type_.to_string();
+	let type_name = if let Some((prefix, _)) = type_name.split_once("<") {
+		prefix
+	} else {
+		&type_name
+	};
+	let type_name = match type_name {
+		"Set" => "ImmutableSet",
+		"Map" => "ImmutableMap",
+		"Array" => "ImmutableArray",
+		"MutSet" => "MutableSet",
+		"MutMap" => "MutableMap",
+		"MutArray" => "MutableArray",
+		"Json" | "MutableArray" | "MutableMap" | "MutableSet" | "ImmutableArray" | "ImmutableMap" | "ImmutableSet"
+		| "String" | "Duration" | "Boolean" | "Number" => type_name,
+		_ => return type_name.to_string(),
+	};
+
+	format!("{WINGSDK_STD_MODULE}.{type_name}")
 }
 
 fn get_completions_from_namespace(namespace: &UnsafeRef<Namespace>) -> Vec<CompletionItem> {
@@ -420,7 +432,7 @@ fn format_symbol_kind_as_completion(name: &str, symbol_kind: &SymbolKind) -> Opt
 			CompletionItem {
 				label: name.to_string(),
 				insert_text: if is_method {
-					Some(format!("{}($0)", name))
+					Some(format!("{name}($0)"))
 				} else {
 					Some(name.to_string())
 				},
@@ -639,6 +651,14 @@ let a = MutMap<str> {};
 if a. 
    //^"#,
 		assert!(!incomplete_if_statement.is_empty())
+	);
+
+	test_completion_list!(
+		json_statics,
+		r#"
+Json. 
+   //^"#,
+		assert!(!json_statics.is_empty())
 	);
 
 	test_completion_list!(

--- a/libs/wingc/src/lsp/snapshots/completions/json_statics.snap
+++ b/libs/wingc/src/lsp/snapshots/completions/json_statics.snap
@@ -1,0 +1,68 @@
+---
+source: libs/wingc/src/lsp/completions.rs
+---
+- label: deepCopyMut
+  kind: 2
+  detail: "(json: Json): MutJson"
+  insertText: deepCopyMut($0)
+  insertTextFormat: 2
+  command:
+    title: triggerParameterHints
+    command: editor.action.triggerParameterHints
+- label: delete
+  kind: 2
+  detail: "(json: Json, key: str): void"
+  insertText: delete($0)
+  insertTextFormat: 2
+  command:
+    title: triggerParameterHints
+    command: editor.action.triggerParameterHints
+- label: has
+  kind: 2
+  detail: "(json: Json, key: str): bool"
+  insertText: has($0)
+  insertTextFormat: 2
+  command:
+    title: triggerParameterHints
+    command: editor.action.triggerParameterHints
+- label: keys
+  kind: 2
+  detail: "(json: Json): Array<str>"
+  insertText: keys($0)
+  insertTextFormat: 2
+  command:
+    title: triggerParameterHints
+    command: editor.action.triggerParameterHints
+- label: parse
+  kind: 2
+  detail: "(str: str): Json"
+  insertText: parse($0)
+  insertTextFormat: 2
+  command:
+    title: triggerParameterHints
+    command: editor.action.triggerParameterHints
+- label: stringify
+  kind: 2
+  detail: "(json: Json, indent: num?): str"
+  insertText: stringify($0)
+  insertTextFormat: 2
+  command:
+    title: triggerParameterHints
+    command: editor.action.triggerParameterHints
+- label: tryParse
+  kind: 2
+  detail: "(str: str): Json?"
+  insertText: tryParse($0)
+  insertTextFormat: 2
+  command:
+    title: triggerParameterHints
+    command: editor.action.triggerParameterHints
+- label: values
+  kind: 2
+  detail: "(json: Json): Array<Json>"
+  insertText: values($0)
+  insertTextFormat: 2
+  command:
+    title: triggerParameterHints
+    command: editor.action.triggerParameterHints
+


### PR DESCRIPTION
Fixes #2872

## Checklist

- [x] Title matches [Winglang's style guide](https://docs.winglang.io/contributors/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [x] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.
