### PR TITLE
fix: labeling during self mutation not working for pull requests from forks

### DIFF
--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -52,16 +52,6 @@ jobs:
             exit 1
           fi
 
-      - name: Add label to block auto merge
-        if: github.event.workflow_run.event == 'pull_request' && steps.download-artifacts.outputs.found_artifact == 'true'
-        run: |
-          curl \
-            -X POST \
-            -H "Authorization: Bearer ${{ secrets.MUTATION_TOKEN }}" \
-            -H "Accept: application/vnd.github.v3+json" \
-            "https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.workflow_run.pull_requests[0].number }}/labels" \
-            -d '["⚠️ pr/review-mutation"]'
-
       - name: Disable Git Hooks
         if: steps.download-artifacts.outputs.found_artifact == 'true'
         run: |
@@ -105,3 +95,25 @@ jobs:
           git add --all
           git commit -s -m "chore: self mutation"
           git push origin HEAD:$HEAD_REF
+
+      - name: Add label to block auto merge
+        uses: actions/github-script@v6
+        if: github.event.workflow_run.event == 'pull_request' && steps.download-artifacts.outputs.found_artifact == 'true'
+        with:
+          github-token: ${{ secrets.MUTATION_TOKEN }}
+          script: |
+            const pulls = await github.rest.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              head: `${context.payload.workflow_run.head_repository.full_name}:${context.payload.workflow_run.head_branch}`
+            });
+
+            const prNumber = pulls.data[0].number;
+            const labels = ["⚠️ pr/review-mutation"];
+            
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              labels: labels
+            });


### PR DESCRIPTION
Labeling during self mutation was added as a cautionary method but seems like it is not working for PRs from forks. This is because github context does not return pull request data (at least in this case) and so there is no way to form the proper url for rest api call using just github context. Instead retrieve the PR number with a rest api call and use it. Also change the labeling to after mutation commit.
Modified the step to use script module instead of run as per @MarkMcCulloh's suggestion.
fixes #3391.
## Checklist

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [ ] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://www.winglang.io/terms-and-policies/contribution-license.html)*.
