### PR TITLE
chore(sdk): adding eslint rules for capitalize comment and explicit member accessibility

### DIFF
--- a/docs/contributing/01-start-here/06-pull-requests.md
+++ b/docs/contributing/01-start-here/06-pull-requests.md
@@ -16,6 +16,7 @@ To help maintainers review them and get them merged in a speedy fashion, please 
 * [ ] A description of your changes are included, and a reference to a corresponding issue. (This is also a great place to shout-out anyone who helped with the changes!)
 * [ ] Tests are added for all changes.
 * [ ] Any handwritten documentation in `docs/` or READMEs are updated where appropriate when features are being added or removed (API docs will be automatically generated for you!).
+Please make sure to start docstrings with a capital letter.
 * [ ] Your fork is in sync with the upstream repository.
 * [ ] All build checks on GitHub are passing.
 

--- a/docs/docs/04-standard-library/01-cloud/bucket.md
+++ b/docs/docs/04-standard-library/01-cloud/bucket.md
@@ -548,7 +548,7 @@ Check failures on the method and retrieve errors if any.
 
 ### BucketEvent <a name="BucketEvent" id="@winglang/sdk.cloud.BucketEvent"></a>
 
-on_event notification payload- will be in use after solving issue: https://github.com/winglang/wing/issues/1927.
+On_event notification payload- will be in use after solving issue: https://github.com/winglang/wing/issues/1927.
 
 #### Initializer <a name="Initializer" id="@winglang/sdk.cloud.BucketEvent.Initializer"></a>
 
@@ -562,8 +562,8 @@ let BucketEvent = cloud.BucketEvent{ ... };
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
-| <code><a href="#@winglang/sdk.cloud.BucketEvent.property.key">key</a></code> | <code>str</code> | the bucket key that triggered the event. |
-| <code><a href="#@winglang/sdk.cloud.BucketEvent.property.type">type</a></code> | <code><a href="#@winglang/sdk.cloud.BucketEventType">BucketEventType</a></code> | type of event. |
+| <code><a href="#@winglang/sdk.cloud.BucketEvent.property.key">key</a></code> | <code>str</code> | The bucket key that triggered the event. |
+| <code><a href="#@winglang/sdk.cloud.BucketEvent.property.type">type</a></code> | <code><a href="#@winglang/sdk.cloud.BucketEventType">BucketEventType</a></code> | Type of event. |
 
 ---
 
@@ -575,7 +575,7 @@ key: str;
 
 - *Type:* str
 
-the bucket key that triggered the event.
+The bucket key that triggered the event.
 
 ---
 
@@ -587,13 +587,13 @@ type: BucketEventType;
 
 - *Type:* <a href="#@winglang/sdk.cloud.BucketEventType">BucketEventType</a>
 
-type of event.
+Type of event.
 
 ---
 
 ### BucketOnCreateProps <a name="BucketOnCreateProps" id="@winglang/sdk.cloud.BucketOnCreateProps"></a>
 
-on create event options.
+`onCreate` event options.
 
 #### Initializer <a name="Initializer" id="@winglang/sdk.cloud.BucketOnCreateProps.Initializer"></a>
 
@@ -606,7 +606,7 @@ let BucketOnCreateProps = cloud.BucketOnCreateProps{ ... };
 
 ### BucketOnDeleteProps <a name="BucketOnDeleteProps" id="@winglang/sdk.cloud.BucketOnDeleteProps"></a>
 
-on delete event options.
+`onDelete` event options.
 
 #### Initializer <a name="Initializer" id="@winglang/sdk.cloud.BucketOnDeleteProps.Initializer"></a>
 
@@ -619,7 +619,7 @@ let BucketOnDeleteProps = cloud.BucketOnDeleteProps{ ... };
 
 ### BucketOnEventProps <a name="BucketOnEventProps" id="@winglang/sdk.cloud.BucketOnEventProps"></a>
 
-on any event options.
+`onEvent` options.
 
 #### Initializer <a name="Initializer" id="@winglang/sdk.cloud.BucketOnEventProps.Initializer"></a>
 
@@ -632,7 +632,7 @@ let BucketOnEventProps = cloud.BucketOnEventProps{ ... };
 
 ### BucketOnUpdateProps <a name="BucketOnUpdateProps" id="@winglang/sdk.cloud.BucketOnUpdateProps"></a>
 
-on update event options.
+`onUpdate` event options.
 
 #### Initializer <a name="Initializer" id="@winglang/sdk.cloud.BucketOnUpdateProps.Initializer"></a>
 
@@ -761,35 +761,35 @@ Function that will be called when an event notification is fired.
 
 ### BucketEventType <a name="BucketEventType" id="@winglang/sdk.cloud.BucketEventType"></a>
 
-bucket events to subscribe to.
+Bucket events to subscribe to.
 
 #### Members <a name="Members" id="Members"></a>
 
 | **Name** | **Description** |
 | --- | --- |
-| <code><a href="#@winglang/sdk.cloud.BucketEventType.CREATE">CREATE</a></code> | create. |
-| <code><a href="#@winglang/sdk.cloud.BucketEventType.DELETE">DELETE</a></code> | delete. |
-| <code><a href="#@winglang/sdk.cloud.BucketEventType.UPDATE">UPDATE</a></code> | update. |
+| <code><a href="#@winglang/sdk.cloud.BucketEventType.CREATE">CREATE</a></code> | Create. |
+| <code><a href="#@winglang/sdk.cloud.BucketEventType.DELETE">DELETE</a></code> | Delete. |
+| <code><a href="#@winglang/sdk.cloud.BucketEventType.UPDATE">UPDATE</a></code> | Update. |
 
 ---
 
 ##### `CREATE` <a name="CREATE" id="@winglang/sdk.cloud.BucketEventType.CREATE"></a>
 
-create.
+Create.
 
 ---
 
 
 ##### `DELETE` <a name="DELETE" id="@winglang/sdk.cloud.BucketEventType.DELETE"></a>
 
-delete.
+Delete.
 
 ---
 
 
 ##### `UPDATE` <a name="UPDATE" id="@winglang/sdk.cloud.BucketEventType.UPDATE"></a>
 
-update.
+Update.
 
 ---
 

--- a/docs/docs/04-standard-library/02-std/api-reference.md
+++ b/docs/docs/04-standard-library/02-std/api-reference.md
@@ -291,7 +291,7 @@ Create a Datetime from UTC timezone.
 | <code><a href="#@winglang/sdk.std.Datetime.property.sec">sec</a></code> | <code>num</code> | Returns the seconds of the local machine time or in utc. |
 | <code><a href="#@winglang/sdk.std.Datetime.property.timestamp">timestamp</a></code> | <code>num</code> | Return a timestamp of non-leap year seconds since epoch. |
 | <code><a href="#@winglang/sdk.std.Datetime.property.timestampMs">timestampMs</a></code> | <code>num</code> | Return a timestamp of non-leap year milliseconds since epoch. |
-| <code><a href="#@winglang/sdk.std.Datetime.property.timezone">timezone</a></code> | <code>num</code> | returns the offset in minutes from UTC. |
+| <code><a href="#@winglang/sdk.std.Datetime.property.timezone">timezone</a></code> | <code>num</code> | Returns the offset in minutes from UTC. |
 | <code><a href="#@winglang/sdk.std.Datetime.property.year">year</a></code> | <code>num</code> | Returns the year of the local machine time or in utc. |
 
 ---
@@ -412,7 +412,7 @@ timezone: num;
 
 - *Type:* num
 
-returns the offset in minutes from UTC.
+Returns the offset in minutes from UTC.
 
 ---
 
@@ -2055,7 +2055,7 @@ The length of the string.
 
 ### DatetimeComponents <a name="DatetimeComponents" id="@winglang/sdk.std.DatetimeComponents"></a>
 
-interface that is used for setting Datetime date.
+Interface that is used for setting Datetime date.
 
 #### Initializer <a name="Initializer" id="@winglang/sdk.std.DatetimeComponents.Initializer"></a>
 
@@ -2067,14 +2067,14 @@ let DatetimeComponents = DatetimeComponents{ ... };
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
-| <code><a href="#@winglang/sdk.std.DatetimeComponents.property.day">day</a></code> | <code>num</code> | day. |
-| <code><a href="#@winglang/sdk.std.DatetimeComponents.property.hour">hour</a></code> | <code>num</code> | hours. |
-| <code><a href="#@winglang/sdk.std.DatetimeComponents.property.min">min</a></code> | <code>num</code> | minutes. |
-| <code><a href="#@winglang/sdk.std.DatetimeComponents.property.month">month</a></code> | <code>num</code> | month. |
-| <code><a href="#@winglang/sdk.std.DatetimeComponents.property.ms">ms</a></code> | <code>num</code> | milliseconds. |
-| <code><a href="#@winglang/sdk.std.DatetimeComponents.property.sec">sec</a></code> | <code>num</code> | seconds. |
-| <code><a href="#@winglang/sdk.std.DatetimeComponents.property.tz">tz</a></code> | <code>num</code> | timezone offset in minutes from UTC. |
-| <code><a href="#@winglang/sdk.std.DatetimeComponents.property.year">year</a></code> | <code>num</code> | year. |
+| <code><a href="#@winglang/sdk.std.DatetimeComponents.property.day">day</a></code> | <code>num</code> | Day. |
+| <code><a href="#@winglang/sdk.std.DatetimeComponents.property.hour">hour</a></code> | <code>num</code> | Hours. |
+| <code><a href="#@winglang/sdk.std.DatetimeComponents.property.min">min</a></code> | <code>num</code> | Minutes. |
+| <code><a href="#@winglang/sdk.std.DatetimeComponents.property.month">month</a></code> | <code>num</code> | Month. |
+| <code><a href="#@winglang/sdk.std.DatetimeComponents.property.ms">ms</a></code> | <code>num</code> | Milliseconds. |
+| <code><a href="#@winglang/sdk.std.DatetimeComponents.property.sec">sec</a></code> | <code>num</code> | Seconds. |
+| <code><a href="#@winglang/sdk.std.DatetimeComponents.property.tz">tz</a></code> | <code>num</code> | Timezone offset in minutes from UTC. |
+| <code><a href="#@winglang/sdk.std.DatetimeComponents.property.year">year</a></code> | <code>num</code> | Year. |
 
 ---
 
@@ -2086,7 +2086,7 @@ day: num;
 
 - *Type:* num
 
-day.
+Day.
 
 ---
 
@@ -2098,7 +2098,7 @@ hour: num;
 
 - *Type:* num
 
-hours.
+Hours.
 
 ---
 
@@ -2110,7 +2110,7 @@ min: num;
 
 - *Type:* num
 
-minutes.
+Minutes.
 
 ---
 
@@ -2122,7 +2122,7 @@ month: num;
 
 - *Type:* num
 
-month.
+Month.
 
 ---
 
@@ -2134,7 +2134,7 @@ ms: num;
 
 - *Type:* num
 
-milliseconds.
+Milliseconds.
 
 ---
 
@@ -2146,7 +2146,7 @@ sec: num;
 
 - *Type:* num
 
-seconds.
+Seconds.
 
 ---
 
@@ -2158,7 +2158,7 @@ tz: num;
 
 - *Type:* num
 
-timezone offset in minutes from UTC.
+Timezone offset in minutes from UTC.
 
 ---
 
@@ -2170,7 +2170,7 @@ year: num;
 
 - *Type:* num
 
-year.
+Year.
 
 ---
 

--- a/docs/docs/04-standard-library/03-http/api-reference.md
+++ b/docs/docs/04-standard-library/03-http/api-reference.md
@@ -16,7 +16,7 @@ sidebar_position: 100
 
 ### Http <a name="Http" id="@winglang/sdk.http.Util"></a>
 
-the Http class is used for calling different HTTP methods and requesting and sending information online,  as well as testing public accessible resources.
+The Http class is used for calling different HTTP methods and requesting and sending information online,  as well as testing public accessible resources.
 
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
@@ -214,7 +214,7 @@ let RequestOptions = http.RequestOptions{ ... };
 | <code><a href="#@winglang/sdk.http.RequestOptions.property.cache">cache</a></code> | <code><a href="#@winglang/sdk.http.RequestCache">RequestCache</a></code> | The cache mode you want to use for the request. |
 | <code><a href="#@winglang/sdk.http.RequestOptions.property.headers">headers</a></code> | <code>MutMap&lt;str&gt;</code> | Any headers you want to add to your request. |
 | <code><a href="#@winglang/sdk.http.RequestOptions.property.method">method</a></code> | <code><a href="#@winglang/sdk.http.HttpMethod">HttpMethod</a></code> | The request method, e.g., GET, POST. The default is GET. |
-| <code><a href="#@winglang/sdk.http.RequestOptions.property.redirect">redirect</a></code> | <code><a href="#@winglang/sdk.http.RequestRedirect">RequestRedirect</a></code> | he redirect mode to use: follow, error. |
+| <code><a href="#@winglang/sdk.http.RequestOptions.property.redirect">redirect</a></code> | <code><a href="#@winglang/sdk.http.RequestRedirect">RequestRedirect</a></code> | The redirect mode to use: follow, error. |
 | <code><a href="#@winglang/sdk.http.RequestOptions.property.referrer">referrer</a></code> | <code>str</code> | A string specifying "no-referrer", client, or a URL. |
 
 ---
@@ -279,7 +279,7 @@ redirect: RequestRedirect;
 - *Type:* <a href="#@winglang/sdk.http.RequestRedirect">RequestRedirect</a>
 - *Default:* follow
 
-he redirect mode to use: follow, error.
+The redirect mode to use: follow, error.
 
 The default is follow.
 

--- a/docs/docs/04-standard-library/06-ex/api-reference.md
+++ b/docs/docs/04-standard-library/06-ex/api-reference.md
@@ -752,45 +752,45 @@ Table column types.
 
 | **Name** | **Description** |
 | --- | --- |
-| <code><a href="#@winglang/sdk.ex.ColumnType.STRING">STRING</a></code> | string type. |
-| <code><a href="#@winglang/sdk.ex.ColumnType.NUMBER">NUMBER</a></code> | number type. |
-| <code><a href="#@winglang/sdk.ex.ColumnType.BOOLEAN">BOOLEAN</a></code> | bool type. |
-| <code><a href="#@winglang/sdk.ex.ColumnType.DATE">DATE</a></code> | date type. |
-| <code><a href="#@winglang/sdk.ex.ColumnType.JSON">JSON</a></code> | json type. |
+| <code><a href="#@winglang/sdk.ex.ColumnType.STRING">STRING</a></code> | String type. |
+| <code><a href="#@winglang/sdk.ex.ColumnType.NUMBER">NUMBER</a></code> | Number type. |
+| <code><a href="#@winglang/sdk.ex.ColumnType.BOOLEAN">BOOLEAN</a></code> | Bool type. |
+| <code><a href="#@winglang/sdk.ex.ColumnType.DATE">DATE</a></code> | Date type. |
+| <code><a href="#@winglang/sdk.ex.ColumnType.JSON">JSON</a></code> | Json type. |
 
 ---
 
 ##### `STRING` <a name="STRING" id="@winglang/sdk.ex.ColumnType.STRING"></a>
 
-string type.
+String type.
 
 ---
 
 
 ##### `NUMBER` <a name="NUMBER" id="@winglang/sdk.ex.ColumnType.NUMBER"></a>
 
-number type.
+Number type.
 
 ---
 
 
 ##### `BOOLEAN` <a name="BOOLEAN" id="@winglang/sdk.ex.ColumnType.BOOLEAN"></a>
 
-bool type.
+Bool type.
 
 ---
 
 
 ##### `DATE` <a name="DATE" id="@winglang/sdk.ex.ColumnType.DATE"></a>
 
-date type.
+Date type.
 
 ---
 
 
 ##### `JSON` <a name="JSON" id="@winglang/sdk.ex.ColumnType.JSON"></a>
 
-json type.
+Json type.
 
 ---
 

--- a/libs/wingc/src/lsp/snapshots/completions/incomplete_inflight_namespace.snap
+++ b/libs/wingc/src/lsp/snapshots/completions/incomplete_inflight_namespace.snap
@@ -143,31 +143,31 @@ source: libs/wingc/src/lsp/completions.rs
   kind: 22
   documentation:
     kind: markdown
-    value: "```wing\nstruct BucketEvent\n```\n---\non_event notification payload- will be in use after solving issue: https://github.com/winglang/wing/issues/1927.\n### Fields\n- `key` — the bucket key that triggered the event.\n- `type` — type of event."
+    value: "```wing\nstruct BucketEvent\n```\n---\nOn_event notification payload- will be in use after solving issue: https://github.com/winglang/wing/issues/1927.\n### Fields\n- `key` — The bucket key that triggered the event.\n- `type` — Type of event."
   sortText: hh|BucketEvent
 - label: BucketOnCreateProps
   kind: 22
   documentation:
     kind: markdown
-    value: "```wing\nstruct BucketOnCreateProps\n```\n---\non create event options."
+    value: "```wing\nstruct BucketOnCreateProps\n```\n---\n`onCreate` event options."
   sortText: hh|BucketOnCreateProps
 - label: BucketOnDeleteProps
   kind: 22
   documentation:
     kind: markdown
-    value: "```wing\nstruct BucketOnDeleteProps\n```\n---\non delete event options."
+    value: "```wing\nstruct BucketOnDeleteProps\n```\n---\n`onDelete` event options."
   sortText: hh|BucketOnDeleteProps
 - label: BucketOnEventProps
   kind: 22
   documentation:
     kind: markdown
-    value: "```wing\nstruct BucketOnEventProps\n```\n---\non any event options."
+    value: "```wing\nstruct BucketOnEventProps\n```\n---\n`onEvent` options."
   sortText: hh|BucketOnEventProps
 - label: BucketOnUpdateProps
   kind: 22
   documentation:
     kind: markdown
-    value: "```wing\nstruct BucketOnUpdateProps\n```\n---\non update event options."
+    value: "```wing\nstruct BucketOnUpdateProps\n```\n---\n`onUpdate` event options."
   sortText: hh|BucketOnUpdateProps
 - label: BucketProps
   kind: 22
@@ -425,7 +425,7 @@ source: libs/wingc/src/lsp/completions.rs
   kind: 13
   documentation:
     kind: markdown
-    value: "```wing\nenum BucketEventType\n```\n---\nbucket events to subscribe to.\n- `CREATE`\n- `DELETE`\n- `UPDATE`"
+    value: "```wing\nenum BucketEventType\n```\n---\nBucket events to subscribe to.\n- `CREATE`\n- `DELETE`\n- `UPDATE`"
   sortText: jj|BucketEventType
 - label: HttpMethod
   kind: 13

--- a/libs/wingc/src/lsp/snapshots/completions/namespace_inflight.snap
+++ b/libs/wingc/src/lsp/snapshots/completions/namespace_inflight.snap
@@ -77,13 +77,13 @@ source: libs/wingc/src/lsp/completions.rs
   kind: 7
   documentation:
     kind: markdown
-    value: "```wing\nclass Util\n```\n---\nthe Http class is used for calling different HTTP methods and requesting and sending information online,  as well as testing public accessible resources."
+    value: "```wing\nclass Util\n```\n---\nThe Http class is used for calling different HTTP methods and requesting and sending information online,  as well as testing public accessible resources."
   sortText: gg|Util
 - label: RequestOptions
   kind: 22
   documentation:
     kind: markdown
-    value: "```wing\nstruct RequestOptions\n```\n---\nAn object containing any custom settings that you want to apply to the request.\n### Fields\n- `body?` — Any body that you want to add to your request.\n- `cache?` — The cache mode you want to use for the request.\n- `headers?` — Any headers you want to add to your request.\n- `method?` — The request method, e.g., GET, POST. The default is GET.\n- `redirect?` — he redirect mode to use: follow, error.\n- `referrer?` — A string specifying \"no-referrer\", client, or a URL."
+    value: "```wing\nstruct RequestOptions\n```\n---\nAn object containing any custom settings that you want to apply to the request.\n### Fields\n- `body?` — Any body that you want to add to your request.\n- `cache?` — The cache mode you want to use for the request.\n- `headers?` — Any headers you want to add to your request.\n- `method?` — The request method, e.g., GET, POST. The default is GET.\n- `redirect?` — The redirect mode to use: follow, error.\n- `referrer?` — A string specifying \"no-referrer\", client, or a URL."
   sortText: hh|RequestOptions
 - label: Response
   kind: 22

--- a/libs/wingc/src/lsp/snapshots/completions/namespace_middle_dot.snap
+++ b/libs/wingc/src/lsp/snapshots/completions/namespace_middle_dot.snap
@@ -143,31 +143,31 @@ source: libs/wingc/src/lsp/completions.rs
   kind: 22
   documentation:
     kind: markdown
-    value: "```wing\nstruct BucketEvent\n```\n---\non_event notification payload- will be in use after solving issue: https://github.com/winglang/wing/issues/1927.\n### Fields\n- `key` — the bucket key that triggered the event.\n- `type` — type of event."
+    value: "```wing\nstruct BucketEvent\n```\n---\nOn_event notification payload- will be in use after solving issue: https://github.com/winglang/wing/issues/1927.\n### Fields\n- `key` — The bucket key that triggered the event.\n- `type` — Type of event."
   sortText: hh|BucketEvent
 - label: BucketOnCreateProps
   kind: 22
   documentation:
     kind: markdown
-    value: "```wing\nstruct BucketOnCreateProps\n```\n---\non create event options."
+    value: "```wing\nstruct BucketOnCreateProps\n```\n---\n`onCreate` event options."
   sortText: hh|BucketOnCreateProps
 - label: BucketOnDeleteProps
   kind: 22
   documentation:
     kind: markdown
-    value: "```wing\nstruct BucketOnDeleteProps\n```\n---\non delete event options."
+    value: "```wing\nstruct BucketOnDeleteProps\n```\n---\n`onDelete` event options."
   sortText: hh|BucketOnDeleteProps
 - label: BucketOnEventProps
   kind: 22
   documentation:
     kind: markdown
-    value: "```wing\nstruct BucketOnEventProps\n```\n---\non any event options."
+    value: "```wing\nstruct BucketOnEventProps\n```\n---\n`onEvent` options."
   sortText: hh|BucketOnEventProps
 - label: BucketOnUpdateProps
   kind: 22
   documentation:
     kind: markdown
-    value: "```wing\nstruct BucketOnUpdateProps\n```\n---\non update event options."
+    value: "```wing\nstruct BucketOnUpdateProps\n```\n---\n`onUpdate` event options."
   sortText: hh|BucketOnUpdateProps
 - label: BucketProps
   kind: 22
@@ -425,7 +425,7 @@ source: libs/wingc/src/lsp/completions.rs
   kind: 13
   documentation:
     kind: markdown
-    value: "```wing\nenum BucketEventType\n```\n---\nbucket events to subscribe to.\n- `CREATE`\n- `DELETE`\n- `UPDATE`"
+    value: "```wing\nenum BucketEventType\n```\n---\nBucket events to subscribe to.\n- `CREATE`\n- `DELETE`\n- `UPDATE`"
   sortText: jj|BucketEventType
 - label: HttpMethod
   kind: 13

--- a/libs/wingc/src/lsp/snapshots/completions/variable_type_annotation_namespace.snap
+++ b/libs/wingc/src/lsp/snapshots/completions/variable_type_annotation_namespace.snap
@@ -143,31 +143,31 @@ source: libs/wingc/src/lsp/completions.rs
   kind: 22
   documentation:
     kind: markdown
-    value: "```wing\nstruct BucketEvent\n```\n---\non_event notification payload- will be in use after solving issue: https://github.com/winglang/wing/issues/1927.\n### Fields\n- `key` — the bucket key that triggered the event.\n- `type` — type of event."
+    value: "```wing\nstruct BucketEvent\n```\n---\nOn_event notification payload- will be in use after solving issue: https://github.com/winglang/wing/issues/1927.\n### Fields\n- `key` — The bucket key that triggered the event.\n- `type` — Type of event."
   sortText: hh|BucketEvent
 - label: BucketOnCreateProps
   kind: 22
   documentation:
     kind: markdown
-    value: "```wing\nstruct BucketOnCreateProps\n```\n---\non create event options."
+    value: "```wing\nstruct BucketOnCreateProps\n```\n---\n`onCreate` event options."
   sortText: hh|BucketOnCreateProps
 - label: BucketOnDeleteProps
   kind: 22
   documentation:
     kind: markdown
-    value: "```wing\nstruct BucketOnDeleteProps\n```\n---\non delete event options."
+    value: "```wing\nstruct BucketOnDeleteProps\n```\n---\n`onDelete` event options."
   sortText: hh|BucketOnDeleteProps
 - label: BucketOnEventProps
   kind: 22
   documentation:
     kind: markdown
-    value: "```wing\nstruct BucketOnEventProps\n```\n---\non any event options."
+    value: "```wing\nstruct BucketOnEventProps\n```\n---\n`onEvent` options."
   sortText: hh|BucketOnEventProps
 - label: BucketOnUpdateProps
   kind: 22
   documentation:
     kind: markdown
-    value: "```wing\nstruct BucketOnUpdateProps\n```\n---\non update event options."
+    value: "```wing\nstruct BucketOnUpdateProps\n```\n---\n`onUpdate` event options."
   sortText: hh|BucketOnUpdateProps
 - label: BucketProps
   kind: 22
@@ -425,7 +425,7 @@ source: libs/wingc/src/lsp/completions.rs
   kind: 13
   documentation:
     kind: markdown
-    value: "```wing\nenum BucketEventType\n```\n---\nbucket events to subscribe to.\n- `CREATE`\n- `DELETE`\n- `UPDATE`"
+    value: "```wing\nenum BucketEventType\n```\n---\nBucket events to subscribe to.\n- `CREATE`\n- `DELETE`\n- `UPDATE`"
   sortText: jj|BucketEventType
 - label: HttpMethod
   kind: 13

--- a/libs/wingsdk/.eslintrc.json
+++ b/libs/wingsdk/.eslintrc.json
@@ -142,6 +142,33 @@
           }
         ]
       }
+    ],
+    "@typescript-eslint/explicit-member-accessibility": [
+      "error",
+      {
+        "accessibility": "explicit",
+        "overrides": {
+          "accessors": "off",
+          "constructors": "off",
+          "methods": "explicit",
+          "properties": "explicit",
+          "parameterProperties": "explicit"
+        }
+      }
+    ],
+    "capitalized-comments": [
+      "error",
+      "always",
+      {
+        "line": {
+          "ignorePattern": ".*"
+        },
+        "block": {
+          "ignoreConsecutiveComments": true,
+          "ignorePattern": "pragma|ignored",
+          "ignoreInlineComments": true
+        }
+      }
     ]
   },
   "overrides": [

--- a/libs/wingsdk/.projenrc.ts
+++ b/libs/wingsdk/.projenrc.ts
@@ -202,6 +202,36 @@ project.eslint!.addRules({
       ],
     },
   ],
+  // Makes sure that all methods and properties are marked with the right member accessibility- public, protected or private
+  "@typescript-eslint/explicit-member-accessibility": [
+    "error",
+    {
+      accessibility: "explicit",
+      overrides: {
+        accessors: "off",
+        constructors: "off",
+        methods: "explicit",
+        properties: "explicit",
+        parameterProperties: "explicit",
+      },
+    },
+  ],
+  // Makes sure comments and doc strings are capitalized
+  "capitalized-comments": [
+    "error",
+    "always",
+    {
+      line: {
+        // ignore everything
+        ignorePattern: ".*",
+      },
+      block: {
+        ignoreConsecutiveComments: true,
+        ignorePattern: "pragma|ignored",
+        ignoreInlineComments: true,
+      },
+    },
+  ],
 });
 
 project.npmignore?.addPatterns(".prettierignore", ".prettierrc.json", "*.tgz");

--- a/libs/wingsdk/src/cloud/api.ts
+++ b/libs/wingsdk/src/cloud/api.ts
@@ -159,7 +159,7 @@ export abstract class Api extends Resource {
     props?: ApiConnectProps
   ): void;
   /**
-   * validating path:
+   * Validating path:
    * if has curly brackets pairs- the part that inside the brackets is only letter, digit or _, not empty and placed before and after "/"
    * @param path
    * @throws if the path is invalid

--- a/libs/wingsdk/src/cloud/bucket.ts
+++ b/libs/wingsdk/src/cloud/bucket.ts
@@ -74,7 +74,7 @@ export abstract class Bucket extends Resource {
   public abstract addObject(key: string, body: string): void;
 
   /**
-   * creates a topic for subscribing to notification events
+   * Creates a topic for subscribing to notification events
    * @param actionType
    * @returns the created topi
    */
@@ -96,7 +96,7 @@ export abstract class Bucket extends Resource {
   }
 
   /**
-   * gets topic form the topics map, or creates if not exists
+   * Gets topic form the topics map, or creates if not exists
    * @param actionType
    * @returns
    */
@@ -108,7 +108,7 @@ export abstract class Bucket extends Resource {
   }
 
   /**
-   * resolves the path to the bucket.onevent.inflight file
+   * Resolves the path to the bucket.onevent.inflight file
    */
   protected eventHandlerLocation(): string {
     throw new Error(
@@ -117,7 +117,7 @@ export abstract class Bucket extends Resource {
   }
 
   /**
-   * creates an inflight handler from inflight code
+   * Creates an inflight handler from inflight code
    * @param eventType
    * @param inflight
    * @returns
@@ -139,7 +139,7 @@ export abstract class Bucket extends Resource {
   }
 
   /**
-   * creates a bucket event notifier
+   * Creates a bucket event notifier
    * @param eventNames the events to subscribe the inflight function to
    * @param inflight the code to run upon event
    * @param opts
@@ -316,31 +316,31 @@ export interface IBucketClient {
 }
 
 /**
- * on create event options
+ * `onCreate` event options
  */
 export interface BucketOnCreateProps {
-  /* elided */
+  /* Elided */
 }
 
 /**
- * on delete event options
+ * `onDelete` event options
  */
 export interface BucketOnDeleteProps {
-  /* elided */
+  /* Elided */
 }
 
 /**
- * on update event options
+ * `onUpdate` event options
  */
 export interface BucketOnUpdateProps {
-  /* elided */
+  /* Elided */
 }
 
 /**
- * on any event options
+ * `onEvent` options
  */
 export interface BucketOnEventProps {
-  /* elided */
+  /* Elided */
 }
 
 /**
@@ -365,33 +365,33 @@ export interface IBucketEventHandlerClient {
 }
 
 /**
- * on_event notification payload- will be in use after solving issue: https://github.com/winglang/wing/issues/1927
+ * On_event notification payload- will be in use after solving issue: https://github.com/winglang/wing/issues/1927
  */
 export interface BucketEvent {
   /**
-   * the bucket key that triggered the event
+   * The bucket key that triggered the event
    */
   readonly key: string;
   /**
-   * type of event
+   * Type of event
    */
   readonly type: BucketEventType;
 }
 
 /**
- * bucket events to subscribe to
+ * Bucket events to subscribe to
  */
 export enum BucketEventType {
   /**
-   * create
+   * Create
    */
   CREATE = "CREATE",
   /**
-   * delete
+   * Delete
    */
   DELETE = "DELETE",
   /**
-   * update
+   * Update
    */
   UPDATE = "UPDATE",
 }

--- a/libs/wingsdk/src/core/plugin-manager.ts
+++ b/libs/wingsdk/src/core/plugin-manager.ts
@@ -8,16 +8,16 @@ import { IConstruct } from "constructs";
  */
 export interface ICompilationHook {
   /**
-   *  name of plugin can be set by plugin as export
+   *  Name of plugin can be set by plugin as export
    *
    * @default - absolute path to plugin file
    */
   name: string;
-  /** preSynth hook */
+  /** PreSynth hook */
   preSynth?(app: IConstruct): void;
-  /** postSynth hook */
+  /** PostSynth hook */
   postSynth?(config: any): any;
-  /** validate hook */
+  /** Validate hook */
   validate?(config: any): void;
 }
 

--- a/libs/wingsdk/src/ex/table.ts
+++ b/libs/wingsdk/src/ex/table.ts
@@ -12,15 +12,15 @@ export const TABLE_FQN = fqnForType("ex.Table");
  * Table column types
  */
 export enum ColumnType {
-  /** string type */
+  /** String type */
   STRING,
-  /** number type */
+  /** Number type */
   NUMBER,
-  /** bool type */
+  /** Bool type */
   BOOLEAN,
-  /** date type */
+  /** Date type */
   DATE,
-  /** json type */
+  /** Json type */
   JSON,
 }
 

--- a/libs/wingsdk/src/http/http.ts
+++ b/libs/wingsdk/src/http/http.ts
@@ -110,7 +110,7 @@ export interface RequestOptions {
    */
   readonly cache?: RequestCache;
   /**
-   * he redirect mode to use: follow, error. The default is follow.
+   * The redirect mode to use: follow, error. The default is follow.
    * @default follow
    */
   readonly redirect?: RequestRedirect;
@@ -147,7 +147,7 @@ export interface Response {
 }
 
 /**
- * default options to attach to any request
+ * Default options to attach to any request
  */
 const defaultOptions: RequestOptions = {
   method: HttpMethod.GET,
@@ -157,7 +157,7 @@ const defaultOptions: RequestOptions = {
 };
 
 /**
- * the Http class is used for calling different HTTP methods and requesting and sending information online,
+ * The Http class is used for calling different HTTP methods and requesting and sending information online,
  *  as well as testing public accessible resources
  * @inflight
  */
@@ -177,7 +177,10 @@ export class Util {
    * @inflight
    * @returns the formatted response of the call
    */
-  static async fetch(url: string, options?: RequestOptions): Promise<Response> {
+  public static async fetch(
+    url: string,
+    options?: RequestOptions
+  ): Promise<Response> {
     const res = await fetch(url, { ...defaultOptions, ...options });
     return this._formatResponse(res);
   }
@@ -188,7 +191,10 @@ export class Util {
    * @inflight
    * @returns the formatted response of the call
    */
-  static async get(url: string, options?: RequestOptions): Promise<Response> {
+  public static async get(
+    url: string,
+    options?: RequestOptions
+  ): Promise<Response> {
     return this.fetch(url, {
       ...defaultOptions,
       ...options,
@@ -202,7 +208,10 @@ export class Util {
    * @inflight
    * @returns the formatted response of the call
    */
-  static async post(url: string, options?: RequestOptions): Promise<Response> {
+  public static async post(
+    url: string,
+    options?: RequestOptions
+  ): Promise<Response> {
     return this.fetch(url, {
       ...defaultOptions,
       ...options,
@@ -216,7 +225,10 @@ export class Util {
    * @inflight
    * @returns the formatted response of the call
    */
-  static async put(url: string, options?: RequestOptions): Promise<Response> {
+  public static async put(
+    url: string,
+    options?: RequestOptions
+  ): Promise<Response> {
     return this.fetch(url, {
       ...defaultOptions,
       ...options,
@@ -230,7 +242,10 @@ export class Util {
    * @inflight
    * @returns the formatted response of the call
    */
-  static async patch(url: string, options?: RequestOptions): Promise<Response> {
+  public static async patch(
+    url: string,
+    options?: RequestOptions
+  ): Promise<Response> {
     return this.fetch(url, {
       ...defaultOptions,
       ...options,
@@ -245,7 +260,7 @@ export class Util {
    * @inflight
    * @returns the formatted response of the call
    */
-  static async delete(
+  public static async delete(
     url: string,
     options?: RequestOptions
   ): Promise<Response> {

--- a/libs/wingsdk/src/shared-aws/bucket.inflight.ts
+++ b/libs/wingsdk/src/shared-aws/bucket.inflight.ts
@@ -208,7 +208,7 @@ export class BucketClient implements IBucketClient {
     return list;
   }
   /**
-   * checks if the bucket is public
+   * Checks if the bucket is public
    * @returns true if the bucket is public and false otherwise
    */
   private async checkIfPublic(): Promise<boolean> {

--- a/libs/wingsdk/src/std/datetime.ts
+++ b/libs/wingsdk/src/std/datetime.ts
@@ -1,39 +1,39 @@
 import { Code, InflightClient } from "../core";
 
 /**
- * interface that is used for setting Datetime date
+ * Interface that is used for setting Datetime date
  */
 export interface DatetimeComponents {
   /**
-   * year
+   * Year
    */
   readonly year: number;
   /**
-   * month
+   * Month
    */
   readonly month: number;
   /**
-   * day
+   * Day
    */
   readonly day: number;
   /**
-   * hours
+   * Hours
    */
   readonly hour: number;
   /**
-   * minutes
+   * Minutes
    */
   readonly min: number;
   /**
-   * seconds
+   * Seconds
    */
   readonly sec: number;
   /**
-   * milliseconds
+   * Milliseconds
    */
   readonly ms: number;
   /**
-   *  timezone offset in minutes from UTC
+   *  Timezone offset in minutes from UTC
    */
   readonly tz: number;
 }
@@ -199,7 +199,7 @@ export class Datetime {
   }
 
   /**
-   * returns the offset in minutes from UTC
+   * Returns the offset in minutes from UTC
    *
    * @returns a number representing the datetime's offset in minutes from UTC
    */

--- a/libs/wingsdk/src/std/resource.ts
+++ b/libs/wingsdk/src/std/resource.ts
@@ -128,7 +128,7 @@ export abstract class Resource extends Construct implements IResource {
    *
    * @internal
    */
-  static _registerTypeBind(host: IInflightHost, ops: string[]): void {
+  public static _registerTypeBind(host: IInflightHost, ops: string[]): void {
     // Do nothing by default
     host;
     ops;

--- a/libs/wingsdk/src/target-awscdk/app.ts
+++ b/libs/wingsdk/src/target-awscdk/app.ts
@@ -112,7 +112,7 @@ export class App extends CoreApp {
    * This method returns a cleaned snapshot of the resulting CDK template
    * for unit testing.
    */
-  synth(): string {
+  public synth(): string {
     if (this.synthed) {
       return this.synthedOutput!;
     }

--- a/libs/wingsdk/src/target-awscdk/topic.ts
+++ b/libs/wingsdk/src/target-awscdk/topic.ts
@@ -23,7 +23,7 @@ export class Topic extends cloud.Topic {
   }
 
   /**
-   * topic's arn
+   * Topic's arn
    */
   public get arn(): string {
     return this.topic.topicArn;

--- a/libs/wingsdk/src/target-sim/queue.inflight.ts
+++ b/libs/wingsdk/src/target-sim/queue.inflight.ts
@@ -178,8 +178,8 @@ export class Queue
 }
 
 class QueueMessage {
-  retentionTimeout: Date;
-  payload: string;
+  public readonly retentionTimeout: Date;
+  public readonly payload: string;
 
   constructor(retentionPeriod: number, message: string) {
     const currentTime = new Date();
@@ -195,7 +195,7 @@ class RandomArrayIterator<T = any> implements Iterable<T> {
     this.length = this.values.length;
   }
 
-  next(): IteratorResult<T> {
+  public next(): IteratorResult<T> {
     if (this.length === 0) {
       return { done: true, value: undefined };
     }
@@ -210,7 +210,7 @@ class RandomArrayIterator<T = any> implements Iterable<T> {
     return { value };
   }
 
-  [Symbol.iterator]() {
+  public [Symbol.iterator]() {
     return this;
   }
 }

--- a/libs/wingsdk/src/target-sim/service.ts
+++ b/libs/wingsdk/src/target-sim/service.ts
@@ -74,7 +74,7 @@ export class Service extends cloud.Service implements ISimulatorResource {
     return fn;
   }
 
-  toSimulator(): BaseResourceSchema {
+  public toSimulator(): BaseResourceSchema {
     const schema: ServiceSchema = {
       type: SERVICE_TYPE,
       path: this.node.path,

--- a/libs/wingsdk/src/target-sim/topic.inflight.ts
+++ b/libs/wingsdk/src/target-sim/topic.inflight.ts
@@ -65,7 +65,7 @@ export class Topic
     }
   }
 
-  async addEventSubscription(
+  public async addEventSubscription(
     subscriber: FunctionHandle,
     subscriptionProps: EventSubscription
   ): Promise<void> {
@@ -76,7 +76,7 @@ export class Topic
     this.subscribers.push(s);
   }
 
-  async publish(message: string): Promise<void> {
+  public async publish(message: string): Promise<void> {
     this.context.addTrace({
       data: {
         message: `Publish (message=${message}).`,

--- a/libs/wingsdk/src/target-tf-aws/function.ts
+++ b/libs/wingsdk/src/target-tf-aws/function.ts
@@ -31,18 +31,18 @@ const FUNCTION_NAME_OPTS: NameOptions = {
  * that should be used when a function is deployed within a VPC.
  */
 export interface FunctionNetworkConfig {
-  /** list of subnets to attach on function */
+  /** List of subnets to attach on function */
   readonly subnetIds: string[];
-  /** list of security groups to place function in */
+  /** List of security groups to place function in */
   readonly securityGroupIds: string[];
 }
 
 /**
- * options for granting invoke permissions to the current function
+ * Options for granting invoke permissions to the current function
  */
 export interface FunctionPermissionsOptions {
   /**
-   * used for keeping function's versioning.
+   * Used for keeping function's versioning.
    */
   readonly qualifier?: string;
 }

--- a/libs/wingsdk/src/target-tf-aws/topic.ts
+++ b/libs/wingsdk/src/target-tf-aws/topic.ts
@@ -28,7 +28,7 @@ const NAME_OPTS: NameOptions = {
 export class Topic extends cloud.Topic {
   private readonly topic: SnsTopic;
   /**
-   * topic's publishing permissions. can be use as a dependency of another resource.
+   * Topic's publishing permissions. can be use as a dependency of another resource.
    * (the one that got the permissions to publish)
    * */
   public permissions!: SnsTopicPolicy;
@@ -42,7 +42,7 @@ export class Topic extends cloud.Topic {
   }
 
   /**
-   * topic's arn
+   * Topic's arn
    */
   public get arn(): string {
     return this.topic.arn;

--- a/libs/wingsdk/test/target-awscdk/__snapshots__/counter.test.ts.snap
+++ b/libs/wingsdk/test/target-awscdk/__snapshots__/counter.test.ts.snap
@@ -129,7 +129,7 @@ exports[`dec() policy statement 2`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "7f88ad6b39756ca47a1f62c4073b16e7d1dd718dccac91f2f477bd8b7d93979b.zip",
+          "S3Key": "f3738bcfd58c05cf71242945f065454f27590bcdafb0ccd96150f36963676a16.zip",
         },
         "Environment": {
           "Variables": {
@@ -367,7 +367,7 @@ exports[`function with a counter binding 2`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "eeb1a09b430750f79d2178a853df4a7c9c3da2b3cd34773230b0e09b686d118e.zip",
+          "S3Key": "b03ff20bc0f7d7c4d3c6ac541eb138884f06868c5412ad8414d7913bebca1b6d.zip",
         },
         "Environment": {
           "Variables": {
@@ -539,7 +539,7 @@ exports[`inc() policy statement 2`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "eeb1a09b430750f79d2178a853df4a7c9c3da2b3cd34773230b0e09b686d118e.zip",
+          "S3Key": "b03ff20bc0f7d7c4d3c6ac541eb138884f06868c5412ad8414d7913bebca1b6d.zip",
         },
         "Environment": {
           "Variables": {
@@ -711,7 +711,7 @@ exports[`peek() policy statement 2`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "c99045e525ddd3aa5e452c244ab0e15d7dccb0c992971ff69d1556a946b4f4ef.zip",
+          "S3Key": "9189a03759b8a966a3e4efb03da3bf6b2546b25b85ccf726d3240bbc1b86e272.zip",
         },
         "Environment": {
           "Variables": {
@@ -883,7 +883,7 @@ exports[`set() policy statement 2`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "239ecd5b27a3e3d0fe03e52540218d631d1790ad7a32eb81f57677613ba2e1c7.zip",
+          "S3Key": "0da3747a941f72aa30762d828c78b18e9f513c3801f61711ae0fd3ff29a218b5.zip",
         },
         "Environment": {
           "Variables": {

--- a/libs/wingsdk/test/target-awscdk/__snapshots__/counter.test.ts.snap
+++ b/libs/wingsdk/test/target-awscdk/__snapshots__/counter.test.ts.snap
@@ -129,7 +129,7 @@ exports[`dec() policy statement 2`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "f3738bcfd58c05cf71242945f065454f27590bcdafb0ccd96150f36963676a16.zip",
+          "S3Key": "7f88ad6b39756ca47a1f62c4073b16e7d1dd718dccac91f2f477bd8b7d93979b.zip",
         },
         "Environment": {
           "Variables": {
@@ -367,7 +367,7 @@ exports[`function with a counter binding 2`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "b03ff20bc0f7d7c4d3c6ac541eb138884f06868c5412ad8414d7913bebca1b6d.zip",
+          "S3Key": "eeb1a09b430750f79d2178a853df4a7c9c3da2b3cd34773230b0e09b686d118e.zip",
         },
         "Environment": {
           "Variables": {
@@ -539,7 +539,7 @@ exports[`inc() policy statement 2`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "b03ff20bc0f7d7c4d3c6ac541eb138884f06868c5412ad8414d7913bebca1b6d.zip",
+          "S3Key": "eeb1a09b430750f79d2178a853df4a7c9c3da2b3cd34773230b0e09b686d118e.zip",
         },
         "Environment": {
           "Variables": {
@@ -711,7 +711,7 @@ exports[`peek() policy statement 2`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "9189a03759b8a966a3e4efb03da3bf6b2546b25b85ccf726d3240bbc1b86e272.zip",
+          "S3Key": "c99045e525ddd3aa5e452c244ab0e15d7dccb0c992971ff69d1556a946b4f4ef.zip",
         },
         "Environment": {
           "Variables": {
@@ -883,7 +883,7 @@ exports[`set() policy statement 2`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "0da3747a941f72aa30762d828c78b18e9f513c3801f61711ae0fd3ff29a218b5.zip",
+          "S3Key": "239ecd5b27a3e3d0fe03e52540218d631d1790ad7a32eb81f57677613ba2e1c7.zip",
         },
         "Environment": {
           "Variables": {

--- a/libs/wingsdk/test/target-tf-azure/bucket.inflight.test.ts
+++ b/libs/wingsdk/test/target-tf-azure/bucket.inflight.test.ts
@@ -382,7 +382,7 @@ test("tryDelete a non-existent object from the bucket", async () => {
 
 // Mock Clients
 class MockBlobClient extends BlobClient {
-  download(): Promise<BlobDownloadResponseParsed> {
+  public download(): Promise<BlobDownloadResponseParsed> {
     switch (TEST_PATH) {
       case "happy":
         return Promise.resolve({
@@ -406,7 +406,7 @@ class MockBlobClient extends BlobClient {
     }
   }
 
-  exists(options?: BlobExistsOptions | undefined): Promise<boolean> {
+  public exists(options?: BlobExistsOptions | undefined): Promise<boolean> {
     options;
     switch (TEST_PATH) {
       case "happy":
@@ -422,25 +422,25 @@ class MockBlobClient extends BlobClient {
 }
 
 class MockBlockBlobClient extends BlockBlobClient {
-  upload(): Promise<BlockBlobUploadResponse> {
+  public upload(): Promise<BlockBlobUploadResponse> {
     return Promise.resolve({} as any);
   }
 
-  delete(): Promise<BlobDeleteResponse> {
+  public delete(): Promise<BlobDeleteResponse> {
     return Promise.resolve({} as any);
   }
 }
 
 class MockContainerClient extends ContainerClient {
-  getBlobClient(key: string): BlobClient {
+  public getBlobClient(key: string): BlobClient {
     return new MockBlobClient(key);
   }
 
-  getBlockBlobClient(blobName: string): BlockBlobClient {
+  public getBlockBlobClient(blobName: string): BlockBlobClient {
     return new MockBlockBlobClient(blobName);
   }
 
-  listBlobsFlat(
+  public listBlobsFlat(
     options?: ContainerListBlobsOptions | undefined
   ): PagedAsyncIterableIterator<
     BlobItem,


### PR DESCRIPTION
Following @Chriscbr's comment: https://github.com/winglang/wing/pull/3570#discussion_r1276452117

I added those two rules to the SDK's linter and ran it once to apply them.
The added regulations are:
* capitalizing comment- makes sure comments and doc strings are capitalized
* explicit member accessibility- makes sure that all methods and properties are marked with the right member accessibility- public, protected, or private

I also added a sentence to the docs referring to the importance of docstrings, which should be capitalized.


## Checklist

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [ ] Tests added (always)
- [x] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
