### PR TITLE
feat(sdk)!: remove cloud.Queue initialMessages

### DIFF
--- a/docs/docs/04-standard-library/01-cloud/queue.md
+++ b/docs/docs/04-standard-library/01-cloud/queue.md
@@ -239,22 +239,8 @@ let QueueProps = cloud.QueueProps{ ... };
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
-| <code><a href="#@winglang/sdk.cloud.QueueProps.property.initialMessages">initialMessages</a></code> | <code>MutArray&lt;str&gt;</code> | Initialize the queue with a set of messages. |
 | <code><a href="#@winglang/sdk.cloud.QueueProps.property.retentionPeriod">retentionPeriod</a></code> | <code><a href="#@winglang/sdk.std.Duration">duration</a></code> | How long a queue retains a message. |
 | <code><a href="#@winglang/sdk.cloud.QueueProps.property.timeout">timeout</a></code> | <code><a href="#@winglang/sdk.std.Duration">duration</a></code> | How long a queue's consumers have to process a message. |
-
----
-
-##### `initialMessages`<sup>Optional</sup> <a name="initialMessages" id="@winglang/sdk.cloud.QueueProps.property.initialMessages"></a>
-
-```wing
-initialMessages: MutArray<str>;
-```
-
-- *Type:* MutArray&lt;str&gt;
-- *Default:* []
-
-Initialize the queue with a set of messages.
 
 ---
 

--- a/libs/wingc/src/lsp/snapshots/completions/incomplete_inflight_namespace.snap
+++ b/libs/wingc/src/lsp/snapshots/completions/incomplete_inflight_namespace.snap
@@ -203,7 +203,7 @@ source: libs/wingc/src/lsp/completions.rs
   kind: 22
   documentation:
     kind: markdown
-    value: "```wing\nstruct QueueProps\n```\n---\nOptions for `Queue`.\n### Fields\n- `initialMessages?` — Initialize the queue with a set of messages.\n- `retentionPeriod?` — How long a queue retains a message.\n- `timeout?` — How long a queue's consumers have to process a message."
+    value: "```wing\nstruct QueueProps\n```\n---\nOptions for `Queue`.\n### Fields\n- `retentionPeriod?` — How long a queue retains a message.\n- `timeout?` — How long a queue's consumers have to process a message."
   sortText: hh|QueueProps
 - label: QueueSetConsumerProps
   kind: 22

--- a/libs/wingc/src/lsp/snapshots/completions/namespace_middle_dot.snap
+++ b/libs/wingc/src/lsp/snapshots/completions/namespace_middle_dot.snap
@@ -203,7 +203,7 @@ source: libs/wingc/src/lsp/completions.rs
   kind: 22
   documentation:
     kind: markdown
-    value: "```wing\nstruct QueueProps\n```\n---\nOptions for `Queue`.\n### Fields\n- `initialMessages?` — Initialize the queue with a set of messages.\n- `retentionPeriod?` — How long a queue retains a message.\n- `timeout?` — How long a queue's consumers have to process a message."
+    value: "```wing\nstruct QueueProps\n```\n---\nOptions for `Queue`.\n### Fields\n- `retentionPeriod?` — How long a queue retains a message.\n- `timeout?` — How long a queue's consumers have to process a message."
   sortText: hh|QueueProps
 - label: QueueSetConsumerProps
   kind: 22

--- a/libs/wingc/src/lsp/snapshots/completions/variable_type_annotation_namespace.snap
+++ b/libs/wingc/src/lsp/snapshots/completions/variable_type_annotation_namespace.snap
@@ -203,7 +203,7 @@ source: libs/wingc/src/lsp/completions.rs
   kind: 22
   documentation:
     kind: markdown
-    value: "```wing\nstruct QueueProps\n```\n---\nOptions for `Queue`.\n### Fields\n- `initialMessages?` — Initialize the queue with a set of messages.\n- `retentionPeriod?` — How long a queue retains a message.\n- `timeout?` — How long a queue's consumers have to process a message."
+    value: "```wing\nstruct QueueProps\n```\n---\nOptions for `Queue`.\n### Fields\n- `retentionPeriod?` — How long a queue retains a message.\n- `timeout?` — How long a queue's consumers have to process a message."
   sortText: hh|QueueProps
 - label: QueueSetConsumerProps
   kind: 22

--- a/libs/wingsdk/src/cloud/queue.ts
+++ b/libs/wingsdk/src/cloud/queue.ts
@@ -24,12 +24,6 @@ export interface QueueProps {
    * @default undefined
    */
   readonly retentionPeriod?: Duration;
-
-  /**
-   * Initialize the queue with a set of messages.
-   * @default []
-   */
-  readonly initialMessages?: string[];
 }
 
 /**

--- a/libs/wingsdk/src/target-awscdk/queue.ts
+++ b/libs/wingsdk/src/target-awscdk/queue.ts
@@ -29,12 +29,6 @@ export class Queue extends cloud.Queue {
         ? Duration.seconds(props.retentionPeriod?.seconds)
         : undefined,
     });
-
-    if ((props.initialMessages ?? []).length) {
-      throw new Error(
-        "initialMessages not supported yet for AWS target - https://github.com/winglang/wing/issues/281"
-      );
-    }
   }
 
   public setConsumer(

--- a/libs/wingsdk/src/target-sim/queue.inflight.ts
+++ b/libs/wingsdk/src/target-sim/queue.inflight.ts
@@ -25,14 +25,6 @@ export class Queue
   private readonly retentionPeriod: number;
 
   constructor(props: QueueSchema["props"], context: ISimulatorContext) {
-    if (props.initialMessages) {
-      this.messages.push(
-        ...props.initialMessages.map(
-          (message) => new QueueMessage(this.retentionPeriod, message)
-        )
-      );
-    }
-
     this.timeout = props.timeout;
     this.retentionPeriod = props.retentionPeriod;
     this.intervalId = setInterval(() => this.processMessages(), 100); // every 0.1 seconds

--- a/libs/wingsdk/src/target-sim/queue.ts
+++ b/libs/wingsdk/src/target-sim/queue.ts
@@ -19,7 +19,6 @@ import { BaseResourceSchema } from "../testing/simulator";
 export class Queue extends cloud.Queue implements ISimulatorResource {
   private readonly timeout: Duration;
   private readonly retentionPeriod: Duration;
-  private readonly initialMessages: string[] = [];
   constructor(scope: Construct, id: string, props: cloud.QueueProps = {}) {
     super(scope, id, props);
 
@@ -31,8 +30,6 @@ export class Queue extends cloud.Queue implements ISimulatorResource {
         "Retention period must be greater than or equal to timeout"
       );
     }
-
-    this.initialMessages.push(...(props.initialMessages ?? []));
   }
 
   public setConsumer(
@@ -104,7 +101,6 @@ export class Queue extends cloud.Queue implements ISimulatorResource {
       props: {
         timeout: this.timeout.seconds,
         retentionPeriod: this.retentionPeriod.seconds,
-        initialMessages: this.initialMessages,
       },
       attrs: {} as any,
     };

--- a/libs/wingsdk/src/target-sim/schema-resources.ts
+++ b/libs/wingsdk/src/target-sim/schema-resources.ts
@@ -80,8 +80,6 @@ export interface QueueSchema extends BaseResourceSchema {
     readonly timeout: number;
     /** How long a queue retains a message, in seconds */
     readonly retentionPeriod: number;
-    /** Initial messages to be pushed to the queue. */
-    readonly initialMessages: string[];
   };
 }
 

--- a/libs/wingsdk/src/target-tf-aws/queue.ts
+++ b/libs/wingsdk/src/target-tf-aws/queue.ts
@@ -35,12 +35,6 @@ export class Queue extends cloud.Queue {
       messageRetentionSeconds: props.retentionPeriod?.seconds,
       name: ResourceNames.generateName(this, NAME_OPTS),
     });
-
-    if ((props.initialMessages ?? []).length) {
-      throw new Error(
-        "initialMessages not supported yet for AWS target - https://github.com/winglang/wing/issues/281"
-      );
-    }
   }
 
   public setConsumer(

--- a/libs/wingsdk/test/target-awscdk/__snapshots__/counter.test.ts.snap
+++ b/libs/wingsdk/test/target-awscdk/__snapshots__/counter.test.ts.snap
@@ -129,7 +129,7 @@ exports[`dec() policy statement 2`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "7f88ad6b39756ca47a1f62c4073b16e7d1dd718dccac91f2f477bd8b7d93979b.zip",
+          "S3Key": "f3738bcfd58c05cf71242945f065454f27590bcdafb0ccd96150f36963676a16.zip",
         },
         "Environment": {
           "Variables": {
@@ -367,7 +367,7 @@ exports[`function with a counter binding 2`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "eeb1a09b430750f79d2178a853df4a7c9c3da2b3cd34773230b0e09b686d118e.zip",
+          "S3Key": "b03ff20bc0f7d7c4d3c6ac541eb138884f06868c5412ad8414d7913bebca1b6d.zip",
         },
         "Environment": {
           "Variables": {
@@ -539,7 +539,7 @@ exports[`inc() policy statement 2`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "eeb1a09b430750f79d2178a853df4a7c9c3da2b3cd34773230b0e09b686d118e.zip",
+          "S3Key": "b03ff20bc0f7d7c4d3c6ac541eb138884f06868c5412ad8414d7913bebca1b6d.zip",
         },
         "Environment": {
           "Variables": {
@@ -711,7 +711,7 @@ exports[`peek() policy statement 2`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "c99045e525ddd3aa5e452c244ab0e15d7dccb0c992971ff69d1556a946b4f4ef.zip",
+          "S3Key": "9189a03759b8a966a3e4efb03da3bf6b2546b25b85ccf726d3240bbc1b86e272.zip",
         },
         "Environment": {
           "Variables": {
@@ -883,7 +883,7 @@ exports[`set() policy statement 2`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "239ecd5b27a3e3d0fe03e52540218d631d1790ad7a32eb81f57677613ba2e1c7.zip",
+          "S3Key": "0da3747a941f72aa30762d828c78b18e9f513c3801f61711ae0fd3ff29a218b5.zip",
         },
         "Environment": {
           "Variables": {

--- a/libs/wingsdk/test/target-awscdk/__snapshots__/counter.test.ts.snap
+++ b/libs/wingsdk/test/target-awscdk/__snapshots__/counter.test.ts.snap
@@ -129,7 +129,7 @@ exports[`dec() policy statement 2`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "f3738bcfd58c05cf71242945f065454f27590bcdafb0ccd96150f36963676a16.zip",
+          "S3Key": "7f88ad6b39756ca47a1f62c4073b16e7d1dd718dccac91f2f477bd8b7d93979b.zip",
         },
         "Environment": {
           "Variables": {
@@ -367,7 +367,7 @@ exports[`function with a counter binding 2`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "b03ff20bc0f7d7c4d3c6ac541eb138884f06868c5412ad8414d7913bebca1b6d.zip",
+          "S3Key": "eeb1a09b430750f79d2178a853df4a7c9c3da2b3cd34773230b0e09b686d118e.zip",
         },
         "Environment": {
           "Variables": {
@@ -539,7 +539,7 @@ exports[`inc() policy statement 2`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "b03ff20bc0f7d7c4d3c6ac541eb138884f06868c5412ad8414d7913bebca1b6d.zip",
+          "S3Key": "eeb1a09b430750f79d2178a853df4a7c9c3da2b3cd34773230b0e09b686d118e.zip",
         },
         "Environment": {
           "Variables": {
@@ -711,7 +711,7 @@ exports[`peek() policy statement 2`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "9189a03759b8a966a3e4efb03da3bf6b2546b25b85ccf726d3240bbc1b86e272.zip",
+          "S3Key": "c99045e525ddd3aa5e452c244ab0e15d7dccb0c992971ff69d1556a946b4f4ef.zip",
         },
         "Environment": {
           "Variables": {
@@ -883,7 +883,7 @@ exports[`set() policy statement 2`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "0da3747a941f72aa30762d828c78b18e9f513c3801f61711ae0fd3ff29a218b5.zip",
+          "S3Key": "239ecd5b27a3e3d0fe03e52540218d631d1790ad7a32eb81f57677613ba2e1c7.zip",
         },
         "Environment": {
           "Variables": {

--- a/libs/wingsdk/test/target-sim/__snapshots__/file-counter.test.ts.snap
+++ b/libs/wingsdk/test/target-sim/__snapshots__/file-counter.test.ts.snap
@@ -79,7 +79,6 @@ bucket: (function(env) {
         "attrs": {},
         "path": "root/HelloWorld/Queue",
         "props": {
-          "initialMessages": [],
           "retentionPeriod": 3600,
           "timeout": 10,
         },

--- a/libs/wingsdk/test/target-sim/__snapshots__/queue.test.ts.snap
+++ b/libs/wingsdk/test/target-sim/__snapshots__/queue.test.ts.snap
@@ -16,7 +16,6 @@ exports[`create a queue 1`] = `
         "attrs": {},
         "path": "root/my_queue",
         "props": {
-          "initialMessages": [],
           "retentionPeriod": 3600,
           "timeout": 10,
         },
@@ -136,7 +135,6 @@ async handle(message) {
         "attrs": {},
         "path": "root/my_queue",
         "props": {
-          "initialMessages": [],
           "retentionPeriod": 1,
           "timeout": 2,
         },
@@ -369,7 +367,6 @@ async handle(message) {
         "attrs": {},
         "path": "root/my_queue",
         "props": {
-          "initialMessages": [],
           "retentionPeriod": 3600,
           "timeout": 1,
         },
@@ -606,7 +603,6 @@ async handle(message) {
         "attrs": {},
         "path": "root/my_queue",
         "props": {
-          "initialMessages": [],
           "retentionPeriod": 3600,
           "timeout": 1,
         },
@@ -805,7 +801,6 @@ exports[`queue batch size of 2, purge the queue 2`] = `
         "attrs": {},
         "path": "root/my_queue",
         "props": {
-          "initialMessages": [],
           "retentionPeriod": 3600,
           "timeout": 10,
         },
@@ -867,8 +862,20 @@ exports[`queue with one subscriber, batch size of 5 1`] = `
   "wingsdk.cloud.Function created.",
   "wingsdk.cloud.Queue created.",
   "wingsdk.sim.EventMapping created.",
+  "wingsdk.cloud.Function created.",
+  "Push (message=A).",
+  "Push (message=B).",
+  "Push (message=C).",
+  "Push (message=D).",
+  "Push (message=E).",
+  "Push (message=F).",
+  "Invoke (payload=\\"\\").",
+  "OnDeploy invoked.",
+  "wingsdk.cloud.OnDeploy created.",
   "Sending messages (messages=[\\"A\\",\\"B\\",\\"C\\",\\"D\\",\\"E\\"], subscriber=sim-1).",
   "Sending messages (messages=[\\"F\\"], subscriber=sim-1).",
+  "wingsdk.cloud.OnDeploy deleted.",
+  "wingsdk.cloud.Function deleted.",
   "wingsdk.sim.EventMapping deleted.",
   "wingsdk.cloud.Queue deleted.",
   "wingsdk.cloud.Function deleted.",
@@ -878,6 +885,33 @@ exports[`queue with one subscriber, batch size of 5 1`] = `
 
 exports[`queue with one subscriber, batch size of 5 2`] = `
 {
+  ".wing/function_c8ab799f.js": "exports.handler = async function(event) {
+  return await (new ((function(){
+return class Handler {
+  constructor(clients) {
+    for (const [name, client] of Object.entries(clients)) {
+      this[name] = client;
+    }
+  }
+  async handle() {
+  await this.queue.push(\\"A\\");
+  await this.queue.push(\\"B\\");
+  await this.queue.push(\\"C\\");
+  await this.queue.push(\\"D\\");
+  await this.queue.push(\\"E\\");
+  await this.queue.push(\\"F\\");
+}
+};
+})())({
+queue: (function(env) {
+        let handle = process.env[env];
+        if (!handle) {
+          throw new Error(\\"Missing environment variable: \\" + env);
+        }
+        return $simulator.findInstance(handle);
+      })(\\"QUEUE_HANDLE_54fcf4cd\\")
+})).handle(event);
+};",
   ".wing/my_queue-setconsumer-e645076f_c8ddc1ce.js": "exports.handler = async function(event) {
   return await (new (require(\\"[REDACTED]/wingsdk/src/target-sim/queue.setconsumer.inflight.js\\")).QueueSetConsumerHandlerClient({ handler: new ((function(){
 return class Handler {
@@ -922,14 +956,6 @@ async handle(message) {
         "attrs": {},
         "path": "root/my_queue",
         "props": {
-          "initialMessages": [
-            "A",
-            "B",
-            "C",
-            "D",
-            "E",
-            "F",
-          ],
           "retentionPeriod": 3600,
           "timeout": 10,
         },
@@ -946,6 +972,27 @@ async handle(message) {
           },
         },
         "type": "wingsdk.sim.EventMapping",
+      },
+      {
+        "attrs": {},
+        "path": "root/my_queue_messages/Function",
+        "props": {
+          "environmentVariables": {
+            "QUEUE_HANDLE_54fcf4cd": "\${root/my_queue#attrs.handle}",
+          },
+          "sourceCodeFile": ".wing/function_c8ab799f.js",
+          "sourceCodeLanguage": "javascript",
+          "timeout": 60000,
+        },
+        "type": "wingsdk.cloud.Function",
+      },
+      {
+        "attrs": {},
+        "path": "root/my_queue_messages",
+        "props": {
+          "functionHandle": "\${root/my_queue_messages/Function#attrs.handle}",
+        },
+        "type": "wingsdk.cloud.OnDeploy",
       },
     ],
     "sdkVersion": "0.0.0",
@@ -982,6 +1029,22 @@ async handle(message) {
           "id": "Handler",
           "path": "root/Handler",
         },
+        "OnDeployHandler": {
+          "attributes": {
+            "wing:resource:connections": [],
+          },
+          "constructInfo": {
+            "fqn": "constructs.Construct",
+            "version": "10.1.314",
+          },
+          "display": {
+            "description": "An inflight resource",
+            "hidden": true,
+            "title": "Inflight",
+          },
+          "id": "OnDeployHandler",
+          "path": "root/OnDeployHandler",
+        },
         "cloud.TestRunner": {
           "attributes": {
             "wing:resource:connections": [],
@@ -1001,6 +1064,18 @@ async handle(message) {
         "my_queue": {
           "attributes": {
             "wing:resource:connections": [
+              {
+                "direction": "inbound",
+                "implicit": false,
+                "relationship": "push()",
+                "resource": "root/my_queue_messages/Function",
+              },
+              {
+                "direction": "inbound",
+                "implicit": false,
+                "relationship": "$inflight_init()",
+                "resource": "root/my_queue_messages/Function",
+              },
               {
                 "direction": "outbound",
                 "implicit": false,
@@ -1085,6 +1160,52 @@ async handle(message) {
           "id": "my_queue",
           "path": "root/my_queue",
         },
+        "my_queue_messages": {
+          "attributes": {
+            "wing:resource:connections": [],
+          },
+          "children": {
+            "Function": {
+              "attributes": {
+                "wing:resource:connections": [
+                  {
+                    "direction": "outbound",
+                    "implicit": false,
+                    "relationship": "push()",
+                    "resource": "root/my_queue",
+                  },
+                  {
+                    "direction": "outbound",
+                    "implicit": false,
+                    "relationship": "$inflight_init()",
+                    "resource": "root/my_queue",
+                  },
+                ],
+              },
+              "constructInfo": {
+                "fqn": "constructs.Construct",
+                "version": "10.1.314",
+              },
+              "display": {
+                "description": "A cloud function (FaaS)",
+                "sourceModule": "@winglang/sdk",
+                "title": "Function",
+              },
+              "id": "Function",
+              "path": "root/my_queue_messages/Function",
+            },
+          },
+          "constructInfo": {
+            "fqn": "constructs.Construct",
+            "version": "10.1.314",
+          },
+          "display": {
+            "description": "Run code during the app's deployment.",
+            "title": "OnDeploy",
+          },
+          "id": "my_queue_messages",
+          "path": "root/my_queue_messages",
+        },
       },
       "constructInfo": {
         "fqn": "constructs.Construct",
@@ -1161,7 +1282,6 @@ async handle(message) {
         "attrs": {},
         "path": "root/my_queue",
         "props": {
-          "initialMessages": [],
           "retentionPeriod": 3600,
           "timeout": 10,
         },

--- a/libs/wingsdk/test/target-sim/__snapshots__/queue.test.ts.snap
+++ b/libs/wingsdk/test/target-sim/__snapshots__/queue.test.ts.snap
@@ -1065,6 +1065,12 @@ async handle(message) {
           "attributes": {
             "wing:resource:connections": [
               {
+                "direction": "outbound",
+                "implicit": false,
+                "relationship": "setConsumer()",
+                "resource": "root/my_queue/my_queue-SetConsumer-e645076f",
+              },
+              {
                 "direction": "inbound",
                 "implicit": false,
                 "relationship": "push()",
@@ -1075,12 +1081,6 @@ async handle(message) {
                 "implicit": false,
                 "relationship": "$inflight_init()",
                 "resource": "root/my_queue_messages/Function",
-              },
-              {
-                "direction": "outbound",
-                "implicit": false,
-                "relationship": "setConsumer()",
-                "resource": "root/my_queue/my_queue-SetConsumer-e645076f",
               },
             ],
           },

--- a/libs/wingsdk/test/target-sim/queue.test.ts
+++ b/libs/wingsdk/test/target-sim/queue.test.ts
@@ -95,10 +95,12 @@ test("queue batch size of 2, purge the queue", async () => {
 test("queue with one subscriber, batch size of 5", async () => {
   // GIVEN
   const app = new SimApp();
+
+  const queue = cloud.Queue._newQueue(app, "my_queue");
   const handler = Testing.makeHandler(app, "Handler", INFLIGHT_CODE);
+  queue.setConsumer(handler, { batchSize: 5 });
 
   // initialize the queue with some messages
-  const queue = cloud.Queue._newQueue(app, "my_queue");
   const onDeployHandler = Testing.makeHandler(
     app,
     "OnDeployHandler",
@@ -118,7 +120,7 @@ test("queue with one subscriber, batch size of 5", async () => {
     }
   );
   cloud.OnDeploy._newOnDeploy(app, "my_queue_messages", onDeployHandler);
-  queue.setConsumer(handler, { batchSize: 5 });
+
   const s = await app.startSimulator();
 
   // WHEN

--- a/libs/wingsdk/test/target-sim/queue.test.ts
+++ b/libs/wingsdk/test/target-sim/queue.test.ts
@@ -298,30 +298,18 @@ test("can pop messages from queue", async () => {
   // GIVEN
   const app = new SimApp();
   const messages = ["A", "B", "C", "D", "E", "F"];
-  const queue = cloud.Queue._newQueue(app, "my_queue");
-  const onDeployHandler = Testing.makeHandler(
-    app,
-    "OnDeployHandler",
-    `async handle() {
-  await this.queue.push("A");
-  await this.queue.push("B");
-  await this.queue.push("C");
-  await this.queue.push("D");
-  await this.queue.push("E");
-  await this.queue.push("F");
-}`,
-    {
-      queue: {
-        obj: queue,
-        ops: [cloud.QueueInflightMethods.PUSH],
-      },
-    }
-  );
-  cloud.OnDeploy._newOnDeploy(app, "my_queue_messages", onDeployHandler);
+  cloud.Queue._newQueue(app, "my_queue");
 
   // WHEN
   const s = await app.startSimulator();
   const queueClient = s.getResource("/my_queue") as cloud.IQueueClient;
+
+  // initialize the messages
+  for (const message of messages) {
+    await queueClient.push(message);
+  }
+
+  // try popping them
   const poppedMessages: Array<string | undefined> = [];
   for (let i = 0; i < messages.length; i++) {
     poppedMessages.push(await queueClient.pop());


### PR DESCRIPTION
Removes the `initialMessages` property from `cloud.Queue` to reduce API surface area in the standard library. This capability has only worked on the `sim` target to date, and it's possible to easily achieve the capability (across clouds) using `cloud.OnDeploy`:

```js
bring cloud;

let queue = new cloud.Queue();
new cloud.OnDeploy(inflight () => {
  queue.push("hello");
  queue.push("world");
});
```

This style of API would have more merit if it's something we could provided an optimized implementation for, but it doesn't appear there are dedicated Terraform resources available that represent AWS SQS messages or Google PubSub items. `OnDeploy` also offers more flexibility since it allows the user to dynamically calculate the queue's initial messages based on the results of other inflight operations.

Closes #281.

BREAKING CHANGE: The field `initialMessages` of `cloud.Queue` has been removed. Instead, use the `cloud.OnDeploy` resource to perform any deploy-time initialization logic.

## Checklist

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [x] Tests added (always)
- [x] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
