### PR TITLE
fix(compiler): subclasses do not implement interfaces of parent classes

### DIFF
--- a/examples/tests/valid/impl_interface.w
+++ b/examples/tests/valid/impl_interface.w
@@ -48,3 +48,12 @@ class Dog impl IAnimal {
 }
 
 let z: IAnimal = new Dog();
+
+// base class is checked for implemention of interface
+class Terrier extends Dog {
+  inflight eat() {
+    return;
+  }
+}
+
+let w: IAnimal = new Terrier();

--- a/libs/wingc/src/type_check.rs
+++ b/libs/wingc/src/type_check.rs
@@ -520,7 +520,14 @@ impl Subtype for Type {
 					parent_type.is_subtype_of(other)
 				});
 
-				if implements_iface {
+				let base_class_implements_iface = if let Some(base_class) = &class.parent {
+					let base_class_type: &Type = base_class;
+					base_class_type.is_subtype_of(other)
+				} else {
+					false
+				};
+
+				if implements_iface || base_class_implements_iface {
 					return true;
 				}
 


### PR DESCRIPTION
Fixes #3349

## Checklist

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [x] Tests added (always)
- [x] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://www.winglang.io/terms-and-policies/contribution-license.html)*.
