### PR TITLE
feat(sdk): `queue.push()` can now handle invalid messages for aws targets

### DIFF
--- a/libs/wingsdk/src/shared-aws/queue.inflight.ts
+++ b/libs/wingsdk/src/shared-aws/queue.inflight.ts
@@ -4,6 +4,7 @@ import {
   PurgeQueueCommand,
   GetQueueAttributesCommand,
   ReceiveMessageCommand,
+  InvalidMessageContents,
 } from "@aws-sdk/client-sqs";
 import { IQueueClient } from "../cloud";
 
@@ -14,11 +15,22 @@ export class QueueClient implements IQueueClient {
   ) {}
 
   public async push(message: string): Promise<void> {
-    const command = new SendMessageCommand({
-      QueueUrl: this.queueUrl,
-      MessageBody: message,
-    });
-    await this.client.send(command);
+    try {
+      const command = new SendMessageCommand({
+        QueueUrl: this.queueUrl,
+        MessageBody: message,
+      });
+      await this.client.send(command);
+    } catch (e) {
+      if (e instanceof InvalidMessageContents) {
+        throw new Error(
+          `The message contains characters outside the allowed set (message=${message}): ${
+            (e as Error).stack
+          })}`
+        );
+      }
+      throw new Error((e as Error).stack);
+    }
   }
 
   public async purge(): Promise<void> {

--- a/libs/wingsdk/test/shared-aws/queue.inflight.test.ts
+++ b/libs/wingsdk/test/shared-aws/queue.inflight.test.ts
@@ -36,7 +36,7 @@ test("push - happy path", async () => {
   expect(response).toEqual(undefined);
 });
 
-test("push - sad path", async () => {
+test("push - sad path invalid message", async () => {
   // GIVEN
   const QUEUE_URL = "QUEUE_URL";
   const MESSAGE = "INVALID_MESSAGE";
@@ -56,6 +56,24 @@ test("push - sad path", async () => {
   // THEN
   await expect(() => client.push(MESSAGE)).rejects.toThrowError(
     /The message contains characters outside the allowed set/
+  );
+});
+
+test("push - sad path unknown error", async () => {
+  // GIVEN
+  const QUEUE_URL = "QUEUE_URL";
+  const MESSAGE = "MESSAGE";
+
+  sqsMock
+    .on(SendMessageCommand, { QueueUrl: QUEUE_URL, MessageBody: MESSAGE })
+    .rejects(new Error("unknown error"));
+
+  // WHEN
+  const client = new QueueClient(QUEUE_URL);
+
+  // THEN
+  await expect(() => client.push(MESSAGE)).rejects.toThrowError(
+    /unknown error/
   );
 });
 


### PR DESCRIPTION
Added error handling for invalid messages in `Queue.push()` following [AWS documentation](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_SendMessage.html).

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
