### PR TITLE
feat(cli): collect analytics

### DIFF
--- a/apps/wing/package.json
+++ b/apps/wing/package.json
@@ -38,6 +38,8 @@
     "ora": "^5.4.1",
     "update-notifier": "^6.0.2",
     "vscode-languageserver": "^8.0.2",
+    "uuid": "^8.3.2",
+    "@segment/analytics-node": "^1.0.0",
     "@wingconsole/app": "workspace:^",
     "@winglang/compiler": "workspace:^",
     "@winglang/sdk": "workspace:^"
@@ -48,6 +50,7 @@
     "@types/node-persist": "^3.1.3",
     "@types/semver-utils": "^1.1.1",
     "@types/update-notifier": "^6.0.1",
+    "@types/uuid": "^9.0.1",
     "bump-pack": "workspace:^",
     "esbuild": "^0.17.19",
     "typescript": "^4.9.4",

--- a/apps/wing/package.json
+++ b/apps/wing/package.json
@@ -50,7 +50,7 @@
     "@types/node-persist": "^3.1.3",
     "@types/semver-utils": "^1.1.1",
     "@types/update-notifier": "^6.0.1",
-    "@types/uuid": "^9.0.1",
+    "@types/uuid": "^8.3.2",
     "bump-pack": "workspace:^",
     "esbuild": "^0.17.19",
     "typescript": "^4.9.4",

--- a/apps/wing/src/analytics/collect.ts
+++ b/apps/wing/src/analytics/collect.ts
@@ -23,7 +23,6 @@ export async function collectCommandAnalytics(cmd: Command): Promise<string> {
   let event: AnalyticEvent = {
     event: `wing cli:${cmd.name()}`,
     properties: {
-      inCI: CICollector.inCI(),
       cli: await cliCollector.collect(),
       os: await osCollector.collect(),
       node: await nodeCollector.collect(),

--- a/apps/wing/src/analytics/collect.ts
+++ b/apps/wing/src/analytics/collect.ts
@@ -5,6 +5,7 @@ import { NodeCollector } from "./collectors/node-collector";
 import { CLICollector } from "./collectors/cli-collector";
 import { CICollector } from "./collectors/ci-collector";
 import { AnalyticsStorage } from "./storage";
+import { GitCollector } from "./collectors/git-collector";
 
 
 /**
@@ -17,6 +18,7 @@ export async function collectCommandAnalytics(cmd: Command): Promise<string | un
   const osCollector = new OSCollector();
   const nodeCollector = new NodeCollector();
   const ciCollector = new CICollector();
+  const gitCollector = new GitCollector();
   const cliCollector = new CLICollector(cmd);
 
   let event: AnalyticEvent = {
@@ -26,6 +28,7 @@ export async function collectCommandAnalytics(cmd: Command): Promise<string | un
       os: await osCollector.collect(),
       node: await nodeCollector.collect(),
       ci: await ciCollector.collect(),
+      anonymous_repo_id: (await gitCollector.collect())?.anonymous_repo_id
     }
   }
 

--- a/apps/wing/src/analytics/collect.ts
+++ b/apps/wing/src/analytics/collect.ts
@@ -21,8 +21,10 @@ export async function collectCommandAnalytics(cmd: Command): Promise<string | un
   const gitCollector = new GitCollector();
   const cliCollector = new CLICollector(cmd);
 
+  const eventName = `cli_${cmd.opts().target ?? ''}_${cmd.name()}`;
+
   let event: AnalyticEvent = {
-    event: `wing cli:${cmd.name()}`,
+    event: eventName.replace(/[^a-zA-Z_]/g, ""),
     properties: {
       cli: await cliCollector.collect(),
       os: await osCollector.collect(),

--- a/apps/wing/src/analytics/collect.ts
+++ b/apps/wing/src/analytics/collect.ts
@@ -14,7 +14,7 @@ import { PACKAGE_VERSION } from "../cli";
  * @param cmd The commander command to collect analytics for
  * @returns string the file path of the stored analytic
  */
-export async function collectCommandAnalytics(cmd: Command): Promise<string> {
+export async function collectCommandAnalytics(cmd: Command): Promise<string | undefined> {
   const osCollector = new OSCollector();
   const nodeCollector = new NodeCollector();
   const ciCollector = new CICollector();
@@ -26,17 +26,16 @@ export async function collectCommandAnalytics(cmd: Command): Promise<string> {
       cli: await cliCollector.collect(),
       os: await osCollector.collect(),
       node: await nodeCollector.collect(),
+      ci: await ciCollector.collect(),
     }
-  }
-
-  if (await ciCollector.canCollect()) {
-    event.properties.ci = await ciCollector.collect();
   }
   
   let analyticFilePath = storeAnalyticEvent(event);
+  
   if (getWingAnalyticsCollectionConfig().debug) {
     console.log(`Analytics event stored at ${analyticFilePath}`);
   }
+  
   return analyticFilePath;
 }
 

--- a/apps/wing/src/analytics/collect.ts
+++ b/apps/wing/src/analytics/collect.ts
@@ -1,0 +1,95 @@
+import { Command } from "commander";
+import { loadAnalyticsConfig, storeAnalyticEvent } from "./storage";
+import { AnalyticEvent } from "./event";
+import { OSCollector } from "./collectors/os-collector";
+import { NodeCollector } from "./collectors/node-collector";
+import { CLICollector } from "./collectors/cli-collector";
+import { CICollector } from "./collectors/ci-collector";
+import { PACKAGE_VERSION } from "../cli";
+
+
+/**
+ * Collects analytics for a given command, stores it for later export
+ * 
+ * @param cmd The commander command to collect analytics for
+ * @returns string the file path of the stored analytic
+ */
+export async function collectCommandAnalytics(cmd: Command): Promise<string> {
+  const osCollector = new OSCollector();
+  const nodeCollector = new NodeCollector();
+  const ciCollector = new CICollector();
+  const cliCollector = new CLICollector(cmd);
+
+  let event: AnalyticEvent = {
+    event: `wing cli:${cmd.name()}`,
+    properties: {
+      inCI: CICollector.inCI(),
+      cli: await cliCollector.collect(),
+      os: await osCollector.collect(),
+      node: await nodeCollector.collect(),
+    }
+  }
+
+  if (await ciCollector.canCollect()) {
+    event.properties.ci = await ciCollector.collect();
+  }
+  
+  let analyticFilePath = storeAnalyticEvent(event);
+  if (getWingAnalyticsCollectionConfig().debug) {
+    console.log(`Analytics event stored at ${analyticFilePath}`);
+  }
+  return analyticFilePath;
+}
+
+/**
+ * Analytics configuration that determines whether to collect or export analytics
+ * Having these options separate makes it easy to debug when developing
+ */
+export interface AnalyticsCollectionConfig {
+  collect: boolean;
+  export: boolean;
+  debug: boolean;
+}
+
+export function getWingAnalyticsCollectionConfig(): AnalyticsCollectionConfig {
+  const optOutCollectionConfig: AnalyticsCollectionConfig = {
+    collect: false,
+    export: false,
+    debug: false,
+  }
+
+  // If user has provided opt out flag, do not collect or export anything
+  if (process.env.WING_DISABLE_ANALYTICS) {
+    return optOutCollectionConfig
+  }
+
+  // If no environment variable is set, check the analytics config file for opt-out
+  const config = loadAnalyticsConfig();
+  // If opt out is set do not 
+  if (config.optOut) {
+    return optOutCollectionConfig;
+  }
+
+  // If no opt out is set, then we should collect and export analytics
+  const optInConfig: AnalyticsCollectionConfig = {
+    collect: true,
+    export: true,
+    debug: false,
+  }
+
+  // check for debug environment variable
+  if (process.env.WING_ANALYTICS_DEBUG) {
+    // If debug is set, do not export analytics but we still want to generate them
+    optInConfig.export = false;
+    optInConfig.debug = true;
+  }
+
+  // If using local development version of wing, do not collect or export anything
+  // unless debug mode is enabled
+  if (PACKAGE_VERSION == "0.0.0" && !optInConfig.debug) {
+    return optOutCollectionConfig;
+  }
+
+  // If we've made it this far, we should collect and export analytics
+  return optInConfig;
+}

--- a/apps/wing/src/analytics/collect.ts
+++ b/apps/wing/src/analytics/collect.ts
@@ -1,11 +1,10 @@
 import { Command } from "commander";
-import { loadAnalyticsConfig, storeAnalyticEvent } from "./storage";
 import { AnalyticEvent } from "./event";
 import { OSCollector } from "./collectors/os-collector";
 import { NodeCollector } from "./collectors/node-collector";
 import { CLICollector } from "./collectors/cli-collector";
 import { CICollector } from "./collectors/ci-collector";
-import { PACKAGE_VERSION } from "../cli";
+import { AnalyticsStorage } from "./storage";
 
 
 /**
@@ -29,65 +28,11 @@ export async function collectCommandAnalytics(cmd: Command): Promise<string | un
       ci: await ciCollector.collect(),
     }
   }
+
+  const storage = new AnalyticsStorage({debug: process.env.DEBUG ? true : false});
   
-  let analyticFilePath = storeAnalyticEvent(event);
-  
-  if (getWingAnalyticsCollectionConfig().debug) {
-    console.log(`Analytics event stored at ${analyticFilePath}`);
-  }
+  let analyticFilePath = storage.storeAnalyticEvent(event);
   
   return analyticFilePath;
 }
 
-/**
- * Analytics configuration that determines whether to collect or export analytics
- * Having these options separate makes it easy to debug when developing
- */
-export interface AnalyticsCollectionConfig {
-  collect: boolean;
-  export: boolean;
-  debug: boolean;
-}
-
-export function getWingAnalyticsCollectionConfig(): AnalyticsCollectionConfig {
-  const optOutCollectionConfig: AnalyticsCollectionConfig = {
-    collect: false,
-    export: false,
-    debug: false,
-  }
-
-  // If user has provided opt out flag, do not collect or export anything
-  if (process.env.WING_DISABLE_ANALYTICS) {
-    return optOutCollectionConfig
-  }
-
-  // If no environment variable is set, check the analytics config file for opt-out
-  const config = loadAnalyticsConfig();
-  // If opt out is set do not 
-  if (config.optOut) {
-    return optOutCollectionConfig;
-  }
-
-  // If no opt out is set, then we should collect and export analytics
-  const optInConfig: AnalyticsCollectionConfig = {
-    collect: true,
-    export: true,
-    debug: false,
-  }
-
-  // check for debug environment variable
-  if (process.env.WING_ANALYTICS_DEBUG) {
-    // If debug is set, do not export analytics but we still want to generate them
-    optInConfig.export = false;
-    optInConfig.debug = true;
-  }
-
-  // If using local development version of wing, do not collect or export anything
-  // unless debug mode is enabled
-  if (PACKAGE_VERSION == "0.0.0" && !optInConfig.debug) {
-    return optOutCollectionConfig;
-  }
-
-  // If we've made it this far, we should collect and export analytics
-  return optInConfig;
-}

--- a/apps/wing/src/analytics/collectors/ci-collector.ts
+++ b/apps/wing/src/analytics/collectors/ci-collector.ts
@@ -4,73 +4,33 @@ export interface CIData {
   name: string;
 }
 
-export enum CIType {
-  GITHUB_ACTIONS = "github_action",
-  GITLAB_CI = "gitlab_ci",
-  JENKINS = "jenkins",
-  CIRCLECI = "circleci",
-  BITBUCKET = "bitbucket",
-  AZURE_DEVOPS = "azure_devops",
-  TEAMCITY = "teamcity",
-  AWS_CODEBUILD = "aws_codebuild",
-  NONE = "none",
+// Map of CI environment variable identifiers to CI names
+const CI_ENV: {[key: string]: string} = {
+  // https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables
+  GITHUB_ACTIONS: "GITHUB_ACTIONS",
+  // https://docs.gitlab.com/ee/ci/variables/predefined_variables.html
+  GITLAB_CI: "GITLAB_CI",
+  // https://www.jenkins.io/doc/book/pipeline/jenkinsfile/#using-environment-variables
+  JENKINS_URL: "JENKINS",
+  // https://circleci.com/docs/variables/#built-in-environment-variables
+  CIRCLECI: "CIRCLECI",
+  // https://support.atlassian.com/bitbucket-cloud/docs/variables-and-secrets/
+  BITBUCKET_BUILD_NUMBER: "BITBUCKET",
+  // https://docs.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml
+  BUILD_BUILDID: "AZURE_DEVOPS",
+  // https://www.jetbrains.com/help/teamcity/predefined-build-parameters.html
+  TEAMCITY_VERSION: "TEAMCITY",
+  // https://docs.aws.amazon.com/codepipeline/latest/userguide/reference-variables.html
+  CODEBUILD_BUILD_ID: "CODEBUILD",
 }
 
 export class CICollector extends Collector {
-  
-  static inCI(): boolean {
-    return this.getCIType() !== CIType.NONE;
-  }
-
-  static getCIType(): CIType {
-    // Github builtin environment variables
-    // https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables
-    if (process.env.GITHUB_ACTIONS) {
-      return CIType.GITHUB_ACTIONS;
+  async collect(): Promise<CIData | undefined> {
+    for (const e in CI_ENV) {
+      if (e in process.env) {
+        return {name: CI_ENV[`${e}`]}
+      }
     }
-    // Gitlab builtin environment variables
-    // https://docs.gitlab.com/ee/ci/variables/predefined_variables.html
-    if (process.env.GITLAB_CI) {
-      return CIType.GITLAB_CI;
-    }
-    // Jenkins builtin environemnt variables
-    // https://www.jenkins.io/doc/book/pipeline/jenkinsfile/#using-environment-variables
-    if (process.env.JENKINS_URL) {
-      return CIType.JENKINS;
-    }
-    // CircleCI builtin environment variables
-    // https://circleci.com/docs/variables/#built-in-environment-variables
-    if (process.env.CIRCLECI) {
-      return CIType.CIRCLECI;
-    }
-    // Bitbucket builtin environment variables
-    // https://support.atlassian.com/bitbucket-cloud/docs/variables-and-secrets/
-    if (process.env.BITBUCKET_BUILD_NUMBER && process.env.CI) {
-      return CIType.BITBUCKET;
-    }
-    // Azure DevOps builtin environment variables
-    // https://docs.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml
-    if (process.env.BUILD_BUILDID) {
-      return CIType.AZURE_DEVOPS;
-    }
-    // TeamCity builtin environment variables
-    // https://www.jetbrains.com/help/teamcity/predefined-build-parameters.html
-    if (process.env.TEAMCITY_VERSION) {
-      return CIType.TEAMCITY;
-    }
-    // AWS Codebuild builtin environment variables
-    // https://docs.aws.amazon.com/codepipeline/latest/userguide/reference-variables.html
-    if (process.env.CODEBUILD_BUILD_ID) {
-      return CIType.AWS_CODEBUILD;
-    }
-    return CIType.NONE;
-  }
-
-  async canCollect(): Promise<boolean> {
-    return CICollector.inCI();
-  }
-
-  async collect(): Promise<CIData> {
-    return { name: CICollector.getCIType() };
+    return undefined;
   }
 }

--- a/apps/wing/src/analytics/collectors/ci-collector.ts
+++ b/apps/wing/src/analytics/collectors/ci-collector.ts
@@ -1,0 +1,76 @@
+import { Collector } from "./collector";
+
+export interface CIData {
+  name: string;
+}
+
+export enum CIType {
+  GITHUB_ACTIONS = "github_action",
+  GITLAB_CI = "gitlab_ci",
+  JENKINS = "jenkins",
+  CIRCLECI = "circleci",
+  BITBUCKET = "bitbucket",
+  AZURE_DEVOPS = "azure_devops",
+  TEAMCITY = "teamcity",
+  AWS_CODEBUILD = "aws_codebuild",
+  NONE = "none",
+}
+
+export class CICollector extends Collector {
+  
+  static inCI(): boolean {
+    return this.getCIType() !== CIType.NONE;
+  }
+
+  static getCIType(): CIType {
+    // Github builtin environment variables
+    // https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables
+    if (process.env.GITHUB_ACTIONS) {
+      return CIType.GITHUB_ACTIONS;
+    }
+    // Gitlab builtin environment variables
+    // https://docs.gitlab.com/ee/ci/variables/predefined_variables.html
+    if (process.env.GITLAB_CI) {
+      return CIType.GITLAB_CI;
+    }
+    // Jenkins builtin environemnt variables
+    // https://www.jenkins.io/doc/book/pipeline/jenkinsfile/#using-environment-variables
+    if (process.env.JENKINS_URL) {
+      return CIType.JENKINS;
+    }
+    // CircleCI builtin environment variables
+    // https://circleci.com/docs/variables/#built-in-environment-variables
+    if (process.env.CIRCLECI) {
+      return CIType.CIRCLECI;
+    }
+    // Bitbucket builtin environment variables
+    // https://support.atlassian.com/bitbucket-cloud/docs/variables-and-secrets/
+    if (process.env.BITBUCKET_BUILD_NUMBER && process.env.CI) {
+      return CIType.BITBUCKET;
+    }
+    // Azure DevOps builtin environment variables
+    // https://docs.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml
+    if (process.env.BUILD_BUILDID) {
+      return CIType.AZURE_DEVOPS;
+    }
+    // TeamCity builtin environment variables
+    // https://www.jetbrains.com/help/teamcity/predefined-build-parameters.html
+    if (process.env.TEAMCITY_VERSION) {
+      return CIType.TEAMCITY;
+    }
+    // AWS Codebuild builtin environment variables
+    // https://docs.aws.amazon.com/codepipeline/latest/userguide/reference-variables.html
+    if (process.env.CODEBUILD_BUILD_ID) {
+      return CIType.AWS_CODEBUILD;
+    }
+    return CIType.NONE;
+  }
+
+  async canCollect(): Promise<boolean> {
+    return CICollector.inCI();
+  }
+
+  async collect(): Promise<CIData> {
+    return { name: CICollector.getCIType() };
+  }
+}

--- a/apps/wing/src/analytics/collectors/cli-collector.ts
+++ b/apps/wing/src/analytics/collectors/cli-collector.ts
@@ -6,8 +6,8 @@ export interface CLIData {
   target: string;
   version: string;
   options: string;
-  wingSDKVersion: string;
-  wingConsoleVersion: string;
+  wing_sdk_version: string;
+  wing_console_version: string;
 }
 
 export class CLICollector extends Collector {
@@ -23,8 +23,8 @@ export class CLICollector extends Collector {
       target: this.cmd.opts().target,
       options: `${JSON.stringify(this.cmd.opts())}`,
       version: PACKAGE_VERSION,
-      wingSDKVersion: require(`@winglang/sdk/package.json`).version as string,
-      wingConsoleVersion: require(`@wingconsole/app/package.json`).version as string
+      wing_sdk_version: require(`@winglang/sdk/package.json`).version as string,
+      wing_console_version: require(`@wingconsole/app/package.json`).version as string
     }
   }
 }

--- a/apps/wing/src/analytics/collectors/cli-collector.ts
+++ b/apps/wing/src/analytics/collectors/cli-collector.ts
@@ -1,10 +1,13 @@
 import { Command } from "commander";
 import { Collector } from "./collector";
+import { PACKAGE_VERSION } from "../../cli";
 
 export interface CLIData {
   target: string;
   version: string;
   options: string;
+  wingSDKVersion: string;
+  wingConsoleVersion: string;
 }
 
 export class CLICollector extends Collector {
@@ -19,7 +22,9 @@ export class CLICollector extends Collector {
     return {
       target: this.cmd.opts().target,
       options: `${JSON.stringify(this.cmd.opts())}`,
-      version: this.cmd.opts().version,
+      version: PACKAGE_VERSION,
+      wingSDKVersion: require(`@winglang/sdk/package.json`).version as string,
+      wingConsoleVersion: require(`@wingconsole/app/package.json`).version as string
     }
   }
 }

--- a/apps/wing/src/analytics/collectors/cli-collector.ts
+++ b/apps/wing/src/analytics/collectors/cli-collector.ts
@@ -6,8 +6,8 @@ export interface CLIData {
   target: string;
   version: string;
   options: string;
-  wing_sdk_version: string;
-  wing_console_version: string;
+  wing_sdk_version?: string;
+  wing_console_version?: string;
 }
 
 export class CLICollector extends Collector {
@@ -19,12 +19,21 @@ export class CLICollector extends Collector {
   }
 
   async collect(): Promise<CLIData> {
+
     return {
       target: this.cmd.opts().target,
       options: `${JSON.stringify(this.cmd.opts())}`,
       version: PACKAGE_VERSION,
-      wing_sdk_version: require(`@winglang/sdk/package.json`).version as string,
-      wing_console_version: require(`@wingconsole/app/package.json`).version as string
+      wing_sdk_version: this.tryGetModuleVersion("@winglang/sdk/package.json"),
+      wing_console_version: this.tryGetModuleVersion(`@wingconsole/app/package.json`)
+    }
+  }
+
+  private tryGetModuleVersion(module: string): string | undefined {
+    try {
+      return require(module).version as string;
+    } catch (error) {
+      return undefined;
     }
   }
 }

--- a/apps/wing/src/analytics/collectors/cli-collector.ts
+++ b/apps/wing/src/analytics/collectors/cli-collector.ts
@@ -15,10 +15,6 @@ export class CLICollector extends Collector {
     this.cmd = cmd;
   }
 
-  async canCollect(): Promise<boolean> {
-    return true;
-  }
-
   async collect(): Promise<CLIData> {
     return {
       target: this.cmd.opts().target,

--- a/apps/wing/src/analytics/collectors/cli-collector.ts
+++ b/apps/wing/src/analytics/collectors/cli-collector.ts
@@ -1,0 +1,29 @@
+import { Command } from "commander";
+import { Collector } from "./collector";
+
+export interface CLIData {
+  target: string;
+  version: string;
+  options: string;
+}
+
+export class CLICollector extends Collector {
+  private cmd: Command;
+
+  constructor(cmd: Command) {
+    super();
+    this.cmd = cmd;
+  }
+
+  async canCollect(): Promise<boolean> {
+    return true;
+  }
+
+  async collect(): Promise<CLIData> {
+    return {
+      target: this.cmd.opts().target,
+      options: `${JSON.stringify(this.cmd.opts())}`,
+      version: this.cmd.opts().version,
+    }
+  }
+}

--- a/apps/wing/src/analytics/collectors/collector.ts
+++ b/apps/wing/src/analytics/collectors/collector.ts
@@ -7,7 +7,7 @@ export interface Data {
 export abstract class Collector {
   abstract collect(): Promise<Data | undefined>;
 
-  async runCommand(cmd: string, args: string[]): Promise<any> {
+  protected async runCommand(cmd: string, args: string[]): Promise<any> {
     try {
       const raw = await new Promise((resolve, reject) => {
         execFile(cmd, args, (error, stdout, stderr) => {

--- a/apps/wing/src/analytics/collectors/collector.ts
+++ b/apps/wing/src/analytics/collectors/collector.ts
@@ -5,8 +5,7 @@ export interface Data {
 }
 
 export abstract class Collector {
-  abstract canCollect(): Promise<boolean>;
-  abstract collect(): Promise<Data>;
+  abstract collect(): Promise<Data | undefined>;
 
   async runCommand(cmd: string, args: string[]): Promise<any> {
     try {

--- a/apps/wing/src/analytics/collectors/collector.ts
+++ b/apps/wing/src/analytics/collectors/collector.ts
@@ -1,0 +1,29 @@
+import { execFile } from "child_process";
+
+export interface Data {
+  [key: string]: any;
+}
+
+export abstract class Collector {
+  abstract canCollect(): Promise<boolean>;
+  abstract collect(): Promise<Data>;
+
+  async runCommand(cmd: string, args: string[]): Promise<any> {
+    try {
+      const raw = await new Promise((resolve, reject) => {
+        execFile(cmd, args, (error, stdout, stderr) => {
+          if (error) {
+            stderr;
+            reject(error);
+          }
+          resolve(stdout);
+        });
+      });
+      return raw;
+    } catch (error) {
+      // We dont want this to cause any issues for users if something failed
+      // so we just return an empty string
+      return "";
+    }
+  }
+}

--- a/apps/wing/src/analytics/collectors/git-collector.ts
+++ b/apps/wing/src/analytics/collectors/git-collector.ts
@@ -1,0 +1,30 @@
+import { Collector } from "./collector";
+import { createHash } from 'crypto';
+
+export interface GitData {
+  anonymous_repo_id: string;
+}
+
+export class GitCollector extends Collector {
+  async collect(): Promise<GitData | undefined> {
+    if (await this.isInGitRepo()) {
+      const remoteUrl = await this.getRemoteUrl();
+      if (remoteUrl) {
+        return {
+          anonymous_repo_id: createHash('md5').update(remoteUrl).digest('hex')
+        }
+      }
+    }
+    return undefined;
+  }
+
+  async isInGitRepo(): Promise<boolean> {
+    const results = await this.runCommand('git', ['rev-parse', '--is-inside-work-tree']);
+    return results.trim() === 'true';
+  }
+
+  async getRemoteUrl(): Promise<string | undefined> {
+    const results = await this.runCommand('git', ['config', '--get', 'remote.origin.url']);
+    return results.trim();
+  }
+}

--- a/apps/wing/src/analytics/collectors/node-collector.ts
+++ b/apps/wing/src/analytics/collectors/node-collector.ts
@@ -1,0 +1,17 @@
+import { Collector } from "./collector";
+
+export interface NodeData {
+  version: string;
+}
+
+export class NodeCollector extends Collector {
+  async canCollect(): Promise<boolean> {
+    return true;
+  }
+
+  async collect(): Promise<NodeData> {
+    return {
+      version: process.version,
+    }
+  }
+}

--- a/apps/wing/src/analytics/collectors/node-collector.ts
+++ b/apps/wing/src/analytics/collectors/node-collector.ts
@@ -5,10 +5,6 @@ export interface NodeData {
 }
 
 export class NodeCollector extends Collector {
-  async canCollect(): Promise<boolean> {
-    return true;
-  }
-
   async collect(): Promise<NodeData> {
     return {
       version: process.version,

--- a/apps/wing/src/analytics/collectors/os-collector.ts
+++ b/apps/wing/src/analytics/collectors/os-collector.ts
@@ -1,0 +1,22 @@
+import { Collector } from "./collector";
+import os from "os";
+
+export interface OSData {
+  arch: string;
+  platform: string;
+  release: string;
+}
+
+export class OSCollector extends Collector {
+  async canCollect(): Promise<boolean> {
+    return true;
+  }
+
+  async collect(): Promise<OSData> {
+    return {
+      arch: os.arch(),
+      platform: os.platform(),
+      release: os.release(),
+    }
+  }
+}

--- a/apps/wing/src/analytics/collectors/os-collector.ts
+++ b/apps/wing/src/analytics/collectors/os-collector.ts
@@ -8,10 +8,6 @@ export interface OSData {
 }
 
 export class OSCollector extends Collector {
-  async canCollect(): Promise<boolean> {
-    return true;
-  }
-
   async collect(): Promise<OSData> {
     return {
       arch: os.arch(),

--- a/apps/wing/src/analytics/disclaimer.test.ts
+++ b/apps/wing/src/analytics/disclaimer.test.ts
@@ -1,0 +1,49 @@
+import {test, expect, describe, beforeEach, afterEach, vi} from "vitest";
+import { AnalyticsStorage } from "./storage";
+import path from "path";
+import * as os from "os";
+import { WING_DISCLAIMER, optionallyDisplayDisclaimer } from "./disclaimer";
+import { existsSync, unlinkSync } from "fs";
+
+
+describe("disclaimer", () => {
+  const nonExistentFile = path.join(os.tmpdir(), "_)(*noWayThis_file_exists%$#@.json");
+
+  let log: any;
+
+  beforeEach(() => {
+    log = console.log;
+    console.log = vi.fn();
+
+    if (existsSync(nonExistentFile)) {
+      unlinkSync(nonExistentFile);
+    }
+  });
+
+  afterEach(() => {
+    console.log = log;
+  });
+
+  test("appears on first run", () => {
+    // GIVEN
+    const storage = new AnalyticsStorage({configFile: nonExistentFile});
+
+    // WHEN
+    optionallyDisplayDisclaimer(storage);
+
+    // THEN
+    expect(console.log).toHaveBeenCalledWith(expect.stringContaining(WING_DISCLAIMER.split("\n")[0]));
+  });
+
+  test("does not appear on second run", () => {
+    // GIVEN
+    const storage = new AnalyticsStorage({configFile: nonExistentFile});
+
+    // WHEN
+    optionallyDisplayDisclaimer(storage);
+    optionallyDisplayDisclaimer(storage);
+
+    // THEN
+    expect(console.log).toHaveBeenCalledTimes(1);
+  });
+})

--- a/apps/wing/src/analytics/disclaimer.ts
+++ b/apps/wing/src/analytics/disclaimer.ts
@@ -1,7 +1,7 @@
 import chalk from "chalk";
-import { loadAnalyticsConfig, saveAnalyticsConfig } from "./storage";
+import { AnalyticsStorage } from "./storage";
 
-const disclaimer = `
+export const WING_DISCLAIMER = `
 🧪 This is an early pre-release of the Wing Programming Language.
   
 We are working hard to make this a great tool, but there's still a pretty good
@@ -22,16 +22,17 @@ ${chalk.redBright("(This message will self-destruct after the first run)")}
 `;
 
 function displayDisclaimer() {
-  console.log(`${chalk.hex("#2AD5C1")(disclaimer)}`);
+  console.log(`${chalk.hex("#2AD5C1")(WING_DISCLAIMER)}`);
 }
 
-export function optionallyDisplayDisclaimer() {
+export function optionallyDisplayDisclaimer(existingStorage?: AnalyticsStorage) {
   try {
-    const analyticsConfig = loadAnalyticsConfig();
+    const storage = existingStorage ?? new AnalyticsStorage();
+    const analyticsConfig = storage.loadConfig();
     if (!analyticsConfig.disclaimerDisplayed) {
       displayDisclaimer();
       analyticsConfig.disclaimerDisplayed = true;
-      saveAnalyticsConfig(analyticsConfig);
+      storage.saveConfig(analyticsConfig);
     }
   } catch (error) {
     // Incase there was any reason the config could not be loaded, 

--- a/apps/wing/src/analytics/disclaimer.ts
+++ b/apps/wing/src/analytics/disclaimer.ts
@@ -1,0 +1,41 @@
+import chalk from "chalk";
+import { loadAnalyticsConfig, saveAnalyticsConfig } from "./storage";
+
+const disclaimer = `
+🧪 This is an early pre-release of the Wing Programming Language (aka "alpha").
+  
+We are working hard to make this a great tool, but there's still a pretty good
+chance you'll encounter missing pieces, rough edges, performance issues and even,
+god forbid, bugs 🐞.
+
+Please don't hesitate to ping us at ${chalk.blueBright.bold.underline(
+      "https://t.winglang.io/slack"
+    )} or file an issue at
+${chalk.blueBright.bold.underline(
+  "https://github.com/winglang/wing"
+)}. We promise to do our best to respond quickly and help out.
+
+To help us identify issues early, we are collecting anonymous analytics.
+To turn this off, set ${chalk.yellowBright.bold("WING_DISABLE_ANALYTICS=1")}.
+For more information see ${chalk.blueBright.bold.underline("https://winglang.io/docs/analytics")}
+${chalk.redBright("(This message will self-destruct after the first run)")}
+`;
+
+function displayDisclaimer() {
+  console.log(`${chalk.hex("#2AD5C1")(disclaimer)}`);
+}
+
+export function optionallyDisplayDisclaimer() {
+  try {
+    const analyticsConfig = loadAnalyticsConfig();
+    if (!analyticsConfig.disclaimerDisplayed) {
+      displayDisclaimer();
+      analyticsConfig.disclaimerDisplayed = true;
+      saveAnalyticsConfig(analyticsConfig);
+    }
+  } catch (error) {
+    // Incase there was any reason the config could not be loaded, 
+    // just display to be super transparent :)
+    displayDisclaimer();
+  }
+}

--- a/apps/wing/src/analytics/disclaimer.ts
+++ b/apps/wing/src/analytics/disclaimer.ts
@@ -2,7 +2,7 @@ import chalk from "chalk";
 import { loadAnalyticsConfig, saveAnalyticsConfig } from "./storage";
 
 const disclaimer = `
-🧪 This is an early pre-release of the Wing Programming Language (aka "alpha").
+🧪 This is an early pre-release of the Wing Programming Language.
   
 We are working hard to make this a great tool, but there's still a pretty good
 chance you'll encounter missing pieces, rough edges, performance issues and even,

--- a/apps/wing/src/analytics/event.ts
+++ b/apps/wing/src/analytics/event.ts
@@ -8,7 +8,6 @@ export interface AnalyticEvent {
   timestamp?: string;
   anonymousId?: string;
   properties: {
-    inCI: boolean;
     cli: CLIData;
     os: OSData;
     node: NodeData;

--- a/apps/wing/src/analytics/event.ts
+++ b/apps/wing/src/analytics/event.ts
@@ -1,0 +1,17 @@
+import { CIData } from "./collectors/ci-collector";
+import { CLIData } from "./collectors/cli-collector";
+import { NodeData } from "./collectors/node-collector";
+import { OSData } from "./collectors/os-collector";
+
+export interface AnalyticEvent {
+  event: string;
+  timestamp?: string;
+  anonymousId?: string;
+  properties: {
+    inCI: boolean;
+    cli: CLIData;
+    os: OSData;
+    node: NodeData;
+    ci?: CIData;
+  }
+}

--- a/apps/wing/src/analytics/event.ts
+++ b/apps/wing/src/analytics/event.ts
@@ -8,6 +8,7 @@ export interface AnalyticEvent {
   timestamp?: string;
   anonymousId?: string;
   properties: {
+    anonymous_repo_id?: string;
     cli: CLIData;
     os: OSData;
     node: NodeData;

--- a/apps/wing/src/analytics/export.ts
+++ b/apps/wing/src/analytics/export.ts
@@ -1,7 +1,7 @@
 import { spawn } from 'child_process';
 
-export function exportAnalytics(filePath: string) {
-  const child = spawn(process.execPath, [require.resolve('./scripts/detached-export'), filePath], {
+export async function exportAnalytics(filePath: Promise<string>) {
+  const child = spawn(process.execPath, [require.resolve('./scripts/detached-export'), await filePath], {
     detached: true,
     stdio: 'ignore',
     windowsHide: true,

--- a/apps/wing/src/analytics/export.ts
+++ b/apps/wing/src/analytics/export.ts
@@ -1,7 +1,11 @@
 import { spawn } from 'child_process';
 
-export async function exportAnalytics(filePath: Promise<string>) {
-  const child = spawn(process.execPath, [require.resolve('./scripts/detached-export'), await filePath], {
+export async function exportAnalytics(filePath: Promise<string | undefined>) {
+  const awaitedFilePath = await filePath;
+  if (!awaitedFilePath) {
+    return;
+  }
+  const child = spawn(process.execPath, [require.resolve('./scripts/detached-export'), awaitedFilePath], {
     detached: true,
     stdio: 'ignore',
     windowsHide: true,

--- a/apps/wing/src/analytics/export.ts
+++ b/apps/wing/src/analytics/export.ts
@@ -2,13 +2,16 @@ import { spawn } from 'child_process';
 
 export async function exportAnalytics(filePath: Promise<string | undefined>) {
   const awaitedFilePath = await filePath;
-  if (!awaitedFilePath) {
+  if (!awaitedFilePath || process.env.WING_DISABLE_ANALYTICS) {
     return;
   }
   const child = spawn(process.execPath, [require.resolve('./scripts/detached-export'), awaitedFilePath], {
     detached: true,
     stdio: 'ignore',
     windowsHide: true,
+    env: {
+      ...process.env,
+    }
   });
 
   child.unref();

--- a/apps/wing/src/analytics/export.ts
+++ b/apps/wing/src/analytics/export.ts
@@ -1,7 +1,7 @@
 import { spawn } from 'child_process';
 
 export function exportAnalytics(filePath: string) {
-  const child = spawn(process.argv[0], [require.resolve('./scripts/detached-export'), filePath], {
+  const child = spawn(process.execPath, [require.resolve('./scripts/detached-export'), filePath], {
     detached: true,
     stdio: 'ignore',
     windowsHide: true,

--- a/apps/wing/src/analytics/export.ts
+++ b/apps/wing/src/analytics/export.ts
@@ -1,0 +1,11 @@
+import { spawn } from 'child_process';
+
+export function exportAnalytics(filePath: string) {
+  const child = spawn(process.argv[0], [require.resolve('./scripts/detached-export'), filePath], {
+    detached: true,
+    stdio: 'ignore',
+    windowsHide: true,
+  });
+
+  child.unref();
+}

--- a/apps/wing/src/analytics/export.ts
+++ b/apps/wing/src/analytics/export.ts
@@ -2,9 +2,11 @@ import { spawn } from 'child_process';
 
 export async function exportAnalytics(filePath: Promise<string | undefined>) {
   const awaitedFilePath = await filePath;
+
   if (!awaitedFilePath || process.env.WING_DISABLE_ANALYTICS) {
     return;
   }
+  
   const child = spawn(process.execPath, [require.resolve('./scripts/detached-export'), awaitedFilePath], {
     detached: true,
     stdio: 'ignore',

--- a/apps/wing/src/analytics/scripts/detached-export.ts
+++ b/apps/wing/src/analytics/scripts/detached-export.ts
@@ -26,7 +26,7 @@ async function reportAnalytic() {
   }
 
   const params = {
-    anonymousId: (event.properties as any).ci_name ? 'ci_run' : storage.getAnonymousId(),
+    anonymousId: storage.getAnonymousId(),
     timestamp: event.timestamp,
     event: event.event,
     properties: event.properties,

--- a/apps/wing/src/analytics/scripts/detached-export.ts
+++ b/apps/wing/src/analytics/scripts/detached-export.ts
@@ -1,0 +1,30 @@
+import { getAnonymousId, loadAnalyticsEvent } from '../storage';
+import * as fs from 'fs';
+import Analytics from '@segment/analytics-node';
+import { getWingAnalyticsCollectionConfig } from '../collect';
+
+// When this file is run as a child process, it will be passed the path 
+// to the analytics report file
+const filePath = process.argv[2];
+
+try {
+  const analytics = new Analytics({ writeKey: 'sCqPF5xSscOjJdi5Tbkqu73vfF8zkZdw'});
+  const event = loadAnalyticsEvent(filePath);
+  const analyticsConfig = getWingAnalyticsCollectionConfig();
+
+  if (analyticsConfig.export) {
+    analytics.track({
+      anonymousId: getAnonymousId(),
+      timestamp: event.timestamp,
+      event: event.event,
+      properties: event.properties,
+    });
+  }
+
+  // Keeps the file around for debugging purposes
+  if (!analyticsConfig.debug) {
+    fs.unlinkSync(filePath);
+  }
+} catch(err) {
+  // TODO: add mechanism to retry
+}

--- a/apps/wing/src/analytics/scripts/detached-export.ts
+++ b/apps/wing/src/analytics/scripts/detached-export.ts
@@ -1,34 +1,39 @@
-import { getAnonymousId, loadAnalyticsEvent } from '../storage';
+import { AnalyticsStorage } from '../storage';
 import * as fs from 'fs';
 import Analytics from '@segment/analytics-node';
-import { getWingAnalyticsCollectionConfig } from '../collect';
+import { exit } from 'process';
 
 // When this file is run as a child process, it will be passed the path 
 // to the analytics report file
 const filePath = process.argv[2];
 
 try {
+  if (process.env.DEBUG) {
+    // In debug mode no need to export the metrics
+    exit(0);
+  }
+  
   if (!filePath) {
     throw new Error('No file analytic path provided');
   }
 
   const analytics = new Analytics({ writeKey: 'sCqPF5xSscOjJdi5Tbkqu73vfF8zkZdw'});
-  const event = loadAnalyticsEvent(filePath);
-  const analyticsConfig = getWingAnalyticsCollectionConfig();
+  const storage = new AnalyticsStorage();
+  const event = storage.loadEvent(filePath);
 
-  if (analyticsConfig.export) {
-    analytics.track({
-      anonymousId: getAnonymousId(),
-      timestamp: event.timestamp,
-      event: event.event,
-      properties: event.properties,
-    });
+  if (!event) {
+    throw new Error(`No analytic event found at: ${filePath}`);
   }
 
-  // Keeps the file around for debugging purposes
-  if (!analyticsConfig.debug) {
-    fs.unlinkSync(filePath);
-  }
+  analytics.track({
+    anonymousId: storage.getAnonymousId(),
+    timestamp: event.timestamp,
+    event: event.event,
+    properties: event.properties,
+  });
+  
+  fs.unlinkSync(filePath);
+  
 } catch(err) {
   // TODO: add mechanism to retry
 }

--- a/apps/wing/src/analytics/scripts/detached-export.ts
+++ b/apps/wing/src/analytics/scripts/detached-export.ts
@@ -8,6 +8,10 @@ import { getWingAnalyticsCollectionConfig } from '../collect';
 const filePath = process.argv[2];
 
 try {
+  if (!filePath) {
+    throw new Error('No file analytic path provided');
+  }
+
   const analytics = new Analytics({ writeKey: 'sCqPF5xSscOjJdi5Tbkqu73vfF8zkZdw'});
   const event = loadAnalyticsEvent(filePath);
   const analyticsConfig = getWingAnalyticsCollectionConfig();

--- a/apps/wing/src/analytics/storage.test.ts
+++ b/apps/wing/src/analytics/storage.test.ts
@@ -58,8 +58,7 @@ describe(
         // THEN
         expect(analyticPath).toBeDefined();
         expect(storedAnalytic).toEqual(expect.objectContaining({
-          event: DUMMY_ANALYTIC.event, 
-          anonymousId: DUMMY_ANALYTIC.anonymousId, 
+          event: DUMMY_ANALYTIC.event,
           properties: {
             "cli_target": "fake-aws",
             "cli_version": "4.2.0",

--- a/apps/wing/src/analytics/storage.test.ts
+++ b/apps/wing/src/analytics/storage.test.ts
@@ -1,0 +1,83 @@
+import {describe, test, expect } from "vitest";
+import { AnalyticEvent } from "./event";
+import { AnalyticsConfig, AnalyticsStorage } from "./storage";
+import { writeFileSync } from "fs";
+import path from "path";
+import * as os from "os";
+
+describe(
+  "storage tests",
+  () => {
+    const DUMMY_ANALYTIC: AnalyticEvent = {
+      event: "some fake:event",
+      properties: {
+        cli: {
+          options: "\{\"-t\": \"fake-aws\"\}",
+          target: "fake-aws",
+          version: "4.2.0",
+          wingConsoleVersion: "1.2.3",
+          wingSDKVersion: "4.5.6"
+        },
+        os: {
+          arch: "x64",
+          platform: "xbox",
+          release: "360",
+        },
+        node: {
+          version: "a million",
+        }
+      }
+    }
+
+    describe("when analytics is opt-in", () => {
+      const fakeAnalyticConfig: AnalyticsConfig = {
+        optOut: false,
+        anonymousId: "fake-anonymous-id"
+      }
+      const storage = createStorageWithFakeConfig(fakeAnalyticConfig);
+
+      test("should store analytic event and return correct filepath", async () => {
+        // WHEN
+        const analyticPath = storage.storeAnalyticEvent(DUMMY_ANALYTIC);
+        const storedAnalytic = storage.loadEvent(analyticPath!);
+  
+        // THEN
+        expect(analyticPath).toBeDefined();
+        expect(storedAnalytic).toEqual(DUMMY_ANALYTIC);
+      });
+
+      test("can retrieve anonymous id", () => {
+        expect(storage.getAnonymousId()).toBe("fake-anonymous-id");
+      });
+    });
+
+
+    describe("when analytics is opt-out", () => {
+      const fakeAnalyticConfig: AnalyticsConfig = {
+        optOut: true,
+        anonymousId: "fake-anonymous-id"
+      }
+
+      const storage = createStorageWithFakeConfig(fakeAnalyticConfig);
+      
+      test("does not store analytic", async () => {
+        // WHEN
+        const analyticPath = storage.storeAnalyticEvent(DUMMY_ANALYTIC);
+        const analytic = storage.loadEvent(analyticPath!);
+  
+        // THEN
+        expect(analyticPath).toBeUndefined();
+        expect(analytic).toBeUndefined();
+      });
+    });
+
+  }
+);
+
+export function createStorageWithFakeConfig(config: AnalyticsConfig): AnalyticsStorage {
+  const tmpDir = path.join(os.tmpdir(), "wing-storage-test");
+  const configFile = path.join(tmpDir, "analytics-fake-config.json");
+
+  writeFileSync(configFile, JSON.stringify(config));
+  return new AnalyticsStorage({configFile: configFile});
+}

--- a/apps/wing/src/analytics/storage.ts
+++ b/apps/wing/src/analytics/storage.ts
@@ -50,11 +50,11 @@ export class AnalyticsStorage {
       event.timestamp = event.timestamp ?? new Date().toISOString();
       
       // We add the anonymousId only if we are not in a CI environment
-      if (!event.properties.ci) {
+      if (event.properties.ci) {
         const anonymousId = this.getAnonymousId();
         event.anonymousId = anonymousId;
       }
-    
+
       this.saveEvent(analyticReportFile, event);
     
       return analyticReportFile;
@@ -76,7 +76,15 @@ export class AnalyticsStorage {
 
   public getAnonymousId(): string {
     let config = this.loadConfig();
+    if (!config.anonymousId) {
+      config.anonymousId = this.generateAnonymousId();
+      this.saveConfig(config);
+    }
     return config.anonymousId;
+  }
+
+  private generateAnonymousId(): string {
+    return randomBytes(16).toString('hex');
   }
 
   public loadConfig(): AnalyticsConfig {
@@ -91,7 +99,7 @@ export class AnalyticsStorage {
       }
   
       const analyticsConfig: AnalyticsConfig = {
-        anonymousId: randomBytes(16).toString('hex'),
+        anonymousId: this.generateAnonymousId(),
         optOut: false,
       }
   

--- a/apps/wing/src/analytics/storage.ts
+++ b/apps/wing/src/analytics/storage.ts
@@ -1,0 +1,94 @@
+import { readFileSync, writeFileSync, mkdirSync, existsSync } from "fs";
+import { AnalyticEvent } from "./event";
+import { randomBytes } from "crypto";
+import {v4 as uuidv4 } from "uuid";
+import path from "path";
+import * as os from "os";
+
+const WING_HOME_DIR = path.join(os.homedir(), ".wing")
+const WING_ANALYTICS_CONFIG_FILE = path.join(WING_HOME_DIR, 'wing-analytics-config.json');
+
+interface AnalyticsConfig {
+  anonymousId: string;
+  disclaimerDisplayed?: boolean;
+  optOut?: boolean;
+}
+
+/**
+ * Stores an analytic event to disk for later export
+ * 
+ * @param event the event to store
+ * @returns string the file path of the stored analytic
+ */
+export function storeAnalyticEvent(event: AnalyticEvent): string {
+  const eventId = uuidv4();
+  const tmpdir = path.join(os.tmpdir(), "wing-analytics");
+  
+  if (!existsSync(tmpdir)) {
+    mkdirSync(tmpdir);
+  }
+
+  const analyticReportFile = path.join(tmpdir, `${eventId}.json`);
+  
+  const anonymousId = getAnonymousId();
+
+  // attach timestamp and anonymousId to event
+  event.timestamp = event.timestamp ?? new Date().toISOString();
+  event.anonymousId = anonymousId;
+
+  saveAnalyticsReport(analyticReportFile, event);
+
+  return analyticReportFile;
+}
+
+export function getAnonymousId(): string {
+  let config = loadAnalyticsConfig();
+  return config.anonymousId;
+}
+
+export function loadAnalyticsConfig(): AnalyticsConfig {
+  try {
+    const fileContents = readFileSync(WING_ANALYTICS_CONFIG_FILE, 'utf-8');
+    return JSON.parse(fileContents) as AnalyticsConfig;
+  } catch (error) {
+    // Possible issue reading analytics config file, first determine if file exists yet
+    if (existsSync(WING_ANALYTICS_CONFIG_FILE)) {
+      // File exists but could not be read. In this case we should not attempt to
+      // make any assumptions about the contents of the file
+      // This exception will only be visible in DEBUG mode
+      throw new Error("Could not read analytics config file")
+    }
+
+    // Since file does NOT exist we can generate a new config and store it
+    const analyticsConfig: AnalyticsConfig = {
+      anonymousId: randomBytes(16).toString('hex'),
+      optOut: false,
+    }
+
+    saveAnalyticsConfig(analyticsConfig);
+
+    return analyticsConfig;
+  }
+}
+
+export function saveAnalyticsConfig(config: AnalyticsConfig) {
+  if (!existsSync(WING_HOME_DIR)) {
+    mkdirSync(WING_HOME_DIR);
+  }
+  writeFileSync(WING_ANALYTICS_CONFIG_FILE, JSON.stringify(config))
+}
+
+export function loadAnalyticsEvent(filePath: string): AnalyticEvent {
+  try {
+    const fileContents = readFileSync(filePath, 'utf-8');
+    return JSON.parse(fileContents) as AnalyticEvent;
+  } catch (error) {
+    // ignore
+    return {} as any;
+  }
+}
+
+function saveAnalyticsReport(filePath: string, event: AnalyticEvent) {
+  // TODO: get rid of the null, 2
+  writeFileSync(filePath, JSON.stringify(event, null, 2))
+}

--- a/apps/wing/src/analytics/storage.ts
+++ b/apps/wing/src/analytics/storage.ts
@@ -6,91 +6,107 @@ import path from "path";
 import * as os from "os";
 
 const WING_HOME_DIR = path.join(os.homedir(), ".wing")
-const WING_ANALYTICS_CONFIG_FILE = path.join(WING_HOME_DIR, 'wing-analytics-config.json');
+const DEFAULT_WING_ANALYTICS_CONFIG_FILE = path.join(WING_HOME_DIR, 'wing-analytics-config.json');
 
-interface AnalyticsConfig {
+export interface AnalyticsConfig {
   anonymousId: string;
   disclaimerDisplayed?: boolean;
   optOut?: boolean;
 }
 
-/**
- * Stores an analytic event to disk for later export
- * 
- * @param event the event to store
- * @returns string the file path of the stored analytic
- */
-export function storeAnalyticEvent(event: AnalyticEvent): string | undefined {
-  try {
-    const eventId = uuidv4();
-    const tmpdir = path.join(os.tmpdir(), "wing-analytics");
+interface AnalyticsStorageProps {
+  configFile?: string;
+  debug?: boolean;
+}
+
+export class AnalyticsStorage {
+  analyticsConfigFile: string;
+  analyticsConfig: AnalyticsConfig;
+  debug?: boolean;
+
+  constructor(props?: AnalyticsStorageProps) {
+    this.analyticsConfigFile = props?.configFile ?? DEFAULT_WING_ANALYTICS_CONFIG_FILE;
+    this.debug = props?.debug;
+    this.analyticsConfig = this.loadConfig();
+  }
+
+  public storeAnalyticEvent(event: AnalyticEvent): string | undefined {
+    try {
+      if (this.analyticsConfig.optOut == true) {
+        return undefined;
+      }
+      const eventId = uuidv4();
+      const tmpdir = path.join(os.tmpdir(), "wing-analytics");
+      
+      if (!existsSync(tmpdir)) {
+        mkdirSync(tmpdir);
+      }
+  
+      const analyticReportFile = path.join(tmpdir, `${eventId}.json`);
+      
+      const anonymousId = this.getAnonymousId();
     
-    if (!existsSync(tmpdir)) {
-      mkdirSync(tmpdir);
-    }
-
-    const analyticReportFile = path.join(tmpdir, `${eventId}.json`);
+      // attach timestamp and anonymousId to event
+      event.timestamp = event.timestamp ?? new Date().toISOString();
+      event.anonymousId = anonymousId;
     
-    const anonymousId = getAnonymousId();
+      this.saveEvent(analyticReportFile, event);
+    
+      return analyticReportFile;
   
-    // attach timestamp and anonymousId to event
-    event.timestamp = event.timestamp ?? new Date().toISOString();
-    event.anonymousId = anonymousId;
-  
-    saveAnalyticsReport(analyticReportFile, event);
-  
-    return analyticReportFile;
-
-  } catch (error) {
-    return undefined;
-  }
-
-}
-
-export function getAnonymousId(): string {
-  let config = loadAnalyticsConfig();
-  return config.anonymousId;
-}
-
-export function loadAnalyticsConfig(): AnalyticsConfig {
-  try {
-    const fileContents = readFileSync(WING_ANALYTICS_CONFIG_FILE, 'utf-8');
-    return JSON.parse(fileContents) as AnalyticsConfig;
-  } catch (error: any) {
-    // Possible issue reading analytics config file, first determine if file exists yet
-
-    if (error.code === 'EACCES') {
-      throw new Error("Not able to access analytics config file due to permissions");
+    } catch (error) {
+      return undefined;
     }
+  }
 
-    const analyticsConfig: AnalyticsConfig = {
-      anonymousId: randomBytes(16).toString('hex'),
-      optOut: false,
+  public loadEvent(filePath: string): AnalyticEvent | undefined {
+    try {
+      const fileContents = readFileSync(filePath, 'utf-8');
+      return JSON.parse(fileContents) as AnalyticEvent;
+    } catch (error) {
+      // ignore
+      return undefined;
     }
-
-    saveAnalyticsConfig(analyticsConfig);
-
-    return analyticsConfig;
   }
-}
 
-export function saveAnalyticsConfig(config: AnalyticsConfig) {
-  if (!existsSync(WING_HOME_DIR)) {
-    mkdirSync(WING_HOME_DIR);
+  public getAnonymousId(): string {
+    let config = this.loadConfig();
+    return config.anonymousId;
   }
-  writeFileSync(WING_ANALYTICS_CONFIG_FILE, JSON.stringify(config))
-}
 
-export function loadAnalyticsEvent(filePath: string): AnalyticEvent {
-  try {
-    const fileContents = readFileSync(filePath, 'utf-8');
-    return JSON.parse(fileContents) as AnalyticEvent;
-  } catch (error) {
-    // ignore
-    return {} as any;
+  public loadConfig(): AnalyticsConfig {
+    try {
+      const fileContents = readFileSync(this.analyticsConfigFile, 'utf-8');
+      return JSON.parse(fileContents) as AnalyticsConfig;
+    } catch (error: any) {
+      // Possible issue reading analytics config file, first determine if file exists yet
+  
+      if (error.code === 'EACCES') {
+        throw new Error("Not able to access analytics config file due to permissions");
+      }
+  
+      const analyticsConfig: AnalyticsConfig = {
+        anonymousId: randomBytes(16).toString('hex'),
+        optOut: false,
+      }
+  
+      this.saveConfig(analyticsConfig);
+  
+      return analyticsConfig;
+    }
   }
-}
 
-function saveAnalyticsReport(filePath: string, event: AnalyticEvent) {
-  writeFileSync(filePath, JSON.stringify(event))
+  public saveConfig(config: AnalyticsConfig) {
+    if (!existsSync(WING_HOME_DIR)) {
+      mkdirSync(WING_HOME_DIR);
+    }
+    writeFileSync(this.analyticsConfigFile, JSON.stringify(config))
+  }
+
+  private saveEvent(filePath: string, event: AnalyticEvent) {
+    writeFileSync(filePath, JSON.stringify(event))
+    if (this.debug) {
+      console.log(`Analytics event stored at ${filePath}`);
+    }
+  }
 }

--- a/apps/wing/src/analytics/storage.ts
+++ b/apps/wing/src/analytics/storage.ts
@@ -142,12 +142,10 @@ export class AnalyticsStorage {
       const fileContents = readFileSync(this.analyticsConfigFile, 'utf-8');
       return JSON.parse(fileContents) as AnalyticsConfig;
     } catch (error: any) {
-      // Possible issue reading analytics config file, first determine if file exists yet
-  
-      if (error.code === 'EACCES') {
-        throw new Error("Not able to access analytics config file due to permissions");
+      if (this.debug) {
+        console.log(`Error loading analytics config: ${error}`)
       }
-  
+
       const analyticsConfig: AnalyticsConfig = {
         anonymousId: this.generateAnonymousId(),
         optOut: false,
@@ -165,10 +163,14 @@ export class AnalyticsStorage {
    * @param config the analytics config to save to disk
    */
   public saveConfig(config: AnalyticsConfig) {
-    if (!existsSync(WING_HOME_DIR)) {
-      mkdirSync(WING_HOME_DIR);
+    try {
+      if (!existsSync(WING_HOME_DIR)) {
+        mkdirSync(WING_HOME_DIR);
+      }
+      writeFileSync(this.analyticsConfigFile, JSON.stringify(config))
+    } catch (error) {
+      if (this.debug) { console.log(`Error saving config file ${error}`) }
     }
-    writeFileSync(this.analyticsConfigFile, JSON.stringify(config))
   }
 
   /**
@@ -193,10 +195,16 @@ export class AnalyticsStorage {
   }
 
   private saveEvent(filePath: string, event: AnalyticEvent) {
-    event.properties = this.flattenProperties(event.properties) as any;
-    writeFileSync(filePath, JSON.stringify(event))
-    if (this.debug) {
-      console.log(`Analytics event stored at ${filePath}`);
+    try {
+      event.properties = this.flattenProperties(event.properties) as any;
+      writeFileSync(filePath, JSON.stringify(event))
+      if (this.debug) {
+        console.log(`Analytics event stored at ${filePath}`);
+      }
+    } catch (error) {
+      if (this.debug) {
+        console.log(`Error storing analytics event: ${error}`)
+      }
     }
   }
 }

--- a/apps/wing/src/analytics/storage.ts
+++ b/apps/wing/src/analytics/storage.ts
@@ -89,6 +89,5 @@ export function loadAnalyticsEvent(filePath: string): AnalyticEvent {
 }
 
 function saveAnalyticsReport(filePath: string, event: AnalyticEvent) {
-  // TODO: get rid of the null, 2
-  writeFileSync(filePath, JSON.stringify(event, null, 2))
+  writeFileSync(filePath, JSON.stringify(event))
 }

--- a/apps/wing/src/cli.ts
+++ b/apps/wing/src/cli.ts
@@ -15,7 +15,7 @@ import { optionallyDisplayDisclaimer } from "./analytics/disclaimer";
 export const PACKAGE_VERSION = require("../package.json").version as string;
 
 const ANALYTICS_COLLECTION_CONFIG = getWingAnalyticsCollectionConfig(); 
-let analyticsExportFile: Promise<string> | undefined = undefined;
+let analyticsExportFile: Promise<string | undefined>;
 
 const SUPPORTED_NODE_VERSION = require("../package.json").engines.node as string;
 if (!SUPPORTED_NODE_VERSION) {

--- a/apps/wing/src/cli.ts
+++ b/apps/wing/src/cli.ts
@@ -15,7 +15,7 @@ import { optionallyDisplayDisclaimer } from "./analytics/disclaimer";
 export const PACKAGE_VERSION = require("../package.json").version as string;
 
 const ANALYTICS_COLLECTION_CONFIG = getWingAnalyticsCollectionConfig(); 
-let ANALYTICS_EXPORT_FILE: string | undefined = undefined;
+let analyticsExportFile: Promise<string> | undefined = undefined;
 
 const SUPPORTED_NODE_VERSION = require("../package.json").engines.node as string;
 if (!SUPPORTED_NODE_VERSION) {
@@ -72,7 +72,7 @@ async function main() {
       // Fail silently if collection fails
       try {
         optionallyDisplayDisclaimer();
-        ANALYTICS_EXPORT_FILE = await collectCommandAnalytics(subCmd);
+        analyticsExportFile = collectCommandAnalytics(subCmd);
       } catch (err) {
         if (ANALYTICS_COLLECTION_CONFIG.debug) {
           console.error(err);
@@ -85,8 +85,8 @@ async function main() {
   
       // Fail silently if export fails
       try {
-        if (ANALYTICS_EXPORT_FILE) {
-          exportAnalytics(ANALYTICS_EXPORT_FILE);
+        if (analyticsExportFile) {
+          await exportAnalytics(analyticsExportFile);
         }
       } catch (err) {
         if (ANALYTICS_COLLECTION_CONFIG.debug) {

--- a/apps/wing/src/cli.ts
+++ b/apps/wing/src/cli.ts
@@ -67,13 +67,12 @@ async function main() {
     });
 
 
-    async function collectAnalyticsHook(cmd: Command) {
+    async function collectAnalyticsHook(_: Command, subCmd: Command) {
       if (!ANALYTICS_COLLECTION_CONFIG.collect) { return; }
-  
       // Fail silently if collection fails
       try {
         optionallyDisplayDisclaimer();
-        ANALYTICS_EXPORT_FILE = await collectCommandAnalytics(cmd);
+        ANALYTICS_EXPORT_FILE = await collectCommandAnalytics(subCmd);
       } catch (err) {
         if (ANALYTICS_COLLECTION_CONFIG.debug) {
           console.error(err);
@@ -113,7 +112,7 @@ async function main() {
     .option("--no-open", "Do not open the Wing Console in the browser")
     .action(run);
 
-  program.command("lsp").description("Run the Wing language server on stdio").action(run_server).hook("preAction", collectAnalyticsHook);
+  program.command("lsp").description("Run the Wing language server on stdio").action(run_server);
 
   program
     .command("compile")
@@ -126,7 +125,6 @@ async function main() {
     )
     .option("-p, --plugins [plugin...]", "Compiler plugins")
     .hook("preAction", progressHook)
-    .hook("preAction", collectAnalyticsHook)
     .action(actionErrorHandler(compile));
 
   program
@@ -142,11 +140,10 @@ async function main() {
     )
     .option("-p, --plugins [plugin...]", "Compiler plugins")
     .hook("preAction", progressHook)
-    .hook("preAction", collectAnalyticsHook)
     .action(actionErrorHandler(test));
 
   program.command("docs").description("Open the Wing documentation").action(docs);
-
+  program.hook("preSubcommand", collectAnalyticsHook)
   program.hook("postAction", exportAnalyticsHook)
   program.parse();
 }

--- a/docs/docs/07-examples/14-wing-analytics.md
+++ b/docs/docs/07-examples/14-wing-analytics.md
@@ -1,0 +1,30 @@
+---
+title: Wing Cli Analytics
+id: wing-analytics
+keywords: [Analytics, Telemetry]
+---
+
+## Wing Anonymous Analytics
+
+The Wing cli collects anonymous usage data in order to help us improve the cli experience. The intent is to collect data that will help us understand how the cli is being used throughout the community, with hopes that this will help us to build the right features and improve the right areas.
+
+You may not feel comfortable sharing this data with us, and that is ok. The gathering of these analytics is completely optional to use the Wing cli, and can be opted out of at any time.
+
+### Opting out
+
+If you would like to opt out of the analytics gathering, then you can do so by simply setting the environment variable `WING_CLI_DISABLE_ANALYTICS=1`. You can also use the flag `--no-analytics` when running any command.
+
+```sh
+wing compile -t sim app.w --no-analytics
+```
+
+### What data is collected
+
+Each run of the Wing cli collects information about various aspects of the environment it is running in. Below are the analytics we gather. As well
+you can always head over to our Github and view the code that collects these metrics, as the code is open source.
+
+- The Wing cli version
+- The command information, including the command name, arguments, and flags
+- Operating system information, including the architecture, version, and platform
+- Node js version
+- CI environment name (if applicable)

--- a/docs/docs/07-examples/14-wing-analytics.md
+++ b/docs/docs/07-examples/14-wing-analytics.md
@@ -8,7 +8,7 @@ keywords: [Analytics, Telemetry]
 
 The Wing cli collects anonymous usage data in order to help us improve the cli experience. The intent is to collect data that will help us understand how the cli is being used throughout the community, with hopes that this will help us to build the right features and improve the right areas.
 
-You may not feel comfortable sharing this data with us, and that is ok. The gathering of these analytics is completely optional to use the Wing cli, and can be opted out of at any time.
+You may not feel comfortable sharing this data with us, and that is ok. The gathering of these analytics is completely optional to use the Wing CLI, and can be opted out of at any time.
 
 ### Opting out
 

--- a/docs/docs/07-examples/14-wing-analytics.md
+++ b/docs/docs/07-examples/14-wing-analytics.md
@@ -26,5 +26,5 @@ you can always head over to our Github and view the code that collects these met
 - The Wing cli version
 - The command information, including the command name, arguments, and flags
 - Operating system information, including the architecture, version, and platform
-- Node js version
+- Node.js version
 - CI environment name (if applicable)

--- a/docs/docs/09-analytics.md
+++ b/docs/docs/09-analytics.md
@@ -1,12 +1,12 @@
 ---
-title: Wing Cli Analytics
-id: wing-analytics
+title: Analytics
+id: analytics
 keywords: [Analytics, Telemetry]
 ---
 
-## Wing Anonymous Analytics
+## Analytics Collection
 
-The Wing cli collects anonymous usage data in order to help us improve the cli experience. The intent is to collect data that will help us understand how the cli is being used throughout the community, with hopes that this will help us to build the right features and improve the right areas.
+The Wing CLI collects anonymous usage data in order to help us improve. The intent is to collect data that will help us understand how it is being used throughout the community, with hopes that this will help us to build the right features and improve the right areas.
 
 You may not feel comfortable sharing this data with us, and that is ok. The gathering of these analytics is completely optional to use the Wing CLI, and can be opted out of at any time.
 
@@ -23,7 +23,7 @@ wing compile -t sim app.w --no-analytics
 Each run of the Wing cli collects information about various aspects of the environment it is running in. Below are the analytics we gather. As well
 you can always head over to our Github and view the code that collects these metrics, as the code is open source.
 
-- The Wing cli version
+- The Wing CLI version
 - The command information, including the command name, arguments, and flags
 - Operating system information, including the architecture, version, and platform
 - Node.js version

--- a/docs/docs/09-analytics.md
+++ b/docs/docs/09-analytics.md
@@ -6,7 +6,7 @@ keywords: [Analytics, Telemetry]
 
 ## Analytics Collection
 
-The Wing CLI collects anonymous usage data in order to help us improve. The intent is to collect data that will help us understand how it is being used throughout the community, with hopes that this will help us to build the right features and improve the right areas.
+The Wing CLI collects anonymous usage data in order to help us improve. The intent is to collect data that will help us understand how it is being used throughout the community, with hopes that this will help us build the right features and improve the right areas.
 
 You may not feel comfortable sharing this data with us, and that is ok. The gathering of these analytics is completely optional to use the Wing CLI, and can be opted out of at any time.
 

--- a/docs/docs/09-analytics.md
+++ b/docs/docs/09-analytics.md
@@ -23,7 +23,7 @@ wing compile -t sim app.w --no-analytics
 Each run of the Wing cli collects information about various aspects of the environment it is running in. Below are the analytics we gather. As well
 you can always head over to our Github and view the code that collects these metrics, as the code is open source.
 
-- The Wing CLI version
+- The Wing CLI, SDK, and Console versions
 - The command information, including the command name, arguments, and flags
 - Operating system information, including the architecture, version, and platform
 - Node.js version

--- a/docs/docs/09-analytics.md
+++ b/docs/docs/09-analytics.md
@@ -28,3 +28,4 @@ you can always head over to our Github and view the code that collects these met
 - Operating system information, including the architecture, version, and platform
 - Node.js version
 - CI environment name (if applicable)
+- Git repo (if applicable) is assigned a hashed anonymous id. This is used to understand how many unique repos are using Wing.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,9 +1,5 @@
 lockfileVersion: '6.0'
 
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false
-
 patchedDependencies:
   '@aws-sdk/is-array-buffer@3.201.0':
     hash: lcduyc25etdvbxthpjpldc7hvu

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -314,8 +314,8 @@ importers:
         specifier: ^6.0.1
         version: 6.0.1
       '@types/uuid':
-        specifier: ^9.0.1
-        version: 9.0.1
+        specifier: ^8.3.2
+        version: 8.3.2
       bump-pack:
         specifier: workspace:^
         version: link:../../tools/bump-pack
@@ -9344,6 +9344,10 @@ packages:
     dependencies:
       '@types/configstore': 6.0.0
       boxen: 7.1.0
+    dev: true
+
+  /@types/uuid@8.3.2:
+    resolution: {integrity: sha512-u40ViizKDmdl5FhOXn9WQbulpigYCaiD5hD4KqR3xyQww6l3+0ND+A9TeFla8tFpqvR+UAkJdYb/8jdaQG4/nw==}
     dev: true
 
   /@types/uuid@9.0.1:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -259,6 +259,9 @@ importers:
 
   apps/wing:
     dependencies:
+      '@segment/analytics-node':
+        specifier: ^1.0.0
+        version: 1.0.0
       '@wingconsole/app':
         specifier: workspace:^
         version: link:../wing-console/console/app
@@ -292,6 +295,9 @@ importers:
       update-notifier:
         specifier: ^6.0.2
         version: 6.0.2
+      uuid:
+        specifier: ^8.3.2
+        version: 8.3.2
       vscode-languageserver:
         specifier: ^8.0.2
         version: 8.0.2
@@ -311,6 +317,9 @@ importers:
       '@types/update-notifier':
         specifier: ^6.0.1
         version: 6.0.1
+      '@types/uuid':
+        specifier: ^9.0.1
+        version: 9.0.1
       bump-pack:
         specifier: workspace:^
         version: link:../../tools/bump-pack
@@ -1014,7 +1023,7 @@ importers:
         version: 0.17.19
       tsup:
         specifier: ^6.7.0
-        version: 6.7.0(typescript@4.9.4)
+        version: 6.7.0(postcss@8.4.24)(typescript@5.1.3)
       typescript:
         specifier: ^4.9.4
         version: 4.9.4
@@ -6694,6 +6703,18 @@ packages:
     resolution: {integrity: sha512-dfLbk+PwWvFzSxwk3n5ySL0hfBog779o8h68wK/7/APo/7cgyWp5jcXockbxdk5kFRkbeXWm4Fbi9FrdN381sA==}
     dev: true
 
+  /@lukeed/csprng@1.1.0:
+    resolution: {integrity: sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==}
+    engines: {node: '>=8'}
+    dev: false
+
+  /@lukeed/uuid@2.0.1:
+    resolution: {integrity: sha512-qC72D4+CDdjGqJvkFMMEAtancHUQ7/d/tAiHf64z8MopFDmcrtbcJuerDtFceuAfQJ2pDSfCKCtbqoGBNnwg0w==}
+    engines: {node: '>=8'}
+    dependencies:
+      '@lukeed/csprng': 1.1.0
+    dev: false
+
   /@mdx-js/react@2.3.0(react@18.2.0):
     resolution: {integrity: sha512-zQH//gdOmuu7nt2oJR29vFhDv88oGPmVw6BggmrHeMI+xgEkp1B2dX9/bMBSYtK0dyLX/aOmesKS09g222K1/g==}
     peerDependencies:
@@ -7530,6 +7551,27 @@ packages:
       estree-walker: 2.0.2
       picomatch: 2.3.1
     dev: true
+
+  /@segment/analytics-core@1.3.0:
+    resolution: {integrity: sha512-ujScWZH49NK1hYlp2/EMw45nOPEh+pmTydAnR6gSkRNucZD4fuinvpPL03rmFCw8ibaMuKLAdgPJfQ0gkLKZ5A==}
+    dependencies:
+      '@lukeed/uuid': 2.0.1
+      dset: 3.1.2
+      tslib: 2.6.0
+    dev: false
+
+  /@segment/analytics-node@1.0.0:
+    resolution: {integrity: sha512-UWFujSxRkRauZuMVF4MPOT5QPvX4i7kiC2QCsozHhltoTiR2SBWRI86cYO/JI/Uk7qKaOxxGFDkJarCyIP7uLA==}
+    engines: {node: '>=14'}
+    dependencies:
+      '@lukeed/uuid': 2.0.1
+      '@segment/analytics-core': 1.3.0
+      buffer: 6.0.3
+      node-fetch: 2.6.12
+      tslib: 2.6.0
+    transitivePeerDependencies:
+      - encoding
+    dev: false
 
   /@segment/loosely-validate-event@2.0.0:
     resolution: {integrity: sha512-ZMCSfztDBqwotkl848ODgVcAmN4OItEWDCkshcKz0/W6gGSQayuuCtWV/MlodFivAZD793d6UgANd6wCXUfrIw==}
@@ -10972,6 +11014,13 @@ packages:
       base64-js: 1.5.1
       ieee754: 1.2.1
 
+  /buffer@6.0.3:
+    resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
+    dev: false
+
   /builtin-modules@3.3.0:
     resolution: {integrity: sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==}
     engines: {node: '>=6'}
@@ -12588,6 +12637,11 @@ packages:
       shelljs: 0.8.5
       typescript: 5.2.0-dev.20230711
     dev: true
+
+  /dset@3.1.2:
+    resolution: {integrity: sha512-g/M9sqy3oHe477Ar4voQxWtaPIFw1jTdKZuomOjhCcBx9nHUNn0pu6NopuFFrTh/TRZIKEj+76vLWFu9BNKk+Q==}
+    engines: {node: '>=4'}
+    dev: false
 
   /duplexer@0.1.2:
     resolution: {integrity: sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==}
@@ -21276,42 +21330,6 @@ packages:
       - ts-node
     dev: true
 
-  /tsup@6.7.0(typescript@4.9.4):
-    resolution: {integrity: sha512-L3o8hGkaHnu5TdJns+mCqFsDBo83bJ44rlK7e6VdanIvpea4ArPcU3swWGsLVbXak1PqQx/V+SSmFPujBK+zEQ==}
-    engines: {node: '>=14.18'}
-    hasBin: true
-    peerDependencies:
-      '@swc/core': ^1
-      postcss: ^8.4.12
-      typescript: '>=4.1.0'
-    peerDependenciesMeta:
-      '@swc/core':
-        optional: true
-      postcss:
-        optional: true
-      typescript:
-        optional: true
-    dependencies:
-      bundle-require: 4.0.1(esbuild@0.17.19)
-      cac: 6.7.14
-      chokidar: 3.5.3
-      debug: 4.3.4
-      esbuild: 0.17.19
-      execa: 5.1.1
-      globby: 11.1.0
-      joycon: 3.1.1
-      postcss-load-config: 3.1.4(postcss@8.4.24)
-      resolve-from: 5.0.0
-      rollup: 3.25.3
-      source-map: 0.8.0-beta.0
-      sucrase: 3.32.0
-      tree-kill: 1.2.2
-      typescript: 4.9.4
-    transitivePeerDependencies:
-      - supports-color
-      - ts-node
-    dev: true
-
   /tsup@7.1.0(postcss@8.4.24)(typescript@5.1.3):
     resolution: {integrity: sha512-mazl/GRAk70j8S43/AbSYXGgvRP54oQeX8Un4iZxzATHt0roW0t6HYDVZIXMw0ZQIpvr1nFMniIVnN5186lW7w==}
     engines: {node: '>=16.14'}
@@ -22846,3 +22864,7 @@ packages:
 
   /zod@3.21.4:
     resolution: {integrity: sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==}
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false

--- a/tools/hangar/src/utils.ts
+++ b/tools/hangar/src/utils.ts
@@ -17,7 +17,7 @@ export async function runWingCommand(options: RunWingCommandOptions) {
   const plugins = options.plugins ? ["--plugins", ...options.plugins] : [];
   const out = await execa(
     wingBin,
-    ["--no-update-check", ...options.args, options.wingFile, ...plugins],
+    ["--no-update-check", "--no-analytics", ...options.args, options.wingFile, ...plugins],
     {
       cwd: options.cwd,
       reject: false,


### PR DESCRIPTION
Currently this PR introduces some recorded analytics that can be opted out of using `WING_DISABLE_ANALYTICS` env var. 

Here are some example analytics:
- User running from non git repo
<img width="400" alt="image" src="https://github.com/winglang/wing/assets/45375125/d4656c8d-79b8-4173-9db4-5d78dbbfb9a2">

- User running from git repo
	- Note `anonymous_repo_id` has been added
<img width="400" alt="image" src="https://github.com/winglang/wing/assets/45375125/cd55dc32-ec84-427d-8a06-00ec4fbd07da">

- Automation running in CI
	- Note `anonymous_repo_id` is added
	- Note `anonymous_id` says 'ci_run' 

<img width="400" alt="image" src="https://github.com/winglang/wing/assets/45375125/d07ebee5-8ed4-4c9a-a0dd-aa4472c6a617">


### Implementation Details

In order to ensure we are not slowing down the user experience when running any CLI command, the process for collecting metrics works in 3 main components. Similar to how other CLI tools I have come across collect metrics. 
- Collectors: Which is responsible for gathering up all the analytics we care about during runtime of the CLI.
- Storage: The analytics gathered by the collector are stored on disk. The storage will house the events until the exporter is able to report the events back to [segment](https://segment.com/)
- Exporter: To avoid any long delays in the CLI commands, the exporter is run as a detached process when the CLI command is complete.

Right now the best way I am seeing to collect cli command specific data is by using Commander hooks around all the commands we want to collect analytics from (which right now I have as all of them)


## TODO:
- [x] Add notification on first run about analytic collection
- [x] Docs
	- [x] 	Document all data being collected
	- [x] Document opt-out policy
- [x] Determine if CLI called within CI
- [x] Collect git metrics (if exists)
- [ ] Legal review
- [ ] Github disclaimer
- [x] Setup privacy email
- [x] Use tmp dir for analytics storage
- [x] Consider best way to manage WriteKey for segment

Closes: https://github.com/winglang/wing/issues/2928
Closes: https://github.com/winglang/wing/issues/2974

## Checklist

- [x] Title matches [Winglang's style guide](https://docs.winglang.io/contributing/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [x] Tests added (always)
- [x] Docs updated (only required for features)
- [x] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://docs.winglang.io/terms-and-policies/contribution-license.html)*.
