### PR TITLE
fix(compiler): optional function args are not type checked

### DIFF
--- a/examples/tests/invalid/optionals.w
+++ b/examples/tests/invalid/optionals.w
@@ -2,10 +2,17 @@ let f = (x: num) => {
   // do something
 };
 
+let fOptional = (x: num?) => {
+  // do something
+};
+
 let x: num? = 1;
 
 f(x);
 //^ error: x is num? but f expects num
+
+fOptional("");
+//        ^^ error: expected num?, got str
 
 let y = true;
 if y? {

--- a/examples/tests/sdk_tests/bucket/delete.w
+++ b/examples/tests/sdk_tests/bucket/delete.w
@@ -13,9 +13,9 @@ test "delete" {
   assert(b.exists("file1.json"));
   assert(b.exists("file2.txt"));
 
-  b.delete("file1.json", { mustExist: true });
+  b.delete("file1.json", mustExist: true);
   try {
-    b.delete("file1.json", { mustExist: true });
+    b.delete("file1.json", mustExist: true);
   } catch e {
     error = e;
   }

--- a/libs/wingc/src/type_check.rs
+++ b/libs/wingc/src/type_check.rs
@@ -2246,10 +2246,7 @@ impl<'a> TypeChecker<'a> {
 			};
 			self.spanned_error(exp, err_text);
 		}
-		let params = func_sig
-			.parameters
-			.iter()
-			.take(func_sig.parameters.len() - num_optionals);
+		let params = func_sig.parameters.iter();
 
 		if index_last_item == arg_list_types.pos_args.len() {
 			for (arg_expr, arg_type, param) in izip!(arg_list.pos_args.iter(), arg_list_types.pos_args.iter(), params) {

--- a/tools/hangar/__snapshots__/invalid.ts.snap
+++ b/tools/hangar/__snapshots__/invalid.ts.snap
@@ -1542,86 +1542,93 @@ Duration <DURATION>"
 
 exports[`optionals.w 1`] = `
 "error: Expected type to be \\"num\\", but got \\"num?\\" instead
-  --> ../../../examples/tests/invalid/optionals.w:7:3
-  |
-7 | f(x);
-  |   ^ Expected type to be \\"num\\", but got \\"num?\\" instead
+   --> ../../../examples/tests/invalid/optionals.w:11:3
+   |
+11 | f(x);
+   |   ^ Expected type to be \\"num\\", but got \\"num?\\" instead
+
+
+error: Expected type to be \\"num?\\", but got \\"str\\" instead
+   --> ../../../examples/tests/invalid/optionals.w:14:11
+   |
+14 | fOptional(\\"\\");
+   |           ^^ Expected type to be \\"num?\\", but got \\"str\\" instead
 
 
 error: Expected optional type, found \\"bool\\"
-   --> ../../../examples/tests/invalid/optionals.w:11:4
+   --> ../../../examples/tests/invalid/optionals.w:18:4
    |
-11 | if y? {
+18 | if y? {
    |    ^ Expected optional type, found \\"bool\\"
 
 
 error: Expected optional type, found \\"bool\\"
-   --> ../../../examples/tests/invalid/optionals.w:15:9
+   --> ../../../examples/tests/invalid/optionals.w:22:9
    |
-15 | let z = y ?? 1;
+22 | let z = y ?? 1;
    |         ^ Expected optional type, found \\"bool\\"
 
 
 error: Expected type to be \\"str\\", but got \\"num\\" instead
-   --> ../../../examples/tests/invalid/optionals.w:18:14
+   --> ../../../examples/tests/invalid/optionals.w:25:14
    |
-18 | let w: str = x ?? 3;
+25 | let w: str = x ?? 3;
    |              ^^^^^^ Expected type to be \\"str\\", but got \\"num\\" instead
 
 
 error: Expected type to be \\"num\\", but got \\"str\\" instead
-   --> ../../../examples/tests/invalid/optionals.w:21:6
+   --> ../../../examples/tests/invalid/optionals.w:28:6
    |
-21 | x ?? \\"hello\\";
+28 | x ?? \\"hello\\";
    |      ^^^^^^^ Expected type to be \\"num\\", but got \\"str\\" instead
 
 
 error: Expected type to be \\"Sub1\\", but got \\"Sub2\\" instead
-   --> ../../../examples/tests/invalid/optionals.w:32:17
+   --> ../../../examples/tests/invalid/optionals.w:39:17
    |
-32 | optionalSub1 ?? new Sub2();
+39 | optionalSub1 ?? new Sub2();
    |                 ^^^^^^^^^^ Expected type to be \\"Sub1\\", but got \\"Sub2\\" instead
 
 
 error: Expected type to be \\"Sub1\\", but got \\"Super\\" instead
-   --> ../../../examples/tests/invalid/optionals.w:34:17
+   --> ../../../examples/tests/invalid/optionals.w:41:17
    |
-34 | optionalSub1 ?? new Super();
+41 | optionalSub1 ?? new Super();
    |                 ^^^^^^^^^^^ Expected type to be \\"Sub1\\", but got \\"Super\\" instead
 
 
 error: Expected type to be optional, but got \\"bool\\" instead
-   --> ../../../examples/tests/invalid/optionals.w:38:12
+   --> ../../../examples/tests/invalid/optionals.w:45:12
    |
-38 | if let x = true {
+45 | if let x = true {
    |            ^^^^ Expected type to be optional, but got \\"bool\\" instead
 
 
 error: Property access on optional type \\"A?\\" requires optional accessor: \\"?.\\"
-   --> ../../../examples/tests/invalid/optionals.w:61:9
+   --> ../../../examples/tests/invalid/optionals.w:68:9
    |
-61 | let c = b.a.val;
+68 | let c = b.a.val;
    |         ^^^ Property access on optional type \\"A?\\" requires optional accessor: \\"?.\\"
 
 
 error: Expected type to be \\"str\\", but got \\"str?\\" instead
-   --> ../../../examples/tests/invalid/optionals.w:84:16
+   --> ../../../examples/tests/invalid/optionals.w:91:16
    |
-84 | let val: str = baz?.bar?.foo?.val;
+91 | let val: str = baz?.bar?.foo?.val;
    |                ^^^^^^^^^^^^^^^^^^ Expected type to be \\"str\\", but got \\"str?\\" instead
 
 
 error: Cannot call an optional function
-   --> ../../../examples/tests/invalid/optionals.w:88:1
+   --> ../../../examples/tests/invalid/optionals.w:95:1
    |
-88 | optionalFunction();
+95 | optionalFunction();
    | ^^^^^^^^^^^^^^^^ Cannot call an optional function
 
 
 error: Variable is not reassignable
-   --> ../../../examples/tests/invalid/optionals.w:46:3
+   --> ../../../examples/tests/invalid/optionals.w:53:3
    |
-46 |   hi = \\"bye\\";
+53 |   hi = \\"bye\\";
    |   ^^ Variable is not reassignable
 
 
@@ -2046,6 +2053,13 @@ error: Expected between 0 and 1 arguments but got 2
   |
 7 | let bucket2 = new cloud.Bucket(2, public: true);
   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Expected between 0 and 1 arguments but got 2
+
+
+error: Expected type to be \\"BucketProps?\\", but got \\"num\\" instead
+  --> ../../../examples/tests/invalid/struct_expansion.w:7:32
+  |
+7 | let bucket2 = new cloud.Bucket(2, public: true);
+  |                                ^ Expected type to be \\"BucketProps?\\", but got \\"num\\" instead
 
 
 error: \\"status\\" is not initialized

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/delete.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/delete.w_compile_tf-aws.md
@@ -16,9 +16,9 @@ module.exports = function({ $b }) {
       (await $b.delete("file1.txt"));
       {((cond) => {if (!cond) throw new Error("assertion failed: b.exists(\"file1.json\")")})((await $b.exists("file1.json")))};
       {((cond) => {if (!cond) throw new Error("assertion failed: b.exists(\"file2.txt\")")})((await $b.exists("file2.txt")))};
-      (await $b.delete("file1.json",Object.freeze({"mustExist":true})));
+      (await $b.delete("file1.json",{ mustExist: true }));
       try {
-        (await $b.delete("file1.json",Object.freeze({"mustExist":true})));
+        (await $b.delete("file1.json",{ mustExist: true }));
       }
       catch ($error_e) {
         const e = $error_e.message;


### PR DESCRIPTION
Fixes #3713

Seems to have existed prior to the big inference changes

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
