### PR TITLE
chore(docs): inflight doc link to interactive tutorial

### DIFF
--- a/docs/docs/02-concepts/01-preflight-and-inflight.md
+++ b/docs/docs/02-concepts/01-preflight-and-inflight.md
@@ -5,6 +5,8 @@ description: "Wing's two execution phases: preflight and inflight"
 keywords: [Inflights, Inflight functions, Preflight, Preflight code]
 ---
 
+> This content is also available in an [interactive tutorial](https://www.winglang.io/learn/preflight-inflight)
+
 One of the main differences between Wing and other languages is that it unifies both infrastructure definitions and application logic under the same programming model. 
 This is enabled by the concepts of the *preflight* and *inflight* execution phases:
 


### PR DESCRIPTION
The inlight concept doc now links to the interactive tutorial about preflight-inflight

## Checklist

- [X] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [X] Description explains motivation and solution
- [ ] Tests added (always)
- [X] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://www.winglang.io/terms-and-policies/contribution-license.html)*.
