### PR TITLE
feat(sdk): parallel sdk spec testing via gh action

### DIFF
--- a/.github/workflows/tf-aws-test.yml
+++ b/.github/workflows/tf-aws-test.yml
@@ -64,7 +64,7 @@ jobs:
           node-version: 18
       - name: Install winglang globally
         run: npm install -g winglang
-      - name: Check for package.json file
+      - name: Installing external js modules
         run: | 
           cd examples/tests/sdk_tests
           npm install
@@ -75,13 +75,13 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ env.AWS_REGION }}
       - name: Execute wing test in matrix directory
-        # env:
-        #   TF_LOG: info
-        #   TF_LOG_PATH: ${{ runner.workspace }}/terraform.log
-        run: wing test -t sim ${{ matrix.test.directory }}/*.w
-      # - name: Output Terraform log
-        # if: failure()
-        # run: cat ${{ runner.workspace }}/terraform.log
+        env:
+          TF_LOG: info
+          TF_LOG_PATH: ${{ runner.workspace }}/terraform.log
+        run: wing test -t tf-aws ${{ matrix.test.directory }}/*.w
+      - name: Output Terraform log
+        if: failure()
+        run: cat ${{ runner.workspace }}/terraform.log
     
     
     # steps:

--- a/.github/workflows/tf-aws-test.yml
+++ b/.github/workflows/tf-aws-test.yml
@@ -77,13 +77,13 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ env.AWS_REGION }}
       - name: Execute wing test in matrix directory
-        env:
-          TF_LOG: info
-          TF_LOG_PATH: ${{ runner.workspace }}/terraform.log
+        # env:
+        #   TF_LOG: info
+        #   TF_LOG_PATH: ${{ runner.workspace }}/terraform.log
         run: cd ${{ matrix.example.directory }} && wing test -t sim /*.w
-      - name: Output Terraform log
-        if: failure()
-        run: cat ${{ runner.workspace }}/terraform.log
+      # - name: Output Terraform log
+        # if: failure()
+        # run: cat ${{ runner.workspace }}/terraform.log
     
     
     # steps:

--- a/.github/workflows/tf-aws-test.yml
+++ b/.github/workflows/tf-aws-test.yml
@@ -4,32 +4,34 @@ on:
     types:
       - published
   workflow_dispatch: {}
+  push:
+    branches:
+      - tsuf/sdk-sepc-tests-parallel-gh-action
 
 env:
-  AWS_REGION : "us-east-1"
+  AWS_REGION: "us-east-1"
 
 jobs:
   setup:
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repository
-      uses: actions/checkout@v3
-    - name: Get list of directories
-      id: setdirs
-      shell: bash
-      run: |
-        dirs=$(ls -d examples/tests/sdk_tests/*/ | sed 's/\/$//' | grep -v "external" | jq -R -s -c 'split("\n")[:-1]')
-        processed_dirs=$(echo "{ \"directory\": $dirs }" | jq -c '[ .directory[] | {directory: ., name: (split("/") | last)}]')
-        wrapped_dirs=$(echo "{ \"test\": $processed_dirs }" | jq -c .)
-        echo "DIRS=$wrapped_dirs" >> $GITHUB_ENV
-    - name: Pass environment variable to output
-      id: passenv
-      run: |
-        echo "::set-output name=dirs::$DIRS"
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+      - name: Get list of directories
+        id: setdirs
+        shell: bash
+        run: |
+          dirs=$(ls -d examples/tests/sdk_tests/*/ | sed 's/\/$//' | grep -v "external" | jq -R -s -c 'split("\n")[:-1]')
+          processed_dirs=$(echo "{ \"directory\": $dirs }" | jq -c '[ .directory[] | {directory: ., name: (split("/") | last)}]')
+          wrapped_dirs=$(echo "{ \"test\": $processed_dirs }" | jq -c .)
+          echo "DIRS=$wrapped_dirs" >> $GITHUB_ENV
+      - name: Pass environment variable to output
+        id: passenv
+        run: |
+          echo "::set-output name=dirs::$DIRS"
     outputs:
       tests: ${{ steps.passenv.outputs.dirs }}
 
-    
   test-tf-aws:
     needs: setup
     runs-on: ubuntu-latest
@@ -47,7 +49,7 @@ jobs:
       - name: Install winglang globally
         run: npm install -g winglang
       - name: Installing external js modules
-        run: | 
+        run: |
           cd examples/tests/sdk_tests
           npm install
       - name: Configure AWS credentials
@@ -64,4 +66,3 @@ jobs:
       - name: Output Terraform log
         if: failure()
         run: cat ${{ runner.workspace }}/terraform.log
-    

--- a/.github/workflows/tf-aws-test.yml
+++ b/.github/workflows/tf-aws-test.yml
@@ -116,3 +116,4 @@ jobs:
 
     #   - name: Run tests
     #     run: wing test -t tf-aws examples/tests/sdk_tests/*/*.w
+#

--- a/.github/workflows/tf-aws-test.yml
+++ b/.github/workflows/tf-aws-test.yml
@@ -80,7 +80,7 @@ jobs:
         # env:
         #   TF_LOG: info
         #   TF_LOG_PATH: ${{ runner.workspace }}/terraform.log
-        run: cd ${{ matrix.example.directory }} && wing test -t sim /*.w
+        run: wing test -t sim ${{ matrix.example.directory }}/*.w
       # - name: Output Terraform log
         # if: failure()
         # run: cat ${{ runner.workspace }}/terraform.log

--- a/.github/workflows/tf-aws-test.yml
+++ b/.github/workflows/tf-aws-test.yml
@@ -28,7 +28,7 @@ jobs:
       run: |
         dirs=$(ls -d examples/tests/sdk_tests/*/ | sed 's/\/$//' | grep -v "provider-specific" | jq -R -s -c 'split("\n")[:-1]')
         processed_dirs=$(echo "{ \"directory\": $dirs }" | jq -c '[ .directory[] | {directory: ., name: (split("/") | last)}]')
-        wrapped_dirs=$(echo "{ \"sdk_tests\": $processed_dirs }" | jq -c .)
+        wrapped_dirs=$(echo "{ \"test\": $processed_dirs }" | jq -c .)
         echo "DIRS=$wrapped_dirs" >> $GITHUB_ENV
   
     - name: Pass environment variable to output
@@ -36,7 +36,7 @@ jobs:
       run: |
         echo "::set-output name=dirs::$DIRS"
     outputs:
-      examples: ${{ steps.passenv.outputs.dirs }}
+      tests: ${{ steps.passenv.outputs.dirs }}
 
     
   test-tf-aws:
@@ -44,8 +44,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix: ${{ fromJson(needs.setup.outputs.examples) }}
-    name: ${{ matrix.example.name }} (AWS)
+      matrix: ${{ fromJson(needs.setup.outputs.tests) }}
+    name: ${{ matrix.test.name }} (AWS)
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v3

--- a/.github/workflows/tf-aws-test.yml
+++ b/.github/workflows/tf-aws-test.yml
@@ -4,9 +4,6 @@ on:
     types:
       - published
   workflow_dispatch: {}
-  push:
-    branches:
-      - tsuf/sdk-sepc-tests-parallel-gh-action
 
 env:
   AWS_REGION: "us-east-1"

--- a/.github/workflows/tf-aws-test.yml
+++ b/.github/workflows/tf-aws-test.yml
@@ -65,11 +65,9 @@ jobs:
       - name: Install winglang globally
         run: npm install -g winglang
       - name: Check for package.json file
-        run: |
-          if [[ -f "../${{ matrix.test.directory }}/package.json" ]]; then
-          cd ${{ matrix.test.directory }}
+        run: | 
+          cd examples/tests/sdk_tests
           npm install
-          fi
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v2
         with:

--- a/.github/workflows/tf-aws-test.yml
+++ b/.github/workflows/tf-aws-test.yml
@@ -64,12 +64,12 @@ jobs:
           node-version: 18
       - name: Install winglang globally
         run: npm install -g winglang
-      # - name: Check for package.json file
-      #   run: |
-      #     if [[ -f "${{ matrix.test.directory }}/package.json" ]]; then
-      #     cd ${{ matrix.test.directory }}
-      #     npm install
-      #     fi
+      - name: Check for package.json file
+        run: |
+          if [[ -f "../${{ matrix.test.directory }}/package.json" ]]; then
+          cd ${{ matrix.test.directory }}
+          npm install
+          fi
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v2
         with:

--- a/.github/workflows/tf-aws-test.yml
+++ b/.github/workflows/tf-aws-test.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch: {}
   push:
     branches:
-      -tsuf/sdk-spec-tests-parallel-gh-action
+      - tsuf/sdk-spec-tests-parallel-gh-action
 
 env:
   AWS_REGION : "us-east-1"

--- a/.github/workflows/tf-aws-test.yml
+++ b/.github/workflows/tf-aws-test.yml
@@ -4,24 +4,16 @@ on:
     types:
       - published
   workflow_dispatch: {}
-  push:
-    branches:
-      - tsuf/sdk-sepc-tests-parallel-gh-action
 
 env:
   AWS_REGION : "us-east-1"
 
 jobs:
-  # install:
-  #   name: Installation & Test
-  #   strategy:
-  #     fail-fast: true
   setup:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repository
       uses: actions/checkout@v3
-   
     - name: Get list of directories
       id: setdirs
       shell: bash
@@ -30,7 +22,6 @@ jobs:
         processed_dirs=$(echo "{ \"directory\": $dirs }" | jq -c '[ .directory[] | {directory: ., name: (split("/") | last)}]')
         wrapped_dirs=$(echo "{ \"test\": $processed_dirs }" | jq -c .)
         echo "DIRS=$wrapped_dirs" >> $GITHUB_ENV
-  
     - name: Pass environment variable to output
       id: passenv
       run: |
@@ -45,19 +36,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.setup.outputs.tests) }}
-    name: ${{ matrix.test.name }} (AWS)
+    name: ${{ matrix.test.name }}
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v3
-      # - name: Check for skip.ci file
-      #   id: check_skip
-      #   run: |
-      #     if [[ -f "${{ matrix.example.directory }}/skip.ci.aws" ]]; then
-      #       echo "skip.ci file detected. Skipping job."
-      #       echo "skip=true" >> $GITHUB_ENV
-      #     else
-      #       echo "skip=false" >> $GITHUB_ENV
-      #     fi
       - name: Setup Node.js v18
         uses: actions/setup-node@v3
         with:
@@ -83,35 +65,3 @@ jobs:
         if: failure()
         run: cat ${{ runner.workspace }}/terraform.log
     
-    
-    # steps:
-    #   - name: Checkout repository
-    #     uses: actions/checkout@v3
-
-    #   - name: Setup Node
-    #     uses: actions/setup-node@v3
-    #     with:
-    #       node-version: 20
-
-    #   - name: Configure AWS Credentials Action For GitHub Actions
-    #     uses: aws-actions/configure-aws-credentials@v1
-    #     with:
-    #       aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
-    #       aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-    #       aws-region: us-east-1
-
-    #   - name: Setup Terraform
-    #     uses: hashicorp/setup-terraform@v2
-    #     with:
-    #       terraform_wrapper: false #important! since we use terraform output command https://github.com/hashicorp/setup-terraform/issues/20#issuecomment-679424701
-
-    #   - name: Get Latest Wing Version
-    #     id: get-version
-    #     run: echo version=$(npm view winglang version) >> $GITHUB_OUTPUT
-
-    #   - name: Install Wing
-    #     run: npm install -g winglang@${{ steps.get-version.outputs.version }}
-
-    #   - name: Run tests
-    #     run: wing test -t tf-aws examples/tests/sdk_tests/*/*.w
-#

--- a/.github/workflows/tf-aws-test.yml
+++ b/.github/workflows/tf-aws-test.yml
@@ -26,7 +26,7 @@ jobs:
       id: setdirs
       shell: bash
       run: |
-        dirs=$(ls -d examples/tests/sdk_tests/*/ | sed 's/\/$//' | grep -v "provider-specific" | jq -R -s -c 'split("\n")[:-1]')
+        dirs=$(ls -d examples/tests/sdk_tests/*/ | sed 's/\/$//' | grep -v "external" | jq -R -s -c 'split("\n")[:-1]')
         processed_dirs=$(echo "{ \"directory\": $dirs }" | jq -c '[ .directory[] | {directory: ., name: (split("/") | last)}]')
         wrapped_dirs=$(echo "{ \"test\": $processed_dirs }" | jq -c .)
         echo "DIRS=$wrapped_dirs" >> $GITHUB_ENV

--- a/.github/workflows/tf-aws-test.yml
+++ b/.github/workflows/tf-aws-test.yml
@@ -4,40 +4,115 @@ on:
     types:
       - published
   workflow_dispatch: {}
+  push:
+    branches:
+      -tsuf/sdk-spec-tests-parallel-gh-action
+
+env:
+  AWS_REGION : "us-east-1"
 
 jobs:
-  install:
-    name: Installation & Test
-    strategy:
-      fail-fast: true
+  # install:
+  #   name: Installation & Test
+  #   strategy:
+  #     fail-fast: true
+  setup:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
+    - name: Checkout Repository
+      uses: actions/checkout@v3
+   
+    - name: Get list of directories
+      id: setdirs
+      shell: bash
+      run: |
+        dirs=$(ls -d examples/*/ | sed 's/\/$//' | grep -v "provider-specific" | jq -R -s -c 'split("\n")[:-1]')
+        processed_dirs=$(echo "{ \"directory\": $dirs }" | jq -c '[ .directory[] | {directory: ., name: (split("/") | last)}]')
+        wrapped_dirs=$(echo "{ \"example\": $processed_dirs }" | jq -c .)
+        echo "DIRS=$wrapped_dirs" >> $GITHUB_ENV
+  
+    - name: Pass environment variable to output
+      id: passenv
+      run: |
+        echo "::set-output name=dirs::$DIRS"
+    outputs:
+      examples: ${{ steps.passenv.outputs.dirs }}
 
-      - name: Setup Node
+    
+  test-tf-aws:
+    needs: setup
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.setup.outputs.examples) }}
+    name: ${{ matrix.example.name }} (AWS)
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+      # - name: Check for skip.ci file
+      #   id: check_skip
+      #   run: |
+      #     if [[ -f "${{ matrix.example.directory }}/skip.ci.aws" ]]; then
+      #       echo "skip.ci file detected. Skipping job."
+      #       echo "skip=true" >> $GITHUB_ENV
+      #     else
+      #       echo "skip=false" >> $GITHUB_ENV
+      #     fi
+      - name: Setup Node.js v18
         uses: actions/setup-node@v3
         with:
-          node-version: 20
-
-      - name: Configure AWS Credentials Action For GitHub Actions
-        uses: aws-actions/configure-aws-credentials@v1
+          node-version: 18
+      - name: Install winglang globally
+        run: npm install -g winglang
+      # - name: Check for package.json file
+      #   run: |
+      #     if [[ -f "${{ matrix.example.directory }}/package.json" ]]; then
+      #     cd ${{ matrix.example.directory }}
+      #     npm install
+      #     fi
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-east-1
+          aws-region: ${{ env.AWS_REGION }}
+      - name: Execute wing test in matrix directory
+        env:
+          TF_LOG: info
+          TF_LOG_PATH: ${{ runner.workspace }}/terraform.log
+        run: cd ${{ matrix.example.directory }} && wing test -t sim /*.w
+      - name: Output Terraform log
+        if: failure()
+        run: cat ${{ runner.workspace }}/terraform.log
+    
+    
+    # steps:
+    #   - name: Checkout repository
+    #     uses: actions/checkout@v3
 
-      - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v2
-        with:
-          terraform_wrapper: false #important! since we use terraform output command https://github.com/hashicorp/setup-terraform/issues/20#issuecomment-679424701
+    #   - name: Setup Node
+    #     uses: actions/setup-node@v3
+    #     with:
+    #       node-version: 20
 
-      - name: Get Latest Wing Version
-        id: get-version
-        run: echo version=$(npm view winglang version) >> $GITHUB_OUTPUT
+    #   - name: Configure AWS Credentials Action For GitHub Actions
+    #     uses: aws-actions/configure-aws-credentials@v1
+    #     with:
+    #       aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
+    #       aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+    #       aws-region: us-east-1
 
-      - name: Install Wing
-        run: npm install -g winglang@${{ steps.get-version.outputs.version }}
+    #   - name: Setup Terraform
+    #     uses: hashicorp/setup-terraform@v2
+    #     with:
+    #       terraform_wrapper: false #important! since we use terraform output command https://github.com/hashicorp/setup-terraform/issues/20#issuecomment-679424701
 
-      - name: Run tests
-        run: wing test -t tf-aws examples/tests/sdk_tests/*/*.w
+    #   - name: Get Latest Wing Version
+    #     id: get-version
+    #     run: echo version=$(npm view winglang version) >> $GITHUB_OUTPUT
+
+    #   - name: Install Wing
+    #     run: npm install -g winglang@${{ steps.get-version.outputs.version }}
+
+    #   - name: Run tests
+    #     run: wing test -t tf-aws examples/tests/sdk_tests/*/*.w

--- a/.github/workflows/tf-aws-test.yml
+++ b/.github/workflows/tf-aws-test.yml
@@ -66,8 +66,8 @@ jobs:
         run: npm install -g winglang
       # - name: Check for package.json file
       #   run: |
-      #     if [[ -f "${{ matrix.example.directory }}/package.json" ]]; then
-      #     cd ${{ matrix.example.directory }}
+      #     if [[ -f "${{ matrix.test.directory }}/package.json" ]]; then
+      #     cd ${{ matrix.test.directory }}
       #     npm install
       #     fi
       - name: Configure AWS credentials
@@ -80,7 +80,7 @@ jobs:
         # env:
         #   TF_LOG: info
         #   TF_LOG_PATH: ${{ runner.workspace }}/terraform.log
-        run: wing test -t sim ${{ matrix.example.directory }}/*.w
+        run: wing test -t sim ${{ matrix.test.directory }}/*.w
       # - name: Output Terraform log
         # if: failure()
         # run: cat ${{ runner.workspace }}/terraform.log

--- a/.github/workflows/tf-aws-test.yml
+++ b/.github/workflows/tf-aws-test.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch: {}
   push:
     branches:
-      - tsuf/sdk-spec-tests-parallel-gh-action
+      - tsuf/sdk-sepc-tests-parallel-gh-action
 
 env:
   AWS_REGION : "us-east-1"

--- a/.github/workflows/tf-aws-test.yml
+++ b/.github/workflows/tf-aws-test.yml
@@ -28,7 +28,7 @@ jobs:
       run: |
         dirs=$(ls -d examples/*/ | sed 's/\/$//' | grep -v "provider-specific" | jq -R -s -c 'split("\n")[:-1]')
         processed_dirs=$(echo "{ \"directory\": $dirs }" | jq -c '[ .directory[] | {directory: ., name: (split("/") | last)}]')
-        wrapped_dirs=$(echo "{ \"example\": $processed_dirs }" | jq -c .)
+        wrapped_dirs=$(echo "{ \"sdk_tests\": $processed_dirs }" | jq -c .)
         echo "DIRS=$wrapped_dirs" >> $GITHUB_ENV
   
     - name: Pass environment variable to output

--- a/.github/workflows/tf-aws-test.yml
+++ b/.github/workflows/tf-aws-test.yml
@@ -26,7 +26,7 @@ jobs:
       id: setdirs
       shell: bash
       run: |
-        dirs=$(ls -d examples/*/ | sed 's/\/$//' | grep -v "provider-specific" | jq -R -s -c 'split("\n")[:-1]')
+        dirs=$(ls -d examples/tests/sdk_tests/*/ | sed 's/\/$//' | grep -v "provider-specific" | jq -R -s -c 'split("\n")[:-1]')
         processed_dirs=$(echo "{ \"directory\": $dirs }" | jq -c '[ .directory[] | {directory: ., name: (split("/") | last)}]')
         wrapped_dirs=$(echo "{ \"sdk_tests\": $processed_dirs }" | jq -c .)
         echo "DIRS=$wrapped_dirs" >> $GITHUB_ENV


### PR DESCRIPTION
## Description

Thanks to @skorfmann's amazing [code](https://github.com/winglang/examples/blob/main/.github/workflows/wing-sdk.yml), I managed to split the SDK spec tests to run in parallel on a few machines based on the tests directory!

Cannot be deployed before #3723 

finally fixes #2689! 🥳 

It looks like that:
![image](https://github.com/winglang/wing/assets/39455181/662eda0f-5e31-49ff-8ef8-78c27060c98a)

## Checklist

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [ ] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
