### PR TITLE
fix: cannot extend non-wing construct

### DIFF
--- a/examples/tests/valid/bring_cdk8s.w
+++ b/examples/tests/valid/bring_cdk8s.w
@@ -1,0 +1,13 @@
+bring "cdk8s" as cdk8s;
+
+class MyChart extends cdk8s.Chart {
+  init() {
+    new cdk8s.ApiObject(kind: "Pod", apiVersion: "v1");
+  }
+}
+
+let c = new MyChart();
+let first: Json = c.toJson().at(0);
+assert(first.get("apiVersion") == "v1");
+assert(first.get("kind") == "Pod");
+assert(first.get("metadata").get("name").asStr().length > 0);

--- a/examples/tests/valid/package.json
+++ b/examples/tests/valid/package.json
@@ -8,6 +8,7 @@
     "@cdktf/provider-aws": "^15.0.0",
     "aws-cdk-lib": "^2.64.0",
     "cdktf": "0.17.0",
+    "cdk8s": "2.35.0",
     "constructs": "^10",
     "jsii-code-samples": "1.7.0",
     "projen": "^0.71.60",

--- a/libs/wingc/src/jsify.rs
+++ b/libs/wingc/src/jsify.rs
@@ -1035,7 +1035,8 @@ impl<'a> JSifier<'a> {
 				.map(|name| format!("\"{}\"", name))
 				.join(", ");
 
-			// insert as the first statement after the super() call
+			// insert as the first statement after the super() call. We using "?.()" to avoid calling the
+			// method if it doesn't exist.
 			body_code.insert_line(1, format!("this._addInflightOps?.({inflight_ops_string});"));
 		}
 

--- a/libs/wingc/src/jsify.rs
+++ b/libs/wingc/src/jsify.rs
@@ -1036,7 +1036,7 @@ impl<'a> JSifier<'a> {
 				.join(", ");
 
 			// insert as the first statement after the super() call
-			body_code.insert_line(1, format!("this._addInflightOps({inflight_ops_string});"));
+			body_code.insert_line(1, format!("this._addInflightOps?.({inflight_ops_string});"));
 		}
 
 		code.add_code(body_code);


### PR DESCRIPTION
When trying to bring `cdk8s` and extend `Chart`, the call to `this._addInflightOps()` fails because non-wing constructs don't have this method.

The fix is to use `?.()` (e.g. `this._addInflightOps?.()`) in order to chain the undefined.

Added a test which verifies that cdk8s can be brought and used.

Fixes https://github.com/winglang/wing/issues/3717

## Checklist

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [x] Tests added (always)
- [x] Docs updated (only required for features)
- [x] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
