### PR TITLE
chore(docs): variadic args section in language ref

### DIFF
--- a/docs/docs/03-language-reference.md
+++ b/docs/docs/03-language-reference.md
@@ -1543,11 +1543,18 @@ f(1, 2, field1: 3, field2: 4);
 // f(1, 2, field1: 3); // can't do this, partial expansion is not allowed
 ```
 
-#### 3.6.3 Roadmap
-
-The following features are not yet implemented, but we are planning to add them in the future:
-
-* Variadic arguments (`...args`) - see https://github.com/winglang/wing/issues/125 to track.
+#### 3.6.3 Variadic Arguments
+If the last argument of a function type is the `...args` keyword followed by an
+`Array` type, then the function accepts typed variadic arguments. The container of variadic
+arguments is accessible with the `args` key like a normal array instance.
+```TS
+let f = (x: num, ...args: Array<num>) => {
+  log("${x + args.length}");
+};
+// last arguments are expanded into their array
+f(4, 8, 15, 16, 23, 42); // logs 9
+```
+```
 
 [`▲ top`][top]
 

--- a/docs/docs/03-language-reference.md
+++ b/docs/docs/03-language-reference.md
@@ -1544,9 +1544,10 @@ f(1, 2, field1: 3, field2: 4);
 ```
 
 #### 3.6.3 Variadic Arguments
-If the last argument of a function type is the `...args` keyword followed by an
-`Array` type, then the function accepts typed variadic arguments. The container of variadic
-arguments is accessible with the `args` key like a normal array instance.
+When a function signature's final parameter is denoted by `...` and annotated as an `Array` type,
+then the function accepts typed variadic arguments. 
+Inside the function, these arguments can be accessed using the designated variable name, 
+just as you would with a regular array instance.
 ```TS
 let f = (x: num, ...args: Array<num>) => {
   log("${x + args.length}");

--- a/docs/docs/03-language-reference.md
+++ b/docs/docs/03-language-reference.md
@@ -1554,7 +1554,6 @@ let f = (x: num, ...args: Array<num>) => {
 // last arguments are expanded into their array
 f(4, 8, 15, 16, 23, 42); // logs 9
 ```
-```
 
 [`▲ top`][top]
 


### PR DESCRIPTION
@marciocadev did a great job adding variadic arguments to the language on #3643. 
In this small PR I'm making sure the language reference is updated with the variadic arguments section.

## Checklist

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [ ] Tests added (always)
- [x] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
