### PR TITLE
fix(console): default height for logs in learn site

### DIFF
--- a/apps/wing-console/console/ui/src/layout/layout-provider.tsx
+++ b/apps/wing-console/console/ui/src/layout/layout-provider.tsx
@@ -10,7 +10,7 @@ export enum LayoutType {
   Tutorial,
 }
 
-const LayoutContext = createContext(LayoutType.Vscode);
+export const LayoutContext = createContext(LayoutType.Vscode);
 
 export interface LayoutProviderProps {
   layoutType?: LayoutType;

--- a/apps/wing-console/console/ui/src/layout/tutorial-layout.tsx
+++ b/apps/wing-console/console/ui/src/layout/tutorial-layout.tsx
@@ -97,7 +97,7 @@ export const TutorialLayout = ({ cloudAppState }: LayoutProps) => {
           "flex relative border-t border-slate-300 bg-slate-50",
           {
             "min-h-[5rem] h-[30rem]": cloudAppState === "error",
-            "min-h-[5rem] h-[15rem]": cloudAppState !== "error",
+            "min-h-[5rem] h-[8rem]": cloudAppState !== "error",
           },
         )}
       >

--- a/apps/wing-console/console/ui/src/ui/bucket-interaction.tsx
+++ b/apps/wing-console/console/ui/src/ui/bucket-interaction.tsx
@@ -15,7 +15,8 @@ import {
   useTheme,
 } from "@wingconsole/design-system";
 import classNames from "classnames";
-import { FormEvent, useMemo, useRef, useState } from "react";
+import { FormEvent, useContext, useMemo, useRef, useState } from "react";
+import { LayoutContext, LayoutType } from "../layout/layout-provider";
 
 export interface BucketInteractionProps {
   selectedEntries: string[];
@@ -61,6 +62,8 @@ export const BucketInteraction = ({
     setShowPreview(false);
     currentRef.current?.focus();
   };
+
+  const layoutType = useContext(LayoutContext);
 
   return (
     <div className="h-full flex-1 flex flex-col text-sm space-y-1.5">
@@ -121,7 +124,11 @@ export const BucketInteraction = ({
               setShowPreview(true);
             }
           }}
-          className="min-h-[6rem] h-48 overflow-y-auto resize-y"
+          className={classNames(
+            "overflow-y-auto resize-y",
+            layoutType === LayoutType.Tutorial && "min-h-[4rem]",
+            layoutType !== LayoutType.Tutorial && "h-48 min-h-[6rem]",
+          )}
         />
       )}
 


### PR DESCRIPTION
This PR reduced back the default height of the logs, for the learn layout.

<img width="769" alt="image" src="https://github.com/winglang/wing/assets/5547636/f8026b3f-7cf7-4f17-890d-7c1d1d8ac7da">

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://www.winglang.io/terms-and-policies/contribution-license.html)*.
