### PR TITLE
revert(docs): added “distributed” to the counter title

### DIFF
--- a/docs/docs/04-standard-library/01-cloud/counter.md
+++ b/docs/docs/04-standard-library/01-cloud/counter.md
@@ -1,7 +1,6 @@
 ---
-title: Distributed Counter
+title: Counter
 id: counter
-sidebar_label: Counter
 description: A built-in resource for representing an container for numbers in the cloud.
 keywords:
   [


### PR DESCRIPTION
doc updated in wrong area
Reverts winglang/wing#3633