### PR TITLE
fix(compiler): could not hydrate optionals

### DIFF
--- a/docs/docs/04-standard-library/02-std/api-reference.md
+++ b/docs/docs/04-standard-library/02-std/api-reference.md
@@ -29,6 +29,7 @@ Immutable Array.
 | <code><a href="#@winglang/sdk.std.Array.indexOf">indexOf</a></code> | Returns the index of the first occurrence of searchElement found. |
 | <code><a href="#@winglang/sdk.std.Array.join">join</a></code> | Returns a new string containing the concatenated values in this array, separated by commas or a specified separator string. |
 | <code><a href="#@winglang/sdk.std.Array.lastIndexOf">lastIndexOf</a></code> | Returns the index of the last occurrence of searchElement found. |
+| <code><a href="#@winglang/sdk.std.Array.tryAt">tryAt</a></code> | Try to get the value at the given index. |
 
 ---
 
@@ -134,6 +135,22 @@ Returns the index of the last occurrence of searchElement found.
 - *Type:* <a href="#@winglang/sdk.std.T1">&lt;T&gt;</a>
 
 to search for.
+
+---
+
+##### `tryAt` <a name="tryAt" id="@winglang/sdk.std.Array.tryAt"></a>
+
+```wing
+tryAt(index: num): <T>
+```
+
+Try to get the value at the given index.
+
+###### `index`<sup>Required</sup> <a name="index" id="@winglang/sdk.std.Array.tryAt.parameter.index"></a>
+
+- *Type:* num
+
+index of the value to get.
 
 ---
 

--- a/docs/docs/04-standard-library/02-std/api-reference.md
+++ b/docs/docs/04-standard-library/02-std/api-reference.md
@@ -29,7 +29,7 @@ Immutable Array.
 | <code><a href="#@winglang/sdk.std.Array.indexOf">indexOf</a></code> | Returns the index of the first occurrence of searchElement found. |
 | <code><a href="#@winglang/sdk.std.Array.join">join</a></code> | Returns a new string containing the concatenated values in this array, separated by commas or a specified separator string. |
 | <code><a href="#@winglang/sdk.std.Array.lastIndexOf">lastIndexOf</a></code> | Returns the index of the last occurrence of searchElement found. |
-| <code><a href="#@winglang/sdk.std.Array.tryAt">tryAt</a></code> | Try to get the value at the given index. |
+| <code><a href="#@winglang/sdk.std.Array.tryAt">tryAt</a></code> | Get the value at the given index, returning nil if the index is out of bounds. |
 
 ---
 
@@ -144,7 +144,7 @@ to search for.
 tryAt(index: num): <T>
 ```
 
-Try to get the value at the given index.
+Get the value at the given index, returning nil if the index is out of bounds.
 
 ###### `index`<sup>Required</sup> <a name="index" id="@winglang/sdk.std.Array.tryAt.parameter.index"></a>
 

--- a/examples/tests/invalid/container_types.w
+++ b/examples/tests/invalid/container_types.w
@@ -5,6 +5,10 @@ let arr3 = Array<str>["hello"];
 let arr4: Array<num> = arr3;
 arr1.someRandomMethod();
 
+let arr5: Array<num> = [1, 2, 3];
+let val: num = arr5.tryAt(0);
+//             ^^^^^^^^^^^^^ Expected type to be "num", but got "num?" instead
+
 //Map tests
 let m1: Map<num> = {"a" => 1, "b" => "2", "c" => 3};
 let m2: Map<num> = ["a" => 1, "b" => "2", "c" => 3];

--- a/examples/tests/valid/container_types.w
+++ b/examples/tests/valid/container_types.w
@@ -31,6 +31,16 @@ let arr7: Array<num> = arr4;
 assert(arr7.length == 3);
 assert(arr7.at(1) == 2);
 
+if let val = emptyArray.tryAt(0) {
+  assert(false); // Should not happen
+}
+
+if let val = arr1.tryAt(0) {
+  assert(val == 1);
+} else {
+  assert(false); // Should not happen
+}
+
 //Map tests
 let emptyMap = Map<num>{};
 assert(emptyMap.size() == 0);

--- a/libs/wingc/src/type_check.rs
+++ b/libs/wingc/src/type_check.rs
@@ -3839,7 +3839,6 @@ impl<'a> TypeChecker<'a> {
 					// Replace type params in function signatures
 					if let Some(sig) = v.as_function_sig() {
 						let new_return_type = self.get_concrete_type_for_generic(sig.return_type, &types_map);
-
 						let new_this_type = if let Some(this_type) = sig.this_type {
 							Some(self.get_concrete_type_for_generic(this_type, &types_map))
 						} else {
@@ -3932,28 +3931,38 @@ impl<'a> TypeChecker<'a> {
 		} else {
 			// Handle generic return types
 			// TODO: If a generic class has a method that returns another generic, it must be a builtin
-			if let Some(c) = type_to_maybe_replace.as_class() {
-				if let Some(type_parameters) = &c.type_parameters {
-					// For now all our generics only have a single type parameter so use the first type parameter as our "T1"
-					let t1 = type_parameters[0];
-					let t1_replacement = *types_map
-						.get(&format!("{t1}"))
-						.filter(|(o, _)| t1.is_same_type_as(o))
-						.map(|(_, n)| n)
-						.expect("generic must have a type parameter");
-					let fqn = format!("{}.{}", WINGSDK_STD_MODULE, c.name.name);
-					return match fqn.as_str() {
-						WINGSDK_MUT_ARRAY => self.types.add_type(Type::MutArray(t1_replacement)),
-						WINGSDK_ARRAY => self.types.add_type(Type::Array(t1_replacement)),
-						WINGSDK_MAP => self.types.add_type(Type::Map(t1_replacement)),
-						WINGSDK_MUT_MAP => self.types.add_type(Type::MutMap(t1_replacement)),
-						WINGSDK_SET => self.types.add_type(Type::Set(t1_replacement)),
-						WINGSDK_MUT_SET => self.types.add_type(Type::MutSet(t1_replacement)),
-						_ => {
-							self.unspanned_error(format!("\"{}\" is not a supported generic return type", fqn));
-							self.types.error()
+
+			match *type_to_maybe_replace {
+				Type::Optional(t) => {
+					let concrete_t = self.get_concrete_type_for_generic(t, types_map);
+					return self.types.add_type(Type::Optional(concrete_t));
+				}
+				_ => {
+					if let Some(c) = type_to_maybe_replace.as_class() {
+						if let Some(type_parameters) = &c.type_parameters {
+							// For now all our generics only have a single type parameter so use the first type parameter as our "T1"
+							let t1 = type_parameters[0];
+							let t1_replacement = *types_map
+								.get(&format!("{t1}"))
+								.filter(|(o, _)| t1.is_same_type_as(o))
+								.map(|(_, n)| n)
+								.expect("generic must have a type parameter");
+							let fqn = format!("{}.{}", WINGSDK_STD_MODULE, c.name.name);
+
+							return match fqn.as_str() {
+								WINGSDK_MUT_ARRAY => self.types.add_type(Type::MutArray(t1_replacement)),
+								WINGSDK_ARRAY => self.types.add_type(Type::Array(t1_replacement)),
+								WINGSDK_MAP => self.types.add_type(Type::Map(t1_replacement)),
+								WINGSDK_MUT_MAP => self.types.add_type(Type::MutMap(t1_replacement)),
+								WINGSDK_SET => self.types.add_type(Type::Set(t1_replacement)),
+								WINGSDK_MUT_SET => self.types.add_type(Type::MutSet(t1_replacement)),
+								_ => {
+									self.unspanned_error(format!("\"{}\" is not a supported generic return type", fqn));
+									self.types.error()
+								}
+							};
 						}
-					};
+					}
 				}
 			}
 		}

--- a/libs/wingsdk/src/std/array.ts
+++ b/libs/wingsdk/src/std/array.ts
@@ -41,7 +41,7 @@ export class Array {
   /**
    * Try to get the value at the given index
    *
-   * @macro ($self$[$args$])
+   * @macro ($self$.at($args$))
    *
    * @param index index of the value to get
    * @returns the value at the given index, or undefined if the index is out of bounds

--- a/libs/wingsdk/src/std/array.ts
+++ b/libs/wingsdk/src/std/array.ts
@@ -39,6 +39,19 @@ export class Array {
   }
 
   /**
+   * Try to get the value at the given index
+   *
+   * @macro ($self$[$args$])
+   *
+   * @param index index of the value to get
+   * @returns the value at the given index, or undefined if the index is out of bounds
+   */
+  public tryAt(index: number): T1 | undefined {
+    index;
+    throw new Error("Macro");
+  }
+
+  /**
    * Merge arr to the end of this array
    * @param arr array to merge
    *

--- a/libs/wingsdk/src/std/array.ts
+++ b/libs/wingsdk/src/std/array.ts
@@ -39,7 +39,7 @@ export class Array {
   }
 
   /**
-   * Try to get the value at the given index
+   * Get the value at the given index, returning nil if the index is out of bounds.
    *
    * @macro ($self$.at($args$))
    *

--- a/libs/wingsdk/test/target-awscdk/__snapshots__/counter.test.ts.snap
+++ b/libs/wingsdk/test/target-awscdk/__snapshots__/counter.test.ts.snap
@@ -129,7 +129,7 @@ exports[`dec() policy statement 2`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "7f88ad6b39756ca47a1f62c4073b16e7d1dd718dccac91f2f477bd8b7d93979b.zip",
+          "S3Key": "f3738bcfd58c05cf71242945f065454f27590bcdafb0ccd96150f36963676a16.zip",
         },
         "Environment": {
           "Variables": {
@@ -367,7 +367,7 @@ exports[`function with a counter binding 2`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "eeb1a09b430750f79d2178a853df4a7c9c3da2b3cd34773230b0e09b686d118e.zip",
+          "S3Key": "b03ff20bc0f7d7c4d3c6ac541eb138884f06868c5412ad8414d7913bebca1b6d.zip",
         },
         "Environment": {
           "Variables": {
@@ -539,7 +539,7 @@ exports[`inc() policy statement 2`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "eeb1a09b430750f79d2178a853df4a7c9c3da2b3cd34773230b0e09b686d118e.zip",
+          "S3Key": "b03ff20bc0f7d7c4d3c6ac541eb138884f06868c5412ad8414d7913bebca1b6d.zip",
         },
         "Environment": {
           "Variables": {
@@ -711,7 +711,7 @@ exports[`peek() policy statement 2`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "c99045e525ddd3aa5e452c244ab0e15d7dccb0c992971ff69d1556a946b4f4ef.zip",
+          "S3Key": "9189a03759b8a966a3e4efb03da3bf6b2546b25b85ccf726d3240bbc1b86e272.zip",
         },
         "Environment": {
           "Variables": {
@@ -883,7 +883,7 @@ exports[`set() policy statement 2`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "239ecd5b27a3e3d0fe03e52540218d631d1790ad7a32eb81f57677613ba2e1c7.zip",
+          "S3Key": "0da3747a941f72aa30762d828c78b18e9f513c3801f61711ae0fd3ff29a218b5.zip",
         },
         "Environment": {
           "Variables": {

--- a/libs/wingsdk/test/target-awscdk/__snapshots__/counter.test.ts.snap
+++ b/libs/wingsdk/test/target-awscdk/__snapshots__/counter.test.ts.snap
@@ -129,7 +129,7 @@ exports[`dec() policy statement 2`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "f3738bcfd58c05cf71242945f065454f27590bcdafb0ccd96150f36963676a16.zip",
+          "S3Key": "7f88ad6b39756ca47a1f62c4073b16e7d1dd718dccac91f2f477bd8b7d93979b.zip",
         },
         "Environment": {
           "Variables": {
@@ -367,7 +367,7 @@ exports[`function with a counter binding 2`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "b03ff20bc0f7d7c4d3c6ac541eb138884f06868c5412ad8414d7913bebca1b6d.zip",
+          "S3Key": "eeb1a09b430750f79d2178a853df4a7c9c3da2b3cd34773230b0e09b686d118e.zip",
         },
         "Environment": {
           "Variables": {
@@ -539,7 +539,7 @@ exports[`inc() policy statement 2`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "b03ff20bc0f7d7c4d3c6ac541eb138884f06868c5412ad8414d7913bebca1b6d.zip",
+          "S3Key": "eeb1a09b430750f79d2178a853df4a7c9c3da2b3cd34773230b0e09b686d118e.zip",
         },
         "Environment": {
           "Variables": {
@@ -711,7 +711,7 @@ exports[`peek() policy statement 2`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "9189a03759b8a966a3e4efb03da3bf6b2546b25b85ccf726d3240bbc1b86e272.zip",
+          "S3Key": "c99045e525ddd3aa5e452c244ab0e15d7dccb0c992971ff69d1556a946b4f4ef.zip",
         },
         "Environment": {
           "Variables": {
@@ -883,7 +883,7 @@ exports[`set() policy statement 2`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "0da3747a941f72aa30762d828c78b18e9f513c3801f61711ae0fd3ff29a218b5.zip",
+          "S3Key": "239ecd5b27a3e3d0fe03e52540218d631d1790ad7a32eb81f57677613ba2e1c7.zip",
         },
         "Environment": {
           "Variables": {

--- a/tools/hangar/__snapshots__/invalid.ts.snap
+++ b/tools/hangar/__snapshots__/invalid.ts.snap
@@ -461,23 +461,23 @@ Duration <DURATION>"
 
 exports[`container_types.w 1`] = `
 "error: Unknown parser error
-   --> ../../../examples/tests/invalid/container_types.w:10:25
+   --> ../../../examples/tests/invalid/container_types.w:14:25
    |
-10 | let m2: Map<num> = [\\"a\\" => 1, \\"b\\" => \\"2\\", \\"c\\" => 3];
+14 | let m2: Map<num> = [\\"a\\" => 1, \\"b\\" => \\"2\\", \\"c\\" => 3];
    |                         ^^^^ Unknown parser error
 
 
 error: Unexpected 'string'
-   --> ../../../examples/tests/invalid/container_types.w:10:31
+   --> ../../../examples/tests/invalid/container_types.w:14:31
    |
-10 | let m2: Map<num> = [\\"a\\" => 1, \\"b\\" => \\"2\\", \\"c\\" => 3];
+14 | let m2: Map<num> = [\\"a\\" => 1, \\"b\\" => \\"2\\", \\"c\\" => 3];
    |                               ^^^ Unexpected 'string'
 
 
 error: Unknown parser error
-   --> ../../../examples/tests/invalid/container_types.w:10:47
+   --> ../../../examples/tests/invalid/container_types.w:14:47
    |
-10 | let m2: Map<num> = [\\"a\\" => 1, \\"b\\" => \\"2\\", \\"c\\" => 3];
+14 | let m2: Map<num> = [\\"a\\" => 1, \\"b\\" => \\"2\\", \\"c\\" => 3];
    |                                               ^^^^ Unknown parser error
 
 
@@ -509,87 +509,94 @@ error: Unknown symbol \\"someRandomMethod\\"
   |      ^^^^^^^^^^^^^^^^ Unknown symbol \\"someRandomMethod\\"
 
 
-error: Expected type to be \\"num\\", but got \\"str\\" instead
-  --> ../../../examples/tests/invalid/container_types.w:9:38
+error: Expected type to be \\"num\\", but got \\"num?\\" instead
+  --> ../../../examples/tests/invalid/container_types.w:9:16
   |
-9 | let m1: Map<num> = {\\"a\\" => 1, \\"b\\" => \\"2\\", \\"c\\" => 3};
-  |                                      ^^^ Expected type to be \\"num\\", but got \\"str\\" instead
+9 | let val: num = arr5.tryAt(0);
+  |                ^^^^^^^^^^^^^ Expected type to be \\"num\\", but got \\"num?\\" instead
+
+
+error: Expected type to be \\"num\\", but got \\"str\\" instead
+   --> ../../../examples/tests/invalid/container_types.w:13:38
+   |
+13 | let m1: Map<num> = {\\"a\\" => 1, \\"b\\" => \\"2\\", \\"c\\" => 3};
+   |                                      ^^^ Expected type to be \\"num\\", but got \\"str\\" instead
 
 
 error: Expected type to be \\"Map<num>\\", but got \\"Array<str>\\" instead
-   --> ../../../examples/tests/invalid/container_types.w:10:20
+   --> ../../../examples/tests/invalid/container_types.w:14:20
    |
-10 | let m2: Map<num> = [\\"a\\" => 1, \\"b\\" => \\"2\\", \\"c\\" => 3];
+14 | let m2: Map<num> = [\\"a\\" => 1, \\"b\\" => \\"2\\", \\"c\\" => 3];
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Expected type to be \\"Map<num>\\", but got \\"Array<str>\\" instead
 
 
 error: Expected type to be \\"Map<num>\\", but got \\"Map<str>\\" instead
-   --> ../../../examples/tests/invalid/container_types.w:12:20
+   --> ../../../examples/tests/invalid/container_types.w:16:20
    |
-12 | let m4: Map<num> = m3;
+16 | let m4: Map<num> = m3;
    |                    ^^ Expected type to be \\"Map<num>\\", but got \\"Map<str>\\" instead
 
 
 error: Unknown symbol \\"someRandomMethod\\"
-   --> ../../../examples/tests/invalid/container_types.w:13:4
+   --> ../../../examples/tests/invalid/container_types.w:17:4
    |
-13 | m1.someRandomMethod();
+17 | m1.someRandomMethod();
    |    ^^^^^^^^^^^^^^^^ Unknown symbol \\"someRandomMethod\\"
 
 
 error: Expected type to be \\"num\\", but got \\"str\\" instead
-   --> ../../../examples/tests/invalid/container_types.w:16:24
+   --> ../../../examples/tests/invalid/container_types.w:20:24
    |
-16 | let s1: Set<num> = {1, \\"2\\", 3};
+20 | let s1: Set<num> = {1, \\"2\\", 3};
    |                        ^^^ Expected type to be \\"num\\", but got \\"str\\" instead
 
 
 error: Expected \\"Array\\" type, found \\"Set<num>\\"
-   --> ../../../examples/tests/invalid/container_types.w:17:10
+   --> ../../../examples/tests/invalid/container_types.w:21:10
    |
-17 | let s2 = Set<num> [1, \\"2\\", 3];
+21 | let s2 = Set<num> [1, \\"2\\", 3];
    |          ^^^^^^^^^^^^^^^^^^^^ Expected \\"Array\\" type, found \\"Set<num>\\"
 
 
 error: Expected type to be \\"num\\", but got \\"str\\" instead
-   --> ../../../examples/tests/invalid/container_types.w:17:23
+   --> ../../../examples/tests/invalid/container_types.w:21:23
    |
-17 | let s2 = Set<num> [1, \\"2\\", 3];
+21 | let s2 = Set<num> [1, \\"2\\", 3];
    |                       ^^^ Expected type to be \\"num\\", but got \\"str\\" instead
 
 
 error: Expected type to be \\"num\\", but got \\"str\\" instead
-   --> ../../../examples/tests/invalid/container_types.w:18:24
+   --> ../../../examples/tests/invalid/container_types.w:22:24
    |
-18 | let s3: Set<num> = [1, \\"2\\", 3];
+22 | let s3: Set<num> = [1, \\"2\\", 3];
    |                        ^^^ Expected type to be \\"num\\", but got \\"str\\" instead
 
 
 error: Expected type to be \\"Set<num>\\", but got \\"Array<num>\\" instead
-   --> ../../../examples/tests/invalid/container_types.w:18:20
+   --> ../../../examples/tests/invalid/container_types.w:22:20
    |
-18 | let s3: Set<num> = [1, \\"2\\", 3];
+22 | let s3: Set<num> = [1, \\"2\\", 3];
    |                    ^^^^^^^^^^^ Expected type to be \\"Set<num>\\", but got \\"Array<num>\\" instead
 
 
 error: Expected type to be \\"Set<str>\\", but got \\"Set<num>\\" instead
-   --> ../../../examples/tests/invalid/container_types.w:20:20
+   --> ../../../examples/tests/invalid/container_types.w:24:20
    |
-20 | let s5: Set<str> = s4;
+24 | let s5: Set<str> = s4;
    |                    ^^ Expected type to be \\"Set<str>\\", but got \\"Set<num>\\" instead
 
 
 error: Unknown symbol \\"someRandomMethod\\"
-   --> ../../../examples/tests/invalid/container_types.w:21:4
+   --> ../../../examples/tests/invalid/container_types.w:25:4
    |
-21 | s1.someRandomMethod();
+25 | s1.someRandomMethod();
    |    ^^^^^^^^^^^^^^^^ Unknown symbol \\"someRandomMethod\\"
 
 
 error: Expected type to be \\"Array<str>\\", but got \\"MutArray<str>\\" instead
-   --> ../../../examples/tests/invalid/container_types.w:23:21
+   --> ../../../examples/tests/invalid/container_types.w:27:21
    |
-23 | let a: Array<str> = MutArray<str>[];
+27 | let a: Array<str> = MutArray<str>[];
    |                     ^^^^^^^^^^^^^^^ Expected type to be \\"Array<str>\\", but got \\"MutArray<str>\\" instead
 
 

--- a/tools/hangar/__snapshots__/test_corpus/valid/container_types.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/container_types.w_compile_tf-aws.md
@@ -195,6 +195,23 @@ class $Root extends $stdlib.std.Resource {
     const arr7 = arr4;
     {((cond) => {if (!cond) throw new Error("assertion failed: arr7.length == 3")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(arr7.length,3)))};
     {((cond) => {if (!cond) throw new Error("assertion failed: arr7.at(1) == 2")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((arr7.at(1)),2)))};
+    {
+      const $IF_LET_VALUE = (emptyArray[0]);
+      if ($IF_LET_VALUE != undefined) {
+        const val = $IF_LET_VALUE;
+        {((cond) => {if (!cond) throw new Error("assertion failed: false")})(false)};
+      }
+    }
+    {
+      const $IF_LET_VALUE = (arr1[0]);
+      if ($IF_LET_VALUE != undefined) {
+        const val = $IF_LET_VALUE;
+        {((cond) => {if (!cond) throw new Error("assertion failed: val == 1")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(val,1)))};
+      }
+      else {
+        {((cond) => {if (!cond) throw new Error("assertion failed: false")})(false)};
+      }
+    }
     const emptyMap = ({});
     {((cond) => {if (!cond) throw new Error("assertion failed: emptyMap.size() == 0")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(Object.keys(emptyMap).length,0)))};
     const emptyMap2 = ({});

--- a/tools/hangar/__snapshots__/test_corpus/valid/container_types.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/container_types.w_compile_tf-aws.md
@@ -196,14 +196,14 @@ class $Root extends $stdlib.std.Resource {
     {((cond) => {if (!cond) throw new Error("assertion failed: arr7.length == 3")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(arr7.length,3)))};
     {((cond) => {if (!cond) throw new Error("assertion failed: arr7.at(1) == 2")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((arr7.at(1)),2)))};
     {
-      const $IF_LET_VALUE = (emptyArray[0]);
+      const $IF_LET_VALUE = (emptyArray.at(0));
       if ($IF_LET_VALUE != undefined) {
         const val = $IF_LET_VALUE;
         {((cond) => {if (!cond) throw new Error("assertion failed: false")})(false)};
       }
     }
     {
-      const $IF_LET_VALUE = (arr1[0]);
+      const $IF_LET_VALUE = (arr1.at(0));
       if ($IF_LET_VALUE != undefined) {
         const val = $IF_LET_VALUE;
         {((cond) => {if (!cond) throw new Error("assertion failed: val == 1")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(val,1)))};


### PR DESCRIPTION
There are several open issues in progress that need to be able to define generic optionals. 
Such as: 
- https://github.com/winglang/wing/issues/1868
- https://github.com/winglang/wing/issues/3575
- https://github.com/winglang/wing/issues/3653

I only added `tryAt` method for Array since the actual work is defined in another issue, but I needed an example to write some test cases with. Since there are several efforts that need this change I opted to not wait and include it in one of those PRs but just add the support here so other efforts can rebase.

## Checklist

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [x] Tests added (always)
- [x] Docs updated (only required for features)
- [x] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
