### PR TITLE
fix(compiler): (performance) duplicate JSII deps are loaded more than once   

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,8 @@ members = [
   "libs/wingc",
   "libs/wingii",
 ]
+
+# For use with `cargo flamegraph --profile flamegraph
+[profile.flamegraph]
+inherits = "release"
+debug = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = [
   "libs/wingii",
 ]
 
-# For use with `cargo flamegraph --profile flamegraph
+# For use with `cargo flamegraph --profile flamegraph`
 [profile.flamegraph]
 inherits = "release"
 debug = true

--- a/libs/wingii/src/util.rs
+++ b/libs/wingii/src/util.rs
@@ -3,15 +3,16 @@ extern crate serde_json;
 
 pub mod package_json {
 	use std::{
+		collections::HashSet,
 		fs,
 		path::{Path, PathBuf},
 	};
 
 	use crate::node_resolve::{is_path_dependency, resolve_from};
 
-	pub fn dependencies_of(package_json: &serde_json::Value) -> Vec<String> {
+	pub fn dependencies_of(package_json: &serde_json::Value) -> HashSet<String> {
 		// merge both dependencies and peerDependencies and return the list of keys
-		let mut deps = Vec::new();
+		let mut deps = HashSet::new();
 		if let Some(deps_obj) = package_json.get("dependencies") {
 			deps.extend(deps_obj.as_object().unwrap().keys().cloned());
 		}


### PR DESCRIPTION
This affected performance of JSII loading.
Profiled using:
`cargo flamegraph --profile flamegraph --freq 20000 --example compile -- ../../examples/tests/valid/hello.w`
Results show that wingii's  `load_module` previously took 40% of the compilation time and now is down to 30%.

This PR also adds a profile to our `Cargo.toml` that's more compatible with `cargo flamegraph` (see the command above).

## Checklist

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [ ] Description explains motivation and solution
- [ ] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
