### PR TITLE
chore: use PROJEN_BUMP_VERSION for versioning

### DIFF
--- a/tools/bump-pack/src/bump.ts
+++ b/tools/bump-pack/src/bump.ts
@@ -18,6 +18,8 @@ export interface SetPackageVersionOptions {
 
   /**
    * If true, dependencies will be removed from the package.json file.
+   *
+   * @default true if `version` is "0.0.0", false otherwise
    */
   devBuild?: boolean;
 
@@ -45,10 +47,16 @@ export async function setPackageVersion(options: SetPackageVersionOptions) {
   const defaultVersion = "0.0.0";
   const packageJsonPath = path.join(options.packageDir, "package.json");
   const packageJson = await readFile(packageJsonPath, "utf8").then(JSON.parse);
-  const devBuild = options.devBuild ?? false;
   const version = options.version ?? defaultVersion;
+  const devBuild = options.devBuild ?? version === defaultVersion;
 
   const originals: Record<string, string> = {};
+
+  console.log(
+    `Setting version to ${version}${
+      devBuild ? " (DEV)" : ""
+    } in ${packageJsonPath}`
+  );
 
   if (options.dryRun) {
     console.log(`DRYRUN: Set version to ${version} in ${packageJsonPath}`);

--- a/tools/bump-pack/src/cli.ts
+++ b/tools/bump-pack/src/cli.ts
@@ -19,7 +19,6 @@ const parsedArgs = parseArgs({
 });
 
 const packageDir = parsedArgs.values.bumpPackage ? process.cwd() : undefined;
-const releaseData = await getReleaseData();
 const dryRun = parsedArgs.values.dryRun ?? false;
 
 if (packageDir !== undefined) {
@@ -27,8 +26,7 @@ if (packageDir !== undefined) {
   const originalVersions = await setPackageVersion({
     packageDir,
     dryRun,
-    version: releaseData.newVersion,
-    devBuild: releaseData.sameVersion,
+    version: process.env.PROJEN_BUMP_VERSION,
   });
 
   try {
@@ -45,6 +43,7 @@ if (packageDir !== undefined) {
   }
 } else {
   // We just want to output the useful release data
+  const releaseData = await getReleaseData();
   console.log(releaseData);
 
   if (!!process.env.GITHUB_ACTIONS) {


### PR DESCRIPTION
Another followup to https://github.com/winglang/wing/pull/2992

Switched back to using PROJEN_BUMP_VERSION, which is what the original script used. The issue with the last change probably was that we were trying to regenerate the version/changelog and it was failing. Using the existing variable should work and it's faster anyways.

Also explicitly added a little log, which shouldn't hurt.

## Checklist

- [x] Title matches [Winglang's style guide](https://docs.winglang.io/contributors/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [ ] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.
