### PR TITLE
chore(docs): make all documentation folders linkable

### DIFF
--- a/docs/docs/02-concepts/_category_.yml
+++ b/docs/docs/02-concepts/_category_.yml
@@ -1,3 +1,6 @@
 label: Core concepts
 collapsible: true
 collapsed: true
+link:
+  type: generated-index
+  title: Wing core concepts

--- a/docs/docs/03-language-guide/_category_.yml
+++ b/docs/docs/03-language-guide/_category_.yml
@@ -1,3 +1,6 @@
 label: Language guide
 collapsible: true
 collapsed: true
+link:
+  type: generated-index
+  title: Wing language guide

--- a/docs/docs/04-standard-library/_category_.yml
+++ b/docs/docs/04-standard-library/_category_.yml
@@ -1,3 +1,6 @@
 label: Standard library
 collapsible: true
 collapsed: true
+link:
+  type: generated-index
+  title: Wing standard library

--- a/docs/docs/06-tools/_category_.yml
+++ b/docs/docs/06-tools/_category_.yml
@@ -1,3 +1,6 @@
 label: Tools
 collapsible: true
 collapsed: true
+link:
+  type: generated-index
+  title: Wing tools

--- a/docs/docs/07-examples/_category_.yml
+++ b/docs/docs/07-examples/_category_.yml
@@ -1,3 +1,6 @@
 label: Examples
 collapsible: true
 collapsed: true
+link:
+  type: generated-index
+  title: Wing examples

--- a/docs/docs/08-guides/_category_.yml
+++ b/docs/docs/08-guides/_category_.yml
@@ -1,3 +1,6 @@
 label: Guides
 collapsible: true
 collapsed: true
+link:
+  type: generated-index
+  title: Wing guides


### PR DESCRIPTION
This PR makes all the documentation folders linkable so we can direct to them from tutorials and elswhere.
For example, we'd like to link to the documentation of Wing's core concepts from the main tutorial. With this tutorial the link would be to https://winglang.io/docs/core-concepts

## Checklist

- [x] Title matches [Winglang's style guide](https://docs.winglang.io/contributing/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [ ] Tests added (always)
- [x] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.
