### PR TITLE
chore: self mutation does not trigger build

### DIFF
--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -14,7 +14,8 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  contents: write
+  contents: read
+  packages: read
   statuses: write
 
 jobs:
@@ -37,6 +38,17 @@ jobs:
         if: steps.download-artifacts.outputs.found_artifact == 'true'
         with:
           github_token: ${{secrets.GITHUB_TOKEN}}
+      - name: Token check
+        if: steps.download-artifacts.outputs.found_artifact == 'true'
+        run: |
+          if ${{ secrets.MUTATION_TOKEN && 'true' || 'false' }}; then
+            echo "Token available, enabling self mutation"
+            exit 0
+          else
+            echo "Add a MUTATION_TOKEN repository secret with a personal access token to enable self mutation.
+            It requires private repo read/write permissions." >> $GITHUB_STEP_SUMMARY
+            exit 1
+          fi
       - name: Disable Git Hooks
         if: steps.download-artifacts.outputs.found_artifact == 'true'
         run: |
@@ -45,7 +57,7 @@ jobs:
         if: steps.download-artifacts.outputs.found_artifact == 'true'
         uses: actions/checkout@v3
         with:
-          token: ${{secrets.GITHUB_TOKEN}}
+          token: ${{secrets.MUTATION_TOKEN}}
           ref: ${{ github.event.workflow_run.head_branch }}
           repository: ${{ github.event.workflow_run.head_repository.full_name }}
           path: repo

--- a/docs/contributing/01-start-here/06-pull-requests.md
+++ b/docs/contributing/01-start-here/06-pull-requests.md
@@ -70,4 +70,4 @@ This label must be present before the build job starts, so if you add it after t
 ## 🧪 How do I set up my PRs to update snapshots?
 
 When PR checks run they may mutate the PR branch with updates to the snapshots or other things you may have missed.
-This behavior has to be enabled manually on forks.
+This behavior has to be enabled manually on forks. Create a repository secret called `MUTATION_TOKEN` with a personal access token that is able to read/write your repo.


### PR DESCRIPTION
Other than security, I now remember the other reason we use a MUTATION_TOKEN rather than GITHUB_TOKEN: Github will not trigger push/pull_request events if a commit is pushed by github actions. We should try to find a way around this, but in the mean time let's go back to using a token

## Checklist

- [x] Title matches [Winglang's style guide](https://docs.winglang.io/contributing/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [ ] Tests added (always)
- [x] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.
