### PR TITLE
fix: build should be triggered when changing libs/wingsdk/src/cloud/ md files

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,10 +5,11 @@ on:
     types:
       - opened
       - synchronize
-    paths-ignore:
-      - "docs/**"
-      - "logo/**"
-      - "*.md"
+    paths:
+      - "!docs/**"
+      - "!logo/**"
+      - "!*.md"
+      - "libs/wingsdk/src/cloud/*.md"
   push:
     branches:
       - main


### PR DESCRIPTION
Before this PR build automation was not trigger on libs/wingsdk/src/cloud/*.md which caused issues (for example https://github.com/winglang/wing/actions/runs/5452545128)

Used paths instead of ignore paths following this doc (https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-including-and-excluding-paths) don't know how to test this

## Checklist

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [ ] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://www.winglang.io/terms-and-policies/contribution-license.html)*.
