### PR TITLE
fix: hangar snapshots have machine-dependent output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -251,15 +251,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
-name = "cpufeatures"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a17b76ff3a4162b0b27f354a0c87015ddad39d35f9c0c36607a3bdd175dde1f1"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "crc32fast"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1031,17 +1022,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha1"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest",
-]
-
-[[package]]
 name = "similar"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1702,7 +1682,6 @@ dependencies = [
  "phf",
  "serde",
  "serde_json",
- "sha1",
  "strum",
  "tempfile",
  "tree-sitter",

--- a/libs/wingc/Cargo.toml
+++ b/libs/wingc/Cargo.toml
@@ -24,7 +24,6 @@ const_format = "0.2.30"
 duplicate = "1.0.0"
 strum = { version = "0.24", features = ["derive"] }
 petgraph = "0.6.3"
-sha1 = "0.10.5"
 
 [lib]
 crate-type = ["rlib", "cdylib"]

--- a/libs/wingc/src/jsify.rs
+++ b/libs/wingc/src/jsify.rs
@@ -4,7 +4,6 @@ use aho_corasick::AhoCorasick;
 use const_format::formatcp;
 use indexmap::{IndexMap, IndexSet};
 use itertools::Itertools;
-use sha1::{Digest, Sha1};
 
 use std::{
 	borrow::Borrow,
@@ -59,6 +58,12 @@ pub struct JSifier<'a> {
 	pub output_files: RefCell<Files>,
 	/// Counter for generating unique preflight file names.
 	preflight_file_counter: RefCell<usize>,
+
+	/// Counter for generating unique inflight file names.
+	inflight_file_counter: RefCell<usize>,
+	/// Map from source file IDs to safe counters.
+	inflight_file_map: RefCell<IndexMap<String, usize>>,
+
 	/// Map from source file paths to the JS file names they are emitted to.
 	/// e.g. "bucket.w" -> "preflight.bucket-1.js"
 	preflight_file_map: RefCell<IndexMap<PathBuf, String>>,
@@ -90,6 +95,8 @@ impl<'a> JSifier<'a> {
 			source_files,
 			entrypoint_file_path,
 			absolute_project_root,
+			inflight_file_counter: RefCell::new(0),
+			inflight_file_map: RefCell::new(IndexMap::new()),
 			preflight_file_counter: RefCell::new(0),
 			preflight_file_map: RefCell::new(IndexMap::new()),
 			output_files: RefCell::new(output_files),
@@ -1051,7 +1058,7 @@ impl<'a> JSifier<'a> {
 	}
 
 	fn jsify_to_inflight_type_method(&self, class: &AstClass, ctx: &JSifyContext) -> CodeMaker {
-		let client_path = inflight_filename(class);
+		let client_path = self.inflight_filename(class);
 
 		let mut code = CodeMaker::default();
 
@@ -1170,7 +1177,7 @@ impl<'a> JSifier<'a> {
 		match self
 			.output_files
 			.borrow_mut()
-			.add_file(inflight_filename(class), code.to_string())
+			.add_file(self.inflight_filename(class), code.to_string())
 		{
 			Ok(()) => {}
 			Err(err) => report_diagnostic(err.into()),
@@ -1287,6 +1294,19 @@ impl<'a> JSifier<'a> {
 		bind_method.close("}");
 		bind_method
 	}
+
+	fn inflight_filename(&self, class: &AstClass) -> String {
+		let mut file_map = self.inflight_file_map.borrow_mut();
+		let id: usize = if file_map.contains_key(&class.name.span.file_id) {
+			file_map[&class.name.span.file_id]
+		} else {
+			let mut id = self.inflight_file_counter.borrow_mut();
+			*id += 1;
+			file_map.insert(class.name.span.file_id.clone(), *id);
+			*id
+		};
+		format!("./inflight.{}-{}.js", class.name.name, id)
+	}
 }
 
 fn get_public_symbols(scope: &Scope) -> Vec<Symbol> {
@@ -1323,13 +1343,6 @@ fn get_public_symbols(scope: &Scope) -> Vec<Symbol> {
 	}
 
 	symbols
-}
-
-fn inflight_filename(class: &AstClass) -> String {
-	let mut hasher = Sha1::new();
-	hasher.update(&class.name.span.file_id);
-	let hash = format!("{:x}", hasher.finalize()); // convert to hex
-	format!("./inflight.{}-{}.js", class.name.name, &hash[hash.len() - 8..])
 }
 
 fn lookup_span(span: &WingSpan, files: &Files) -> String {

--- a/libs/wingc/src/jsify/snapshots/access_methods_and_properties_on_collections.snap
+++ b/libs/wingc/src/jsify/snapshots/access_methods_and_properties_on_collections.snap
@@ -15,7 +15,7 @@ source: libs/wingc/src/jsify/tests.rs
     
 ```
 
-## inflight.$Closure1-220cc4cd.js
+## inflight.$Closure1-1.js
 
 ```js
 module.exports = function({ $_y_at_0__, $x_length }) {
@@ -52,7 +52,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-220cc4cd.js")({
+          require("./inflight.$Closure1-1.js")({
             $_y_at_0__: ${context._lift((y.at(0)))},
             $x_length: ${context._lift(x.length)},
           })

--- a/libs/wingc/src/jsify/snapshots/access_property_on_primitive.snap
+++ b/libs/wingc/src/jsify/snapshots/access_property_on_primitive.snap
@@ -13,7 +13,7 @@ source: libs/wingc/src/jsify/tests.rs
     
 ```
 
-## inflight.$Closure1-220cc4cd.js
+## inflight.$Closure1-1.js
 
 ```js
 module.exports = function({ $s_length }) {
@@ -49,7 +49,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-220cc4cd.js")({
+          require("./inflight.$Closure1-1.js")({
             $s_length: ${context._lift(s.length)},
           })
         `);

--- a/libs/wingc/src/jsify/snapshots/access_property_on_value_returned_from_collection.snap
+++ b/libs/wingc/src/jsify/snapshots/access_property_on_value_returned_from_collection.snap
@@ -13,7 +13,7 @@ source: libs/wingc/src/jsify/tests.rs
     
 ```
 
-## inflight.$Closure1-220cc4cd.js
+## inflight.$Closure1-1.js
 
 ```js
 module.exports = function({ $_s___hello___length }) {
@@ -49,7 +49,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-220cc4cd.js")({
+          require("./inflight.$Closure1-1.js")({
             $_s___hello___length: ${context._lift((s)["hello"].length)},
           })
         `);

--- a/libs/wingc/src/jsify/snapshots/base_class_captures_inflight.snap
+++ b/libs/wingc/src/jsify/snapshots/base_class_captures_inflight.snap
@@ -21,7 +21,7 @@ source: libs/wingc/src/jsify/tests.rs
     
 ```
 
-## inflight.Base-220cc4cd.js
+## inflight.Base-1.js
 
 ```js
 module.exports = function({ $x }) {
@@ -36,7 +36,7 @@ module.exports = function({ $x }) {
 }
 ```
 
-## inflight.Derived-220cc4cd.js
+## inflight.Derived-1.js
 
 ```js
 module.exports = function({ $Base }) {
@@ -69,7 +69,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.Base-220cc4cd.js")({
+          require("./inflight.Base-1.js")({
             $x: ${context._lift(x)},
           })
         `);
@@ -99,7 +99,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.Derived-220cc4cd.js")({
+          require("./inflight.Derived-1.js")({
             $Base: ${context._lift(Base)},
           })
         `);

--- a/libs/wingc/src/jsify/snapshots/base_class_captures_preflight.snap
+++ b/libs/wingc/src/jsify/snapshots/base_class_captures_preflight.snap
@@ -21,7 +21,7 @@ source: libs/wingc/src/jsify/tests.rs
     
 ```
 
-## inflight.Base-220cc4cd.js
+## inflight.Base-1.js
 
 ```js
 module.exports = function({  }) {
@@ -33,7 +33,7 @@ module.exports = function({  }) {
 }
 ```
 
-## inflight.Derived-220cc4cd.js
+## inflight.Derived-1.js
 
 ```js
 module.exports = function({ $Base }) {
@@ -66,7 +66,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.Base-220cc4cd.js")({
+          require("./inflight.Base-1.js")({
           })
         `);
       }
@@ -92,7 +92,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.Derived-220cc4cd.js")({
+          require("./inflight.Derived-1.js")({
             $Base: ${context._lift(Base)},
           })
         `);

--- a/libs/wingc/src/jsify/snapshots/base_class_lift_indirect.snap
+++ b/libs/wingc/src/jsify/snapshots/base_class_lift_indirect.snap
@@ -27,7 +27,7 @@ source: libs/wingc/src/jsify/tests.rs
     
 ```
 
-## inflight.Base-220cc4cd.js
+## inflight.Base-1.js
 
 ```js
 module.exports = function({  }) {
@@ -44,7 +44,7 @@ module.exports = function({  }) {
 }
 ```
 
-## inflight.Derived-220cc4cd.js
+## inflight.Derived-1.js
 
 ```js
 module.exports = function({ $Base }) {
@@ -79,7 +79,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.Base-220cc4cd.js")({
+          require("./inflight.Base-1.js")({
           })
         `);
       }
@@ -112,7 +112,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.Derived-220cc4cd.js")({
+          require("./inflight.Derived-1.js")({
             $Base: ${context._lift(Base)},
           })
         `);

--- a/libs/wingc/src/jsify/snapshots/base_class_with_fields_inflight.snap
+++ b/libs/wingc/src/jsify/snapshots/base_class_with_fields_inflight.snap
@@ -26,7 +26,7 @@ source: libs/wingc/src/jsify/tests.rs
     
 ```
 
-## inflight.Base-220cc4cd.js
+## inflight.Base-1.js
 
 ```js
 module.exports = function({  }) {
@@ -41,7 +41,7 @@ module.exports = function({  }) {
 }
 ```
 
-## inflight.Derived-220cc4cd.js
+## inflight.Derived-1.js
 
 ```js
 module.exports = function({ $Base }) {
@@ -78,7 +78,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.Base-220cc4cd.js")({
+          require("./inflight.Base-1.js")({
           })
         `);
       }
@@ -101,7 +101,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.Derived-220cc4cd.js")({
+          require("./inflight.Derived-1.js")({
             $Base: ${context._lift(Base)},
           })
         `);

--- a/libs/wingc/src/jsify/snapshots/base_class_with_fields_preflight.snap
+++ b/libs/wingc/src/jsify/snapshots/base_class_with_fields_preflight.snap
@@ -26,7 +26,7 @@ source: libs/wingc/src/jsify/tests.rs
     
 ```
 
-## inflight.Base-220cc4cd.js
+## inflight.Base-1.js
 
 ```js
 module.exports = function({  }) {
@@ -38,7 +38,7 @@ module.exports = function({  }) {
 }
 ```
 
-## inflight.Derived-220cc4cd.js
+## inflight.Derived-1.js
 
 ```js
 module.exports = function({ $Base }) {
@@ -69,7 +69,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.Base-220cc4cd.js")({
+          require("./inflight.Base-1.js")({
           })
         `);
       }
@@ -97,7 +97,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.Derived-220cc4cd.js")({
+          require("./inflight.Derived-1.js")({
             $Base: ${context._lift(Base)},
           })
         `);

--- a/libs/wingc/src/jsify/snapshots/base_class_with_lifted_field_object.snap
+++ b/libs/wingc/src/jsify/snapshots/base_class_with_lifted_field_object.snap
@@ -22,7 +22,7 @@ source: libs/wingc/src/jsify/tests.rs
     
 ```
 
-## inflight.Base-220cc4cd.js
+## inflight.Base-1.js
 
 ```js
 module.exports = function({  }) {
@@ -34,7 +34,7 @@ module.exports = function({  }) {
 }
 ```
 
-## inflight.Derived-220cc4cd.js
+## inflight.Derived-1.js
 
 ```js
 module.exports = function({ $Base }) {
@@ -70,7 +70,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.Base-220cc4cd.js")({
+          require("./inflight.Base-1.js")({
           })
         `);
       }
@@ -93,7 +93,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.Derived-220cc4cd.js")({
+          require("./inflight.Derived-1.js")({
             $Base: ${context._lift(Base)},
           })
         `);

--- a/libs/wingc/src/jsify/snapshots/base_class_with_lifted_fields.snap
+++ b/libs/wingc/src/jsify/snapshots/base_class_with_lifted_fields.snap
@@ -22,7 +22,7 @@ source: libs/wingc/src/jsify/tests.rs
     
 ```
 
-## inflight.Base-220cc4cd.js
+## inflight.Base-1.js
 
 ```js
 module.exports = function({  }) {
@@ -34,7 +34,7 @@ module.exports = function({  }) {
 }
 ```
 
-## inflight.Derived-220cc4cd.js
+## inflight.Derived-1.js
 
 ```js
 module.exports = function({ $Base }) {
@@ -69,7 +69,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.Base-220cc4cd.js")({
+          require("./inflight.Base-1.js")({
           })
         `);
       }
@@ -92,7 +92,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.Derived-220cc4cd.js")({
+          require("./inflight.Derived-1.js")({
             $Base: ${context._lift(Base)},
           })
         `);

--- a/libs/wingc/src/jsify/snapshots/builtins.snap
+++ b/libs/wingc/src/jsify/snapshots/builtins.snap
@@ -11,7 +11,7 @@ source: libs/wingc/src/jsify/tests.rs
     
 ```
 
-## inflight.$Closure1-220cc4cd.js
+## inflight.$Closure1-1.js
 
 ```js
 module.exports = function({  }) {
@@ -47,7 +47,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-220cc4cd.js")({
+          require("./inflight.$Closure1-1.js")({
           })
         `);
       }

--- a/libs/wingc/src/jsify/snapshots/call_static_inflight_from_static_inflight.snap
+++ b/libs/wingc/src/jsify/snapshots/call_static_inflight_from_static_inflight.snap
@@ -17,7 +17,7 @@ source: libs/wingc/src/jsify/tests.rs
     
 ```
 
-## inflight.A-220cc4cd.js
+## inflight.A-1.js
 
 ```js
 module.exports = function({  }) {
@@ -32,7 +32,7 @@ module.exports = function({  }) {
 }
 ```
 
-## inflight.B-220cc4cd.js
+## inflight.B-1.js
 
 ```js
 module.exports = function({ $A }) {
@@ -62,7 +62,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.A-220cc4cd.js")({
+          require("./inflight.A-1.js")({
           })
         `);
       }
@@ -85,7 +85,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.B-220cc4cd.js")({
+          require("./inflight.B-1.js")({
             $A: ${context._lift(A)},
           })
         `);

--- a/libs/wingc/src/jsify/snapshots/calls_methods_on_preflight_object.snap
+++ b/libs/wingc/src/jsify/snapshots/calls_methods_on_preflight_object.snap
@@ -15,7 +15,7 @@ source: libs/wingc/src/jsify/tests.rs
     
 ```
 
-## inflight.$Closure1-220cc4cd.js
+## inflight.$Closure1-1.js
 
 ```js
 module.exports = function({ $b }) {
@@ -53,7 +53,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-220cc4cd.js")({
+          require("./inflight.$Closure1-1.js")({
             $b: ${context._lift(b)},
           })
         `);

--- a/libs/wingc/src/jsify/snapshots/capture_from_inside_an_inflight_closure.snap
+++ b/libs/wingc/src/jsify/snapshots/capture_from_inside_an_inflight_closure.snap
@@ -14,7 +14,7 @@ source: libs/wingc/src/jsify/tests.rs
     }
 ```
 
-## inflight.$Closure1-220cc4cd.js
+## inflight.$Closure1-1.js
 
 ```js
 module.exports = function({ $foo }) {
@@ -54,7 +54,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-220cc4cd.js")({
+          require("./inflight.$Closure1-1.js")({
             $foo: ${context._lift(foo)},
           })
         `);

--- a/libs/wingc/src/jsify/snapshots/capture_identifier_closure_from_preflight_scope.snap
+++ b/libs/wingc/src/jsify/snapshots/capture_identifier_closure_from_preflight_scope.snap
@@ -12,7 +12,7 @@ source: libs/wingc/src/jsify/tests.rs
     
 ```
 
-## inflight.$Closure1-220cc4cd.js
+## inflight.$Closure1-1.js
 
 ```js
 module.exports = function({  }) {
@@ -29,7 +29,7 @@ module.exports = function({  }) {
 }
 ```
 
-## inflight.$Closure2-220cc4cd.js
+## inflight.$Closure2-1.js
 
 ```js
 module.exports = function({ $foo }) {
@@ -65,7 +65,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-220cc4cd.js")({
+          require("./inflight.$Closure1-1.js")({
           })
         `);
       }
@@ -89,7 +89,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure2-220cc4cd.js")({
+          require("./inflight.$Closure2-1.js")({
             $foo: ${context._lift(foo)},
           })
         `);

--- a/libs/wingc/src/jsify/snapshots/capture_identifier_from_preflight_scope.snap
+++ b/libs/wingc/src/jsify/snapshots/capture_identifier_from_preflight_scope.snap
@@ -12,7 +12,7 @@ source: libs/wingc/src/jsify/tests.rs
     
 ```
 
-## inflight.$Closure1-220cc4cd.js
+## inflight.$Closure1-1.js
 
 ```js
 module.exports = function({ $x }) {
@@ -48,7 +48,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-220cc4cd.js")({
+          require("./inflight.$Closure1-1.js")({
             $x: ${context._lift(x)},
           })
         `);

--- a/libs/wingc/src/jsify/snapshots/capture_identifier_from_preflight_scope_with_method_call.snap
+++ b/libs/wingc/src/jsify/snapshots/capture_identifier_from_preflight_scope_with_method_call.snap
@@ -16,7 +16,7 @@ source: libs/wingc/src/jsify/tests.rs
     
 ```
 
-## inflight.$Closure1-220cc4cd.js
+## inflight.$Closure1-1.js
 
 ```js
 module.exports = function({ $f }) {
@@ -34,7 +34,7 @@ module.exports = function({ $f }) {
 }
 ```
 
-## inflight.Foo-220cc4cd.js
+## inflight.Foo-1.js
 
 ```js
 module.exports = function({  }) {
@@ -65,7 +65,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.Foo-220cc4cd.js")({
+          require("./inflight.Foo-1.js")({
           })
         `);
       }
@@ -89,7 +89,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-220cc4cd.js")({
+          require("./inflight.$Closure1-1.js")({
             $f: ${context._lift(f)},
           })
         `);

--- a/libs/wingc/src/jsify/snapshots/capture_identifier_from_preflight_scope_with_nested_object.snap
+++ b/libs/wingc/src/jsify/snapshots/capture_identifier_from_preflight_scope_with_nested_object.snap
@@ -21,7 +21,7 @@ source: libs/wingc/src/jsify/tests.rs
     
 ```
 
-## inflight.$Closure1-220cc4cd.js
+## inflight.$Closure1-1.js
 
 ```js
 module.exports = function({ $f_b }) {
@@ -39,7 +39,7 @@ module.exports = function({ $f_b }) {
 }
 ```
 
-## inflight.Foo-220cc4cd.js
+## inflight.Foo-1.js
 
 ```js
 module.exports = function({  }) {
@@ -70,7 +70,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.Foo-220cc4cd.js")({
+          require("./inflight.Foo-1.js")({
           })
         `);
       }
@@ -94,7 +94,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-220cc4cd.js")({
+          require("./inflight.$Closure1-1.js")({
             $f_b: ${context._lift(f.b)},
           })
         `);

--- a/libs/wingc/src/jsify/snapshots/capture_identifier_from_preflight_scope_with_property.snap
+++ b/libs/wingc/src/jsify/snapshots/capture_identifier_from_preflight_scope_with_property.snap
@@ -12,7 +12,7 @@ source: libs/wingc/src/jsify/tests.rs
     
 ```
 
-## inflight.$Closure1-220cc4cd.js
+## inflight.$Closure1-1.js
 
 ```js
 module.exports = function({ $x_length }) {
@@ -48,7 +48,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-220cc4cd.js")({
+          require("./inflight.$Closure1-1.js")({
             $x_length: ${context._lift(x.length)},
           })
         `);

--- a/libs/wingc/src/jsify/snapshots/capture_in_keyword_args.snap
+++ b/libs/wingc/src/jsify/snapshots/capture_in_keyword_args.snap
@@ -15,7 +15,7 @@ source: libs/wingc/src/jsify/tests.rs
     
 ```
 
-## inflight.$Closure1-220cc4cd.js
+## inflight.$Closure1-1.js
 
 ```js
 module.exports = function({ $util_Util, $x }) {
@@ -54,7 +54,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-220cc4cd.js")({
+          require("./inflight.$Closure1-1.js")({
             $util_Util: ${context._lift(util.Util)},
             $x: ${context._lift(x)},
           })

--- a/libs/wingc/src/jsify/snapshots/capture_object_with_this_in_name.snap
+++ b/libs/wingc/src/jsify/snapshots/capture_object_with_this_in_name.snap
@@ -13,7 +13,7 @@ source: libs/wingc/src/jsify/tests.rs
     
 ```
 
-## inflight.$Closure1-220cc4cd.js
+## inflight.$Closure1-1.js
 
 ```js
 module.exports = function({ $bucket_this }) {
@@ -50,7 +50,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-220cc4cd.js")({
+          require("./inflight.$Closure1-1.js")({
             $bucket_this: ${context._lift(bucket_this)},
           })
         `);

--- a/libs/wingc/src/jsify/snapshots/capture_token.snap
+++ b/libs/wingc/src/jsify/snapshots/capture_token.snap
@@ -12,7 +12,7 @@ source: libs/wingc/src/jsify/tests.rs
     }
 ```
 
-## inflight.$Closure1-220cc4cd.js
+## inflight.$Closure1-1.js
 
 ```js
 module.exports = function({ $api_url }) {
@@ -49,7 +49,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-220cc4cd.js")({
+          require("./inflight.$Closure1-1.js")({
             $api_url: ${context._lift(api.url)},
           })
         `);

--- a/libs/wingc/src/jsify/snapshots/capture_type_inflight_class_sibling_from_init.snap
+++ b/libs/wingc/src/jsify/snapshots/capture_type_inflight_class_sibling_from_init.snap
@@ -22,7 +22,7 @@ source: libs/wingc/src/jsify/tests.rs
     
 ```
 
-## inflight.$Closure1-220cc4cd.js
+## inflight.$Closure1-1.js
 
 ```js
 module.exports = function({  }) {
@@ -70,7 +70,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-220cc4cd.js")({
+          require("./inflight.$Closure1-1.js")({
           })
         `);
       }

--- a/libs/wingc/src/jsify/snapshots/capture_type_inflight_class_sibling_from_method.snap
+++ b/libs/wingc/src/jsify/snapshots/capture_type_inflight_class_sibling_from_method.snap
@@ -16,7 +16,7 @@ source: libs/wingc/src/jsify/tests.rs
     
 ```
 
-## inflight.$Closure1-220cc4cd.js
+## inflight.$Closure1-1.js
 
 ```js
 module.exports = function({  }) {
@@ -58,7 +58,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-220cc4cd.js")({
+          require("./inflight.$Closure1-1.js")({
           })
         `);
       }

--- a/libs/wingc/src/jsify/snapshots/capture_type_new_inflight_class_inner_no_capture.snap
+++ b/libs/wingc/src/jsify/snapshots/capture_type_new_inflight_class_inner_no_capture.snap
@@ -12,7 +12,7 @@ source: libs/wingc/src/jsify/tests.rs
     
 ```
 
-## inflight.$Closure1-220cc4cd.js
+## inflight.$Closure1-1.js
 
 ```js
 module.exports = function({  }) {
@@ -50,7 +50,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-220cc4cd.js")({
+          require("./inflight.$Closure1-1.js")({
           })
         `);
       }

--- a/libs/wingc/src/jsify/snapshots/capture_type_new_inflight_class_outer.snap
+++ b/libs/wingc/src/jsify/snapshots/capture_type_new_inflight_class_outer.snap
@@ -13,7 +13,7 @@ source: libs/wingc/src/jsify/tests.rs
     
 ```
 
-## inflight.$Closure1-220cc4cd.js
+## inflight.$Closure1-1.js
 
 ```js
 module.exports = function({ $Foo }) {
@@ -31,7 +31,7 @@ module.exports = function({ $Foo }) {
 }
 ```
 
-## inflight.Foo-220cc4cd.js
+## inflight.Foo-1.js
 
 ```js
 module.exports = function({  }) {
@@ -58,7 +58,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.Foo-220cc4cd.js")({
+          require("./inflight.Foo-1.js")({
           })
         `);
       }
@@ -82,7 +82,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-220cc4cd.js")({
+          require("./inflight.$Closure1-1.js")({
             $Foo: ${context._lift(Foo)},
           })
         `);

--- a/libs/wingc/src/jsify/snapshots/capture_type_static_method.snap
+++ b/libs/wingc/src/jsify/snapshots/capture_type_static_method.snap
@@ -15,7 +15,7 @@ source: libs/wingc/src/jsify/tests.rs
     
 ```
 
-## inflight.$Closure1-220cc4cd.js
+## inflight.$Closure1-1.js
 
 ```js
 module.exports = function({ $Foo }) {
@@ -33,7 +33,7 @@ module.exports = function({ $Foo }) {
 }
 ```
 
-## inflight.Foo-220cc4cd.js
+## inflight.Foo-1.js
 
 ```js
 module.exports = function({  }) {
@@ -65,7 +65,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.Foo-220cc4cd.js")({
+          require("./inflight.Foo-1.js")({
           })
         `);
       }
@@ -89,7 +89,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-220cc4cd.js")({
+          require("./inflight.$Closure1-1.js")({
             $Foo: ${context._lift(Foo)},
           })
         `);

--- a/libs/wingc/src/jsify/snapshots/capture_type_static_method_inflight_class.snap
+++ b/libs/wingc/src/jsify/snapshots/capture_type_static_method_inflight_class.snap
@@ -15,7 +15,7 @@ source: libs/wingc/src/jsify/tests.rs
     
 ```
 
-## inflight.$Closure1-220cc4cd.js
+## inflight.$Closure1-1.js
 
 ```js
 module.exports = function({ $Foo }) {
@@ -33,7 +33,7 @@ module.exports = function({ $Foo }) {
 }
 ```
 
-## inflight.Foo-220cc4cd.js
+## inflight.Foo-1.js
 
 ```js
 module.exports = function({  }) {
@@ -63,7 +63,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.Foo-220cc4cd.js")({
+          require("./inflight.Foo-1.js")({
           })
         `);
       }
@@ -87,7 +87,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-220cc4cd.js")({
+          require("./inflight.$Closure1-1.js")({
             $Foo: ${context._lift(Foo)},
           })
         `);

--- a/libs/wingc/src/jsify/snapshots/capture_var_from_method_inflight.snap
+++ b/libs/wingc/src/jsify/snapshots/capture_var_from_method_inflight.snap
@@ -14,7 +14,7 @@ source: libs/wingc/src/jsify/tests.rs
     
 ```
 
-## inflight.$Closure1-220cc4cd.js
+## inflight.$Closure1-1.js
 
 ```js
 module.exports = function({  }) {
@@ -55,7 +55,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-220cc4cd.js")({
+          require("./inflight.$Closure1-1.js")({
           })
         `);
       }

--- a/libs/wingc/src/jsify/snapshots/closed_inflight_class_extends_outer_inflight_class.snap
+++ b/libs/wingc/src/jsify/snapshots/closed_inflight_class_extends_outer_inflight_class.snap
@@ -14,7 +14,7 @@ source: libs/wingc/src/jsify/tests.rs
     
 ```
 
-## inflight.$Closure1-220cc4cd.js
+## inflight.$Closure1-1.js
 
 ```js
 module.exports = function({ $Base }) {
@@ -34,7 +34,7 @@ module.exports = function({ $Base }) {
 }
 ```
 
-## inflight.Base-220cc4cd.js
+## inflight.Base-1.js
 
 ```js
 module.exports = function({  }) {
@@ -61,7 +61,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.Base-220cc4cd.js")({
+          require("./inflight.Base-1.js")({
           })
         `);
       }
@@ -85,7 +85,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-220cc4cd.js")({
+          require("./inflight.$Closure1-1.js")({
             $Base: ${context._lift(Base)},
           })
         `);

--- a/libs/wingc/src/jsify/snapshots/closure_field.snap
+++ b/libs/wingc/src/jsify/snapshots/closure_field.snap
@@ -32,7 +32,7 @@ source: libs/wingc/src/jsify/tests.rs
     
 ```
 
-## inflight.$Closure1-220cc4cd.js
+## inflight.$Closure1-1.js
 
 ```js
 module.exports = function({ $globalBucket }) {
@@ -51,7 +51,7 @@ module.exports = function({ $globalBucket }) {
 }
 ```
 
-## inflight.$Closure2-220cc4cd.js
+## inflight.$Closure2-1.js
 
 ```js
 module.exports = function({ $x }) {
@@ -70,7 +70,7 @@ module.exports = function({ $x }) {
 }
 ```
 
-## inflight.MyResource-220cc4cd.js
+## inflight.MyResource-1.js
 
 ```js
 module.exports = function({  }) {
@@ -110,7 +110,7 @@ class $Root extends $stdlib.std.Resource {
           }
           static _toInflightType(context) {
             return $stdlib.core.NodeJsCode.fromInline(`
-              require("./inflight.$Closure1-220cc4cd.js")({
+              require("./inflight.$Closure1-1.js")({
                 $globalBucket: ${context._lift(globalBucket)},
               })
             `);
@@ -137,7 +137,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.MyResource-220cc4cd.js")({
+          require("./inflight.MyResource-1.js")({
           })
         `);
       }
@@ -171,7 +171,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure2-220cc4cd.js")({
+          require("./inflight.$Closure2-1.js")({
             $x: ${context._lift(x)},
           })
         `);

--- a/libs/wingc/src/jsify/snapshots/enum_value.snap
+++ b/libs/wingc/src/jsify/snapshots/enum_value.snap
@@ -15,7 +15,7 @@ source: libs/wingc/src/jsify/tests.rs
     
 ```
 
-## inflight.$Closure1-220cc4cd.js
+## inflight.$Closure1-1.js
 
 ```js
 module.exports = function({ $MyEnum, $x }) {
@@ -52,7 +52,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-220cc4cd.js")({
+          require("./inflight.$Closure1-1.js")({
             $MyEnum: ${context._lift(MyEnum)},
             $x: ${context._lift(x)},
           })

--- a/libs/wingc/src/jsify/snapshots/free_inflight_obj_from_inflight.snap
+++ b/libs/wingc/src/jsify/snapshots/free_inflight_obj_from_inflight.snap
@@ -17,7 +17,7 @@ source: libs/wingc/src/jsify/tests.rs
     
 ```
 
-## inflight.$Closure1-220cc4cd.js
+## inflight.$Closure1-1.js
 
 ```js
 module.exports = function({  }) {
@@ -58,7 +58,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-220cc4cd.js")({
+          require("./inflight.$Closure1-1.js")({
           })
         `);
       }

--- a/libs/wingc/src/jsify/snapshots/free_preflight_object_from_preflight.snap
+++ b/libs/wingc/src/jsify/snapshots/free_preflight_object_from_preflight.snap
@@ -13,7 +13,7 @@ source: libs/wingc/src/jsify/tests.rs
     
 ```
 
-## inflight.A-220cc4cd.js
+## inflight.A-1.js
 
 ```js
 module.exports = function({  }) {
@@ -45,7 +45,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.A-220cc4cd.js")({
+          require("./inflight.A-1.js")({
           })
         `);
       }

--- a/libs/wingc/src/jsify/snapshots/func_returns_func.snap
+++ b/libs/wingc/src/jsify/snapshots/func_returns_func.snap
@@ -15,7 +15,7 @@ source: libs/wingc/src/jsify/tests.rs
     
 ```
 
-## inflight.$Closure1-220cc4cd.js
+## inflight.$Closure1-1.js
 
 ```js
 module.exports = function({  }) {
@@ -57,7 +57,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-220cc4cd.js")({
+          require("./inflight.$Closure1-1.js")({
           })
         `);
       }

--- a/libs/wingc/src/jsify/snapshots/identify_field.snap
+++ b/libs/wingc/src/jsify/snapshots/identify_field.snap
@@ -18,7 +18,7 @@ source: libs/wingc/src/jsify/tests.rs
     
 ```
 
-## inflight.A-220cc4cd.js
+## inflight.A-1.js
 
 ```js
 module.exports = function({  }) {
@@ -53,7 +53,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.A-220cc4cd.js")({
+          require("./inflight.A-1.js")({
           })
         `);
       }

--- a/libs/wingc/src/jsify/snapshots/implicit_lift_inflight_init.snap
+++ b/libs/wingc/src/jsify/snapshots/implicit_lift_inflight_init.snap
@@ -30,7 +30,7 @@ source: libs/wingc/src/jsify/tests.rs
     
 ```
 
-## inflight.Foo-220cc4cd.js
+## inflight.Foo-1.js
 
 ```js
 module.exports = function({  }) {
@@ -71,7 +71,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.Foo-220cc4cd.js")({
+          require("./inflight.Foo-1.js")({
           })
         `);
       }

--- a/libs/wingc/src/jsify/snapshots/indirect_capture.snap
+++ b/libs/wingc/src/jsify/snapshots/indirect_capture.snap
@@ -28,7 +28,7 @@ source: libs/wingc/src/jsify/tests.rs
     
 ```
 
-## inflight.$Closure1-220cc4cd.js
+## inflight.$Closure1-1.js
 
 ```js
 module.exports = function({ $f }) {
@@ -46,7 +46,7 @@ module.exports = function({ $f }) {
 }
 ```
 
-## inflight.Capture-220cc4cd.js
+## inflight.Capture-1.js
 
 ```js
 module.exports = function({ $b }) {
@@ -83,7 +83,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.Capture-220cc4cd.js")({
+          require("./inflight.Capture-1.js")({
             $b: ${context._lift(b)},
           })
         `);
@@ -117,7 +117,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-220cc4cd.js")({
+          require("./inflight.$Closure1-1.js")({
             $f: ${context._lift(f)},
           })
         `);

--- a/libs/wingc/src/jsify/snapshots/inflight_class_extends_both_inside_inflight_closure.snap
+++ b/libs/wingc/src/jsify/snapshots/inflight_class_extends_both_inside_inflight_closure.snap
@@ -12,7 +12,7 @@ source: libs/wingc/src/jsify/tests.rs
     
 ```
 
-## inflight.$Closure1-220cc4cd.js
+## inflight.$Closure1-1.js
 
 ```js
 module.exports = function({  }) {
@@ -51,7 +51,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-220cc4cd.js")({
+          require("./inflight.$Closure1-1.js")({
           })
         `);
       }

--- a/libs/wingc/src/jsify/snapshots/inflight_class_extends_inflight_class.snap
+++ b/libs/wingc/src/jsify/snapshots/inflight_class_extends_inflight_class.snap
@@ -10,7 +10,7 @@ source: libs/wingc/src/jsify/tests.rs
     
 ```
 
-## inflight.A-220cc4cd.js
+## inflight.A-1.js
 
 ```js
 module.exports = function({  }) {
@@ -20,7 +20,7 @@ module.exports = function({  }) {
 }
 ```
 
-## inflight.B-220cc4cd.js
+## inflight.B-1.js
 
 ```js
 module.exports = function({ $A }) {
@@ -47,7 +47,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.A-220cc4cd.js")({
+          require("./inflight.A-1.js")({
           })
         `);
       }
@@ -70,7 +70,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.B-220cc4cd.js")({
+          require("./inflight.B-1.js")({
             $A: ${context._lift(A)},
           })
         `);

--- a/libs/wingc/src/jsify/snapshots/inflight_constructor.snap
+++ b/libs/wingc/src/jsify/snapshots/inflight_constructor.snap
@@ -19,7 +19,7 @@ source: libs/wingc/src/jsify/tests.rs
     
 ```
 
-## inflight.Foo-220cc4cd.js
+## inflight.Foo-1.js
 
 ```js
 module.exports = function({  }) {
@@ -54,7 +54,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.Foo-220cc4cd.js")({
+          require("./inflight.Foo-1.js")({
           })
         `);
       }

--- a/libs/wingc/src/jsify/snapshots/inflight_field.snap
+++ b/libs/wingc/src/jsify/snapshots/inflight_field.snap
@@ -18,7 +18,7 @@ source: libs/wingc/src/jsify/tests.rs
     
 ```
 
-## inflight.A-220cc4cd.js
+## inflight.A-1.js
 
 ```js
 module.exports = function({  }) {
@@ -53,7 +53,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.A-220cc4cd.js")({
+          require("./inflight.A-1.js")({
           })
         `);
       }

--- a/libs/wingc/src/jsify/snapshots/inflight_field_from_inflight.snap
+++ b/libs/wingc/src/jsify/snapshots/inflight_field_from_inflight.snap
@@ -17,7 +17,7 @@ source: libs/wingc/src/jsify/tests.rs
     
 ```
 
-## inflight.MyType-220cc4cd.js
+## inflight.MyType-1.js
 
 ```js
 module.exports = function({  }) {
@@ -52,7 +52,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.MyType-220cc4cd.js")({
+          require("./inflight.MyType-1.js")({
           })
         `);
       }

--- a/libs/wingc/src/jsify/snapshots/inflight_field_from_inflight_class.snap
+++ b/libs/wingc/src/jsify/snapshots/inflight_field_from_inflight_class.snap
@@ -16,7 +16,7 @@ source: libs/wingc/src/jsify/tests.rs
   
 ```
 
-## inflight.MyType-220cc4cd.js
+## inflight.MyType-1.js
 
 ```js
 module.exports = function({  }) {
@@ -49,7 +49,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.MyType-220cc4cd.js")({
+          require("./inflight.MyType-1.js")({
           })
         `);
       }

--- a/libs/wingc/src/jsify/snapshots/inline_inflight_class.snap
+++ b/libs/wingc/src/jsify/snapshots/inline_inflight_class.snap
@@ -22,7 +22,7 @@ source: libs/wingc/src/jsify/tests.rs
     
 ```
 
-## inflight.$Closure1-220cc4cd.js
+## inflight.$Closure1-1.js
 
 ```js
 module.exports = function({ $__parent_this_1_b }) {
@@ -40,7 +40,7 @@ module.exports = function({ $__parent_this_1_b }) {
 }
 ```
 
-## inflight.Foo-220cc4cd.js
+## inflight.Foo-1.js
 
 ```js
 module.exports = function({  }) {
@@ -78,7 +78,7 @@ class $Root extends $stdlib.std.Resource {
           }
           static _toInflightType(context) {
             return $stdlib.core.NodeJsCode.fromInline(`
-              require("./inflight.$Closure1-220cc4cd.js")({
+              require("./inflight.$Closure1-1.js")({
                 $__parent_this_1_b: ${context._lift(__parent_this_1.b)},
               })
             `);
@@ -105,7 +105,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.Foo-220cc4cd.js")({
+          require("./inflight.Foo-1.js")({
           })
         `);
       }

--- a/libs/wingc/src/jsify/snapshots/json_object.snap
+++ b/libs/wingc/src/jsify/snapshots/json_object.snap
@@ -13,7 +13,7 @@ source: libs/wingc/src/jsify/tests.rs
     
 ```
 
-## inflight.$Closure1-220cc4cd.js
+## inflight.$Closure1-1.js
 
 ```js
 module.exports = function({ $jsonObj1, $std_Json }) {
@@ -49,7 +49,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-220cc4cd.js")({
+          require("./inflight.$Closure1-1.js")({
             $jsonObj1: ${context._lift(jsonObj1)},
             $std_Json: ${context._lift(std.Json)},
           })

--- a/libs/wingc/src/jsify/snapshots/lift_binary_preflight_and_inflight_expression.snap
+++ b/libs/wingc/src/jsify/snapshots/lift_binary_preflight_and_inflight_expression.snap
@@ -13,7 +13,7 @@ source: libs/wingc/src/jsify/tests.rs
     
 ```
 
-## inflight.$Closure1-220cc4cd.js
+## inflight.$Closure1-1.js
 
 ```js
 module.exports = function({ $x }) {
@@ -50,7 +50,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-220cc4cd.js")({
+          require("./inflight.$Closure1-1.js")({
             $x: ${context._lift(x)},
           })
         `);

--- a/libs/wingc/src/jsify/snapshots/lift_binary_preflight_expression.snap
+++ b/libs/wingc/src/jsify/snapshots/lift_binary_preflight_expression.snap
@@ -13,7 +13,7 @@ source: libs/wingc/src/jsify/tests.rs
     
 ```
 
-## inflight.$Closure1-220cc4cd.js
+## inflight.$Closure1-1.js
 
 ```js
 module.exports = function({ $x, $y }) {
@@ -49,7 +49,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-220cc4cd.js")({
+          require("./inflight.$Closure1-1.js")({
             $x: ${context._lift(x)},
             $y: ${context._lift(y)},
           })

--- a/libs/wingc/src/jsify/snapshots/lift_element_from_collection_as_field.snap
+++ b/libs/wingc/src/jsify/snapshots/lift_element_from_collection_as_field.snap
@@ -19,7 +19,7 @@ source: libs/wingc/src/jsify/tests.rs
     
 ```
 
-## inflight.Foo-220cc4cd.js
+## inflight.Foo-1.js
 
 ```js
 module.exports = function({  }) {
@@ -54,7 +54,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.Foo-220cc4cd.js")({
+          require("./inflight.Foo-1.js")({
           })
         `);
       }

--- a/libs/wingc/src/jsify/snapshots/lift_element_from_collection_of_objects.snap
+++ b/libs/wingc/src/jsify/snapshots/lift_element_from_collection_of_objects.snap
@@ -14,7 +14,7 @@ source: libs/wingc/src/jsify/tests.rs
     
 ```
 
-## inflight.$Closure1-220cc4cd.js
+## inflight.$Closure1-1.js
 
 ```js
 module.exports = function({ $_a_at_0__ }) {
@@ -51,7 +51,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-220cc4cd.js")({
+          require("./inflight.$Closure1-1.js")({
             $_a_at_0__: ${context._lift((a.at(0)))},
           })
         `);

--- a/libs/wingc/src/jsify/snapshots/lift_inflight_closure.snap
+++ b/libs/wingc/src/jsify/snapshots/lift_inflight_closure.snap
@@ -13,7 +13,7 @@ source: libs/wingc/src/jsify/tests.rs
     
 ```
 
-## inflight.$Closure1-220cc4cd.js
+## inflight.$Closure1-1.js
 
 ```js
 module.exports = function({  }) {
@@ -30,7 +30,7 @@ module.exports = function({  }) {
 }
 ```
 
-## inflight.$Closure2-220cc4cd.js
+## inflight.$Closure2-1.js
 
 ```js
 module.exports = function({ $f }) {
@@ -66,7 +66,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-220cc4cd.js")({
+          require("./inflight.$Closure1-1.js")({
           })
         `);
       }
@@ -90,7 +90,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure2-220cc4cd.js")({
+          require("./inflight.$Closure2-1.js")({
             $f: ${context._lift(f)},
           })
         `);

--- a/libs/wingc/src/jsify/snapshots/lift_inside_preflight_method.snap
+++ b/libs/wingc/src/jsify/snapshots/lift_inside_preflight_method.snap
@@ -23,7 +23,7 @@ source: libs/wingc/src/jsify/tests.rs
     
 ```
 
-## inflight.$Closure1-220cc4cd.js
+## inflight.$Closure1-1.js
 
 ```js
 module.exports = function({ $b }) {
@@ -41,7 +41,7 @@ module.exports = function({ $b }) {
 }
 ```
 
-## inflight.Foo-220cc4cd.js
+## inflight.Foo-1.js
 
 ```js
 module.exports = function({  }) {
@@ -82,7 +82,7 @@ class $Root extends $stdlib.std.Resource {
           }
           static _toInflightType(context) {
             return $stdlib.core.NodeJsCode.fromInline(`
-              require("./inflight.$Closure1-220cc4cd.js")({
+              require("./inflight.$Closure1-1.js")({
                 $b: ${context._lift(b)},
               })
             `);
@@ -109,7 +109,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.Foo-220cc4cd.js")({
+          require("./inflight.Foo-1.js")({
           })
         `);
       }

--- a/libs/wingc/src/jsify/snapshots/lift_string.snap
+++ b/libs/wingc/src/jsify/snapshots/lift_string.snap
@@ -12,7 +12,7 @@ source: libs/wingc/src/jsify/tests.rs
     
 ```
 
-## inflight.$Closure1-220cc4cd.js
+## inflight.$Closure1-1.js
 
 ```js
 module.exports = function({ $b }) {
@@ -48,7 +48,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-220cc4cd.js")({
+          require("./inflight.$Closure1-1.js")({
             $b: ${context._lift(b)},
           })
         `);

--- a/libs/wingc/src/jsify/snapshots/lift_this.snap
+++ b/libs/wingc/src/jsify/snapshots/lift_this.snap
@@ -26,7 +26,7 @@ source: libs/wingc/src/jsify/tests.rs
     
 ```
 
-## inflight.$Closure1-220cc4cd.js
+## inflight.$Closure1-1.js
 
 ```js
 module.exports = function({ $f }) {
@@ -44,7 +44,7 @@ module.exports = function({ $f }) {
 }
 ```
 
-## inflight.Foo-220cc4cd.js
+## inflight.Foo-1.js
 
 ```js
 module.exports = function({  }) {
@@ -82,7 +82,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.Foo-220cc4cd.js")({
+          require("./inflight.Foo-1.js")({
           })
         `);
       }
@@ -112,7 +112,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-220cc4cd.js")({
+          require("./inflight.$Closure1-1.js")({
             $f: ${context._lift(f)},
           })
         `);

--- a/libs/wingc/src/jsify/snapshots/lift_var_with_this.snap
+++ b/libs/wingc/src/jsify/snapshots/lift_var_with_this.snap
@@ -17,7 +17,7 @@ source: libs/wingc/src/jsify/tests.rs
     
 ```
 
-## inflight.$Closure1-220cc4cd.js
+## inflight.$Closure1-1.js
 
 ```js
 module.exports = function({  }) {
@@ -36,7 +36,7 @@ module.exports = function({  }) {
 }
 ```
 
-## inflight.Foo-220cc4cd.js
+## inflight.Foo-1.js
 
 ```js
 module.exports = function({  }) {
@@ -66,7 +66,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.Foo-220cc4cd.js")({
+          require("./inflight.Foo-1.js")({
           })
         `);
       }
@@ -90,7 +90,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-220cc4cd.js")({
+          require("./inflight.$Closure1-1.js")({
           })
         `);
       }

--- a/libs/wingc/src/jsify/snapshots/lift_via_closure.snap
+++ b/libs/wingc/src/jsify/snapshots/lift_via_closure.snap
@@ -19,7 +19,7 @@ source: libs/wingc/src/jsify/tests.rs
     
 ```
 
-## inflight.$Closure1-220cc4cd.js
+## inflight.$Closure1-1.js
 
 ```js
 module.exports = function({ $bucket }) {
@@ -37,7 +37,7 @@ module.exports = function({ $bucket }) {
 }
 ```
 
-## inflight.$Closure2-220cc4cd.js
+## inflight.$Closure2-1.js
 
 ```js
 module.exports = function({ $fn }) {
@@ -74,7 +74,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-220cc4cd.js")({
+          require("./inflight.$Closure1-1.js")({
             $bucket: ${context._lift(bucket)},
           })
         `);
@@ -105,7 +105,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure2-220cc4cd.js")({
+          require("./inflight.$Closure2-1.js")({
             $fn: ${context._lift(fn)},
           })
         `);

--- a/libs/wingc/src/jsify/snapshots/lift_via_closure_class_explicit.snap
+++ b/libs/wingc/src/jsify/snapshots/lift_via_closure_class_explicit.snap
@@ -30,7 +30,7 @@ source: libs/wingc/src/jsify/tests.rs
     
 ```
 
-## inflight.$Closure1-220cc4cd.js
+## inflight.$Closure1-1.js
 
 ```js
 module.exports = function({ $fn }) {
@@ -48,7 +48,7 @@ module.exports = function({ $fn }) {
 }
 ```
 
-## inflight.MyClosure-220cc4cd.js
+## inflight.MyClosure-1.js
 
 ```js
 module.exports = function({  }) {
@@ -89,7 +89,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.MyClosure-220cc4cd.js")({
+          require("./inflight.MyClosure-1.js")({
           })
         `);
       }
@@ -126,7 +126,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-220cc4cd.js")({
+          require("./inflight.$Closure1-1.js")({
             $fn: ${context._lift(fn)},
           })
         `);

--- a/libs/wingc/src/jsify/snapshots/namespaced_static_from_inflight.snap
+++ b/libs/wingc/src/jsify/snapshots/namespaced_static_from_inflight.snap
@@ -12,7 +12,7 @@ source: libs/wingc/src/jsify/tests.rs
     
 ```
 
-## inflight.$Closure1-220cc4cd.js
+## inflight.$Closure1-1.js
 
 ```js
 module.exports = function({ $util_Util }) {
@@ -49,7 +49,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-220cc4cd.js")({
+          require("./inflight.$Closure1-1.js")({
             $util_Util: ${context._lift(util.Util)},
           })
         `);

--- a/libs/wingc/src/jsify/snapshots/nested_inflight_after_preflight_operation.snap
+++ b/libs/wingc/src/jsify/snapshots/nested_inflight_after_preflight_operation.snap
@@ -21,7 +21,7 @@ source: libs/wingc/src/jsify/tests.rs
     
 ```
 
-## inflight.$Closure1-220cc4cd.js
+## inflight.$Closure1-1.js
 
 ```js
 module.exports = function({ $y }) {
@@ -39,7 +39,7 @@ module.exports = function({ $y }) {
 }
 ```
 
-## inflight.YourType-220cc4cd.js
+## inflight.YourType-1.js
 
 ```js
 module.exports = function({  }) {
@@ -72,7 +72,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.YourType-220cc4cd.js")({
+          require("./inflight.YourType-1.js")({
           })
         `);
       }
@@ -96,7 +96,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-220cc4cd.js")({
+          require("./inflight.$Closure1-1.js")({
             $y: ${context._lift(y)},
           })
         `);

--- a/libs/wingc/src/jsify/snapshots/nested_preflight_operation.snap
+++ b/libs/wingc/src/jsify/snapshots/nested_preflight_operation.snap
@@ -27,7 +27,7 @@ source: libs/wingc/src/jsify/tests.rs
     
 ```
 
-## inflight.$Closure1-220cc4cd.js
+## inflight.$Closure1-1.js
 
 ```js
 module.exports = function({ $t_y_b }) {
@@ -45,7 +45,7 @@ module.exports = function({ $t_y_b }) {
 }
 ```
 
-## inflight.MyType-220cc4cd.js
+## inflight.MyType-1.js
 
 ```js
 module.exports = function({  }) {
@@ -57,7 +57,7 @@ module.exports = function({  }) {
 }
 ```
 
-## inflight.YourType-220cc4cd.js
+## inflight.YourType-1.js
 
 ```js
 module.exports = function({  }) {
@@ -88,7 +88,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.YourType-220cc4cd.js")({
+          require("./inflight.YourType-1.js")({
           })
         `);
       }
@@ -112,7 +112,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.MyType-220cc4cd.js")({
+          require("./inflight.MyType-1.js")({
           })
         `);
       }
@@ -136,7 +136,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-220cc4cd.js")({
+          require("./inflight.$Closure1-1.js")({
             $t_y_b: ${context._lift(t.y.b)},
           })
         `);

--- a/libs/wingc/src/jsify/snapshots/new_inflight_object.snap
+++ b/libs/wingc/src/jsify/snapshots/new_inflight_object.snap
@@ -13,7 +13,7 @@ source: libs/wingc/src/jsify/tests.rs
     
 ```
 
-## inflight.$Closure1-220cc4cd.js
+## inflight.$Closure1-1.js
 
 ```js
 module.exports = function({ $Foo }) {
@@ -31,7 +31,7 @@ module.exports = function({ $Foo }) {
 }
 ```
 
-## inflight.Foo-220cc4cd.js
+## inflight.Foo-1.js
 
 ```js
 module.exports = function({  }) {
@@ -58,7 +58,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.Foo-220cc4cd.js")({
+          require("./inflight.Foo-1.js")({
           })
         `);
       }
@@ -82,7 +82,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-220cc4cd.js")({
+          require("./inflight.$Closure1-1.js")({
             $Foo: ${context._lift(Foo)},
           })
         `);

--- a/libs/wingc/src/jsify/snapshots/no_capture_inside_methods.snap
+++ b/libs/wingc/src/jsify/snapshots/no_capture_inside_methods.snap
@@ -14,7 +14,7 @@ source: libs/wingc/src/jsify/tests.rs
     
 ```
 
-## inflight.$Closure1-220cc4cd.js
+## inflight.$Closure1-1.js
 
 ```js
 module.exports = function({  }) {
@@ -53,7 +53,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-220cc4cd.js")({
+          require("./inflight.$Closure1-1.js")({
           })
         `);
       }

--- a/libs/wingc/src/jsify/snapshots/no_capture_of_identifier_from_inner_scope.snap
+++ b/libs/wingc/src/jsify/snapshots/no_capture_of_identifier_from_inner_scope.snap
@@ -14,7 +14,7 @@ source: libs/wingc/src/jsify/tests.rs
     
 ```
 
-## inflight.$Closure1-220cc4cd.js
+## inflight.$Closure1-1.js
 
 ```js
 module.exports = function({  }) {
@@ -53,7 +53,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-220cc4cd.js")({
+          require("./inflight.$Closure1-1.js")({
           })
         `);
       }

--- a/libs/wingc/src/jsify/snapshots/no_capture_of_identifier_from_same_scope.snap
+++ b/libs/wingc/src/jsify/snapshots/no_capture_of_identifier_from_same_scope.snap
@@ -12,7 +12,7 @@ source: libs/wingc/src/jsify/tests.rs
     
 ```
 
-## inflight.$Closure1-220cc4cd.js
+## inflight.$Closure1-1.js
 
 ```js
 module.exports = function({  }) {
@@ -49,7 +49,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-220cc4cd.js")({
+          require("./inflight.$Closure1-1.js")({
           })
         `);
       }

--- a/libs/wingc/src/jsify/snapshots/no_capture_shadow_inside_inner_scopes.snap
+++ b/libs/wingc/src/jsify/snapshots/no_capture_shadow_inside_inner_scopes.snap
@@ -19,7 +19,7 @@ source: libs/wingc/src/jsify/tests.rs
     
 ```
 
-## inflight.$Closure1-220cc4cd.js
+## inflight.$Closure1-1.js
 
 ```js
 module.exports = function({  }) {
@@ -61,7 +61,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-220cc4cd.js")({
+          require("./inflight.$Closure1-1.js")({
           })
         `);
       }

--- a/libs/wingc/src/jsify/snapshots/no_lift_shadow_inside_inner_scopes.snap
+++ b/libs/wingc/src/jsify/snapshots/no_lift_shadow_inside_inner_scopes.snap
@@ -18,7 +18,7 @@ source: libs/wingc/src/jsify/tests.rs
     
 ```
 
-## inflight.$Closure1-220cc4cd.js
+## inflight.$Closure1-1.js
 
 ```js
 module.exports = function({ $i }) {
@@ -59,7 +59,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-220cc4cd.js")({
+          require("./inflight.$Closure1-1.js")({
             $i: ${context._lift(i)},
           })
         `);

--- a/libs/wingc/src/jsify/snapshots/preflight_class_extends_preflight_class.snap
+++ b/libs/wingc/src/jsify/snapshots/preflight_class_extends_preflight_class.snap
@@ -10,7 +10,7 @@ source: libs/wingc/src/jsify/tests.rs
     
 ```
 
-## inflight.Base-220cc4cd.js
+## inflight.Base-1.js
 
 ```js
 module.exports = function({  }) {
@@ -22,7 +22,7 @@ module.exports = function({  }) {
 }
 ```
 
-## inflight.Derived-220cc4cd.js
+## inflight.Derived-1.js
 
 ```js
 module.exports = function({ $Base }) {
@@ -52,7 +52,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.Base-220cc4cd.js")({
+          require("./inflight.Base-1.js")({
           })
         `);
       }
@@ -75,7 +75,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.Derived-220cc4cd.js")({
+          require("./inflight.Derived-1.js")({
             $Base: ${context._lift(Base)},
           })
         `);

--- a/libs/wingc/src/jsify/snapshots/preflight_collection.snap
+++ b/libs/wingc/src/jsify/snapshots/preflight_collection.snap
@@ -13,7 +13,7 @@ source: libs/wingc/src/jsify/tests.rs
     
 ```
 
-## inflight.$Closure1-220cc4cd.js
+## inflight.$Closure1-1.js
 
 ```js
 module.exports = function({ $_a_at_0__, $a_length }) {
@@ -50,7 +50,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-220cc4cd.js")({
+          require("./inflight.$Closure1-1.js")({
             $_a_at_0__: ${context._lift((a.at(0)))},
             $a_length: ${context._lift(a.length)},
           })

--- a/libs/wingc/src/jsify/snapshots/preflight_collection_of_preflight_objects.snap
+++ b/libs/wingc/src/jsify/snapshots/preflight_collection_of_preflight_objects.snap
@@ -17,7 +17,7 @@ source: libs/wingc/src/jsify/tests.rs
     
 ```
 
-## inflight.$Closure1-220cc4cd.js
+## inflight.$Closure1-1.js
 
 ```js
 module.exports = function({ $_arr_at_0__, $arr_length }) {
@@ -55,7 +55,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-220cc4cd.js")({
+          require("./inflight.$Closure1-1.js")({
             $_arr_at_0__: ${context._lift((arr.at(0)))},
             $arr_length: ${context._lift(arr.length)},
           })

--- a/libs/wingc/src/jsify/snapshots/preflight_nested_object_with_operations.snap
+++ b/libs/wingc/src/jsify/snapshots/preflight_nested_object_with_operations.snap
@@ -21,7 +21,7 @@ source: libs/wingc/src/jsify/tests.rs
     
 ```
 
-## inflight.$Closure1-220cc4cd.js
+## inflight.$Closure1-1.js
 
 ```js
 module.exports = function({ $a_bucky }) {
@@ -39,7 +39,7 @@ module.exports = function({ $a_bucky }) {
 }
 ```
 
-## inflight.A-220cc4cd.js
+## inflight.A-1.js
 
 ```js
 module.exports = function({  }) {
@@ -70,7 +70,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.A-220cc4cd.js")({
+          require("./inflight.A-1.js")({
           })
         `);
       }
@@ -94,7 +94,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-220cc4cd.js")({
+          require("./inflight.$Closure1-1.js")({
             $a_bucky: ${context._lift(a.bucky)},
           })
         `);

--- a/libs/wingc/src/jsify/snapshots/preflight_object.snap
+++ b/libs/wingc/src/jsify/snapshots/preflight_object.snap
@@ -17,7 +17,7 @@ source: libs/wingc/src/jsify/tests.rs
     
 ```
 
-## inflight.$Closure1-220cc4cd.js
+## inflight.$Closure1-1.js
 
 ```js
 module.exports = function({ $pf_obj }) {
@@ -36,7 +36,7 @@ module.exports = function({ $pf_obj }) {
 }
 ```
 
-## inflight.A-220cc4cd.js
+## inflight.A-1.js
 
 ```js
 module.exports = function({  }) {
@@ -69,7 +69,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.A-220cc4cd.js")({
+          require("./inflight.A-1.js")({
           })
         `);
       }
@@ -93,7 +93,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-220cc4cd.js")({
+          require("./inflight.$Closure1-1.js")({
             $pf_obj: ${context._lift(pf_obj)},
           })
         `);

--- a/libs/wingc/src/jsify/snapshots/preflight_object_through_property.snap
+++ b/libs/wingc/src/jsify/snapshots/preflight_object_through_property.snap
@@ -22,7 +22,7 @@ source: libs/wingc/src/jsify/tests.rs
     
 ```
 
-## inflight.$Closure1-220cc4cd.js
+## inflight.$Closure1-1.js
 
 ```js
 module.exports = function({ $t_b }) {
@@ -40,7 +40,7 @@ module.exports = function({ $t_b }) {
 }
 ```
 
-## inflight.MyType-220cc4cd.js
+## inflight.MyType-1.js
 
 ```js
 module.exports = function({  }) {
@@ -71,7 +71,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.MyType-220cc4cd.js")({
+          require("./inflight.MyType-1.js")({
           })
         `);
       }
@@ -95,7 +95,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-220cc4cd.js")({
+          require("./inflight.$Closure1-1.js")({
             $t_b: ${context._lift(t.b)},
           })
         `);

--- a/libs/wingc/src/jsify/snapshots/preflight_object_with_operations.snap
+++ b/libs/wingc/src/jsify/snapshots/preflight_object_with_operations.snap
@@ -14,7 +14,7 @@ source: libs/wingc/src/jsify/tests.rs
     
 ```
 
-## inflight.$Closure1-220cc4cd.js
+## inflight.$Closure1-1.js
 
 ```js
 module.exports = function({ $b }) {
@@ -52,7 +52,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-220cc4cd.js")({
+          require("./inflight.$Closure1-1.js")({
             $b: ${context._lift(b)},
           })
         `);

--- a/libs/wingc/src/jsify/snapshots/preflight_object_with_operations_multiple_methods.snap
+++ b/libs/wingc/src/jsify/snapshots/preflight_object_with_operations_multiple_methods.snap
@@ -20,7 +20,7 @@ source: libs/wingc/src/jsify/tests.rs
     
 ```
 
-## inflight.Foo-220cc4cd.js
+## inflight.Foo-1.js
 
 ```js
 module.exports = function({ $b }) {
@@ -56,7 +56,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.Foo-220cc4cd.js")({
+          require("./inflight.Foo-1.js")({
             $b: ${context._lift(b)},
           })
         `);

--- a/libs/wingc/src/jsify/snapshots/preflight_value_field.snap
+++ b/libs/wingc/src/jsify/snapshots/preflight_value_field.snap
@@ -25,7 +25,7 @@ source: libs/wingc/src/jsify/tests.rs
     
 ```
 
-## inflight.$Closure1-220cc4cd.js
+## inflight.$Closure1-1.js
 
 ```js
 module.exports = function({ $t_last, $t_name, $t_name_length }) {
@@ -45,7 +45,7 @@ module.exports = function({ $t_last, $t_name, $t_name_length }) {
 }
 ```
 
-## inflight.MyType-220cc4cd.js
+## inflight.MyType-1.js
 
 ```js
 module.exports = function({  }) {
@@ -76,7 +76,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.MyType-220cc4cd.js")({
+          require("./inflight.MyType-1.js")({
           })
         `);
       }
@@ -100,7 +100,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-220cc4cd.js")({
+          require("./inflight.$Closure1-1.js")({
             $t_last: ${context._lift(t.last)},
             $t_name: ${context._lift(t.name)},
             $t_name_length: ${context._lift(t.name.length)},

--- a/libs/wingc/src/jsify/snapshots/read_primitive_value.snap
+++ b/libs/wingc/src/jsify/snapshots/read_primitive_value.snap
@@ -13,7 +13,7 @@ source: libs/wingc/src/jsify/tests.rs
     
 ```
 
-## inflight.$Closure1-220cc4cd.js
+## inflight.$Closure1-1.js
 
 ```js
 module.exports = function({ $x }) {
@@ -49,7 +49,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-220cc4cd.js")({
+          require("./inflight.$Closure1-1.js")({
             $x: ${context._lift(x)},
           })
         `);

--- a/libs/wingc/src/jsify/snapshots/reassign_captured_variable.snap
+++ b/libs/wingc/src/jsify/snapshots/reassign_captured_variable.snap
@@ -17,7 +17,7 @@ source: libs/wingc/src/jsify/tests.rs
     
 ```
 
-## inflight.$Closure1-220cc4cd.js
+## inflight.$Closure1-1.js
 
 ```js
 module.exports = function({  }) {
@@ -58,7 +58,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-220cc4cd.js")({
+          require("./inflight.$Closure1-1.js")({
           })
         `);
       }

--- a/libs/wingc/src/jsify/snapshots/ref_std_macro.snap
+++ b/libs/wingc/src/jsify/snapshots/ref_std_macro.snap
@@ -13,7 +13,7 @@ source: libs/wingc/src/jsify/tests.rs
     
 ```
 
-## inflight.$Closure1-220cc4cd.js
+## inflight.$Closure1-1.js
 
 ```js
 module.exports = function({ $arr_length }) {
@@ -49,7 +49,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-220cc4cd.js")({
+          require("./inflight.$Closure1-1.js")({
             $arr_length: ${context._lift(arr.length)},
           })
         `);

--- a/libs/wingc/src/jsify/snapshots/reference_from_static_inflight.snap
+++ b/libs/wingc/src/jsify/snapshots/reference_from_static_inflight.snap
@@ -15,7 +15,7 @@ source: libs/wingc/src/jsify/tests.rs
     
 ```
 
-## inflight.MyType-220cc4cd.js
+## inflight.MyType-1.js
 
 ```js
 module.exports = function({ $s }) {
@@ -47,7 +47,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.MyType-220cc4cd.js")({
+          require("./inflight.MyType-1.js")({
             $s: ${context._lift(s)},
           })
         `);

--- a/libs/wingc/src/jsify/snapshots/reference_inflight_class.snap
+++ b/libs/wingc/src/jsify/snapshots/reference_inflight_class.snap
@@ -15,7 +15,7 @@ source: libs/wingc/src/jsify/tests.rs
     
 ```
 
-## inflight.$Closure1-220cc4cd.js
+## inflight.$Closure1-1.js
 
 ```js
 module.exports = function({ $Foo }) {
@@ -33,7 +33,7 @@ module.exports = function({ $Foo }) {
 }
 ```
 
-## inflight.Foo-220cc4cd.js
+## inflight.Foo-1.js
 
 ```js
 module.exports = function({  }) {
@@ -63,7 +63,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.Foo-220cc4cd.js")({
+          require("./inflight.Foo-1.js")({
           })
         `);
       }
@@ -87,7 +87,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-220cc4cd.js")({
+          require("./inflight.$Closure1-1.js")({
             $Foo: ${context._lift(Foo)},
           })
         `);

--- a/libs/wingc/src/jsify/snapshots/reference_inflight_field.snap
+++ b/libs/wingc/src/jsify/snapshots/reference_inflight_field.snap
@@ -19,7 +19,7 @@ source: libs/wingc/src/jsify/tests.rs
     
 ```
 
-## inflight.Foo-220cc4cd.js
+## inflight.Foo-1.js
 
 ```js
 module.exports = function({  }) {
@@ -54,7 +54,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.Foo-220cc4cd.js")({
+          require("./inflight.Foo-1.js")({
           })
         `);
       }

--- a/libs/wingc/src/jsify/snapshots/reference_inflight_from_inflight.snap
+++ b/libs/wingc/src/jsify/snapshots/reference_inflight_from_inflight.snap
@@ -27,7 +27,7 @@ source: libs/wingc/src/jsify/tests.rs
     
 ```
 
-## inflight.$Closure1-220cc4cd.js
+## inflight.$Closure1-1.js
 
 ```js
 module.exports = function({ $Foo }) {
@@ -45,7 +45,7 @@ module.exports = function({ $Foo }) {
 }
 ```
 
-## inflight.Foo-220cc4cd.js
+## inflight.Foo-1.js
 
 ```js
 module.exports = function({ $s }) {
@@ -75,7 +75,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.Foo-220cc4cd.js")({
+          require("./inflight.Foo-1.js")({
             $s: ${context._lift(s)},
           })
         `);
@@ -106,7 +106,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-220cc4cd.js")({
+          require("./inflight.$Closure1-1.js")({
             $Foo: ${context._lift(Foo)},
           })
         `);

--- a/libs/wingc/src/jsify/snapshots/reference_preflight_field.snap
+++ b/libs/wingc/src/jsify/snapshots/reference_preflight_field.snap
@@ -19,7 +19,7 @@ source: libs/wingc/src/jsify/tests.rs
     
 ```
 
-## inflight.Foo-220cc4cd.js
+## inflight.Foo-1.js
 
 ```js
 module.exports = function({  }) {
@@ -53,7 +53,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.Foo-220cc4cd.js")({
+          require("./inflight.Foo-1.js")({
           })
         `);
       }

--- a/libs/wingc/src/jsify/snapshots/reference_preflight_field_call_independent_method.snap
+++ b/libs/wingc/src/jsify/snapshots/reference_preflight_field_call_independent_method.snap
@@ -19,7 +19,7 @@ source: libs/wingc/src/jsify/tests.rs
     
 ```
 
-## inflight.Foo-220cc4cd.js
+## inflight.Foo-1.js
 
 ```js
 module.exports = function({  }) {
@@ -53,7 +53,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.Foo-220cc4cd.js")({
+          require("./inflight.Foo-1.js")({
           })
         `);
       }

--- a/libs/wingc/src/jsify/snapshots/reference_preflight_fields.snap
+++ b/libs/wingc/src/jsify/snapshots/reference_preflight_fields.snap
@@ -29,7 +29,7 @@ source: libs/wingc/src/jsify/tests.rs
     
 ```
 
-## inflight.MyType-220cc4cd.js
+## inflight.MyType-1.js
 
 ```js
 module.exports = function({  }) {
@@ -71,7 +71,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.MyType-220cc4cd.js")({
+          require("./inflight.MyType-1.js")({
           })
         `);
       }

--- a/libs/wingc/src/jsify/snapshots/reference_preflight_free_variable_with_this_in_the_expression.snap
+++ b/libs/wingc/src/jsify/snapshots/reference_preflight_free_variable_with_this_in_the_expression.snap
@@ -22,7 +22,7 @@ source: libs/wingc/src/jsify/tests.rs
     
 ```
 
-## inflight.Foo-220cc4cd.js
+## inflight.Foo-1.js
 
 ```js
 module.exports = function({ $b }) {
@@ -57,7 +57,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.Foo-220cc4cd.js")({
+          require("./inflight.Foo-1.js")({
             $b: ${context._lift(b)},
           })
         `);

--- a/libs/wingc/src/jsify/snapshots/reference_preflight_object_from_static_inflight.snap
+++ b/libs/wingc/src/jsify/snapshots/reference_preflight_object_from_static_inflight.snap
@@ -17,7 +17,7 @@ source: libs/wingc/src/jsify/tests.rs
     
 ```
 
-## inflight.MyType-220cc4cd.js
+## inflight.MyType-1.js
 
 ```js
 module.exports = function({ $q }) {
@@ -50,7 +50,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.MyType-220cc4cd.js")({
+          require("./inflight.MyType-1.js")({
             $q: ${context._lift(q)},
           })
         `);

--- a/libs/wingc/src/jsify/snapshots/reference_static_inflight.snap
+++ b/libs/wingc/src/jsify/snapshots/reference_static_inflight.snap
@@ -15,7 +15,7 @@ source: libs/wingc/src/jsify/tests.rs
     
 ```
 
-## inflight.$Closure1-220cc4cd.js
+## inflight.$Closure1-1.js
 
 ```js
 module.exports = function({ $MyType }) {
@@ -33,7 +33,7 @@ module.exports = function({ $MyType }) {
 }
 ```
 
-## inflight.MyType-220cc4cd.js
+## inflight.MyType-1.js
 
 ```js
 module.exports = function({  }) {
@@ -64,7 +64,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.MyType-220cc4cd.js")({
+          require("./inflight.MyType-1.js")({
           })
         `);
       }
@@ -88,7 +88,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-220cc4cd.js")({
+          require("./inflight.$Closure1-1.js")({
             $MyType: ${context._lift(MyType)},
           })
         `);

--- a/libs/wingc/src/jsify/snapshots/reference_static_inflight_which_references_preflight_object.snap
+++ b/libs/wingc/src/jsify/snapshots/reference_static_inflight_which_references_preflight_object.snap
@@ -22,7 +22,7 @@ source: libs/wingc/src/jsify/tests.rs
     
 ```
 
-## inflight.$Closure1-220cc4cd.js
+## inflight.$Closure1-1.js
 
 ```js
 module.exports = function({ $MyType }) {
@@ -40,7 +40,7 @@ module.exports = function({ $MyType }) {
 }
 ```
 
-## inflight.MyType-220cc4cd.js
+## inflight.MyType-1.js
 
 ```js
 module.exports = function({ $b }) {
@@ -74,7 +74,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.MyType-220cc4cd.js")({
+          require("./inflight.MyType-1.js")({
             $b: ${context._lift(b)},
           })
         `);
@@ -105,7 +105,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-220cc4cd.js")({
+          require("./inflight.$Closure1-1.js")({
             $MyType: ${context._lift(MyType)},
           })
         `);

--- a/libs/wingc/src/jsify/snapshots/static_external_inflight_class.snap
+++ b/libs/wingc/src/jsify/snapshots/static_external_inflight_class.snap
@@ -21,7 +21,7 @@ source: libs/wingc/src/jsify/tests.rs
     
 ```
 
-## inflight.$Closure1-220cc4cd.js
+## inflight.$Closure1-1.js
 
 ```js
 module.exports = function({ $A }) {
@@ -44,7 +44,7 @@ module.exports = function({ $A }) {
 }
 ```
 
-## inflight.A-220cc4cd.js
+## inflight.A-1.js
 
 ```js
 module.exports = function({  }) {
@@ -74,7 +74,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.A-220cc4cd.js")({
+          require("./inflight.A-1.js")({
           })
         `);
       }
@@ -98,7 +98,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-220cc4cd.js")({
+          require("./inflight.$Closure1-1.js")({
             $A: ${context._lift(A)},
           })
         `);

--- a/libs/wingc/src/jsify/snapshots/static_external_preflight_class.snap
+++ b/libs/wingc/src/jsify/snapshots/static_external_preflight_class.snap
@@ -19,7 +19,7 @@ source: libs/wingc/src/jsify/tests.rs
     
 ```
 
-## inflight.$Closure1-220cc4cd.js
+## inflight.$Closure1-1.js
 
 ```js
 module.exports = function({ $A }) {
@@ -41,7 +41,7 @@ module.exports = function({ $A }) {
 }
 ```
 
-## inflight.A-220cc4cd.js
+## inflight.A-1.js
 
 ```js
 module.exports = function({  }) {
@@ -73,7 +73,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.A-220cc4cd.js")({
+          require("./inflight.A-1.js")({
           })
         `);
       }
@@ -97,7 +97,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-220cc4cd.js")({
+          require("./inflight.$Closure1-1.js")({
             $A: ${context._lift(A)},
           })
         `);

--- a/libs/wingc/src/jsify/snapshots/static_inflight_operation.snap
+++ b/libs/wingc/src/jsify/snapshots/static_inflight_operation.snap
@@ -20,7 +20,7 @@ source: libs/wingc/src/jsify/tests.rs
     
 ```
 
-## inflight.$Closure1-220cc4cd.js
+## inflight.$Closure1-1.js
 
 ```js
 module.exports = function({ $A }) {
@@ -38,7 +38,7 @@ module.exports = function({ $A }) {
 }
 ```
 
-## inflight.A-220cc4cd.js
+## inflight.A-1.js
 
 ```js
 module.exports = function({ $b }) {
@@ -71,7 +71,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.A-220cc4cd.js")({
+          require("./inflight.A-1.js")({
             $b: ${context._lift(b)},
           })
         `);
@@ -102,7 +102,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-220cc4cd.js")({
+          require("./inflight.$Closure1-1.js")({
             $A: ${context._lift(A)},
           })
         `);

--- a/libs/wingc/src/jsify/snapshots/static_local_inflight_class.snap
+++ b/libs/wingc/src/jsify/snapshots/static_local_inflight_class.snap
@@ -21,7 +21,7 @@ source: libs/wingc/src/jsify/tests.rs
     
 ```
 
-## inflight.$Closure1-220cc4cd.js
+## inflight.$Closure1-1.js
 
 ```js
 module.exports = function({  }) {
@@ -67,7 +67,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-220cc4cd.js")({
+          require("./inflight.$Closure1-1.js")({
           })
         `);
       }

--- a/libs/wingc/src/jsify/snapshots/static_on_std_type.snap
+++ b/libs/wingc/src/jsify/snapshots/static_on_std_type.snap
@@ -12,7 +12,7 @@ source: libs/wingc/src/jsify/tests.rs
     
 ```
 
-## inflight.$Closure1-220cc4cd.js
+## inflight.$Closure1-1.js
 
 ```js
 module.exports = function({ $std_Json, $std_String }) {
@@ -49,7 +49,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-220cc4cd.js")({
+          require("./inflight.$Closure1-1.js")({
             $std_Json: ${context._lift(std.Json)},
             $std_String: ${context._lift(std.String)},
           })

--- a/libs/wingc/src/jsify/snapshots/transitive_reference.snap
+++ b/libs/wingc/src/jsify/snapshots/transitive_reference.snap
@@ -32,7 +32,7 @@ source: libs/wingc/src/jsify/tests.rs
     
 ```
 
-## inflight.$Closure1-220cc4cd.js
+## inflight.$Closure1-1.js
 
 ```js
 module.exports = function({ $t }) {
@@ -50,7 +50,7 @@ module.exports = function({ $t }) {
 }
 ```
 
-## inflight.MyType-220cc4cd.js
+## inflight.MyType-1.js
 
 ```js
 module.exports = function({  }) {
@@ -90,7 +90,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.MyType-220cc4cd.js")({
+          require("./inflight.MyType-1.js")({
           })
         `);
       }
@@ -127,7 +127,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-220cc4cd.js")({
+          require("./inflight.$Closure1-1.js")({
             $t: ${context._lift(t)},
           })
         `);

--- a/libs/wingc/src/jsify/snapshots/transitive_reference_via_inflight_class.snap
+++ b/libs/wingc/src/jsify/snapshots/transitive_reference_via_inflight_class.snap
@@ -22,7 +22,7 @@ source: libs/wingc/src/jsify/tests.rs
     
 ```
 
-## inflight.$Closure1-220cc4cd.js
+## inflight.$Closure1-1.js
 
 ```js
 module.exports = function({ $MyInflightClass }) {
@@ -41,7 +41,7 @@ module.exports = function({ $MyInflightClass }) {
 }
 ```
 
-## inflight.MyInflightClass-220cc4cd.js
+## inflight.MyInflightClass-1.js
 
 ```js
 module.exports = function({ $b }) {
@@ -72,7 +72,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.MyInflightClass-220cc4cd.js")({
+          require("./inflight.MyInflightClass-1.js")({
             $b: ${context._lift(b)},
           })
         `);
@@ -103,7 +103,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-220cc4cd.js")({
+          require("./inflight.$Closure1-1.js")({
             $MyInflightClass: ${context._lift(MyInflightClass)},
           })
         `);

--- a/libs/wingc/src/jsify/snapshots/transitive_reference_via_static.snap
+++ b/libs/wingc/src/jsify/snapshots/transitive_reference_via_static.snap
@@ -28,7 +28,7 @@ source: libs/wingc/src/jsify/tests.rs
     
 ```
 
-## inflight.$Closure1-220cc4cd.js
+## inflight.$Closure1-1.js
 
 ```js
 module.exports = function({ $t }) {
@@ -46,7 +46,7 @@ module.exports = function({ $t }) {
 }
 ```
 
-## inflight.MyType-220cc4cd.js
+## inflight.MyType-1.js
 
 ```js
 module.exports = function({ $b }) {
@@ -61,7 +61,7 @@ module.exports = function({ $b }) {
 }
 ```
 
-## inflight.YourType-220cc4cd.js
+## inflight.YourType-1.js
 
 ```js
 module.exports = function({ $MyType }) {
@@ -94,7 +94,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.MyType-220cc4cd.js")({
+          require("./inflight.MyType-1.js")({
             $b: ${context._lift(b)},
           })
         `);
@@ -124,7 +124,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.YourType-220cc4cd.js")({
+          require("./inflight.YourType-1.js")({
             $MyType: ${context._lift(MyType)},
           })
         `);
@@ -155,7 +155,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-220cc4cd.js")({
+          require("./inflight.$Closure1-1.js")({
             $t: ${context._lift(t)},
           })
         `);

--- a/libs/wingc/src/jsify/snapshots/two_identical_lifts.snap
+++ b/libs/wingc/src/jsify/snapshots/two_identical_lifts.snap
@@ -18,7 +18,7 @@ source: libs/wingc/src/jsify/tests.rs
     
 ```
 
-## inflight.$Closure1-220cc4cd.js
+## inflight.$Closure1-1.js
 
 ```js
 module.exports = function({ $b }) {
@@ -59,7 +59,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-220cc4cd.js")({
+          require("./inflight.$Closure1-1.js")({
             $b: ${context._lift(b)},
           })
         `);

--- a/libs/wingc/src/jsify/snapshots/unqualified_lift_of_collection.snap
+++ b/libs/wingc/src/jsify/snapshots/unqualified_lift_of_collection.snap
@@ -13,7 +13,7 @@ source: libs/wingc/src/jsify/tests.rs
     
 ```
 
-## inflight.$Closure1-220cc4cd.js
+## inflight.$Closure1-1.js
 
 ```js
 module.exports = function({ $a }) {
@@ -49,7 +49,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-220cc4cd.js")({
+          require("./inflight.$Closure1-1.js")({
             $a: ${context._lift(a)},
           })
         `);

--- a/libs/wingc/src/jsify/snapshots/use_util_functions.snap
+++ b/libs/wingc/src/jsify/snapshots/use_util_functions.snap
@@ -11,7 +11,7 @@ source: libs/wingc/src/jsify/tests.rs
     }
 ```
 
-## inflight.$Closure1-220cc4cd.js
+## inflight.$Closure1-1.js
 
 ```js
 module.exports = function({ $util_Util }) {
@@ -48,7 +48,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-220cc4cd.js")({
+          require("./inflight.$Closure1-1.js")({
             $util_Util: ${context._lift(util.Util)},
           })
         `);

--- a/libs/wingc/src/jsify/snapshots/var_inflight_field_from_inflight.snap
+++ b/libs/wingc/src/jsify/snapshots/var_inflight_field_from_inflight.snap
@@ -18,7 +18,7 @@ source: libs/wingc/src/jsify/tests.rs
     
 ```
 
-## inflight.MyType-220cc4cd.js
+## inflight.MyType-1.js
 
 ```js
 module.exports = function({  }) {
@@ -54,7 +54,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.MyType-220cc4cd.js")({
+          require("./inflight.MyType-1.js")({
           })
         `);
       }

--- a/libs/wingc/src/jsify/snapshots/wait_util.snap
+++ b/libs/wingc/src/jsify/snapshots/wait_util.snap
@@ -15,7 +15,7 @@ source: libs/wingc/src/jsify/tests.rs
     }
 ```
 
-## inflight.$Closure1-220cc4cd.js
+## inflight.$Closure1-1.js
 
 ```js
 module.exports = function({ $util_Util }) {
@@ -56,7 +56,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-220cc4cd.js")({
+          require("./inflight.$Closure1-1.js")({
             $util_Util: ${context._lift(util.Util)},
           })
         `);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/api/delete.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/api/delete.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [delete.w](../../../../../../examples/tests/sdk_tests/api/delete.w) | compile | tf-aws
 
-## inflight.$Closure1-a341dc30.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $api_DELETE }) {
   class $Closure1 {
@@ -22,7 +22,7 @@ module.exports = function({ $api_DELETE }) {
 
 ```
 
-## inflight.$Closure2-a341dc30.js
+## inflight.$Closure2-1.js
 ```js
 module.exports = function({ $api_url, $http_DELETE, $http_Util }) {
   class $Closure2 {
@@ -258,7 +258,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-a341dc30.js")({
+          require("./inflight.$Closure1-1.js")({
             $api_DELETE: ${context._lift(api_DELETE)},
           })
         `);
@@ -294,7 +294,7 @@ class $Root extends $stdlib.std.Resource {
         }
         static _toInflightType(context) {
           return $stdlib.core.NodeJsCode.fromInline(`
-            require("./inflight.$Closure2-a341dc30.js")({
+            require("./inflight.$Closure2-1.js")({
               $api_url: ${context._lift(api.url)},
               $http_DELETE: ${context._lift(http_DELETE)},
               $http_Util: ${context._lift(http.Util)},

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/api/get.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/api/get.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [get.w](../../../../../../examples/tests/sdk_tests/api/get.w) | compile | tf-aws
 
-## inflight.$Closure1-831a9f01.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $api_GET, $body }) {
   class $Closure1 {
@@ -21,7 +21,7 @@ module.exports = function({ $api_GET, $body }) {
 
 ```
 
-## inflight.$Closure2-831a9f01.js
+## inflight.$Closure2-1.js
 ```js
 module.exports = function({ $api_url, $body, $http_GET, $http_Util }) {
   class $Closure2 {
@@ -261,7 +261,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-831a9f01.js")({
+          require("./inflight.$Closure1-1.js")({
             $api_GET: ${context._lift(api_GET)},
             $body: ${context._lift(body)},
           })
@@ -300,7 +300,7 @@ class $Root extends $stdlib.std.Resource {
         }
         static _toInflightType(context) {
           return $stdlib.core.NodeJsCode.fromInline(`
-            require("./inflight.$Closure2-831a9f01.js")({
+            require("./inflight.$Closure2-1.js")({
               $api_url: ${context._lift(api.url)},
               $body: ${context._lift(body)},
               $http_GET: ${context._lift(http_GET)},

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/api/options.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/api/options.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [options.w](../../../../../../examples/tests/sdk_tests/api/options.w) | compile | tf-aws
 
-## inflight.$Closure1-430ae1b7.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $api_OPTIONS, $path }) {
   class $Closure1 {
@@ -20,7 +20,7 @@ module.exports = function({ $api_OPTIONS, $path }) {
 
 ```
 
-## inflight.$Closure2-430ae1b7.js
+## inflight.$Closure2-1.js
 ```js
 module.exports = function({ $api_HEAD, $path }) {
   class $Closure2 {
@@ -40,7 +40,7 @@ module.exports = function({ $api_HEAD, $path }) {
 
 ```
 
-## inflight.$Closure3-430ae1b7.js
+## inflight.$Closure3-1.js
 ```js
 module.exports = function({  }) {
   class $Closure3 {
@@ -58,7 +58,7 @@ module.exports = function({  }) {
 
 ```
 
-## inflight.$Closure4-430ae1b7.js
+## inflight.$Closure4-1.js
 ```js
 module.exports = function({ $api_url, $http_HEAD, $http_OPTIONS, $http_Util, $path }) {
   class $Closure4 {
@@ -448,7 +448,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-430ae1b7.js")({
+          require("./inflight.$Closure1-1.js")({
             $api_OPTIONS: ${context._lift(api_OPTIONS)},
             $path: ${context._lift(path)},
           })
@@ -481,7 +481,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure2-430ae1b7.js")({
+          require("./inflight.$Closure2-1.js")({
             $api_HEAD: ${context._lift(api_HEAD)},
             $path: ${context._lift(path)},
           })
@@ -514,7 +514,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure3-430ae1b7.js")({
+          require("./inflight.$Closure3-1.js")({
           })
         `);
       }
@@ -549,7 +549,7 @@ class $Root extends $stdlib.std.Resource {
         }
         static _toInflightType(context) {
           return $stdlib.core.NodeJsCode.fromInline(`
-            require("./inflight.$Closure4-430ae1b7.js")({
+            require("./inflight.$Closure4-1.js")({
               $api_url: ${context._lift(api.url)},
               $http_HEAD: ${context._lift(http_HEAD)},
               $http_OPTIONS: ${context._lift(http_OPTIONS)},

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/api/patch.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/api/patch.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [patch.w](../../../../../../examples/tests/sdk_tests/api/patch.w) | compile | tf-aws
 
-## inflight.$Closure1-d24fdba0.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $_id, $api_PATCH, $body, $std_Json }) {
   class $Closure1 {
@@ -23,7 +23,7 @@ module.exports = function({ $_id, $api_PATCH, $body, $std_Json }) {
 
 ```
 
-## inflight.$Closure2-d24fdba0.js
+## inflight.$Closure2-1.js
 ```js
 module.exports = function({ $_id, $api_url, $body, $http_PATCH, $http_Util, $std_Json }) {
   class $Closure2 {
@@ -259,7 +259,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-d24fdba0.js")({
+          require("./inflight.$Closure1-1.js")({
             $_id: ${context._lift(_id)},
             $api_PATCH: ${context._lift(api_PATCH)},
             $body: ${context._lift(body)},
@@ -302,7 +302,7 @@ class $Root extends $stdlib.std.Resource {
         }
         static _toInflightType(context) {
           return $stdlib.core.NodeJsCode.fromInline(`
-            require("./inflight.$Closure2-d24fdba0.js")({
+            require("./inflight.$Closure2-1.js")({
               $_id: ${context._lift(_id)},
               $api_url: ${context._lift(api.url)},
               $body: ${context._lift(body)},

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/api/post.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/api/post.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [post.w](../../../../../../examples/tests/sdk_tests/api/post.w) | compile | tf-aws
 
-## inflight.$Closure1-2c0ae3f6.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $api_POST, $body, $std_Json }) {
   class $Closure1 {
@@ -22,7 +22,7 @@ module.exports = function({ $api_POST, $body, $std_Json }) {
 
 ```
 
-## inflight.$Closure2-2c0ae3f6.js
+## inflight.$Closure2-1.js
 ```js
 module.exports = function({ $api_url, $body, $http_POST, $http_Util, $std_Json }) {
   class $Closure2 {
@@ -258,7 +258,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-2c0ae3f6.js")({
+          require("./inflight.$Closure1-1.js")({
             $api_POST: ${context._lift(api_POST)},
             $body: ${context._lift(body)},
             $std_Json: ${context._lift(std.Json)},
@@ -298,7 +298,7 @@ class $Root extends $stdlib.std.Resource {
         }
         static _toInflightType(context) {
           return $stdlib.core.NodeJsCode.fromInline(`
-            require("./inflight.$Closure2-2c0ae3f6.js")({
+            require("./inflight.$Closure2-1.js")({
               $api_url: ${context._lift(api.url)},
               $body: ${context._lift(body)},
               $http_POST: ${context._lift(http_POST)},

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/api/put.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/api/put.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [put.w](../../../../../../examples/tests/sdk_tests/api/put.w) | compile | tf-aws
 
-## inflight.$Closure1-82fde447.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $_id, $api_PUT, $body, $std_Json, $user }) {
   class $Closure1 {
@@ -25,7 +25,7 @@ module.exports = function({ $_id, $api_PUT, $body, $std_Json, $user }) {
 
 ```
 
-## inflight.$Closure2-82fde447.js
+## inflight.$Closure2-1.js
 ```js
 module.exports = function({ $_id, $api_url, $body, $http_PUT, $http_Util, $std_Json, $user }) {
   class $Closure2 {
@@ -263,7 +263,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-82fde447.js")({
+          require("./inflight.$Closure1-1.js")({
             $_id: ${context._lift(_id)},
             $api_PUT: ${context._lift(api_PUT)},
             $body: ${context._lift(body)},
@@ -309,7 +309,7 @@ class $Root extends $stdlib.std.Resource {
         }
         static _toInflightType(context) {
           return $stdlib.core.NodeJsCode.fromInline(`
-            require("./inflight.$Closure2-82fde447.js")({
+            require("./inflight.$Closure2-1.js")({
               $_id: ${context._lift(_id)},
               $api_url: ${context._lift(api.url)},
               $body: ${context._lift(body)},

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/add_object.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/add_object.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [add_object.w](../../../../../../examples/tests/sdk_tests/bucket/add_object.w) | compile | tf-aws
 
-## inflight.$Closure1-1fe7d16f.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $b, $jsonObj1, $std_Json }) {
   class $Closure1 {
@@ -225,7 +225,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-1fe7d16f.js")({
+          require("./inflight.$Closure1-1.js")({
             $b: ${context._lift(b)},
             $jsonObj1: ${context._lift(jsonObj1)},
             $std_Json: ${context._lift(std.Json)},

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/bucket_list.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/bucket_list.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [bucket_list.w](../../../../../../examples/tests/sdk_tests/bucket/bucket_list.w) | compile | tf-aws
 
-## inflight.$Closure1-c8a7ac21.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $b }) {
   class $Closure1 {
@@ -228,7 +228,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-c8a7ac21.js")({
+          require("./inflight.$Closure1-1.js")({
             $b: ${context._lift(b)},
           })
         `);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/delete.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/delete.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [delete.w](../../../../../../examples/tests/sdk_tests/bucket/delete.w) | compile | tf-aws
 
-## inflight.$Closure1-b38ee22d.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $b }) {
   class $Closure1 {
@@ -229,7 +229,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-b38ee22d.js")({
+          require("./inflight.$Closure1-1.js")({
             $b: ${context._lift(b)},
           })
         `);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/events.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/events.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [events.w](../../../../../../examples/tests/sdk_tests/bucket/events.w) | compile | tf-aws
 
-## inflight.$Closure1-39c56500.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $idsCounter, $table }) {
   class $Closure1 {
@@ -18,7 +18,7 @@ module.exports = function({ $idsCounter, $table }) {
 
 ```
 
-## inflight.$Closure2-39c56500.js
+## inflight.$Closure2-1.js
 ```js
 module.exports = function({ $Source, $logHistory }) {
   class $Closure2 {
@@ -36,7 +36,7 @@ module.exports = function({ $Source, $logHistory }) {
 
 ```
 
-## inflight.$Closure3-39c56500.js
+## inflight.$Closure3-1.js
 ```js
 module.exports = function({ $Source, $logHistory }) {
   class $Closure3 {
@@ -54,7 +54,7 @@ module.exports = function({ $Source, $logHistory }) {
 
 ```
 
-## inflight.$Closure4-39c56500.js
+## inflight.$Closure4-1.js
 ```js
 module.exports = function({ $Source, $logHistory }) {
   class $Closure4 {
@@ -72,7 +72,7 @@ module.exports = function({ $Source, $logHistory }) {
 
 ```
 
-## inflight.$Closure5-39c56500.js
+## inflight.$Closure5-1.js
 ```js
 module.exports = function({ $Source, $logHistory }) {
   class $Closure5 {
@@ -90,7 +90,7 @@ module.exports = function({ $Source, $logHistory }) {
 
 ```
 
-## inflight.$Closure6-39c56500.js
+## inflight.$Closure6-1.js
 ```js
 module.exports = function({ $std_Duration, $util_Util }) {
   class $Closure6 {
@@ -116,7 +116,7 @@ module.exports = function({ $std_Duration, $util_Util }) {
 
 ```
 
-## inflight.$Closure7-39c56500.js
+## inflight.$Closure7-1.js
 ```js
 module.exports = function({ $table }) {
   class $Closure7 {
@@ -143,7 +143,7 @@ module.exports = function({ $table }) {
 
 ```
 
-## inflight.$Closure8-39c56500.js
+## inflight.$Closure8-1.js
 ```js
 module.exports = function({ $Source, $b, $checkHitCount, $util_Util, $wait }) {
   class $Closure8 {
@@ -1063,7 +1063,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-39c56500.js")({
+          require("./inflight.$Closure1-1.js")({
             $idsCounter: ${context._lift(idsCounter)},
             $table: ${context._lift(table)},
           })
@@ -1096,7 +1096,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure2-39c56500.js")({
+          require("./inflight.$Closure2-1.js")({
             $Source: ${context._lift(Source)},
             $logHistory: ${context._lift(logHistory)},
           })
@@ -1128,7 +1128,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure3-39c56500.js")({
+          require("./inflight.$Closure3-1.js")({
             $Source: ${context._lift(Source)},
             $logHistory: ${context._lift(logHistory)},
           })
@@ -1160,7 +1160,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure4-39c56500.js")({
+          require("./inflight.$Closure4-1.js")({
             $Source: ${context._lift(Source)},
             $logHistory: ${context._lift(logHistory)},
           })
@@ -1192,7 +1192,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure5-39c56500.js")({
+          require("./inflight.$Closure5-1.js")({
             $Source: ${context._lift(Source)},
             $logHistory: ${context._lift(logHistory)},
           })
@@ -1224,7 +1224,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure6-39c56500.js")({
+          require("./inflight.$Closure6-1.js")({
             $std_Duration: ${context._lift(std.Duration)},
             $util_Util: ${context._lift(util.Util)},
           })
@@ -1250,7 +1250,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure7-39c56500.js")({
+          require("./inflight.$Closure7-1.js")({
             $table: ${context._lift(table)},
           })
         `);
@@ -1281,7 +1281,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure8-39c56500.js")({
+          require("./inflight.$Closure8-1.js")({
             $Source: ${context._lift(Source)},
             $b: ${context._lift(b)},
             $checkHitCount: ${context._lift(checkHitCount)},

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/exists.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/exists.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [exists.w](../../../../../../examples/tests/sdk_tests/bucket/exists.w) | compile | tf-aws
 
-## inflight.$Closure1-a5de5776.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $b }) {
   class $Closure1 {
@@ -207,7 +207,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-a5de5776.js")({
+          require("./inflight.$Closure1-1.js")({
             $b: ${context._lift(b)},
           })
         `);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/public_url.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/public_url.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [public_url.w](../../../../../../examples/tests/sdk_tests/bucket/public_url.w) | compile | tf-aws
 
-## inflight.$Closure1-df86b73d.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $http_Util, $privateBucket, $publicBucket, $util_Util }) {
   class $Closure1 {
@@ -273,7 +273,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-df86b73d.js")({
+          require("./inflight.$Closure1-1.js")({
             $http_Util: ${context._lift(http.Util)},
             $privateBucket: ${context._lift(privateBucket)},
             $publicBucket: ${context._lift(publicBucket)},

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/put.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/put.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [put.w](../../../../../../examples/tests/sdk_tests/bucket/put.w) | compile | tf-aws
 
-## inflight.$Closure1-d5cee1aa.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $b }) {
   class $Closure1 {
@@ -213,7 +213,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-d5cee1aa.js")({
+          require("./inflight.$Closure1-1.js")({
             $b: ${context._lift(b)},
           })
         `);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/put_json.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/put_json.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [put_json.w](../../../../../../examples/tests/sdk_tests/bucket/put_json.w) | compile | tf-aws
 
-## inflight.$Closure1-e4a0acde.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $b }) {
   class $Closure1 {
@@ -216,7 +216,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-e4a0acde.js")({
+          require("./inflight.$Closure1-1.js")({
             $b: ${context._lift(b)},
           })
         `);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/try_delete.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/try_delete.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [try_delete.w](../../../../../../examples/tests/sdk_tests/bucket/try_delete.w) | compile | tf-aws
 
-## inflight.$Closure1-bb7670ac.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $b }) {
   class $Closure1 {
@@ -211,7 +211,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-bb7670ac.js")({
+          require("./inflight.$Closure1-1.js")({
             $b: ${context._lift(b)},
           })
         `);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/try_get.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/try_get.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [try_get.w](../../../../../../examples/tests/sdk_tests/bucket/try_get.w) | compile | tf-aws
 
-## inflight.$Closure1-9a0d3fbd.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $b }) {
   class $Closure1 {
@@ -207,7 +207,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-9a0d3fbd.js")({
+          require("./inflight.$Closure1-1.js")({
             $b: ${context._lift(b)},
           })
         `);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/try_get_json.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/try_get_json.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [try_get_json.w](../../../../../../examples/tests/sdk_tests/bucket/try_get_json.w) | compile | tf-aws
 
-## inflight.$Closure1-8e1d4bcb.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $b, $std_Json }) {
   class $Closure1 {
@@ -211,7 +211,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-8e1d4bcb.js")({
+          require("./inflight.$Closure1-1.js")({
             $b: ${context._lift(b)},
             $std_Json: ${context._lift(std.Json)},
           })

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/counter/dec.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/counter/dec.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [dec.w](../../../../../../examples/tests/sdk_tests/counter/dec.w) | compile | tf-aws
 
-## inflight.$Closure1-84e76f17.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $counter }) {
   class $Closure1 {
@@ -24,7 +24,7 @@ module.exports = function({ $counter }) {
 
 ```
 
-## inflight.$Closure2-84e76f17.js
+## inflight.$Closure2-1.js
 ```js
 module.exports = function({ $counter }) {
   class $Closure2 {
@@ -275,7 +275,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-84e76f17.js")({
+          require("./inflight.$Closure1-1.js")({
             $counter: ${context._lift(counter)},
           })
         `);
@@ -306,7 +306,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure2-84e76f17.js")({
+          require("./inflight.$Closure2-1.js")({
             $counter: ${context._lift(counter)},
           })
         `);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/counter/inc.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/counter/inc.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [inc.w](../../../../../../examples/tests/sdk_tests/counter/inc.w) | compile | tf-aws
 
-## inflight.$Closure1-a90b9e65.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $counter }) {
   class $Closure1 {
@@ -29,7 +29,7 @@ module.exports = function({ $counter }) {
 
 ```
 
-## inflight.$Closure2-a90b9e65.js
+## inflight.$Closure2-1.js
 ```js
 module.exports = function({ $counter }) {
   class $Closure2 {
@@ -285,7 +285,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-a90b9e65.js")({
+          require("./inflight.$Closure1-1.js")({
             $counter: ${context._lift(counter)},
           })
         `);
@@ -316,7 +316,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure2-a90b9e65.js")({
+          require("./inflight.$Closure2-1.js")({
             $counter: ${context._lift(counter)},
           })
         `);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/counter/initial.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/counter/initial.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [initial.w](../../../../../../examples/tests/sdk_tests/counter/initial.w) | compile | tf-aws
 
-## inflight.$Closure1-c0b8b902.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $counterA }) {
   class $Closure1 {
@@ -18,7 +18,7 @@ module.exports = function({ $counterA }) {
 
 ```
 
-## inflight.$Closure2-c0b8b902.js
+## inflight.$Closure2-1.js
 ```js
 module.exports = function({ $counterB }) {
   class $Closure2 {
@@ -36,7 +36,7 @@ module.exports = function({ $counterB }) {
 
 ```
 
-## inflight.$Closure3-c0b8b902.js
+## inflight.$Closure3-1.js
 ```js
 module.exports = function({ $counterC }) {
   class $Closure3 {
@@ -381,7 +381,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-c0b8b902.js")({
+          require("./inflight.$Closure1-1.js")({
             $counterA: ${context._lift(counterA)},
           })
         `);
@@ -412,7 +412,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure2-c0b8b902.js")({
+          require("./inflight.$Closure2-1.js")({
             $counterB: ${context._lift(counterB)},
           })
         `);
@@ -443,7 +443,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure3-c0b8b902.js")({
+          require("./inflight.$Closure3-1.js")({
             $counterC: ${context._lift(counterC)},
           })
         `);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/counter/peek.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/counter/peek.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [peek.w](../../../../../../examples/tests/sdk_tests/counter/peek.w) | compile | tf-aws
 
-## inflight.$Closure1-1121d6e2.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $c }) {
   class $Closure1 {
@@ -21,7 +21,7 @@ module.exports = function({ $c }) {
 
 ```
 
-## inflight.$Closure2-1121d6e2.js
+## inflight.$Closure2-1.js
 ```js
 module.exports = function({ $c }) {
   class $Closure2 {
@@ -269,7 +269,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-1121d6e2.js")({
+          require("./inflight.$Closure1-1.js")({
             $c: ${context._lift(c)},
           })
         `);
@@ -300,7 +300,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure2-1121d6e2.js")({
+          require("./inflight.$Closure2-1.js")({
             $c: ${context._lift(c)},
           })
         `);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/counter/set.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/counter/set.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [set.w](../../../../../../examples/tests/sdk_tests/counter/set.w) | compile | tf-aws
 
-## inflight.$Closure1-092c8d3d.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $counter }) {
   class $Closure1 {
@@ -26,7 +26,7 @@ module.exports = function({ $counter }) {
 
 ```
 
-## inflight.$Closure2-092c8d3d.js
+## inflight.$Closure2-1.js
 ```js
 module.exports = function({ $counter }) {
   class $Closure2 {
@@ -279,7 +279,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-092c8d3d.js")({
+          require("./inflight.$Closure1-1.js")({
             $counter: ${context._lift(counter)},
           })
         `);
@@ -310,7 +310,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure2-092c8d3d.js")({
+          require("./inflight.$Closure2-1.js")({
             $counter: ${context._lift(counter)},
           })
         `);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/function/invoke.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/function/invoke.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [invoke.w](../../../../../../examples/tests/sdk_tests/function/invoke.w) | compile | tf-aws
 
-## inflight.$Closure1-de711b60.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $util_Util }) {
   class $Closure1 {
@@ -21,7 +21,7 @@ module.exports = function({ $util_Util }) {
 
 ```
 
-## inflight.$Closure2-de711b60.js
+## inflight.$Closure2-1.js
 ```js
 module.exports = function({ $f }) {
   class $Closure2 {
@@ -248,7 +248,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-de711b60.js")({
+          require("./inflight.$Closure1-1.js")({
             $util_Util: ${context._lift(util.Util)},
           })
         `);
@@ -273,7 +273,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure2-de711b60.js")({
+          require("./inflight.$Closure2-1.js")({
             $f: ${context._lift(f)},
           })
         `);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/function/logging.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/function/logging.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [logging.w](../../../../../../examples/tests/sdk_tests/function/logging.w) | compile | tf-aws
 
-## inflight.$Closure1-9984c212.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({  }) {
   class $Closure1 {
@@ -18,7 +18,7 @@ module.exports = function({  }) {
 
 ```
 
-## inflight.$Closure2-9984c212.js
+## inflight.$Closure2-1.js
 ```js
 module.exports = function({ $f1 }) {
   class $Closure2 {
@@ -38,7 +38,7 @@ module.exports = function({ $f1 }) {
 
 ```
 
-## inflight.$Closure3-9984c212.js
+## inflight.$Closure3-1.js
 ```js
 module.exports = function({ $Util, $f2 }) {
   class $Closure3 {
@@ -59,7 +59,7 @@ module.exports = function({ $Util, $f2 }) {
 
 ```
 
-## inflight.Util-9984c212.js
+## inflight.Util-1.js
 ```js
 module.exports = function({  }) {
   class Util {
@@ -346,7 +346,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.Util-9984c212.js")({
+          require("./inflight.Util-1.js")({
           })
         `);
       }
@@ -370,7 +370,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-9984c212.js")({
+          require("./inflight.$Closure1-1.js")({
           })
         `);
       }
@@ -394,7 +394,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure2-9984c212.js")({
+          require("./inflight.$Closure2-1.js")({
             $f1: ${context._lift(f1)},
           })
         `);
@@ -425,7 +425,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure3-9984c212.js")({
+          require("./inflight.$Closure3-1.js")({
             $Util: ${context._lift(Util)},
             $f2: ${context._lift(f2)},
           })

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/function/memory_and_env.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/function/memory_and_env.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [memory_and_env.w](../../../../../../examples/tests/sdk_tests/function/memory_and_env.w) | compile | tf-aws
 
-## inflight.$Closure1-775c8373.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $c }) {
   class $Closure1 {
@@ -18,7 +18,7 @@ module.exports = function({ $c }) {
 
 ```
 
-## inflight.$Closure2-775c8373.js
+## inflight.$Closure2-1.js
 ```js
 module.exports = function({ $c, $util_Util }) {
   class $Closure2 {
@@ -37,7 +37,7 @@ module.exports = function({ $c, $util_Util }) {
 
 ```
 
-## inflight.$Closure3-775c8373.js
+## inflight.$Closure3-1.js
 ```js
 module.exports = function({ $c, $f1, $f2 }) {
   class $Closure3 {
@@ -401,7 +401,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-775c8373.js")({
+          require("./inflight.$Closure1-1.js")({
             $c: ${context._lift(c)},
           })
         `);
@@ -432,7 +432,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure2-775c8373.js")({
+          require("./inflight.$Closure2-1.js")({
             $c: ${context._lift(c)},
             $util_Util: ${context._lift(util.Util)},
           })
@@ -464,7 +464,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure3-775c8373.js")({
+          require("./inflight.$Closure3-1.js")({
             $c: ${context._lift(c)},
             $f1: ${context._lift(f1)},
             $f2: ${context._lift(f2)},

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/abs.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/abs.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [abs.w](../../../../../../examples/tests/sdk_tests/math/abs.w) | compile | tf-aws
 
-## inflight.$Closure1-931e59f7.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $math_Util, $x, $y }) {
   class $Closure1 {
@@ -158,7 +158,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-931e59f7.js")({
+          require("./inflight.$Closure1-1.js")({
             $math_Util: ${context._lift(math.Util)},
             $x: ${context._lift(x)},
             $y: ${context._lift(y)},

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/acos.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/acos.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [acos.w](../../../../../../examples/tests/sdk_tests/math/acos.w) | compile | tf-aws
 
-## inflight.$Closure1-062bb9d1.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $math_Util }) {
   class $Closure1 {
@@ -175,7 +175,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-062bb9d1.js")({
+          require("./inflight.$Closure1-1.js")({
             $math_Util: ${context._lift(math.Util)},
           })
         `);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/acot.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/acot.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [acot.w](../../../../../../examples/tests/sdk_tests/math/acot.w) | compile | tf-aws
 
-## inflight.$Closure1-341ae3d6.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $math_Util }) {
   class $Closure1 {
@@ -161,7 +161,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-341ae3d6.js")({
+          require("./inflight.$Closure1-1.js")({
             $math_Util: ${context._lift(math.Util)},
           })
         `);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/acsc.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/acsc.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [acsc.w](../../../../../../examples/tests/sdk_tests/math/acsc.w) | compile | tf-aws
 
-## inflight.$Closure1-bbe62bd0.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $math_Util }) {
   class $Closure1 {
@@ -168,7 +168,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-bbe62bd0.js")({
+          require("./inflight.$Closure1-1.js")({
             $math_Util: ${context._lift(math.Util)},
           })
         `);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/angular_conversion.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/angular_conversion.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [angular_conversion.w](../../../../../../examples/tests/sdk_tests/math/angular_conversion.w) | compile | tf-aws
 
-## inflight.$Closure1-b44a2ed1.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $math_Util }) {
   class $Closure1 {
@@ -168,7 +168,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-b44a2ed1.js")({
+          require("./inflight.$Closure1-1.js")({
             $math_Util: ${context._lift(math.Util)},
           })
         `);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/asec.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/asec.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [asec.w](../../../../../../examples/tests/sdk_tests/math/asec.w) | compile | tf-aws
 
-## inflight.$Closure1-891ec051.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $math_Util }) {
   class $Closure1 {
@@ -169,7 +169,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-891ec051.js")({
+          require("./inflight.$Closure1-1.js")({
             $math_Util: ${context._lift(math.Util)},
           })
         `);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/asin.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/asin.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [asin.w](../../../../../../examples/tests/sdk_tests/math/asin.w) | compile | tf-aws
 
-## inflight.$Closure1-ce0d6391.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $math_Util }) {
   class $Closure1 {
@@ -175,7 +175,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-ce0d6391.js")({
+          require("./inflight.$Closure1-1.js")({
             $math_Util: ${context._lift(math.Util)},
           })
         `);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/atan.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/atan.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [atan.w](../../../../../../examples/tests/sdk_tests/math/atan.w) | compile | tf-aws
 
-## inflight.$Closure1-92590c8d.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $math_Util }) {
   class $Closure1 {
@@ -160,7 +160,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-92590c8d.js")({
+          require("./inflight.$Closure1-1.js")({
             $math_Util: ${context._lift(math.Util)},
           })
         `);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/atan2.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/atan2.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [atan2.w](../../../../../../examples/tests/sdk_tests/math/atan2.w) | compile | tf-aws
 
-## inflight.$Closure1-9a4804d0.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $math_Util }) {
   class $Closure1 {
@@ -163,7 +163,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-9a4804d0.js")({
+          require("./inflight.$Closure1-1.js")({
             $math_Util: ${context._lift(math.Util)},
           })
         `);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/combinations.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/combinations.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [combinations.w](../../../../../../examples/tests/sdk_tests/math/combinations.w) | compile | tf-aws
 
-## inflight.$Closure1-072aad42.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $math_Util, $population, $subset }) {
   class $Closure1 {
@@ -157,7 +157,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-072aad42.js")({
+          require("./inflight.$Closure1-1.js")({
             $math_Util: ${context._lift(math.Util)},
             $population: ${context._lift(population)},
             $subset: ${context._lift(subset)},

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/cos.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/cos.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [cos.w](../../../../../../examples/tests/sdk_tests/math/cos.w) | compile | tf-aws
 
-## inflight.$Closure1-d3e87e45.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $math_Util }) {
   class $Closure1 {
@@ -162,7 +162,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-d3e87e45.js")({
+          require("./inflight.$Closure1-1.js")({
             $math_Util: ${context._lift(math.Util)},
           })
         `);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/cot.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/cot.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [cot.w](../../../../../../examples/tests/sdk_tests/math/cot.w) | compile | tf-aws
 
-## inflight.$Closure1-532c3ad2.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $math_Util }) {
   class $Closure1 {
@@ -160,7 +160,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-532c3ad2.js")({
+          require("./inflight.$Closure1-1.js")({
             $math_Util: ${context._lift(math.Util)},
           })
         `);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/csc.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/csc.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [csc.w](../../../../../../examples/tests/sdk_tests/math/csc.w) | compile | tf-aws
 
-## inflight.$Closure1-8c5fc8ea.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $math_Util }) {
   class $Closure1 {
@@ -164,7 +164,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-8c5fc8ea.js")({
+          require("./inflight.$Closure1-1.js")({
             $math_Util: ${context._lift(math.Util)},
           })
         `);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/euler.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/euler.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [euler.w](../../../../../../examples/tests/sdk_tests/math/euler.w) | compile | tf-aws
 
-## inflight.$Closure1-da112a8f.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $math_Util }) {
   class $Closure1 {
@@ -18,7 +18,7 @@ module.exports = function({ $math_Util }) {
 
 ```
 
-## inflight.$Closure2-da112a8f.js
+## inflight.$Closure2-1.js
 ```js
 module.exports = function({ $compoundOneYear, $interest, $math_Util, $value }) {
   class $Closure2 {
@@ -175,7 +175,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-da112a8f.js")({
+          require("./inflight.$Closure1-1.js")({
             $math_Util: ${context._lift(math.Util)},
           })
         `);
@@ -200,7 +200,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure2-da112a8f.js")({
+          require("./inflight.$Closure2-1.js")({
             $compoundOneYear: ${context._lift(compoundOneYear)},
             $interest: ${context._lift(interest)},
             $math_Util: ${context._lift(math.Util)},

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/factorial.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/factorial.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [factorial.w](../../../../../../examples/tests/sdk_tests/math/factorial.w) | compile | tf-aws
 
-## inflight.$Closure1-98e573ad.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $math_Util }) {
   class $Closure1 {
@@ -162,7 +162,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-98e573ad.js")({
+          require("./inflight.$Closure1-1.js")({
             $math_Util: ${context._lift(math.Util)},
           })
         `);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/fibonacci.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/fibonacci.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [fibonacci.w](../../../../../../examples/tests/sdk_tests/math/fibonacci.w) | compile | tf-aws
 
-## inflight.$Closure1-e3853de5.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $math_Util }) {
   class $Closure1 {
@@ -167,7 +167,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-e3853de5.js")({
+          require("./inflight.$Closure1-1.js")({
             $math_Util: ${context._lift(math.Util)},
           })
         `);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/floor_ceil_round.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/floor_ceil_round.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [floor_ceil_round.w](../../../../../../examples/tests/sdk_tests/math/floor_ceil_round.w) | compile | tf-aws
 
-## inflight.$Closure1-ac45e5ed.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $__x_, $__y_, $math_Util, $x, $y }) {
   class $Closure1 {
@@ -167,7 +167,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-ac45e5ed.js")({
+          require("./inflight.$Closure1-1.js")({
             $__x_: ${context._lift((-x))},
             $__y_: ${context._lift((-y))},
             $math_Util: ${context._lift(math.Util)},

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/hypot.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/hypot.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [hypot.w](../../../../../../examples/tests/sdk_tests/math/hypot.w) | compile | tf-aws
 
-## inflight.$Closure1-7ad77081.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $math_Util }) {
   class $Closure1 {
@@ -160,7 +160,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-7ad77081.js")({
+          require("./inflight.$Closure1-1.js")({
             $math_Util: ${context._lift(math.Util)},
           })
         `);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/median_mode_mean.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/median_mode_mean.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [median_mode_mean.w](../../../../../../examples/tests/sdk_tests/math/median_mode_mean.w) | compile | tf-aws
 
-## inflight.$Closure1-8a582068.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $even_arr, $math_Util, $odd_arr }) {
   class $Closure1 {
@@ -19,7 +19,7 @@ module.exports = function({ $even_arr, $math_Util, $odd_arr }) {
 
 ```
 
-## inflight.$Closure2-8a582068.js
+## inflight.$Closure2-1.js
 ```js
 module.exports = function({ $_bimodal_at_0__, $_bimodal_at_1__, $_multimodal_at_0__, $_multimodal_at_1__, $_multimodal_at_2__, $math_Util, $modal_arr }) {
   class $Closure2 {
@@ -42,7 +42,7 @@ module.exports = function({ $_bimodal_at_0__, $_bimodal_at_1__, $_multimodal_at_
 
 ```
 
-## inflight.$Closure3-8a582068.js
+## inflight.$Closure3-1.js
 ```js
 module.exports = function({ $math_Util, $mean_arr }) {
   class $Closure3 {
@@ -333,7 +333,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-8a582068.js")({
+          require("./inflight.$Closure1-1.js")({
             $even_arr: ${context._lift(even_arr)},
             $math_Util: ${context._lift(math.Util)},
             $odd_arr: ${context._lift(odd_arr)},
@@ -367,7 +367,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure2-8a582068.js")({
+          require("./inflight.$Closure2-1.js")({
             $_bimodal_at_0__: ${context._lift((bimodal.at(0)))},
             $_bimodal_at_1__: ${context._lift((bimodal.at(1)))},
             $_multimodal_at_0__: ${context._lift((multimodal.at(0)))},
@@ -409,7 +409,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure3-8a582068.js")({
+          require("./inflight.$Closure3-1.js")({
             $math_Util: ${context._lift(math.Util)},
             $mean_arr: ${context._lift(mean_arr)},
           })

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/min_max.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/min_max.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [min_max.w](../../../../../../examples/tests/sdk_tests/math/min_max.w) | compile | tf-aws
 
-## inflight.$Closure1-1c9b6073.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $math_Util, $myArray }) {
   class $Closure1 {
@@ -158,7 +158,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-1c9b6073.js")({
+          require("./inflight.$Closure1-1.js")({
             $math_Util: ${context._lift(math.Util)},
             $myArray: ${context._lift(myArray)},
           })

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/pi.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/pi.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [pi.w](../../../../../../examples/tests/sdk_tests/math/pi.w) | compile | tf-aws
 
-## inflight.$Closure1-a47f743e.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $math_Util }) {
   class $Closure1 {
@@ -18,7 +18,7 @@ module.exports = function({ $math_Util }) {
 
 ```
 
-## inflight.$Closure2-a47f743e.js
+## inflight.$Closure2-1.js
 ```js
 module.exports = function({ $circumference, $math_Util, $r }) {
   class $Closure2 {
@@ -175,7 +175,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-a47f743e.js")({
+          require("./inflight.$Closure1-1.js")({
             $math_Util: ${context._lift(math.Util)},
           })
         `);
@@ -200,7 +200,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure2-a47f743e.js")({
+          require("./inflight.$Closure2-1.js")({
             $circumference: ${context._lift(circumference)},
             $math_Util: ${context._lift(math.Util)},
             $r: ${context._lift(r)},

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/prime.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/prime.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [prime.w](../../../../../../examples/tests/sdk_tests/math/prime.w) | compile | tf-aws
 
-## inflight.$Closure1-e2f47188.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $math_Util }) {
   class $Closure1 {
@@ -163,7 +163,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-e2f47188.js")({
+          require("./inflight.$Closure1-1.js")({
             $math_Util: ${context._lift(math.Util)},
           })
         `);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/random.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/random.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [random.w](../../../../../../examples/tests/sdk_tests/math/random.w) | compile | tf-aws
 
-## inflight.$Closure1-991cb6f5.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $math_Util }) {
   class $Closure1 {
@@ -158,7 +158,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-991cb6f5.js")({
+          require("./inflight.$Closure1-1.js")({
             $math_Util: ${context._lift(math.Util)},
           })
         `);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/sec.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/sec.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [sec.w](../../../../../../examples/tests/sdk_tests/math/sec.w) | compile | tf-aws
 
-## inflight.$Closure1-370dd8b3.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $math_Util }) {
   class $Closure1 {
@@ -162,7 +162,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-370dd8b3.js")({
+          require("./inflight.$Closure1-1.js")({
             $math_Util: ${context._lift(math.Util)},
           })
         `);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/sin.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/sin.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [sin.w](../../../../../../examples/tests/sdk_tests/math/sin.w) | compile | tf-aws
 
-## inflight.$Closure1-6c080223.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $math_Util }) {
   class $Closure1 {
@@ -161,7 +161,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-6c080223.js")({
+          require("./inflight.$Closure1-1.js")({
             $math_Util: ${context._lift(math.Util)},
           })
         `);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/sqrt.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/sqrt.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [sqrt.w](../../../../../../examples/tests/sdk_tests/math/sqrt.w) | compile | tf-aws
 
-## inflight.$Closure1-664ef544.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $math_Util }) {
   class $Closure1 {
@@ -169,7 +169,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-664ef544.js")({
+          require("./inflight.$Closure1-1.js")({
             $math_Util: ${context._lift(math.Util)},
           })
         `);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/tan.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/tan.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [tan.w](../../../../../../examples/tests/sdk_tests/math/tan.w) | compile | tf-aws
 
-## inflight.$Closure1-3da2d4c1.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $math_Util }) {
   class $Closure1 {
@@ -160,7 +160,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-3da2d4c1.js")({
+          require("./inflight.$Closure1-1.js")({
             $math_Util: ${context._lift(math.Util)},
           })
         `);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/tau.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/tau.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [tau.w](../../../../../../examples/tests/sdk_tests/math/tau.w) | compile | tf-aws
 
-## inflight.$Closure1-5acd9297.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $math_Util }) {
   class $Closure1 {
@@ -160,7 +160,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-5acd9297.js")({
+          require("./inflight.$Closure1-1.js")({
             $math_Util: ${context._lift(math.Util)},
           })
         `);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/on_deploy/execute_after.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/on_deploy/execute_after.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [execute_after.w](../../../../../../examples/tests/sdk_tests/on_deploy/execute_after.w) | compile | tf-aws
 
-## inflight.$Closure1-cd076677.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $counter }) {
   class $Closure1 {
@@ -18,7 +18,7 @@ module.exports = function({ $counter }) {
 
 ```
 
-## inflight.$Closure2-cd076677.js
+## inflight.$Closure2-1.js
 ```js
 module.exports = function({ $counter }) {
   class $Closure2 {
@@ -36,7 +36,7 @@ module.exports = function({ $counter }) {
 
 ```
 
-## inflight.$Closure3-cd076677.js
+## inflight.$Closure3-1.js
 ```js
 module.exports = function({ $counter }) {
   class $Closure3 {
@@ -380,7 +380,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-cd076677.js")({
+          require("./inflight.$Closure1-1.js")({
             $counter: ${context._lift(counter)},
           })
         `);
@@ -411,7 +411,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure2-cd076677.js")({
+          require("./inflight.$Closure2-1.js")({
             $counter: ${context._lift(counter)},
           })
         `);
@@ -442,7 +442,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure3-cd076677.js")({
+          require("./inflight.$Closure3-1.js")({
             $counter: ${context._lift(counter)},
           })
         `);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/queue/pop.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/queue/pop.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [pop.w](../../../../../../examples/tests/sdk_tests/queue/pop.w) | compile | tf-aws
 
-## inflight.$Closure1-cb9e4b7a.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $NIL, $q }) {
   class $Closure1 {
@@ -178,7 +178,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-cb9e4b7a.js")({
+          require("./inflight.$Closure1-1.js")({
             $NIL: ${context._lift(NIL)},
             $q: ${context._lift(q)},
           })

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/queue/purge.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/queue/purge.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [purge.w](../../../../../../examples/tests/sdk_tests/queue/purge.w) | compile | tf-aws
 
-## inflight.$Closure1-a7d62b8e.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $q, $std_Duration, $util_Util }) {
   class $Closure1 {
@@ -193,7 +193,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-a7d62b8e.js")({
+          require("./inflight.$Closure1-1.js")({
             $q: ${context._lift(q)},
             $std_Duration: ${context._lift(std.Duration)},
             $util_Util: ${context._lift(util.Util)},

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/queue/set_consumer.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/queue/set_consumer.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [set_consumer.w](../../../../../../examples/tests/sdk_tests/queue/set_consumer.w) | compile | tf-aws
 
-## inflight.$Closure1-40ee0a8d.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $c }) {
   class $Closure1 {
@@ -18,7 +18,7 @@ module.exports = function({ $c }) {
 
 ```
 
-## inflight.$Closure2-40ee0a8d.js
+## inflight.$Closure2-1.js
 ```js
 module.exports = function({ $predicate, $q, $std_Duration, $util_Util }) {
   class $Closure2 {
@@ -47,7 +47,7 @@ module.exports = function({ $predicate, $q, $std_Duration, $util_Util }) {
 
 ```
 
-## inflight.Predicate-40ee0a8d.js
+## inflight.Predicate-1.js
 ```js
 module.exports = function({  }) {
   class Predicate {
@@ -315,7 +315,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.Predicate-40ee0a8d.js")({
+          require("./inflight.Predicate-1.js")({
           })
         `);
       }
@@ -349,7 +349,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-40ee0a8d.js")({
+          require("./inflight.$Closure1-1.js")({
             $c: ${context._lift(c)},
           })
         `);
@@ -380,7 +380,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure2-40ee0a8d.js")({
+          require("./inflight.$Closure2-1.js")({
             $predicate: ${context._lift(predicate)},
             $q: ${context._lift(q)},
             $std_Duration: ${context._lift(std.Duration)},

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/schedule/on_tick.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/schedule/on_tick.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [on_tick.w](../../../../../../examples/tests/sdk_tests/schedule/on_tick.w) | compile | tf-aws
 
-## inflight.$Closure1-fa1bf34b.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $c1 }) {
   class $Closure1 {
@@ -18,7 +18,7 @@ module.exports = function({ $c1 }) {
 
 ```
 
-## inflight.$Closure2-fa1bf34b.js
+## inflight.$Closure2-1.js
 ```js
 module.exports = function({ $c2 }) {
   class $Closure2 {
@@ -36,7 +36,7 @@ module.exports = function({ $c2 }) {
 
 ```
 
-## inflight.$Closure3-fa1bf34b.js
+## inflight.$Closure3-1.js
 ```js
 module.exports = function({ $c1, $c2, $std_Duration, $util_Util }) {
   class $Closure3 {
@@ -442,7 +442,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-fa1bf34b.js")({
+          require("./inflight.$Closure1-1.js")({
             $c1: ${context._lift(c1)},
           })
         `);
@@ -473,7 +473,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure2-fa1bf34b.js")({
+          require("./inflight.$Closure2-1.js")({
             $c2: ${context._lift(c2)},
           })
         `);
@@ -504,7 +504,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure3-fa1bf34b.js")({
+          require("./inflight.$Closure3-1.js")({
             $c1: ${context._lift(c1)},
             $c2: ${context._lift(c2)},
             $std_Duration: ${context._lift(std.Duration)},

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/std/array.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/std/array.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [array.w](../../../../../../examples/tests/sdk_tests/std/array.w) | compile | tf-aws
 
-## inflight.$Closure1-a3b40665.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({  }) {
   class $Closure1 {
@@ -19,7 +19,7 @@ module.exports = function({  }) {
 
 ```
 
-## inflight.$Closure10-a3b40665.js
+## inflight.$Closure10-1.js
 ```js
 module.exports = function({  }) {
   class $Closure10 {
@@ -41,7 +41,7 @@ module.exports = function({  }) {
 
 ```
 
-## inflight.$Closure11-a3b40665.js
+## inflight.$Closure11-1.js
 ```js
 module.exports = function({  }) {
   class $Closure11 {
@@ -62,7 +62,7 @@ module.exports = function({  }) {
 
 ```
 
-## inflight.$Closure12-a3b40665.js
+## inflight.$Closure12-1.js
 ```js
 module.exports = function({  }) {
   class $Closure12 {
@@ -83,7 +83,7 @@ module.exports = function({  }) {
 
 ```
 
-## inflight.$Closure13-a3b40665.js
+## inflight.$Closure13-1.js
 ```js
 module.exports = function({  }) {
   class $Closure13 {
@@ -104,7 +104,7 @@ module.exports = function({  }) {
 
 ```
 
-## inflight.$Closure2-a3b40665.js
+## inflight.$Closure2-1.js
 ```js
 module.exports = function({  }) {
   class $Closure2 {
@@ -123,7 +123,7 @@ module.exports = function({  }) {
 
 ```
 
-## inflight.$Closure3-a3b40665.js
+## inflight.$Closure3-1.js
 ```js
 module.exports = function({  }) {
   class $Closure3 {
@@ -150,7 +150,7 @@ module.exports = function({  }) {
 
 ```
 
-## inflight.$Closure4-a3b40665.js
+## inflight.$Closure4-1.js
 ```js
 module.exports = function({  }) {
   class $Closure4 {
@@ -173,7 +173,7 @@ module.exports = function({  }) {
 
 ```
 
-## inflight.$Closure5-a3b40665.js
+## inflight.$Closure5-1.js
 ```js
 module.exports = function({  }) {
   class $Closure5 {
@@ -198,7 +198,7 @@ module.exports = function({  }) {
 
 ```
 
-## inflight.$Closure6-a3b40665.js
+## inflight.$Closure6-1.js
 ```js
 module.exports = function({  }) {
   class $Closure6 {
@@ -221,7 +221,7 @@ module.exports = function({  }) {
 
 ```
 
-## inflight.$Closure7-a3b40665.js
+## inflight.$Closure7-1.js
 ```js
 module.exports = function({  }) {
   class $Closure7 {
@@ -241,7 +241,7 @@ module.exports = function({  }) {
 
 ```
 
-## inflight.$Closure8-a3b40665.js
+## inflight.$Closure8-1.js
 ```js
 module.exports = function({  }) {
   class $Closure8 {
@@ -261,7 +261,7 @@ module.exports = function({  }) {
 
 ```
 
-## inflight.$Closure9-a3b40665.js
+## inflight.$Closure9-1.js
 ```js
 module.exports = function({  }) {
   class $Closure9 {
@@ -1335,7 +1335,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-a3b40665.js")({
+          require("./inflight.$Closure1-1.js")({
           })
         `);
       }
@@ -1359,7 +1359,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure2-a3b40665.js")({
+          require("./inflight.$Closure2-1.js")({
           })
         `);
       }
@@ -1383,7 +1383,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure3-a3b40665.js")({
+          require("./inflight.$Closure3-1.js")({
           })
         `);
       }
@@ -1407,7 +1407,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure4-a3b40665.js")({
+          require("./inflight.$Closure4-1.js")({
           })
         `);
       }
@@ -1431,7 +1431,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure5-a3b40665.js")({
+          require("./inflight.$Closure5-1.js")({
           })
         `);
       }
@@ -1455,7 +1455,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure6-a3b40665.js")({
+          require("./inflight.$Closure6-1.js")({
           })
         `);
       }
@@ -1479,7 +1479,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure7-a3b40665.js")({
+          require("./inflight.$Closure7-1.js")({
           })
         `);
       }
@@ -1503,7 +1503,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure8-a3b40665.js")({
+          require("./inflight.$Closure8-1.js")({
           })
         `);
       }
@@ -1527,7 +1527,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure9-a3b40665.js")({
+          require("./inflight.$Closure9-1.js")({
           })
         `);
       }
@@ -1551,7 +1551,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure10-a3b40665.js")({
+          require("./inflight.$Closure10-1.js")({
           })
         `);
       }
@@ -1575,7 +1575,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure11-a3b40665.js")({
+          require("./inflight.$Closure11-1.js")({
           })
         `);
       }
@@ -1599,7 +1599,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure12-a3b40665.js")({
+          require("./inflight.$Closure12-1.js")({
           })
         `);
       }
@@ -1623,7 +1623,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure13-a3b40665.js")({
+          require("./inflight.$Closure13-1.js")({
           })
         `);
       }

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/std/bool.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/std/bool.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [bool.w](../../../../../../examples/tests/sdk_tests/std/bool.w) | compile | tf-aws
 
-## inflight.$Closure1-7166a183.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $PARSE_ERROR, $std_Boolean, $std_Json }) {
   class $Closure1 {
@@ -166,7 +166,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-7166a183.js")({
+          require("./inflight.$Closure1-1.js")({
             $PARSE_ERROR: ${context._lift(PARSE_ERROR)},
             $std_Boolean: ${context._lift(std.Boolean)},
             $std_Json: ${context._lift(std.Json)},

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/std/datetime.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/std/datetime.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [datetime.w](../../../../../../examples/tests/sdk_tests/std/datetime.w) | compile | tf-aws
 
-## inflight.$Closure1-84bbc79c.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $_d4_toUtc____hours, $d4_hours, $d4_timezone, $math_Util, $std_Datetime, $std_Duration, $util_Util }) {
   class $Closure1 {
@@ -180,7 +180,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-84bbc79c.js")({
+          require("./inflight.$Closure1-1.js")({
             $_d4_toUtc____hours: ${context._lift((d4.toUtc()).hours)},
             $d4_hours: ${context._lift(d4.hours)},
             $d4_timezone: ${context._lift(d4.timezone)},

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/std/duration.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/std/duration.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [duration.w](../../../../../../examples/tests/sdk_tests/std/duration.w) | compile | tf-aws
 
-## inflight.$Closure1-d7689ded.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $std_Duration }) {
   class $Closure1 {
@@ -175,7 +175,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-d7689ded.js")({
+          require("./inflight.$Closure1-1.js")({
             $std_Duration: ${context._lift(std.Duration)},
           })
         `);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/std/json.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/std/json.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [json.w](../../../../../../examples/tests/sdk_tests/std/json.w) | compile | tf-aws
 
-## inflight.$Closure1-532141bc.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({  }) {
   class $Closure1 {
@@ -21,7 +21,7 @@ module.exports = function({  }) {
 
 ```
 
-## inflight.$Closure2-532141bc.js
+## inflight.$Closure2-1.js
 ```js
 module.exports = function({  }) {
   class $Closure2 {
@@ -248,7 +248,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-532141bc.js")({
+          require("./inflight.$Closure1-1.js")({
           })
         `);
       }
@@ -272,7 +272,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure2-532141bc.js")({
+          require("./inflight.$Closure2-1.js")({
           })
         `);
       }

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/std/number.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/std/number.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [number.w](../../../../../../examples/tests/sdk_tests/std/number.w) | compile | tf-aws
 
-## inflight.$Closure1-8d5aabd4.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $std_Number }) {
   class $Closure1 {
@@ -18,7 +18,7 @@ module.exports = function({ $std_Number }) {
 
 ```
 
-## inflight.$Closure2-8d5aabd4.js
+## inflight.$Closure2-1.js
 ```js
 module.exports = function({ $std_Number }) {
   class $Closure2 {
@@ -240,7 +240,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-8d5aabd4.js")({
+          require("./inflight.$Closure1-1.js")({
             $std_Number: ${context._lift(std.Number)},
           })
         `);
@@ -265,7 +265,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure2-8d5aabd4.js")({
+          require("./inflight.$Closure2-1.js")({
             $std_Number: ${context._lift(std.Number)},
           })
         `);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/std/string.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/std/string.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [string.w](../../../../../../examples/tests/sdk_tests/std/string.w) | compile | tf-aws
 
-## inflight.$Closure1-f670a7f9.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $PARSE_ERROR, $std_String }) {
   class $Closure1 {
@@ -25,7 +25,7 @@ module.exports = function({ $PARSE_ERROR, $std_String }) {
 
 ```
 
-## inflight.$Closure10-f670a7f9.js
+## inflight.$Closure10-1.js
 ```js
 module.exports = function({  }) {
   class $Closure10 {
@@ -45,7 +45,7 @@ module.exports = function({  }) {
 
 ```
 
-## inflight.$Closure11-f670a7f9.js
+## inflight.$Closure11-1.js
 ```js
 module.exports = function({  }) {
   class $Closure11 {
@@ -64,7 +64,7 @@ module.exports = function({  }) {
 
 ```
 
-## inflight.$Closure12-f670a7f9.js
+## inflight.$Closure12-1.js
 ```js
 module.exports = function({  }) {
   class $Closure12 {
@@ -85,7 +85,7 @@ module.exports = function({  }) {
 
 ```
 
-## inflight.$Closure13-f670a7f9.js
+## inflight.$Closure13-1.js
 ```js
 module.exports = function({  }) {
   class $Closure13 {
@@ -105,7 +105,7 @@ module.exports = function({  }) {
 
 ```
 
-## inflight.$Closure14-f670a7f9.js
+## inflight.$Closure14-1.js
 ```js
 module.exports = function({  }) {
   class $Closure14 {
@@ -127,7 +127,7 @@ module.exports = function({  }) {
 
 ```
 
-## inflight.$Closure2-f670a7f9.js
+## inflight.$Closure2-1.js
 ```js
 module.exports = function({  }) {
   class $Closure2 {
@@ -146,7 +146,7 @@ module.exports = function({  }) {
 
 ```
 
-## inflight.$Closure3-f670a7f9.js
+## inflight.$Closure3-1.js
 ```js
 module.exports = function({ $INDEX_OUT_OF_BOUNDS_ERROR }) {
   class $Closure3 {
@@ -180,7 +180,7 @@ module.exports = function({ $INDEX_OUT_OF_BOUNDS_ERROR }) {
 
 ```
 
-## inflight.$Closure4-f670a7f9.js
+## inflight.$Closure4-1.js
 ```js
 module.exports = function({  }) {
   class $Closure4 {
@@ -198,7 +198,7 @@ module.exports = function({  }) {
 
 ```
 
-## inflight.$Closure5-f670a7f9.js
+## inflight.$Closure5-1.js
 ```js
 module.exports = function({  }) {
   class $Closure5 {
@@ -217,7 +217,7 @@ module.exports = function({  }) {
 
 ```
 
-## inflight.$Closure6-f670a7f9.js
+## inflight.$Closure6-1.js
 ```js
 module.exports = function({  }) {
   class $Closure6 {
@@ -236,7 +236,7 @@ module.exports = function({  }) {
 
 ```
 
-## inflight.$Closure7-f670a7f9.js
+## inflight.$Closure7-1.js
 ```js
 module.exports = function({  }) {
   class $Closure7 {
@@ -257,7 +257,7 @@ module.exports = function({  }) {
 
 ```
 
-## inflight.$Closure8-f670a7f9.js
+## inflight.$Closure8-1.js
 ```js
 module.exports = function({  }) {
   class $Closure8 {
@@ -278,7 +278,7 @@ module.exports = function({  }) {
 
 ```
 
-## inflight.$Closure9-f670a7f9.js
+## inflight.$Closure9-1.js
 ```js
 module.exports = function({  }) {
   class $Closure9 {
@@ -1298,7 +1298,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-f670a7f9.js")({
+          require("./inflight.$Closure1-1.js")({
             $PARSE_ERROR: ${context._lift(PARSE_ERROR)},
             $std_String: ${context._lift(std.String)},
           })
@@ -1330,7 +1330,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure2-f670a7f9.js")({
+          require("./inflight.$Closure2-1.js")({
           })
         `);
       }
@@ -1354,7 +1354,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure3-f670a7f9.js")({
+          require("./inflight.$Closure3-1.js")({
             $INDEX_OUT_OF_BOUNDS_ERROR: ${context._lift(INDEX_OUT_OF_BOUNDS_ERROR)},
           })
         `);
@@ -1385,7 +1385,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure4-f670a7f9.js")({
+          require("./inflight.$Closure4-1.js")({
           })
         `);
       }
@@ -1409,7 +1409,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure5-f670a7f9.js")({
+          require("./inflight.$Closure5-1.js")({
           })
         `);
       }
@@ -1433,7 +1433,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure6-f670a7f9.js")({
+          require("./inflight.$Closure6-1.js")({
           })
         `);
       }
@@ -1457,7 +1457,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure7-f670a7f9.js")({
+          require("./inflight.$Closure7-1.js")({
           })
         `);
       }
@@ -1481,7 +1481,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure8-f670a7f9.js")({
+          require("./inflight.$Closure8-1.js")({
           })
         `);
       }
@@ -1505,7 +1505,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure9-f670a7f9.js")({
+          require("./inflight.$Closure9-1.js")({
           })
         `);
       }
@@ -1529,7 +1529,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure10-f670a7f9.js")({
+          require("./inflight.$Closure10-1.js")({
           })
         `);
       }
@@ -1553,7 +1553,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure11-f670a7f9.js")({
+          require("./inflight.$Closure11-1.js")({
           })
         `);
       }
@@ -1577,7 +1577,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure12-f670a7f9.js")({
+          require("./inflight.$Closure12-1.js")({
           })
         `);
       }
@@ -1601,7 +1601,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure13-f670a7f9.js")({
+          require("./inflight.$Closure13-1.js")({
           })
         `);
       }
@@ -1625,7 +1625,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure14-f670a7f9.js")({
+          require("./inflight.$Closure14-1.js")({
           })
         `);
       }

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/table/add_row.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/table/add_row.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [add_row.w](../../../../../../examples/tests/sdk_tests/table/add_row.w) | compile | tf-aws
 
-## inflight.$Closure1-082294db.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $_marioInfo___gender__, $_marioInfo___role__, $_peachInfo___gender__, $_peachInfo___role__, $table }) {
   class $Closure1 {
@@ -209,7 +209,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-082294db.js")({
+          require("./inflight.$Closure1-1.js")({
             $_marioInfo___gender__: ${context._lift((marioInfo)["gender"])},
             $_marioInfo___role__: ${context._lift((marioInfo)["role"])},
             $_peachInfo___gender__: ${context._lift((peachInfo)["gender"])},

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/table/list.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/table/list.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [list.w](../../../../../../examples/tests/sdk_tests/table/list.w) | compile | tf-aws
 
-## inflight.$Closure1-7d618190.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $std_String, $table }) {
   class $Closure1 {
@@ -191,7 +191,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-7d618190.js")({
+          require("./inflight.$Closure1-1.js")({
             $std_String: ${context._lift(std.String)},
             $table: ${context._lift(table)},
           })

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/topic/on_message.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/topic/on_message.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [on_message.w](../../../../../../examples/tests/sdk_tests/topic/on_message.w) | compile | tf-aws
 
-## inflight.$Closure1-63270894.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $c }) {
   class $Closure1 {
@@ -18,7 +18,7 @@ module.exports = function({ $c }) {
 
 ```
 
-## inflight.$Closure2-63270894.js
+## inflight.$Closure2-1.js
 ```js
 module.exports = function({ $c }) {
   class $Closure2 {
@@ -36,7 +36,7 @@ module.exports = function({ $c }) {
 
 ```
 
-## inflight.$Closure3-63270894.js
+## inflight.$Closure3-1.js
 ```js
 module.exports = function({ $predicate, $std_Duration, $t, $util_Util }) {
   class $Closure3 {
@@ -66,7 +66,7 @@ module.exports = function({ $predicate, $std_Duration, $t, $util_Util }) {
 
 ```
 
-## inflight.Predicate-63270894.js
+## inflight.Predicate-1.js
 ```js
 module.exports = function({  }) {
   class Predicate {
@@ -438,7 +438,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.Predicate-63270894.js")({
+          require("./inflight.Predicate-1.js")({
           })
         `);
       }
@@ -472,7 +472,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-63270894.js")({
+          require("./inflight.$Closure1-1.js")({
             $c: ${context._lift(c)},
           })
         `);
@@ -503,7 +503,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure2-63270894.js")({
+          require("./inflight.$Closure2-1.js")({
             $c: ${context._lift(c)},
           })
         `);
@@ -534,7 +534,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure3-63270894.js")({
+          require("./inflight.$Closure3-1.js")({
             $predicate: ${context._lift(predicate)},
             $std_Duration: ${context._lift(std.Duration)},
             $t: ${context._lift(t)},

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/util/base64.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/util/base64.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [base64.w](../../../../../../examples/tests/sdk_tests/util/base64.w) | compile | tf-aws
 
-## inflight.$Closure1-a20e31be.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $util_Util }) {
   class $Closure1 {
@@ -165,7 +165,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-a20e31be.js")({
+          require("./inflight.$Closure1-1.js")({
             $util_Util: ${context._lift(util.Util)},
           })
         `);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/util/env.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/util/env.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [env.w](../../../../../../examples/tests/sdk_tests/util/env.w) | compile | tf-aws
 
-## inflight.$Closure1-3f319a77.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $NIL, $RANDOM, $util_Util }) {
   class $Closure1 {
@@ -159,7 +159,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-3f319a77.js")({
+          require("./inflight.$Closure1-1.js")({
             $NIL: ${context._lift(NIL)},
             $RANDOM: ${context._lift(RANDOM)},
             $util_Util: ${context._lift(util.Util)},

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/util/nanoid.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/util/nanoid.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [nanoid.w](../../../../../../examples/tests/sdk_tests/util/nanoid.w) | compile | tf-aws
 
-## inflight.$Closure1-893d438e.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $util_Util }) {
   class $Closure1 {
@@ -170,7 +170,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-893d438e.js")({
+          require("./inflight.$Closure1-1.js")({
             $util_Util: ${context._lift(util.Util)},
           })
         `);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/util/sha256.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/util/sha256.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [sha256.w](../../../../../../examples/tests/sdk_tests/util/sha256.w) | compile | tf-aws
 
-## inflight.$Closure1-0c6f10a9.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $util_Util }) {
   class $Closure1 {
@@ -158,7 +158,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-0c6f10a9.js")({
+          require("./inflight.$Closure1-1.js")({
             $util_Util: ${context._lift(util.Util)},
           })
         `);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/util/sleep.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/util/sleep.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [sleep.w](../../../../../../examples/tests/sdk_tests/util/sleep.w) | compile | tf-aws
 
-## inflight.$Closure1-1cfed39d.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $JSHelper, $oneHundredMiliseconds, $util_Util }) {
   class $Closure1 {
@@ -22,7 +22,7 @@ module.exports = function({ $JSHelper, $oneHundredMiliseconds, $util_Util }) {
 
 ```
 
-## inflight.JSHelper-1cfed39d.js
+## inflight.JSHelper-1.js
 ```js
 module.exports = function({  }) {
   class JSHelper {
@@ -175,7 +175,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.JSHelper-1cfed39d.js")({
+          require("./inflight.JSHelper-1.js")({
           })
         `);
       }
@@ -199,7 +199,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-1cfed39d.js")({
+          require("./inflight.$Closure1-1.js")({
             $JSHelper: ${context._lift(JSHelper)},
             $oneHundredMiliseconds: ${context._lift(oneHundredMiliseconds)},
             $util_Util: ${context._lift(util.Util)},

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/util/uuidv4.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/util/uuidv4.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [uuidv4.w](../../../../../../examples/tests/sdk_tests/util/uuidv4.w) | compile | tf-aws
 
-## inflight.$Closure1-2073181a.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $JSHelperInflight, $util_Util }) {
   class $Closure1 {
@@ -19,7 +19,7 @@ module.exports = function({ $JSHelperInflight, $util_Util }) {
 
 ```
 
-## inflight.JSHelper-2073181a.js
+## inflight.JSHelper-1.js
 ```js
 module.exports = function({  }) {
   class JSHelper {
@@ -31,7 +31,7 @@ module.exports = function({  }) {
 
 ```
 
-## inflight.JSHelperInflight-2073181a.js
+## inflight.JSHelperInflight-1.js
 ```js
 module.exports = function({  }) {
   class JSHelperInflight {
@@ -187,7 +187,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.JSHelper-2073181a.js")({
+          require("./inflight.JSHelper-1.js")({
           })
         `);
       }
@@ -210,7 +210,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.JSHelperInflight-2073181a.js")({
+          require("./inflight.JSHelperInflight-1.js")({
           })
         `);
       }
@@ -234,7 +234,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-2073181a.js")({
+          require("./inflight.$Closure1-1.js")({
             $JSHelperInflight: ${context._lift(JSHelperInflight)},
             $util_Util: ${context._lift(util.Util)},
           })

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/util/wait-until.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/util/wait-until.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [wait-until.w](../../../../../../examples/tests/sdk_tests/util/wait-until.w) | compile | tf-aws
 
-## inflight.$Closure1-6bd4ce96.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $JSHelper, $util_Util }) {
   class $Closure1 {
@@ -27,7 +27,7 @@ module.exports = function({ $JSHelper, $util_Util }) {
 
 ```
 
-## inflight.$Closure2-6bd4ce96.js
+## inflight.$Closure2-1.js
 ```js
 module.exports = function({ $JSHelper, $oneSecond, $util_Util }) {
   class $Closure2 {
@@ -54,7 +54,7 @@ module.exports = function({ $JSHelper, $oneSecond, $util_Util }) {
 
 ```
 
-## inflight.$Closure3-6bd4ce96.js
+## inflight.$Closure3-1.js
 ```js
 module.exports = function({ $JSHelper, $invokeCounter, $oneSecond, $util_Util }) {
   class $Closure3 {
@@ -84,7 +84,7 @@ module.exports = function({ $JSHelper, $invokeCounter, $oneSecond, $util_Util })
 
 ```
 
-## inflight.$Closure4-6bd4ce96.js
+## inflight.$Closure4-1.js
 ```js
 module.exports = function({ $JSHelper, $fiveSeconds, $invokeCounter, $oneSecond, $util_Util }) {
   class $Closure4 {
@@ -114,7 +114,7 @@ module.exports = function({ $JSHelper, $fiveSeconds, $invokeCounter, $oneSecond,
 
 ```
 
-## inflight.$Closure5-6bd4ce96.js
+## inflight.$Closure5-1.js
 ```js
 module.exports = function({ $invokeCounter, $util_Util }) {
   class $Closure5 {
@@ -142,7 +142,7 @@ module.exports = function({ $invokeCounter, $util_Util }) {
 
 ```
 
-## inflight.JSHelper-6bd4ce96.js
+## inflight.JSHelper-1.js
 ```js
 module.exports = function({  }) {
   class JSHelper {
@@ -582,7 +582,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.JSHelper-6bd4ce96.js")({
+          require("./inflight.JSHelper-1.js")({
           })
         `);
       }
@@ -606,7 +606,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-6bd4ce96.js")({
+          require("./inflight.$Closure1-1.js")({
             $JSHelper: ${context._lift(JSHelper)},
             $util_Util: ${context._lift(util.Util)},
           })
@@ -638,7 +638,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure2-6bd4ce96.js")({
+          require("./inflight.$Closure2-1.js")({
             $JSHelper: ${context._lift(JSHelper)},
             $oneSecond: ${context._lift(oneSecond)},
             $util_Util: ${context._lift(util.Util)},
@@ -672,7 +672,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure3-6bd4ce96.js")({
+          require("./inflight.$Closure3-1.js")({
             $JSHelper: ${context._lift(JSHelper)},
             $invokeCounter: ${context._lift(invokeCounter)},
             $oneSecond: ${context._lift(oneSecond)},
@@ -708,7 +708,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure4-6bd4ce96.js")({
+          require("./inflight.$Closure4-1.js")({
             $JSHelper: ${context._lift(JSHelper)},
             $fiveSeconds: ${context._lift(fiveSeconds)},
             $invokeCounter: ${context._lift(invokeCounter)},
@@ -746,7 +746,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure5-6bd4ce96.js")({
+          require("./inflight.$Closure5-1.js")({
             $invokeCounter: ${context._lift(invokeCounter)},
             $util_Util: ${context._lift(util.Util)},
           })

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/website/two_websites.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/website/two_websites.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [two_websites.w](../../../../../../examples/tests/sdk_tests/website/two_websites.w) | compile | tf-aws
 
-## inflight.$Closure1-a326613a.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $http_Util, $w1_url, $w2_url }) {
   class $Closure1 {
@@ -559,7 +559,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-a326613a.js")({
+          require("./inflight.$Closure1-1.js")({
             $http_Util: ${context._lift(http.Util)},
             $w1_url: ${context._lift(w1.url)},
             $w2_url: ${context._lift(w2.url)},

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/website/website.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/website/website.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [website.w](../../../../../../examples/tests/sdk_tests/website/website.w) | compile | tf-aws
 
-## inflight.$Closure1-7671e25c.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $config, $http_Util, $indexFile, $otherFile, $std_Json, $w_url }) {
   class $Closure1 {
@@ -24,7 +24,7 @@ module.exports = function({ $config, $http_Util, $indexFile, $otherFile, $std_Js
 
 ```
 
-## inflight.Util-7671e25c.js
+## inflight.Util-1.js
 ```js
 module.exports = function({  }) {
   class Util {
@@ -397,7 +397,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.Util-7671e25c.js")({
+          require("./inflight.Util-1.js")({
           })
         `);
       }
@@ -421,7 +421,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-7671e25c.js")({
+          require("./inflight.$Closure1-1.js")({
             $config: ${context._lift(config)},
             $http_Util: ${context._lift(http.Util)},
             $indexFile: ${context._lift(indexFile)},

--- a/tools/hangar/__snapshots__/test_corpus/valid/api.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/api.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [api.w](../../../../../examples/tests/valid/api.w) | compile | tf-aws
 
-## inflight.$Closure1-e9b01342.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $counter, $std_Json }) {
   class $Closure1 {
@@ -21,7 +21,7 @@ module.exports = function({ $counter, $std_Json }) {
 
 ```
 
-## inflight.$Closure2-e9b01342.js
+## inflight.$Closure2-1.js
 ```js
 module.exports = function({ $api_url }) {
   class $Closure2 {
@@ -40,7 +40,7 @@ module.exports = function({ $api_url }) {
 
 ```
 
-## inflight.$Closure3-e9b01342.js
+## inflight.$Closure3-1.js
 ```js
 module.exports = function({ $__parent_this_3_api_url }) {
   class $Closure3 {
@@ -59,7 +59,7 @@ module.exports = function({ $__parent_this_3_api_url }) {
 
 ```
 
-## inflight.A-e9b01342.js
+## inflight.A-1.js
 ```js
 module.exports = function({  }) {
   class A {
@@ -482,7 +482,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-e9b01342.js")({
+          require("./inflight.$Closure1-1.js")({
             $counter: ${context._lift(counter)},
             $std_Json: ${context._lift(std.Json)},
           })
@@ -514,7 +514,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure2-e9b01342.js")({
+          require("./inflight.$Closure2-1.js")({
             $api_url: ${context._lift(api.url)},
           })
         `);
@@ -551,7 +551,7 @@ class $Root extends $stdlib.std.Resource {
           }
           static _toInflightType(context) {
             return $stdlib.core.NodeJsCode.fromInline(`
-              require("./inflight.$Closure3-e9b01342.js")({
+              require("./inflight.$Closure3-1.js")({
                 $__parent_this_3_api_url: ${context._lift(__parent_this_3.api.url)},
               })
             `);
@@ -578,7 +578,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.A-e9b01342.js")({
+          require("./inflight.A-1.js")({
           })
         `);
       }

--- a/tools/hangar/__snapshots__/test_corpus/valid/api_path_vars.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/api_path_vars.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [api_path_vars.w](../../../../../examples/tests/valid/api_path_vars.w) | compile | tf-aws
 
-## inflight.$Closure1-b06597fe.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $std_Json }) {
   class $Closure1 {
@@ -18,7 +18,7 @@ module.exports = function({ $std_Json }) {
 
 ```
 
-## inflight.$Closure2-b06597fe.js
+## inflight.$Closure2-1.js
 ```js
 module.exports = function({ $api_url, $http_Util, $std_Json }) {
   class $Closure2 {
@@ -315,7 +315,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-b06597fe.js")({
+          require("./inflight.$Closure1-1.js")({
             $std_Json: ${context._lift(std.Json)},
           })
         `);
@@ -340,7 +340,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure2-b06597fe.js")({
+          require("./inflight.$Closure2-1.js")({
             $api_url: ${context._lift(api.url)},
             $http_Util: ${context._lift(http.Util)},
             $std_Json: ${context._lift(std.Json)},

--- a/tools/hangar/__snapshots__/test_corpus/valid/api_valid_path.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/api_valid_path.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [api_valid_path.w](../../../../../examples/tests/valid/api_valid_path.w) | compile | tf-aws
 
-## inflight.$Closure1-055654ca.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({  }) {
   class $Closure1 {
@@ -278,7 +278,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-055654ca.js")({
+          require("./inflight.$Closure1-1.js")({
           })
         `);
       }

--- a/tools/hangar/__snapshots__/test_corpus/valid/assert.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/assert.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [assert.w](../../../../../examples/tests/valid/assert.w) | compile | tf-aws
 
-## inflight.$Closure1-13109c33.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $s1, $s2 }) {
   class $Closure1 {
@@ -170,7 +170,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-13109c33.js")({
+          require("./inflight.$Closure1-1.js")({
             $s1: ${context._lift(s1)},
             $s2: ${context._lift(s2)},
           })

--- a/tools/hangar/__snapshots__/test_corpus/valid/asynchronous_model_implicit_await_in_functions.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/asynchronous_model_implicit_await_in_functions.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [asynchronous_model_implicit_await_in_functions.w](../../../../../examples/tests/valid/asynchronous_model_implicit_await_in_functions.w) | compile | tf-aws
 
-## inflight.$Closure1-4a68397a.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({  }) {
   class $Closure1 {
@@ -17,7 +17,7 @@ module.exports = function({  }) {
 
 ```
 
-## inflight.$Closure2-4a68397a.js
+## inflight.$Closure2-1.js
 ```js
 module.exports = function({ $strToStr }) {
   class $Closure2 {
@@ -253,7 +253,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-4a68397a.js")({
+          require("./inflight.$Closure1-1.js")({
           })
         `);
       }
@@ -277,7 +277,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure2-4a68397a.js")({
+          require("./inflight.$Closure2-1.js")({
             $strToStr: ${context._lift(strToStr)},
           })
         `);

--- a/tools/hangar/__snapshots__/test_corpus/valid/baz.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/baz.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [baz.w](../../../../../examples/tests/valid/baz.w) | compile | tf-aws
 
-## inflight.Baz-5dfb7457.js
+## inflight.Baz-1.js
 ```js
 module.exports = function({  }) {
   class Baz {
@@ -63,7 +63,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.Baz-5dfb7457.js")({
+          require("./inflight.Baz-1.js")({
           })
         `);
       }

--- a/tools/hangar/__snapshots__/test_corpus/valid/bring_awscdk.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/bring_awscdk.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [bring_awscdk.w](../../../../../examples/tests/valid/bring_awscdk.w) | compile | tf-aws
 
-## inflight.CdkDockerImageFunction-14bd564e.js
+## inflight.CdkDockerImageFunction-1.js
 ```js
 module.exports = function({  }) {
   class CdkDockerImageFunction {
@@ -62,7 +62,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.CdkDockerImageFunction-14bd564e.js")({
+          require("./inflight.CdkDockerImageFunction-1.js")({
           })
         `);
       }

--- a/tools/hangar/__snapshots__/test_corpus/valid/bring_cdktf.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/bring_cdktf.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [bring_cdktf.w](../../../../../examples/tests/valid/bring_cdktf.w) | compile | tf-aws
 
-## inflight.Foo-81955910.js
+## inflight.Foo-1.js
 ```js
 module.exports = function({  }) {
   class Foo {
@@ -80,7 +80,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.Foo-81955910.js")({
+          require("./inflight.Foo-1.js")({
           })
         `);
       }

--- a/tools/hangar/__snapshots__/test_corpus/valid/bring_jsii.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/bring_jsii.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [bring_jsii.w](../../../../../examples/tests/valid/bring_jsii.w) | compile | tf-aws
 
-## inflight.$Closure1-67bc8a8d.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $greeting }) {
   class $Closure1 {
@@ -158,7 +158,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-67bc8a8d.js")({
+          require("./inflight.$Closure1-1.js")({
             $greeting: ${context._lift(greeting)},
           })
         `);

--- a/tools/hangar/__snapshots__/test_corpus/valid/bring_jsii_path.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/bring_jsii_path.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [bring_jsii_path.w](../../../../../examples/tests/valid/bring_jsii_path.w) | compile | tf-aws
 
-## inflight.$Closure1-0a633ca8.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $greeting }) {
   class $Closure1 {
@@ -158,7 +158,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-0a633ca8.js")({
+          require("./inflight.$Closure1-1.js")({
             $greeting: ${context._lift(greeting)},
           })
         `);

--- a/tools/hangar/__snapshots__/test_corpus/valid/bring_local.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/bring_local.w_compile_tf-aws.md
@@ -1,24 +1,6 @@
 # [bring_local.w](../../../../../examples/tests/valid/bring_local.w) | compile | tf-aws
 
-## inflight.$Closure1-19981082.js
-```js
-module.exports = function({ $store }) {
-  class $Closure1 {
-    constructor({  }) {
-      const $obj = (...args) => this.handle(...args);
-      Object.setPrototypeOf($obj, this);
-      return $obj;
-    }
-    async handle() {
-      (await $store.store("foo"));
-    }
-  }
-  return $Closure1;
-}
-
-```
-
-## inflight.$Closure1-dd1a0085.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $__parent_this_1_b }) {
   class $Closure1 {
@@ -36,7 +18,25 @@ module.exports = function({ $__parent_this_1_b }) {
 
 ```
 
-## inflight.Q-40b852c3.js
+## inflight.$Closure1-3.js
+```js
+module.exports = function({ $store }) {
+  class $Closure1 {
+    constructor({  }) {
+      const $obj = (...args) => this.handle(...args);
+      Object.setPrototypeOf($obj, this);
+      return $obj;
+    }
+    async handle() {
+      (await $store.store("foo"));
+    }
+  }
+  return $Closure1;
+}
+
+```
+
+## inflight.Q-2.js
 ```js
 module.exports = function({  }) {
   class Q {
@@ -48,7 +48,7 @@ module.exports = function({  }) {
 
 ```
 
-## inflight.Store-dd1a0085.js
+## inflight.Store-1.js
 ```js
 module.exports = function({  }) {
   class Store {
@@ -64,7 +64,7 @@ module.exports = function({  }) {
 
 ```
 
-## inflight.Triangle-19981082.js
+## inflight.Triangle-3.js
 ```js
 module.exports = function({  }) {
   class Triangle {
@@ -76,7 +76,7 @@ module.exports = function({  }) {
 
 ```
 
-## inflight.Util-19981082.js
+## inflight.Util-1.js
 ```js
 module.exports = function({  }) {
   class Util {
@@ -88,7 +88,7 @@ module.exports = function({  }) {
 
 ```
 
-## inflight.Util-dd1a0085.js
+## inflight.Util-3.js
 ```js
 module.exports = function({  }) {
   class Util {
@@ -377,7 +377,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-19981082.js")({
+          require("./inflight.$Closure1-3.js")({
             $store: ${context._lift(store)},
           })
         `);
@@ -410,7 +410,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.Triangle-19981082.js")({
+          require("./inflight.Triangle-3.js")({
           })
         `);
       }
@@ -433,7 +433,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.Util-19981082.js")({
+          require("./inflight.Util-3.js")({
           })
         `);
       }
@@ -477,7 +477,7 @@ module.exports = function({ $stdlib }) {
     }
     static _toInflightType(context) {
       return $stdlib.core.NodeJsCode.fromInline(`
-        require("./inflight.Util-dd1a0085.js")({
+        require("./inflight.Util-1.js")({
         })
       `);
     }
@@ -507,7 +507,7 @@ module.exports = function({ $stdlib }) {
         }
         static _toInflightType(context) {
           return $stdlib.core.NodeJsCode.fromInline(`
-            require("./inflight.$Closure1-dd1a0085.js")({
+            require("./inflight.$Closure1-1.js")({
               $__parent_this_1_b: ${context._lift(__parent_this_1.b)},
             })
           `);
@@ -534,7 +534,7 @@ module.exports = function({ $stdlib }) {
     }
     static _toInflightType(context) {
       return $stdlib.core.NodeJsCode.fromInline(`
-        require("./inflight.Store-dd1a0085.js")({
+        require("./inflight.Store-1.js")({
         })
       `);
     }
@@ -585,7 +585,7 @@ module.exports = function({ $stdlib }) {
     }
     static _toInflightType(context) {
       return $stdlib.core.NodeJsCode.fromInline(`
-        require("./inflight.Q-40b852c3.js")({
+        require("./inflight.Q-2.js")({
         })
       `);
     }

--- a/tools/hangar/__snapshots__/test_corpus/valid/bring_local_normalization.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/bring_local_normalization.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [bring_local_normalization.w](../../../../../examples/tests/valid/bring_local_normalization.w) | compile | tf-aws
 
-## inflight.Bar-5db5f9ce.js
+## inflight.Bar-1.js
 ```js
 module.exports = function({  }) {
   class Bar {
@@ -12,7 +12,7 @@ module.exports = function({  }) {
 
 ```
 
-## inflight.Baz-5dfb7457.js
+## inflight.Baz-2.js
 ```js
 module.exports = function({  }) {
   class Baz {
@@ -24,7 +24,7 @@ module.exports = function({  }) {
 
 ```
 
-## inflight.Foo-3c3a1336.js
+## inflight.Foo-3.js
 ```js
 module.exports = function({  }) {
   class Foo {
@@ -82,7 +82,7 @@ module.exports = function({ $stdlib }) {
     }
     static _toInflightType(context) {
       return $stdlib.core.NodeJsCode.fromInline(`
-        require("./inflight.Bar-5db5f9ce.js")({
+        require("./inflight.Bar-1.js")({
         })
       `);
     }
@@ -117,7 +117,7 @@ module.exports = function({ $stdlib }) {
     }
     static _toInflightType(context) {
       return $stdlib.core.NodeJsCode.fromInline(`
-        require("./inflight.Baz-5dfb7457.js")({
+        require("./inflight.Baz-2.js")({
         })
       `);
     }
@@ -160,7 +160,7 @@ module.exports = function({ $stdlib }) {
     }
     static _toInflightType(context) {
       return $stdlib.core.NodeJsCode.fromInline(`
-        require("./inflight.Foo-3c3a1336.js")({
+        require("./inflight.Foo-3.js")({
         })
       `);
     }

--- a/tools/hangar/__snapshots__/test_corpus/valid/bucket_events.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/bucket_events.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [bucket_events.w](../../../../../examples/tests/valid/bucket_events.w) | compile | tf-aws
 
-## inflight.$Closure1-2e2af741.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({  }) {
   class $Closure1 {
@@ -18,7 +18,7 @@ module.exports = function({  }) {
 
 ```
 
-## inflight.$Closure2-2e2af741.js
+## inflight.$Closure2-1.js
 ```js
 module.exports = function({  }) {
   class $Closure2 {
@@ -36,7 +36,7 @@ module.exports = function({  }) {
 
 ```
 
-## inflight.$Closure3-2e2af741.js
+## inflight.$Closure3-1.js
 ```js
 module.exports = function({  }) {
   class $Closure3 {
@@ -54,7 +54,7 @@ module.exports = function({  }) {
 
 ```
 
-## inflight.$Closure4-2e2af741.js
+## inflight.$Closure4-1.js
 ```js
 module.exports = function({ $other }) {
   class $Closure4 {
@@ -72,7 +72,7 @@ module.exports = function({ $other }) {
 
 ```
 
-## inflight.$Closure5-2e2af741.js
+## inflight.$Closure5-1.js
 ```js
 module.exports = function({  }) {
   class $Closure5 {
@@ -90,7 +90,7 @@ module.exports = function({  }) {
 
 ```
 
-## inflight.$Closure6-2e2af741.js
+## inflight.$Closure6-1.js
 ```js
 module.exports = function({ $b }) {
   class $Closure6 {
@@ -1336,7 +1336,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-2e2af741.js")({
+          require("./inflight.$Closure1-1.js")({
           })
         `);
       }
@@ -1360,7 +1360,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure2-2e2af741.js")({
+          require("./inflight.$Closure2-1.js")({
           })
         `);
       }
@@ -1384,7 +1384,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure3-2e2af741.js")({
+          require("./inflight.$Closure3-1.js")({
           })
         `);
       }
@@ -1408,7 +1408,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure4-2e2af741.js")({
+          require("./inflight.$Closure4-1.js")({
             $other: ${context._lift(other)},
           })
         `);
@@ -1439,7 +1439,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure5-2e2af741.js")({
+          require("./inflight.$Closure5-1.js")({
           })
         `);
       }
@@ -1463,7 +1463,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure6-2e2af741.js")({
+          require("./inflight.$Closure6-1.js")({
             $b: ${context._lift(b)},
           })
         `);

--- a/tools/hangar/__snapshots__/test_corpus/valid/bucket_keys.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/bucket_keys.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [bucket_keys.w](../../../../../examples/tests/valid/bucket_keys.w) | compile | tf-aws
 
-## inflight.$Closure1-23a55716.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $b }) {
   class $Closure1 {
@@ -211,7 +211,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-23a55716.js")({
+          require("./inflight.$Closure1-1.js")({
             $b: ${context._lift(b)},
           })
         `);

--- a/tools/hangar/__snapshots__/test_corpus/valid/call_static_of_myself.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/call_static_of_myself.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [call_static_of_myself.w](../../../../../examples/tests/valid/call_static_of_myself.w) | compile | tf-aws
 
-## inflight.$Closure1-49cfef1d.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $Bar, $Foo, $foo }) {
   class $Closure1 {
@@ -28,7 +28,7 @@ module.exports = function({ $Bar, $Foo, $foo }) {
 
 ```
 
-## inflight.Bar-49cfef1d.js
+## inflight.Bar-1.js
 ```js
 module.exports = function({  }) {
   class Bar {
@@ -44,7 +44,7 @@ module.exports = function({  }) {
 
 ```
 
-## inflight.Foo-49cfef1d.js
+## inflight.Foo-1.js
 ```js
 module.exports = function({  }) {
   class Foo {
@@ -202,7 +202,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.Foo-49cfef1d.js")({
+          require("./inflight.Foo-1.js")({
           })
         `);
       }
@@ -225,7 +225,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.Bar-49cfef1d.js")({
+          require("./inflight.Bar-1.js")({
           })
         `);
       }
@@ -249,7 +249,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-49cfef1d.js")({
+          require("./inflight.$Closure1-1.js")({
             $Bar: ${context._lift(Bar)},
             $Foo: ${context._lift(Foo)},
             $foo: ${context._lift(foo)},

--- a/tools/hangar/__snapshots__/test_corpus/valid/calling_inflight_variants.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/calling_inflight_variants.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [calling_inflight_variants.w](../../../../../examples/tests/valid/calling_inflight_variants.w) | compile | tf-aws
 
-## inflight.$Closure1-2f095dd8.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({  }) {
   class $Closure1 {
@@ -18,7 +18,7 @@ module.exports = function({  }) {
 
 ```
 
-## inflight.$Closure2-2f095dd8.js
+## inflight.$Closure2-1.js
 ```js
 module.exports = function({ $foo }) {
   class $Closure2 {
@@ -38,7 +38,7 @@ module.exports = function({ $foo }) {
 
 ```
 
-## inflight.Foo-2f095dd8.js
+## inflight.Foo-1.js
 ```js
 module.exports = function({  }) {
   class Foo {
@@ -220,7 +220,7 @@ class $Root extends $stdlib.std.Resource {
           }
           static _toInflightType(context) {
             return $stdlib.core.NodeJsCode.fromInline(`
-              require("./inflight.$Closure1-2f095dd8.js")({
+              require("./inflight.$Closure1-1.js")({
               })
             `);
           }
@@ -240,7 +240,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.Foo-2f095dd8.js")({
+          require("./inflight.Foo-1.js")({
           })
         `);
       }
@@ -283,7 +283,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure2-2f095dd8.js")({
+          require("./inflight.$Closure2-1.js")({
             $foo: ${context._lift(foo)},
           })
         `);

--- a/tools/hangar/__snapshots__/test_corpus/valid/capture_containers.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/capture_containers.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [capture_containers.w](../../../../../examples/tests/valid/capture_containers.w) | compile | tf-aws
 
-## inflight.$Closure1-316eb35b.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $Object_keys_myMap__length, $__bang__in___arrOfMap_at_0____, $__world__in__myMap__, $_arr_at_0__, $_arr_at_1__, $_j___b__, $_mySet_has__my___, $arr_length, $mySet_size }) {
   class $Closure1 {
@@ -165,7 +165,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-316eb35b.js")({
+          require("./inflight.$Closure1-1.js")({
             $Object_keys_myMap__length: ${context._lift(Object.keys(myMap).length)},
             $__bang__in___arrOfMap_at_0____: ${context._lift(("bang" in ((arrOfMap.at(0)))))},
             $__world__in__myMap__: ${context._lift(("world" in (myMap)))},

--- a/tools/hangar/__snapshots__/test_corpus/valid/capture_in_binary.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/capture_in_binary.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [capture_in_binary.w](../../../../../examples/tests/valid/capture_in_binary.w) | compile | tf-aws
 
-## inflight.$Closure1-6675bccd.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $b, $x }) {
   class $Closure1 {
@@ -203,7 +203,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-6675bccd.js")({
+          require("./inflight.$Closure1-1.js")({
             $b: ${context._lift(b)},
             $x: ${context._lift(x)},
           })

--- a/tools/hangar/__snapshots__/test_corpus/valid/capture_mutables.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/capture_mutables.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [capture_mutables.w](../../../../../examples/tests/valid/capture_mutables.w) | compile | tf-aws
 
-## inflight.$Closure1-40b03a59.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $Object_keys_m__length, $aCloned_length, $a_length, $s_size }) {
   class $Closure1 {
@@ -21,7 +21,7 @@ module.exports = function({ $Object_keys_m__length, $aCloned_length, $a_length, 
 
 ```
 
-## inflight.$Closure2-40b03a59.js
+## inflight.$Closure2-1.js
 ```js
 module.exports = function({ $handler }) {
   class $Closure2 {
@@ -177,7 +177,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-40b03a59.js")({
+          require("./inflight.$Closure1-1.js")({
             $Object_keys_m__length: ${context._lift(Object.keys(m).length)},
             $aCloned_length: ${context._lift(aCloned.length)},
             $a_length: ${context._lift(a.length)},
@@ -214,7 +214,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure2-40b03a59.js")({
+          require("./inflight.$Closure2-1.js")({
             $handler: ${context._lift(handler)},
           })
         `);

--- a/tools/hangar/__snapshots__/test_corpus/valid/capture_primitives.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/capture_primitives.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [capture_primitives.w](../../../../../examples/tests/valid/capture_primitives.w) | compile | tf-aws
 
-## inflight.$Closure1-97dc65b1.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $myBool, $myDur_hours, $myDur_minutes, $myDur_seconds, $myNum, $mySecondBool, $myStr }) {
   class $Closure1 {
@@ -171,7 +171,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-97dc65b1.js")({
+          require("./inflight.$Closure1-1.js")({
             $myBool: ${context._lift(myBool)},
             $myDur_hours: ${context._lift(myDur.hours)},
             $myDur_minutes: ${context._lift(myDur.minutes)},

--- a/tools/hangar/__snapshots__/test_corpus/valid/capture_reassigable_class_field.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/capture_reassigable_class_field.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [capture_reassigable_class_field.w](../../../../../examples/tests/valid/capture_reassigable_class_field.w) | compile | tf-aws
 
-## inflight.$Closure1-60624ed0.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({  }) {
   class $Closure1 {
@@ -17,7 +17,7 @@ module.exports = function({  }) {
 
 ```
 
-## inflight.$Closure2-60624ed0.js
+## inflight.$Closure2-1.js
 ```js
 module.exports = function({ $counter }) {
   class $Closure2 {
@@ -35,7 +35,7 @@ module.exports = function({ $counter }) {
 
 ```
 
-## inflight.$Closure3-60624ed0.js
+## inflight.$Closure3-1.js
 ```js
 module.exports = function({ $counter, $kv, $util_Util }) {
   class $Closure3 {
@@ -65,7 +65,7 @@ module.exports = function({ $counter, $kv, $util_Util }) {
 
 ```
 
-## inflight.KeyValueStore-60624ed0.js
+## inflight.KeyValueStore-1.js
 ```js
 module.exports = function({  }) {
   class KeyValueStore {
@@ -296,7 +296,7 @@ class $Root extends $stdlib.std.Resource {
           }
           static _toInflightType(context) {
             return $stdlib.core.NodeJsCode.fromInline(`
-              require("./inflight.$Closure1-60624ed0.js")({
+              require("./inflight.$Closure1-1.js")({
               })
             `);
           }
@@ -319,7 +319,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.KeyValueStore-60624ed0.js")({
+          require("./inflight.KeyValueStore-1.js")({
           })
         `);
       }
@@ -359,7 +359,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure2-60624ed0.js")({
+          require("./inflight.$Closure2-1.js")({
             $counter: ${context._lift(counter)},
           })
         `);
@@ -390,7 +390,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure3-60624ed0.js")({
+          require("./inflight.$Closure3-1.js")({
             $counter: ${context._lift(counter)},
             $kv: ${context._lift(kv)},
             $util_Util: ${context._lift(util.Util)},

--- a/tools/hangar/__snapshots__/test_corpus/valid/capture_reassignable.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/capture_reassignable.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [capture_reassignable.w](../../../../../examples/tests/valid/capture_reassignable.w) | compile | tf-aws
 
-## inflight.$Closure1-14642631.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $x }) {
   class $Closure1 {
@@ -18,7 +18,7 @@ module.exports = function({ $x }) {
 
 ```
 
-## inflight.$Closure2-14642631.js
+## inflight.$Closure2-1.js
 ```js
 module.exports = function({ $handler }) {
   class $Closure2 {
@@ -175,7 +175,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-14642631.js")({
+          require("./inflight.$Closure1-1.js")({
             $x: ${context._lift(x)},
           })
         `);
@@ -206,7 +206,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure2-14642631.js")({
+          require("./inflight.$Closure2-1.js")({
             $handler: ${context._lift(handler)},
           })
         `);

--- a/tools/hangar/__snapshots__/test_corpus/valid/capture_resource_and_data.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/capture_resource_and_data.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [capture_resource_and_data.w](../../../../../examples/tests/valid/capture_resource_and_data.w) | compile | tf-aws
 
-## inflight.$Closure1-1d3b2101.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $data_size, $queue, $res }) {
   class $Closure1 {
@@ -216,7 +216,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-1d3b2101.js")({
+          require("./inflight.$Closure1-1.js")({
             $data_size: ${context._lift(data.size)},
             $queue: ${context._lift(queue)},
             $res: ${context._lift(res)},

--- a/tools/hangar/__snapshots__/test_corpus/valid/capture_resource_with_no_inflight.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/capture_resource_with_no_inflight.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [capture_resource_with_no_inflight.w](../../../../../examples/tests/valid/capture_resource_with_no_inflight.w) | compile | tf-aws
 
-## inflight.$Closure1-ff5cf507.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $a, $a_field }) {
   class $Closure1 {
@@ -19,7 +19,7 @@ module.exports = function({ $a, $a_field }) {
 
 ```
 
-## inflight.A-ff5cf507.js
+## inflight.A-1.js
 ```js
 module.exports = function({  }) {
   class A {
@@ -197,7 +197,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.A-ff5cf507.js")({
+          require("./inflight.A-1.js")({
           })
         `);
       }
@@ -231,7 +231,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-ff5cf507.js")({
+          require("./inflight.$Closure1-1.js")({
             $a: ${context._lift(a)},
             $a_field: ${context._lift(a.field)},
           })

--- a/tools/hangar/__snapshots__/test_corpus/valid/capture_tokens.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/capture_tokens.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [capture_tokens.w](../../../../../examples/tests/valid/capture_tokens.w) | compile | tf-aws
 
-## inflight.$Closure1-eac9abad.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $r }) {
   class $Closure1 {
@@ -18,7 +18,7 @@ module.exports = function({ $r }) {
 
 ```
 
-## inflight.$Closure2-eac9abad.js
+## inflight.$Closure2-1.js
 ```js
 module.exports = function({ $MyResource, $api_url, $url }) {
   class $Closure2 {
@@ -37,7 +37,7 @@ module.exports = function({ $MyResource, $api_url, $url }) {
 
 ```
 
-## inflight.MyResource-eac9abad.js
+## inflight.MyResource-1.js
 ```js
 module.exports = function({  }) {
   class MyResource {
@@ -359,7 +359,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.MyResource-eac9abad.js")({
+          require("./inflight.MyResource-1.js")({
           })
         `);
       }
@@ -396,7 +396,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-eac9abad.js")({
+          require("./inflight.$Closure1-1.js")({
             $r: ${context._lift(r)},
           })
         `);
@@ -427,7 +427,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure2-eac9abad.js")({
+          require("./inflight.$Closure2-1.js")({
             $MyResource: ${context._lift(MyResource)},
             $api_url: ${context._lift(api.url)},
             $url: ${context._lift(url)},

--- a/tools/hangar/__snapshots__/test_corpus/valid/captures.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/captures.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [captures.w](../../../../../examples/tests/valid/captures.w) | compile | tf-aws
 
-## inflight.$Closure1-e47f9950.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $bucket1, $bucket2, $bucket3 }) {
   class $Closure1 {
@@ -472,7 +472,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-e47f9950.js")({
+          require("./inflight.$Closure1-1.js")({
             $bucket1: ${context._lift(bucket1)},
             $bucket2: ${context._lift(bucket2)},
             $bucket3: ${context._lift(bucket3)},

--- a/tools/hangar/__snapshots__/test_corpus/valid/class.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/class.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [class.w](../../../../../examples/tests/valid/class.w) | compile | tf-aws
 
-## inflight.$Closure1-a5640aba.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $c5 }) {
   class $Closure1 {
@@ -21,7 +21,7 @@ module.exports = function({ $c5 }) {
 
 ```
 
-## inflight.$Closure2-a5640aba.js
+## inflight.$Closure2-1.js
 ```js
 module.exports = function({ $student_hrlyWage, $student_major, $student_name }) {
   class $Closure2 {
@@ -41,7 +41,7 @@ module.exports = function({ $student_hrlyWage, $student_major, $student_name }) 
 
 ```
 
-## inflight.$Closure3-a5640aba.js
+## inflight.$Closure3-1.js
 ```js
 module.exports = function({ $ta_hrlyWage }) {
   class $Closure3 {
@@ -59,7 +59,7 @@ module.exports = function({ $ta_hrlyWage }) {
 
 ```
 
-## inflight.$Closure4-a5640aba.js
+## inflight.$Closure4-1.js
 ```js
 module.exports = function({ $B }) {
   class $Closure4 {
@@ -78,7 +78,7 @@ module.exports = function({ $B }) {
 
 ```
 
-## inflight.A-a5640aba.js
+## inflight.A-1.js
 ```js
 module.exports = function({  }) {
   class A {
@@ -91,7 +91,7 @@ module.exports = function({  }) {
 
 ```
 
-## inflight.B-a5640aba.js
+## inflight.B-1.js
 ```js
 module.exports = function({ $A }) {
   class B extends $A {
@@ -104,7 +104,7 @@ module.exports = function({ $A }) {
 
 ```
 
-## inflight.Bam-a5640aba.js
+## inflight.Bam-1.js
 ```js
 module.exports = function({ $Boom }) {
   class Bam extends $Boom {
@@ -117,7 +117,7 @@ module.exports = function({ $Boom }) {
 
 ```
 
-## inflight.Bar-a5640aba.js
+## inflight.Bar-1.js
 ```js
 module.exports = function({  }) {
   class Bar {
@@ -129,7 +129,7 @@ module.exports = function({  }) {
 
 ```
 
-## inflight.Baz-a5640aba.js
+## inflight.Baz-1.js
 ```js
 module.exports = function({ $Bar }) {
   class Baz extends $Bar {
@@ -142,7 +142,7 @@ module.exports = function({ $Bar }) {
 
 ```
 
-## inflight.Boom-a5640aba.js
+## inflight.Boom-1.js
 ```js
 module.exports = function({  }) {
   class Boom {
@@ -154,7 +154,7 @@ module.exports = function({  }) {
 
 ```
 
-## inflight.C1-a5640aba.js
+## inflight.C1-1.js
 ```js
 module.exports = function({  }) {
   class C1 {
@@ -166,7 +166,7 @@ module.exports = function({  }) {
 
 ```
 
-## inflight.C2-a5640aba.js
+## inflight.C2-1.js
 ```js
 module.exports = function({  }) {
   class C2 {
@@ -178,7 +178,7 @@ module.exports = function({  }) {
 
 ```
 
-## inflight.C3-a5640aba.js
+## inflight.C3-1.js
 ```js
 module.exports = function({  }) {
   class C3 {
@@ -190,7 +190,7 @@ module.exports = function({  }) {
 
 ```
 
-## inflight.C4-a5640aba.js
+## inflight.C4-1.js
 ```js
 module.exports = function({  }) {
   class C4 {
@@ -202,7 +202,7 @@ module.exports = function({  }) {
 
 ```
 
-## inflight.C5-a5640aba.js
+## inflight.C5-1.js
 ```js
 module.exports = function({  }) {
   class C5 {
@@ -221,7 +221,7 @@ module.exports = function({  }) {
 
 ```
 
-## inflight.Foo-a5640aba.js
+## inflight.Foo-1.js
 ```js
 module.exports = function({ $Bar }) {
   class Foo extends $Bar {
@@ -236,7 +236,7 @@ module.exports = function({ $Bar }) {
 
 ```
 
-## inflight.PaidStudent-a5640aba.js
+## inflight.PaidStudent-1.js
 ```js
 module.exports = function({ $Student }) {
   class PaidStudent extends $Student {
@@ -249,7 +249,7 @@ module.exports = function({ $Student }) {
 
 ```
 
-## inflight.Person-a5640aba.js
+## inflight.Person-1.js
 ```js
 module.exports = function({  }) {
   class Person {
@@ -261,7 +261,7 @@ module.exports = function({  }) {
 
 ```
 
-## inflight.Student-a5640aba.js
+## inflight.Student-1.js
 ```js
 module.exports = function({ $Person }) {
   class Student extends $Person {
@@ -274,7 +274,7 @@ module.exports = function({ $Person }) {
 
 ```
 
-## inflight.TeacherAid-a5640aba.js
+## inflight.TeacherAid-1.js
 ```js
 module.exports = function({ $PaidStudent }) {
   class TeacherAid extends $PaidStudent {
@@ -623,7 +623,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.C1-a5640aba.js")({
+          require("./inflight.C1-1.js")({
           })
         `);
       }
@@ -647,7 +647,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.C2-a5640aba.js")({
+          require("./inflight.C2-1.js")({
           })
         `);
       }
@@ -674,7 +674,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.C3-a5640aba.js")({
+          require("./inflight.C3-1.js")({
           })
         `);
       }
@@ -700,7 +700,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.C4-a5640aba.js")({
+          require("./inflight.C4-1.js")({
           })
         `);
       }
@@ -723,7 +723,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.C5-a5640aba.js")({
+          require("./inflight.C5-1.js")({
           })
         `);
       }
@@ -747,7 +747,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-a5640aba.js")({
+          require("./inflight.$Closure1-1.js")({
             $c5: ${context._lift(c5)},
           })
         `);
@@ -778,7 +778,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.Person-a5640aba.js")({
+          require("./inflight.Person-1.js")({
           })
         `);
       }
@@ -802,7 +802,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.Student-a5640aba.js")({
+          require("./inflight.Student-1.js")({
             $Person: ${context._lift(Person)},
           })
         `);
@@ -827,7 +827,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.PaidStudent-a5640aba.js")({
+          require("./inflight.PaidStudent-1.js")({
             $Student: ${context._lift(Student)},
           })
         `);
@@ -852,7 +852,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure2-a5640aba.js")({
+          require("./inflight.$Closure2-1.js")({
             $student_hrlyWage: ${context._lift(student.hrlyWage)},
             $student_major: ${context._lift(student.major)},
             $student_name: ${context._lift(student.name)},
@@ -887,7 +887,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.TeacherAid-a5640aba.js")({
+          require("./inflight.TeacherAid-1.js")({
             $PaidStudent: ${context._lift(PaidStudent)},
           })
         `);
@@ -912,7 +912,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure3-a5640aba.js")({
+          require("./inflight.$Closure3-1.js")({
             $ta_hrlyWage: ${context._lift(ta.hrlyWage)},
           })
         `);
@@ -942,7 +942,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.A-a5640aba.js")({
+          require("./inflight.A-1.js")({
           })
         `);
       }
@@ -971,7 +971,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.B-a5640aba.js")({
+          require("./inflight.B-1.js")({
             $A: ${context._lift(A)},
           })
         `);
@@ -996,7 +996,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure4-a5640aba.js")({
+          require("./inflight.$Closure4-1.js")({
             $B: ${context._lift(B)},
           })
         `);
@@ -1020,7 +1020,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.Bar-a5640aba.js")({
+          require("./inflight.Bar-1.js")({
           })
         `);
       }
@@ -1043,7 +1043,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.Foo-a5640aba.js")({
+          require("./inflight.Foo-1.js")({
             $Bar: ${context._lift(Bar)},
           })
         `);
@@ -1067,7 +1067,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.Baz-a5640aba.js")({
+          require("./inflight.Baz-1.js")({
             $Bar: ${context._lift(Bar)},
           })
         `);
@@ -1091,7 +1091,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.Boom-a5640aba.js")({
+          require("./inflight.Boom-1.js")({
           })
         `);
       }
@@ -1114,7 +1114,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.Bam-a5640aba.js")({
+          require("./inflight.Bam-1.js")({
             $Boom: ${context._lift(Boom)},
           })
         `);

--- a/tools/hangar/__snapshots__/test_corpus/valid/closure_class.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/closure_class.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [closure_class.w](../../../../../examples/tests/valid/closure_class.w) | compile | tf-aws
 
-## inflight.$Closure1-4e52d7fc.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $fn }) {
   class $Closure1 {
@@ -19,7 +19,7 @@ module.exports = function({ $fn }) {
 
 ```
 
-## inflight.MyClosure-4e52d7fc.js
+## inflight.MyClosure-1.js
 ```js
 module.exports = function({  }) {
   class MyClosure {
@@ -177,7 +177,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.MyClosure-4e52d7fc.js")({
+          require("./inflight.MyClosure-1.js")({
           })
         `);
       }
@@ -201,7 +201,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-4e52d7fc.js")({
+          require("./inflight.$Closure1-1.js")({
             $fn: ${context._lift(fn)},
           })
         `);

--- a/tools/hangar/__snapshots__/test_corpus/valid/construct-base.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/construct-base.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [construct-base.w](../../../../../examples/tests/valid/construct-base.w) | compile | tf-aws
 
-## inflight.WingResource-6c674da9.js
+## inflight.WingResource-1.js
 ```js
 module.exports = function({  }) {
   class WingResource {
@@ -76,7 +76,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.WingResource-6c674da9.js")({
+          require("./inflight.WingResource-1.js")({
           })
         `);
       }

--- a/tools/hangar/__snapshots__/test_corpus/valid/custom_obj_id.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/custom_obj_id.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [custom_obj_id.w](../../../../../examples/tests/valid/custom_obj_id.w) | compile | tf-aws
 
-## inflight.Foo-359d998f.js
+## inflight.Foo-1.js
 ```js
 module.exports = function({  }) {
   class Foo {
@@ -60,7 +60,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.Foo-359d998f.js")({
+          require("./inflight.Foo-1.js")({
           })
         `);
       }

--- a/tools/hangar/__snapshots__/test_corpus/valid/debug_env.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/debug_env.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [debug_env.w](../../../../../examples/tests/valid/debug_env.w) | compile | tf-aws
 
-## inflight.A-a3c93f14.js
+## inflight.A-1.js
 ```js
 module.exports = function({  }) {
   class A {
@@ -62,7 +62,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.A-a3c93f14.js")({
+          require("./inflight.A-1.js")({
           })
         `);
       }

--- a/tools/hangar/__snapshots__/test_corpus/valid/deep_equality.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/deep_equality.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [deep_equality.w](../../../../../examples/tests/valid/deep_equality.w) | compile | tf-aws
 
-## inflight.$Closure1-45a58018.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $numA, $numB, $strA, $strB }) {
   class $Closure1 {
@@ -21,7 +21,7 @@ module.exports = function({ $numA, $numB, $strA, $strB }) {
 
 ```
 
-## inflight.$Closure10-45a58018.js
+## inflight.$Closure10-1.js
 ```js
 module.exports = function({ $arrayA, $arrayC }) {
   class $Closure10 {
@@ -39,7 +39,7 @@ module.exports = function({ $arrayA, $arrayC }) {
 
 ```
 
-## inflight.$Closure11-45a58018.js
+## inflight.$Closure11-1.js
 ```js
 module.exports = function({ $cat1, $cat2 }) {
   class $Closure11 {
@@ -58,7 +58,7 @@ module.exports = function({ $cat1, $cat2 }) {
 
 ```
 
-## inflight.$Closure12-45a58018.js
+## inflight.$Closure12-1.js
 ```js
 module.exports = function({ $cat1, $cat3 }) {
   class $Closure12 {
@@ -76,7 +76,7 @@ module.exports = function({ $cat1, $cat3 }) {
 
 ```
 
-## inflight.$Closure2-45a58018.js
+## inflight.$Closure2-1.js
 ```js
 module.exports = function({ $numA, $numC, $strA, $strC }) {
   class $Closure2 {
@@ -95,7 +95,7 @@ module.exports = function({ $numA, $numC, $strA, $strC }) {
 
 ```
 
-## inflight.$Closure3-45a58018.js
+## inflight.$Closure3-1.js
 ```js
 module.exports = function({ $jsonA, $jsonB }) {
   class $Closure3 {
@@ -114,7 +114,7 @@ module.exports = function({ $jsonA, $jsonB }) {
 
 ```
 
-## inflight.$Closure4-45a58018.js
+## inflight.$Closure4-1.js
 ```js
 module.exports = function({ $jsonA, $jsonC }) {
   class $Closure4 {
@@ -132,7 +132,7 @@ module.exports = function({ $jsonA, $jsonC }) {
 
 ```
 
-## inflight.$Closure5-45a58018.js
+## inflight.$Closure5-1.js
 ```js
 module.exports = function({ $new_Set_setB_, $setA }) {
   class $Closure5 {
@@ -151,7 +151,7 @@ module.exports = function({ $new_Set_setB_, $setA }) {
 
 ```
 
-## inflight.$Closure6-45a58018.js
+## inflight.$Closure6-1.js
 ```js
 module.exports = function({ $setA, $setC }) {
   class $Closure6 {
@@ -169,7 +169,7 @@ module.exports = function({ $setA, $setC }) {
 
 ```
 
-## inflight.$Closure7-45a58018.js
+## inflight.$Closure7-1.js
 ```js
 module.exports = function({ $______mapB___, $mapA }) {
   class $Closure7 {
@@ -188,7 +188,7 @@ module.exports = function({ $______mapB___, $mapA }) {
 
 ```
 
-## inflight.$Closure8-45a58018.js
+## inflight.$Closure8-1.js
 ```js
 module.exports = function({ $mapA, $mapC }) {
   class $Closure8 {
@@ -206,7 +206,7 @@ module.exports = function({ $mapA, $mapC }) {
 
 ```
 
-## inflight.$Closure9-45a58018.js
+## inflight.$Closure9-1.js
 ```js
 module.exports = function({ $_____arrayB__, $arrayA }) {
   class $Closure9 {
@@ -1089,7 +1089,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-45a58018.js")({
+          require("./inflight.$Closure1-1.js")({
             $numA: ${context._lift(numA)},
             $numB: ${context._lift(numB)},
             $strA: ${context._lift(strA)},
@@ -1126,7 +1126,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure2-45a58018.js")({
+          require("./inflight.$Closure2-1.js")({
             $numA: ${context._lift(numA)},
             $numC: ${context._lift(numC)},
             $strA: ${context._lift(strA)},
@@ -1163,7 +1163,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure3-45a58018.js")({
+          require("./inflight.$Closure3-1.js")({
             $jsonA: ${context._lift(jsonA)},
             $jsonB: ${context._lift(jsonB)},
           })
@@ -1196,7 +1196,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure4-45a58018.js")({
+          require("./inflight.$Closure4-1.js")({
             $jsonA: ${context._lift(jsonA)},
             $jsonC: ${context._lift(jsonC)},
           })
@@ -1229,7 +1229,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure5-45a58018.js")({
+          require("./inflight.$Closure5-1.js")({
             $new_Set_setB_: ${context._lift(new Set(setB))},
             $setA: ${context._lift(setA)},
           })
@@ -1262,7 +1262,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure6-45a58018.js")({
+          require("./inflight.$Closure6-1.js")({
             $setA: ${context._lift(setA)},
             $setC: ${context._lift(setC)},
           })
@@ -1295,7 +1295,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure7-45a58018.js")({
+          require("./inflight.$Closure7-1.js")({
             $______mapB___: ${context._lift(({...(mapB)}))},
             $mapA: ${context._lift(mapA)},
           })
@@ -1328,7 +1328,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure8-45a58018.js")({
+          require("./inflight.$Closure8-1.js")({
             $mapA: ${context._lift(mapA)},
             $mapC: ${context._lift(mapC)},
           })
@@ -1361,7 +1361,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure9-45a58018.js")({
+          require("./inflight.$Closure9-1.js")({
             $_____arrayB__: ${context._lift([...(arrayB)])},
             $arrayA: ${context._lift(arrayA)},
           })
@@ -1394,7 +1394,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure10-45a58018.js")({
+          require("./inflight.$Closure10-1.js")({
             $arrayA: ${context._lift(arrayA)},
             $arrayC: ${context._lift(arrayC)},
           })
@@ -1427,7 +1427,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure11-45a58018.js")({
+          require("./inflight.$Closure11-1.js")({
             $cat1: ${context._lift(cat1)},
             $cat2: ${context._lift(cat2)},
           })
@@ -1460,7 +1460,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure12-45a58018.js")({
+          require("./inflight.$Closure12-1.js")({
             $cat1: ${context._lift(cat1)},
             $cat3: ${context._lift(cat3)},
           })

--- a/tools/hangar/__snapshots__/test_corpus/valid/double_reference.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/double_reference.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [double_reference.w](../../../../../examples/tests/valid/double_reference.w) | compile | tf-aws
 
-## inflight.$Closure1-265ad9b3.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $bar, $bar_foo, $initCount }) {
   class $Closure1 {
@@ -20,7 +20,7 @@ module.exports = function({ $bar, $bar_foo, $initCount }) {
 
 ```
 
-## inflight.Bar-265ad9b3.js
+## inflight.Bar-1.js
 ```js
 module.exports = function({  }) {
   class Bar {
@@ -36,7 +36,7 @@ module.exports = function({  }) {
 
 ```
 
-## inflight.Foo-265ad9b3.js
+## inflight.Foo-1.js
 ```js
 module.exports = function({ $initCount }) {
   class Foo {
@@ -211,7 +211,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.Foo-265ad9b3.js")({
+          require("./inflight.Foo-1.js")({
             $initCount: ${context._lift(initCount)},
           })
         `);
@@ -242,7 +242,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.Bar-265ad9b3.js")({
+          require("./inflight.Bar-1.js")({
           })
         `);
       }
@@ -276,7 +276,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-265ad9b3.js")({
+          require("./inflight.$Closure1-1.js")({
             $bar: ${context._lift(bar)},
             $bar_foo: ${context._lift(bar.foo)},
             $initCount: ${context._lift(initCount)},

--- a/tools/hangar/__snapshots__/test_corpus/valid/doubler.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/doubler.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [doubler.w](../../../../../examples/tests/valid/doubler.w) | compile | tf-aws
 
-## inflight.$Closure1-c3c49216.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({  }) {
   class $Closure1 {
@@ -18,7 +18,7 @@ module.exports = function({  }) {
 
 ```
 
-## inflight.$Closure2-c3c49216.js
+## inflight.$Closure2-1.js
 ```js
 module.exports = function({ $handler, $std_Json, $std_Number }) {
   class $Closure2 {
@@ -39,7 +39,7 @@ module.exports = function({ $handler, $std_Json, $std_Number }) {
 
 ```
 
-## inflight.$Closure3-c3c49216.js
+## inflight.$Closure3-1.js
 ```js
 module.exports = function({  }) {
   class $Closure3 {
@@ -57,7 +57,7 @@ module.exports = function({  }) {
 
 ```
 
-## inflight.$Closure4-c3c49216.js
+## inflight.$Closure4-1.js
 ```js
 module.exports = function({ $f }) {
   class $Closure4 {
@@ -76,7 +76,7 @@ module.exports = function({ $f }) {
 
 ```
 
-## inflight.Doubler-c3c49216.js
+## inflight.Doubler-1.js
 ```js
 module.exports = function({  }) {
   class Doubler {
@@ -93,7 +93,7 @@ module.exports = function({  }) {
 
 ```
 
-## inflight.Doubler2-c3c49216.js
+## inflight.Doubler2-1.js
 ```js
 module.exports = function({  }) {
   class Doubler2 {
@@ -311,7 +311,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.Doubler-c3c49216.js")({
+          require("./inflight.Doubler-1.js")({
           })
         `);
       }
@@ -345,7 +345,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-c3c49216.js")({
+          require("./inflight.$Closure1-1.js")({
           })
         `);
       }
@@ -376,7 +376,7 @@ class $Root extends $stdlib.std.Resource {
           }
           static _toInflightType(context) {
             return $stdlib.core.NodeJsCode.fromInline(`
-              require("./inflight.$Closure2-c3c49216.js")({
+              require("./inflight.$Closure2-1.js")({
                 $handler: ${context._lift(handler)},
                 $std_Json: ${context._lift(std.Json)},
                 $std_Number: ${context._lift(std.Number)},
@@ -405,7 +405,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.Doubler2-c3c49216.js")({
+          require("./inflight.Doubler2-1.js")({
           })
         `);
       }
@@ -429,7 +429,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure3-c3c49216.js")({
+          require("./inflight.$Closure3-1.js")({
           })
         `);
       }
@@ -453,7 +453,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure4-c3c49216.js")({
+          require("./inflight.$Closure4-1.js")({
             $f: ${context._lift(f)},
           })
         `);

--- a/tools/hangar/__snapshots__/test_corpus/valid/enums.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/enums.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [enums.w](../../../../../examples/tests/valid/enums.w) | compile | tf-aws
 
-## inflight.$Closure1-4bebe83f.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $SomeEnum, $one, $two }) {
   class $Closure1 {
@@ -157,7 +157,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-4bebe83f.js")({
+          require("./inflight.$Closure1-1.js")({
             $SomeEnum: ${context._lift(SomeEnum)},
             $one: ${context._lift(one)},
             $two: ${context._lift(two)},

--- a/tools/hangar/__snapshots__/test_corpus/valid/extern_implementation.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/extern_implementation.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [extern_implementation.w](../../../../../examples/tests/valid/extern_implementation.w) | compile | tf-aws
 
-## inflight.$Closure1-38b38cb4.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $f }) {
   class $Closure1 {
@@ -18,7 +18,7 @@ module.exports = function({ $f }) {
 
 ```
 
-## inflight.$Closure2-38b38cb4.js
+## inflight.$Closure2-1.js
 ```js
 module.exports = function({ $f }) {
   class $Closure2 {
@@ -36,7 +36,7 @@ module.exports = function({ $f }) {
 
 ```
 
-## inflight.Foo-38b38cb4.js
+## inflight.Foo-1.js
 ```js
 module.exports = function({  }) {
   class Foo {
@@ -276,7 +276,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.Foo-38b38cb4.js")({
+          require("./inflight.Foo-1.js")({
           })
         `);
       }
@@ -300,7 +300,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-38b38cb4.js")({
+          require("./inflight.$Closure1-1.js")({
             $f: ${context._lift(f)},
           })
         `);
@@ -331,7 +331,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure2-38b38cb4.js")({
+          require("./inflight.$Closure2-1.js")({
             $f: ${context._lift(f)},
           })
         `);

--- a/tools/hangar/__snapshots__/test_corpus/valid/file_counter.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/file_counter.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [file_counter.w](../../../../../examples/tests/valid/file_counter.w) | compile | tf-aws
 
-## inflight.$Closure1-843a9f01.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $bucket, $counter }) {
   class $Closure1 {
@@ -248,7 +248,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-843a9f01.js")({
+          require("./inflight.$Closure1-1.js")({
             $bucket: ${context._lift(bucket)},
             $counter: ${context._lift(counter)},
           })

--- a/tools/hangar/__snapshots__/test_corpus/valid/for_loop.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/for_loop.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [for_loop.w](../../../../../examples/tests/valid/for_loop.w) | compile | tf-aws
 
-## inflight.$Closure1-49e58b70.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({  }) {
   class $Closure1 {
@@ -22,7 +22,7 @@ module.exports = function({  }) {
 
 ```
 
-## inflight.Foo-49e58b70.js
+## inflight.Foo-1.js
 ```js
 module.exports = function({  }) {
   class Foo {
@@ -178,7 +178,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-49e58b70.js")({
+          require("./inflight.$Closure1-1.js")({
           })
         `);
       }
@@ -201,7 +201,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.Foo-49e58b70.js")({
+          require("./inflight.Foo-1.js")({
           })
         `);
       }

--- a/tools/hangar/__snapshots__/test_corpus/valid/forward_decl.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/forward_decl.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [forward_decl.w](../../../../../examples/tests/valid/forward_decl.w) | compile | tf-aws
 
-## inflight.R-f4ac3af3.js
+## inflight.R-1.js
 ```js
 module.exports = function({  }) {
   class R {
@@ -68,7 +68,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.R-f4ac3af3.js")({
+          require("./inflight.R-1.js")({
           })
         `);
       }

--- a/tools/hangar/__snapshots__/test_corpus/valid/function_returns_function.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/function_returns_function.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [function_returns_function.w](../../../../../examples/tests/valid/function_returns_function.w) | compile | tf-aws
 
-## inflight.$Closure1-f1181706.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({  }) {
   class $Closure1 {
@@ -167,7 +167,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-f1181706.js")({
+          require("./inflight.$Closure1-1.js")({
           })
         `);
       }

--- a/tools/hangar/__snapshots__/test_corpus/valid/function_type.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/function_type.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [function_type.w](../../../../../examples/tests/valid/function_type.w) | compile | tf-aws
 
-## inflight.$Closure1-66090bc9.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({  }) {
   class $Closure1 {
@@ -17,7 +17,7 @@ module.exports = function({  }) {
 
 ```
 
-## inflight.$Closure2-66090bc9.js
+## inflight.$Closure2-1.js
 ```js
 module.exports = function({  }) {
   class $Closure2 {
@@ -34,7 +34,7 @@ module.exports = function({  }) {
 
 ```
 
-## inflight.C-66090bc9.js
+## inflight.C-1.js
 ```js
 module.exports = function({  }) {
   class C {
@@ -99,7 +99,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-66090bc9.js")({
+          require("./inflight.$Closure1-1.js")({
           })
         `);
       }
@@ -123,7 +123,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure2-66090bc9.js")({
+          require("./inflight.$Closure2-1.js")({
           })
         `);
       }
@@ -150,7 +150,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.C-66090bc9.js")({
+          require("./inflight.C-1.js")({
           })
         `);
       }

--- a/tools/hangar/__snapshots__/test_corpus/valid/hello.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/hello.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [hello.w](../../../../../examples/tests/valid/hello.w) | compile | tf-aws
 
-## inflight.$Closure1-9e2c94b6.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $bucket }) {
   class $Closure1 {
@@ -225,7 +225,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-9e2c94b6.js")({
+          require("./inflight.$Closure1-1.js")({
             $bucket: ${context._lift(bucket)},
           })
         `);

--- a/tools/hangar/__snapshots__/test_corpus/valid/identical_inflights.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/identical_inflights.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [identical_inflights.w](../../../../../examples/tests/valid/identical_inflights.w) | compile | tf-aws
 
-## inflight.$Closure1-66fbcf5a.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({  }) {
   class $Closure1 {
@@ -17,7 +17,7 @@ module.exports = function({  }) {
 
 ```
 
-## inflight.$Closure2-66fbcf5a.js
+## inflight.$Closure2-1.js
 ```js
 module.exports = function({  }) {
   class $Closure2 {
@@ -83,7 +83,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-66fbcf5a.js")({
+          require("./inflight.$Closure1-1.js")({
           })
         `);
       }
@@ -107,7 +107,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure2-66fbcf5a.js")({
+          require("./inflight.$Closure2-1.js")({
           })
         `);
       }

--- a/tools/hangar/__snapshots__/test_corpus/valid/impl_interface.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/impl_interface.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [impl_interface.w](../../../../../examples/tests/valid/impl_interface.w) | compile | tf-aws
 
-## inflight.$Closure1-7c38e052.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $x }) {
   class $Closure1 {
@@ -18,7 +18,7 @@ module.exports = function({ $x }) {
 
 ```
 
-## inflight.A-7c38e052.js
+## inflight.A-1.js
 ```js
 module.exports = function({  }) {
   class A {
@@ -36,7 +36,7 @@ module.exports = function({  }) {
 
 ```
 
-## inflight.Dog-7c38e052.js
+## inflight.Dog-1.js
 ```js
 module.exports = function({  }) {
   class Dog {
@@ -51,7 +51,7 @@ module.exports = function({  }) {
 
 ```
 
-## inflight.Terrier-7c38e052.js
+## inflight.Terrier-1.js
 ```js
 module.exports = function({ $Dog }) {
   class Terrier extends $Dog {
@@ -67,7 +67,7 @@ module.exports = function({ $Dog }) {
 
 ```
 
-## inflight.r-7c38e052.js
+## inflight.r-1.js
 ```js
 module.exports = function({  }) {
   class r {
@@ -131,7 +131,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.A-7c38e052.js")({
+          require("./inflight.A-1.js")({
           })
         `);
       }
@@ -155,7 +155,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-7c38e052.js")({
+          require("./inflight.$Closure1-1.js")({
             $x: ${context._lift(x)},
           })
         `);
@@ -191,7 +191,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.r-7c38e052.js")({
+          require("./inflight.r-1.js")({
           })
         `);
       }
@@ -214,7 +214,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.Dog-7c38e052.js")({
+          require("./inflight.Dog-1.js")({
           })
         `);
       }
@@ -237,7 +237,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.Terrier-7c38e052.js")({
+          require("./inflight.Terrier-1.js")({
             $Dog: ${context._lift(Dog)},
           })
         `);

--- a/tools/hangar/__snapshots__/test_corpus/valid/inference.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/inference.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [inference.w](../../../../../examples/tests/valid/inference.w) | compile | tf-aws
 
-## inflight.$Closure1-f249137d.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({  }) {
   class $Closure1 {
@@ -226,7 +226,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-f249137d.js")({
+          require("./inflight.$Closure1-1.js")({
           })
         `);
       }

--- a/tools/hangar/__snapshots__/test_corpus/valid/inflight-subscribers.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/inflight-subscribers.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [inflight-subscribers.w](../../../../../examples/tests/valid/inflight-subscribers.w) | compile | tf-aws
 
-## inflight.$Closure1-6aaf9eb5.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({  }) {
   class $Closure1 {
@@ -18,7 +18,7 @@ module.exports = function({  }) {
 
 ```
 
-## inflight.$Closure2-6aaf9eb5.js
+## inflight.$Closure2-1.js
 ```js
 module.exports = function({  }) {
   class $Closure2 {
@@ -303,7 +303,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-6aaf9eb5.js")({
+          require("./inflight.$Closure1-1.js")({
           })
         `);
       }
@@ -327,7 +327,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure2-6aaf9eb5.js")({
+          require("./inflight.$Closure2-1.js")({
           })
         `);
       }

--- a/tools/hangar/__snapshots__/test_corpus/valid/inflight_capture_static.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/inflight_capture_static.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [inflight_capture_static.w](../../../../../examples/tests/valid/inflight_capture_static.w) | compile | tf-aws
 
-## inflight.$Closure1-caeda159.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $Preflight }) {
   class $Closure1 {
@@ -18,7 +18,7 @@ module.exports = function({ $Preflight }) {
 
 ```
 
-## inflight.$Closure2-caeda159.js
+## inflight.$Closure2-1.js
 ```js
 module.exports = function({ $OuterInflight }) {
   class $Closure2 {
@@ -36,7 +36,7 @@ module.exports = function({ $OuterInflight }) {
 
 ```
 
-## inflight.$Closure3-caeda159.js
+## inflight.$Closure3-1.js
 ```js
 module.exports = function({  }) {
   class $Closure3 {
@@ -59,7 +59,7 @@ module.exports = function({  }) {
 
 ```
 
-## inflight.$Closure4-caeda159.js
+## inflight.$Closure4-1.js
 ```js
 module.exports = function({ $util_Util }) {
   class $Closure4 {
@@ -86,7 +86,7 @@ module.exports = function({ $util_Util }) {
 
 ```
 
-## inflight.OuterInflight-caeda159.js
+## inflight.OuterInflight-1.js
 ```js
 module.exports = function({  }) {
   class OuterInflight {
@@ -99,7 +99,7 @@ module.exports = function({  }) {
 
 ```
 
-## inflight.Preflight-caeda159.js
+## inflight.Preflight-1.js
 ```js
 module.exports = function({  }) {
   class Preflight {
@@ -450,7 +450,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.Preflight-caeda159.js")({
+          require("./inflight.Preflight-1.js")({
           })
         `);
       }
@@ -473,7 +473,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.OuterInflight-caeda159.js")({
+          require("./inflight.OuterInflight-1.js")({
           })
         `);
       }
@@ -497,7 +497,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-caeda159.js")({
+          require("./inflight.$Closure1-1.js")({
             $Preflight: ${context._lift(Preflight)},
           })
         `);
@@ -528,7 +528,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure2-caeda159.js")({
+          require("./inflight.$Closure2-1.js")({
             $OuterInflight: ${context._lift(OuterInflight)},
           })
         `);
@@ -553,7 +553,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure3-caeda159.js")({
+          require("./inflight.$Closure3-1.js")({
           })
         `);
       }
@@ -577,7 +577,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure4-caeda159.js")({
+          require("./inflight.$Closure4-1.js")({
             $util_Util: ${context._lift(util.Util)},
           })
         `);

--- a/tools/hangar/__snapshots__/test_corpus/valid/inflight_class_as_struct_members.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/inflight_class_as_struct_members.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [inflight_class_as_struct_members.w](../../../../../examples/tests/valid/inflight_class_as_struct_members.w) | compile | tf-aws
 
-## inflight.$Closure1-476fa6d4.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $Foo }) {
   class $Closure1 {
@@ -18,7 +18,7 @@ module.exports = function({ $Foo }) {
 
 ```
 
-## inflight.$Closure2-476fa6d4.js
+## inflight.$Closure2-1.js
 ```js
 module.exports = function({ $getBar }) {
   class $Closure2 {
@@ -37,7 +37,7 @@ module.exports = function({ $getBar }) {
 
 ```
 
-## inflight.Foo-476fa6d4.js
+## inflight.Foo-1.js
 ```js
 module.exports = function({  }) {
   class Foo {
@@ -187,7 +187,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.Foo-476fa6d4.js")({
+          require("./inflight.Foo-1.js")({
           })
         `);
       }
@@ -211,7 +211,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-476fa6d4.js")({
+          require("./inflight.$Closure1-1.js")({
             $Foo: ${context._lift(Foo)},
           })
         `);
@@ -236,7 +236,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure2-476fa6d4.js")({
+          require("./inflight.$Closure2-1.js")({
             $getBar: ${context._lift(getBar)},
           })
         `);

--- a/tools/hangar/__snapshots__/test_corpus/valid/inflight_class_capture_const.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/inflight_class_capture_const.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [inflight_class_capture_const.w](../../../../../examples/tests/valid/inflight_class_capture_const.w) | compile | tf-aws
 
-## inflight.$Closure1-66c44101.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $Foo, $myConst }) {
   class $Closure1 {
@@ -19,7 +19,7 @@ module.exports = function({ $Foo, $myConst }) {
 
 ```
 
-## inflight.Foo-66c44101.js
+## inflight.Foo-1.js
 ```js
 module.exports = function({ $myConst }) {
   class Foo {
@@ -170,7 +170,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.Foo-66c44101.js")({
+          require("./inflight.Foo-1.js")({
             $myConst: ${context._lift(myConst)},
           })
         `);
@@ -201,7 +201,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-66c44101.js")({
+          require("./inflight.$Closure1-1.js")({
             $Foo: ${context._lift(Foo)},
             $myConst: ${context._lift(myConst)},
           })

--- a/tools/hangar/__snapshots__/test_corpus/valid/inflight_class_definitions.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/inflight_class_definitions.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [inflight_class_definitions.w](../../../../../examples/tests/valid/inflight_class_definitions.w) | compile | tf-aws
 
-## inflight.$Closure1-3edfd2de.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({  }) {
   class $Closure1 {
@@ -24,7 +24,7 @@ module.exports = function({  }) {
 
 ```
 
-## inflight.$Closure2-3edfd2de.js
+## inflight.$Closure2-1.js
 ```js
 module.exports = function({ $F }) {
   class $Closure2 {
@@ -42,7 +42,7 @@ module.exports = function({ $F }) {
 
 ```
 
-## inflight.$Closure3-3edfd2de.js
+## inflight.$Closure3-1.js
 ```js
 module.exports = function({ $B, $a, $d, $fn, $innerD }) {
   class $Closure3 {
@@ -65,7 +65,7 @@ module.exports = function({ $B, $a, $d, $fn, $innerD }) {
 
 ```
 
-## inflight.A-3edfd2de.js
+## inflight.A-1.js
 ```js
 module.exports = function({  }) {
   class A {
@@ -80,7 +80,7 @@ module.exports = function({  }) {
 
 ```
 
-## inflight.B-3edfd2de.js
+## inflight.B-1.js
 ```js
 module.exports = function({  }) {
   class B {
@@ -93,7 +93,7 @@ module.exports = function({  }) {
 
 ```
 
-## inflight.D-3edfd2de.js
+## inflight.D-1.js
 ```js
 module.exports = function({  }) {
   class D {
@@ -109,7 +109,7 @@ module.exports = function({  }) {
 
 ```
 
-## inflight.E-3edfd2de.js
+## inflight.E-1.js
 ```js
 module.exports = function({  }) {
   class E {
@@ -121,7 +121,7 @@ module.exports = function({  }) {
 
 ```
 
-## inflight.F-3edfd2de.js
+## inflight.F-1.js
 ```js
 module.exports = function({  }) {
   class F {
@@ -274,7 +274,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.A-3edfd2de.js")({
+          require("./inflight.A-1.js")({
           })
         `);
       }
@@ -297,7 +297,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.B-3edfd2de.js")({
+          require("./inflight.B-1.js")({
           })
         `);
       }
@@ -321,7 +321,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-3edfd2de.js")({
+          require("./inflight.$Closure1-1.js")({
           })
         `);
       }
@@ -351,7 +351,7 @@ class $Root extends $stdlib.std.Resource {
           }
           static _toInflightType(context) {
             return $stdlib.core.NodeJsCode.fromInline(`
-              require("./inflight.E-3edfd2de.js")({
+              require("./inflight.E-1.js")({
               })
             `);
           }
@@ -376,7 +376,7 @@ class $Root extends $stdlib.std.Resource {
           }
           static _toInflightType(context) {
             return $stdlib.core.NodeJsCode.fromInline(`
-              require("./inflight.F-3edfd2de.js")({
+              require("./inflight.F-1.js")({
               })
             `);
           }
@@ -401,7 +401,7 @@ class $Root extends $stdlib.std.Resource {
           }
           static _toInflightType(context) {
             return $stdlib.core.NodeJsCode.fromInline(`
-              require("./inflight.$Closure2-3edfd2de.js")({
+              require("./inflight.$Closure2-1.js")({
                 $F: ${context._lift(F)},
               })
             `);
@@ -425,7 +425,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.D-3edfd2de.js")({
+          require("./inflight.D-1.js")({
           })
         `);
       }
@@ -459,7 +459,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure3-3edfd2de.js")({
+          require("./inflight.$Closure3-1.js")({
             $B: ${context._lift(B)},
             $a: ${context._lift(a)},
             $d: ${context._lift(d)},

--- a/tools/hangar/__snapshots__/test_corpus/valid/inflight_class_inner_capture_mutable.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/inflight_class_inner_capture_mutable.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [inflight_class_inner_capture_mutable.w](../../../../../examples/tests/valid/inflight_class_inner_capture_mutable.w) | compile | tf-aws
 
-## inflight.$Closure1-dc50657f.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({  }) {
   class $Closure1 {
@@ -168,7 +168,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-dc50657f.js")({
+          require("./inflight.$Closure1-1.js")({
           })
         `);
       }

--- a/tools/hangar/__snapshots__/test_corpus/valid/inflight_class_inside_inflight_closure.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/inflight_class_inside_inflight_closure.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [inflight_class_inside_inflight_closure.w](../../../../../examples/tests/valid/inflight_class_inside_inflight_closure.w) | compile | tf-aws
 
-## inflight.$Closure1-69928404.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $__parent_this_1_b }) {
   class $Closure1 {
@@ -28,7 +28,7 @@ module.exports = function({ $__parent_this_1_b }) {
 
 ```
 
-## inflight.$Closure2-69928404.js
+## inflight.$Closure2-1.js
 ```js
 module.exports = function({ $f }) {
   class $Closure2 {
@@ -46,7 +46,7 @@ module.exports = function({ $f }) {
 
 ```
 
-## inflight.$Closure3-69928404.js
+## inflight.$Closure3-1.js
 ```js
 module.exports = function({  }) {
   class $Closure3 {
@@ -72,7 +72,7 @@ module.exports = function({  }) {
 
 ```
 
-## inflight.PreflightClass-69928404.js
+## inflight.PreflightClass-1.js
 ```js
 module.exports = function({  }) {
   class PreflightClass {
@@ -408,7 +408,7 @@ class $Root extends $stdlib.std.Resource {
           }
           static _toInflightType(context) {
             return $stdlib.core.NodeJsCode.fromInline(`
-              require("./inflight.$Closure1-69928404.js")({
+              require("./inflight.$Closure1-1.js")({
                 $__parent_this_1_b: ${context._lift(__parent_this_1.b)},
               })
             `);
@@ -436,7 +436,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.PreflightClass-69928404.js")({
+          require("./inflight.PreflightClass-1.js")({
           })
         `);
       }
@@ -460,7 +460,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure2-69928404.js")({
+          require("./inflight.$Closure2-1.js")({
             $f: ${context._lift(f)},
           })
         `);
@@ -491,7 +491,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure3-69928404.js")({
+          require("./inflight.$Closure3-1.js")({
           })
         `);
       }

--- a/tools/hangar/__snapshots__/test_corpus/valid/inflight_class_modifiers.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/inflight_class_modifiers.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [inflight_class_modifiers.w](../../../../../examples/tests/valid/inflight_class_modifiers.w) | compile | tf-aws
 
-## inflight.C-5fe48c55.js
+## inflight.C-1.js
 ```js
 module.exports = function({  }) {
   class C {
@@ -63,7 +63,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.C-5fe48c55.js")({
+          require("./inflight.C-1.js")({
           })
         `);
       }

--- a/tools/hangar/__snapshots__/test_corpus/valid/inflight_class_outside_inflight_closure.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/inflight_class_outside_inflight_closure.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [inflight_class_outside_inflight_closure.w](../../../../../examples/tests/valid/inflight_class_outside_inflight_closure.w) | compile | tf-aws
 
-## inflight.$Closure1-30b48674.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $BinaryOperation }) {
   class $Closure1 {
@@ -19,7 +19,7 @@ module.exports = function({ $BinaryOperation }) {
 
 ```
 
-## inflight.BinaryOperation-30b48674.js
+## inflight.BinaryOperation-1.js
 ```js
 module.exports = function({  }) {
   class BinaryOperation {
@@ -174,7 +174,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.BinaryOperation-30b48674.js")({
+          require("./inflight.BinaryOperation-1.js")({
           })
         `);
       }
@@ -207,7 +207,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-30b48674.js")({
+          require("./inflight.$Closure1-1.js")({
             $BinaryOperation: ${context._lift(BinaryOperation)},
           })
         `);

--- a/tools/hangar/__snapshots__/test_corpus/valid/inflight_class_structural_interace_handler.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/inflight_class_structural_interace_handler.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [inflight_class_structural_interace_handler.w](../../../../../examples/tests/valid/inflight_class_structural_interace_handler.w) | compile | tf-aws
 
-## inflight.$Closure1-521ab3bb.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $NotGoo }) {
   class $Closure1 {
@@ -29,7 +29,7 @@ module.exports = function({ $NotGoo }) {
 
 ```
 
-## inflight.NotGoo-521ab3bb.js
+## inflight.NotGoo-1.js
 ```js
 module.exports = function({  }) {
   class NotGoo {
@@ -180,7 +180,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.NotGoo-521ab3bb.js")({
+          require("./inflight.NotGoo-1.js")({
           })
         `);
       }
@@ -204,7 +204,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-521ab3bb.js")({
+          require("./inflight.$Closure1-1.js")({
             $NotGoo: ${context._lift(NotGoo)},
           })
         `);

--- a/tools/hangar/__snapshots__/test_corpus/valid/inflight_class_without_init.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/inflight_class_without_init.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [inflight_class_without_init.w](../../../../../examples/tests/valid/inflight_class_without_init.w) | compile | tf-aws
 
-## inflight.$Closure1-e3163392.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $Foo }) {
   class $Closure1 {
@@ -18,7 +18,7 @@ module.exports = function({ $Foo }) {
 
 ```
 
-## inflight.Foo-e3163392.js
+## inflight.Foo-1.js
 ```js
 module.exports = function({  }) {
   class Foo {
@@ -166,7 +166,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.Foo-e3163392.js")({
+          require("./inflight.Foo-1.js")({
           })
         `);
       }
@@ -190,7 +190,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-e3163392.js")({
+          require("./inflight.$Closure1-1.js")({
             $Foo: ${context._lift(Foo)},
           })
         `);

--- a/tools/hangar/__snapshots__/test_corpus/valid/inflight_concat.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/inflight_concat.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [inflight_concat.w](../../../../../examples/tests/valid/inflight_concat.w) | compile | tf-aws
 
-## inflight.R-8bbb300b.js
+## inflight.R-1.js
 ```js
 module.exports = function({  }) {
   class R {
@@ -66,7 +66,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.R-8bbb300b.js")({
+          require("./inflight.R-1.js")({
           })
         `);
       }

--- a/tools/hangar/__snapshots__/test_corpus/valid/inflights_calling_inflights.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/inflights_calling_inflights.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [inflights_calling_inflights.w](../../../../../examples/tests/valid/inflights_calling_inflights.w) | compile | tf-aws
 
-## inflight.$Closure1-33c2835d.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $globalBucket }) {
   class $Closure1 {
@@ -18,7 +18,7 @@ module.exports = function({ $globalBucket }) {
 
 ```
 
-## inflight.$Closure2-33c2835d.js
+## inflight.$Closure2-1.js
 ```js
 module.exports = function({ $storeInBucket }) {
   class $Closure2 {
@@ -36,7 +36,7 @@ module.exports = function({ $storeInBucket }) {
 
 ```
 
-## inflight.$Closure3-33c2835d.js
+## inflight.$Closure3-1.js
 ```js
 module.exports = function({ $func1, $globalBucket }) {
   class $Closure3 {
@@ -55,7 +55,7 @@ module.exports = function({ $func1, $globalBucket }) {
 
 ```
 
-## inflight.$Closure4-33c2835d.js
+## inflight.$Closure4-1.js
 ```js
 module.exports = function({ $globalBucket }) {
   class $Closure4 {
@@ -74,7 +74,7 @@ module.exports = function({ $globalBucket }) {
 
 ```
 
-## inflight.$Closure5-33c2835d.js
+## inflight.$Closure5-1.js
 ```js
 module.exports = function({ $x }) {
   class $Closure5 {
@@ -93,7 +93,7 @@ module.exports = function({ $x }) {
 
 ```
 
-## inflight.MyResource-33c2835d.js
+## inflight.MyResource-1.js
 ```js
 module.exports = function({  }) {
   class MyResource {
@@ -427,7 +427,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-33c2835d.js")({
+          require("./inflight.$Closure1-1.js")({
             $globalBucket: ${context._lift(globalBucket)},
           })
         `);
@@ -458,7 +458,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure2-33c2835d.js")({
+          require("./inflight.$Closure2-1.js")({
             $storeInBucket: ${context._lift(storeInBucket)},
           })
         `);
@@ -489,7 +489,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure3-33c2835d.js")({
+          require("./inflight.$Closure3-1.js")({
             $func1: ${context._lift(func1)},
             $globalBucket: ${context._lift(globalBucket)},
           })
@@ -527,7 +527,7 @@ class $Root extends $stdlib.std.Resource {
           }
           static _toInflightType(context) {
             return $stdlib.core.NodeJsCode.fromInline(`
-              require("./inflight.$Closure4-33c2835d.js")({
+              require("./inflight.$Closure4-1.js")({
                 $globalBucket: ${context._lift(globalBucket)},
               })
             `);
@@ -554,7 +554,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.MyResource-33c2835d.js")({
+          require("./inflight.MyResource-1.js")({
           })
         `);
       }
@@ -588,7 +588,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure5-33c2835d.js")({
+          require("./inflight.$Closure5-1.js")({
             $x: ${context._lift(x)},
           })
         `);

--- a/tools/hangar/__snapshots__/test_corpus/valid/issue_2889.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/issue_2889.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [issue_2889.w](../../../../../examples/tests/valid/issue_2889.w) | compile | tf-aws
 
-## inflight.$Closure1-6951a395.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $std_Json }) {
   class $Closure1 {
@@ -19,7 +19,7 @@ module.exports = function({ $std_Json }) {
 
 ```
 
-## inflight.$Closure2-6951a395.js
+## inflight.$Closure2-1.js
 ```js
 module.exports = function({ $api_url, $http_Util, $std_Json }) {
   class $Closure2 {
@@ -316,7 +316,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-6951a395.js")({
+          require("./inflight.$Closure1-1.js")({
             $std_Json: ${context._lift(std.Json)},
           })
         `);
@@ -341,7 +341,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure2-6951a395.js")({
+          require("./inflight.$Closure2-1.js")({
             $api_url: ${context._lift(api.url)},
             $http_Util: ${context._lift(http.Util)},
             $std_Json: ${context._lift(std.Json)},

--- a/tools/hangar/__snapshots__/test_corpus/valid/json.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/json.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [json.w](../../../../../examples/tests/valid/json.w) | compile | tf-aws
 
-## inflight.Foo-42b15166.js
+## inflight.Foo-1.js
 ```js
 module.exports = function({  }) {
   class Foo {
@@ -61,7 +61,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.Foo-42b15166.js")({
+          require("./inflight.Foo-1.js")({
           })
         `);
       }

--- a/tools/hangar/__snapshots__/test_corpus/valid/json_bucket.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/json_bucket.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [json_bucket.w](../../../../../examples/tests/valid/json_bucket.w) | compile | tf-aws
 
-## inflight.$Closure1-d3601604.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $b, $fileName }) {
   class $Closure1 {
@@ -19,7 +19,7 @@ module.exports = function({ $b, $fileName }) {
 
 ```
 
-## inflight.$Closure2-d3601604.js
+## inflight.$Closure2-1.js
 ```js
 module.exports = function({ $b, $fileName, $getJson, $j }) {
   class $Closure2 {
@@ -289,7 +289,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-d3601604.js")({
+          require("./inflight.$Closure1-1.js")({
             $b: ${context._lift(b)},
             $fileName: ${context._lift(fileName)},
           })
@@ -322,7 +322,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure2-d3601604.js")({
+          require("./inflight.$Closure2-1.js")({
             $b: ${context._lift(b)},
             $fileName: ${context._lift(fileName)},
             $getJson: ${context._lift(getJson)},

--- a/tools/hangar/__snapshots__/test_corpus/valid/json_static.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/json_static.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [json_static.w](../../../../../examples/tests/valid/json_static.w) | compile | tf-aws
 
-## inflight.$Closure1-7de15668.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $jj, $std_Json }) {
   class $Closure1 {
@@ -19,7 +19,7 @@ module.exports = function({ $jj, $std_Json }) {
 
 ```
 
-## inflight.$Closure2-7de15668.js
+## inflight.$Closure2-1.js
 ```js
 module.exports = function({ $std_Json }) {
   class $Closure2 {
@@ -244,7 +244,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-7de15668.js")({
+          require("./inflight.$Closure1-1.js")({
             $jj: ${context._lift(jj)},
             $std_Json: ${context._lift(std.Json)},
           })
@@ -276,7 +276,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure2-7de15668.js")({
+          require("./inflight.$Closure2-1.js")({
             $std_Json: ${context._lift(std.Json)},
           })
         `);

--- a/tools/hangar/__snapshots__/test_corpus/valid/lift_expr_with_this.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/lift_expr_with_this.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [lift_expr_with_this.w](../../../../../examples/tests/valid/lift_expr_with_this.w) | compile | tf-aws
 
-## inflight.$Closure1-e1901373.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({  }) {
   class $Closure1 {
@@ -19,7 +19,7 @@ module.exports = function({  }) {
 
 ```
 
-## inflight.Foo-e1901373.js
+## inflight.Foo-1.js
 ```js
 module.exports = function({  }) {
   class Foo {
@@ -169,7 +169,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.Foo-e1901373.js")({
+          require("./inflight.Foo-1.js")({
           })
         `);
       }
@@ -193,7 +193,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-e1901373.js")({
+          require("./inflight.$Closure1-1.js")({
           })
         `);
       }

--- a/tools/hangar/__snapshots__/test_corpus/valid/lift_redefinition.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/lift_redefinition.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [lift_redefinition.w](../../../../../examples/tests/valid/lift_redefinition.w) | compile | tf-aws
 
-## inflight.$Closure1-f6fea614.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $y }) {
   class $Closure1 {
@@ -158,7 +158,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-f6fea614.js")({
+          require("./inflight.$Closure1-1.js")({
             $y: ${context._lift(y)},
           })
         `);

--- a/tools/hangar/__snapshots__/test_corpus/valid/lift_this.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/lift_this.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [lift_this.w](../../../../../examples/tests/valid/lift_this.w) | compile | tf-aws
 
-## inflight.$Closure1-a18a6589.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $f }) {
   class $Closure1 {
@@ -18,7 +18,7 @@ module.exports = function({ $f }) {
 
 ```
 
-## inflight.Foo-a18a6589.js
+## inflight.Foo-1.js
 ```js
 module.exports = function({  }) {
   class Foo {
@@ -176,7 +176,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.Foo-a18a6589.js")({
+          require("./inflight.Foo-1.js")({
           })
         `);
       }
@@ -206,7 +206,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-a18a6589.js")({
+          require("./inflight.$Closure1-1.js")({
             $f: ${context._lift(f)},
           })
         `);

--- a/tools/hangar/__snapshots__/test_corpus/valid/lift_via_closure.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/lift_via_closure.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [lift_via_closure.w](../../../../../examples/tests/valid/lift_via_closure.w) | compile | tf-aws
 
-## inflight.$Closure1-437a91ea.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $bucket2 }) {
   class $Closure1 {
@@ -18,7 +18,7 @@ module.exports = function({ $bucket2 }) {
 
 ```
 
-## inflight.$Closure2-437a91ea.js
+## inflight.$Closure2-1.js
 ```js
 module.exports = function({ $fn }) {
   class $Closure2 {
@@ -36,7 +36,7 @@ module.exports = function({ $fn }) {
 
 ```
 
-## inflight.$Closure3-437a91ea.js
+## inflight.$Closure3-1.js
 ```js
 module.exports = function({ $bucket2, $fn2, $fn2_bucket }) {
   class $Closure3 {
@@ -57,7 +57,7 @@ module.exports = function({ $bucket2, $fn2, $fn2_bucket }) {
 
 ```
 
-## inflight.MyClosure-437a91ea.js
+## inflight.MyClosure-1.js
 ```js
 module.exports = function({ $bucket2 }) {
   class MyClosure {
@@ -375,7 +375,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-437a91ea.js")({
+          require("./inflight.$Closure1-1.js")({
             $bucket2: ${context._lift(bucket2)},
           })
         `);
@@ -406,7 +406,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.MyClosure-437a91ea.js")({
+          require("./inflight.MyClosure-1.js")({
             $bucket2: ${context._lift(bucket2)},
           })
         `);
@@ -448,7 +448,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure2-437a91ea.js")({
+          require("./inflight.$Closure2-1.js")({
             $fn: ${context._lift(fn)},
           })
         `);
@@ -479,7 +479,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure3-437a91ea.js")({
+          require("./inflight.$Closure3-1.js")({
             $bucket2: ${context._lift(bucket2)},
             $fn2: ${context._lift(fn2)},
             $fn2_bucket: ${context._lift(fn2.bucket)},

--- a/tools/hangar/__snapshots__/test_corpus/valid/lift_via_closure_explicit.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/lift_via_closure_explicit.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [lift_via_closure_explicit.w](../../../../../examples/tests/valid/lift_via_closure_explicit.w) | compile | tf-aws
 
-## inflight.$Closure1-50cb6ba1.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $fn }) {
   class $Closure1 {
@@ -18,7 +18,7 @@ module.exports = function({ $fn }) {
 
 ```
 
-## inflight.MyClosure-50cb6ba1.js
+## inflight.MyClosure-1.js
 ```js
 module.exports = function({  }) {
   class MyClosure {
@@ -188,7 +188,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.MyClosure-50cb6ba1.js")({
+          require("./inflight.MyClosure-1.js")({
           })
         `);
       }
@@ -222,7 +222,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-50cb6ba1.js")({
+          require("./inflight.$Closure1-1.js")({
             $fn: ${context._lift(fn)},
           })
         `);

--- a/tools/hangar/__snapshots__/test_corpus/valid/nil.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/nil.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [nil.w](../../../../../examples/tests/valid/nil.w) | compile | tf-aws
 
-## inflight.$Closure1-2399f47d.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $foo }) {
   class $Closure1 {
@@ -19,7 +19,7 @@ module.exports = function({ $foo }) {
 
 ```
 
-## inflight.$Closure2-2399f47d.js
+## inflight.$Closure2-1.js
 ```js
 module.exports = function({ $foo }) {
   class $Closure2 {
@@ -43,7 +43,7 @@ module.exports = function({ $foo }) {
 
 ```
 
-## inflight.Foo-2399f47d.js
+## inflight.Foo-1.js
 ```js
 module.exports = function({  }) {
   class Foo {
@@ -274,7 +274,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.Foo-2399f47d.js")({
+          require("./inflight.Foo-1.js")({
           })
         `);
       }
@@ -298,7 +298,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-2399f47d.js")({
+          require("./inflight.$Closure1-1.js")({
             $foo: ${context._lift(foo)},
           })
         `);
@@ -329,7 +329,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure2-2399f47d.js")({
+          require("./inflight.$Closure2-1.js")({
             $foo: ${context._lift(foo)},
           })
         `);

--- a/tools/hangar/__snapshots__/test_corpus/valid/optionals.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/optionals.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [optionals.w](../../../../../examples/tests/valid/optionals.w) | compile | tf-aws
 
-## inflight.$Closure1-574184ca.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $__payloadWithBucket_c_____null_, $__payloadWithoutOptions_b_____null_, $payloadWithBucket_c }) {
   class $Closure1 {
@@ -21,7 +21,7 @@ module.exports = function({ $__payloadWithBucket_c_____null_, $__payloadWithoutO
 
 ```
 
-## inflight.Node-574184ca.js
+## inflight.Node-1.js
 ```js
 module.exports = function({  }) {
   class Node {
@@ -33,7 +33,7 @@ module.exports = function({  }) {
 
 ```
 
-## inflight.Sub-574184ca.js
+## inflight.Sub-1.js
 ```js
 module.exports = function({ $Super }) {
   class Sub extends $Super {
@@ -46,7 +46,7 @@ module.exports = function({ $Super }) {
 
 ```
 
-## inflight.Sub1-574184ca.js
+## inflight.Sub1-1.js
 ```js
 module.exports = function({ $Super }) {
   class Sub1 extends $Super {
@@ -59,7 +59,7 @@ module.exports = function({ $Super }) {
 
 ```
 
-## inflight.Super-574184ca.js
+## inflight.Super-1.js
 ```js
 module.exports = function({  }) {
   class Super {
@@ -254,7 +254,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.Super-574184ca.js")({
+          require("./inflight.Super-1.js")({
           })
         `);
       }
@@ -278,7 +278,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.Sub-574184ca.js")({
+          require("./inflight.Sub-1.js")({
             $Super: ${context._lift(Super)},
           })
         `);
@@ -303,7 +303,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.Sub1-574184ca.js")({
+          require("./inflight.Sub1-1.js")({
             $Super: ${context._lift(Super)},
           })
         `);
@@ -330,7 +330,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.Node-574184ca.js")({
+          require("./inflight.Node-1.js")({
           })
         `);
       }
@@ -354,7 +354,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-574184ca.js")({
+          require("./inflight.$Closure1-1.js")({
             $__payloadWithBucket_c_____null_: ${context._lift(((payloadWithBucket.c) != null))},
             $__payloadWithoutOptions_b_____null_: ${context._lift(((payloadWithoutOptions.b) != null))},
             $payloadWithBucket_c: ${context._lift(payloadWithBucket.c)},

--- a/tools/hangar/__snapshots__/test_corpus/valid/print.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/print.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [print.w](../../../../../examples/tests/valid/print.w) | compile | tf-aws
 
-## inflight.$Closure1-4d8118a8.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({  }) {
   class $Closure1 {
@@ -19,7 +19,7 @@ module.exports = function({  }) {
 
 ```
 
-## inflight.$Closure2-4d8118a8.js
+## inflight.$Closure2-1.js
 ```js
 module.exports = function({  }) {
   class $Closure2 {
@@ -243,7 +243,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-4d8118a8.js")({
+          require("./inflight.$Closure1-1.js")({
           })
         `);
       }
@@ -267,7 +267,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure2-4d8118a8.js")({
+          require("./inflight.$Closure2-1.js")({
           })
         `);
       }

--- a/tools/hangar/__snapshots__/test_corpus/valid/reassignment.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/reassignment.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [reassignment.w](../../../../../examples/tests/valid/reassignment.w) | compile | tf-aws
 
-## inflight.R-85a23554.js
+## inflight.R-1.js
 ```js
 module.exports = function({  }) {
   class R {
@@ -67,7 +67,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.R-85a23554.js")({
+          require("./inflight.R-1.js")({
           })
         `);
       }

--- a/tools/hangar/__snapshots__/test_corpus/valid/redis.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/redis.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [redis.w](../../../../../examples/tests/valid/redis.w) | compile | tf-aws
 
-## inflight.$Closure1-fa9d88b1.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $r, $r2 }) {
   class $Closure1 {
@@ -487,7 +487,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-fa9d88b1.js")({
+          require("./inflight.$Closure1-1.js")({
             $r: ${context._lift(r)},
             $r2: ${context._lift(r2)},
           })

--- a/tools/hangar/__snapshots__/test_corpus/valid/resource.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/resource.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [resource.w](../../../../../examples/tests/valid/resource.w) | compile | tf-aws
 
-## inflight.$Closure1-1080d41c.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $bucket, $res, $res_foo }) {
   class $Closure1 {
@@ -23,7 +23,7 @@ module.exports = function({ $bucket, $res, $res_foo }) {
 
 ```
 
-## inflight.$Closure2-1080d41c.js
+## inflight.$Closure2-1.js
 ```js
 module.exports = function({ $__parent_this_2_b }) {
   class $Closure2 {
@@ -41,7 +41,7 @@ module.exports = function({ $__parent_this_2_b }) {
 
 ```
 
-## inflight.$Closure3-1080d41c.js
+## inflight.$Closure3-1.js
 ```js
 module.exports = function({ $__parent_this_3_b }) {
   class $Closure3 {
@@ -59,7 +59,7 @@ module.exports = function({ $__parent_this_3_b }) {
 
 ```
 
-## inflight.$Closure4-1080d41c.js
+## inflight.$Closure4-1.js
 ```js
 module.exports = function({ $__parent_this_4_q }) {
   class $Closure4 {
@@ -77,7 +77,7 @@ module.exports = function({ $__parent_this_4_q }) {
 
 ```
 
-## inflight.$Closure5-1080d41c.js
+## inflight.$Closure5-1.js
 ```js
 module.exports = function({ $bigOlPublisher }) {
   class $Closure5 {
@@ -96,7 +96,7 @@ module.exports = function({ $bigOlPublisher }) {
 
 ```
 
-## inflight.Bar-1080d41c.js
+## inflight.Bar-1.js
 ```js
 module.exports = function({ $Foo, $MyEnum }) {
   class Bar {
@@ -127,7 +127,7 @@ module.exports = function({ $Foo, $MyEnum }) {
 
 ```
 
-## inflight.BigPublisher-1080d41c.js
+## inflight.BigPublisher-1.js
 ```js
 module.exports = function({  }) {
   class BigPublisher {
@@ -151,7 +151,7 @@ module.exports = function({  }) {
 
 ```
 
-## inflight.Dummy-1080d41c.js
+## inflight.Dummy-1.js
 ```js
 module.exports = function({  }) {
   class Dummy {
@@ -163,7 +163,7 @@ module.exports = function({  }) {
 
 ```
 
-## inflight.Foo-1080d41c.js
+## inflight.Foo-1.js
 ```js
 module.exports = function({  }) {
   class Foo {
@@ -190,7 +190,7 @@ module.exports = function({  }) {
 
 ```
 
-## inflight.ScopeAndIdTestClass-1080d41c.js
+## inflight.ScopeAndIdTestClass-1.js
 ```js
 module.exports = function({  }) {
   class ScopeAndIdTestClass {
@@ -883,7 +883,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.Foo-1080d41c.js")({
+          require("./inflight.Foo-1.js")({
           })
         `);
       }
@@ -923,7 +923,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.Bar-1080d41c.js")({
+          require("./inflight.Bar-1.js")({
             $Foo: ${context._lift(Foo)},
             $MyEnum: ${context._lift(MyEnum)},
           })
@@ -969,7 +969,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-1080d41c.js")({
+          require("./inflight.$Closure1-1.js")({
             $bucket: ${context._lift(bucket)},
             $res: ${context._lift(res)},
             $res_foo: ${context._lift(res.foo)},
@@ -1013,7 +1013,7 @@ class $Root extends $stdlib.std.Resource {
           }
           static _toInflightType(context) {
             return $stdlib.core.NodeJsCode.fromInline(`
-              require("./inflight.$Closure2-1080d41c.js")({
+              require("./inflight.$Closure2-1.js")({
                 $__parent_this_2_b: ${context._lift(__parent_this_2.b)},
               })
             `);
@@ -1046,7 +1046,7 @@ class $Root extends $stdlib.std.Resource {
           }
           static _toInflightType(context) {
             return $stdlib.core.NodeJsCode.fromInline(`
-              require("./inflight.$Closure3-1080d41c.js")({
+              require("./inflight.$Closure3-1.js")({
                 $__parent_this_3_b: ${context._lift(__parent_this_3.b)},
               })
             `);
@@ -1079,7 +1079,7 @@ class $Root extends $stdlib.std.Resource {
           }
           static _toInflightType(context) {
             return $stdlib.core.NodeJsCode.fromInline(`
-              require("./inflight.$Closure4-1080d41c.js")({
+              require("./inflight.$Closure4-1.js")({
                 $__parent_this_4_q: ${context._lift(__parent_this_4.q)},
               })
             `);
@@ -1106,7 +1106,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.BigPublisher-1080d41c.js")({
+          require("./inflight.BigPublisher-1.js")({
           })
         `);
       }
@@ -1151,7 +1151,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure5-1080d41c.js")({
+          require("./inflight.$Closure5-1.js")({
             $bigOlPublisher: ${context._lift(bigOlPublisher)},
           })
         `);
@@ -1181,7 +1181,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.Dummy-1080d41c.js")({
+          require("./inflight.Dummy-1.js")({
           })
         `);
       }
@@ -1213,7 +1213,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.ScopeAndIdTestClass-1080d41c.js")({
+          require("./inflight.ScopeAndIdTestClass-1.js")({
           })
         `);
       }

--- a/tools/hangar/__snapshots__/test_corpus/valid/resource_as_inflight_literal.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/resource_as_inflight_literal.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [resource_as_inflight_literal.w](../../../../../examples/tests/valid/resource_as_inflight_literal.w) | compile | tf-aws
 
-## inflight.$Closure1-bf385a5b.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $fn }) {
   class $Closure1 {
@@ -18,7 +18,7 @@ module.exports = function({ $fn }) {
 
 ```
 
-## inflight.Foo-bf385a5b.js
+## inflight.Foo-1.js
 ```js
 module.exports = function({  }) {
   class Foo {
@@ -241,7 +241,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.Foo-bf385a5b.js")({
+          require("./inflight.Foo-1.js")({
           })
         `);
       }
@@ -265,7 +265,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-bf385a5b.js")({
+          require("./inflight.$Closure1-1.js")({
             $fn: ${context._lift(fn)},
           })
         `);

--- a/tools/hangar/__snapshots__/test_corpus/valid/resource_call_static.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/resource_call_static.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [resource_call_static.w](../../../../../examples/tests/valid/resource_call_static.w) | compile | tf-aws
 
-## inflight.$Closure1-172235ac.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $Another }) {
   class $Closure1 {
@@ -18,7 +18,7 @@ module.exports = function({ $Another }) {
 
 ```
 
-## inflight.Another-172235ac.js
+## inflight.Another-1.js
 ```js
 module.exports = function({ $globalCounter }) {
   class Another {
@@ -191,7 +191,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.Another-172235ac.js")({
+          require("./inflight.Another-1.js")({
             $globalCounter: ${context._lift(globalCounter)},
           })
         `);
@@ -222,7 +222,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-172235ac.js")({
+          require("./inflight.$Closure1-1.js")({
             $Another: ${context._lift(Another)},
           })
         `);

--- a/tools/hangar/__snapshots__/test_corpus/valid/resource_captures.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/resource_captures.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [resource_captures.w](../../../../../examples/tests/valid/resource_captures.w) | compile | tf-aws
 
-## inflight.$Closure1-65dd83bd.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $r }) {
   class $Closure1 {
@@ -28,7 +28,7 @@ module.exports = function({ $r }) {
 
 ```
 
-## inflight.Another-65dd83bd.js
+## inflight.Another-1.js
 ```js
 module.exports = function({  }) {
   class Another {
@@ -46,7 +46,7 @@ module.exports = function({  }) {
 
 ```
 
-## inflight.First-65dd83bd.js
+## inflight.First-1.js
 ```js
 module.exports = function({  }) {
   class First {
@@ -58,7 +58,7 @@ module.exports = function({  }) {
 
 ```
 
-## inflight.MyResource-65dd83bd.js
+## inflight.MyResource-1.js
 ```js
 module.exports = function({  }) {
   class MyResource {
@@ -437,7 +437,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.First-65dd83bd.js")({
+          require("./inflight.First-1.js")({
           })
         `);
       }
@@ -462,7 +462,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.Another-65dd83bd.js")({
+          require("./inflight.Another-1.js")({
           })
         `);
       }
@@ -501,7 +501,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.MyResource-65dd83bd.js")({
+          require("./inflight.MyResource-1.js")({
           })
         `);
       }
@@ -607,7 +607,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-65dd83bd.js")({
+          require("./inflight.$Closure1-1.js")({
             $r: ${context._lift(r)},
           })
         `);

--- a/tools/hangar/__snapshots__/test_corpus/valid/resource_captures_globals.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/resource_captures_globals.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [resource_captures_globals.w](../../../../../examples/tests/valid/resource_captures_globals.w) | compile | tf-aws
 
-## inflight.$Closure1-b77e1245.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $res }) {
   class $Closure1 {
@@ -18,7 +18,7 @@ module.exports = function({ $res }) {
 
 ```
 
-## inflight.$Closure2-b77e1245.js
+## inflight.$Closure2-1.js
 ```js
 module.exports = function({ $Another }) {
   class $Closure2 {
@@ -36,7 +36,7 @@ module.exports = function({ $Another }) {
 
 ```
 
-## inflight.Another-b77e1245.js
+## inflight.Another-1.js
 ```js
 module.exports = function({ $globalCounter }) {
   class Another {
@@ -58,7 +58,7 @@ module.exports = function({ $globalCounter }) {
 
 ```
 
-## inflight.First-b77e1245.js
+## inflight.First-1.js
 ```js
 module.exports = function({  }) {
   class First {
@@ -70,7 +70,7 @@ module.exports = function({  }) {
 
 ```
 
-## inflight.MyResource-b77e1245.js
+## inflight.MyResource-1.js
 ```js
 module.exports = function({ $Another, $_globalArrayOfStr_at_0__, $_globalMapOfNum___a__, $_globalSetOfStr_has__a___, $globalAnother, $globalAnother_first_myResource, $globalAnother_myField, $globalBool, $globalBucket, $globalNum, $globalStr }) {
   class MyResource {
@@ -97,7 +97,7 @@ module.exports = function({ $Another, $_globalArrayOfStr_at_0__, $_globalMapOfNu
 
 ```
 
-## inflight.R-b77e1245.js
+## inflight.R-1.js
 ```js
 module.exports = function({ $_parentThis_localCounter, $globalCounter }) {
   class R {
@@ -550,7 +550,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.First-b77e1245.js")({
+          require("./inflight.First-1.js")({
           })
         `);
       }
@@ -575,7 +575,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.Another-b77e1245.js")({
+          require("./inflight.Another-1.js")({
             $globalCounter: ${context._lift(globalCounter)},
           })
         `);
@@ -621,7 +621,7 @@ class $Root extends $stdlib.std.Resource {
           }
           static _toInflightType(context) {
             return $stdlib.core.NodeJsCode.fromInline(`
-              require("./inflight.R-b77e1245.js")({
+              require("./inflight.R-1.js")({
                 $_parentThis_localCounter: ${context._lift($parentThis.localCounter)},
                 $globalCounter: ${context._lift(globalCounter)},
               })
@@ -650,7 +650,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.MyResource-b77e1245.js")({
+          require("./inflight.MyResource-1.js")({
             $Another: ${context._lift(Another)},
             $_globalArrayOfStr_at_0__: ${context._lift((globalArrayOfStr.at(0)))},
             $_globalMapOfNum___a__: ${context._lift((globalMapOfNum)["a"])},
@@ -706,7 +706,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-b77e1245.js")({
+          require("./inflight.$Closure1-1.js")({
             $res: ${context._lift(res)},
           })
         `);
@@ -737,7 +737,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure2-b77e1245.js")({
+          require("./inflight.$Closure2-1.js")({
             $Another: ${context._lift(Another)},
           })
         `);

--- a/tools/hangar/__snapshots__/test_corpus/valid/shadowing.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/shadowing.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [shadowing.w](../../../../../examples/tests/valid/shadowing.w) | compile | tf-aws
 
-## inflight.$Closure1-a62cc855.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $bar }) {
   class $Closure1 {
@@ -26,7 +26,7 @@ module.exports = function({ $bar }) {
 
 ```
 
-## inflight.$Closure2-a62cc855.js
+## inflight.$Closure2-1.js
 ```js
 module.exports = function({ $fn }) {
   class $Closure2 {
@@ -187,7 +187,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-a62cc855.js")({
+          require("./inflight.$Closure1-1.js")({
             $bar: ${context._lift(bar)},
           })
         `);
@@ -218,7 +218,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure2-a62cc855.js")({
+          require("./inflight.$Closure2-1.js")({
             $fn: ${context._lift(fn)},
           })
         `);

--- a/tools/hangar/__snapshots__/test_corpus/valid/statements_if.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/statements_if.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [statements_if.w](../../../../../examples/tests/valid/statements_if.w) | compile | tf-aws
 
-## inflight.$Closure1-2c098492.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({  }) {
   class $Closure1 {
@@ -176,7 +176,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-2c098492.js")({
+          require("./inflight.$Closure1-1.js")({
           })
         `);
       }

--- a/tools/hangar/__snapshots__/test_corpus/valid/static_members.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/static_members.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [static_members.w](../../../../../examples/tests/valid/static_members.w) | compile | tf-aws
 
-## inflight.$Closure1-4e327a2d.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({  }) {
   class $Closure1 {
@@ -28,7 +28,7 @@ module.exports = function({  }) {
 
 ```
 
-## inflight.Foo-4e327a2d.js
+## inflight.Foo-1.js
 ```js
 module.exports = function({  }) {
   class Foo {
@@ -185,7 +185,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.Foo-4e327a2d.js")({
+          require("./inflight.Foo-1.js")({
           })
         `);
       }
@@ -209,7 +209,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-4e327a2d.js")({
+          require("./inflight.$Closure1-1.js")({
           })
         `);
       }

--- a/tools/hangar/__snapshots__/test_corpus/valid/std_string.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/std_string.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [std_string.w](../../../../../examples/tests/valid/std_string.w) | compile | tf-aws
 
-## inflight.$Closure1-fd0d498f.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $__s1_split_______at_1__, $_s1_concat_s2__, $s1_indexOf__s__ }) {
   class $Closure1 {
@@ -158,7 +158,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-fd0d498f.js")({
+          require("./inflight.$Closure1-1.js")({
             $__s1_split_______at_1__: ${context._lift(((s1.split(" ")).at(1)))},
             $_s1_concat_s2__: ${context._lift((s1.concat(s2)))},
             $s1_indexOf__s__: ${context._lift(s1.indexOf("s"))},

--- a/tools/hangar/__snapshots__/test_corpus/valid/store.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/store.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [store.w](../../../../../examples/tests/valid/store.w) | compile | tf-aws
 
-## inflight.$Closure1-dd1a0085.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $__parent_this_1_b }) {
   class $Closure1 {
@@ -18,7 +18,7 @@ module.exports = function({ $__parent_this_1_b }) {
 
 ```
 
-## inflight.Store-dd1a0085.js
+## inflight.Store-1.js
 ```js
 module.exports = function({  }) {
   class Store {
@@ -34,7 +34,7 @@ module.exports = function({  }) {
 
 ```
 
-## inflight.Util-dd1a0085.js
+## inflight.Util-1.js
 ```js
 module.exports = function({  }) {
   class Util {
@@ -106,7 +106,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.Util-dd1a0085.js")({
+          require("./inflight.Util-1.js")({
           })
         `);
       }
@@ -136,7 +136,7 @@ class $Root extends $stdlib.std.Resource {
           }
           static _toInflightType(context) {
             return $stdlib.core.NodeJsCode.fromInline(`
-              require("./inflight.$Closure1-dd1a0085.js")({
+              require("./inflight.$Closure1-1.js")({
                 $__parent_this_1_b: ${context._lift(__parent_this_1.b)},
               })
             `);
@@ -163,7 +163,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.Store-dd1a0085.js")({
+          require("./inflight.Store-1.js")({
           })
         `);
       }

--- a/tools/hangar/__snapshots__/test_corpus/valid/structs.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/structs.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [structs.w](../../../../../examples/tests/valid/structs.w) | compile | tf-aws
 
-## inflight.$Closure1-7ff6d6fc.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({  }) {
   class $Closure1 {
@@ -19,7 +19,7 @@ module.exports = function({  }) {
 
 ```
 
-## inflight.Foo-7ff6d6fc.js
+## inflight.Foo-1.js
 ```js
 module.exports = function({  }) {
   class Foo {
@@ -173,7 +173,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.Foo-7ff6d6fc.js")({
+          require("./inflight.Foo-1.js")({
           })
         `);
       }
@@ -207,7 +207,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-7ff6d6fc.js")({
+          require("./inflight.$Closure1-1.js")({
           })
         `);
       }

--- a/tools/hangar/__snapshots__/test_corpus/valid/super_call.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/super_call.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [super_call.w](../../../../../examples/tests/valid/super_call.w) | compile | tf-aws
 
-## inflight.$Closure1-9ebec15f.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $InflightB }) {
   class $Closure1 {
@@ -19,7 +19,7 @@ module.exports = function({ $InflightB }) {
 
 ```
 
-## inflight.$Closure2-9ebec15f.js
+## inflight.$Closure2-1.js
 ```js
 module.exports = function({ $extended }) {
   class $Closure2 {
@@ -37,7 +37,7 @@ module.exports = function({ $extended }) {
 
 ```
 
-## inflight.A-9ebec15f.js
+## inflight.A-1.js
 ```js
 module.exports = function({  }) {
   class A {
@@ -49,7 +49,7 @@ module.exports = function({  }) {
 
 ```
 
-## inflight.B-9ebec15f.js
+## inflight.B-1.js
 ```js
 module.exports = function({ $A }) {
   class B extends $A {
@@ -62,7 +62,7 @@ module.exports = function({ $A }) {
 
 ```
 
-## inflight.BaseClass-9ebec15f.js
+## inflight.BaseClass-1.js
 ```js
 module.exports = function({ $b }) {
   class BaseClass {
@@ -77,7 +77,7 @@ module.exports = function({ $b }) {
 
 ```
 
-## inflight.C-9ebec15f.js
+## inflight.C-1.js
 ```js
 module.exports = function({ $B }) {
   class C extends $B {
@@ -90,7 +90,7 @@ module.exports = function({ $B }) {
 
 ```
 
-## inflight.D-9ebec15f.js
+## inflight.D-1.js
 ```js
 module.exports = function({ $C }) {
   class D extends $C {
@@ -103,7 +103,7 @@ module.exports = function({ $C }) {
 
 ```
 
-## inflight.E-9ebec15f.js
+## inflight.E-1.js
 ```js
 module.exports = function({ $D }) {
   class E extends $D {
@@ -116,7 +116,7 @@ module.exports = function({ $D }) {
 
 ```
 
-## inflight.ExtendedClass-9ebec15f.js
+## inflight.ExtendedClass-1.js
 ```js
 module.exports = function({ $BaseClass, $b }) {
   class ExtendedClass extends $BaseClass {
@@ -133,7 +133,7 @@ module.exports = function({ $BaseClass, $b }) {
 
 ```
 
-## inflight.InflightA-9ebec15f.js
+## inflight.InflightA-1.js
 ```js
 module.exports = function({  }) {
   class InflightA {
@@ -146,7 +146,7 @@ module.exports = function({  }) {
 
 ```
 
-## inflight.InflightB-9ebec15f.js
+## inflight.InflightB-1.js
 ```js
 module.exports = function({ $InflightA }) {
   class InflightB extends $InflightA {
@@ -408,7 +408,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.A-9ebec15f.js")({
+          require("./inflight.A-1.js")({
           })
         `);
       }
@@ -434,7 +434,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.B-9ebec15f.js")({
+          require("./inflight.B-1.js")({
             $A: ${context._lift(A)},
           })
         `);
@@ -461,7 +461,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.C-9ebec15f.js")({
+          require("./inflight.C-1.js")({
             $B: ${context._lift(B)},
           })
         `);
@@ -485,7 +485,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.D-9ebec15f.js")({
+          require("./inflight.D-1.js")({
             $C: ${context._lift(C)},
           })
         `);
@@ -512,7 +512,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.E-9ebec15f.js")({
+          require("./inflight.E-1.js")({
             $D: ${context._lift(D)},
           })
         `);
@@ -536,7 +536,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.InflightA-9ebec15f.js")({
+          require("./inflight.InflightA-1.js")({
           })
         `);
       }
@@ -559,7 +559,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.InflightB-9ebec15f.js")({
+          require("./inflight.InflightB-1.js")({
             $InflightA: ${context._lift(InflightA)},
           })
         `);
@@ -584,7 +584,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-9ebec15f.js")({
+          require("./inflight.$Closure1-1.js")({
             $InflightB: ${context._lift(InflightB)},
           })
         `);
@@ -608,7 +608,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.BaseClass-9ebec15f.js")({
+          require("./inflight.BaseClass-1.js")({
             $b: ${context._lift(b)},
           })
         `);
@@ -638,7 +638,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.ExtendedClass-9ebec15f.js")({
+          require("./inflight.ExtendedClass-1.js")({
             $BaseClass: ${context._lift(BaseClass)},
             $b: ${context._lift(b)},
           })
@@ -670,7 +670,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure2-9ebec15f.js")({
+          require("./inflight.$Closure2-1.js")({
             $extended: ${context._lift(extended)},
           })
         `);

--- a/tools/hangar/__snapshots__/test_corpus/valid/symbol_shadow.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/symbol_shadow.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [symbol_shadow.w](../../../../../examples/tests/valid/symbol_shadow.w) | compile | tf-aws
 
-## inflight.$Closure1-5327428f.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $s }) {
   class $Closure1 {
@@ -18,7 +18,7 @@ module.exports = function({ $s }) {
 
 ```
 
-## inflight.$Closure2-5327428f.js
+## inflight.$Closure2-1.js
 ```js
 module.exports = function({ $s }) {
   class $Closure2 {
@@ -36,7 +36,7 @@ module.exports = function({ $s }) {
 
 ```
 
-## inflight.$Closure3-5327428f.js
+## inflight.$Closure3-1.js
 ```js
 module.exports = function({ $s }) {
   class $Closure3 {
@@ -54,7 +54,7 @@ module.exports = function({ $s }) {
 
 ```
 
-## inflight.$Closure4-5327428f.js
+## inflight.$Closure4-1.js
 ```js
 module.exports = function({  }) {
   class $Closure4 {
@@ -73,7 +73,7 @@ module.exports = function({  }) {
 
 ```
 
-## inflight.A-5327428f.js
+## inflight.A-1.js
 ```js
 module.exports = function({  }) {
   class A {
@@ -429,7 +429,7 @@ class $Root extends $stdlib.std.Resource {
           }
           static _toInflightType(context) {
             return $stdlib.core.NodeJsCode.fromInline(`
-              require("./inflight.$Closure2-5327428f.js")({
+              require("./inflight.$Closure2-1.js")({
                 $s: ${context._lift(s)},
               })
             `);
@@ -456,7 +456,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.A-5327428f.js")({
+          require("./inflight.A-1.js")({
           })
         `);
       }
@@ -480,7 +480,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure3-5327428f.js")({
+          require("./inflight.$Closure3-1.js")({
             $s: ${context._lift(s)},
           })
         `);
@@ -511,7 +511,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure4-5327428f.js")({
+          require("./inflight.$Closure4-1.js")({
           })
         `);
       }
@@ -539,7 +539,7 @@ class $Root extends $stdlib.std.Resource {
         }
         static _toInflightType(context) {
           return $stdlib.core.NodeJsCode.fromInline(`
-            require("./inflight.$Closure1-5327428f.js")({
+            require("./inflight.$Closure1-1.js")({
               $s: ${context._lift(s)},
             })
           `);

--- a/tools/hangar/__snapshots__/test_corpus/valid/test_bucket.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/test_bucket.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [test_bucket.w](../../../../../examples/tests/valid/test_bucket.w) | compile | tf-aws
 
-## inflight.$Closure1-525b6218.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $b }) {
   class $Closure1 {
@@ -20,7 +20,7 @@ module.exports = function({ $b }) {
 
 ```
 
-## inflight.$Closure2-525b6218.js
+## inflight.$Closure2-1.js
 ```js
 module.exports = function({ $b }) {
   class $Closure2 {
@@ -289,7 +289,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-525b6218.js")({
+          require("./inflight.$Closure1-1.js")({
             $b: ${context._lift(b)},
           })
         `);
@@ -320,7 +320,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure2-525b6218.js")({
+          require("./inflight.$Closure2-1.js")({
             $b: ${context._lift(b)},
           })
         `);

--- a/tools/hangar/__snapshots__/test_corpus/valid/test_without_bring.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/test_without_bring.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [test_without_bring.w](../../../../../examples/tests/valid/test_without_bring.w) | compile | tf-aws
 
-## inflight.$Closure1-3b3a0a2a.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({  }) {
   class $Closure1 {
@@ -156,7 +156,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-3b3a0a2a.js")({
+          require("./inflight.$Closure1-1.js")({
           })
         `);
       }

--- a/tools/hangar/__snapshots__/test_corpus/valid/use_inflight_method_inside_init_closure.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/use_inflight_method_inside_init_closure.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [use_inflight_method_inside_init_closure.w](../../../../../examples/tests/valid/use_inflight_method_inside_init_closure.w) | compile | tf-aws
 
-## inflight.$Closure1-09fcf003.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $__parent_this_1 }) {
   class $Closure1 {
@@ -18,7 +18,7 @@ module.exports = function({ $__parent_this_1 }) {
 
 ```
 
-## inflight.Foo-09fcf003.js
+## inflight.Foo-1.js
 ```js
 module.exports = function({  }) {
   class Foo {
@@ -176,7 +176,7 @@ class $Root extends $stdlib.std.Resource {
           }
           static _toInflightType(context) {
             return $stdlib.core.NodeJsCode.fromInline(`
-              require("./inflight.$Closure1-09fcf003.js")({
+              require("./inflight.$Closure1-1.js")({
                 $__parent_this_1: ${context._lift(__parent_this_1)},
               })
             `);
@@ -203,7 +203,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.Foo-09fcf003.js")({
+          require("./inflight.Foo-1.js")({
           })
         `);
       }

--- a/tools/hangar/__snapshots__/test_corpus/valid/website_with_api.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/website_with_api.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [website_with_api.w](../../../../../examples/tests/valid/website_with_api.w) | compile | tf-aws
 
-## inflight.$Closure1-108a257d.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({ $std_Json, $usersTable }) {
   class $Closure1 {
@@ -18,7 +18,7 @@ module.exports = function({ $std_Json, $usersTable }) {
 
 ```
 
-## inflight.$Closure2-108a257d.js
+## inflight.$Closure2-1.js
 ```js
 module.exports = function({ $std_Json, $usersTable }) {
   class $Closure2 {
@@ -41,7 +41,7 @@ module.exports = function({ $std_Json, $usersTable }) {
 
 ```
 
-## inflight.$Closure3-108a257d.js
+## inflight.$Closure3-1.js
 ```js
 module.exports = function({  }) {
   class $Closure3 {
@@ -652,7 +652,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-108a257d.js")({
+          require("./inflight.$Closure1-1.js")({
             $std_Json: ${context._lift(std.Json)},
             $usersTable: ${context._lift(usersTable)},
           })
@@ -684,7 +684,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure2-108a257d.js")({
+          require("./inflight.$Closure2-1.js")({
             $std_Json: ${context._lift(std.Json)},
             $usersTable: ${context._lift(usersTable)},
           })
@@ -716,7 +716,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure3-108a257d.js")({
+          require("./inflight.$Closure3-1.js")({
           })
         `);
       }

--- a/tools/hangar/__snapshots__/test_corpus/valid/while_loop_await.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/while_loop_await.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [while_loop_await.w](../../../../../examples/tests/valid/while_loop_await.w) | compile | tf-aws
 
-## inflight.$Closure1-d7846267.js
+## inflight.$Closure1-1.js
 ```js
 module.exports = function({  }) {
   class $Closure1 {
@@ -188,7 +188,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return $stdlib.core.NodeJsCode.fromInline(`
-          require("./inflight.$Closure1-d7846267.js")({
+          require("./inflight.$Closure1-1.js")({
           })
         `);
       }


### PR DESCRIPTION
In #3743 I introduced some code to avoid name collisions in our code generation by hashing file paths. It seems this was adequate for many cases, but it caused problems for contribution since our `hangar` E2E tests currently compile most Wing programs using absolute paths. That means in these scenarios the hashes will be machine dependent. According to @MarkMcCulloh these tests are needed since there were bugs with absolute paths in the past. To that end, this PR changes the name deduplication strategy to be based around incrementing numbers.

## Checklist

- [ ] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [ ] Description explains motivation and solution
- [ ] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
