### PR TITLE
fix(console): open external links in the browser directly

### DIFF
--- a/apps/wing-console/console/app/src/index.ts
+++ b/apps/wing-console/console/app/src/index.ts
@@ -4,7 +4,6 @@ import {
   LogInterface,
   Updater,
   Config,
-  HostUtils,
   Trace,
 } from "@wingconsole/server";
 import express from "express";
@@ -13,7 +12,6 @@ export type {
   LogInterface,
   Updater,
   Config,
-  HostUtils,
   UpdaterStatus,
   Trace,
 } from "@wingconsole/server";
@@ -24,7 +22,6 @@ export interface CreateConsoleAppOptions {
   updater?: Updater;
   config?: Config;
   requestedPort?: number;
-  hostUtils?: HostUtils;
   onTrace?: (trace: Trace) => void;
   onExpressCreated?: CreateConsoleServerOptions["onExpressCreated"];
 }

--- a/apps/wing-console/console/server/src/expressServer.ts
+++ b/apps/wing-console/console/server/src/expressServer.ts
@@ -10,7 +10,6 @@ import { WebSocketServer } from "ws";
 
 import { Config } from "./config.js";
 import { ConsoleLogger } from "./consoleLogger.js";
-import { HostUtils } from "./hostUtils.js";
 import { mergeAllRouters } from "./router/index.js";
 import { State } from "./types.js";
 import { Updater } from "./updater.js";
@@ -31,7 +30,6 @@ export interface CreateExpressServerOptions {
   config: Config;
   requestedPort?: number;
   appState(): State;
-  hostUtils?: HostUtils;
   onExpressCreated?: (app: express.Express) => void;
 }
 
@@ -45,7 +43,6 @@ export const createExpressServer = async ({
   config,
   requestedPort,
   appState,
-  hostUtils,
   onExpressCreated,
 }: CreateExpressServerOptions) => {
   const app = express();
@@ -70,7 +67,6 @@ export const createExpressServer = async ({
       updater,
       config,
       appState,
-      hostUtils,
     };
   };
   app.use(

--- a/apps/wing-console/console/server/src/hostUtils.ts
+++ b/apps/wing-console/console/server/src/hostUtils.ts
@@ -1,3 +1,0 @@
-export interface HostUtils {
-  openExternal(url: string): Promise<void>;
-}

--- a/apps/wing-console/console/server/src/index.ts
+++ b/apps/wing-console/console/server/src/index.ts
@@ -6,7 +6,6 @@ import type { Application as ExpressApplication } from "express";
 import type { Config } from "./config.js";
 import { type ConsoleLogger, createConsoleLogger } from "./consoleLogger.js";
 import { createExpressServer } from "./expressServer.js";
-import type { HostUtils } from "./hostUtils.js";
 import type { Router } from "./router/index.js";
 import type { State } from "./types.js";
 import type { Updater } from "./updater.js";
@@ -23,7 +22,6 @@ export type { WingSimulatorSchema, BaseResourceSchema } from "./wingsdk.js";
 export type { Updater, UpdaterStatus } from "./updater.js";
 export type { Config } from "./config.js";
 export type { Router } from "./router/index.js";
-export type { HostUtils } from "./hostUtils.js";
 export type { RouterContext } from "./utils/createRouter.js";
 export type { MapNode, MapEdge } from "./router/app.js";
 export type { InternalTestResult } from "./router/test.js";
@@ -38,7 +36,6 @@ export interface CreateConsoleServerOptions {
   updater?: Updater;
   config: Config;
   requestedPort?: number;
-  hostUtils?: HostUtils;
   onTrace?: (trace: Trace) => void;
   onExpressCreated?: (app: ExpressApplication) => void;
 }
@@ -49,7 +46,6 @@ export const createConsoleServer = async ({
   updater,
   config,
   requestedPort,
-  hostUtils,
   onTrace,
   onExpressCreated,
 }: CreateConsoleServerOptions) => {
@@ -173,7 +169,6 @@ export const createConsoleServer = async ({
     appState() {
       return appState;
     },
-    hostUtils,
     onExpressCreated,
   });
 

--- a/apps/wing-console/console/server/src/router/app.ts
+++ b/apps/wing-console/console/server/src/router/app.ts
@@ -1,8 +1,6 @@
 import { TRPCError } from "@trpc/server";
 import { observable } from "@trpc/server/observable";
 import { Trace } from "@winglang/sdk/lib/cloud/test-runner.js";
-import { ConstructTree } from "@winglang/sdk/lib/core";
-import { ConstructInfo, DisplayInfo } from "@winglang/sdk/lib/core/tree";
 import uniqby from "lodash.uniqby";
 import { z } from "zod";
 
@@ -402,15 +400,6 @@ export const createAppRouter = () => {
     "app.state": createProcedure.query(async ({ ctx }) => {
       return ctx.appState();
     }),
-    "app.openExternal": createProcedure
-      .input(
-        z.object({
-          url: z.string(),
-        }),
-      )
-      .mutation(async ({ ctx, input }) => {
-        await ctx.hostUtils?.openExternal(input.url);
-      }),
   });
 
   return { router };

--- a/apps/wing-console/console/server/src/utils/createRouter.ts
+++ b/apps/wing-console/console/server/src/utils/createRouter.ts
@@ -5,7 +5,6 @@ import Emittery from "emittery";
 
 import { Config } from "../config.js";
 import { ConsoleLogger } from "../consoleLogger.js";
-import { HostUtils } from "../hostUtils.js";
 import { State } from "../types.js";
 import { Updater } from "../updater.js";
 
@@ -38,7 +37,6 @@ export interface RouterContext {
   logger: ConsoleLogger;
   updater?: Updater;
   config?: Config;
-  hostUtils?: HostUtils;
 }
 
 const t = initTRPC.context<RouterContext>().create();

--- a/apps/wing-console/console/ui/src/services/use-open-external.ts
+++ b/apps/wing-console/console/ui/src/services/use-open-external.ts
@@ -1,25 +1,9 @@
-import { useMemo } from "react";
-
-import { trpc } from "./trpc.js";
-
 export const useOpenExternal = () => {
-  const openExternal = trpc["app.openExternal"].useMutation();
-
   const open = (url: string) => {
-    openExternal.mutate({ url });
+    window.open(url, "_blank");
   };
-
-  const isError = useMemo(() => {
-    return openExternal.isError;
-  }, [openExternal.isError]);
-
-  const isLoading = useMemo(() => {
-    return openExternal.isLoading;
-  }, [openExternal.isLoading]);
 
   return {
     open,
-    isLoading,
-    isError,
   };
 };


### PR DESCRIPTION
Stops relying on the server to open external links.

Fixes #3066.