### PR TITLE
fix(cli): logging stdout

### DIFF
--- a/apps/wing/src/commands/test.ts
+++ b/apps/wing/src/commands/test.ts
@@ -103,14 +103,16 @@ function printResults(
   // prints a summary of how many tests passed and failed
   results.push(" ");
   results.push(
-    `${chalk.dim("Tests")}${failingTestsNumber ? chalk.red(` ${failingTestsNumber} failed`) : ""}${failingTestsNumber && passingTestsNumber ? chalk.dim(" |") : ""
+    `${chalk.dim("Tests")}${failingTestsNumber ? chalk.red(` ${failingTestsNumber} failed`) : ""}${
+      failingTestsNumber && passingTestsNumber ? chalk.dim(" |") : ""
     }${passingTestsNumber ? chalk.green(` ${passingTestsNumber} passed`) : ""} ${chalk.dim(
       `(${failingTestsNumber + passingTestsNumber})`
     )}`
   );
   // prints a summary of how many tests files passed and failed
   results.push(
-    `${chalk.dim("Test Files")}${failing.length ? chalk.red(` ${failing.length} failed`) : ""}${failing.length && passing.length ? chalk.dim(" |") : ""
+    `${chalk.dim("Test Files")}${failing.length ? chalk.red(` ${failing.length} failed`) : ""}${
+      failing.length && passing.length ? chalk.dim(" |") : ""
     }${passing.length ? chalk.green(` ${passing.length} passed`) : ""} ${chalk.dim(
       `(${totalSum})`
     )}`
@@ -479,5 +481,6 @@ async function execCapture(command: string, options: { cwd: string }) {
   if (stderr) {
     throw new Error(stderr);
   }
+  log(stdout);
   return stdout;
 }


### PR DESCRIPTION
for debugging why does the SDK spec tests command fail

## Checklist

- [x] Title matches [Winglang's style guide](https://docs.winglang.io/contributing/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [ ] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.
