### PR TITLE
chore(sdk): adding auto retry to the sdk gh workflow

### DIFF
--- a/.github/workflows/tf-aws-test.yml
+++ b/.github/workflows/tf-aws-test.yml
@@ -51,6 +51,7 @@ jobs:
         with:
           max_attempts: 3
           retry_on: error
+          timeout_minutes: 5
           command: npm install -g winglang
       - name: Installing external js modules
         run: |
@@ -70,6 +71,7 @@ jobs:
         with:
           max_attempts: 3
           retry_on: error
+          timeout_minutes: 20
           command: wing test -t tf-aws ${{ matrix.test.directory }}/*.w
       - name: Output Terraform log
         if: failure()

--- a/.github/workflows/tf-aws-test.yml
+++ b/.github/workflows/tf-aws-test.yml
@@ -7,7 +7,7 @@ on:
   push:
     branches:
       - tsuf/auto-retry
-
+#
 env:
   AWS_REGION: "us-east-1"
 

--- a/.github/workflows/tf-aws-test.yml
+++ b/.github/workflows/tf-aws-test.yml
@@ -4,10 +4,7 @@ on:
     types:
       - published
   workflow_dispatch: {}
-  push:
-    branches:
-      - tsuf/auto-retry
-#
+
 env:
   AWS_REGION: "us-east-1"
 

--- a/.github/workflows/tf-aws-test.yml
+++ b/.github/workflows/tf-aws-test.yml
@@ -4,6 +4,9 @@ on:
     types:
       - published
   workflow_dispatch: {}
+  push:
+    branches:
+      - tsuf/auto-retry
 
 env:
   AWS_REGION: "us-east-1"
@@ -44,7 +47,11 @@ jobs:
         with:
           node-version: 18
       - name: Install winglang globally
-        run: npm install -g winglang
+        uses: nick-fields/retry@v2
+        with:
+          max_attempts: 3
+          retry_on: error
+          command: npm install -g winglang
       - name: Installing external js modules
         run: |
           cd examples/tests/sdk_tests
@@ -56,10 +63,14 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ env.AWS_REGION }}
       - name: Execute wing test in matrix directory
+        uses: nick-fields/retry@v2
         env:
           TF_LOG: info
           TF_LOG_PATH: ${{ runner.workspace }}/terraform.log
-        run: wing test -t tf-aws ${{ matrix.test.directory }}/*.w
+        with:
+          max_attempts: 3
+          retry_on: error
+          command: wing test -t tf-aws ${{ matrix.test.directory }}/*.w
       - name: Output Terraform log
         if: failure()
         run: cat ${{ runner.workspace }}/terraform.log


### PR DESCRIPTION
From the few runs I looked into, it seems like the reason for failure is either a network error installing wing (is it blocked by NPM in any way?) or occasional fails in the tests themselves...
I added a retry option to make them more stable:
https://github.com/winglang/wing/actions/runs/5818534372 

## Checklist

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [ ] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
