### PR TITLE
fix: mergify comment is incorrect if the pull request contains mergify config change

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -2,6 +2,7 @@
 queue_rules:
   - name: default
     conditions:
+      - files=.mergify.yml
       - status-success=Validate PR title
       - or:
         - status-success=Quality Gate
@@ -19,7 +20,8 @@ pull_request_rules:
           {{ title }} (#{{ number }})
           {{ body }}
     conditions:
-      - -title~=(WIP|wip)
+      - -files=.mergify.yml
+      - -title~=(?i)wip
       - -label~=(🚧 pr/do-not-merge|⚠️ pr/review-mutation)
       - -merged
       - -closed
@@ -38,6 +40,38 @@ pull_request_rules:
       - or:
         - check-success=Quality Gate
         - -files~=^(?!docs/|logo/)
+
+  - name: requires manual merge
+    conditions:
+      - files=.mergify.yml
+      - -title~=(?i)wip
+      - -label~=(🚧 pr/do-not-merge|⚠️ pr/review-mutation|⚠️ mergify/review-config)
+      - -merged
+      - -closed
+      - "#approved-reviews-by>=1"
+      - "#changes-requested-reviews-by=0"
+      - "#review-threads-unresolved=0"
+      - -approved-reviews-by~=author
+      - check-success=Validate PR title
+      - or:
+        -  base=main
+        -  base=dev
+      - or:
+        # Code freeze at 7am utc July 13th 2023
+        - updated-at<=2023-07-13T07:00:00Z
+        - base=dev
+      - or:
+        - check-success=Quality Gate
+        - -files~=^(?!docs/|logo/)
+    actions:
+      comment:
+        message: Thank you for contributing! Your pull request contains megify configuration changes and needs manual merge from a maintainer (be sure to [allow changes to be pushed to your fork](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)).
+      label:
+        add:
+          - ⚠️ mergify/review-config
+      request_reviews:
+        teams:
+          - "@winglang/maintainers"
 
   - name: backport change to main
     conditions:


### PR DESCRIPTION
Mergify is not configured to auto merge if the PR contains mergify config changes, however the message that is commented is still that it'll be auto merged. This PR changes the response comment to appear conditionally and adds some explicit conditions to make sure that mergify config change is given the necessary attention.
fixes #3389.
## Checklist

- [ ] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [ ] Description explains motivation and solution
- [ ] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://www.winglang.io/terms-and-policies/contribution-license.html)*.
