### PR TITLE
chore(docs): beef up the learn more page

### DIFF
--- a/docs/docs/01-start-here/06-learn-more.md
+++ b/docs/docs/01-start-here/06-learn-more.md
@@ -7,6 +7,14 @@ keywords: [Wing, Tutorial, Documentation, Learn, Resources]
 
 To learn more, you can check out our various tutorials and documentation pages and other resources.
 
+### Documentation
+
+Learn about Wing's [core concepts](https://www.winglang.io/docs/category/core-concepts), including Wing's main differentiator, the [preflight and inflight execution phases](https://www.winglang.io/docs/concepts/inflights).
+
+Or check out the documentation of the varios resources in Wing's [standard library](https://www.winglang.io/docs/category/standard-library) which abstracts the cloud.
+
+You can also check out Wing's [toolchain](https://www.winglang.io/docs/category/tools), including the [compiler plugins](https://www.winglang.io/docs/tools/compiler-plugins) that allow you to go below the abstraction layer and tweak the infrastructure definitions directly.
+
 ### Interactive Tutorials 
 
 [Intro to Wing](https://www.winglang.io/learn/)
@@ -20,14 +28,6 @@ To learn more, you can check out our various tutorials and documentation pages a
 [Working with Queue](https://www.winglang.io/learn/queue)
 
 [The Topic resource](https://www.winglang.io/learn/topic)
-
-### Documentation
-
-Learn about Wing's [core concepts](https://www.winglang.io/docs/category/core-concepts), including Wing's main differentiator, the [preflight and inflight execution phases](https://www.winglang.io/docs/concepts/inflights).
-
-Or check out the documentation of the varios resources in Wing's [standard library](https://www.winglang.io/docs/category/standard-library) which abstracts the cloud.
-
-You can also check out Wing's [toolchain](https://www.winglang.io/docs/category/tools), including the [compiler plugins](https://www.winglang.io/docs/tools/compiler-plugins) that allow you to go below the abstraction layer and tweak the infrastructure definitions directly.
 
 ### Guides
 Check out our [guides](https://www.winglang.io/docs/category/guides) to learn how to use Wing to build real-world applications.

--- a/docs/docs/01-start-here/06-learn-more.md
+++ b/docs/docs/01-start-here/06-learn-more.md
@@ -1,13 +1,45 @@
 ---
 title: Learn more
 id: learn-more
-description: Tutorials and Workshopts
-keywords: [Wing]
+description: Tutorials, Documentation and more resources to help with learning Wing
+keywords: [Wing, Tutorial, Documentation, Learn, Resources]
 ---
 
-To learn more, check out the rest of our docs where we cover all the basics with Wing, or check out our [examples repository](https://github.com/winglang/examples) to see some samples of Wing applications.
+To learn more, you can check out our various tutorials and documentation pages and other resources.
 
+### Interactive Tutorials 
+
+[Intro to Wing](https://www.winglang.io/learn/)
+
+[Preflight and Inflight execution phases](https://www.winglang.io/learn/preflight-inflight)
+
+[The Bucket resource](https://www.winglang.io/learn/bucket)
+
+[Introduction to Counter](https://www.winglang.io/learn/counter)
+
+[Working with Queue](https://www.winglang.io/learn/queue)
+
+[The Topic resource](https://www.winglang.io/learn/topic)
+
+### Documentation
+
+Learn about Wing's [core concepts](https://www.winglang.io/docs/category/core-concepts), including Wing's main differentiator, the [preflight and inflight execution phases](https://www.winglang.io/docs/concepts/inflights).
+
+Or check out the documentation of the varios resources in Wing's [standard library](https://www.winglang.io/docs/category/standard-library) which abstracts the cloud.
+
+You can also check out Wing's [toolchain](https://www.winglang.io/docs/category/tools), including the [compiler plugins](https://www.winglang.io/docs/tools/compiler-plugins) that allow you to go below the abstraction layer and tweak the infrastructure definitions directly.
+
+### Guides
+Check out our [guides](https://www.winglang.io/docs/category/guides) to learn how to use Wing to build real-world applications.
+
+### Examples
+Check out our [examples repository](https://github.com/winglang/examples) to see some samples of Wing applications.
+There are also smaller code examples by theme in the [docs](https://www.winglang.io/docs/category/examples).
+
+### Playground
+Put your skills to the test using the [playground](https://docs.winglang.io/getting-started).
+
+### Community
 We also have a [YouTube channel](https://www.youtube.com/@winglangio) where we share clips of demos and guest interviews on our [Twitch show](https://www.twitch.tv/winglangio), and a [blog](https://www.winglang.io/blog).
 
-Finally, we encourage you to join our [Wing Slack](http://t.winglang.io/slack).
-We're here to help each other, answer questions, and share our cloud adventures.
+Finally, we encourage you to join our [Wing Slack](http://t.winglang.io/slack) where we help each other, answer questions, and share our cloud adventures.


### PR DESCRIPTION
Add some meet on the 'learn more' page in the docs.

Fixes: #3325

## Checklist

- [X] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [X] Description explains motivation and solution
- [ ] Tests added (always)
- [X] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://www.winglang.io/terms-and-policies/contribution-license.html)*.
