### PR TITLE
fix(console): open url in external browser window

### DIFF
--- a/apps/wing-console/console/app/scripts/dev.mjs
+++ b/apps/wing-console/console/app/scripts/dev.mjs
@@ -28,6 +28,11 @@ const { port } = await createConsoleServer({
     },
     set(key, value) {},
   },
+  hostUtils: {
+    async openExternal(url) {
+      await open(url);
+    },
+  },
 });
 
 await open(`http://localhost:${port}`);

--- a/apps/wing-console/console/app/scripts/preview.mjs
+++ b/apps/wing-console/console/app/scripts/preview.mjs
@@ -8,5 +8,10 @@ const { port } = await createConsoleApp({
   wingfile: fileURLToPath(
     new URL("../../desktop/demo/index.w", import.meta.url),
   ),
+  hostUtils: {
+    async openExternal(url) {
+      await open(url);
+    },
+  },
 });
 await open(`http://localhost:${port}`);


### PR DESCRIPTION
console dev scripts didn't provide the proper hosting utils functions to open url in external browser windows
resolves: https://github.com/winglang/wing/issues/3066

## Checklist

- [x] Title matches [Winglang's style guide](https://docs.winglang.io/contributing/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [ ] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.
