### PR TITLE
chore(docs): change title to "Wing Programming Language Reference"

### DIFF
--- a/docs/docs/03-language-reference.md
+++ b/docs/docs/03-language-reference.md
@@ -1,5 +1,5 @@
 ---
-title: Language Reference
+title: Wing Programming Language Reference
 id: language-reference
 description: The Wing Language Reference
 keywords: [Wing reference, Wing language, language, Wing language spec, Wing programming language]


### PR DESCRIPTION
Adds "Wing Programming" to title for SEO suggested change

See: https://github.com/winglang/wing/issues/3164

## Checklist

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [x] Tests added (always)
- [x] Docs updated (only required for features)
- [x] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
