### PR TITLE
fix(docs): analytic opt-out env var outdated

### DIFF
--- a/docs/docs/09-analytics.md
+++ b/docs/docs/09-analytics.md
@@ -12,7 +12,7 @@ You may not feel comfortable sharing this data with us, and that is ok. The gath
 
 ### Opting out
 
-If you would like to opt out of the analytics gathering, then you can do so by simply setting the environment variable `WING_CLI_DISABLE_ANALYTICS=1`. You can also use the flag `--no-analytics` when running any command.
+If you would like to opt out of the analytics gathering, then you can do so by simply setting the environment variable `WING_DISABLE_ANALYTICS=1`. You can also use the flag `--no-analytics` when running any command.
 
 ```sh
 wing compile -t sim app.w --no-analytics


### PR DESCRIPTION
The analytic docs were using the original env var for opting out. Since then the `CLI` term was removed.

## Checklist

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [x] Tests added (always)
- [x] Docs updated (only required for features)
- [x] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://www.winglang.io/terms-and-policies/contribution-license.html)*.
