### PR TITLE
fix(vscode): missing completions in lazy-loaded jsii namespaces

### DIFF
--- a/libs/wingc/src/lsp/completions.rs
+++ b/libs/wingc/src/lsp/completions.rs
@@ -149,10 +149,9 @@ pub fn on_completion(params: lsp_types::CompletionParams) -> CompletionResponse 
 						if let Ok(type_lookup) = type_lookup {
 							return get_completions_from_type(&type_lookup, types, Some(found_env.phase), false);
 						} else {
-							// this is probably a namespace
-							// `resolve_user_defined_type` will fail for namespaces, let's just look it up instead
+							// this is probably a namespace, let's look it up
 							let namespace = root_env
-								.lookup_nested_str(&udt.root.name, scope_visitor.found_stmt_index)
+								.lookup_nested_str(&udt.full_path_str(), scope_visitor.found_stmt_index)
 								.ok();
 							if let Some((namespace, _)) = namespace {
 								if let SymbolKind::Namespace(namespace) = namespace {

--- a/libs/wingc/src/type_check.rs
+++ b/libs/wingc/src/type_check.rs
@@ -3566,6 +3566,8 @@ impl<'a> TypeChecker<'a> {
 				};
 				udt_string.push_str(&user_defined_type.fields.iter().map(|g| g.name.clone()).join("."));
 
+				dbg!(&udt_string);
+
 				if importer.import_type(&FQN::from(udt_string.as_str())) {
 					return resolve_user_defined_type(user_defined_type, env, statement_idx);
 				} else {

--- a/libs/wingc/src/type_check.rs
+++ b/libs/wingc/src/type_check.rs
@@ -120,7 +120,7 @@ impl SymbolKind {
 		}
 	}
 
-	fn as_namespace_ref(&self) -> Option<NamespaceRef> {
+	pub fn as_namespace_ref(&self) -> Option<NamespaceRef> {
 		match self {
 			SymbolKind::Namespace(ns) => Some(*ns),
 			_ => None,

--- a/libs/wingc/src/type_check.rs
+++ b/libs/wingc/src/type_check.rs
@@ -3566,8 +3566,6 @@ impl<'a> TypeChecker<'a> {
 				};
 				udt_string.push_str(&user_defined_type.fields.iter().map(|g| g.name.clone()).join("."));
 
-				dbg!(&udt_string);
-
 				if importer.import_type(&FQN::from(udt_string.as_str())) {
 					return resolve_user_defined_type(user_defined_type, env, statement_idx);
 				} else {

--- a/libs/wingc/src/type_check/jsii_importer.rs
+++ b/libs/wingc/src/type_check/jsii_importer.rs
@@ -759,8 +759,8 @@ impl<'a> JsiiImporter<'a> {
 	fn parameter_to_wing_type(&mut self, parameter: &jsii::Parameter) -> TypeRef {
 		let mut param_type = self.type_ref_to_wing_type(&parameter.type_);
 
+		// TODO variadic parameter support https://github.com/winglang/wing/issues/397
 		if parameter.variadic.unwrap_or(false) {
-			// TODO properly thought out variadic parameter support https://github.com/winglang/wing/issues/397
 			param_type = self.wing_types.add_type(Type::Array(param_type));
 			param_type = self.wing_types.add_type(Type::Optional(param_type));
 		}


### PR DESCRIPTION
Due to the jsii type lazy loading, completions only show types that were used in the current file. We now eagerly load namespaces when referenced (even if incomplete).

For example:

```
bring "aws-cdk-lib" as awscdk;

new awscdk.aws_lambda.
                    //^ completions will show here
```

https://github.com/winglang/wing/assets/1237390/d6edeee2-8c64-428d-a2ef-0aa51b5e3b96

## Notes
  - I couldn't think of a reasonable way to test this, the lsp tests need a good jsii fixture system
  - refactored some code into a `reference_to_udt` and as part of it, allowed a udt to basically refer to a namespace
  - We also now also eagerly load jsii types that don't belong to a namespace, just to cover that base

Fixes #2639

## Checklist

- [x] Title matches [Winglang's style guide](https://docs.winglang.io/contributors/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [ ] Tests added (always)
  - See notes above 
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.
