### PR TITLE
chore: ensure bundled deps are actually fully bundled on mac

### DIFF
--- a/libs/wingsdk/patches/@aws-sdk+util-utf8-browser+3.259.0.patch
+++ b/libs/wingsdk/patches/@aws-sdk+util-utf8-browser+3.259.0.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/@aws-sdk/util-utf8-browser/package.json b/node_modules/@aws-sdk/util-utf8-browser/package.json
+index f3dd61f..73ec398 100644
+--- a/node_modules/@aws-sdk/util-utf8-browser/package.json
++++ b/node_modules/@aws-sdk/util-utf8-browser/package.json
+@@ -31,7 +31,7 @@
+     }
+   },
+   "files": [
+-    "dist-*"
++    "dist-*/**"
+   ],
+   "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/main/packages/util-utf8-browser",
+   "repository": {

--- a/libs/wingsdk/patches/@aws-sdk+util-utf8-node++@aws-sdk+is-array-buffer+3.201.0.patch
+++ b/libs/wingsdk/patches/@aws-sdk+util-utf8-node++@aws-sdk+is-array-buffer+3.201.0.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/@aws-sdk/util-utf8-node/node_modules/@aws-sdk/is-array-buffer/package.json b/node_modules/@aws-sdk/util-utf8-node/node_modules/@aws-sdk/is-array-buffer/package.json
+index 97e05bc..3ff0894 100644
+--- a/node_modules/@aws-sdk/util-utf8-node/node_modules/@aws-sdk/is-array-buffer/package.json
++++ b/node_modules/@aws-sdk/util-utf8-node/node_modules/@aws-sdk/is-array-buffer/package.json
+@@ -34,7 +34,7 @@
+     }
+   },
+   "files": [
+-    "dist-*"
++    "dist-*/**"
+   ],
+   "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/main/packages/is-array-buffer",
+   "repository": {

--- a/libs/wingsdk/patches/@aws-sdk+util-utf8-node++@aws-sdk+util-buffer-from+3.208.0.patch
+++ b/libs/wingsdk/patches/@aws-sdk+util-utf8-node++@aws-sdk+util-buffer-from+3.208.0.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/@aws-sdk/util-utf8-node/node_modules/@aws-sdk/util-buffer-from/package.json b/node_modules/@aws-sdk/util-utf8-node/node_modules/@aws-sdk/util-buffer-from/package.json
+index 665aa8c..80fce64 100644
+--- a/node_modules/@aws-sdk/util-utf8-node/node_modules/@aws-sdk/util-buffer-from/package.json
++++ b/node_modules/@aws-sdk/util-utf8-node/node_modules/@aws-sdk/util-buffer-from/package.json
+@@ -43,7 +43,7 @@
+     }
+   },
+   "files": [
+-    "dist-*"
++    "dist-*/**"
+   ],
+   "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/main/packages/util-buffer-from",
+   "repository": {

--- a/libs/wingsdk/patches/@aws-sdk+util-utf8-node+3.259.0.patch
+++ b/libs/wingsdk/patches/@aws-sdk+util-utf8-node+3.259.0.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/@aws-sdk/util-utf8-node/package.json b/node_modules/@aws-sdk/util-utf8-node/package.json
+index 6a456a1..9914406 100644
+--- a/node_modules/@aws-sdk/util-utf8-node/package.json
++++ b/node_modules/@aws-sdk/util-utf8-node/package.json
+@@ -44,7 +44,7 @@
+     }
+   },
+   "files": [
+-    "dist-*"
++    "dist-*/**"
+   ],
+   "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/main/packages/util-utf8-node",
+   "repository": {


### PR DESCRIPTION
So you may be looking at the diff and saying out loud "get this disgusting change out of my face" but hold on, I have a reason.

`@aws-sdk/util-utf8-node` and `@aws-sdk/util-utf8-browser` are bundled dependencies of the SDK. Both of them have a typo in the package.json `files` field. `"dist-*"` is supposed to designate all of the `dist-*` folders **and** their content. On linux, this works fine. On mac, it does not include these files. This matters when you try to run the equivalent of the ci on mac (basically `npm pack`) because these packages are missing those files. `"dist-*/**"` works for both OSes, and it's what other `@aws-sdk` do as well.

The reason there are 4 patches is because `@aws-sdk/util-utf8-node` also bundles 2 deps of its own with the same problem lol.

This change does not affect the published result since we use linux for that.

## Checklist

- [x] Title matches [Winglang's style guide](https://docs.winglang.io/contributing/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [ ] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.
