### PR TITLE
chore: add release commenter back in

### DIFF
--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -110,7 +110,7 @@ jobs:
 
             const prNumber = pulls.data[0].number;
             const labels = ["⚠️ pr/review-mutation"];
-            
+
             await github.rest.issues.addLabels({
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -22,7 +22,7 @@ jobs:
   mutate:
     runs-on: ubuntu-latest
     # Run if the workflow run is a pull request
-    if: github.event.workflow_run.conclusion == 'failure' && (contains(fromJSON('["main", "dev"]'), github.event.workflow_run.head_branch) || github.event.workflow_run.head_repository.fork)
+    if: github.event.workflow_run.conclusion == 'failure' && (!contains(fromJSON('["main", "dev"]'), github.event.workflow_run.head_branch) || github.event.workflow_run.head_repository.fork)
     steps:
       - name: Download artifacts
         id: download-artifacts

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -22,7 +22,7 @@ jobs:
   mutate:
     runs-on: ubuntu-latest
     # Run if the workflow run is a pull request
-    if: github.event.workflow_run.conclusion == 'failure' && (github.event.workflow_run.head_branch != 'main' || github.event.workflow_run.head_repository.fork)
+    if: github.event.workflow_run.conclusion == 'failure' && (contains(fromJSON('["main", "dev"]'), github.event.workflow_run.head_branch) || github.event.workflow_run.head_repository.fork)
     steps:
       - name: Download artifacts
         id: download-artifacts

--- a/.github/workflows/release-commenter.yml
+++ b/.github/workflows/release-commenter.yml
@@ -1,0 +1,18 @@
+name: Create Release Comment
+
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  release:
+    name: "Post release comments"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: apexskier/github-release-commenter@v1
+        with:
+          GITHUB_TOKEN: ${{ secrets.PROJEN_GITHUB_TOKEN }}
+          skip-label: pr/backport
+          comment-template: |
+            Congrats! :rocket: This was released in {release_link}.


### PR DESCRIPTION
Added the release commenter back in, but now ignoring any PRs with the pr/backport label.

Also disabled any pr mutations from happening on the dev branch.

## Checklist

- [ ] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [ ] Description explains motivation and solution
- [ ] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
