### PR TITLE
chore(sdk): typos in json method signatures

### DIFF
--- a/docs/docs/04-standard-library/02-std/api-reference.md
+++ b/docs/docs/04-standard-library/02-std/api-reference.md
@@ -926,13 +926,13 @@ new std.Json()
 
 | **Name** | **Description** |
 | --- | --- |
-| <code><a href="#@winglang/sdk.std.Json.asBool">asBool</a></code> | Convert Json element to number if possible. |
+| <code><a href="#@winglang/sdk.std.Json.asBool">asBool</a></code> | Convert Json element to boolean if possible. |
 | <code><a href="#@winglang/sdk.std.Json.asNum">asNum</a></code> | Convert Json element to number if possible. |
 | <code><a href="#@winglang/sdk.std.Json.asStr">asStr</a></code> | Convert Json element to string if possible. |
 | <code><a href="#@winglang/sdk.std.Json.get">get</a></code> | Returns a specified element from the Json. |
 | <code><a href="#@winglang/sdk.std.Json.getAt">getAt</a></code> | Returns a specified element at a given index from Json Array. |
 | <code><a href="#@winglang/sdk.std.Json.tryAsBool">tryAsBool</a></code> | Convert Json element to boolean if possible. |
-| <code><a href="#@winglang/sdk.std.Json.tryAsNum">tryAsNum</a></code> | Convert Json element to string if possible. |
+| <code><a href="#@winglang/sdk.std.Json.tryAsNum">tryAsNum</a></code> | Convert Json element to number if possible. |
 | <code><a href="#@winglang/sdk.std.Json.tryAsStr">tryAsStr</a></code> | Convert Json element to string if possible. |
 | <code><a href="#@winglang/sdk.std.Json.tryGet">tryGet</a></code> | Optionally returns an specified element from the Json. |
 | <code><a href="#@winglang/sdk.std.Json.tryGetAt">tryGetAt</a></code> | Optionally returns a specified element at a given index from Json Array. |
@@ -945,7 +945,7 @@ new std.Json()
 asBool(): bool
 ```
 
-Convert Json element to number if possible.
+Convert Json element to boolean if possible.
 
 ##### `asNum` <a name="asNum" id="@winglang/sdk.std.Json.asNum"></a>
 
@@ -1009,7 +1009,7 @@ Convert Json element to boolean if possible.
 tryAsNum(): num
 ```
 
-Convert Json element to string if possible.
+Convert Json element to number if possible.
 
 ##### `tryAsStr` <a name="tryAsStr" id="@winglang/sdk.std.Json.tryAsStr"></a>
 
@@ -1536,7 +1536,7 @@ new std.MutJson()
 
 | **Name** | **Description** |
 | --- | --- |
-| <code><a href="#@winglang/sdk.std.MutJson.asBool">asBool</a></code> | Convert Json element to number if possible. |
+| <code><a href="#@winglang/sdk.std.MutJson.asBool">asBool</a></code> | Convert Json element to boolean if possible. |
 | <code><a href="#@winglang/sdk.std.MutJson.asNum">asNum</a></code> | Convert Json element to number if possible. |
 | <code><a href="#@winglang/sdk.std.MutJson.asStr">asStr</a></code> | Convert Json element to string if possible. |
 | <code><a href="#@winglang/sdk.std.MutJson.get">get</a></code> | Returns a specified element from the Json. |
@@ -1544,7 +1544,7 @@ new std.MutJson()
 | <code><a href="#@winglang/sdk.std.MutJson.set">set</a></code> | Adds or updates an element in MutJson with a specific key and value. |
 | <code><a href="#@winglang/sdk.std.MutJson.setAt">setAt</a></code> | Set element in MutJson Array with a specific key and value. |
 | <code><a href="#@winglang/sdk.std.MutJson.tryAsBool">tryAsBool</a></code> | Convert Json element to boolean if possible. |
-| <code><a href="#@winglang/sdk.std.MutJson.tryAsNum">tryAsNum</a></code> | Convert Json element to string if possible. |
+| <code><a href="#@winglang/sdk.std.MutJson.tryAsNum">tryAsNum</a></code> | Convert Json element to number if possible. |
 | <code><a href="#@winglang/sdk.std.MutJson.tryAsStr">tryAsStr</a></code> | Convert Json element to string if possible. |
 | <code><a href="#@winglang/sdk.std.MutJson.tryGet">tryGet</a></code> | Optionally returns an specified element from the Json. |
 | <code><a href="#@winglang/sdk.std.MutJson.tryGetAt">tryGetAt</a></code> | Optionally returns a specified element at a given index from Json Array. |
@@ -1557,7 +1557,7 @@ new std.MutJson()
 asBool(): bool
 ```
 
-Convert Json element to number if possible.
+Convert Json element to boolean if possible.
 
 ##### `asNum` <a name="asNum" id="@winglang/sdk.std.MutJson.asNum"></a>
 
@@ -1667,7 +1667,7 @@ Convert Json element to boolean if possible.
 tryAsNum(): num
 ```
 
-Convert Json element to string if possible.
+Convert Json element to number if possible.
 
 ##### `tryAsStr` <a name="tryAsStr" id="@winglang/sdk.std.MutJson.tryAsStr"></a>
 

--- a/libs/wingc/src/lsp/snapshots/completions/mut_json_methods.snap
+++ b/libs/wingc/src/lsp/snapshots/completions/mut_json_methods.snap
@@ -5,7 +5,7 @@ source: libs/wingc/src/lsp/completions.rs
   kind: 2
   documentation:
     kind: markdown
-    value: "```wing\n asBool: (): bool\n```\n---\nConvert Json element to number if possible.\n\n### Returns\na string."
+    value: "```wing\n asBool: (): bool\n```\n---\nConvert Json element to boolean if possible.\n\n### Returns\na boolean."
   sortText: ff|asBool
   insertText: asBool($0)
   insertTextFormat: 2
@@ -16,7 +16,7 @@ source: libs/wingc/src/lsp/completions.rs
   kind: 2
   documentation:
     kind: markdown
-    value: "```wing\n asNum: (): num\n```\n---\nConvert Json element to number if possible.\n\n### Returns\na string."
+    value: "```wing\n asNum: (): num\n```\n---\nConvert Json element to number if possible.\n\n### Returns\na number."
   sortText: ff|asNum
   insertText: asNum($0)
   insertTextFormat: 2
@@ -82,7 +82,7 @@ source: libs/wingc/src/lsp/completions.rs
   kind: 2
   documentation:
     kind: markdown
-    value: "```wing\n tryAsBool: (): bool?\n```\n---\nConvert Json element to boolean if possible.\n\n### Returns\na string."
+    value: "```wing\n tryAsBool: (): bool?\n```\n---\nConvert Json element to boolean if possible.\n\n### Returns\na boolean."
   sortText: ff|tryAsBool
   insertText: tryAsBool($0)
   insertTextFormat: 2
@@ -93,7 +93,7 @@ source: libs/wingc/src/lsp/completions.rs
   kind: 2
   documentation:
     kind: markdown
-    value: "```wing\n tryAsNum: (): num?\n```\n---\nConvert Json element to string if possible.\n\n### Returns\na string."
+    value: "```wing\n tryAsNum: (): num?\n```\n---\nConvert Json element to number if possible.\n\n### Returns\na number."
   sortText: ff|tryAsNum
   insertText: tryAsNum($0)
   insertTextFormat: 2

--- a/libs/wingc/src/lsp/snapshots/completions/optional_chaining.snap
+++ b/libs/wingc/src/lsp/snapshots/completions/optional_chaining.snap
@@ -5,7 +5,7 @@ source: libs/wingc/src/lsp/completions.rs
   kind: 2
   documentation:
     kind: markdown
-    value: "```wing\n asBool: (): bool\n```\n---\nConvert Json element to number if possible.\n\n### Returns\na string."
+    value: "```wing\n asBool: (): bool\n```\n---\nConvert Json element to boolean if possible.\n\n### Returns\na boolean."
   sortText: ff|asBool
   insertText: asBool($0)
   insertTextFormat: 2
@@ -16,7 +16,7 @@ source: libs/wingc/src/lsp/completions.rs
   kind: 2
   documentation:
     kind: markdown
-    value: "```wing\n asNum: (): num\n```\n---\nConvert Json element to number if possible.\n\n### Returns\na string."
+    value: "```wing\n asNum: (): num\n```\n---\nConvert Json element to number if possible.\n\n### Returns\na number."
   sortText: ff|asNum
   insertText: asNum($0)
   insertTextFormat: 2
@@ -60,7 +60,7 @@ source: libs/wingc/src/lsp/completions.rs
   kind: 2
   documentation:
     kind: markdown
-    value: "```wing\n tryAsBool: (): bool?\n```\n---\nConvert Json element to boolean if possible.\n\n### Returns\na string."
+    value: "```wing\n tryAsBool: (): bool?\n```\n---\nConvert Json element to boolean if possible.\n\n### Returns\na boolean."
   sortText: ff|tryAsBool
   insertText: tryAsBool($0)
   insertTextFormat: 2
@@ -71,7 +71,7 @@ source: libs/wingc/src/lsp/completions.rs
   kind: 2
   documentation:
     kind: markdown
-    value: "```wing\n tryAsNum: (): num?\n```\n---\nConvert Json element to string if possible.\n\n### Returns\na string."
+    value: "```wing\n tryAsNum: (): num?\n```\n---\nConvert Json element to number if possible.\n\n### Returns\na number."
   sortText: ff|tryAsNum
   insertText: tryAsNum($0)
   insertTextFormat: 2

--- a/libs/wingc/src/lsp/snapshots/completions/optional_chaining_auto.snap
+++ b/libs/wingc/src/lsp/snapshots/completions/optional_chaining_auto.snap
@@ -5,7 +5,7 @@ source: libs/wingc/src/lsp/completions.rs
   kind: 2
   documentation:
     kind: markdown
-    value: "```wing\n asBool: (): bool\n```\n---\nConvert Json element to number if possible.\n\n### Returns\na string."
+    value: "```wing\n asBool: (): bool\n```\n---\nConvert Json element to boolean if possible.\n\n### Returns\na boolean."
   sortText: ff|asBool
   insertText: asBool($0)
   insertTextFormat: 2
@@ -25,7 +25,7 @@ source: libs/wingc/src/lsp/completions.rs
   kind: 2
   documentation:
     kind: markdown
-    value: "```wing\n asNum: (): num\n```\n---\nConvert Json element to number if possible.\n\n### Returns\na string."
+    value: "```wing\n asNum: (): num\n```\n---\nConvert Json element to number if possible.\n\n### Returns\na number."
   sortText: ff|asNum
   insertText: asNum($0)
   insertTextFormat: 2
@@ -105,7 +105,7 @@ source: libs/wingc/src/lsp/completions.rs
   kind: 2
   documentation:
     kind: markdown
-    value: "```wing\n tryAsBool: (): bool?\n```\n---\nConvert Json element to boolean if possible.\n\n### Returns\na string."
+    value: "```wing\n tryAsBool: (): bool?\n```\n---\nConvert Json element to boolean if possible.\n\n### Returns\na boolean."
   sortText: ff|tryAsBool
   insertText: tryAsBool($0)
   insertTextFormat: 2
@@ -125,7 +125,7 @@ source: libs/wingc/src/lsp/completions.rs
   kind: 2
   documentation:
     kind: markdown
-    value: "```wing\n tryAsNum: (): num?\n```\n---\nConvert Json element to string if possible.\n\n### Returns\na string."
+    value: "```wing\n tryAsNum: (): num?\n```\n---\nConvert Json element to number if possible.\n\n### Returns\na number."
   sortText: ff|tryAsNum
   insertText: tryAsNum($0)
   insertTextFormat: 2

--- a/libs/wingc/src/lsp/snapshots/completions/parentheses_expression.snap
+++ b/libs/wingc/src/lsp/snapshots/completions/parentheses_expression.snap
@@ -5,7 +5,7 @@ source: libs/wingc/src/lsp/completions.rs
   kind: 2
   documentation:
     kind: markdown
-    value: "```wing\n asBool: (): bool\n```\n---\nConvert Json element to number if possible.\n\n### Returns\na string."
+    value: "```wing\n asBool: (): bool\n```\n---\nConvert Json element to boolean if possible.\n\n### Returns\na boolean."
   sortText: ff|asBool
   insertText: asBool($0)
   insertTextFormat: 2
@@ -16,7 +16,7 @@ source: libs/wingc/src/lsp/completions.rs
   kind: 2
   documentation:
     kind: markdown
-    value: "```wing\n asNum: (): num\n```\n---\nConvert Json element to number if possible.\n\n### Returns\na string."
+    value: "```wing\n asNum: (): num\n```\n---\nConvert Json element to number if possible.\n\n### Returns\na number."
   sortText: ff|asNum
   insertText: asNum($0)
   insertTextFormat: 2
@@ -60,7 +60,7 @@ source: libs/wingc/src/lsp/completions.rs
   kind: 2
   documentation:
     kind: markdown
-    value: "```wing\n tryAsBool: (): bool?\n```\n---\nConvert Json element to boolean if possible.\n\n### Returns\na string."
+    value: "```wing\n tryAsBool: (): bool?\n```\n---\nConvert Json element to boolean if possible.\n\n### Returns\na boolean."
   sortText: ff|tryAsBool
   insertText: tryAsBool($0)
   insertTextFormat: 2
@@ -71,7 +71,7 @@ source: libs/wingc/src/lsp/completions.rs
   kind: 2
   documentation:
     kind: markdown
-    value: "```wing\n tryAsNum: (): num?\n```\n---\nConvert Json element to string if possible.\n\n### Returns\na string."
+    value: "```wing\n tryAsNum: (): num?\n```\n---\nConvert Json element to number if possible.\n\n### Returns\na number."
   sortText: ff|tryAsNum
   insertText: tryAsNum($0)
   insertTextFormat: 2

--- a/libs/wingsdk/src/std/json.ts
+++ b/libs/wingsdk/src/std/json.ts
@@ -213,29 +213,29 @@ export class Json {
    *
    * @macro ((arg) => { if (typeof arg !== "number") {throw new Error("unable to parse " + typeof arg + " " + arg + " as a number")}; return JSON.parse(JSON.stringify(arg)) })($self$)
    *
-   * @returns a string.
+   * @returns a number.
    */
   public asNum(): number {
     throw new Error("Macro");
   }
 
   /**
-   * Convert Json element to string if possible.
+   * Convert Json element to number if possible.
    *
    * @macro ((arg) => { return (typeof arg === "number") ? JSON.parse(JSON.stringify(arg)) : undefined })($self$)
    *
-   * @returns a string.
+   * @returns a number.
    */
   public tryAsNum(): number | undefined {
     throw new Error("Macro");
   }
 
   /**
-   * Convert Json element to number if possible.
+   * Convert Json element to boolean if possible.
    *
    * @macro ((arg) => { if (typeof arg !== "boolean") {throw new Error("unable to parse " + typeof arg + " " + arg + " as a boolean")}; return JSON.parse(JSON.stringify(arg)) })($self$)
    *
-   * @returns a string.
+   * @returns a boolean.
    */
   public asBool(): boolean {
     throw new Error("Macro");
@@ -246,7 +246,7 @@ export class Json {
    *
    * @macro ((arg) => { return (typeof arg === "boolean") ? JSON.parse(JSON.stringify(arg)) : undefined })($self$)
    *
-   * @returns a string.
+   * @returns a boolean.
    */
   public tryAsBool(): boolean | undefined {
     throw new Error("Macro");
@@ -370,29 +370,29 @@ export class MutJson {
    *
    * @macro ((arg) => { if (typeof arg !== "number") {throw new Error("unable to parse " + typeof arg + " " + arg + " as a number")}; return JSON.parse(JSON.stringify(arg)) })($self$)
    *
-   * @returns a string.
+   * @returns a number.
    */
   public asNum(): number {
     throw new Error("Macro");
   }
 
   /**
-   * Convert Json element to string if possible.
+   * Convert Json element to number if possible.
    *
    * @macro ((arg) => { return (typeof arg === "number") ? JSON.parse(JSON.stringify(arg)) : undefined })($self$)
    *
-   * @returns a string.
+   * @returns a number.
    */
   public tryAsNum(): number | undefined {
     throw new Error("Macro");
   }
 
   /**
-   * Convert Json element to number if possible.
+   * Convert Json element to boolean if possible.
    *
    * @macro ((arg) => { if (typeof arg !== "boolean") {throw new Error("unable to parse " + typeof arg + " " + arg + " as a boolean")}; return JSON.parse(JSON.stringify(arg)) })($self$)
    *
-   * @returns a string.
+   * @returns a boolean.
    */
   public asBool(): boolean {
     throw new Error("Macro");
@@ -403,7 +403,7 @@ export class MutJson {
    *
    * @macro ((arg) => { return (typeof arg === "boolean") ? JSON.parse(JSON.stringify(arg)) : undefined })($self$)
    *
-   * @returns a string.
+   * @returns a boolean.
    */
   public tryAsBool(): boolean | undefined {
     throw new Error("Macro");


### PR DESCRIPTION
Fixing some typos in `json` method docstrings, reported by Jordin Gardner [here](https://winglang.slack.com/archives/C048QCN2XLJ/p1688619629755739?thread_ts=1688597325.876739&cid=C048QCN2XLJ).

## Checklist

- [ ] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [ ] Description explains motivation and solution
- [ ] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://www.winglang.io/terms-and-policies/contribution-license.html)*.
