### PR TITLE
fix(compiler): compile to cjs rather than js

### DIFF
--- a/libs/wingc/src/jsify.rs
+++ b/libs/wingc/src/jsify.rs
@@ -28,7 +28,7 @@ use crate::{
 
 use self::codemaker::CodeMaker;
 
-const PREFLIGHT_FILE_NAME: &str = "preflight.js";
+const PREFLIGHT_FILE_NAME: &str = "preflight.cjs";
 
 const STDLIB: &str = "$stdlib";
 const STDLIB_CORE_RESOURCE: &str = formatcp!("{}.{}", STDLIB, WINGSDK_RESOURCE);
@@ -1311,7 +1311,7 @@ fn get_public_symbols(scope: &Scope) -> Vec<Symbol> {
 }
 
 fn inflight_filename(class: &AstClass) -> String {
-	format!("./inflight.{}.js", class.name.name)
+	format!("./inflight.{}.cjs", class.name.name)
 }
 
 fn lookup_span(span: &WingSpan, files: &Files) -> String {

--- a/libs/wingcompiler/src/compile.ts
+++ b/libs/wingcompiler/src/compile.ts
@@ -16,7 +16,7 @@ Error.stackTraceLimit = 50;
 
 // const log = debug("wing:compile");
 const WINGC_COMPILE = "wingc_compile";
-const WINGC_PREFLIGHT = "preflight.js";
+const WINGC_PREFLIGHT = "preflight.cjs";
 
 const DEFAULT_SYNTH_DIR_SUFFIX: Record<Target, string | undefined> = {
   [Target.TF_AWS]: "tfaws",
@@ -123,16 +123,13 @@ export async function compile(entrypoint: string, options: CompileOptions): Prom
     imports: {
       env: {
         send_diagnostic,
-      }
-    }
+      },
+    },
   });
 
   const errors: wingCompiler.WingDiagnostic[] = [];
 
-  function send_diagnostic(
-    data_ptr: number,
-    data_len: number
-  ) {
+  function send_diagnostic(data_ptr: number, data_len: number) {
     const data_buf = Buffer.from(
       (wingc.exports.memory as WebAssembly.Memory).buffer,
       data_ptr,
@@ -148,7 +145,7 @@ export async function compile(entrypoint: string, options: CompileOptions): Prom
   try {
     compileSuccess = wingCompiler.invoke(wingc, WINGC_COMPILE, arg) !== 0;
   } catch (error) {
-    // This is a bug in the compiler, indicate a compilation failure. 
+    // This is a bug in the compiler, indicate a compilation failure.
     // The bug details should be part of the diagnostics handling below.
     compileSuccess = false;
   }

--- a/libs/wingsdk/src/cloud/function.ts
+++ b/libs/wingsdk/src/cloud/function.ts
@@ -101,7 +101,7 @@ export abstract class Function extends Resource implements IInflightHost {
 
     const workdir = App.of(this).workdir;
     mkdirSync(workdir, { recursive: true });
-    const entrypoint = join(workdir, `${assetName}.js`);
+    const entrypoint = join(workdir, `${assetName}.cjs`);
     writeFileSync(entrypoint, lines.join("\n"));
     this.entrypoint = entrypoint;
 

--- a/libs/wingsdk/src/core/plugin-manager.ts
+++ b/libs/wingsdk/src/core/plugin-manager.ts
@@ -49,7 +49,10 @@ export class PluginManager {
    */
   public add(pluginAbsolutePath: string) {
     // maybe we support other plugin types in the future (e.g. npm modules)
-    if (!pluginAbsolutePath.endsWith(".js")) {
+    if (
+      !pluginAbsolutePath.endsWith(".js") ||
+      !pluginAbsolutePath.endsWith(".cjs")
+    ) {
       throw new Error(
         `Currently only javascript files are supported as plugins. Got: ${pluginAbsolutePath}`
       );

--- a/libs/wingsdk/src/shared/bundling.ts
+++ b/libs/wingsdk/src/shared/bundling.ts
@@ -19,7 +19,7 @@ export interface Bundle {
 export function createBundle(entrypoint: string, outputDir?: string): Bundle {
   const outdir = resolve(outputDir ?? entrypoint + ".bundle");
   mkdirSync(outdir, { recursive: true });
-  const outfile = join(outdir, "index.js");
+  const outfile = join(outdir, "index.cjs");
 
   let esbuild = buildSync({
     bundle: true,

--- a/libs/wingsdk/src/target-awscdk/bucket.ts
+++ b/libs/wingsdk/src/target-awscdk/bucket.ts
@@ -56,7 +56,7 @@ export class Bucket extends cloud.Bucket {
   }
 
   protected eventHandlerLocation(): string {
-    return join(__dirname, "bucket.onevent.inflight.js");
+    return join(__dirname, "bucket.onevent.inflight.cjs");
   }
 
   private onEventFunction(

--- a/libs/wingsdk/src/target-awscdk/queue.ts
+++ b/libs/wingsdk/src/target-awscdk/queue.ts
@@ -48,7 +48,7 @@ export class Queue extends cloud.Queue {
       inflight,
       join(
         __dirname.replace("target-awscdk", "shared-aws"),
-        "queue.setconsumer.inflight.js"
+        "queue.setconsumer.inflight.cjs"
       ),
       "QueueSetConsumerHandlerClient"
     );

--- a/libs/wingsdk/src/target-awscdk/schedule.ts
+++ b/libs/wingsdk/src/target-awscdk/schedule.ts
@@ -72,7 +72,7 @@ export class Schedule extends cloud.Schedule {
       inflight,
       join(
         __dirname.replace("target-awscdk", "shared-aws"),
-        "schedule.ontick.inflight.js"
+        "schedule.ontick.inflight.cjs"
       ),
       "ScheduleOnTickHandlerClient"
     );

--- a/libs/wingsdk/src/target-awscdk/topic.ts
+++ b/libs/wingsdk/src/target-awscdk/topic.ts
@@ -40,7 +40,7 @@ export class Topic extends cloud.Topic {
       inflight,
       join(
         __dirname.replace("target-awscdk", "shared-aws"),
-        "topic.onmessage.inflight.js"
+        "topic.onmessage.inflight.cjs"
       ),
       "TopicOnMessageHandlerClient"
     );

--- a/libs/wingsdk/src/target-sim/bucket.ts
+++ b/libs/wingsdk/src/target-sim/bucket.ts
@@ -42,7 +42,7 @@ export class Bucket extends cloud.Bucket implements ISimulatorResource {
   }
 
   protected eventHandlerLocation(): string {
-    return join(__dirname, "bucket.onevent.inflight.js");
+    return join(__dirname, "bucket.onevent.inflight.cjs");
   }
 
   public toSimulator(): BaseResourceSchema {

--- a/libs/wingsdk/src/target-sim/queue.ts
+++ b/libs/wingsdk/src/target-sim/queue.ts
@@ -67,7 +67,7 @@ export class Queue extends cloud.Queue implements ISimulatorResource {
       this.node.scope!, // ok since we're not a tree root
       `${this.node.id}-SetConsumerHandler-${hash}`,
       inflight,
-      join(__dirname, "queue.setconsumer.inflight.js"),
+      join(__dirname, "queue.setconsumer.inflight.cjs"),
       "QueueSetConsumerHandlerClient"
     );
 

--- a/libs/wingsdk/src/target-sim/schedule.ts
+++ b/libs/wingsdk/src/target-sim/schedule.ts
@@ -39,7 +39,7 @@ export class Schedule extends cloud.Schedule implements ISimulatorResource {
       this.node.scope!,
       `${this.node.id}OnTickHandler${hash}`,
       inflight,
-      join(__dirname, "schedule.ontick.inflight.js"),
+      join(__dirname, "schedule.ontick.inflight.cjs"),
       "ScheduleOnTickHandlerClient"
     );
 

--- a/libs/wingsdk/src/target-sim/service.ts
+++ b/libs/wingsdk/src/target-sim/service.ts
@@ -59,7 +59,7 @@ export class Service extends cloud.Service implements ISimulatorResource {
       this.node.scope!,
       `${this.node.id}-${id}-${onStartHash}`,
       handler,
-      join(__dirname, "service.onevent.inflight.js"),
+      join(__dirname, "service.onevent.inflight.cjs"),
       "ServiceOnEventHandler"
     );
 

--- a/libs/wingsdk/src/target-sim/topic.ts
+++ b/libs/wingsdk/src/target-sim/topic.ts
@@ -30,7 +30,7 @@ export class Topic extends cloud.Topic implements ISimulatorResource {
       this.node.scope!, // ok since we're not a tree root
       `${this.node.id}-OnMessageHandler-${hash}`,
       inflight,
-      join(__dirname, "topic.onmessage.inflight.js"),
+      join(__dirname, "topic.onmessage.inflight.cjs"),
       "TopicOnMessageHandlerClient"
     );
 

--- a/libs/wingsdk/src/target-tf-aws/api.ts
+++ b/libs/wingsdk/src/target-tf-aws/api.ts
@@ -322,7 +322,7 @@ export class Api extends cloud.Api {
       inflight,
       join(
         __dirname.replace("target-tf-aws", "shared-aws"),
-        "api.onrequest.inflight.js"
+        "api.onrequest.inflight.cjs"
       ),
       "ApiOnRequestHandlerClient"
     );

--- a/libs/wingsdk/src/target-tf-aws/bucket.ts
+++ b/libs/wingsdk/src/target-tf-aws/bucket.ts
@@ -74,7 +74,7 @@ export class Bucket extends cloud.Bucket {
   }
 
   protected eventHandlerLocation(): string {
-    return join(__dirname, "bucket.onevent.inflight.js");
+    return join(__dirname, "bucket.onevent.inflight.cjs");
   }
 
   protected createTopic(actionType: cloud.BucketEventType): cloud.Topic {

--- a/libs/wingsdk/src/target-tf-aws/queue.ts
+++ b/libs/wingsdk/src/target-tf-aws/queue.ts
@@ -54,7 +54,7 @@ export class Queue extends cloud.Queue {
       inflight,
       join(
         __dirname.replace("target-tf-aws", "shared-aws"),
-        "queue.setconsumer.inflight.js"
+        "queue.setconsumer.inflight.cjs"
       ),
       "QueueSetConsumerHandlerClient"
     );

--- a/libs/wingsdk/src/target-tf-aws/schedule.ts
+++ b/libs/wingsdk/src/target-tf-aws/schedule.ts
@@ -52,7 +52,7 @@ export class Schedule extends cloud.Schedule {
       inflight,
       join(
         __dirname.replace("target-tf-aws", "shared-aws"),
-        "schedule.ontick.inflight.js"
+        "schedule.ontick.inflight.cjs"
       ),
       "ScheduleOnTickHandlerClient"
     );

--- a/libs/wingsdk/src/target-tf-aws/topic.ts
+++ b/libs/wingsdk/src/target-tf-aws/topic.ts
@@ -59,7 +59,7 @@ export class Topic extends cloud.Topic {
       inflight,
       join(
         __dirname.replace("target-tf-aws", "shared-aws"),
-        "topic.onmessage.inflight.js"
+        "topic.onmessage.inflight.cjs"
       ),
       "TopicOnMessageHandlerClient"
     );

--- a/libs/wingsdk/test/util.ts
+++ b/libs/wingsdk/test/util.ts
@@ -141,7 +141,7 @@ export function directorySnapshot(initialRoot: string) {
             snapshot[key] = JSON.parse(data);
             break;
 
-          case ".js":
+          case ".cjs":
             const code = readFileSync(abspath, "utf-8");
             snapshot[key] = sanitizeCodeText(code);
             break;

--- a/tools/hangar/src/generated_test_targets.ts
+++ b/tools/hangar/src/generated_test_targets.ts
@@ -38,7 +38,7 @@ export async function compileTest(
 
   // which files to include from the .wing directory
   const dotWing = join(targetDir, ".wing");
-  const include = ["preflight.js", "inflight.", "extern/", "proc"];
+  const include = ["preflight.cjs", "inflight.", "extern/", "proc"];
 
   for await (const dotFile of walkdir(dotWing)) {
     const subpath = relative(dotWing, dotFile).replace(/\\/g, "/");

--- a/tools/hangar/src/unsupported.test.ts
+++ b/tools/hangar/src/unsupported.test.ts
@@ -32,7 +32,7 @@ test("unsupported resource in target", async ({ expect }) => {
   expect(sanitizeOutput(result.stderr)).toMatchInlineSnapshot(`
     "ERROR: Unable to create an instance of abstract type \\"@winglang/sdk.cloud.Schedule\\" for this target
 
-    target/test.tfgcp.[REDACTED].tmp/.wing/preflight.js:8
+    target/test.tfgcp.[REDACTED].tmp/.wing/preflight.cjs:8
          constructor(scope, id) {
            super(scope, id);
     >>     this.node.root.newAbstract(\\"@winglang/sdk.cloud.Schedule\\",this,\\"cloud.Schedule\\");


### PR DESCRIPTION
The Wing suite only works with CJS files. Trying to use the Console or the SImulator inside an ESM package will fail during function invocations because Wing-generated files will be treated as ESM.

Fixes #3601.
