### PR TITLE
fix(build): playwright cannot find browser executables in a new env

### DIFF
--- a/apps/wing-console/console/app/package.json
+++ b/apps/wing-console/console/app/package.json
@@ -14,6 +14,7 @@
     "dev": "tsx watch scripts/dev.mjs",
     "compile": "tsup",
     "eslint": "eslint --ext .js,.cjs,.ts,.cts,.mts,.tsx --no-error-on-unmatched-pattern . --fix",
+    "pre-test": "playwright install",
     "test": "playwright test --update-snapshots",
     "package": "bump-pack -b"
   },

--- a/apps/wing-console/console/app/turbo.json
+++ b/apps/wing-console/console/app/turbo.json
@@ -6,6 +6,12 @@
       "outputs": ["dist/**"],
       "env": ["SEGMENT_WRITE_KEY"]
     },
+    "pre-test": {
+      "dependsOn": ["compile"]
+    },
+    "test": {
+      "dependsOn": ["pre-test"]
+    },
     "package": {
       "outputs": ["../../../../dist/wingconsole-app-*.tgz"]
     }

--- a/libs/wingsdk/test/target-awscdk/__snapshots__/counter.test.ts.snap
+++ b/libs/wingsdk/test/target-awscdk/__snapshots__/counter.test.ts.snap
@@ -129,7 +129,7 @@ exports[`dec() policy statement 2`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "f3738bcfd58c05cf71242945f065454f27590bcdafb0ccd96150f36963676a16.zip",
+          "S3Key": "7f88ad6b39756ca47a1f62c4073b16e7d1dd718dccac91f2f477bd8b7d93979b.zip",
         },
         "Environment": {
           "Variables": {
@@ -367,7 +367,7 @@ exports[`function with a counter binding 2`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "b03ff20bc0f7d7c4d3c6ac541eb138884f06868c5412ad8414d7913bebca1b6d.zip",
+          "S3Key": "eeb1a09b430750f79d2178a853df4a7c9c3da2b3cd34773230b0e09b686d118e.zip",
         },
         "Environment": {
           "Variables": {
@@ -539,7 +539,7 @@ exports[`inc() policy statement 2`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "b03ff20bc0f7d7c4d3c6ac541eb138884f06868c5412ad8414d7913bebca1b6d.zip",
+          "S3Key": "eeb1a09b430750f79d2178a853df4a7c9c3da2b3cd34773230b0e09b686d118e.zip",
         },
         "Environment": {
           "Variables": {
@@ -711,7 +711,7 @@ exports[`peek() policy statement 2`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "9189a03759b8a966a3e4efb03da3bf6b2546b25b85ccf726d3240bbc1b86e272.zip",
+          "S3Key": "c99045e525ddd3aa5e452c244ab0e15d7dccb0c992971ff69d1556a946b4f4ef.zip",
         },
         "Environment": {
           "Variables": {
@@ -883,7 +883,7 @@ exports[`set() policy statement 2`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "0da3747a941f72aa30762d828c78b18e9f513c3801f61711ae0fd3ff29a218b5.zip",
+          "S3Key": "239ecd5b27a3e3d0fe03e52540218d631d1790ad7a32eb81f57677613ba2e1c7.zip",
         },
         "Environment": {
           "Variables": {


### PR DESCRIPTION
For a new development environment, [`pnpm build`](https://www.winglang.io/contributing/start-here/development#full-build) fails due to missing browser deps for playwright tests with error messages like:
```
Error: browserType.launch: Executable doesn't exist at /<...>/.cache/ms-playwright/<...>
```
It is required to install manually with `pnpm exec playwright install` within `apps/wing-console/console/app`, which breaks the `pnpm build` flow.

This fix is a try to ensure the browser deps are always installed and being the latest before running tests. It works fine for local development. Although the installation "runs" before every test run, turbo does a pretty good job to cut corners:
```
@wingconsole/app:pre-test: cache hit (outputs already on disk), replaying logs 00d0d93700261d4e
```

Just not sure about if this is okay for the CI environment, please suggest


## Checklist

- [X] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [X] Description explains motivation and solution
- [ ] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
