### PR TITLE
fix(console): show url for api resource when running the console locally

### DIFF
--- a/apps/wing-console/console/app/web/index.tsx
+++ b/apps/wing-console/console/app/web/index.tsx
@@ -9,7 +9,7 @@ ReactDOM.createRoot(document.querySelector("#root")!).render(
     <Console
       trpcUrl="/trpc"
       wsUrl={`ws://${location.host}`}
-      layout={Number(query.get("layout"))}
+      layout={Number(query.get("layout")) || 1} // default to 1 = vscode (2 = playground, 3 = tutorial)
       theme={query.get("theme") as any}
       onTrace={(trace) => {
         // Playground and Learn need to be able to listen to all traces.

--- a/apps/wing-console/console/ui/src/AppContext.ts
+++ b/apps/wing-console/console/ui/src/AppContext.ts
@@ -1,6 +1,6 @@
 import React from "react";
 
-export type AppMode = "webapp" | "electron";
+export type AppMode = "remote" | "local";
 
 export interface AppContextValue {
   appMode: AppMode;
@@ -8,6 +8,6 @@ export interface AppContextValue {
 }
 
 export const AppContext = React.createContext<AppContextValue>({
-  appMode: "electron",
+  appMode: "local",
   title: "Wing Console",
 });

--- a/apps/wing-console/console/ui/src/Console.tsx
+++ b/apps/wing-console/console/ui/src/Console.tsx
@@ -56,8 +56,7 @@ export const Console = ({
 
   let windowTitle = title ?? "Wing Console";
 
-  const appMode = layout === LayoutType.Vscode ? "electron" : "webapp";
-
+  const appMode = layout === LayoutType.Vscode ? "local" : "remote";
   return (
     <AppContext.Provider value={{ appMode, title: windowTitle }}>
       <trpc.Provider client={trpcClient} queryClient={queryClient}>

--- a/apps/wing-console/console/ui/src/ui/api-interaction.tsx
+++ b/apps/wing-console/console/ui/src/ui/api-interaction.tsx
@@ -196,7 +196,7 @@ export const ApiInteraction = ({
   return (
     <div className="h-full flex-1 flex flex-col text-sm space-y-1">
       <div className="relative grow">
-        {appMode !== "webapp" && (
+        {appMode === "local" && (
           <Attribute name="URL" value={url} noLeftPadding />
         )}
         <div className="space-y-2 flex-col grow mt-4">


### PR DESCRIPTION
when running the console locally (`wing it` for example), show the api resource url in the api interaction panel

resolves: https://github.com/winglang/wing/issues/3108

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.
