### PR TITLE
fix(cli): removed duplicate export hook call

### DIFF
--- a/apps/wing/src/cli.ts
+++ b/apps/wing/src/cli.ts
@@ -25,7 +25,6 @@ if (!SUPPORTED_NODE_VERSION) {
 function runSubCommand(subCommand: string) {
   return async (...args: any[]) => {
     try {
-      await exportAnalyticsHook();
       const exitCode = await import(`./commands/${subCommand}`).then((m) => m[subCommand](...args));
       if (exitCode === 1) {
         await exportAnalyticsHook();


### PR DESCRIPTION
Look.. merge conflicts are hard man 😅 

This exporthook call was supposed to be removed in my previous fix but my best guess is when I resolved a conflict I goofed and left the original call.

Closes: https://github.com/winglang/wing/issues/3423

## Checklist

- [ ] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [ ] Description explains motivation and solution
- [ ] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://www.winglang.io/terms-and-policies/contribution-license.html)*.
