### PR TITLE
chore(docs): remove `cloud.` from resource topics

### DIFF
--- a/libs/wingsdk/src/cloud/bucket.md
+++ b/libs/wingsdk/src/cloud/bucket.md
@@ -1,5 +1,5 @@
 ---
-title: cloud.Bucket
+title: Bucket
 id: bucket
 description: A built-in resource for handling object storage in the cloud.
 keywords:

--- a/libs/wingsdk/src/cloud/counter.md
+++ b/libs/wingsdk/src/cloud/counter.md
@@ -1,5 +1,5 @@
 ---
-title: cloud.Counter 
+title: Counter 
 id: counter
 description: A built-in resource for representing an container for numbers in the cloud.
 keywords: [Wing reference, Wing language, language, Wing standard library, Wing programming language, Counter]

--- a/libs/wingsdk/src/cloud/secret.md
+++ b/libs/wingsdk/src/cloud/secret.md
@@ -1,5 +1,5 @@
 ---
-title: cloud.Secret 
+title: Secret 
 id: secret
 description: A built-in resource for securely storing secrets in the cloud.
 keywords: [Wing reference, Wing language, language, Wing standard library, Wing programming language, secrets]

--- a/libs/wingsdk/src/cloud/service.md
+++ b/libs/wingsdk/src/cloud/service.md
@@ -1,5 +1,5 @@
 ---
-title: cloud.Service 
+title: Service 
 id: service
 description: A built-in resource for publishing messages to subscribers.
 keywords: [Wing reference, Wing language, language, Wing standard library, Wing programming language, services]

--- a/libs/wingsdk/src/cloud/topic.md
+++ b/libs/wingsdk/src/cloud/topic.md
@@ -1,5 +1,5 @@
 ---
-title: cloud.Topic 
+title: Topic 
 id: topic
 description: A built-in resource for publishing messages to subscribers.
 keywords: [Wing reference, Wing language, language, Wing standard library, Wing programming language, topics]


### PR DESCRIPTION
Since all of them are under "Cloud Library", I don't think we really need the titles to include the `cloud.` prefix in these titles.

## Checklist

- [x] Title matches [Winglang's style guide](https://docs.winglang.io/contributors/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [x] Tests added (always)
- [x] Docs updated (only required for features)
- [x] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.
