### PR TITLE
fix(sdk): tryGet optional chaining with nil members

### DIFF
--- a/examples/tests/valid/json.w
+++ b/examples/tests/valid/json.w
@@ -180,3 +180,13 @@ if let truth = jsonElements.tryGet("bools")?.tryGet("t")?.tryAsBool() {
   // This should not happen
   assert(false);
 }
+
+// tryGet Chains where members are missing
+if let val = jsonElements.tryGet("strings")?.tryGet("non")?.tryGet("existant")?.tryGet("element") {
+  assert(false); // nothing should have been found
+}
+
+// tryGetAt chains with missing members
+if let val = jsonElements.tryGet("cant")?.tryGetAt(1000)?.tryGetAt(42) {
+  assert(false); // nothing should have been found
+}

--- a/libs/wingsdk/src/std/json.ts
+++ b/libs/wingsdk/src/std/json.ts
@@ -163,7 +163,7 @@ export class Json {
   /**
    * Optionally returns an specified element from the Json.
    *
-   * @macro ($self$)[$args$]
+   * @macro ($self$)?.[$args$]
    *
    * @param key The key of the element to return
    * @returns The element associated with the specified key, or undefined if the key can't be found
@@ -176,7 +176,7 @@ export class Json {
   /**
    * Optionally returns a specified element at a given index from Json Array
    *
-   * @macro ($self$)[$args$]
+   * @macro ($self$)?.[$args$]
    *
    * @param index The index of the element in the Json Array to return
    * @returns The element at given index in Json Array, or undefined if index is not valid
@@ -320,7 +320,7 @@ export class MutJson {
   /**
    * Optionally returns an specified element from the Json.
    *
-   * @macro ($self$)[$args$]
+   * @macro ($self$)?.[$args$]
    *
    * @param key The key of the element to return
    * @returns The element associated with the specified key, or undefined if the key can't be found
@@ -333,7 +333,7 @@ export class MutJson {
   /**
    * Optionally returns a specified element at a given index from Json Array
    *
-   * @macro ($self$)[$args$]
+   * @macro ($self$)?.[$args$]
    *
    * @param index The index of the element in the Json Array to return
    * @returns The element at given index in Json Array, or undefined if index is not valid

--- a/tools/hangar/__snapshots__/test_corpus/valid/json.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/json.w_compile_tf-aws.md
@@ -141,7 +141,7 @@ class $Root extends $stdlib.std.Resource {
     {((cond) => {if (!cond) throw new Error("assertion failed: unestedJsonArr.getAt(0) == 1")})(((unestedJsonArr)[0] === 1))};
     const jsonElements = Object.freeze({"strings":{"single":"Hello","array":["Hello", "World", "!"]},"numbers":{"one":1,"two":2,"three":3},"bools":{"t":true,"f":false}});
     {
-      const $IF_LET_VALUE = ((arg) => { return (typeof arg === "string") ? JSON.parse(JSON.stringify(arg)) : undefined })(((jsonElements)["strings"])["single"]);
+      const $IF_LET_VALUE = ((arg) => { return (typeof arg === "string") ? JSON.parse(JSON.stringify(arg)) : undefined })(((jsonElements)?.["strings"])?.["single"]);
       if ($IF_LET_VALUE != undefined) {
         const val = $IF_LET_VALUE;
         {((cond) => {if (!cond) throw new Error("assertion failed: val == \"Hello\"")})((val === "Hello"))};
@@ -151,11 +151,11 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     {
-      const $IF_LET_VALUE = ((jsonElements)["strings"])["array"];
+      const $IF_LET_VALUE = ((jsonElements)?.["strings"])?.["array"];
       if ($IF_LET_VALUE != undefined) {
         const vals = $IF_LET_VALUE;
         {
-          const $IF_LET_VALUE = (vals)[0];
+          const $IF_LET_VALUE = (vals)?.[0];
           if ($IF_LET_VALUE != undefined) {
             const hello = $IF_LET_VALUE;
             {((cond) => {if (!cond) throw new Error("assertion failed: hello == \"Hello\"")})((hello === "Hello"))};
@@ -170,7 +170,7 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     {
-      const $IF_LET_VALUE = ((arg) => { return (typeof arg === "number") ? JSON.parse(JSON.stringify(arg)) : undefined })(((jsonElements)["numbers"])["two"]);
+      const $IF_LET_VALUE = ((arg) => { return (typeof arg === "number") ? JSON.parse(JSON.stringify(arg)) : undefined })(((jsonElements)?.["numbers"])?.["two"]);
       if ($IF_LET_VALUE != undefined) {
         const two = $IF_LET_VALUE;
         {((cond) => {if (!cond) throw new Error("assertion failed: two + 2 == 4")})(((two + 2) === 4))};
@@ -180,12 +180,26 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     {
-      const $IF_LET_VALUE = ((arg) => { return (typeof arg === "boolean") ? JSON.parse(JSON.stringify(arg)) : undefined })(((jsonElements)["bools"])["t"]);
+      const $IF_LET_VALUE = ((arg) => { return (typeof arg === "boolean") ? JSON.parse(JSON.stringify(arg)) : undefined })(((jsonElements)?.["bools"])?.["t"]);
       if ($IF_LET_VALUE != undefined) {
         const truth = $IF_LET_VALUE;
         {((cond) => {if (!cond) throw new Error("assertion failed: truth")})(truth)};
       }
       else {
+        {((cond) => {if (!cond) throw new Error("assertion failed: false")})(false)};
+      }
+    }
+    {
+      const $IF_LET_VALUE = ((((jsonElements)?.["strings"])?.["non"])?.["existant"])?.["element"];
+      if ($IF_LET_VALUE != undefined) {
+        const val = $IF_LET_VALUE;
+        {((cond) => {if (!cond) throw new Error("assertion failed: false")})(false)};
+      }
+    }
+    {
+      const $IF_LET_VALUE = (((jsonElements)?.["cant"])?.[1000])?.[42];
+      if ($IF_LET_VALUE != undefined) {
+        const val = $IF_LET_VALUE;
         {((cond) => {if (!cond) throw new Error("assertion failed: false")})(false)};
       }
     }


### PR DESCRIPTION
😅 I forgot to make the optional part optional in javascript for the Json Macros

This uses `?.` to index the objects in javascript when calling `tryGet` or `tryGetAt` on Json and MutJson

Closes: https://github.com/winglang/wing/issues/3106

## Checklist

- [x] Title matches [Winglang's style guide](https://docs.winglang.io/contributing/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [x] Tests added (always)
- [x] Docs updated (only required for features)
- [x] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.
