### PR TITLE
fix(sdk): kill all redis zombies

### DIFF
--- a/libs/wingsdk/src/testing/simulator.ts
+++ b/libs/wingsdk/src/testing/simulator.ts
@@ -235,8 +235,12 @@ export class Simulator {
           `Resource ${resourceConfig.path} could not be cleaned up, no handle for it was found.`
         );
       }
-      const resource = this._handles.deallocate(resourceConfig.attrs!.handle);
-      await resource.cleanup();
+      try {
+        const resource = this._handles.deallocate(resourceConfig.attrs!.handle);
+        await resource.cleanup();
+      } catch (err) {
+        console.warn(err);
+      }
 
       let event: Trace = {
         type: TraceType.RESOURCE,


### PR DESCRIPTION
Fixes #3492 
* Happened because of un-handled SIGINT termination
* Prevented the simulator from being started twice (perhaps more work is needed- for stopping compilation from happening twice)
* Changed the error to a warning while cleaning resources- to be able to clean later resources if one fails

Here is the result:
https://www.loom.com/share/56bddc36c7724d3589a23aebf1141f7a

## Checklist

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [ ] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
