### PR TITLE
fix: invalid vscode highlight syntax

### DIFF
--- a/apps/vscode-wing/syntaxes/wing.tmLanguage.json
+++ b/apps/vscode-wing/syntaxes/wing.tmLanguage.json
@@ -149,7 +149,7 @@
       "patterns": [
         {
           "name": "constant.numeric.wing",
-          "match": "(-?[0-9]+(\.[0-9]+)?(s|ms|h|m)?\\b)"
+          "match": "(-?[0-9]+(\\.[0-9]+)?(s|ms|h|m)?\\b)"
         }
       ]
     },


### PR DESCRIPTION
Regression from https://github.com/winglang/wing/pull/3404

## Checklist

- [ ] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [ ] Description explains motivation and solution
- [ ] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://www.winglang.io/terms-and-policies/contribution-license.html)*.
