### PR TITLE
feat(sdk): sim.Object

### DIFF
--- a/examples/tests/sdk_tests/std/shared-state.w
+++ b/examples/tests/sdk_tests/std/shared-state.w
@@ -1,0 +1,33 @@
+bring cloud;
+
+class QueueSim {
+  rawMessages: std.SharedState;
+
+  init() {
+    this.rawMessages = new std.SharedState(MutArray<str>[]);
+  }
+
+  inflight push(message: str) {
+    let rawMessages = this.rawMessages.get();
+    rawMessages.push(message);
+  }
+
+  inflight pop(): str {
+    let rawMessages = this.rawMessages.get();
+    return rawMessages.pop();
+  }
+}
+
+let queue = new QueueSim();
+
+let pusher = new cloud.Function(inflight () => {
+  queue.push("hello");
+}) as "pusher";
+let popper = new cloud.Function(inflight (): str => {
+  return queue.pop();
+}) as "popper";
+
+test "push and pop from different functions" {
+  pusher.invoke("");
+  assert(popper.invoke("") == "hello");
+}

--- a/libs/wingsdk/src/std/index.ts
+++ b/libs/wingsdk/src/std/index.ts
@@ -9,6 +9,7 @@ export * from "./number";
 export * from "./range";
 export * from "./resource";
 export * from "./set";
+export * from "./shared-state";
 export * from "./string";
 export * from "./test";
 export * from "./test-runner";

--- a/libs/wingsdk/src/std/shared-state.ts
+++ b/libs/wingsdk/src/std/shared-state.ts
@@ -1,0 +1,69 @@
+import { Construct } from "constructs";
+import { IResource, Resource } from "./resource";
+import { fqnForType } from "../constants";
+import { App } from "../core";
+
+/**
+ * Global identifier for `SharedState`.
+ */
+export const SHARED_STATE_FQN = fqnForType("std.SharedState");
+
+/**
+ * A container for a value that can be shared and mutated across inflight consumers.
+ * Only supported in the `sim` compilation target.
+ *
+ * @inflight `@winglang/sdk.std.ISharedStateClient`
+ */
+export abstract class SharedState extends Resource implements IResource {
+  /**
+   * Create a new SharedState instance.
+   * @internal
+   */
+  public static _newSharedState(
+    scope: Construct,
+    id: string,
+    initial: any
+  ): SharedState {
+    return App.of(scope).newAbstract(SHARED_STATE_FQN, scope, id, initial);
+  }
+
+  constructor(scope: Construct, id: string, initial: any) {
+    super(scope, id);
+
+    initial;
+
+    this.display.title = "SharedState";
+    this.display.description =
+      "A container that can share a value across inflight consumers.";
+
+    this._addInflightOps(SharedStateMethods.GET, SharedStateMethods.SET);
+  }
+}
+
+/**
+ * Inflight interface for `SharedState`.
+ */
+export interface ISharedStateClient {
+  /**
+   * Get the inner value.
+   * @inflight
+   */
+  get(): Promise<any>;
+
+  /**
+   * Replace the inner value with a new value.
+   * @inflight
+   */
+  set(value: any): Promise<void>;
+}
+
+/**
+ * List of inflight operations available for `SharedState`.
+ * @internal
+ */
+export enum SharedStateMethods {
+  /** `SharedState.get` */
+  GET = "get",
+  /** `SharedState.set` */
+  SET = "set",
+}

--- a/libs/wingsdk/src/target-sim/app.ts
+++ b/libs/wingsdk/src/target-sim/app.ts
@@ -12,6 +12,7 @@ import { isSimulatorResource } from "./resource";
 import { Schedule } from "./schedule";
 import { Secret } from "./secret";
 import { Service } from "./service";
+import { SharedState } from "./shared-state";
 import { Table } from "./table";
 import { TestRunner } from "./test-runner";
 import { SimTokens } from "./tokens";
@@ -34,7 +35,7 @@ import { SDK_VERSION } from "../constants";
 import * as core from "../core";
 import { preSynthesizeAllConstructs } from "../core/app";
 import { TABLE_FQN, REDIS_FQN } from "../ex";
-import { TEST_RUNNER_FQN } from "../std";
+import { SHARED_STATE_FQN, TEST_RUNNER_FQN } from "../std";
 import { WingSimulatorSchema } from "../testing/simulator";
 
 /**
@@ -118,6 +119,9 @@ export class App extends core.App {
 
       case ON_DEPLOY_FQN:
         return new OnDeploy(scope, id, args[0], args[1]);
+
+      case SHARED_STATE_FQN:
+        return new SharedState(scope, id, args[0]);
     }
 
     return undefined;

--- a/libs/wingsdk/src/target-sim/factory.inflight.ts
+++ b/libs/wingsdk/src/target-sim/factory.inflight.ts
@@ -15,6 +15,7 @@ import {
   SCHEDULE_TYPE,
   SERVICE_TYPE,
   ON_DEPLOY_TYPE,
+  SHARED_STATE_TYPE,
 } from "./schema-resources";
 import type {
   ISimulatorFactory,
@@ -82,6 +83,9 @@ export class DefaultSimulatorFactory implements ISimulatorFactory {
       case ON_DEPLOY_TYPE:
         const OnDeploy = require("./on-deploy.inflight").OnDeploy;
         return new OnDeploy(props, context);
+      case SHARED_STATE_TYPE:
+        const SharedState = require("./shared-state.inflight").SharedState;
+        return new SharedState(props, context);
       default:
         throw new Error(`Type ${type} not implemented by the simulator.`);
     }

--- a/libs/wingsdk/src/target-sim/schema-resources.ts
+++ b/libs/wingsdk/src/target-sim/schema-resources.ts
@@ -23,6 +23,8 @@ export const SECRET_TYPE = "wingsdk.cloud.Secret";
 export const SERVICE_TYPE = "wingsdk.cloud.Service";
 export const ON_DEPLOY_TYPE = "wingsdk.cloud.OnDeploy";
 
+export const SHARED_STATE_TYPE = "wingsdk.std.SharedState";
+
 export type FunctionHandle = string;
 export type PublisherHandle = string;
 
@@ -265,3 +267,15 @@ export interface OnDeploySchema extends BaseResourceSchema {
 
 /** Runtime attributes for cloud.OnDeploy */
 export interface OnDeployAttributes {}
+
+/** Schema for std.SharedState */
+export interface SharedStateSchema extends BaseResourceSchema {
+  readonly type: typeof SHARED_STATE_TYPE;
+  readonly props: {
+    /** The initial value. */
+    readonly initialValue: any;
+  };
+}
+
+/** Runtime attributes for std.SharedState */
+export interface SharedStateAttributes {}

--- a/libs/wingsdk/src/target-sim/shared-state.inflight.ts
+++ b/libs/wingsdk/src/target-sim/shared-state.inflight.ts
@@ -1,0 +1,44 @@
+import { SharedStateAttributes, SharedStateSchema } from "./schema-resources";
+import { ISharedStateClient } from "../std";
+import { ISimulatorContext, ISimulatorResourceInstance } from "../testing";
+
+export class SharedState
+  implements ISharedStateClient, ISimulatorResourceInstance
+{
+  private value: any;
+  private readonly context: ISimulatorContext;
+
+  public constructor(
+    props: SharedStateSchema["props"],
+    context: ISimulatorContext
+  ) {
+    this.value = props.initialValue;
+    this.context = context;
+  }
+
+  public async init(): Promise<SharedStateAttributes> {
+    return {};
+  }
+
+  public async cleanup(): Promise<void> {
+    return;
+  }
+
+  public async get(): Promise<any> {
+    return this.context.withTrace({
+      message: `Get.`,
+      activity: async () => {
+        return this.value;
+      },
+    });
+  }
+
+  public async set(value: any): Promise<void> {
+    return this.context.withTrace({
+      message: `Set.`,
+      activity: async () => {
+        this.value = value;
+      },
+    });
+  }
+}

--- a/libs/wingsdk/src/target-sim/shared-state.ts
+++ b/libs/wingsdk/src/target-sim/shared-state.ts
@@ -1,0 +1,42 @@
+import { Construct } from "constructs";
+import { ISimulatorResource } from "./resource";
+import { SHARED_STATE_TYPE, SharedStateSchema } from "./schema-resources";
+import { bindSimulatorResource, makeSimulatorJsClient } from "./util";
+import * as core from "../core";
+import * as std from "../std";
+import { BaseResourceSchema } from "../testing/simulator";
+
+/**
+ * Simulator implementation of `std.SharedState`
+ *
+ * @inflight `@winglang/sdk.std.ISharedStateClient`
+ */
+export class SharedState extends std.SharedState implements ISimulatorResource {
+  private readonly initial: std.MutJson;
+  constructor(scope: Construct, id: string, initial: any) {
+    super(scope, id, initial);
+    this.initial = initial;
+  }
+
+  public bind(host: std.IInflightHost, ops: string[]): void {
+    bindSimulatorResource(__filename, this, host);
+    super.bind(host, ops);
+  }
+
+  /** @internal */
+  public _toInflight(): core.Code {
+    return makeSimulatorJsClient(__filename, this);
+  }
+
+  public toSimulator(): BaseResourceSchema {
+    const schema: SharedStateSchema = {
+      type: SHARED_STATE_TYPE,
+      path: this.node.path,
+      props: {
+        initialValue: this.initial,
+      },
+      attrs: {} as any,
+    };
+    return schema;
+  }
+}

--- a/libs/wingsdk/src/testing/simulator.ts
+++ b/libs/wingsdk/src/testing/simulator.ts
@@ -138,6 +138,14 @@ export class Simulator {
     this._handles = new HandleManager();
     this._traces = new Array();
     this._traceSubscribers = new Array();
+
+    if (process.env.DEBUG) {
+      this._traceSubscribers.push({
+        callback: (event: Trace) => {
+          console.error("[simulator]", event);
+        },
+      });
+    }
   }
 
   private _loadApp(simdir: string): {


### PR DESCRIPTION
Today, it can be difficult or awkward to write `sim` implementations for user-defined Wing classes because there isn't a way to persist data across multiple inflight consumers. To illustrate this point, suppose you create a class in Wing that is implemented as follows:

```js
class Table {
  inflight items: MutArray<num>;
  inflight putItem(x: num) {
    this.items.push(x);
  }
}
```

Since `items` is an inflight field, when `putItem` is called by a resource like a `cloud.Function`, the array mutation will only be visible to that running `cloud.Function` instance. Other instances of `cloud.Function` or other compute resources will not see the change. To make an analogy to the operating systems world, inflight class members are a lot like thread-local variables -- they may persist as long as a piece of compute is running, but gets cleared as soon as that thread (or compute instance) is killed.

It's possible to work around this by using one of the existing SDK resources like `cloud.Bucket` or `cloud.Queue` etc. that have data persistence built in. However this doesn't always feel idiomatic, since `cloud.Bucket` doesn't provide strong typing for the data stored inside, thus requiring you to write data wrapping / unwrapping logic yourself. `cloud.Bucket` can also only store serializable data.

To that end, I'm proposing a dedicated resource / class in the standard library called `sim.SharedState` for sharing mutable data between inflight consumers. The class is only available on the `sim` target. Example usage:

```js
class QueueSim {
  messages: sim.SharedState;
  init() {
    this.messages = new sim.SharedState(MutArray<str>[]);
  }
  inflight push(message: str) {
    let messages = this.messages.get();
    messages.push(message);
  }
  inflight pop(): str {
    let messages = this.messages.get();
    return messages.pop();
  }
}
```

So far this seems most useful for sharing mutable types like `MutArray`, `MutSet`, `MutMap`, and `MutJson`.

Any and all ideas / feedback welcome. 🙂 

Some of the questions that crossed my mind:

- Is it possible to make this class parameterized like some other built-in types (`SharedState<T>`)? What changes to the compiler would this need?
- How could we support initializing `SharedState` with a lifted value like a `cloud.Bucket` client or an inflight class instance? Perhaps instead of accepting `initial: any` in the constructor it should accept `initializer: inflight () -> any`?
- Alternative names?
- Would it make sense to make this a dedicated language feature or keyword at some point? Calling `.get()` and `.set()` seems like extra work for the user that could be desugared away.

TODO:
- [ ] unit tests
- [ ] rename impl to sim.Object or sim.SharedState

## Checklist

- [ ] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [ ] Description explains motivation and solution
- [ ] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
