### PR TITLE
chore: bump-pack does not set package version during release

### DIFF
--- a/tools/bump-pack/src/bump.ts
+++ b/tools/bump-pack/src/bump.ts
@@ -14,6 +14,24 @@ export async function setPackageVersion(options: SetPackageVersionOptions) {
 
   const originals: Record<string, string> = {};
 
+  if (typeof options.version === "string") {
+    if (options.dryRun) {
+      console.log(
+        `DRYRUN: Set version to ${options.version} in ${packageJsonPath}`
+      );
+    } else {
+      packageJson.version = options.version;
+    }
+  } else {
+    if (options.dryRun) {
+      console.log(
+        `DRYRUN: Set version to 0.0.0 (default) in ${packageJsonPath}`
+      );
+    } else {
+      packageJson.version = "0.0.0";
+    }
+  }
+
   for (const [packageName, packageVersion] of Object.entries(
     packageJson.dependencies ?? {}
   )) {
@@ -50,10 +68,7 @@ export async function setPackageVersion(options: SetPackageVersionOptions) {
     }
   }
 
-  await writeFile(
-    packageJsonPath,
-    JSON.stringify(packageJson, undefined, 2)
-  );
+  await writeFile(packageJsonPath, JSON.stringify(packageJson, undefined, 2));
 
   return originals;
 }

--- a/tools/bump-pack/src/cli.ts
+++ b/tools/bump-pack/src/cli.ts
@@ -24,11 +24,11 @@ const dryRun = parsedArgs.values.dryRun ?? false;
 
 if (packageDir !== undefined) {
   // We want to make sure a package is versioned and is pointing to the correct dep versions
-
   const originalVersions = await setPackageVersion({
     packageDir,
     dryRun,
     version: releaseData.newVersion,
+    devBuild: releaseData.sameVersion,
   });
 
   try {
@@ -40,7 +40,7 @@ if (packageDir !== undefined) {
     await setPackageVersion({
       packageDir,
       dryRun,
-      version: originalVersions,
+      versionMap: originalVersions,
     });
   }
 } else {


### PR DESCRIPTION
refactored to make the logic simpler as well

## Checklist

- [x] Title matches [Winglang's style guide](https://docs.winglang.io/contributors/pull_requests#how-are-pull-request-titles-formatted)
- [ ] Description explains motivation and solution
- [ ] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.
