### PR TITLE
fix(compiler): struct definitions were not phase independent

### DIFF
--- a/examples/tests/valid/structs.w
+++ b/examples/tests/valid/structs.w
@@ -63,3 +63,11 @@ struct Showtime extends Razzle, Dazzle {}
 let s = Showtime {
   a: "Boom baby"
 };
+
+test "struct definitions are phase independant" {
+  let s2 = Showtime {
+    a: "foo"
+  };
+
+  assert(s2.a == "foo");
+}

--- a/libs/wingc/src/type_check.rs
+++ b/libs/wingc/src/type_check.rs
@@ -2973,7 +2973,7 @@ impl<'a> TypeChecker<'a> {
 				//   fail type checking.
 
 				// Create an environment for the struct
-				let mut struct_env = SymbolEnv::new(None, self.types.void(), false, false, env.phase, stmt.idx);
+				let mut struct_env = SymbolEnv::new(None, self.types.void(), false, false, Phase::Independent, stmt.idx);
 
 				// Add fields to the struct env
 				for field in fields.iter() {

--- a/tools/hangar/__snapshots__/test_corpus/valid/structs.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/structs.w_compile_tf-aws.md
@@ -1,5 +1,26 @@
 # [structs.w](../../../../../examples/tests/valid/structs.w) | compile | tf-aws
 
+## inflight.$Closure1.js
+```js
+module.exports = function({  }) {
+  class $Closure1 {
+    constructor({  }) {
+      const $obj = (...args) => this.handle(...args);
+      Object.setPrototypeOf($obj, this);
+      return $obj;
+    }
+    async handle() {
+      const s2 = {
+      "a": "foo",}
+      ;
+      {((cond) => {if (!cond) throw new Error("assertion failed: s2.a == \"foo\"")})((s2.a === "foo"))};
+    }
+  }
+  return $Closure1;
+}
+
+```
+
 ## inflight.Foo.js
 ```js
 module.exports = function({  }) {
@@ -37,13 +58,102 @@ module.exports = function({  }) {
   },
   "output": {
     "WING_TEST_RUNNER_FUNCTION_ARNS": {
-      "value": "[]"
+      "value": "[[\"root/Default/Default/test:struct definitions are phase independant\",\"${aws_lambda_function.teststructdefinitionsarephaseindependant_Handler_F8CACE9E.arn}\"]]"
     }
   },
   "provider": {
     "aws": [
       {}
     ]
+  },
+  "resource": {
+    "aws_iam_role": {
+      "teststructdefinitionsarephaseindependant_Handler_IamRole_4609E5D7": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/Default/test:struct definitions are phase independant/Handler/IamRole",
+            "uniqueId": "teststructdefinitionsarephaseindependant_Handler_IamRole_4609E5D7"
+          }
+        },
+        "assume_role_policy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Action\":\"sts:AssumeRole\",\"Principal\":{\"Service\":\"lambda.amazonaws.com\"},\"Effect\":\"Allow\"}]}"
+      }
+    },
+    "aws_iam_role_policy": {
+      "teststructdefinitionsarephaseindependant_Handler_IamRolePolicy_25856004": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/Default/test:struct definitions are phase independant/Handler/IamRolePolicy",
+            "uniqueId": "teststructdefinitionsarephaseindependant_Handler_IamRolePolicy_25856004"
+          }
+        },
+        "policy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Action\":\"none:null\",\"Resource\":\"*\"}]}",
+        "role": "${aws_iam_role.teststructdefinitionsarephaseindependant_Handler_IamRole_4609E5D7.name}"
+      }
+    },
+    "aws_iam_role_policy_attachment": {
+      "teststructdefinitionsarephaseindependant_Handler_IamRolePolicyAttachment_E9A6A66B": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/Default/test:struct definitions are phase independant/Handler/IamRolePolicyAttachment",
+            "uniqueId": "teststructdefinitionsarephaseindependant_Handler_IamRolePolicyAttachment_E9A6A66B"
+          }
+        },
+        "policy_arn": "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+        "role": "${aws_iam_role.teststructdefinitionsarephaseindependant_Handler_IamRole_4609E5D7.name}"
+      }
+    },
+    "aws_lambda_function": {
+      "teststructdefinitionsarephaseindependant_Handler_F8CACE9E": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/Default/test:struct definitions are phase independant/Handler/Default",
+            "uniqueId": "teststructdefinitionsarephaseindependant_Handler_F8CACE9E"
+          }
+        },
+        "environment": {
+          "variables": {
+            "WING_FUNCTION_NAME": "Handler-c8158c42",
+            "WING_TARGET": "tf-aws"
+          }
+        },
+        "function_name": "Handler-c8158c42",
+        "handler": "index.handler",
+        "publish": true,
+        "role": "${aws_iam_role.teststructdefinitionsarephaseindependant_Handler_IamRole_4609E5D7.arn}",
+        "runtime": "nodejs18.x",
+        "s3_bucket": "${aws_s3_bucket.Code.bucket}",
+        "s3_key": "${aws_s3_object.teststructdefinitionsarephaseindependant_Handler_S3Object_9394B2A7.key}",
+        "timeout": 30,
+        "vpc_config": {
+          "security_group_ids": [],
+          "subnet_ids": []
+        }
+      }
+    },
+    "aws_s3_bucket": {
+      "Code": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/Code",
+            "uniqueId": "Code"
+          }
+        },
+        "bucket_prefix": "code-c84a50b1-"
+      }
+    },
+    "aws_s3_object": {
+      "teststructdefinitionsarephaseindependant_Handler_S3Object_9394B2A7": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/Default/test:struct definitions are phase independant/Handler/S3Object",
+            "uniqueId": "teststructdefinitionsarephaseindependant_Handler_S3Object_9394B2A7"
+          }
+        },
+        "bucket": "${aws_s3_bucket.Code.bucket}",
+        "key": "<ASSET_KEY>",
+        "source": "<ASSET_SOURCE>"
+      }
+    }
   }
 }
 ```
@@ -91,6 +201,30 @@ class $Root extends $stdlib.std.Resource {
         super._registerBind(host, ops);
       }
     }
+    class $Closure1 extends $stdlib.std.Resource {
+      constructor(scope, id, ) {
+        super(scope, id);
+        this._addInflightOps("handle", "$inflight_init");
+        this.display.hidden = true;
+      }
+      static _toInflightType(context) {
+        return $stdlib.core.NodeJsCode.fromInline(`
+          require("./inflight.$Closure1.js")({
+          })
+        `);
+      }
+      _toInflight() {
+        return $stdlib.core.NodeJsCode.fromInline(`
+          (await (async () => {
+            const $Closure1Client = ${$Closure1._toInflightType(this).text};
+            const client = new $Closure1Client({
+            });
+            if (client.$inflight_init) { await client.$inflight_init(); }
+            return client;
+          })())
+        `);
+      }
+    }
     const x = {
     "field0": "Sup",}
     ;
@@ -108,6 +242,7 @@ class $Root extends $stdlib.std.Resource {
     const s = {
     "a": "Boom baby",}
     ;
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:struct definitions are phase independant",new $Closure1(this,"$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/valid/structs.w_test_sim.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/structs.w_test_sim.md
@@ -2,7 +2,7 @@
 
 ## stdout.log
 ```log
-pass ─ structs.wsim (no tests)
+pass ─ structs.wsim » root/env0/test:struct definitions are phase independant
  
  
 Tests 1 passed (1)


### PR DESCRIPTION
Resolves a fun bug where structs were not always phase independent example

```js
struct A {
	val: str
}

struct B extends A {
	val2: num
}

test "blah" {
	let b = B { val: "cool", val2: "beans" };
	assert(b.val == "cool");
}
```

would result in an error where the compiler believed `b` was preflight expression

## Checklist 

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [x] Tests added (always)
- [x] Docs updated (only required for features)
- [x] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
