### PR TITLE
feat(vscode): insert `?.` automatically and ensure structs and enums show up in type completions

### DIFF
--- a/libs/wingc/src/lsp/completions.rs
+++ b/libs/wingc/src/lsp/completions.rs
@@ -1,6 +1,6 @@
 use lsp_types::{
 	Command, CompletionItem, CompletionItemKind, CompletionResponse, Documentation, InsertTextFormat, MarkupContent,
-	MarkupKind,
+	MarkupKind, Position, Range, TextEdit,
 };
 use std::cmp::max;
 use tree_sitter::Point;
@@ -92,7 +92,25 @@ pub fn on_completion(params: lsp_types::CompletionParams) -> CompletionResponse 
 						}
 					}
 
-					return get_completions_from_type(&nearest_expr_type, types, Some(found_env.phase), true);
+					let mut completions = get_completions_from_type(&nearest_expr_type, types, Some(found_env.phase), true);
+					if nearest_expr_type.is_option() && node_to_complete.kind() == "." {
+						let extra_insert_position = Position {
+							character: node_to_complete.start_position().column as u32,
+							line: node_to_complete.start_position().row as u32,
+						};
+						let extra_edit = Some(vec![TextEdit {
+							new_text: "?.".to_string(),
+							range: Range {
+								start: extra_insert_position,
+								end: extra_insert_position,
+							},
+						}]);
+						for completion in completions.iter_mut() {
+							completion.additional_text_edits = extra_edit.clone();
+						}
+					}
+
+					return completions;
 				}
 			}
 
@@ -279,13 +297,16 @@ pub fn on_completion(params: lsp_types::CompletionParams) -> CompletionResponse 
 		}
 
 		if in_type {
-			// show only namespaces and types
+			// show only namespaces, types,
 			completions
 				.into_iter()
 				.filter(|c| {
 					matches!(
 						c.kind,
-						Some(CompletionItemKind::CLASS) | Some(CompletionItemKind::MODULE)
+						Some(CompletionItemKind::CLASS)
+							| Some(CompletionItemKind::MODULE)
+							| Some(CompletionItemKind::ENUM)
+							| Some(CompletionItemKind::STRUCT)
 					)
 				})
 				.collect()
@@ -1006,5 +1027,27 @@ j.tryGet("")?.
             //^
 "#,
 		assert!(!optional_chaining.is_empty())
+	);
+
+	test_completion_list!(
+		optional_chaining_auto,
+		r#"
+let j = Json {};
+j.tryGet("").
+           //^
+"#,
+		assert!(!optional_chaining_auto.is_empty())
+	);
+
+	test_completion_list!(
+		type_annotation_shows_struct,
+		r#"
+struct Foo {}
+
+let x: 
+    //^
+"#,
+		assert!(type_annotation_shows_struct.len() == 1)
+		assert!(type_annotation_shows_struct.get(0).unwrap().label == "Foo")
 	);
 }

--- a/libs/wingc/src/lsp/snapshots/completions/optional_chaining_auto.snap
+++ b/libs/wingc/src/lsp/snapshots/completions/optional_chaining_auto.snap
@@ -1,0 +1,204 @@
+---
+source: libs/wingc/src/lsp/completions.rs
+---
+- label: asBool
+  kind: 2
+  documentation:
+    kind: markdown
+    value: "```wing\n asBool: (): bool\n```\n---\nConvert Json element to number if possible.\n\n### Returns\na string."
+  sortText: ff|asBool
+  insertText: asBool($0)
+  insertTextFormat: 2
+  additionalTextEdits:
+    - range:
+        start:
+          line: 2
+          character: 12
+        end:
+          line: 2
+          character: 12
+      newText: "?."
+  command:
+    title: triggerParameterHints
+    command: editor.action.triggerParameterHints
+- label: asNum
+  kind: 2
+  documentation:
+    kind: markdown
+    value: "```wing\n asNum: (): num\n```\n---\nConvert Json element to number if possible.\n\n### Returns\na string."
+  sortText: ff|asNum
+  insertText: asNum($0)
+  insertTextFormat: 2
+  additionalTextEdits:
+    - range:
+        start:
+          line: 2
+          character: 12
+        end:
+          line: 2
+          character: 12
+      newText: "?."
+  command:
+    title: triggerParameterHints
+    command: editor.action.triggerParameterHints
+- label: asStr
+  kind: 2
+  documentation:
+    kind: markdown
+    value: "```wing\n asStr: (): str\n```\n---\nConvert Json element to string if possible.\n\n### Returns\na string."
+  sortText: ff|asStr
+  insertText: asStr($0)
+  insertTextFormat: 2
+  additionalTextEdits:
+    - range:
+        start:
+          line: 2
+          character: 12
+        end:
+          line: 2
+          character: 12
+      newText: "?."
+  command:
+    title: triggerParameterHints
+    command: editor.action.triggerParameterHints
+- label: get
+  kind: 2
+  documentation:
+    kind: markdown
+    value: "```wing\n get: (key: str): Json\n```\n---\nReturns a specified element from the Json.\n\n### Parameters\n - *key* - The key of the element to return.\n\n### Returns\nThe element associated with the specified key, or undefined if the key can't be found"
+  sortText: ff|get
+  insertText: get($0)
+  insertTextFormat: 2
+  additionalTextEdits:
+    - range:
+        start:
+          line: 2
+          character: 12
+        end:
+          line: 2
+          character: 12
+      newText: "?."
+  command:
+    title: triggerParameterHints
+    command: editor.action.triggerParameterHints
+- label: getAt
+  kind: 2
+  documentation:
+    kind: markdown
+    value: "```wing\n getAt: (index: num): Json\n```\n---\nReturns a specified element at a given index from Json Array.\n\n### Parameters\n - *index* - The index of the element in the Json Array to return.\n\n### Returns\nThe element at given index in Json Array, or undefined if index is not valid"
+  sortText: ff|getAt
+  insertText: getAt($0)
+  insertTextFormat: 2
+  additionalTextEdits:
+    - range:
+        start:
+          line: 2
+          character: 12
+        end:
+          line: 2
+          character: 12
+      newText: "?."
+  command:
+    title: triggerParameterHints
+    command: editor.action.triggerParameterHints
+- label: tryAsBool
+  kind: 2
+  documentation:
+    kind: markdown
+    value: "```wing\n tryAsBool: (): bool?\n```\n---\nConvert Json element to boolean if possible.\n\n### Returns\na string."
+  sortText: ff|tryAsBool
+  insertText: tryAsBool($0)
+  insertTextFormat: 2
+  additionalTextEdits:
+    - range:
+        start:
+          line: 2
+          character: 12
+        end:
+          line: 2
+          character: 12
+      newText: "?."
+  command:
+    title: triggerParameterHints
+    command: editor.action.triggerParameterHints
+- label: tryAsNum
+  kind: 2
+  documentation:
+    kind: markdown
+    value: "```wing\n tryAsNum: (): num?\n```\n---\nConvert Json element to string if possible.\n\n### Returns\na string."
+  sortText: ff|tryAsNum
+  insertText: tryAsNum($0)
+  insertTextFormat: 2
+  additionalTextEdits:
+    - range:
+        start:
+          line: 2
+          character: 12
+        end:
+          line: 2
+          character: 12
+      newText: "?."
+  command:
+    title: triggerParameterHints
+    command: editor.action.triggerParameterHints
+- label: tryAsStr
+  kind: 2
+  documentation:
+    kind: markdown
+    value: "```wing\n tryAsStr: (): str?\n```\n---\nConvert Json element to string if possible.\n\n### Returns\na string."
+  sortText: ff|tryAsStr
+  insertText: tryAsStr($0)
+  insertTextFormat: 2
+  additionalTextEdits:
+    - range:
+        start:
+          line: 2
+          character: 12
+        end:
+          line: 2
+          character: 12
+      newText: "?."
+  command:
+    title: triggerParameterHints
+    command: editor.action.triggerParameterHints
+- label: tryGet
+  kind: 2
+  documentation:
+    kind: markdown
+    value: "```wing\n tryGet: (key: str): Json?\n```\n---\nOptionally returns an specified element from the Json.\n\n### Parameters\n - *key* - The key of the element to return.\n\n### Returns\nThe element associated with the specified key, or undefined if the key can't be found"
+  sortText: ff|tryGet
+  insertText: tryGet($0)
+  insertTextFormat: 2
+  additionalTextEdits:
+    - range:
+        start:
+          line: 2
+          character: 12
+        end:
+          line: 2
+          character: 12
+      newText: "?."
+  command:
+    title: triggerParameterHints
+    command: editor.action.triggerParameterHints
+- label: tryGetAt
+  kind: 2
+  documentation:
+    kind: markdown
+    value: "```wing\n tryGetAt: (index: num): Json?\n```\n---\nOptionally returns a specified element at a given index from Json Array.\n\n### Parameters\n - *index* - The index of the element in the Json Array to return.\n\n### Returns\nThe element at given index in Json Array, or undefined if index is not valid"
+  sortText: ff|tryGetAt
+  insertText: tryGetAt($0)
+  insertTextFormat: 2
+  additionalTextEdits:
+    - range:
+        start:
+          line: 2
+          character: 12
+        end:
+          line: 2
+          character: 12
+      newText: "?."
+  command:
+    title: triggerParameterHints
+    command: editor.action.triggerParameterHints
+

--- a/libs/wingc/src/lsp/snapshots/completions/type_annotation_shows_struct.snap
+++ b/libs/wingc/src/lsp/snapshots/completions/type_annotation_shows_struct.snap
@@ -1,0 +1,10 @@
+---
+source: libs/wingc/src/lsp/completions.rs
+---
+- label: Foo
+  kind: 22
+  documentation:
+    kind: markdown
+    value: "```wing\nFoo\n```\n---"
+  sortText: hh|Foo
+


### PR DESCRIPTION
https://github.com/winglang/wing/assets/1237390/b86d3748-7d83-4c6b-a163-589afad01cda

Fixes #3143
Fixes #3306

## Checklist

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [x] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://www.winglang.io/terms-and-policies/contribution-license.html)*.
