### PR TITLE
fix: capture diagnostics missing from language server

### DIFF
--- a/libs/wingc/src/diagnostic.rs
+++ b/libs/wingc/src/diagnostic.rs
@@ -207,7 +207,8 @@ pub fn found_errors() -> bool {
 	})
 }
 
-/// Asserts that no panics occurred during compilation
+#[cfg(test)]
+/// Asserts that no panics occurred during compilation. Should only be used for testing
 pub fn assert_no_panics() {
 	let panics = DIAGNOSTICS.with(|diagnostics| {
 		let diagnostics = diagnostics.borrow();

--- a/libs/wingc/src/diagnostic.rs
+++ b/libs/wingc/src/diagnostic.rs
@@ -207,6 +207,20 @@ pub fn found_errors() -> bool {
 	})
 }
 
+/// Asserts that no panics occurred during compilation
+pub fn assert_no_panics() {
+	let panics = DIAGNOSTICS.with(|diagnostics| {
+		let diagnostics = diagnostics.borrow();
+		diagnostics
+			.iter()
+			.filter(|d| d.message.starts_with("Compiler bug"))
+			.cloned()
+			.collect::<Vec<_>>()
+	});
+
+	assert_eq!(panics.len(), 0, "Compiler bug detected: {:#?}", panics);
+}
+
 /// Returns the list of diagnostics
 pub fn get_diagnostics() -> Vec<Diagnostic> {
 	DIAGNOSTICS.with(|diagnostics| {

--- a/libs/wingc/src/jsify.rs
+++ b/libs/wingc/src/jsify.rs
@@ -1083,7 +1083,7 @@ impl<'a> JSifier<'a> {
 				_ => {
 					for sym in n {
 						report_diagnostic(Diagnostic {
-							message: format!("Unexpected type: \"{t}\" referenced inflight"),
+							message: format!("Unexpected type \"{t}\" referenced inflight"),
 							span: Some(sym.span.clone()),
 						});
 					}

--- a/libs/wingc/src/jsify.rs
+++ b/libs/wingc/src/jsify.rs
@@ -291,7 +291,9 @@ impl<'a> JSifier<'a> {
 				let expression_type = self.get_expr_type(&expression);
 				let is_preflight_class = expression_type.is_preflight_class();
 
-				let class_type = expression_type.as_class().expect("type to be a class");
+				let class_type = if let Some(class_type) = expression_type.as_class() { class_type } else {
+					return "".to_string();
+				};
 				let is_abstract = class_type.is_abstract;
 
 				// if we have an FQN, we emit a call to the "new" (or "newAbstract") factory method to allow
@@ -368,10 +370,6 @@ impl<'a> JSifier<'a> {
 			ExprKind::Call { callee, arg_list } => {
 				let function_type = self.get_expr_type(callee);
 				let function_sig = function_type.as_function_sig();
-				assert!(
-					function_sig.is_some() || function_type.is_anything() || function_type.is_handler_preflight_class(),
-					"Expected expression to be callable"
-				);
 
 				let expr_string = match &callee.kind {
 					ExprKind::Reference(reference) => self.jsify_reference(reference, ctx),
@@ -1082,7 +1080,14 @@ impl<'a> JSifier<'a> {
 					code.add_code(self.jsify_enum(&e.values));
 					code.close("`);");
 				}
-				_ => panic!("Unexpected type: \"{t}\" referenced inflight"),
+				_ => {
+					for sym in n {
+						report_diagnostic(Diagnostic {
+							message: format!("Unexpected type: \"{t}\" referenced inflight"),
+							span: Some(sym.span.clone()),
+						});
+					}
+				}
 			}
 		}
 
@@ -1185,8 +1190,9 @@ impl<'a> JSifier<'a> {
 		// Handle parent class: Need to call super and pass its captured fields (we assume the parent client is already written)
 		let mut lifted_by_parent = vec![];
 		if let Some(parent) = &class.parent {
-			let parent_type = resolve_user_defined_type(parent, env, 0).unwrap();
-			lifted_by_parent.extend(self.get_lifted_fields(parent_type));
+			if let Ok(parent_type) = resolve_user_defined_type(parent, env, 0) {
+				lifted_by_parent.extend(self.get_lifted_fields(parent_type));
+			}
 		}
 
 		// Get the fields that are lifted by this class but not by its parent, they will be initialized
@@ -1323,18 +1329,20 @@ impl<'a> JSifier<'a> {
 
 	// Get the type and capture info for fields that are captured in the client of the given resource
 	fn get_lifted_fields(&self, resource_type: TypeRef) -> Vec<String> {
-		resource_type
-			.as_class()
-			.unwrap()
-			.env
-			.iter(true)
-			.filter(|(_, kind, _)| {
-				let var = kind.as_variable().unwrap();
-				// We capture preflight non-reassignable fields
-				var.phase != Phase::Inflight && !var.reassignable && var.type_.is_capturable()
-			})
-			.map(|(name, ..)| name)
-			.collect_vec()
+		if let Some(resource_class) = resource_type.as_class() {
+			resource_class
+				.env
+				.iter(true)
+				.filter(|(_, kind, _)| {
+					let var = kind.as_variable().unwrap();
+					// We capture preflight non-reassignable fields
+					var.phase != Phase::Inflight && !var.reassignable && var.type_.is_capturable()
+				})
+				.map(|(name, ..)| name)
+				.collect_vec()
+		} else {
+			vec![]
+		}
 	}
 
 	fn jsify_register_bind_method(
@@ -1569,7 +1577,13 @@ impl<'ast> Visit<'ast> for FieldReferenceVisitor<'ast> {
 					capture.push(curr);
 					index = index + 1;
 				}
-				ComponentKind::Unsupported => panic!("all components should be valid at this point"),
+				ComponentKind::Unsupported => {
+					report_diagnostic(Diagnostic {
+						message: format!("Unsupported component \"{}\"", curr.text),
+						span: Some(curr.span.clone()),
+					});
+					return;
+				}
 			}
 		}
 
@@ -1663,7 +1677,11 @@ impl<'a> FieldReferenceVisitor<'a> {
 				}
 
 				let LookupResult::Found(kind, _) = lookup else {
-					panic!("reference to undefined symbol");
+					return vec![Component {
+						text: x.name.clone(),
+						span: x.span.clone(),
+						kind: ComponentKind::Unsupported,
+					}];
 				};
 
 				let var = kind.as_variable().expect("variable");
@@ -1702,8 +1720,9 @@ impl<'a> FieldReferenceVisitor<'a> {
 				let env = self.env.unwrap();
 
 				// Get the type we're accessing a member of
-				let t = resolve_user_defined_type(type_, &env, self.statement_index).expect("covered by type checking");
-
+				let Ok(t) = resolve_user_defined_type(type_, &env, self.statement_index) else {
+					return vec![];
+				};
 				// If the type we're referencing isn't a preflight class then skip it
 				let Some(class) = t.as_preflight_class() else {
 					return vec![];
@@ -1753,29 +1772,9 @@ impl<'a> FieldReferenceVisitor<'a> {
 			Type::Array(_) | Type::MutArray(_) | Type::Map(_) | Type::MutMap(_) | Type::Set(_) | Type::MutSet(_) => {
 				Some(ComponentKind::Unsupported)
 			}
-			Type::Class(cls) => Some(ComponentKind::Member(
-				cls
-					.env
-					.lookup(&property, None)
-					.expect("covered by type checking")
-					.as_variable()
-					.unwrap(),
-			)),
-			Type::Interface(iface) => Some(ComponentKind::Member(
-				iface
-					.env
-					.lookup(&property, None)
-					.expect("covered by type checking")
-					.as_variable()
-					.unwrap(),
-			)),
-			Type::Struct(st) => Some(ComponentKind::Member(
-				st.env
-					.lookup(&property, None)
-					.expect("covered by type checking")
-					.as_variable()
-					.unwrap(),
-			)),
+			Type::Class(cls) => Some(ComponentKind::Member(cls.env.lookup(&property, None)?.as_variable()?)),
+			Type::Interface(iface) => Some(ComponentKind::Member(iface.env.lookup(&property, None)?.as_variable()?)),
+			Type::Struct(st) => Some(ComponentKind::Member(st.env.lookup(&property, None)?.as_variable()?)),
 		}
 	}
 }
@@ -1841,9 +1840,9 @@ impl<'a> CaptureScanner<'a> {
 			return;
 		}
 
-		// any other lookup failure is likely a bug in the compiler
+		// any other lookup failure is likely a an invalid reference so we can skip it
 		let LookupResult::Found(kind, symbol_info) = lookup else {
-			panic!("unable to find symbol in current environment");
+			return;
 		};
 
 		// now, we need to determine if the environment this symbol is defined in is a parent of the

--- a/libs/wingc/src/lib.rs
+++ b/libs/wingc/src/lib.rs
@@ -365,7 +365,7 @@ fn is_project_dir_absolute(project_dir: &PathBuf) -> bool {
 
 #[cfg(test)]
 mod sanity {
-	use crate::compile;
+	use crate::{compile, diagnostic::get_diagnostics};
 	use std::{
 		fs,
 		path::{Path, PathBuf},
@@ -409,6 +409,14 @@ mod sanity {
 					test_file.display(),
 					result.err().unwrap()
 				);
+
+				// Even if the test fails when we expect it to, none of the failures should be due to a compiler bug
+				let diags = get_diagnostics();
+				let panic_diags = diags
+					.iter()
+					.filter(|d| d.message.starts_with("Compiler bug"))
+					.collect::<Vec<_>>();
+				assert_eq!(panic_diags.len(), 0, "Compiler bug detected: {:#?}", panic_diags);
 			} else {
 				assert!(
 					!expect_failure,

--- a/libs/wingc/src/lib.rs
+++ b/libs/wingc/src/lib.rs
@@ -365,7 +365,10 @@ fn is_project_dir_absolute(project_dir: &PathBuf) -> bool {
 
 #[cfg(test)]
 mod sanity {
-	use crate::{compile, diagnostic::get_diagnostics};
+	use crate::{
+		compile,
+		diagnostic::{assert_no_panics},
+	};
 	use std::{
 		fs,
 		path::{Path, PathBuf},
@@ -411,12 +414,7 @@ mod sanity {
 				);
 
 				// Even if the test fails when we expect it to, none of the failures should be due to a compiler bug
-				let diags = get_diagnostics();
-				let panic_diags = diags
-					.iter()
-					.filter(|d| d.message.starts_with("Compiler bug"))
-					.collect::<Vec<_>>();
-				assert_eq!(panic_diags.len(), 0, "Compiler bug detected: {:#?}", panic_diags);
+				assert_no_panics();
 			} else {
 				assert!(
 					!expect_failure,

--- a/libs/wingc/src/lib.rs
+++ b/libs/wingc/src/lib.rs
@@ -365,10 +365,7 @@ fn is_project_dir_absolute(project_dir: &PathBuf) -> bool {
 
 #[cfg(test)]
 mod sanity {
-	use crate::{
-		compile,
-		diagnostic::{assert_no_panics},
-	};
+	use crate::{compile, diagnostic::assert_no_panics};
 	use std::{
 		fs,
 		path::{Path, PathBuf},

--- a/libs/wingc/src/lsp/sync.rs
+++ b/libs/wingc/src/lsp/sync.rs
@@ -8,6 +8,7 @@ use tree_sitter::Tree;
 use crate::closure_transform::ClosureTransformer;
 use crate::diagnostic::{get_diagnostics, reset_diagnostics, Diagnostic};
 use crate::fold::Fold;
+use crate::jsify::JSifier;
 use crate::parser::Parser;
 use crate::type_check;
 use crate::{ast::Scope, type_check::Types, wasm_util::ptr_to_string};
@@ -116,6 +117,16 @@ fn partial_compile(source_file: &str, text: &[u8], jsii_types: &mut TypeSystem) 
 
 	type_check(&mut scope, &mut types, &Path::new(source_file), jsii_types);
 
+	// -- JSIFICATION PHASE --
+
+	// source_file will never be "" because it is the path to the file being compiled and lsp does not allow empty paths
+	let source_path = Path::new(source_file);
+	let app_name = source_path.file_stem().expect("Empty filename").to_str().unwrap();
+	let project_dir = source_path.parent().expect("Empty filename");
+
+	let mut jsifier = JSifier::new(&types, app_name, &project_dir, true);
+	jsifier.jsify(&scope);
+
 	return FileData {
 		contents: String::from_utf8(text.to_vec()).unwrap(),
 		tree,
@@ -131,6 +142,8 @@ pub mod test_utils {
 	use uuid::Uuid;
 
 	use lsp_types::*;
+
+	use crate::diagnostic::get_diagnostics;
 
 	use super::on_document_did_open;
 
@@ -164,6 +177,14 @@ pub mod test_utils {
 				text: content.to_string(),
 			},
 		});
+
+		let diags = get_diagnostics();
+		// none of these should be panics
+		let panic_diags = diags
+			.iter()
+			.filter(|d| d.message.starts_with("Compiler bug"))
+			.collect::<Vec<_>>();
+		assert_eq!(panic_diags.len(), 0, "Compiler bug detected: {:#?}", panic_diags);
 
 		// find the character cursor position by looking for the character above the ^
 		let mut char_pos = 0_i32;

--- a/libs/wingc/src/lsp/sync.rs
+++ b/libs/wingc/src/lsp/sync.rs
@@ -143,7 +143,7 @@ pub mod test_utils {
 
 	use lsp_types::*;
 
-	use crate::diagnostic::{assert_no_panics};
+	use crate::diagnostic::assert_no_panics;
 
 	use super::on_document_did_open;
 

--- a/libs/wingc/src/lsp/sync.rs
+++ b/libs/wingc/src/lsp/sync.rs
@@ -143,7 +143,7 @@ pub mod test_utils {
 
 	use lsp_types::*;
 
-	use crate::diagnostic::get_diagnostics;
+	use crate::diagnostic::{assert_no_panics};
 
 	use super::on_document_did_open;
 
@@ -178,13 +178,7 @@ pub mod test_utils {
 			},
 		});
 
-		let diags = get_diagnostics();
-		// none of these should be panics
-		let panic_diags = diags
-			.iter()
-			.filter(|d| d.message.starts_with("Compiler bug"))
-			.collect::<Vec<_>>();
-		assert_eq!(panic_diags.len(), 0, "Compiler bug detected: {:#?}", panic_diags);
+		assert_no_panics();
 
 		// find the character cursor position by looking for the character above the ^
 		let mut char_pos = 0_i32;


### PR DESCRIPTION
Certain errors were not available in the lsp because we didn't run the jsify phase. This PR changes that and also avoids many panics. 

So far it seems the perf overhead of running jsify in the lsp is minimal. On my PC, it adds between 1ms and 8ms. This time scales with classes/inflight/externs.

## Checklist

- [x] Title matches [Winglang's style guide](https://docs.winglang.io/contributors/pull_requests#how-are-pull-request-titles-formatted)
- [ ] Description explains motivation and solution
- [ ] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.
