### PR TITLE
fix(vscode): extension's readme shows a wrong wing install command

### DIFF
--- a/apps/vscode-wing/README.md
+++ b/apps/vscode-wing/README.md
@@ -34,7 +34,7 @@
 This extension uses the globally installed `wing` CLI to provide language services. You can install it via npm:
 
 ```sh
-npm install -g @winglang/wing
+npm install -g winglang
 ```
 
 ### Planned Features


### PR DESCRIPTION
The vscode extension's readme shows an incorrect command for installing wing.
Shows:
```sh
npm install -g @winglang/wing
```
Should instead be:
```sh
npm install -g winglang
```

Fixes #2380 

## Checklist

- [ ] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [ ] Description explains motivation and solution
- [ ] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://www.winglang.io/terms-and-policies/contribution-license.html)*.
