### PR TITLE
fix(vscode): lsp crashes when a non-spanned diagnostics is encountered

### DIFF
--- a/apps/wing/src/commands/compile.ts
+++ b/apps/wing/src/commands/compile.ts
@@ -51,7 +51,7 @@ export async function compile(entrypoint: string, options: CompileOptions): Prom
         let labels: Label[] = [];
 
         // file_id might be "" if the span is synthetic (see #2521)
-        if (span !== null && span.file_id) {
+        if (span?.file_id) {
           // `span` should only be null if source file couldn't be read etc.
           const source = await fsPromise.readFile(span.file_id, "utf8");
           const start = byteOffsetFromLineAndColumn(source, span.start.line, span.start.col);

--- a/apps/wing/src/commands/lsp.ts
+++ b/apps/wing/src/commands/lsp.ts
@@ -118,7 +118,11 @@ export async function lsp() {
     connection.sendDiagnostics({
       uri,
       diagnostics: raw_diagnostics.map((rd) => {
-        return Diagnostic.create(Range.create(rd.span.start.line, rd.span.start.col, rd.span.end.line, rd.span.end.col), rd.message)
+        if(rd.span) {
+          return Diagnostic.create(Range.create(rd.span.start.line, rd.span.start.col, rd.span.end.line, rd.span.end.col), rd.message)
+        } else {
+          return Diagnostic.create(Range.create(0, 0, 0, 0), rd.message)
+        }
       })
     });
   }

--- a/libs/wingcompiler/src/wingc.ts
+++ b/libs/wingcompiler/src/wingc.ts
@@ -210,7 +210,7 @@ const HIGH_MASK = BigInt(32);
 // From diagnostic.rs
 export interface WingDiagnostic {
   message: string;
-  span: {
+  span?: {
     start: {
       line: number;
       col: number;


### PR DESCRIPTION
Fixes #3426 

## Checklist

- [ ] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [ ] Description explains motivation and solution
- [ ] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://www.winglang.io/terms-and-policies/contribution-license.html)*.
