### PR TITLE
feat(console): website resource

### DIFF
--- a/apps/wing-console/console/design-system/src/utils/icon-utils.ts
+++ b/apps/wing-console/console/design-system/src/utils/icon-utils.ts
@@ -50,7 +50,7 @@ export const getResourceIconComponent = (
     case "wingsdk.cloud.Queue": {
       return solid ? SolidQueueListIcon : QueueListIcon;
     }
-    case "wingsdk.cloud.Website": // todo [sa] search for icon
+    case "wingsdk.cloud.Website":
     case "wingsdk.cloud.Endpoint": {
       return solid ? SolidGlobeAltIcon : GlobeAltIcon;
     }

--- a/apps/wing-console/console/design-system/src/utils/icon-utils.ts
+++ b/apps/wing-console/console/design-system/src/utils/icon-utils.ts
@@ -50,6 +50,7 @@ export const getResourceIconComponent = (
     case "wingsdk.cloud.Queue": {
       return solid ? SolidQueueListIcon : QueueListIcon;
     }
+    case "wingsdk.cloud.Website": // todo [sa] search for icon
     case "wingsdk.cloud.Endpoint": {
       return solid ? SolidGlobeAltIcon : GlobeAltIcon;
     }
@@ -164,6 +165,14 @@ export const getResourceIconColors = (options: {
         options.darkenOnGroupHover &&
           "group-hover:text-red-700 dark:group-hover:text-red-300",
         options.forceDarken && "text-red-700 dark:text-red-300",
+      ];
+    }
+    case "wingsdk.cloud.Website": {
+      return [
+        "text-violet-700 dark:text-violet-400",
+        options.darkenOnGroupHover &&
+        "group-hover:text-violet-700 dark:group-hover:text-violet-300",
+        options.forceDarken && "text-violet-700 dark:text-violet-300",
       ];
     }
     default: {

--- a/apps/wing-console/console/server/src/router/index.ts
+++ b/apps/wing-console/console/server/src/router/index.ts
@@ -11,6 +11,7 @@ import { createRedisRouter } from "./redis.js";
 import { createTableRouter } from "./table.js";
 import { createTestRouter } from "./test.js";
 import { createTopicRouter } from "./topic.js";
+import { createWebsiteRouter } from "./website.js";
 import { createUpdaterRouter } from "./updater.js";
 
 export const mergeAllRouters = () => {
@@ -28,6 +29,7 @@ export const mergeAllRouters = () => {
     createTableRouter(),
     createUpdaterRouter(),
     createRedisRouter(),
+    createWebsiteRouter(),
     createConfigRouter(),
   );
 

--- a/apps/wing-console/console/server/src/router/website.ts
+++ b/apps/wing-console/console/server/src/router/website.ts
@@ -1,24 +1,24 @@
-import {createProcedure, createRouter} from "../utils/createRouter";
-import {z} from "zod";
-import {WebsiteSchema} from "../wingsdk.js";
+import { createProcedure, createRouter } from "../utils/createRouter";
+import { z } from "zod";
+import { WebsiteSchema } from "../wingsdk.js";
 
 export const createWebsiteRouter = () => {
-   return createRouter({
+  return createRouter({
     "website.url": createProcedure
-        .input(
-            z.object({
-                resourcePath: z.string(),
-            }),
-        )
-        .query(async ({ input, ctx }) => {
-            const simulator = await ctx.simulator();
-            const config = simulator.getResourceConfig(
-                input.resourcePath,
-            ) as WebsiteSchema;
-            if (!config || !config.attrs?.url) {
-                return "";
-            }
-            return config.attrs.url;
-        })
-   });
-}
+      .input(
+        z.object({
+          resourcePath: z.string(),
+        }),
+      )
+      .query(async ({ input, ctx }) => {
+        const simulator = await ctx.simulator();
+        const config = simulator.getResourceConfig(
+          input.resourcePath,
+        ) as WebsiteSchema;
+        if (!config || !config.attrs?.url) {
+          return "";
+        }
+        return config.attrs.url;
+      }),
+  });
+};

--- a/apps/wing-console/console/server/src/router/website.ts
+++ b/apps/wing-console/console/server/src/router/website.ts
@@ -1,0 +1,24 @@
+import {createProcedure, createRouter} from "../utils/createRouter";
+import {z} from "zod";
+import {WebsiteSchema} from "../wingsdk.js";
+
+export const createWebsiteRouter = () => {
+   return createRouter({
+    "website.url": createProcedure
+        .input(
+            z.object({
+                resourcePath: z.string(),
+            }),
+        )
+        .query(async ({ input, ctx }) => {
+            const simulator = await ctx.simulator();
+            const config = simulator.getResourceConfig(
+                input.resourcePath,
+            ) as WebsiteSchema;
+            if (!config || !config.attrs?.url) {
+                return "";
+            }
+            return config.attrs.url;
+        })
+   });
+}

--- a/apps/wing-console/console/server/src/utils/createRouter.ts
+++ b/apps/wing-console/console/server/src/utils/createRouter.ts
@@ -17,6 +17,7 @@ export type QueryNames = {
     | "queue.approxSize"
     | "updater.currentStatus"
     | "config.getThemeMode"
+    | "website.url"
     | undefined;
 };
 

--- a/apps/wing-console/console/server/src/wingsdk.ts
+++ b/apps/wing-console/console/server/src/wingsdk.ts
@@ -23,4 +23,5 @@ export type { IRedisClient } from "@winglang/sdk/lib/redis/index.js";
 export type {
   ApiSchema,
   TableSchema,
+  WebsiteSchema,
 } from "@winglang/sdk/lib/target-sim/schema-resources.js";

--- a/apps/wing-console/console/ui/src/features/resource-interaction-view.tsx
+++ b/apps/wing-console/console/ui/src/features/resource-interaction-view.tsx
@@ -8,7 +8,7 @@ import { ScheduleInteractionView } from "./schedule-interaction-view.js";
 import { TableInteractionView } from "./table-interaction-view.js";
 import { TopicInteractionView } from "./topic-interaction-view.js";
 import { UnsupportedInteractionView } from "./unsupported-interaction-view.js";
-import {WebsiteInteractionView} from "./website-interaction-view";
+import { WebsiteInteractionView } from "./website-interaction-view";
 
 export interface ResourceViewProps {
   resourceType: string;

--- a/apps/wing-console/console/ui/src/features/resource-interaction-view.tsx
+++ b/apps/wing-console/console/ui/src/features/resource-interaction-view.tsx
@@ -8,6 +8,7 @@ import { ScheduleInteractionView } from "./schedule-interaction-view.js";
 import { TableInteractionView } from "./table-interaction-view.js";
 import { TopicInteractionView } from "./topic-interaction-view.js";
 import { UnsupportedInteractionView } from "./unsupported-interaction-view.js";
+import {WebsiteInteractionView} from "./website-interaction-view";
 
 export interface ResourceViewProps {
   resourceType: string;
@@ -45,6 +46,9 @@ export const ResourceInteractionView = ({
       }
       case "wingsdk.redis.Redis": {
         return <RedisInteractionView resourcePath={resourcePath} />;
+      }
+      case "wingsdk.cloud.Website": {
+        return <WebsiteInteractionView resourcePath={resourcePath} />;
       }
       default: {
         return <UnsupportedInteractionView resourceType={resourceType} />;

--- a/apps/wing-console/console/ui/src/features/website-interaction-view.tsx
+++ b/apps/wing-console/console/ui/src/features/website-interaction-view.tsx
@@ -1,18 +1,18 @@
-import {WebsiteInteraction} from "../ui/website-interaction";
-import {useContext} from "react";
-import {AppContext} from "../AppContext";
-import {useOpenExternal} from "../services/use-open-external";
-import {useWebsite} from "../services/use-website";
+import { WebsiteInteraction } from "../ui/website-interaction";
+import { useContext } from "react";
+import { AppContext } from "../AppContext";
+import { useOpenExternal } from "../services/use-open-external";
+import { useWebsite } from "../services/use-website";
 
 export interface WebsiteInteractionViewProps {
-    resourcePath: string;
+  resourcePath: string;
 }
-export const WebsiteInteractionView = ({resourcePath}: WebsiteInteractionViewProps) => {
-    const { appMode } = useContext(AppContext);
-    const {open} = useOpenExternal();
-    const {url} = useWebsite({resourcePath});
+export const WebsiteInteractionView = ({
+  resourcePath,
+}: WebsiteInteractionViewProps) => {
+  const { appMode } = useContext(AppContext);
+  const { open } = useOpenExternal();
+  const { url } = useWebsite({ resourcePath });
 
-    return (
-        <WebsiteInteraction appMode={appMode} onUrlClick={open} url={url} />
-    );
-}
+  return <WebsiteInteraction appMode={appMode} onUrlClick={open} url={url} />;
+};

--- a/apps/wing-console/console/ui/src/features/website-interaction-view.tsx
+++ b/apps/wing-console/console/ui/src/features/website-interaction-view.tsx
@@ -1,0 +1,18 @@
+import {WebsiteInteraction} from "../ui/website-interaction";
+import {useContext} from "react";
+import {AppContext} from "../AppContext";
+import {useOpenExternal} from "../services/use-open-external";
+import {useWebsite} from "../services/use-website";
+
+export interface WebsiteInteractionViewProps {
+    resourcePath: string;
+}
+export const WebsiteInteractionView = ({resourcePath}: WebsiteInteractionViewProps) => {
+    const { appMode } = useContext(AppContext);
+    const {open} = useOpenExternal();
+    const {url} = useWebsite({resourcePath});
+
+    return (
+        <WebsiteInteraction appMode={appMode} onUrlClick={open} url={url} />
+    );
+}

--- a/apps/wing-console/console/ui/src/services/use-website.ts
+++ b/apps/wing-console/console/ui/src/services/use-website.ts
@@ -1,0 +1,18 @@
+import {trpc} from "./trpc.js";
+import {useEffect, useState} from "react";
+
+export interface UseWebsiteOptions {
+    resourcePath: string;
+}
+export const useWebsite = ({ resourcePath }: UseWebsiteOptions) => {
+    const websiteUrl = trpc["website.url"].useQuery({ resourcePath });
+    const [url, setUrl] = useState("");
+
+    useEffect(() => {
+        setUrl(websiteUrl.data ?? "");
+    }, [websiteUrl.data]);
+
+    return {
+        url
+    }
+}

--- a/apps/wing-console/console/ui/src/services/use-website.ts
+++ b/apps/wing-console/console/ui/src/services/use-website.ts
@@ -1,18 +1,18 @@
-import {trpc} from "./trpc.js";
-import {useEffect, useState} from "react";
+import { trpc } from "./trpc.js";
+import { useEffect, useState } from "react";
 
 export interface UseWebsiteOptions {
-    resourcePath: string;
+  resourcePath: string;
 }
 export const useWebsite = ({ resourcePath }: UseWebsiteOptions) => {
-    const websiteUrl = trpc["website.url"].useQuery({ resourcePath });
-    const [url, setUrl] = useState("");
+  const websiteUrl = trpc["website.url"].useQuery({ resourcePath });
+  const [url, setUrl] = useState("");
 
-    useEffect(() => {
-        setUrl(websiteUrl.data ?? "");
-    }, [websiteUrl.data]);
+  useEffect(() => {
+    setUrl(websiteUrl.data ?? "");
+  }, [websiteUrl.data]);
 
-    return {
-        url
-    }
-}
+  return {
+    url,
+  };
+};

--- a/apps/wing-console/console/ui/src/ui/elk-map-nodes.tsx
+++ b/apps/wing-console/console/ui/src/ui/elk-map-nodes.tsx
@@ -37,6 +37,9 @@ const getResourceBorderColor = (
     case "wingsdk.redis.Redis": {
       return "border-t-[3px] border-t-red-700 group-hover:border-t-red-700 group-focus:border-t-red-700 dark:border-t-red-700 dark:group-hover:border-t-red-700 dark:group-focus:border-t-red-700";
     }
+    case "wingsdk.cloud.Website": {
+      return "border-t-[3px] border-t-violet-500 group-hover:border-t-violet-500 group-focus:border-t-violet-500 dark:border-t-violet-500 dark:group-hover:border-t-violet-500 dark:group-focus:border-t-violet-500";
+    }
   }
 };
 

--- a/apps/wing-console/console/ui/src/ui/website-interaction.tsx
+++ b/apps/wing-console/console/ui/src/ui/website-interaction.tsx
@@ -1,28 +1,35 @@
-import {Attribute, useTheme} from "@wingconsole/design-system";
-import {ArrowTopRightOnSquareIcon} from "@heroicons/react/24/solid"
+import { Attribute, useTheme } from "@wingconsole/design-system";
+import { ArrowTopRightOnSquareIcon } from "@heroicons/react/24/solid";
 import { AppMode } from "../AppContext.js";
 import classNames from "classnames";
 
 export interface WebsiteInteractionProps {
-    url: string;
-    appMode: AppMode;
-    onUrlClick: (url: string) => void;
+  url: string;
+  appMode: AppMode;
+  onUrlClick: (url: string) => void;
 }
-export const WebsiteInteraction = ({appMode, url, onUrlClick}: WebsiteInteractionProps) => {
-    const {theme} = useTheme();
-    return (
-        <div className="h-full flex-1 flex flex-col text-sm space-y-1">
-            <div className="relative grow flex-row flex items-center">
-                {appMode === "local" && (
-                    <>
-                        <Attribute name="URL" value={url} noLeftPadding />
-                        <ArrowTopRightOnSquareIcon
-                            className={classNames(theme.text2, "text-sm flex ml-2 h-4 w-4 cursor-pointer")}
-                            onClick={() => onUrlClick(url)}
-                        />
-                    </>
-                )}
-            </div>
-        </div>
-    );
-}
+export const WebsiteInteraction = ({
+  appMode,
+  url,
+  onUrlClick,
+}: WebsiteInteractionProps) => {
+  const { theme } = useTheme();
+  return (
+    <div className="h-full flex-1 flex flex-col text-sm space-y-1">
+      <div className="relative grow flex-row flex items-center">
+        {appMode === "local" && (
+          <>
+            <Attribute name="URL" value={url} noLeftPadding />
+            <ArrowTopRightOnSquareIcon
+              className={classNames(
+                theme.text2,
+                "text-sm flex ml-2 h-4 w-4 cursor-pointer",
+              )}
+              onClick={() => onUrlClick(url)}
+            />
+          </>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/apps/wing-console/console/ui/src/ui/website-interaction.tsx
+++ b/apps/wing-console/console/ui/src/ui/website-interaction.tsx
@@ -1,0 +1,28 @@
+import {Attribute, useTheme} from "@wingconsole/design-system";
+import {ArrowTopRightOnSquareIcon} from "@heroicons/react/24/solid"
+import { AppMode } from "../AppContext.js";
+import classNames from "classnames";
+
+export interface WebsiteInteractionProps {
+    url: string;
+    appMode: AppMode;
+    onUrlClick: (url: string) => void;
+}
+export const WebsiteInteraction = ({appMode, url, onUrlClick}: WebsiteInteractionProps) => {
+    const {theme} = useTheme();
+    return (
+        <div className="h-full flex-1 flex flex-col text-sm space-y-1">
+            <div className="relative grow flex-row flex items-center">
+                {appMode === "local" && (
+                    <>
+                        <Attribute name="URL" value={url} noLeftPadding />
+                        <ArrowTopRightOnSquareIcon
+                            className={classNames(theme.text2, "text-sm flex ml-2 h-4 w-4 cursor-pointer")}
+                            onClick={() => onUrlClick(url)}
+                        />
+                    </>
+                )}
+            </div>
+        </div>
+    );
+}


### PR DESCRIPTION
add website resource support to the console.
users can open the website url in a different browser tab from the website resource interaction view

resolves: https://github.com/winglang/wing/issues/2973

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.
