### PR TITLE
fix(build): canary job step no-ops on Windows

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -30,6 +30,7 @@ jobs:
           node-version: ${{ matrix.node }}
       - name: Get Latest Wing Version
         id: get-version
+        shell: bash
         run: |
           echo version=$(npm view winglang version) >> $GITHUB_OUTPUT
       - name: Install Wing


### PR DESCRIPTION
The `echo "foo=bar" >> $GITHUB_ENV` syntax doesn't work in powershell, which is the default shell for Windows jobs. Running the the job step in bash should fix it.

## Checklist

- [ ] Title matches [Winglang's style guide](https://docs.winglang.io/contributors/pull_requests#how-are-pull-request-titles-formatted)
- [ ] Description explains motivation and solution
- [ ] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.
