### PR TITLE
fix: windows really wants to load stuff from a floppy drive

### DIFF
--- a/libs/wingcompiler/src/wingc.ts
+++ b/libs/wingcompiler/src/wingc.ts
@@ -99,7 +99,7 @@ export async function load(options: WingCompilerLoadOptions) {
 
     const drives = wmicCommand.stdout
       .split("\r\r\n")
-      .filter((value) => /[A-Za-z]:/.test(value))
+      .filter((value) => /[C-Zc-z]:/.test(value))
       .map((value) => value.trim());
 
     for (const drive of drives) {


### PR DESCRIPTION
Drive A and B are typically reserved for floppy drives. Making sure we have a preopen available for them is error-prone. If someone wants to load their node modules from a floppy then they can file an issue.

See related canary failure https://github.com/winglang/wing/actions/runs/5345295516/jobs/9690782570

## Checklist

- [x] Title matches [Winglang's style guide](https://docs.winglang.io/contributors/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [ ] Tests added (always)
- [ ] Docs updated (only required for features)
- [x] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.
