### PR TITLE
chore: fix topic title

### DIFF
--- a/docs/docs/07-examples/04-flow-controls.md
+++ b/docs/docs/07-examples/04-flow-controls.md
@@ -1,6 +1,6 @@
 ---
-title: Flow controls
-id: flow-controls
+title: Flow control
+id: flow-control
 keywords: [Wing example]
 ---
 


### PR DESCRIPTION
It's "flow control" instead of "flow controls"

## Checklist

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [x] Tests added (always)
- [x] Docs updated (only required for features)
- [x] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://www.winglang.io/terms-and-policies/contribution-license.html)*.
