### PR TITLE
fix(compiler): `@inflight` docstring on methods was ignored by the jsii_importer 

### DIFF
--- a/examples/tests/invalid/call_inflight_from_preflight.w
+++ b/examples/tests/invalid/call_inflight_from_preflight.w
@@ -1,0 +1,13 @@
+bring util;
+
+// Call an inflight only SDK function
+util.sleep(1s);
+//^^^^^^^^^^^^^^ Cannot call into inflight phase while preflight
+
+class Foo {
+  inflight do() {}
+}
+let foo = new Foo();
+// Call an inflight method
+foo.do();
+//^^^^^^ Cannot call into inflight phase while preflight

--- a/libs/wingc/src/lsp/snapshots/completions/namespace_inflight.snap
+++ b/libs/wingc/src/lsp/snapshots/completions/namespace_inflight.snap
@@ -3,10 +3,10 @@ source: libs/wingc/src/lsp/completions.rs
 ---
 - label: delete
   kind: 2
-  detail: "(url: str, options: RequestOptions?): Response"
+  detail: "inflight (url: str, options: RequestOptions?): Response"
   documentation:
     kind: markdown
-    value: "```wing\nstatic delete: (url: str, options: RequestOptions?): Response\n```\n---\nExecutes a DELETE request to a specified URL and provides a formatted response.\n\n\n### Returns\nthe formatted response of the call"
+    value: "```wing\nstatic inflight delete: inflight (url: str, options: RequestOptions?): Response\n```\n---\nExecutes a DELETE request to a specified URL and provides a formatted response.\n\n\n### Returns\nthe formatted response of the call"
   sortText: ff|delete
   insertText: delete($0)
   insertTextFormat: 2
@@ -15,10 +15,10 @@ source: libs/wingc/src/lsp/completions.rs
     command: editor.action.triggerParameterHints
 - label: fetch
   kind: 2
-  detail: "(url: str, options: RequestOptions?): Response"
+  detail: "inflight (url: str, options: RequestOptions?): Response"
   documentation:
     kind: markdown
-    value: "```wing\nstatic fetch: (url: str, options: RequestOptions?): Response\n```\n---\nExecutes a HTTP request to a specified URL and provides a formatted response.\n\n\n### Returns\nthe formatted response of the call\n\n### Remarks\nThis method allows various HTTP methods based on the provided options.\n\n*@throws* *Only throws if there is a networking error*"
+    value: "```wing\nstatic inflight fetch: inflight (url: str, options: RequestOptions?): Response\n```\n---\nExecutes a HTTP request to a specified URL and provides a formatted response.\n\n\n### Returns\nthe formatted response of the call\n\n### Remarks\nThis method allows various HTTP methods based on the provided options.\n\n*@throws* *Only throws if there is a networking error*"
   sortText: ff|fetch
   insertText: fetch($0)
   insertTextFormat: 2
@@ -27,10 +27,10 @@ source: libs/wingc/src/lsp/completions.rs
     command: editor.action.triggerParameterHints
 - label: get
   kind: 2
-  detail: "(url: str, options: RequestOptions?): Response"
+  detail: "inflight (url: str, options: RequestOptions?): Response"
   documentation:
     kind: markdown
-    value: "```wing\nstatic get: (url: str, options: RequestOptions?): Response\n```\n---\nExecutes a GET request to a specified URL and provides a formatted response.\n\n\n### Returns\nthe formatted response of the call"
+    value: "```wing\nstatic inflight get: inflight (url: str, options: RequestOptions?): Response\n```\n---\nExecutes a GET request to a specified URL and provides a formatted response.\n\n\n### Returns\nthe formatted response of the call"
   sortText: ff|get
   insertText: get($0)
   insertTextFormat: 2
@@ -39,10 +39,10 @@ source: libs/wingc/src/lsp/completions.rs
     command: editor.action.triggerParameterHints
 - label: patch
   kind: 2
-  detail: "(url: str, options: RequestOptions?): Response"
+  detail: "inflight (url: str, options: RequestOptions?): Response"
   documentation:
     kind: markdown
-    value: "```wing\nstatic patch: (url: str, options: RequestOptions?): Response\n```\n---\nExecutes a PATCH request to a specified URL and provides a formatted response.\n\n\n### Returns\nthe formatted response of the call"
+    value: "```wing\nstatic inflight patch: inflight (url: str, options: RequestOptions?): Response\n```\n---\nExecutes a PATCH request to a specified URL and provides a formatted response.\n\n\n### Returns\nthe formatted response of the call"
   sortText: ff|patch
   insertText: patch($0)
   insertTextFormat: 2
@@ -51,10 +51,10 @@ source: libs/wingc/src/lsp/completions.rs
     command: editor.action.triggerParameterHints
 - label: post
   kind: 2
-  detail: "(url: str, options: RequestOptions?): Response"
+  detail: "inflight (url: str, options: RequestOptions?): Response"
   documentation:
     kind: markdown
-    value: "```wing\nstatic post: (url: str, options: RequestOptions?): Response\n```\n---\nExecutes a POST request to a specified URL and provides a formatted response.\n\n\n### Returns\nthe formatted response of the call"
+    value: "```wing\nstatic inflight post: inflight (url: str, options: RequestOptions?): Response\n```\n---\nExecutes a POST request to a specified URL and provides a formatted response.\n\n\n### Returns\nthe formatted response of the call"
   sortText: ff|post
   insertText: post($0)
   insertTextFormat: 2
@@ -63,10 +63,10 @@ source: libs/wingc/src/lsp/completions.rs
     command: editor.action.triggerParameterHints
 - label: put
   kind: 2
-  detail: "(url: str, options: RequestOptions?): Response"
+  detail: "inflight (url: str, options: RequestOptions?): Response"
   documentation:
     kind: markdown
-    value: "```wing\nstatic put: (url: str, options: RequestOptions?): Response\n```\n---\nExecutes a PUT request to a specified URL and provides a formatted response.\n\n\n### Returns\nthe formatted response of the call"
+    value: "```wing\nstatic inflight put: inflight (url: str, options: RequestOptions?): Response\n```\n---\nExecutes a PUT request to a specified URL and provides a formatted response.\n\n\n### Returns\nthe formatted response of the call"
   sortText: ff|put
   insertText: put($0)
   insertTextFormat: 2

--- a/libs/wingc/src/lsp/snapshots/completions/util_static_methods.snap
+++ b/libs/wingc/src/lsp/snapshots/completions/util_static_methods.snap
@@ -37,18 +37,6 @@ source: libs/wingc/src/lsp/completions.rs
   command:
     title: triggerParameterHints
     command: editor.action.triggerParameterHints
-- label: sleep
-  kind: 2
-  detail: "(delay: duration): void"
-  documentation:
-    kind: markdown
-    value: "```wing\nstatic sleep: (delay: duration): void\n```\n---\nSuspends execution for a given duration."
-  sortText: ff|sleep
-  insertText: sleep($0)
-  insertTextFormat: 2
-  command:
-    title: triggerParameterHints
-    command: editor.action.triggerParameterHints
 - label: tryEnv
   kind: 2
   detail: "(name: str): str?"
@@ -69,18 +57,6 @@ source: libs/wingc/src/lsp/completions.rs
     value: "```wing\nstatic uuidv4: (): str\n```\n---\nGenerates a version 4 UUID."
   sortText: ff|uuidv4
   insertText: uuidv4()
-- label: waitUntil
-  kind: 2
-  detail: "(predicate: inflight (): bool, props: WaitUntilProps?): bool"
-  documentation:
-    kind: markdown
-    value: "```wing\nstatic waitUntil: (predicate: inflight (): bool, props: WaitUntilProps?): bool\n```\n---\nRun a predicate repeatedly, waiting until it returns true or until the timeout elapses.\n\n\n### Returns\nTrue if predicate is truthful within timeout.\n\n*@throws* *Will throw if the given predicate throws.*"
-  sortText: ff|waitUntil
-  insertText: waitUntil($0)
-  insertTextFormat: 2
-  command:
-    title: triggerParameterHints
-    command: editor.action.triggerParameterHints
 - label: Util
   kind: 7
   documentation:

--- a/libs/wingc/src/type_check/jsii_importer.rs
+++ b/libs/wingc/src/type_check/jsii_importer.rs
@@ -441,6 +441,11 @@ impl<'a> JsiiImporter<'a> {
 					self.wing_types.void()
 				};
 
+				// Check if there's an explicit inflight phase override on this method
+				let member_phase = extract_docstring_tag(&m.docs, "inflight")
+					.map(|_| Phase::Inflight)
+					.unwrap_or(member_phase);
+
 				let mut fn_params = vec![];
 
 				// Define the rest of the arguments and create the method signature

--- a/tools/hangar/__snapshots__/invalid.ts.snap
+++ b/tools/hangar/__snapshots__/invalid.ts.snap
@@ -152,6 +152,28 @@ Test Files 1 failed (1)
 Duration <DURATION>"
 `;
 
+exports[`call_inflight_from_preflight.w 1`] = `
+"error: Cannot call into inflight phase while preflight
+  --> ../../../examples/tests/invalid/call_inflight_from_preflight.w:4:1
+  |
+4 | util.sleep(1s);
+  | ^^^^^^^^^^^^^^ Cannot call into inflight phase while preflight
+
+
+error: Cannot call into inflight phase while preflight
+   --> ../../../examples/tests/invalid/call_inflight_from_preflight.w:12:1
+   |
+12 | foo.do();
+   | ^^^^^^^^ Cannot call into inflight phase while preflight
+
+
+ 
+ 
+Tests 1 failed (1)
+Test Files 1 failed (1)
+Duration <DURATION>"
+`;
+
 exports[`capture_redefinition.w 1`] = `
 "error: Cannot capture symbol \\"y\\" because it is shadowed by another symbol with the same name
    --> ../../../examples/tests/invalid/capture_redefinition.w:14:9


### PR DESCRIPTION
`@inflight` docstring on methods was ignored by the jsii_importer. This meant that it was possible to call inflight util functions (such as `util.waitUntil`) from preflight. Now you receive an appropriate compiler error.
## Checklist

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [x] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Monada Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
