### PR TITLE
chore(vscode): semicolon added to inflight snippet

### DIFF
--- a/libs/wingc/src/lsp/completions.rs
+++ b/libs/wingc/src/lsp/completions.rs
@@ -244,8 +244,8 @@ pub fn on_completion(params: lsp_types::CompletionParams) -> CompletionResponse 
 
 		// lets also add some fun snippets
 		completions.push(CompletionItem {
-			label: "inflight () => {}".to_string(),
-			insert_text: Some("inflight ($1) => {$2}".to_string()),
+			label: "inflight () => {};".to_string(),
+			insert_text: Some("inflight ($1) => {$2};".to_string()),
 			insert_text_format: Some(InsertTextFormat::SNIPPET),
 			kind: Some(CompletionItemKind::SNIPPET),
 			..Default::default()

--- a/libs/wingc/src/lsp/snapshots/completions/empty.snap
+++ b/libs/wingc/src/lsp/snapshots/completions/empty.snap
@@ -45,10 +45,10 @@ source: libs/wingc/src/lsp/completions.rs
   command:
     title: triggerParameterHints
     command: editor.action.triggerParameterHints
-- label: "inflight () => {}"
+- label: "inflight () => {};"
   kind: 15
-  sortText: "ll|inflight () => {}"
-  insertText: "inflight ($1) => {$2}"
+  sortText: "ll|inflight () => {};"
+  insertText: "inflight ($1) => {$2};"
   insertTextFormat: 2
 - label: "test \"\" { }"
   kind: 15

--- a/libs/wingc/src/lsp/snapshots/completions/mut_json_methods.snap
+++ b/libs/wingc/src/lsp/snapshots/completions/mut_json_methods.snap
@@ -53,10 +53,10 @@ source: libs/wingc/src/lsp/completions.rs
   command:
     title: triggerParameterHints
     command: editor.action.triggerParameterHints
-- label: "inflight () => {}"
+- label: "inflight () => {};"
   kind: 15
-  sortText: "ll|inflight () => {}"
-  insertText: "inflight ($1) => {$2}"
+  sortText: "ll|inflight () => {};"
+  insertText: "inflight ($1) => {$2};"
   insertTextFormat: 2
 - label: "test \"\" { }"
   kind: 15

--- a/libs/wingc/src/lsp/snapshots/completions/only_show_symbols_in_scope.snap
+++ b/libs/wingc/src/lsp/snapshots/completions/only_show_symbols_in_scope.snap
@@ -61,10 +61,10 @@ source: libs/wingc/src/lsp/completions.rs
   command:
     title: triggerParameterHints
     command: editor.action.triggerParameterHints
-- label: "inflight () => {}"
+- label: "inflight () => {};"
   kind: 15
-  sortText: "ll|inflight () => {}"
-  insertText: "inflight ($1) => {$2}"
+  sortText: "ll|inflight () => {};"
+  insertText: "inflight ($1) => {$2};"
   insertTextFormat: 2
 - label: "test \"\" { }"
   kind: 15


### PR DESCRIPTION
The inflight snippet completion needs a semicolon at the end.
## Checklist

- [x] Title matches [Winglang's style guide](https://docs.winglang.io/contributing/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [ ] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.
