### PR TITLE
fix(compiler): missing type check for partially inferred function

### DIFF
--- a/examples/tests/invalid/inference.w
+++ b/examples/tests/invalid/inference.w
@@ -81,3 +81,6 @@ class NeedAnnotations {
     log(nice);
   }
 }
+
+let badFunc: inflight (str): void = inflight (arg1: num) => {};
+//                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ Expected type to be "inflight (str): void", but got "inflight (arg1: num): unknown" instead

--- a/libs/wingc/src/type_check.rs
+++ b/libs/wingc/src/type_check.rs
@@ -2419,6 +2419,7 @@ impl<'a> TypeChecker<'a> {
 		if expected_types.len() == 1 {
 			// First check if the actual type is an inference that can be replaced with the expected type
 			if self.add_new_inference(&actual_type, &expected_types[0]) {
+				// Update the type we validate and return
 				return_type = self.types.maybe_unwrap_inference(return_type);
 			} else {
 				// otherwise, check if the expected type is an inference that can be replaced with the actual type

--- a/libs/wingc/src/type_check.rs
+++ b/libs/wingc/src/type_check.rs
@@ -2419,7 +2419,7 @@ impl<'a> TypeChecker<'a> {
 		if expected_types.len() == 1 {
 			// First check if the actual type is an inference that can be replaced with the expected type
 			if self.add_new_inference(&actual_type, &expected_types[0]) {
-				return_type = expected_types[0];
+				return_type = self.types.maybe_unwrap_inference(return_type);
 			} else {
 				// otherwise, check if the expected type is an inference that can be replaced with the actual type
 				self.add_new_inference(&expected_types[0], &actual_type);

--- a/tools/hangar/__snapshots__/invalid.ts.snap
+++ b/tools/hangar/__snapshots__/invalid.ts.snap
@@ -437,6 +437,17 @@ exports[`cloud_function_expects_inflight.w 1`] = `
   | \\\\-^ Expected type to be \\"inflight (event: str): void\\", but got \\"preflight (name: str): str\\" instead
 
 
+error: Expected type to be \\"inflight (message: str): void\\", but got \\"inflight (x: num): unknown\\" instead
+   --> ../../../examples/tests/invalid/cloud_function_expects_inflight.w:9:15
+   |  
+ 9 |   q.setConsumer(inflight (x: num) => {
+   | /---------------^
+10 | |                      // ^ \\"num\\" doesn't match the expected type \\"str\\"
+11 | |   return;
+12 | | });
+   | \\\\-^ Expected type to be \\"inflight (message: str): void\\", but got \\"inflight (x: num): unknown\\" instead
+
+
  
  
 Tests 1 failed (1)
@@ -880,6 +891,13 @@ error: Expected \\"Json\\" elements to be Json values (https://www.json.org/json
    |
 71 | Json { cool: anotherEmptyArray };
    |              ^^^^^^^^^^^^^^^^^ Expected \\"Json\\" elements to be Json values (https://www.json.org/json-en.html), but got \\"Array<unknown>\\" which is not a Json value
+
+
+error: Expected type to be \\"inflight (str): void\\", but got \\"inflight (arg1: num): unknown\\" instead
+   --> ../../../examples/tests/invalid/inference.w:85:37
+   |
+85 | let badFunc: inflight (str): void = inflight (arg1: num) => {};
+   |                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^ Expected type to be \\"inflight (str): void\\", but got \\"inflight (arg1: num): unknown\\" instead
 
 
 error: Unexpected return value from void function. Return type annotations are required for methods.


### PR DESCRIPTION
Fixes #3714

When making an inference in type validation, the inferred type was originally thrown away. This change instead unwraps it if needed since updating the original typeref itself won't happen til later. It's worth noting the error message will be missing information for deeply inferred types (like the return type).

Also it turns out this regression was noticeable in the snapshots before, but not noticed. So the snapshot update included 2 changes.

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
