### PR TITLE
chore(console): remove lottie player

### DIFF
--- a/apps/wing-console/console/design-system/package.json
+++ b/apps/wing-console/console/design-system/package.json
@@ -37,7 +37,6 @@
     "nanoid": "^4.0.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-lottie-player": "^1.5.4",
     "react-popper": "^2.3.0",
     "tailwindcss": "^3.3.2"
   },

--- a/apps/wing-console/console/design-system/src/loader.tsx
+++ b/apps/wing-console/console/design-system/src/loader.tsx
@@ -1,23 +1,29 @@
-import Lottie from "react-lottie-player";
-
-import lottieJson from "./assets/wingLoader.json";
+import { SpinnerLoader } from "./spinner-loader.js";
 
 export const Loader = ({
   text = "",
   size,
 }: {
+  /**
+   * @deprecated
+   */
   text?: string;
+
+  /**
+   * @deprecated
+   */
   size: string;
 }) => {
-  return (
-    <div className="flex pointer-events-none space-x-1">
-      <Lottie
-        loop
-        animationData={lottieJson}
-        play
-        style={{ width: size, height: size }}
-      />
-      <span>{text}</span>
-    </div>
-  );
+  return <SpinnerLoader size="sm" />;
+  // return (
+  //   <div className="flex pointer-events-none space-x-1">
+  //     <Lottie
+  //       loop
+  //       animationData={lottieJson}
+  //       play
+  //       style={{ width: size, height: size }}
+  //     />
+  //     <span>{text}</span>
+  //   </div>
+  // );
 };

--- a/apps/wing-console/console/design-system/src/loader.tsx
+++ b/apps/wing-console/console/design-system/src/loader.tsx
@@ -1,15 +1,18 @@
-import { SpinnerLoader } from "./spinner-loader.js";
+import { SpinnerLoader, SpinnerLoaderSize } from "./spinner-loader.js";
 
-export const Loader = ({}: {
+export const Loader = ({
+  size,
+  className,
+  text,
+}: {
   /**
    * @deprecated
    */
   text?: string;
 
-  /**
-   * @deprecated
-   */
-  size: string;
+  size?: SpinnerLoaderSize;
+
+  className?: string;
 }) => {
-  return <SpinnerLoader size="sm" />;
+  return <SpinnerLoader size={size || "sm"} className={className} />;
 };

--- a/apps/wing-console/console/design-system/src/loader.tsx
+++ b/apps/wing-console/console/design-system/src/loader.tsx
@@ -1,9 +1,6 @@
 import { SpinnerLoader } from "./spinner-loader.js";
 
-export const Loader = ({
-  text = "",
-  size,
-}: {
+export const Loader = ({}: {
   /**
    * @deprecated
    */
@@ -15,15 +12,4 @@ export const Loader = ({
   size: string;
 }) => {
   return <SpinnerLoader size="sm" />;
-  // return (
-  //   <div className="flex pointer-events-none space-x-1">
-  //     <Lottie
-  //       loop
-  //       animationData={lottieJson}
-  //       play
-  //       style={{ width: size, height: size }}
-  //     />
-  //     <span>{text}</span>
-  //   </div>
-  // );
 };

--- a/apps/wing-console/console/design-system/src/spinner-loader.tsx
+++ b/apps/wing-console/console/design-system/src/spinner-loader.tsx
@@ -1,19 +1,27 @@
 import classNames from "classnames";
 
+export type SpinnerLoaderSize = "xs" | "sm" | "md" | "lg";
+
 export interface SpinnerLoaderProps {
   /**
    * The size of the progress bar.
    */
-  size?: "sm" | "md" | "lg";
+  size?: SpinnerLoaderSize;
+  /**
+   * className
+   */
+  className?: string;
 }
 
-export const SpinnerLoader = ({ size = "md" }: SpinnerLoaderProps) => {
+export const SpinnerLoader = ({ className, size = "md" }: SpinnerLoaderProps) => {
   return (
-    <div role="status">
+    <div role="status" className={"self-center"}>
       <svg
         aria-hidden="true"
         className={classNames(
           "text-slate-200 animate-spin dark:text-slate-600 fill-slate-600 dark:fill-slate-200",
+          className,
+          size === "xs" && "w-4 h-4",
           size === "sm" && "w-5 h-5",
           size === "md" && "w-8 h-8",
           size === "lg" && "w-10 h-10",

--- a/apps/wing-console/console/design-system/src/spinner-loader.tsx
+++ b/apps/wing-console/console/design-system/src/spinner-loader.tsx
@@ -13,7 +13,10 @@ export interface SpinnerLoaderProps {
   className?: string;
 }
 
-export const SpinnerLoader = ({ className, size = "md" }: SpinnerLoaderProps) => {
+export const SpinnerLoader = ({
+  className,
+  size = "md",
+}: SpinnerLoaderProps) => {
   return (
     <div role="status" className={"self-center"}>
       <svg

--- a/apps/wing-console/console/design-system/src/spinner-loader.tsx
+++ b/apps/wing-console/console/design-system/src/spinner-loader.tsx
@@ -9,7 +9,7 @@ export interface SpinnerLoaderProps {
 
 export const SpinnerLoader = ({ size = "md" }: SpinnerLoaderProps) => {
   return (
-    <div role="status" data-testid="main-view-loader">
+    <div role="status">
       <svg
         aria-hidden="true"
         className={classNames(

--- a/apps/wing-console/console/ui/package.json
+++ b/apps/wing-console/console/ui/package.json
@@ -49,7 +49,6 @@
     "nanoid": "^4.0.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-lottie-player": "^1.5.4",
     "zod": "^3.21.4"
   },
   "devDependencies": {

--- a/apps/wing-console/console/ui/src/layout/status-bar.tsx
+++ b/apps/wing-console/console/ui/src/layout/status-bar.tsx
@@ -53,7 +53,7 @@ export const StatusBar = ({
                 "flex",
               ])}
             >
-              {loading && <Loader size="1rem" />}
+              {loading && <Loader size="xs" className={"mr-1"} />}
               {cloudAppStateString[cloudAppState]}
             </span>
           </span>

--- a/apps/wing-console/console/ui/src/layout/vscode-layout.tsx
+++ b/apps/wing-console/console/ui/src/layout/vscode-layout.tsx
@@ -109,7 +109,7 @@ export const VscodeLayout = ({ cloudAppState, wingVersion }: LayoutProps) => {
                   data-testid="loading-overlay"
                 >
                   <div className=" absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2">
-                    <SpinnerLoader />
+                    <SpinnerLoader data-testid="main-view-loader" />
                   </div>
                 </div>
               )}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.1'
+lockfileVersion: '6.0'
 
 settings:
   autoInstallPeers: true
@@ -523,9 +523,6 @@ importers:
       react-dom:
         specifier: ^18.2.0
         version: 18.2.0(react@18.2.0)
-      react-lottie-player:
-        specifier: ^1.5.4
-        version: 1.5.4(react@18.2.0)
       react-popper:
         specifier: ^2.3.0
         version: 2.3.0(@popperjs/core@2.11.8)(react-dom@18.2.0)(react@18.2.0)
@@ -753,9 +750,6 @@ importers:
       react-dom:
         specifier: ^18.2.0
         version: 18.2.0(react@18.2.0)
-      react-lottie-player:
-        specifier: ^1.5.4
-        version: 1.5.4(react@18.2.0)
       zod:
         specifier: ^3.21.4
         version: 3.21.4
@@ -1026,7 +1020,7 @@ importers:
         version: link:../../tools/bump-pack
       tsup:
         specifier: ^6.7.0
-        version: 6.7.0(postcss@8.4.24)(typescript@5.1.3)
+        version: 6.7.0(typescript@4.9.4)
       typescript:
         specifier: ^4.9.4
         version: 4.9.4
@@ -5520,6 +5514,7 @@ packages:
 
   /@emotion/memoize@0.7.4:
     resolution: {integrity: sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==}
+    requiresBuild: true
     dev: false
     optional: true
 
@@ -12597,7 +12592,7 @@ packages:
     dependencies:
       semver: 7.5.2
       shelljs: 0.8.5
-      typescript: 5.2.0-dev.20230727
+      typescript: 5.2.0-dev.20230801
     dev: true
 
   /dset@3.1.2:
@@ -17055,10 +17050,6 @@ packages:
     dependencies:
       js-tokens: 4.0.0
 
-  /lottie-web@5.12.2:
-    resolution: {integrity: sha512-uvhvYPC8kGPjXT3MyKMrL3JitEAmDMp30lVkuq/590Mw9ok6pWcFCwXJveo0t5uqYw1UREQHofD+jVpdjBv8wg==}
-    dev: false
-
   /loud-rejection@1.6.0:
     resolution: {integrity: sha512-RPNliZOFkqFumDhvYqOaNY4Uz9oJM2K9tC6JWsJJsNdhuONW4LQHRBpb0qf4pJApVffI5N39SwzWZJuEhfd7eQ==}
     engines: {node: '>=0.10.0'}
@@ -17910,6 +17901,7 @@ packages:
 
   /node-addon-api@4.3.0:
     resolution: {integrity: sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ==}
+    requiresBuild: true
     dev: true
     optional: true
 
@@ -19484,18 +19476,6 @@ packages:
   /react-is@18.2.0:
     resolution: {integrity: sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==}
     dev: true
-
-  /react-lottie-player@1.5.4(react@18.2.0):
-    resolution: {integrity: sha512-eM0g11bAc4EJJuDDfCoNloaAYphfXlIpYnriOt4nRU66PpVmvKhajvP2aif4YflGY2ArAFXhWxs418YzdebK9w==}
-    engines: {node: '>=10'}
-    peerDependencies:
-      react: ^16.0.0 || ^17.0.0 || ^18.0.0
-    dependencies:
-      fast-deep-equal: 3.1.3
-      lottie-web: 5.12.2
-      react: 18.2.0
-      rfdc: 1.3.0
-    dev: false
 
   /react-markdown@8.0.7(@types/react@18.2.12)(react@18.2.0):
     resolution: {integrity: sha512-bvWbzG4MtOU62XqBx3Xx+zB2raaFFsq4mYiAzfjXJMEz2sixgeAfraA3tvzULF02ZdOMUOKTBFFaZJDDrq+BJQ==}
@@ -21324,6 +21304,42 @@ packages:
       - ts-node
     dev: true
 
+  /tsup@6.7.0(typescript@4.9.4):
+    resolution: {integrity: sha512-L3o8hGkaHnu5TdJns+mCqFsDBo83bJ44rlK7e6VdanIvpea4ArPcU3swWGsLVbXak1PqQx/V+SSmFPujBK+zEQ==}
+    engines: {node: '>=14.18'}
+    hasBin: true
+    peerDependencies:
+      '@swc/core': ^1
+      postcss: ^8.4.12
+      typescript: '>=4.1.0'
+    peerDependenciesMeta:
+      '@swc/core':
+        optional: true
+      postcss:
+        optional: true
+      typescript:
+        optional: true
+    dependencies:
+      bundle-require: 4.0.1(esbuild@0.17.19)
+      cac: 6.7.14
+      chokidar: 3.5.3
+      debug: 4.3.4
+      esbuild: 0.17.19
+      execa: 5.1.1
+      globby: 11.1.0
+      joycon: 3.1.1
+      postcss-load-config: 3.1.4(postcss@8.4.24)
+      resolve-from: 5.0.0
+      rollup: 3.25.3
+      source-map: 0.8.0-beta.0
+      sucrase: 3.32.0
+      tree-kill: 1.2.2
+      typescript: 4.9.4
+    transitivePeerDependencies:
+      - supports-color
+      - ts-node
+    dev: true
+
   /tsup@7.1.0(postcss@8.4.24)(typescript@5.1.3):
     resolution: {integrity: sha512-mazl/GRAk70j8S43/AbSYXGgvRP54oQeX8Un4iZxzATHt0roW0t6HYDVZIXMw0ZQIpvr1nFMniIVnN5186lW7w==}
     engines: {node: '>=16.14'}
@@ -21515,8 +21531,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  /typescript@5.2.0-dev.20230727:
-    resolution: {integrity: sha512-HTNqxwU5roYnvWrrdTxKLREZ+fygKOpf7q2DAhfZntqgyQNxZzZdDypigMS8tNmeQN2X/ohbNzX9PnhHoCCmfw==}
+  /typescript@5.2.0-dev.20230801:
+    resolution: {integrity: sha512-f8FmzL+1+agawPPUzsd38vTiZD/z+RtGax/3+tzxsBP15O/4lMsliTEXRXF7ESC7a1s/f9HsNNRMne438PPZsw==}
     engines: {node: '>=14.17'}
     hasBin: true
     dev: true


### PR DESCRIPTION
Reduces the bundle size of `@wingconsole/app` about 600 KB by removing the lottie player package, which is only used in a very small loading animation.

Closes #3615.