### PR TITLE
chore: wingsdk requires build before test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -163,9 +163,6 @@ jobs:
       - name: Install Dependencies
         uses: bahmutov/npm-install@v1
 
-      - name: Build
-        run: npm run build:ci
-
       - name: Test
         run: npm run test:ci
 

--- a/libs/wingsdk/project.json
+++ b/libs/wingsdk/project.json
@@ -15,6 +15,7 @@
       }
     },
     "test": {
+      "dependsOn": ["^build", "build"],
       "options": {
         "commands": ["npm run post-compile", "npm run test"],
         "cwd": "libs/wingsdk",


### PR DESCRIPTION
`post-compile` requires `compile` to run, so we might as well run the whole build step.

## Checklist

- [x] Title matches [Winglang's style guide](https://docs.winglang.io/contributors/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [ ] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.
