### PR TITLE
fix(cli): breaks without globally installed aws-cdk-lib

### DIFF
--- a/libs/wingsdk/src/shared-aws/function.ts
+++ b/libs/wingsdk/src/shared-aws/function.ts
@@ -1,6 +1,5 @@
 import { PolicyStatement } from "./types";
 import { IInflightHost } from "../std";
-import { Function as AwsCdkFunction } from "../target-awscdk";
 import { Function as TfAwsFunction } from "../target-tf-aws";
 
 /**
@@ -32,10 +31,6 @@ export class Function {
    */
   public static from(host: IInflightHost): IAwsFunction | undefined {
     if (host instanceof TfAwsFunction) {
-      return host;
-    }
-
-    if (host instanceof AwsCdkFunction) {
       return host;
     }
 


### PR DESCRIPTION
Fixes #3396

This "instanceof" check is causing problems since it results in several other modules to get imported, including those that require `aws-cdk-lib` to be installed -- even if you're not compiling to the `awscdk` target. Removing this code path as a hotfix.

## Checklist

- [ ] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [ ] Description explains motivation and solution
- [ ] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://www.winglang.io/terms-and-policies/contribution-license.html)*.
