### PR TITLE
fix(sdk): adjust local schedule to UTC

### DIFF
--- a/docs/docs/04-standard-library/01-cloud/schedule.md
+++ b/docs/docs/04-standard-library/01-cloud/schedule.md
@@ -17,6 +17,7 @@ sidebar_position: 1
 
 The `cloud.Schedule` resource is used to trigger events at a regular interval.
 Schedules are useful for periodic tasks, such as running backups or sending daily reports.
+The timezone used in cron expressions is always UTC.
 
 ## Usage
 
@@ -246,6 +247,7 @@ cron: str;
 
 Trigger events according to a cron schedule using the UNIX cron format.
 
+Timezone is UTC.
 [minute] [hour] [day of month] [month] [day of week]
 
 ---

--- a/examples/tests/sdk_tests/bucket/events.w
+++ b/examples/tests/sdk_tests/bucket/events.w
@@ -20,9 +20,6 @@ let table = new ex.Table(
   }
 );
 
-class Util {
-  extern "../external/sleep.js" static inflight sleep(milli: num);
-}
 
 
 let logHistory = inflight (key: str, operation: str, source: Source) => {
@@ -55,7 +52,7 @@ let wait = inflight (pred: inflight (): bool): bool => {
       return true;
     } 
   
-    Util.sleep(10000);
+    util.sleep(10s);
 
     i = i + 1;
   }

--- a/examples/tests/sdk_tests/external/sleep.js
+++ b/examples/tests/sdk_tests/external/sleep.js
@@ -1,3 +1,0 @@
-exports.sleep = function (ms) {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-};

--- a/examples/tests/sdk_tests/queue/purge.w
+++ b/examples/tests/sdk_tests/queue/purge.w
@@ -1,12 +1,8 @@
 bring cloud;
+bring util;
 
 let q = new cloud.Queue();
-class TestHelper {
-  init(){}
-  extern "../external/sleep.js" inflight sleep(milli: num);
-}
 
-let js = new TestHelper();
 
 test "purge" {
   q.push("foo");
@@ -20,7 +16,7 @@ test "purge" {
         return true;
       } 
   
-      js.sleep(100);
+      util.sleep(1s);
       i = i + 1;
     }
   

--- a/examples/tests/sdk_tests/queue/set_consumer.w
+++ b/examples/tests/sdk_tests/queue/set_consumer.w
@@ -1,4 +1,5 @@
 bring cloud;
+bring util;
 
 let q = new cloud.Queue();
 let c = new cloud.Counter();
@@ -16,16 +17,12 @@ class Predicate {
   }
 }
 
-class TestHelper {
-  init(){}
-  extern "../external/sleep.js" inflight sleep(milli: num);
-}
+
 
 q.setConsumer(inflight (msg: str): str => {
   c.inc();
 });
 
-let js = new TestHelper();
 
 let predicate = new Predicate(c);
 test "setConsumer" {
@@ -39,7 +36,7 @@ test "setConsumer" {
       assert(predicate.test());
       return;
     } 
-    js.sleep(100);
+    util.sleep(1s);
   }
   assert(predicate.test());
 }

--- a/examples/tests/sdk_tests/schedule/on_tick.w
+++ b/examples/tests/sdk_tests/schedule/on_tick.w
@@ -1,4 +1,5 @@
 bring cloud;
+bring util;
 
 // every minute
 let from_cron = new cloud.Schedule( cron: "* * * * ?" ) as "from_cron";
@@ -15,9 +16,6 @@ from_rate.onTick(inflight () => {
     c2.inc();
 });
 
-class Utils {
-    extern "../external/sleep.js" static inflight sleep(milli: num);
-}
 
 // std.Test is used setting the timeout property
 new std.Test(inflight () => {
@@ -26,7 +24,7 @@ new std.Test(inflight () => {
     assert(c2.peek() == 0);
 
     // wait at least one minute
-    Utils.sleep(60 * 1000 * 1.1);
+    util.sleep(1.1m);
 
     // check that both counters have been incremented
     assert(c1.peek() >= 1);

--- a/examples/tests/sdk_tests/topic/on_message.w
+++ b/examples/tests/sdk_tests/topic/on_message.w
@@ -1,4 +1,5 @@
 bring cloud;
+bring util;
 
 let t = new cloud.Topic();
 let c = new cloud.Counter();
@@ -40,7 +41,7 @@ test "onMessage" {
         assert(predicate.test());
         return;
       } 
-      TestHelper.sleep(100);
+      util.sleep(1s);
     }
     assert(predicate.test());
 }

--- a/examples/tests/sdk_tests/topic/on_message.w
+++ b/examples/tests/sdk_tests/topic/on_message.w
@@ -15,10 +15,6 @@ class Predicate {
   }
 }
 
-class TestHelper {
-  extern "../external/sleep.js" static inflight sleep(milli: num);
-}
-
 t.onMessage(inflight() => {
   c.inc();
 });
@@ -27,7 +23,6 @@ t.onMessage(inflight() => {
   c.inc();
 });
 
-let js = new TestHelper();
 
 let predicate = new Predicate(c);
 test "onMessage" {

--- a/libs/wingsdk/src/cloud/schedule.md
+++ b/libs/wingsdk/src/cloud/schedule.md
@@ -17,6 +17,7 @@ sidebar_position: 1
 
 The `cloud.Schedule` resource is used to trigger events at a regular interval.
 Schedules are useful for periodic tasks, such as running backups or sending daily reports.
+The timezone used in cron expressions is always UTC.
 
 ## Usage
 

--- a/libs/wingsdk/src/cloud/schedule.ts
+++ b/libs/wingsdk/src/cloud/schedule.ts
@@ -21,7 +21,7 @@ export interface ScheduleProps {
   readonly rate?: Duration;
 
   /**
-   * Trigger events according to a cron schedule using the UNIX cron format.
+   * Trigger events according to a cron schedule using the UNIX cron format. Timezone is UTC.
    * [minute] [hour] [day of month] [month] [day of week]
    * @example "0/1 * ? * *"
    * @default undefined

--- a/libs/wingsdk/src/target-sim/schedule.inflight.ts
+++ b/libs/wingsdk/src/target-sim/schedule.inflight.ts
@@ -20,7 +20,7 @@ export class Schedule
 
   constructor(props: ScheduleSchema["props"], context: ISimulatorContext) {
     this.context = context;
-    this.interval = parseExpression(props.cronExpression);
+    this.interval = parseExpression(props.cronExpression, { utc: true });
     this.scheduleFunction();
   }
 

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/events.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/events.w_compile_tf-aws.md
@@ -92,7 +92,7 @@ module.exports = function({ $Source, $logHistory }) {
 
 ## inflight.$Closure6.js
 ```js
-module.exports = function({ $Util }) {
+module.exports = function({ $std_Duration, $util_Util }) {
   class $Closure6 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
@@ -105,7 +105,7 @@ module.exports = function({ $Util }) {
         if ((await pred())) {
           return true;
         }
-        (await $Util.sleep(10000));
+        (await $util_Util.sleep((await $std_Duration.fromSeconds(10))));
         i = (i + 1);
       }
       return false;
@@ -173,21 +173,6 @@ module.exports = function({ $Source, $b, $checkHitCount, $util_Util, $wait }) {
     }
   }
   return $Closure8;
-}
-
-```
-
-## inflight.Util.js
-```js
-module.exports = function({  }) {
-  class Util {
-    constructor({  }) {
-    }
-    static async sleep(milli) {
-      return (require("<ABSOLUTE_PATH>/sleep.js")["sleep"])(milli)
-    }
-  }
-  return Util;
 }
 
 ```
@@ -1071,29 +1056,6 @@ const util = require('@winglang/sdk').util;
 class $Root extends $stdlib.std.Resource {
   constructor(scope, id) {
     super(scope, id);
-    class Util extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
-        this._addInflightOps("sleep", "$inflight_init");
-      }
-      static _toInflightType(context) {
-        return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.Util.js")({
-          })
-        `);
-      }
-      _toInflight() {
-        return $stdlib.core.NodeJsCode.fromInline(`
-          (await (async () => {
-            const UtilClient = ${Util._toInflightType(this).text};
-            const client = new UtilClient({
-            });
-            if (client.$inflight_init) { await client.$inflight_init(); }
-            return client;
-          })())
-        `);
-      }
-    }
     class $Closure1 extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
@@ -1264,7 +1226,8 @@ class $Root extends $stdlib.std.Resource {
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
           require("./inflight.$Closure6.js")({
-            $Util: ${context._lift(Util)},
+            $std_Duration: ${context._lift(std.Duration)},
+            $util_Util: ${context._lift(util.Util)},
           })
         `);
       }
@@ -1278,12 +1241,6 @@ class $Root extends $stdlib.std.Resource {
             return client;
           })())
         `);
-      }
-      _registerBind(host, ops) {
-        if (ops.includes("handle")) {
-          $Closure6._registerBindObject(Util, host, ["sleep"]);
-        }
-        super._registerBind(host, ops);
       }
     }
     class $Closure7 extends $stdlib.std.Resource {

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/queue/purge.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/queue/purge.w_compile_tf-aws.md
@@ -2,7 +2,7 @@
 
 ## inflight.$Closure1.js
 ```js
-module.exports = function({ $js, $q }) {
+module.exports = function({ $q, $std_Duration, $util_Util }) {
   class $Closure1 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
@@ -19,7 +19,7 @@ module.exports = function({ $js, $q }) {
           if ((await pred())) {
             return true;
           }
-          (await $js.sleep(100));
+          (await $util_Util.sleep((await $std_Duration.fromSeconds(1))));
           i = (i + 1);
         }
         return false;
@@ -37,21 +37,6 @@ module.exports = function({ $js, $q }) {
     }
   }
   return $Closure1;
-}
-
-```
-
-## inflight.TestHelper.js
-```js
-module.exports = function({  }) {
-  class TestHelper {
-    constructor({  }) {
-    }
-    async sleep(milli) {
-      return (require("<ABSOLUTE_PATH>/sleep.js")["sleep"])(milli)
-    }
-  }
-  return TestHelper;
 }
 
 ```
@@ -197,32 +182,10 @@ const std = $stdlib.std;
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const $AppBase = $stdlib.core.App.for(process.env.WING_TARGET);
 const cloud = require('@winglang/sdk').cloud;
+const util = require('@winglang/sdk').util;
 class $Root extends $stdlib.std.Resource {
   constructor(scope, id) {
     super(scope, id);
-    class TestHelper extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
-        this._addInflightOps("sleep", "$inflight_init");
-      }
-      static _toInflightType(context) {
-        return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.TestHelper.js")({
-          })
-        `);
-      }
-      _toInflight() {
-        return $stdlib.core.NodeJsCode.fromInline(`
-          (await (async () => {
-            const TestHelperClient = ${TestHelper._toInflightType(this).text};
-            const client = new TestHelperClient({
-            });
-            if (client.$inflight_init) { await client.$inflight_init(); }
-            return client;
-          })())
-        `);
-      }
-    }
     class $Closure1 extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
@@ -232,8 +195,9 @@ class $Root extends $stdlib.std.Resource {
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
           require("./inflight.$Closure1.js")({
-            $js: ${context._lift(js)},
             $q: ${context._lift(q)},
+            $std_Duration: ${context._lift(std.Duration)},
+            $util_Util: ${context._lift(util.Util)},
           })
         `);
       }
@@ -250,14 +214,12 @@ class $Root extends $stdlib.std.Resource {
       }
       _registerBind(host, ops) {
         if (ops.includes("handle")) {
-          $Closure1._registerBindObject(js, host, ["sleep"]);
           $Closure1._registerBindObject(q, host, ["approxSize", "purge", "push"]);
         }
         super._registerBind(host, ops);
       }
     }
     const q = this.node.root.newAbstract("@winglang/sdk.cloud.Queue",this,"cloud.Queue");
-    const js = new TestHelper(this,"TestHelper");
     this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:purge",new $Closure1(this,"$Closure1"));
   }
 }

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/queue/set_consumer.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/queue/set_consumer.w_compile_tf-aws.md
@@ -20,7 +20,7 @@ module.exports = function({ $c }) {
 
 ## inflight.$Closure2.js
 ```js
-module.exports = function({ $js, $predicate, $q }) {
+module.exports = function({ $predicate, $q, $std_Duration, $util_Util }) {
   class $Closure2 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
@@ -37,7 +37,7 @@ module.exports = function({ $js, $predicate, $q }) {
           {((cond) => {if (!cond) throw new Error("assertion failed: predicate.test()")})((await $predicate.test()))};
           return;
         }
-        (await $js.sleep(100));
+        (await $util_Util.sleep((await $std_Duration.fromSeconds(1))));
       }
       {((cond) => {if (!cond) throw new Error("assertion failed: predicate.test()")})((await $predicate.test()))};
     }
@@ -59,21 +59,6 @@ module.exports = function({  }) {
     }
   }
   return Predicate;
-}
-
-```
-
-## inflight.TestHelper.js
-```js
-module.exports = function({  }) {
-  class TestHelper {
-    constructor({  }) {
-    }
-    async sleep(milli) {
-      return (require("<ABSOLUTE_PATH>/sleep.js")["sleep"])(milli)
-    }
-  }
-  return TestHelper;
 }
 
 ```
@@ -319,6 +304,7 @@ const std = $stdlib.std;
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const $AppBase = $stdlib.core.App.for(process.env.WING_TARGET);
 const cloud = require('@winglang/sdk').cloud;
+const util = require('@winglang/sdk').util;
 class $Root extends $stdlib.std.Resource {
   constructor(scope, id) {
     super(scope, id);
@@ -354,29 +340,6 @@ class $Root extends $stdlib.std.Resource {
           Predicate._registerBindObject(this.c, host, ["peek"]);
         }
         super._registerBind(host, ops);
-      }
-    }
-    class TestHelper extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
-        this._addInflightOps("sleep", "$inflight_init");
-      }
-      static _toInflightType(context) {
-        return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.TestHelper.js")({
-          })
-        `);
-      }
-      _toInflight() {
-        return $stdlib.core.NodeJsCode.fromInline(`
-          (await (async () => {
-            const TestHelperClient = ${TestHelper._toInflightType(this).text};
-            const client = new TestHelperClient({
-            });
-            if (client.$inflight_init) { await client.$inflight_init(); }
-            return client;
-          })())
-        `);
       }
     }
     class $Closure1 extends $stdlib.std.Resource {
@@ -419,9 +382,10 @@ class $Root extends $stdlib.std.Resource {
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
           require("./inflight.$Closure2.js")({
-            $js: ${context._lift(js)},
             $predicate: ${context._lift(predicate)},
             $q: ${context._lift(q)},
+            $std_Duration: ${context._lift(std.Duration)},
+            $util_Util: ${context._lift(util.Util)},
           })
         `);
       }
@@ -438,7 +402,6 @@ class $Root extends $stdlib.std.Resource {
       }
       _registerBind(host, ops) {
         if (ops.includes("handle")) {
-          $Closure2._registerBindObject(js, host, ["sleep"]);
           $Closure2._registerBindObject(predicate, host, ["test"]);
           $Closure2._registerBindObject(q, host, ["push"]);
         }
@@ -448,7 +411,6 @@ class $Root extends $stdlib.std.Resource {
     const q = this.node.root.newAbstract("@winglang/sdk.cloud.Queue",this,"cloud.Queue");
     const c = this.node.root.newAbstract("@winglang/sdk.cloud.Counter",this,"cloud.Counter");
     (q.setConsumer(new $Closure1(this,"$Closure1")));
-    const js = new TestHelper(this,"TestHelper");
     const predicate = new Predicate(this,"Predicate",c);
     this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:setConsumer",new $Closure2(this,"$Closure2"));
   }

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/schedule/on_tick.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/schedule/on_tick.w_compile_tf-aws.md
@@ -38,7 +38,7 @@ module.exports = function({ $c2 }) {
 
 ## inflight.$Closure3.js
 ```js
-module.exports = function({ $Utils, $c1, $c2 }) {
+module.exports = function({ $c1, $c2, $std_Duration, $util_Util }) {
   class $Closure3 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
@@ -48,27 +48,12 @@ module.exports = function({ $Utils, $c1, $c2 }) {
     async handle() {
       {((cond) => {if (!cond) throw new Error("assertion failed: c1.peek() == 0")})(((await $c1.peek()) === 0))};
       {((cond) => {if (!cond) throw new Error("assertion failed: c2.peek() == 0")})(((await $c2.peek()) === 0))};
-      (await $Utils.sleep(((60 * 1000) * 1.1)));
+      (await $util_Util.sleep((await $std_Duration.fromSeconds(66))));
       {((cond) => {if (!cond) throw new Error("assertion failed: c1.peek() >= 1")})(((await $c1.peek()) >= 1))};
       {((cond) => {if (!cond) throw new Error("assertion failed: c2.peek() >= 1")})(((await $c2.peek()) >= 1))};
     }
   }
   return $Closure3;
-}
-
-```
-
-## inflight.Utils.js
-```js
-module.exports = function({  }) {
-  class Utils {
-    constructor({  }) {
-    }
-    static async sleep(milli) {
-      return (require("<ABSOLUTE_PATH>/sleep.js")["sleep"])(milli)
-    }
-  }
-  return Utils;
 }
 
 ```
@@ -446,6 +431,7 @@ const std = $stdlib.std;
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const $AppBase = $stdlib.core.App.for(process.env.WING_TARGET);
 const cloud = require('@winglang/sdk').cloud;
+const util = require('@winglang/sdk').util;
 class $Root extends $stdlib.std.Resource {
   constructor(scope, id) {
     super(scope, id);
@@ -511,29 +497,6 @@ class $Root extends $stdlib.std.Resource {
         super._registerBind(host, ops);
       }
     }
-    class Utils extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
-        this._addInflightOps("sleep", "$inflight_init");
-      }
-      static _toInflightType(context) {
-        return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.Utils.js")({
-          })
-        `);
-      }
-      _toInflight() {
-        return $stdlib.core.NodeJsCode.fromInline(`
-          (await (async () => {
-            const UtilsClient = ${Utils._toInflightType(this).text};
-            const client = new UtilsClient({
-            });
-            if (client.$inflight_init) { await client.$inflight_init(); }
-            return client;
-          })())
-        `);
-      }
-    }
     class $Closure3 extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
@@ -543,9 +506,10 @@ class $Root extends $stdlib.std.Resource {
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
           require("./inflight.$Closure3.js")({
-            $Utils: ${context._lift(Utils)},
             $c1: ${context._lift(c1)},
             $c2: ${context._lift(c2)},
+            $std_Duration: ${context._lift(std.Duration)},
+            $util_Util: ${context._lift(util.Util)},
           })
         `);
       }
@@ -562,7 +526,6 @@ class $Root extends $stdlib.std.Resource {
       }
       _registerBind(host, ops) {
         if (ops.includes("handle")) {
-          $Closure3._registerBindObject(Utils, host, ["sleep"]);
           $Closure3._registerBindObject(c1, host, ["peek"]);
           $Closure3._registerBindObject(c2, host, ["peek"]);
         }

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/topic/on_message.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/topic/on_message.w_compile_tf-aws.md
@@ -38,7 +38,7 @@ module.exports = function({ $c }) {
 
 ## inflight.$Closure3.js
 ```js
-module.exports = function({ $TestHelper, $predicate, $t }) {
+module.exports = function({ $predicate, $std_Duration, $t, $util_Util }) {
   class $Closure3 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
@@ -56,7 +56,7 @@ module.exports = function({ $TestHelper, $predicate, $t }) {
           {((cond) => {if (!cond) throw new Error("assertion failed: predicate.test()")})((await $predicate.test()))};
           return;
         }
-        (await $TestHelper.sleep(100));
+        (await $util_Util.sleep((await $std_Duration.fromSeconds(1))));
       }
       {((cond) => {if (!cond) throw new Error("assertion failed: predicate.test()")})((await $predicate.test()))};
     }
@@ -78,21 +78,6 @@ module.exports = function({  }) {
     }
   }
   return Predicate;
-}
-
-```
-
-## inflight.TestHelper.js
-```js
-module.exports = function({  }) {
-  class TestHelper {
-    constructor({  }) {
-    }
-    static async sleep(milli) {
-      return (require("<ABSOLUTE_PATH>/sleep.js")["sleep"])(milli)
-    }
-  }
-  return TestHelper;
 }
 
 ```
@@ -442,6 +427,7 @@ const std = $stdlib.std;
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const $AppBase = $stdlib.core.App.for(process.env.WING_TARGET);
 const cloud = require('@winglang/sdk').cloud;
+const util = require('@winglang/sdk').util;
 class $Root extends $stdlib.std.Resource {
   constructor(scope, id) {
     super(scope, id);
@@ -477,29 +463,6 @@ class $Root extends $stdlib.std.Resource {
           Predicate._registerBindObject(this.c, host, ["peek"]);
         }
         super._registerBind(host, ops);
-      }
-    }
-    class TestHelper extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
-        this._addInflightOps("sleep", "$inflight_init");
-      }
-      static _toInflightType(context) {
-        return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.TestHelper.js")({
-          })
-        `);
-      }
-      _toInflight() {
-        return $stdlib.core.NodeJsCode.fromInline(`
-          (await (async () => {
-            const TestHelperClient = ${TestHelper._toInflightType(this).text};
-            const client = new TestHelperClient({
-            });
-            if (client.$inflight_init) { await client.$inflight_init(); }
-            return client;
-          })())
-        `);
       }
     }
     class $Closure1 extends $stdlib.std.Resource {
@@ -573,9 +536,10 @@ class $Root extends $stdlib.std.Resource {
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
           require("./inflight.$Closure3.js")({
-            $TestHelper: ${context._lift(TestHelper)},
             $predicate: ${context._lift(predicate)},
+            $std_Duration: ${context._lift(std.Duration)},
             $t: ${context._lift(t)},
+            $util_Util: ${context._lift(util.Util)},
           })
         `);
       }
@@ -592,7 +556,6 @@ class $Root extends $stdlib.std.Resource {
       }
       _registerBind(host, ops) {
         if (ops.includes("handle")) {
-          $Closure3._registerBindObject(TestHelper, host, ["sleep"]);
           $Closure3._registerBindObject(predicate, host, ["test"]);
           $Closure3._registerBindObject(t, host, ["publish"]);
         }
@@ -603,7 +566,6 @@ class $Root extends $stdlib.std.Resource {
     const c = this.node.root.newAbstract("@winglang/sdk.cloud.Counter",this,"cloud.Counter");
     (t.onMessage(new $Closure1(this,"$Closure1")));
     (t.onMessage(new $Closure2(this,"$Closure2")));
-    const js = new TestHelper(this,"TestHelper");
     const predicate = new Predicate(this,"Predicate",c);
     this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:onMessage",new $Closure3(this,"$Closure3"));
   }


### PR DESCRIPTION
## Description
Fixes #3120
* Since translating a cron expression from one timezone to another is pretty tough, I also adjusted the local schedule to be in the UTC timezone.
* Removed external sleep.js and replaces it with `util.sleep` 

## Checklist

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [ ] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://www.winglang.io/terms-and-policies/contribution-license.html)*.
