### PR TITLE
chore: sanitize awscdk snapshot tests and cleanup cdktf snapshots

### DIFF
--- a/libs/wingsdk/test/target-awscdk/__snapshots__/bucket.test.ts.snap
+++ b/libs/wingsdk/test/target-awscdk/__snapshots__/bucket.test.ts.snap
@@ -371,7 +371,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "b9deba0f7dc17e61cf9f7e0fa901af6e57ec811a13882b7048ee9aa75797378d.zip",
+          "S3Key": "<S3Key>",
         },
         "Handler": "index.handler",
         "Role": {
@@ -722,7 +722,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "b9deba0f7dc17e61cf9f7e0fa901af6e57ec811a13882b7048ee9aa75797378d.zip",
+          "S3Key": "<S3Key>",
         },
         "Handler": "index.handler",
         "Role": {
@@ -1095,7 +1095,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "b9deba0f7dc17e61cf9f7e0fa901af6e57ec811a13882b7048ee9aa75797378d.zip",
+          "S3Key": "<S3Key>",
         },
         "Handler": "index.handler",
         "Role": {
@@ -1446,7 +1446,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "b9deba0f7dc17e61cf9f7e0fa901af6e57ec811a13882b7048ee9aa75797378d.zip",
+          "S3Key": "<S3Key>",
         },
         "Handler": "index.handler",
         "Role": {
@@ -1547,7 +1547,7 @@ exports[`bucket with two preflight objects 1`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "2bc265c5e0569aeb24a6349c15bd54e76e845892376515e036627ab0cc70bb64.zip",
+          "S3Key": "<S3Key>",
         },
         "Handler": "index.handler",
         "Layers": [
@@ -1757,7 +1757,7 @@ exports[`bucket with two preflight objects 1`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "f8e422c63159c82c409e8254300a3134e020892c27382902d4c8c0a5b35d0a06.zip",
+          "S3Key": "<S3Key>",
         },
         "Description": "/opt/awscli/aws",
       },
@@ -1797,7 +1797,7 @@ exports[`bucket with two preflight objects 1`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "f8e422c63159c82c409e8254300a3134e020892c27382902d4c8c0a5b35d0a06.zip",
+          "S3Key": "<S3Key>",
         },
         "Description": "/opt/awscli/aws",
       },

--- a/libs/wingsdk/test/target-awscdk/__snapshots__/counter.test.ts.snap
+++ b/libs/wingsdk/test/target-awscdk/__snapshots__/counter.test.ts.snap
@@ -129,7 +129,7 @@ exports[`dec() policy statement 2`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "f3738bcfd58c05cf71242945f065454f27590bcdafb0ccd96150f36963676a16.zip",
+          "S3Key": "<S3Key>",
         },
         "Environment": {
           "Variables": {
@@ -367,7 +367,7 @@ exports[`function with a counter binding 2`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "b03ff20bc0f7d7c4d3c6ac541eb138884f06868c5412ad8414d7913bebca1b6d.zip",
+          "S3Key": "<S3Key>",
         },
         "Environment": {
           "Variables": {
@@ -539,7 +539,7 @@ exports[`inc() policy statement 2`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "b03ff20bc0f7d7c4d3c6ac541eb138884f06868c5412ad8414d7913bebca1b6d.zip",
+          "S3Key": "<S3Key>",
         },
         "Environment": {
           "Variables": {
@@ -711,7 +711,7 @@ exports[`peek() policy statement 2`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "9189a03759b8a966a3e4efb03da3bf6b2546b25b85ccf726d3240bbc1b86e272.zip",
+          "S3Key": "<S3Key>",
         },
         "Environment": {
           "Variables": {
@@ -883,7 +883,7 @@ exports[`set() policy statement 2`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "0da3747a941f72aa30762d828c78b18e9f513c3801f61711ae0fd3ff29a218b5.zip",
+          "S3Key": "<S3Key>",
         },
         "Environment": {
           "Variables": {

--- a/libs/wingsdk/test/target-awscdk/__snapshots__/function.test.ts.snap
+++ b/libs/wingsdk/test/target-awscdk/__snapshots__/function.test.ts.snap
@@ -24,7 +24,7 @@ exports[`basic function 1`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "34031e10a718327bb9ec731d7b54025eebeef68c03bb4f5a3d8e6ad5262a0517.zip",
+          "S3Key": "<S3Key>",
         },
         "Handler": "index.handler",
         "Role": {
@@ -124,7 +124,7 @@ exports[`basic function with environment variables 1`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "34031e10a718327bb9ec731d7b54025eebeef68c03bb4f5a3d8e6ad5262a0517.zip",
+          "S3Key": "<S3Key>",
         },
         "Environment": {
           "Variables": {
@@ -230,7 +230,7 @@ exports[`basic function with memory size specified 1`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "34031e10a718327bb9ec731d7b54025eebeef68c03bb4f5a3d8e6ad5262a0517.zip",
+          "S3Key": "<S3Key>",
         },
         "Handler": "index.handler",
         "MemorySize": 512,
@@ -331,7 +331,7 @@ exports[`basic function with timeout explicitly set 1`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "34031e10a718327bb9ec731d7b54025eebeef68c03bb4f5a3d8e6ad5262a0517.zip",
+          "S3Key": "<S3Key>",
         },
         "Handler": "index.handler",
         "Role": {

--- a/libs/wingsdk/test/target-awscdk/__snapshots__/queue.test.ts.snap
+++ b/libs/wingsdk/test/target-awscdk/__snapshots__/queue.test.ts.snap
@@ -86,7 +86,7 @@ exports[`queue with a consumer function 2`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "a028d8321beb7aea3bd17a266a795b276daefdce58f7b21e35e64db6463e08bc.zip",
+          "S3Key": "<S3Key>",
         },
         "Handler": "index.handler",
         "Role": {

--- a/libs/wingsdk/test/target-awscdk/__snapshots__/schedule.test.ts.snap
+++ b/libs/wingsdk/test/target-awscdk/__snapshots__/schedule.test.ts.snap
@@ -61,7 +61,7 @@ exports[`schedule behavior with cron 1`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "99cc55258c346f62db746a74a3b335f909d0326a46c142758fdf8f8d189b2678.zip",
+          "S3Key": "<S3Key>",
         },
         "Handler": "index.handler",
         "Role": {
@@ -198,7 +198,7 @@ exports[`schedule behavior with rate 1`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "99cc55258c346f62db746a74a3b335f909d0326a46c142758fdf8f8d189b2678.zip",
+          "S3Key": "<S3Key>",
         },
         "Handler": "index.handler",
         "Role": {
@@ -363,7 +363,7 @@ exports[`schedule with two functions 1`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "99cc55258c346f62db746a74a3b335f909d0326a46c142758fdf8f8d189b2678.zip",
+          "S3Key": "<S3Key>",
         },
         "Handler": "index.handler",
         "Role": {
@@ -417,7 +417,7 @@ exports[`schedule with two functions 1`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "99cc55258c346f62db746a74a3b335f909d0326a46c142758fdf8f8d189b2678.zip",
+          "S3Key": "<S3Key>",
         },
         "Handler": "index.handler",
         "Role": {

--- a/libs/wingsdk/test/target-awscdk/__snapshots__/topic.test.ts.snap
+++ b/libs/wingsdk/test/target-awscdk/__snapshots__/topic.test.ts.snap
@@ -106,7 +106,7 @@ exports[`topic with multiple subscribers 3`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "4ab62cb5f98ad2f9b2b3dd82c783136bb4211456f7f49afad99a73e6c40a7e6a.zip",
+          "S3Key": "<S3Key>",
         },
         "Handler": "index.handler",
         "Role": {
@@ -191,7 +191,7 @@ exports[`topic with multiple subscribers 3`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "f13044b492c96c95c553740c33ce68a00d453711d947fd68ff5ed4ac51e58c34.zip",
+          "S3Key": "<S3Key>",
         },
         "Handler": "index.handler",
         "Role": {
@@ -340,7 +340,7 @@ exports[`topic with subscriber function 2`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "2ec978de802295e114de200ac50fa06d9a5236c445ecf719650e5f86f9ba6c87.zip",
+          "S3Key": "<S3Key>",
         },
         "Handler": "index.handler",
         "Role": {

--- a/libs/wingsdk/test/target-awscdk/bucket.test.ts
+++ b/libs/wingsdk/test/target-awscdk/bucket.test.ts
@@ -3,10 +3,11 @@ import { test, expect } from "vitest";
 import { Bucket } from "../../src/cloud";
 import * as awscdk from "../../src/target-awscdk";
 import { Testing } from "../../src/testing";
-import { mkdtemp } from "../util";
+import { mkdtemp, awscdkSanitize } from "../util";
 
 const CDK_APP_OPTS = {
   stackName: "my-project",
+  entrypointDir: __dirname,
 };
 
 test("create a bucket", async () => {
@@ -28,7 +29,7 @@ test("create a bucket", async () => {
       },
     })
   );
-  expect(template.toJSON()).toMatchSnapshot();
+  expect(awscdkSanitize(template)).toMatchSnapshot();
 });
 
 test("bucket is public", () => {
@@ -40,7 +41,7 @@ test("bucket is public", () => {
   // THEN
   const template = Template.fromJSON(JSON.parse(output));
   template.resourceCountIs("AWS::S3::Bucket", 1);
-  expect(template.toJSON()).toMatchSnapshot();
+  expect(awscdkSanitize(template)).toMatchSnapshot();
 });
 
 test("bucket with two preflight objects", () => {
@@ -54,7 +55,7 @@ test("bucket with two preflight objects", () => {
   // THEN
   const template = Template.fromJSON(JSON.parse(output));
   template.resourceCountIs("Custom::CDKBucketDeployment", 2);
-  expect(template.toJSON()).toMatchSnapshot();
+  expect(awscdkSanitize(template)).toMatchSnapshot();
 });
 
 test("bucket with onCreate method", () => {
@@ -86,7 +87,7 @@ async handle(event) {
       },
     })
   );
-  expect(template.toJSON()).toMatchSnapshot();
+  expect(awscdkSanitize(template)).toMatchSnapshot();
 });
 
 test("bucket with onDelete method", () => {
@@ -118,7 +119,7 @@ async handle(event) {
       },
     })
   );
-  expect(template.toJSON()).toMatchSnapshot();
+  expect(awscdkSanitize(template)).toMatchSnapshot();
 });
 
 test("bucket with onUpdate method", () => {
@@ -150,7 +151,7 @@ async handle(event) {
       },
     })
   );
-  expect(template.toJSON()).toMatchSnapshot();
+  expect(awscdkSanitize(template)).toMatchSnapshot();
 });
 
 test("bucket with onEvent method", () => {
@@ -182,5 +183,5 @@ async handle(event) {
       },
     })
   );
-  expect(template.toJSON()).toMatchSnapshot();
+  expect(awscdkSanitize(template)).toMatchSnapshot();
 });

--- a/libs/wingsdk/test/target-awscdk/counter.test.ts
+++ b/libs/wingsdk/test/target-awscdk/counter.test.ts
@@ -3,10 +3,11 @@ import { test, expect } from "vitest";
 import { Counter, Function, CounterInflightMethods } from "../../src/cloud";
 import * as awscdk from "../../src/target-awscdk";
 import { Testing } from "../../src/testing";
-import { sanitizeCode, mkdtemp } from "../util";
+import { sanitizeCode, mkdtemp, awscdkSanitize } from "../util";
 
 const CDK_APP_OPTS = {
   stackName: "my-project",
+  entrypointDir: __dirname,
 };
 
 test("default counter behavior", () => {
@@ -23,7 +24,7 @@ test("default counter behavior", () => {
       BillingMode: "PAY_PER_REQUEST",
     })
   );
-  expect(template.toJSON()).toMatchSnapshot();
+  expect(awscdkSanitize(template)).toMatchSnapshot();
 });
 
 test("counter with initial value", () => {
@@ -42,7 +43,7 @@ test("counter with initial value", () => {
       BillingMode: "PAY_PER_REQUEST",
     })
   );
-  expect(template.toJSON()).toMatchSnapshot();
+  expect(awscdkSanitize(template)).toMatchSnapshot();
 });
 
 test("function with a counter binding", () => {
@@ -71,7 +72,7 @@ test("function with a counter binding", () => {
   template.resourceCountIs("AWS::IAM::Role", 1);
   template.resourceCountIs("AWS::IAM::Policy", 1);
   template.resourceCountIs("AWS::Lambda::Function", 1);
-  expect(template.toJSON()).toMatchSnapshot();
+  expect(awscdkSanitize(template)).toMatchSnapshot();
 });
 
 test("inc() policy statement", () => {
@@ -106,7 +107,7 @@ test("inc() policy statement", () => {
       ]),
     },
   });
-  expect(template.toJSON()).toMatchSnapshot();
+  expect(awscdkSanitize(template)).toMatchSnapshot();
 });
 
 test("dec() policy statement", () => {
@@ -141,7 +142,7 @@ test("dec() policy statement", () => {
       ]),
     },
   });
-  expect(template.toJSON()).toMatchSnapshot();
+  expect(awscdkSanitize(template)).toMatchSnapshot();
 });
 
 test("peek() policy statement", () => {
@@ -176,7 +177,7 @@ test("peek() policy statement", () => {
       ]),
     },
   });
-  expect(template.toJSON()).toMatchSnapshot();
+  expect(awscdkSanitize(template)).toMatchSnapshot();
 });
 
 test("set() policy statement", () => {
@@ -211,5 +212,5 @@ test("set() policy statement", () => {
       ]),
     },
   });
-  expect(template.toJSON()).toMatchSnapshot();
+  expect(awscdkSanitize(template)).toMatchSnapshot();
 });

--- a/libs/wingsdk/test/target-awscdk/function.test.ts
+++ b/libs/wingsdk/test/target-awscdk/function.test.ts
@@ -4,10 +4,11 @@ import { Function } from "../../src/cloud";
 import { Duration } from "../../src/std";
 import * as awscdk from "../../src/target-awscdk";
 import { Testing } from "../../src/testing";
-import { mkdtemp } from "../util";
+import { mkdtemp, awscdkSanitize } from "../util";
 
 const CDK_APP_OPTS = {
   stackName: "my-project",
+  entrypointDir: __dirname,
 };
 
 const INFLIGHT_CODE = `async handle(name) { console.log("Hello, " + name); }`;
@@ -29,7 +30,7 @@ test("basic function", () => {
       Timeout: 30,
     })
   );
-  expect(template.toJSON()).toMatchSnapshot();
+  expect(awscdkSanitize(template)).toMatchSnapshot();
 });
 
 test("basic function with environment variables", () => {
@@ -60,7 +61,7 @@ test("basic function with environment variables", () => {
       },
     })
   );
-  expect(template.toJSON()).toMatchSnapshot();
+  expect(awscdkSanitize(template)).toMatchSnapshot();
 });
 
 test("basic function with timeout explicitly set", () => {
@@ -82,7 +83,7 @@ test("basic function with timeout explicitly set", () => {
       Timeout: 300,
     })
   );
-  expect(template.toJSON()).toMatchSnapshot();
+  expect(awscdkSanitize(template)).toMatchSnapshot();
 });
 
 test("basic function with memory size specified", () => {
@@ -102,5 +103,5 @@ test("basic function with memory size specified", () => {
       MemorySize: 512,
     })
   );
-  expect(template.toJSON()).toMatchSnapshot();
+  expect(awscdkSanitize(template)).toMatchSnapshot();
 });

--- a/libs/wingsdk/test/target-awscdk/queue.test.ts
+++ b/libs/wingsdk/test/target-awscdk/queue.test.ts
@@ -4,10 +4,11 @@ import { Queue } from "../../src/cloud";
 import * as std from "../../src/std";
 import * as awscdk from "../../src/target-awscdk";
 import { Testing } from "../../src/testing";
-import { mkdtemp, sanitizeCode } from "../util";
+import { mkdtemp, sanitizeCode, awscdkSanitize } from "../util";
 
 const CDK_APP_OPTS = {
   stackName: "my-project",
+  entrypointDir: __dirname,
 };
 
 test("default queue behavior", () => {
@@ -18,7 +19,7 @@ test("default queue behavior", () => {
 
   // THEN
   const template = Template.fromJSON(JSON.parse(output));
-  expect(template.toJSON()).toMatchSnapshot();
+  expect(awscdkSanitize(template)).toMatchSnapshot();
 });
 
 test("queue with custom timeout", () => {
@@ -31,7 +32,7 @@ test("queue with custom timeout", () => {
 
   // THEN
   const template = Template.fromJSON(JSON.parse(output));
-  expect(template.toJSON()).toMatchSnapshot();
+  expect(awscdkSanitize(template)).toMatchSnapshot();
 });
 
 test("queue with custom retention", () => {
@@ -44,7 +45,7 @@ test("queue with custom retention", () => {
 
   // THEN
   const template = Template.fromJSON(JSON.parse(output));
-  expect(template.toJSON()).toMatchSnapshot();
+  expect(awscdkSanitize(template)).toMatchSnapshot();
 });
 
 test("queue with a consumer function", () => {
@@ -73,5 +74,5 @@ async handle(event) {
   template.resourceCountIs("AWS::IAM::Role", 1);
   template.resourceCountIs("AWS::IAM::Policy", 1);
   template.resourceCountIs("AWS::Lambda::EventSourceMapping", 1);
-  expect(template.toJSON()).toMatchSnapshot();
+  expect(awscdkSanitize(template)).toMatchSnapshot();
 });

--- a/libs/wingsdk/test/target-awscdk/schedule.test.ts
+++ b/libs/wingsdk/test/target-awscdk/schedule.test.ts
@@ -4,10 +4,11 @@ import { Schedule } from "../../src/cloud";
 import * as std from "../../src/std";
 import * as awscdk from "../../src/target-awscdk";
 import { Testing } from "../../src/testing";
-import { mkdtemp } from "../util";
+import { mkdtemp, awscdkSanitize } from "../util";
 
 const CDK_APP_OPTS = {
   stackName: "my-project",
+  entrypointDir: __dirname,
 };
 
 test("schedule behavior with rate", () => {
@@ -30,7 +31,7 @@ test("schedule behavior with rate", () => {
   template.hasResourceProperties("AWS::Events::Rule", {
     ScheduleExpression: "rate(2 minutes)",
   });
-  expect(template.toJSON()).toMatchSnapshot();
+  expect(awscdkSanitize(template)).toMatchSnapshot();
 });
 
 test("schedule behavior with cron", () => {
@@ -53,7 +54,7 @@ test("schedule behavior with cron", () => {
   template.hasResourceProperties("AWS::Events::Rule", {
     ScheduleExpression: "cron(0/1 * ? * * *)",
   });
-  expect(template.toJSON()).toMatchSnapshot();
+  expect(awscdkSanitize(template)).toMatchSnapshot();
 });
 
 test("schedule with two functions", () => {
@@ -88,7 +89,7 @@ test("schedule with two functions", () => {
       }),
     ]),
   });
-  expect(template.toJSON()).toMatchSnapshot();
+  expect(awscdkSanitize(template)).toMatchSnapshot();
 });
 
 test("schedule with rate and cron simultaneously", () => {

--- a/libs/wingsdk/test/target-awscdk/secret.test.ts
+++ b/libs/wingsdk/test/target-awscdk/secret.test.ts
@@ -7,6 +7,7 @@ import { mkdtemp } from "../util";
 
 const CDK_APP_OPTS = {
   stackName: "my-project",
+  entrypointDir: __dirname,
 };
 
 test("default secret behavior", () => {

--- a/libs/wingsdk/test/target-awscdk/topic.test.ts
+++ b/libs/wingsdk/test/target-awscdk/topic.test.ts
@@ -3,10 +3,11 @@ import { test, expect } from "vitest";
 import { Topic } from "../../src/cloud";
 import * as awscdk from "../../src/target-awscdk";
 import { Testing } from "../../src/testing";
-import { mkdtemp, sanitizeCode } from "../util";
+import { mkdtemp, sanitizeCode, awscdkSanitize } from "../util";
 
 const CDK_APP_OPTS = {
   stackName: "my-project",
+  entrypointDir: __dirname,
 };
 
 test("default topic behavior", () => {
@@ -17,7 +18,7 @@ test("default topic behavior", () => {
 
   // THEN
   const template = Template.fromJSON(JSON.parse(output));
-  expect(template.toJSON()).toMatchSnapshot();
+  expect(awscdkSanitize(template)).toMatchSnapshot();
 });
 
 test("topic with subscriber function", () => {
@@ -40,7 +41,7 @@ test("topic with subscriber function", () => {
   template.resourceCountIs("AWS::Lambda::Permission", 1);
   template.resourceCountIs("AWS::IAM::Role", 1);
   template.resourceCountIs("AWS::SNS::Subscription", 1);
-  expect(template.toJSON()).toMatchSnapshot();
+  expect(awscdkSanitize(template)).toMatchSnapshot();
 });
 
 test("topic with multiple subscribers", () => {
@@ -74,5 +75,5 @@ test("topic with multiple subscribers", () => {
   template.resourceCountIs("AWS::Lambda::Permission", 2);
   template.resourceCountIs("AWS::IAM::Role", 2);
   template.resourceCountIs("AWS::SNS::Subscription", 2);
-  expect(template.toJSON()).toMatchSnapshot();
+  expect(awscdkSanitize(template)).toMatchSnapshot();
 });

--- a/libs/wingsdk/test/target-tf-aws/__snapshots__/bucket.test.ts.snap
+++ b/libs/wingsdk/test/target-tf-aws/__snapshots__/bucket.test.ts.snap
@@ -1,51 +1,51 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`bucket is public 1`] = `
-"{
-  \\"output\\": {
-    \\"WING_TEST_RUNNER_FUNCTION_ARNS\\": {
-      \\"value\\": \\"[]\\"
-    }
+{
+  "output": {
+    "WING_TEST_RUNNER_FUNCTION_ARNS": {
+      "value": "[]",
+    },
   },
-  \\"resource\\": {
-    \\"aws_s3_bucket\\": {
-      \\"my_bucket\\": {
-        \\"bucket_prefix\\": \\"my-bucket-c8045fcc-\\",
-        \\"force_destroy\\": false
-      }
+  "resource": {
+    "aws_s3_bucket": {
+      "my_bucket": {
+        "bucket_prefix": "my-bucket-c8045fcc-",
+        "force_destroy": false,
+      },
     },
-    \\"aws_s3_bucket_policy\\": {
-      \\"my_bucket_PublicPolicy_AF351571\\": {
-        \\"bucket\\": \\"\${aws_s3_bucket.my_bucket.bucket}\\",
-        \\"depends_on\\": [
-          \\"aws_s3_bucket_public_access_block.my_bucket_PublicAccessBlock_538547C0\\"
+    "aws_s3_bucket_policy": {
+      "my_bucket_PublicPolicy_AF351571": {
+        "bucket": "\${aws_s3_bucket.my_bucket.bucket}",
+        "depends_on": [
+          "aws_s3_bucket_public_access_block.my_bucket_PublicAccessBlock_538547C0",
         ],
-        \\"policy\\": \\"{\\\\\\"Version\\\\\\":\\\\\\"2012-10-17\\\\\\",\\\\\\"Statement\\\\\\":[{\\\\\\"Effect\\\\\\":\\\\\\"Allow\\\\\\",\\\\\\"Principal\\\\\\":\\\\\\"*\\\\\\",\\\\\\"Action\\\\\\":[\\\\\\"s3:GetObject\\\\\\"],\\\\\\"Resource\\\\\\":[\\\\\\"\${aws_s3_bucket.my_bucket.arn}/*\\\\\\"]}]}\\"
-      }
+        "policy": "{\\"Version\\":\\"2012-10-17\\",\\"Statement\\":[{\\"Effect\\":\\"Allow\\",\\"Principal\\":\\"*\\",\\"Action\\":[\\"s3:GetObject\\"],\\"Resource\\":[\\"\${aws_s3_bucket.my_bucket.arn}/*\\"]}]}",
+      },
     },
-    \\"aws_s3_bucket_public_access_block\\": {
-      \\"my_bucket_PublicAccessBlock_538547C0\\": {
-        \\"block_public_acls\\": false,
-        \\"block_public_policy\\": false,
-        \\"bucket\\": \\"\${aws_s3_bucket.my_bucket.bucket}\\",
-        \\"ignore_public_acls\\": false,
-        \\"restrict_public_buckets\\": false
-      }
+    "aws_s3_bucket_public_access_block": {
+      "my_bucket_PublicAccessBlock_538547C0": {
+        "block_public_acls": false,
+        "block_public_policy": false,
+        "bucket": "\${aws_s3_bucket.my_bucket.bucket}",
+        "ignore_public_acls": false,
+        "restrict_public_buckets": false,
+      },
     },
-    \\"aws_s3_bucket_server_side_encryption_configuration\\": {
-      \\"my_bucket_Encryption_3B1569A4\\": {
-        \\"bucket\\": \\"\${aws_s3_bucket.my_bucket.bucket}\\",
-        \\"rule\\": [
+    "aws_s3_bucket_server_side_encryption_configuration": {
+      "my_bucket_Encryption_3B1569A4": {
+        "bucket": "\${aws_s3_bucket.my_bucket.bucket}",
+        "rule": [
           {
-            \\"apply_server_side_encryption_by_default\\": {
-              \\"sse_algorithm\\": \\"AES256\\"
-            }
-          }
-        ]
-      }
-    }
-  }
-}"
+            "apply_server_side_encryption_by_default": {
+              "sse_algorithm": "AES256",
+            },
+          },
+        ],
+      },
+    },
+  },
+}
 `;
 
 exports[`bucket is public 2`] = `
@@ -176,42 +176,42 @@ exports[`bucket is public 2`] = `
 `;
 
 exports[`bucket prefix must be lowercase 1`] = `
-"{
-  \\"output\\": {
-    \\"WING_TEST_RUNNER_FUNCTION_ARNS\\": {
-      \\"value\\": \\"[]\\"
-    }
+{
+  "output": {
+    "WING_TEST_RUNNER_FUNCTION_ARNS": {
+      "value": "[]",
+    },
   },
-  \\"resource\\": {
-    \\"aws_s3_bucket\\": {
-      \\"The-UncannyBucket\\": {
-        \\"bucket_prefix\\": \\"the-uncanny-bucket-c88a0953-\\",
-        \\"force_destroy\\": false
-      }
+  "resource": {
+    "aws_s3_bucket": {
+      "The-UncannyBucket": {
+        "bucket_prefix": "the-uncanny-bucket-c88a0953-",
+        "force_destroy": false,
+      },
     },
-    \\"aws_s3_bucket_public_access_block\\": {
-      \\"The-UncannyBucket_PublicAccessBlock_88AA9BF7\\": {
-        \\"block_public_acls\\": true,
-        \\"block_public_policy\\": true,
-        \\"bucket\\": \\"\${aws_s3_bucket.The-UncannyBucket.bucket}\\",
-        \\"ignore_public_acls\\": true,
-        \\"restrict_public_buckets\\": true
-      }
+    "aws_s3_bucket_public_access_block": {
+      "The-UncannyBucket_PublicAccessBlock_88AA9BF7": {
+        "block_public_acls": true,
+        "block_public_policy": true,
+        "bucket": "\${aws_s3_bucket.The-UncannyBucket.bucket}",
+        "ignore_public_acls": true,
+        "restrict_public_buckets": true,
+      },
     },
-    \\"aws_s3_bucket_server_side_encryption_configuration\\": {
-      \\"The-UncannyBucket_Encryption_4CFC1E98\\": {
-        \\"bucket\\": \\"\${aws_s3_bucket.The-UncannyBucket.bucket}\\",
-        \\"rule\\": [
+    "aws_s3_bucket_server_side_encryption_configuration": {
+      "The-UncannyBucket_Encryption_4CFC1E98": {
+        "bucket": "\${aws_s3_bucket.The-UncannyBucket.bucket}",
+        "rule": [
           {
-            \\"apply_server_side_encryption_by_default\\": {
-              \\"sse_algorithm\\": \\"AES256\\"
-            }
-          }
-        ]
-      }
-    }
-  }
-}"
+            "apply_server_side_encryption_by_default": {
+              "sse_algorithm": "AES256",
+            },
+          },
+        ],
+      },
+    },
+  },
+}
 `;
 
 exports[`bucket prefix must be lowercase 2`] = `
@@ -334,42 +334,42 @@ exports[`bucket prefix must be lowercase 2`] = `
 `;
 
 exports[`bucket prefix valid 1`] = `
-"{
-  \\"output\\": {
-    \\"WING_TEST_RUNNER_FUNCTION_ARNS\\": {
-      \\"value\\": \\"[]\\"
-    }
+{
+  "output": {
+    "WING_TEST_RUNNER_FUNCTION_ARNS": {
+      "value": "[]",
+    },
   },
-  \\"resource\\": {
-    \\"aws_s3_bucket\\": {
-      \\"the-uncannybucket\\": {
-        \\"bucket_prefix\\": \\"the-uncanny-bucket-c8e2755c-\\",
-        \\"force_destroy\\": false
-      }
+  "resource": {
+    "aws_s3_bucket": {
+      "the-uncannybucket": {
+        "bucket_prefix": "the-uncanny-bucket-c8e2755c-",
+        "force_destroy": false,
+      },
     },
-    \\"aws_s3_bucket_public_access_block\\": {
-      \\"the-uncannybucket_PublicAccessBlock_AC5BC68C\\": {
-        \\"block_public_acls\\": true,
-        \\"block_public_policy\\": true,
-        \\"bucket\\": \\"\${aws_s3_bucket.the-uncannybucket.bucket}\\",
-        \\"ignore_public_acls\\": true,
-        \\"restrict_public_buckets\\": true
-      }
+    "aws_s3_bucket_public_access_block": {
+      "the-uncannybucket_PublicAccessBlock_AC5BC68C": {
+        "block_public_acls": true,
+        "block_public_policy": true,
+        "bucket": "\${aws_s3_bucket.the-uncannybucket.bucket}",
+        "ignore_public_acls": true,
+        "restrict_public_buckets": true,
+      },
     },
-    \\"aws_s3_bucket_server_side_encryption_configuration\\": {
-      \\"the-uncannybucket_Encryption_78D02B71\\": {
-        \\"bucket\\": \\"\${aws_s3_bucket.the-uncannybucket.bucket}\\",
-        \\"rule\\": [
+    "aws_s3_bucket_server_side_encryption_configuration": {
+      "the-uncannybucket_Encryption_78D02B71": {
+        "bucket": "\${aws_s3_bucket.the-uncannybucket.bucket}",
+        "rule": [
           {
-            \\"apply_server_side_encryption_by_default\\": {
-              \\"sse_algorithm\\": \\"AES256\\"
-            }
-          }
-        ]
-      }
-    }
-  }
-}"
+            "apply_server_side_encryption_by_default": {
+              "sse_algorithm": "AES256",
+            },
+          },
+        ],
+      },
+    },
+  },
+}
 `;
 
 exports[`bucket prefix valid 2`] = `
@@ -492,142 +492,142 @@ exports[`bucket prefix valid 2`] = `
 `;
 
 exports[`bucket with onCreate method 1`] = `
-"{
-  \\"output\\": {
-    \\"WING_TEST_RUNNER_FUNCTION_ARNS\\": {
-      \\"value\\": \\"[]\\"
-    }
+{
+  "output": {
+    "WING_TEST_RUNNER_FUNCTION_ARNS": {
+      "value": "[]",
+    },
   },
-  \\"resource\\": {
-    \\"aws_iam_role\\": {
-      \\"my_bucket_my_bucket-oncreate-OnMessage-7b961f4d_IamRole_7FA5AA01\\": {
-        \\"assume_role_policy\\": \\"{\\\\\\"Version\\\\\\":\\\\\\"2012-10-17\\\\\\",\\\\\\"Statement\\\\\\":[{\\\\\\"Action\\\\\\":\\\\\\"sts:AssumeRole\\\\\\",\\\\\\"Principal\\\\\\":{\\\\\\"Service\\\\\\":\\\\\\"lambda.amazonaws.com\\\\\\"},\\\\\\"Effect\\\\\\":\\\\\\"Allow\\\\\\"}]}\\"
-      }
-    },
-    \\"aws_iam_role_policy\\": {
-      \\"my_bucket_my_bucket-oncreate-OnMessage-7b961f4d_IamRolePolicy_6F968127\\": {
-        \\"policy\\": \\"{\\\\\\"Version\\\\\\":\\\\\\"2012-10-17\\\\\\",\\\\\\"Statement\\\\\\":[{\\\\\\"Effect\\\\\\":\\\\\\"Allow\\\\\\",\\\\\\"Action\\\\\\":\\\\\\"none:null\\\\\\",\\\\\\"Resource\\\\\\":\\\\\\"*\\\\\\"}]}\\",
-        \\"role\\": \\"\${aws_iam_role.my_bucket_my_bucket-oncreate-OnMessage-7b961f4d_IamRole_7FA5AA01.name}\\"
-      }
-    },
-    \\"aws_iam_role_policy_attachment\\": {
-      \\"my_bucket_my_bucket-oncreate-OnMessage-7b961f4d_IamRolePolicyAttachment_73145579\\": {
-        \\"policy_arn\\": \\"arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole\\",
-        \\"role\\": \\"\${aws_iam_role.my_bucket_my_bucket-oncreate-OnMessage-7b961f4d_IamRole_7FA5AA01.name}\\"
-      }
-    },
-    \\"aws_lambda_function\\": {
-      \\"my_bucket_my_bucket-oncreate-OnMessage-7b961f4d_8104FB90\\": {
-        \\"environment\\": {
-          \\"variables\\": {
-            \\"WING_FUNCTION_NAME\\": \\"my_bucket-oncreate-OnMessage-7b961f4d-c81311dd\\"
-          }
-        },
-        \\"function_name\\": \\"my_bucket-oncreate-OnMessage-7b961f4d-c81311dd\\",
-        \\"handler\\": \\"index.handler\\",
-        \\"publish\\": true,
-        \\"role\\": \\"\${aws_iam_role.my_bucket_my_bucket-oncreate-OnMessage-7b961f4d_IamRole_7FA5AA01.arn}\\",
-        \\"runtime\\": \\"nodejs18.x\\",
-        \\"s3_bucket\\": \\"\${aws_s3_bucket.Code.bucket}\\",
-        \\"s3_key\\": \\"\${aws_s3_object.my_bucket_my_bucket-oncreate-OnMessage-7b961f4d_S3Object_AA8B2734.key}\\",
-        \\"timeout\\": 30,
-        \\"vpc_config\\": {
-          \\"security_group_ids\\": [],
-          \\"subnet_ids\\": []
-        }
-      }
-    },
-    \\"aws_lambda_permission\\": {
-      \\"my_bucket_my_bucket-oncreate-OnMessage-7b961f4d_InvokePermission-c81e8728eb64a11308ced47594c2396d2467e4d9d3_8DD58C41\\": {
-        \\"action\\": \\"lambda:InvokeFunction\\",
-        \\"function_name\\": \\"\${aws_lambda_function.my_bucket_my_bucket-oncreate-OnMessage-7b961f4d_8104FB90.function_name}\\",
-        \\"principal\\": \\"sns.amazonaws.com\\",
-        \\"source_arn\\": \\"\${aws_sns_topic.my_bucket_my_bucket-oncreate_820372FA.arn}\\"
-      }
-    },
-    \\"aws_s3_bucket\\": {
-      \\"Code\\": {
-        \\"bucket_prefix\\": \\"code-c84a50b1-\\"
+  "resource": {
+    "aws_iam_role": {
+      "my_bucket_my_bucket-oncreate-OnMessage-7b961f4d_IamRole_7FA5AA01": {
+        "assume_role_policy": "{\\"Version\\":\\"2012-10-17\\",\\"Statement\\":[{\\"Action\\":\\"sts:AssumeRole\\",\\"Principal\\":{\\"Service\\":\\"lambda.amazonaws.com\\"},\\"Effect\\":\\"Allow\\"}]}",
       },
-      \\"my_bucket\\": {
-        \\"bucket_prefix\\": \\"my-bucket-c8045fcc-\\",
-        \\"force_destroy\\": false
-      }
     },
-    \\"aws_s3_bucket_notification\\": {
-      \\"my_bucket_S3BucketNotification_DDA29E8F\\": {
-        \\"bucket\\": \\"\${aws_s3_bucket.my_bucket.id}\\",
-        \\"depends_on\\": [
-          \\"aws_sns_topic_policy.my_bucket_my_bucket-oncreate_PublishPermission-c8045fccc85a7ef42d5391d87958e5ce36c53a401a_DC469583\\"
+    "aws_iam_role_policy": {
+      "my_bucket_my_bucket-oncreate-OnMessage-7b961f4d_IamRolePolicy_6F968127": {
+        "policy": "{\\"Version\\":\\"2012-10-17\\",\\"Statement\\":[{\\"Effect\\":\\"Allow\\",\\"Action\\":\\"none:null\\",\\"Resource\\":\\"*\\"}]}",
+        "role": "\${aws_iam_role.my_bucket_my_bucket-oncreate-OnMessage-7b961f4d_IamRole_7FA5AA01.name}",
+      },
+    },
+    "aws_iam_role_policy_attachment": {
+      "my_bucket_my_bucket-oncreate-OnMessage-7b961f4d_IamRolePolicyAttachment_73145579": {
+        "policy_arn": "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+        "role": "\${aws_iam_role.my_bucket_my_bucket-oncreate-OnMessage-7b961f4d_IamRole_7FA5AA01.name}",
+      },
+    },
+    "aws_lambda_function": {
+      "my_bucket_my_bucket-oncreate-OnMessage-7b961f4d_8104FB90": {
+        "environment": {
+          "variables": {
+            "WING_FUNCTION_NAME": "my_bucket-oncreate-OnMessage-7b961f4d-c81311dd",
+          },
+        },
+        "function_name": "my_bucket-oncreate-OnMessage-7b961f4d-c81311dd",
+        "handler": "index.handler",
+        "publish": true,
+        "role": "\${aws_iam_role.my_bucket_my_bucket-oncreate-OnMessage-7b961f4d_IamRole_7FA5AA01.arn}",
+        "runtime": "nodejs18.x",
+        "s3_bucket": "\${aws_s3_bucket.Code.bucket}",
+        "s3_key": "\${aws_s3_object.my_bucket_my_bucket-oncreate-OnMessage-7b961f4d_S3Object_AA8B2734.key}",
+        "timeout": 30,
+        "vpc_config": {
+          "security_group_ids": [],
+          "subnet_ids": [],
+        },
+      },
+    },
+    "aws_lambda_permission": {
+      "my_bucket_my_bucket-oncreate-OnMessage-7b961f4d_InvokePermission-c81e8728eb64a11308ced47594c2396d2467e4d9d3_8DD58C41": {
+        "action": "lambda:InvokeFunction",
+        "function_name": "\${aws_lambda_function.my_bucket_my_bucket-oncreate-OnMessage-7b961f4d_8104FB90.function_name}",
+        "principal": "sns.amazonaws.com",
+        "source_arn": "\${aws_sns_topic.my_bucket_my_bucket-oncreate_820372FA.arn}",
+      },
+    },
+    "aws_s3_bucket": {
+      "Code": {
+        "bucket_prefix": "code-c84a50b1-",
+      },
+      "my_bucket": {
+        "bucket_prefix": "my-bucket-c8045fcc-",
+        "force_destroy": false,
+      },
+    },
+    "aws_s3_bucket_notification": {
+      "my_bucket_S3BucketNotification_DDA29E8F": {
+        "bucket": "\${aws_s3_bucket.my_bucket.id}",
+        "depends_on": [
+          "aws_sns_topic_policy.my_bucket_my_bucket-oncreate_PublishPermission-c8045fccc85a7ef42d5391d87958e5ce36c53a401a_DC469583",
         ],
-        \\"topic\\": [
+        "topic": [
           {
-            \\"events\\": [
-              \\"s3:ObjectCreated:Put\\"
+            "events": [
+              "s3:ObjectCreated:Put",
             ],
-            \\"id\\": \\"on-oncreate-notification\\",
-            \\"topic_arn\\": \\"\${aws_sns_topic.my_bucket_my_bucket-oncreate_820372FA.arn}\\"
-          }
-        ]
-      }
-    },
-    \\"aws_s3_bucket_policy\\": {
-      \\"my_bucket_PublicPolicy_AF351571\\": {
-        \\"bucket\\": \\"\${aws_s3_bucket.my_bucket.bucket}\\",
-        \\"depends_on\\": [
-          \\"aws_s3_bucket_public_access_block.my_bucket_PublicAccessBlock_538547C0\\"
+            "id": "on-oncreate-notification",
+            "topic_arn": "\${aws_sns_topic.my_bucket_my_bucket-oncreate_820372FA.arn}",
+          },
         ],
-        \\"policy\\": \\"{\\\\\\"Version\\\\\\":\\\\\\"2012-10-17\\\\\\",\\\\\\"Statement\\\\\\":[{\\\\\\"Effect\\\\\\":\\\\\\"Allow\\\\\\",\\\\\\"Principal\\\\\\":\\\\\\"*\\\\\\",\\\\\\"Action\\\\\\":[\\\\\\"s3:GetObject\\\\\\"],\\\\\\"Resource\\\\\\":[\\\\\\"\${aws_s3_bucket.my_bucket.arn}/*\\\\\\"]}]}\\"
-      }
+      },
     },
-    \\"aws_s3_bucket_public_access_block\\": {
-      \\"my_bucket_PublicAccessBlock_538547C0\\": {
-        \\"block_public_acls\\": false,
-        \\"block_public_policy\\": false,
-        \\"bucket\\": \\"\${aws_s3_bucket.my_bucket.bucket}\\",
-        \\"ignore_public_acls\\": false,
-        \\"restrict_public_buckets\\": false
-      }
+    "aws_s3_bucket_policy": {
+      "my_bucket_PublicPolicy_AF351571": {
+        "bucket": "\${aws_s3_bucket.my_bucket.bucket}",
+        "depends_on": [
+          "aws_s3_bucket_public_access_block.my_bucket_PublicAccessBlock_538547C0",
+        ],
+        "policy": "{\\"Version\\":\\"2012-10-17\\",\\"Statement\\":[{\\"Effect\\":\\"Allow\\",\\"Principal\\":\\"*\\",\\"Action\\":[\\"s3:GetObject\\"],\\"Resource\\":[\\"\${aws_s3_bucket.my_bucket.arn}/*\\"]}]}",
+      },
     },
-    \\"aws_s3_bucket_server_side_encryption_configuration\\": {
-      \\"my_bucket_Encryption_3B1569A4\\": {
-        \\"bucket\\": \\"\${aws_s3_bucket.my_bucket.bucket}\\",
-        \\"rule\\": [
+    "aws_s3_bucket_public_access_block": {
+      "my_bucket_PublicAccessBlock_538547C0": {
+        "block_public_acls": false,
+        "block_public_policy": false,
+        "bucket": "\${aws_s3_bucket.my_bucket.bucket}",
+        "ignore_public_acls": false,
+        "restrict_public_buckets": false,
+      },
+    },
+    "aws_s3_bucket_server_side_encryption_configuration": {
+      "my_bucket_Encryption_3B1569A4": {
+        "bucket": "\${aws_s3_bucket.my_bucket.bucket}",
+        "rule": [
           {
-            \\"apply_server_side_encryption_by_default\\": {
-              \\"sse_algorithm\\": \\"AES256\\"
-            }
-          }
-        ]
-      }
+            "apply_server_side_encryption_by_default": {
+              "sse_algorithm": "AES256",
+            },
+          },
+        ],
+      },
     },
-    \\"aws_s3_object\\": {
-      \\"my_bucket_my_bucket-oncreate-OnMessage-7b961f4d_S3Object_AA8B2734\\": {
-        \\"bucket\\": \\"\${aws_s3_bucket.Code.bucket}\\",
-        \\"key\\": \\"<key>\\",
-        \\"source\\": \\"<source>\\"
-      }
+    "aws_s3_object": {
+      "my_bucket_my_bucket-oncreate-OnMessage-7b961f4d_S3Object_AA8B2734": {
+        "bucket": "\${aws_s3_bucket.Code.bucket}",
+        "key": "<key>",
+        "source": "<source>",
+      },
     },
-    \\"aws_sns_topic\\": {
-      \\"my_bucket_my_bucket-oncreate_820372FA\\": {
-        \\"name\\": \\"my_bucket-oncreate-c81e8728\\"
-      }
+    "aws_sns_topic": {
+      "my_bucket_my_bucket-oncreate_820372FA": {
+        "name": "my_bucket-oncreate-c81e8728",
+      },
     },
-    \\"aws_sns_topic_policy\\": {
-      \\"my_bucket_my_bucket-oncreate_PublishPermission-c8045fccc85a7ef42d5391d87958e5ce36c53a401a_DC469583\\": {
-        \\"arn\\": \\"\${aws_sns_topic.my_bucket_my_bucket-oncreate_820372FA.arn}\\",
-        \\"policy\\": \\"{\\\\\\"Statement\\\\\\":[{\\\\\\"Effect\\\\\\":\\\\\\"Allow\\\\\\",\\\\\\"Principal\\\\\\":{\\\\\\"Service\\\\\\":\\\\\\"s3.amazonaws.com\\\\\\"},\\\\\\"Action\\\\\\":\\\\\\"sns:Publish\\\\\\",\\\\\\"Resource\\\\\\":\\\\\\"\${aws_sns_topic.my_bucket_my_bucket-oncreate_820372FA.arn}\\\\\\",\\\\\\"Condition\\\\\\":{\\\\\\"ArnEquals\\\\\\":{\\\\\\"aws:SourceArn\\\\\\":\\\\\\"\${aws_s3_bucket.my_bucket.arn}\\\\\\"}}}]}\\"
-      }
+    "aws_sns_topic_policy": {
+      "my_bucket_my_bucket-oncreate_PublishPermission-c8045fccc85a7ef42d5391d87958e5ce36c53a401a_DC469583": {
+        "arn": "\${aws_sns_topic.my_bucket_my_bucket-oncreate_820372FA.arn}",
+        "policy": "{\\"Statement\\":[{\\"Effect\\":\\"Allow\\",\\"Principal\\":{\\"Service\\":\\"s3.amazonaws.com\\"},\\"Action\\":\\"sns:Publish\\",\\"Resource\\":\\"\${aws_sns_topic.my_bucket_my_bucket-oncreate_820372FA.arn}\\",\\"Condition\\":{\\"ArnEquals\\":{\\"aws:SourceArn\\":\\"\${aws_s3_bucket.my_bucket.arn}\\"}}}]}",
+      },
     },
-    \\"aws_sns_topic_subscription\\": {
-      \\"my_bucket_my_bucket-oncreate_my_bucket-oncreate-TopicSubscription-7b961f4d_E00E14CE\\": {
-        \\"endpoint\\": \\"\${aws_lambda_function.my_bucket_my_bucket-oncreate-OnMessage-7b961f4d_8104FB90.arn}\\",
-        \\"protocol\\": \\"lambda\\",
-        \\"topic_arn\\": \\"\${aws_sns_topic.my_bucket_my_bucket-oncreate_820372FA.arn}\\"
-      }
-    }
-  }
-}"
+    "aws_sns_topic_subscription": {
+      "my_bucket_my_bucket-oncreate_my_bucket-oncreate-TopicSubscription-7b961f4d_E00E14CE": {
+        "endpoint": "\${aws_lambda_function.my_bucket_my_bucket-oncreate-OnMessage-7b961f4d_8104FB90.arn}",
+        "protocol": "lambda",
+        "topic_arn": "\${aws_sns_topic.my_bucket_my_bucket-oncreate_820372FA.arn}",
+      },
+    },
+  },
+}
 `;
 
 exports[`bucket with onCreate method 2`] = `
@@ -1009,142 +1009,142 @@ exports[`bucket with onCreate method 2`] = `
 `;
 
 exports[`bucket with onDelete method 1`] = `
-"{
-  \\"output\\": {
-    \\"WING_TEST_RUNNER_FUNCTION_ARNS\\": {
-      \\"value\\": \\"[]\\"
-    }
+{
+  "output": {
+    "WING_TEST_RUNNER_FUNCTION_ARNS": {
+      "value": "[]",
+    },
   },
-  \\"resource\\": {
-    \\"aws_iam_role\\": {
-      \\"my_bucket_my_bucket-ondelete-OnMessage-1de1a361_IamRole_94D9A7C9\\": {
-        \\"assume_role_policy\\": \\"{\\\\\\"Version\\\\\\":\\\\\\"2012-10-17\\\\\\",\\\\\\"Statement\\\\\\":[{\\\\\\"Action\\\\\\":\\\\\\"sts:AssumeRole\\\\\\",\\\\\\"Principal\\\\\\":{\\\\\\"Service\\\\\\":\\\\\\"lambda.amazonaws.com\\\\\\"},\\\\\\"Effect\\\\\\":\\\\\\"Allow\\\\\\"}]}\\"
-      }
-    },
-    \\"aws_iam_role_policy\\": {
-      \\"my_bucket_my_bucket-ondelete-OnMessage-1de1a361_IamRolePolicy_F888D4CE\\": {
-        \\"policy\\": \\"{\\\\\\"Version\\\\\\":\\\\\\"2012-10-17\\\\\\",\\\\\\"Statement\\\\\\":[{\\\\\\"Effect\\\\\\":\\\\\\"Allow\\\\\\",\\\\\\"Action\\\\\\":\\\\\\"none:null\\\\\\",\\\\\\"Resource\\\\\\":\\\\\\"*\\\\\\"}]}\\",
-        \\"role\\": \\"\${aws_iam_role.my_bucket_my_bucket-ondelete-OnMessage-1de1a361_IamRole_94D9A7C9.name}\\"
-      }
-    },
-    \\"aws_iam_role_policy_attachment\\": {
-      \\"my_bucket_my_bucket-ondelete-OnMessage-1de1a361_IamRolePolicyAttachment_4EB0BCD1\\": {
-        \\"policy_arn\\": \\"arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole\\",
-        \\"role\\": \\"\${aws_iam_role.my_bucket_my_bucket-ondelete-OnMessage-1de1a361_IamRole_94D9A7C9.name}\\"
-      }
-    },
-    \\"aws_lambda_function\\": {
-      \\"my_bucket_my_bucket-ondelete-OnMessage-1de1a361_37C9E1F7\\": {
-        \\"environment\\": {
-          \\"variables\\": {
-            \\"WING_FUNCTION_NAME\\": \\"my_bucket-ondelete-OnMessage-1de1a361-c89e08bf\\"
-          }
-        },
-        \\"function_name\\": \\"my_bucket-ondelete-OnMessage-1de1a361-c89e08bf\\",
-        \\"handler\\": \\"index.handler\\",
-        \\"publish\\": true,
-        \\"role\\": \\"\${aws_iam_role.my_bucket_my_bucket-ondelete-OnMessage-1de1a361_IamRole_94D9A7C9.arn}\\",
-        \\"runtime\\": \\"nodejs18.x\\",
-        \\"s3_bucket\\": \\"\${aws_s3_bucket.Code.bucket}\\",
-        \\"s3_key\\": \\"\${aws_s3_object.my_bucket_my_bucket-ondelete-OnMessage-1de1a361_S3Object_2203B527.key}\\",
-        \\"timeout\\": 30,
-        \\"vpc_config\\": {
-          \\"security_group_ids\\": [],
-          \\"subnet_ids\\": []
-        }
-      }
-    },
-    \\"aws_lambda_permission\\": {
-      \\"my_bucket_my_bucket-ondelete-OnMessage-1de1a361_InvokePermission-c804d947f12e6d883f018387429c0ba10b852c46ba_1CD63BDF\\": {
-        \\"action\\": \\"lambda:InvokeFunction\\",
-        \\"function_name\\": \\"\${aws_lambda_function.my_bucket_my_bucket-ondelete-OnMessage-1de1a361_37C9E1F7.function_name}\\",
-        \\"principal\\": \\"sns.amazonaws.com\\",
-        \\"source_arn\\": \\"\${aws_sns_topic.my_bucket_my_bucket-ondelete_D8AB43D6.arn}\\"
-      }
-    },
-    \\"aws_s3_bucket\\": {
-      \\"Code\\": {
-        \\"bucket_prefix\\": \\"code-c84a50b1-\\"
+  "resource": {
+    "aws_iam_role": {
+      "my_bucket_my_bucket-ondelete-OnMessage-1de1a361_IamRole_94D9A7C9": {
+        "assume_role_policy": "{\\"Version\\":\\"2012-10-17\\",\\"Statement\\":[{\\"Action\\":\\"sts:AssumeRole\\",\\"Principal\\":{\\"Service\\":\\"lambda.amazonaws.com\\"},\\"Effect\\":\\"Allow\\"}]}",
       },
-      \\"my_bucket\\": {
-        \\"bucket_prefix\\": \\"my-bucket-c8045fcc-\\",
-        \\"force_destroy\\": false
-      }
     },
-    \\"aws_s3_bucket_notification\\": {
-      \\"my_bucket_S3BucketNotification_DDA29E8F\\": {
-        \\"bucket\\": \\"\${aws_s3_bucket.my_bucket.id}\\",
-        \\"depends_on\\": [
-          \\"aws_sns_topic_policy.my_bucket_my_bucket-ondelete_PublishPermission-c8045fccc85a7ef42d5391d87958e5ce36c53a401a_87361222\\"
+    "aws_iam_role_policy": {
+      "my_bucket_my_bucket-ondelete-OnMessage-1de1a361_IamRolePolicy_F888D4CE": {
+        "policy": "{\\"Version\\":\\"2012-10-17\\",\\"Statement\\":[{\\"Effect\\":\\"Allow\\",\\"Action\\":\\"none:null\\",\\"Resource\\":\\"*\\"}]}",
+        "role": "\${aws_iam_role.my_bucket_my_bucket-ondelete-OnMessage-1de1a361_IamRole_94D9A7C9.name}",
+      },
+    },
+    "aws_iam_role_policy_attachment": {
+      "my_bucket_my_bucket-ondelete-OnMessage-1de1a361_IamRolePolicyAttachment_4EB0BCD1": {
+        "policy_arn": "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+        "role": "\${aws_iam_role.my_bucket_my_bucket-ondelete-OnMessage-1de1a361_IamRole_94D9A7C9.name}",
+      },
+    },
+    "aws_lambda_function": {
+      "my_bucket_my_bucket-ondelete-OnMessage-1de1a361_37C9E1F7": {
+        "environment": {
+          "variables": {
+            "WING_FUNCTION_NAME": "my_bucket-ondelete-OnMessage-1de1a361-c89e08bf",
+          },
+        },
+        "function_name": "my_bucket-ondelete-OnMessage-1de1a361-c89e08bf",
+        "handler": "index.handler",
+        "publish": true,
+        "role": "\${aws_iam_role.my_bucket_my_bucket-ondelete-OnMessage-1de1a361_IamRole_94D9A7C9.arn}",
+        "runtime": "nodejs18.x",
+        "s3_bucket": "\${aws_s3_bucket.Code.bucket}",
+        "s3_key": "\${aws_s3_object.my_bucket_my_bucket-ondelete-OnMessage-1de1a361_S3Object_2203B527.key}",
+        "timeout": 30,
+        "vpc_config": {
+          "security_group_ids": [],
+          "subnet_ids": [],
+        },
+      },
+    },
+    "aws_lambda_permission": {
+      "my_bucket_my_bucket-ondelete-OnMessage-1de1a361_InvokePermission-c804d947f12e6d883f018387429c0ba10b852c46ba_1CD63BDF": {
+        "action": "lambda:InvokeFunction",
+        "function_name": "\${aws_lambda_function.my_bucket_my_bucket-ondelete-OnMessage-1de1a361_37C9E1F7.function_name}",
+        "principal": "sns.amazonaws.com",
+        "source_arn": "\${aws_sns_topic.my_bucket_my_bucket-ondelete_D8AB43D6.arn}",
+      },
+    },
+    "aws_s3_bucket": {
+      "Code": {
+        "bucket_prefix": "code-c84a50b1-",
+      },
+      "my_bucket": {
+        "bucket_prefix": "my-bucket-c8045fcc-",
+        "force_destroy": false,
+      },
+    },
+    "aws_s3_bucket_notification": {
+      "my_bucket_S3BucketNotification_DDA29E8F": {
+        "bucket": "\${aws_s3_bucket.my_bucket.id}",
+        "depends_on": [
+          "aws_sns_topic_policy.my_bucket_my_bucket-ondelete_PublishPermission-c8045fccc85a7ef42d5391d87958e5ce36c53a401a_87361222",
         ],
-        \\"topic\\": [
+        "topic": [
           {
-            \\"events\\": [
-              \\"s3:ObjectRemoved:*\\"
+            "events": [
+              "s3:ObjectRemoved:*",
             ],
-            \\"id\\": \\"on-ondelete-notification\\",
-            \\"topic_arn\\": \\"\${aws_sns_topic.my_bucket_my_bucket-ondelete_D8AB43D6.arn}\\"
-          }
-        ]
-      }
-    },
-    \\"aws_s3_bucket_policy\\": {
-      \\"my_bucket_PublicPolicy_AF351571\\": {
-        \\"bucket\\": \\"\${aws_s3_bucket.my_bucket.bucket}\\",
-        \\"depends_on\\": [
-          \\"aws_s3_bucket_public_access_block.my_bucket_PublicAccessBlock_538547C0\\"
+            "id": "on-ondelete-notification",
+            "topic_arn": "\${aws_sns_topic.my_bucket_my_bucket-ondelete_D8AB43D6.arn}",
+          },
         ],
-        \\"policy\\": \\"{\\\\\\"Version\\\\\\":\\\\\\"2012-10-17\\\\\\",\\\\\\"Statement\\\\\\":[{\\\\\\"Effect\\\\\\":\\\\\\"Allow\\\\\\",\\\\\\"Principal\\\\\\":\\\\\\"*\\\\\\",\\\\\\"Action\\\\\\":[\\\\\\"s3:GetObject\\\\\\"],\\\\\\"Resource\\\\\\":[\\\\\\"\${aws_s3_bucket.my_bucket.arn}/*\\\\\\"]}]}\\"
-      }
+      },
     },
-    \\"aws_s3_bucket_public_access_block\\": {
-      \\"my_bucket_PublicAccessBlock_538547C0\\": {
-        \\"block_public_acls\\": false,
-        \\"block_public_policy\\": false,
-        \\"bucket\\": \\"\${aws_s3_bucket.my_bucket.bucket}\\",
-        \\"ignore_public_acls\\": false,
-        \\"restrict_public_buckets\\": false
-      }
+    "aws_s3_bucket_policy": {
+      "my_bucket_PublicPolicy_AF351571": {
+        "bucket": "\${aws_s3_bucket.my_bucket.bucket}",
+        "depends_on": [
+          "aws_s3_bucket_public_access_block.my_bucket_PublicAccessBlock_538547C0",
+        ],
+        "policy": "{\\"Version\\":\\"2012-10-17\\",\\"Statement\\":[{\\"Effect\\":\\"Allow\\",\\"Principal\\":\\"*\\",\\"Action\\":[\\"s3:GetObject\\"],\\"Resource\\":[\\"\${aws_s3_bucket.my_bucket.arn}/*\\"]}]}",
+      },
     },
-    \\"aws_s3_bucket_server_side_encryption_configuration\\": {
-      \\"my_bucket_Encryption_3B1569A4\\": {
-        \\"bucket\\": \\"\${aws_s3_bucket.my_bucket.bucket}\\",
-        \\"rule\\": [
+    "aws_s3_bucket_public_access_block": {
+      "my_bucket_PublicAccessBlock_538547C0": {
+        "block_public_acls": false,
+        "block_public_policy": false,
+        "bucket": "\${aws_s3_bucket.my_bucket.bucket}",
+        "ignore_public_acls": false,
+        "restrict_public_buckets": false,
+      },
+    },
+    "aws_s3_bucket_server_side_encryption_configuration": {
+      "my_bucket_Encryption_3B1569A4": {
+        "bucket": "\${aws_s3_bucket.my_bucket.bucket}",
+        "rule": [
           {
-            \\"apply_server_side_encryption_by_default\\": {
-              \\"sse_algorithm\\": \\"AES256\\"
-            }
-          }
-        ]
-      }
+            "apply_server_side_encryption_by_default": {
+              "sse_algorithm": "AES256",
+            },
+          },
+        ],
+      },
     },
-    \\"aws_s3_object\\": {
-      \\"my_bucket_my_bucket-ondelete-OnMessage-1de1a361_S3Object_2203B527\\": {
-        \\"bucket\\": \\"\${aws_s3_bucket.Code.bucket}\\",
-        \\"key\\": \\"<key>\\",
-        \\"source\\": \\"<source>\\"
-      }
+    "aws_s3_object": {
+      "my_bucket_my_bucket-ondelete-OnMessage-1de1a361_S3Object_2203B527": {
+        "bucket": "\${aws_s3_bucket.Code.bucket}",
+        "key": "<key>",
+        "source": "<source>",
+      },
     },
-    \\"aws_sns_topic\\": {
-      \\"my_bucket_my_bucket-ondelete_D8AB43D6\\": {
-        \\"name\\": \\"my_bucket-ondelete-c804d947\\"
-      }
+    "aws_sns_topic": {
+      "my_bucket_my_bucket-ondelete_D8AB43D6": {
+        "name": "my_bucket-ondelete-c804d947",
+      },
     },
-    \\"aws_sns_topic_policy\\": {
-      \\"my_bucket_my_bucket-ondelete_PublishPermission-c8045fccc85a7ef42d5391d87958e5ce36c53a401a_87361222\\": {
-        \\"arn\\": \\"\${aws_sns_topic.my_bucket_my_bucket-ondelete_D8AB43D6.arn}\\",
-        \\"policy\\": \\"{\\\\\\"Statement\\\\\\":[{\\\\\\"Effect\\\\\\":\\\\\\"Allow\\\\\\",\\\\\\"Principal\\\\\\":{\\\\\\"Service\\\\\\":\\\\\\"s3.amazonaws.com\\\\\\"},\\\\\\"Action\\\\\\":\\\\\\"sns:Publish\\\\\\",\\\\\\"Resource\\\\\\":\\\\\\"\${aws_sns_topic.my_bucket_my_bucket-ondelete_D8AB43D6.arn}\\\\\\",\\\\\\"Condition\\\\\\":{\\\\\\"ArnEquals\\\\\\":{\\\\\\"aws:SourceArn\\\\\\":\\\\\\"\${aws_s3_bucket.my_bucket.arn}\\\\\\"}}}]}\\"
-      }
+    "aws_sns_topic_policy": {
+      "my_bucket_my_bucket-ondelete_PublishPermission-c8045fccc85a7ef42d5391d87958e5ce36c53a401a_87361222": {
+        "arn": "\${aws_sns_topic.my_bucket_my_bucket-ondelete_D8AB43D6.arn}",
+        "policy": "{\\"Statement\\":[{\\"Effect\\":\\"Allow\\",\\"Principal\\":{\\"Service\\":\\"s3.amazonaws.com\\"},\\"Action\\":\\"sns:Publish\\",\\"Resource\\":\\"\${aws_sns_topic.my_bucket_my_bucket-ondelete_D8AB43D6.arn}\\",\\"Condition\\":{\\"ArnEquals\\":{\\"aws:SourceArn\\":\\"\${aws_s3_bucket.my_bucket.arn}\\"}}}]}",
+      },
     },
-    \\"aws_sns_topic_subscription\\": {
-      \\"my_bucket_my_bucket-ondelete_my_bucket-ondelete-TopicSubscription-1de1a361_7E4EBD35\\": {
-        \\"endpoint\\": \\"\${aws_lambda_function.my_bucket_my_bucket-ondelete-OnMessage-1de1a361_37C9E1F7.arn}\\",
-        \\"protocol\\": \\"lambda\\",
-        \\"topic_arn\\": \\"\${aws_sns_topic.my_bucket_my_bucket-ondelete_D8AB43D6.arn}\\"
-      }
-    }
-  }
-}"
+    "aws_sns_topic_subscription": {
+      "my_bucket_my_bucket-ondelete_my_bucket-ondelete-TopicSubscription-1de1a361_7E4EBD35": {
+        "endpoint": "\${aws_lambda_function.my_bucket_my_bucket-ondelete-OnMessage-1de1a361_37C9E1F7.arn}",
+        "protocol": "lambda",
+        "topic_arn": "\${aws_sns_topic.my_bucket_my_bucket-ondelete_D8AB43D6.arn}",
+      },
+    },
+  },
+}
 `;
 
 exports[`bucket with onDelete method 2`] = `
@@ -1526,264 +1526,264 @@ exports[`bucket with onDelete method 2`] = `
 `;
 
 exports[`bucket with onEvent method 1`] = `
-"{
-  \\"output\\": {
-    \\"WING_TEST_RUNNER_FUNCTION_ARNS\\": {
-      \\"value\\": \\"[]\\"
-    }
+{
+  "output": {
+    "WING_TEST_RUNNER_FUNCTION_ARNS": {
+      "value": "[]",
+    },
   },
-  \\"resource\\": {
-    \\"aws_iam_role\\": {
-      \\"my_bucket_my_bucket-oncreate-OnMessage-7b961f4d_IamRole_7FA5AA01\\": {
-        \\"assume_role_policy\\": \\"{\\\\\\"Version\\\\\\":\\\\\\"2012-10-17\\\\\\",\\\\\\"Statement\\\\\\":[{\\\\\\"Action\\\\\\":\\\\\\"sts:AssumeRole\\\\\\",\\\\\\"Principal\\\\\\":{\\\\\\"Service\\\\\\":\\\\\\"lambda.amazonaws.com\\\\\\"},\\\\\\"Effect\\\\\\":\\\\\\"Allow\\\\\\"}]}\\"
+  "resource": {
+    "aws_iam_role": {
+      "my_bucket_my_bucket-oncreate-OnMessage-7b961f4d_IamRole_7FA5AA01": {
+        "assume_role_policy": "{\\"Version\\":\\"2012-10-17\\",\\"Statement\\":[{\\"Action\\":\\"sts:AssumeRole\\",\\"Principal\\":{\\"Service\\":\\"lambda.amazonaws.com\\"},\\"Effect\\":\\"Allow\\"}]}",
       },
-      \\"my_bucket_my_bucket-ondelete-OnMessage-1de1a361_IamRole_94D9A7C9\\": {
-        \\"assume_role_policy\\": \\"{\\\\\\"Version\\\\\\":\\\\\\"2012-10-17\\\\\\",\\\\\\"Statement\\\\\\":[{\\\\\\"Action\\\\\\":\\\\\\"sts:AssumeRole\\\\\\",\\\\\\"Principal\\\\\\":{\\\\\\"Service\\\\\\":\\\\\\"lambda.amazonaws.com\\\\\\"},\\\\\\"Effect\\\\\\":\\\\\\"Allow\\\\\\"}]}\\"
+      "my_bucket_my_bucket-ondelete-OnMessage-1de1a361_IamRole_94D9A7C9": {
+        "assume_role_policy": "{\\"Version\\":\\"2012-10-17\\",\\"Statement\\":[{\\"Action\\":\\"sts:AssumeRole\\",\\"Principal\\":{\\"Service\\":\\"lambda.amazonaws.com\\"},\\"Effect\\":\\"Allow\\"}]}",
       },
-      \\"my_bucket_my_bucket-onupdate-OnMessage-46c07356_IamRole_4FC47AD3\\": {
-        \\"assume_role_policy\\": \\"{\\\\\\"Version\\\\\\":\\\\\\"2012-10-17\\\\\\",\\\\\\"Statement\\\\\\":[{\\\\\\"Action\\\\\\":\\\\\\"sts:AssumeRole\\\\\\",\\\\\\"Principal\\\\\\":{\\\\\\"Service\\\\\\":\\\\\\"lambda.amazonaws.com\\\\\\"},\\\\\\"Effect\\\\\\":\\\\\\"Allow\\\\\\"}]}\\"
-      }
+      "my_bucket_my_bucket-onupdate-OnMessage-46c07356_IamRole_4FC47AD3": {
+        "assume_role_policy": "{\\"Version\\":\\"2012-10-17\\",\\"Statement\\":[{\\"Action\\":\\"sts:AssumeRole\\",\\"Principal\\":{\\"Service\\":\\"lambda.amazonaws.com\\"},\\"Effect\\":\\"Allow\\"}]}",
+      },
     },
-    \\"aws_iam_role_policy\\": {
-      \\"my_bucket_my_bucket-oncreate-OnMessage-7b961f4d_IamRolePolicy_6F968127\\": {
-        \\"policy\\": \\"{\\\\\\"Version\\\\\\":\\\\\\"2012-10-17\\\\\\",\\\\\\"Statement\\\\\\":[{\\\\\\"Effect\\\\\\":\\\\\\"Allow\\\\\\",\\\\\\"Action\\\\\\":\\\\\\"none:null\\\\\\",\\\\\\"Resource\\\\\\":\\\\\\"*\\\\\\"}]}\\",
-        \\"role\\": \\"\${aws_iam_role.my_bucket_my_bucket-oncreate-OnMessage-7b961f4d_IamRole_7FA5AA01.name}\\"
+    "aws_iam_role_policy": {
+      "my_bucket_my_bucket-oncreate-OnMessage-7b961f4d_IamRolePolicy_6F968127": {
+        "policy": "{\\"Version\\":\\"2012-10-17\\",\\"Statement\\":[{\\"Effect\\":\\"Allow\\",\\"Action\\":\\"none:null\\",\\"Resource\\":\\"*\\"}]}",
+        "role": "\${aws_iam_role.my_bucket_my_bucket-oncreate-OnMessage-7b961f4d_IamRole_7FA5AA01.name}",
       },
-      \\"my_bucket_my_bucket-ondelete-OnMessage-1de1a361_IamRolePolicy_F888D4CE\\": {
-        \\"policy\\": \\"{\\\\\\"Version\\\\\\":\\\\\\"2012-10-17\\\\\\",\\\\\\"Statement\\\\\\":[{\\\\\\"Effect\\\\\\":\\\\\\"Allow\\\\\\",\\\\\\"Action\\\\\\":\\\\\\"none:null\\\\\\",\\\\\\"Resource\\\\\\":\\\\\\"*\\\\\\"}]}\\",
-        \\"role\\": \\"\${aws_iam_role.my_bucket_my_bucket-ondelete-OnMessage-1de1a361_IamRole_94D9A7C9.name}\\"
+      "my_bucket_my_bucket-ondelete-OnMessage-1de1a361_IamRolePolicy_F888D4CE": {
+        "policy": "{\\"Version\\":\\"2012-10-17\\",\\"Statement\\":[{\\"Effect\\":\\"Allow\\",\\"Action\\":\\"none:null\\",\\"Resource\\":\\"*\\"}]}",
+        "role": "\${aws_iam_role.my_bucket_my_bucket-ondelete-OnMessage-1de1a361_IamRole_94D9A7C9.name}",
       },
-      \\"my_bucket_my_bucket-onupdate-OnMessage-46c07356_IamRolePolicy_4F7EE7F8\\": {
-        \\"policy\\": \\"{\\\\\\"Version\\\\\\":\\\\\\"2012-10-17\\\\\\",\\\\\\"Statement\\\\\\":[{\\\\\\"Effect\\\\\\":\\\\\\"Allow\\\\\\",\\\\\\"Action\\\\\\":\\\\\\"none:null\\\\\\",\\\\\\"Resource\\\\\\":\\\\\\"*\\\\\\"}]}\\",
-        \\"role\\": \\"\${aws_iam_role.my_bucket_my_bucket-onupdate-OnMessage-46c07356_IamRole_4FC47AD3.name}\\"
-      }
+      "my_bucket_my_bucket-onupdate-OnMessage-46c07356_IamRolePolicy_4F7EE7F8": {
+        "policy": "{\\"Version\\":\\"2012-10-17\\",\\"Statement\\":[{\\"Effect\\":\\"Allow\\",\\"Action\\":\\"none:null\\",\\"Resource\\":\\"*\\"}]}",
+        "role": "\${aws_iam_role.my_bucket_my_bucket-onupdate-OnMessage-46c07356_IamRole_4FC47AD3.name}",
+      },
     },
-    \\"aws_iam_role_policy_attachment\\": {
-      \\"my_bucket_my_bucket-oncreate-OnMessage-7b961f4d_IamRolePolicyAttachment_73145579\\": {
-        \\"policy_arn\\": \\"arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole\\",
-        \\"role\\": \\"\${aws_iam_role.my_bucket_my_bucket-oncreate-OnMessage-7b961f4d_IamRole_7FA5AA01.name}\\"
+    "aws_iam_role_policy_attachment": {
+      "my_bucket_my_bucket-oncreate-OnMessage-7b961f4d_IamRolePolicyAttachment_73145579": {
+        "policy_arn": "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+        "role": "\${aws_iam_role.my_bucket_my_bucket-oncreate-OnMessage-7b961f4d_IamRole_7FA5AA01.name}",
       },
-      \\"my_bucket_my_bucket-ondelete-OnMessage-1de1a361_IamRolePolicyAttachment_4EB0BCD1\\": {
-        \\"policy_arn\\": \\"arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole\\",
-        \\"role\\": \\"\${aws_iam_role.my_bucket_my_bucket-ondelete-OnMessage-1de1a361_IamRole_94D9A7C9.name}\\"
+      "my_bucket_my_bucket-ondelete-OnMessage-1de1a361_IamRolePolicyAttachment_4EB0BCD1": {
+        "policy_arn": "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+        "role": "\${aws_iam_role.my_bucket_my_bucket-ondelete-OnMessage-1de1a361_IamRole_94D9A7C9.name}",
       },
-      \\"my_bucket_my_bucket-onupdate-OnMessage-46c07356_IamRolePolicyAttachment_925666B1\\": {
-        \\"policy_arn\\": \\"arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole\\",
-        \\"role\\": \\"\${aws_iam_role.my_bucket_my_bucket-onupdate-OnMessage-46c07356_IamRole_4FC47AD3.name}\\"
-      }
+      "my_bucket_my_bucket-onupdate-OnMessage-46c07356_IamRolePolicyAttachment_925666B1": {
+        "policy_arn": "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+        "role": "\${aws_iam_role.my_bucket_my_bucket-onupdate-OnMessage-46c07356_IamRole_4FC47AD3.name}",
+      },
     },
-    \\"aws_lambda_function\\": {
-      \\"my_bucket_my_bucket-oncreate-OnMessage-7b961f4d_8104FB90\\": {
-        \\"environment\\": {
-          \\"variables\\": {
-            \\"WING_FUNCTION_NAME\\": \\"my_bucket-oncreate-OnMessage-7b961f4d-c81311dd\\"
-          }
+    "aws_lambda_function": {
+      "my_bucket_my_bucket-oncreate-OnMessage-7b961f4d_8104FB90": {
+        "environment": {
+          "variables": {
+            "WING_FUNCTION_NAME": "my_bucket-oncreate-OnMessage-7b961f4d-c81311dd",
+          },
         },
-        \\"function_name\\": \\"my_bucket-oncreate-OnMessage-7b961f4d-c81311dd\\",
-        \\"handler\\": \\"index.handler\\",
-        \\"publish\\": true,
-        \\"role\\": \\"\${aws_iam_role.my_bucket_my_bucket-oncreate-OnMessage-7b961f4d_IamRole_7FA5AA01.arn}\\",
-        \\"runtime\\": \\"nodejs18.x\\",
-        \\"s3_bucket\\": \\"\${aws_s3_bucket.Code.bucket}\\",
-        \\"s3_key\\": \\"\${aws_s3_object.my_bucket_my_bucket-oncreate-OnMessage-7b961f4d_S3Object_AA8B2734.key}\\",
-        \\"timeout\\": 30,
-        \\"vpc_config\\": {
-          \\"security_group_ids\\": [],
-          \\"subnet_ids\\": []
-        }
-      },
-      \\"my_bucket_my_bucket-ondelete-OnMessage-1de1a361_37C9E1F7\\": {
-        \\"environment\\": {
-          \\"variables\\": {
-            \\"WING_FUNCTION_NAME\\": \\"my_bucket-ondelete-OnMessage-1de1a361-c89e08bf\\"
-          }
+        "function_name": "my_bucket-oncreate-OnMessage-7b961f4d-c81311dd",
+        "handler": "index.handler",
+        "publish": true,
+        "role": "\${aws_iam_role.my_bucket_my_bucket-oncreate-OnMessage-7b961f4d_IamRole_7FA5AA01.arn}",
+        "runtime": "nodejs18.x",
+        "s3_bucket": "\${aws_s3_bucket.Code.bucket}",
+        "s3_key": "\${aws_s3_object.my_bucket_my_bucket-oncreate-OnMessage-7b961f4d_S3Object_AA8B2734.key}",
+        "timeout": 30,
+        "vpc_config": {
+          "security_group_ids": [],
+          "subnet_ids": [],
         },
-        \\"function_name\\": \\"my_bucket-ondelete-OnMessage-1de1a361-c89e08bf\\",
-        \\"handler\\": \\"index.handler\\",
-        \\"publish\\": true,
-        \\"role\\": \\"\${aws_iam_role.my_bucket_my_bucket-ondelete-OnMessage-1de1a361_IamRole_94D9A7C9.arn}\\",
-        \\"runtime\\": \\"nodejs18.x\\",
-        \\"s3_bucket\\": \\"\${aws_s3_bucket.Code.bucket}\\",
-        \\"s3_key\\": \\"\${aws_s3_object.my_bucket_my_bucket-ondelete-OnMessage-1de1a361_S3Object_2203B527.key}\\",
-        \\"timeout\\": 30,
-        \\"vpc_config\\": {
-          \\"security_group_ids\\": [],
-          \\"subnet_ids\\": []
-        }
       },
-      \\"my_bucket_my_bucket-onupdate-OnMessage-46c07356_F3040BF9\\": {
-        \\"environment\\": {
-          \\"variables\\": {
-            \\"WING_FUNCTION_NAME\\": \\"my_bucket-onupdate-OnMessage-46c07356-c844b8ba\\"
-          }
+      "my_bucket_my_bucket-ondelete-OnMessage-1de1a361_37C9E1F7": {
+        "environment": {
+          "variables": {
+            "WING_FUNCTION_NAME": "my_bucket-ondelete-OnMessage-1de1a361-c89e08bf",
+          },
         },
-        \\"function_name\\": \\"my_bucket-onupdate-OnMessage-46c07356-c844b8ba\\",
-        \\"handler\\": \\"index.handler\\",
-        \\"publish\\": true,
-        \\"role\\": \\"\${aws_iam_role.my_bucket_my_bucket-onupdate-OnMessage-46c07356_IamRole_4FC47AD3.arn}\\",
-        \\"runtime\\": \\"nodejs18.x\\",
-        \\"s3_bucket\\": \\"\${aws_s3_bucket.Code.bucket}\\",
-        \\"s3_key\\": \\"\${aws_s3_object.my_bucket_my_bucket-onupdate-OnMessage-46c07356_S3Object_0B6EDB66.key}\\",
-        \\"timeout\\": 30,
-        \\"vpc_config\\": {
-          \\"security_group_ids\\": [],
-          \\"subnet_ids\\": []
-        }
-      }
-    },
-    \\"aws_lambda_permission\\": {
-      \\"my_bucket_my_bucket-oncreate-OnMessage-7b961f4d_InvokePermission-c81e8728eb64a11308ced47594c2396d2467e4d9d3_8DD58C41\\": {
-        \\"action\\": \\"lambda:InvokeFunction\\",
-        \\"function_name\\": \\"\${aws_lambda_function.my_bucket_my_bucket-oncreate-OnMessage-7b961f4d_8104FB90.function_name}\\",
-        \\"principal\\": \\"sns.amazonaws.com\\",
-        \\"source_arn\\": \\"\${aws_sns_topic.my_bucket_my_bucket-oncreate_820372FA.arn}\\"
+        "function_name": "my_bucket-ondelete-OnMessage-1de1a361-c89e08bf",
+        "handler": "index.handler",
+        "publish": true,
+        "role": "\${aws_iam_role.my_bucket_my_bucket-ondelete-OnMessage-1de1a361_IamRole_94D9A7C9.arn}",
+        "runtime": "nodejs18.x",
+        "s3_bucket": "\${aws_s3_bucket.Code.bucket}",
+        "s3_key": "\${aws_s3_object.my_bucket_my_bucket-ondelete-OnMessage-1de1a361_S3Object_2203B527.key}",
+        "timeout": 30,
+        "vpc_config": {
+          "security_group_ids": [],
+          "subnet_ids": [],
+        },
       },
-      \\"my_bucket_my_bucket-ondelete-OnMessage-1de1a361_InvokePermission-c804d947f12e6d883f018387429c0ba10b852c46ba_1CD63BDF\\": {
-        \\"action\\": \\"lambda:InvokeFunction\\",
-        \\"function_name\\": \\"\${aws_lambda_function.my_bucket_my_bucket-ondelete-OnMessage-1de1a361_37C9E1F7.function_name}\\",
-        \\"principal\\": \\"sns.amazonaws.com\\",
-        \\"source_arn\\": \\"\${aws_sns_topic.my_bucket_my_bucket-ondelete_D8AB43D6.arn}\\"
+      "my_bucket_my_bucket-onupdate-OnMessage-46c07356_F3040BF9": {
+        "environment": {
+          "variables": {
+            "WING_FUNCTION_NAME": "my_bucket-onupdate-OnMessage-46c07356-c844b8ba",
+          },
+        },
+        "function_name": "my_bucket-onupdate-OnMessage-46c07356-c844b8ba",
+        "handler": "index.handler",
+        "publish": true,
+        "role": "\${aws_iam_role.my_bucket_my_bucket-onupdate-OnMessage-46c07356_IamRole_4FC47AD3.arn}",
+        "runtime": "nodejs18.x",
+        "s3_bucket": "\${aws_s3_bucket.Code.bucket}",
+        "s3_key": "\${aws_s3_object.my_bucket_my_bucket-onupdate-OnMessage-46c07356_S3Object_0B6EDB66.key}",
+        "timeout": 30,
+        "vpc_config": {
+          "security_group_ids": [],
+          "subnet_ids": [],
+        },
       },
-      \\"my_bucket_my_bucket-onupdate-OnMessage-46c07356_InvokePermission-c85a09033744f6af2426f88e40823fbfd778fbdc16_84A15817\\": {
-        \\"action\\": \\"lambda:InvokeFunction\\",
-        \\"function_name\\": \\"\${aws_lambda_function.my_bucket_my_bucket-onupdate-OnMessage-46c07356_F3040BF9.function_name}\\",
-        \\"principal\\": \\"sns.amazonaws.com\\",
-        \\"source_arn\\": \\"\${aws_sns_topic.my_bucket_my_bucket-onupdate_ADC4AA5B.arn}\\"
-      }
     },
-    \\"aws_s3_bucket\\": {
-      \\"Code\\": {
-        \\"bucket_prefix\\": \\"code-c84a50b1-\\"
+    "aws_lambda_permission": {
+      "my_bucket_my_bucket-oncreate-OnMessage-7b961f4d_InvokePermission-c81e8728eb64a11308ced47594c2396d2467e4d9d3_8DD58C41": {
+        "action": "lambda:InvokeFunction",
+        "function_name": "\${aws_lambda_function.my_bucket_my_bucket-oncreate-OnMessage-7b961f4d_8104FB90.function_name}",
+        "principal": "sns.amazonaws.com",
+        "source_arn": "\${aws_sns_topic.my_bucket_my_bucket-oncreate_820372FA.arn}",
       },
-      \\"my_bucket\\": {
-        \\"bucket_prefix\\": \\"my-bucket-c8045fcc-\\",
-        \\"force_destroy\\": false
-      }
+      "my_bucket_my_bucket-ondelete-OnMessage-1de1a361_InvokePermission-c804d947f12e6d883f018387429c0ba10b852c46ba_1CD63BDF": {
+        "action": "lambda:InvokeFunction",
+        "function_name": "\${aws_lambda_function.my_bucket_my_bucket-ondelete-OnMessage-1de1a361_37C9E1F7.function_name}",
+        "principal": "sns.amazonaws.com",
+        "source_arn": "\${aws_sns_topic.my_bucket_my_bucket-ondelete_D8AB43D6.arn}",
+      },
+      "my_bucket_my_bucket-onupdate-OnMessage-46c07356_InvokePermission-c85a09033744f6af2426f88e40823fbfd778fbdc16_84A15817": {
+        "action": "lambda:InvokeFunction",
+        "function_name": "\${aws_lambda_function.my_bucket_my_bucket-onupdate-OnMessage-46c07356_F3040BF9.function_name}",
+        "principal": "sns.amazonaws.com",
+        "source_arn": "\${aws_sns_topic.my_bucket_my_bucket-onupdate_ADC4AA5B.arn}",
+      },
     },
-    \\"aws_s3_bucket_notification\\": {
-      \\"my_bucket_S3BucketNotification_DDA29E8F\\": {
-        \\"bucket\\": \\"\${aws_s3_bucket.my_bucket.id}\\",
-        \\"depends_on\\": [
-          \\"aws_sns_topic_policy.my_bucket_my_bucket-oncreate_PublishPermission-c8045fccc85a7ef42d5391d87958e5ce36c53a401a_DC469583\\",
-          \\"aws_sns_topic_policy.my_bucket_my_bucket-onupdate_PublishPermission-c8045fccc85a7ef42d5391d87958e5ce36c53a401a_CDA9888A\\",
-          \\"aws_sns_topic_policy.my_bucket_my_bucket-ondelete_PublishPermission-c8045fccc85a7ef42d5391d87958e5ce36c53a401a_87361222\\"
+    "aws_s3_bucket": {
+      "Code": {
+        "bucket_prefix": "code-c84a50b1-",
+      },
+      "my_bucket": {
+        "bucket_prefix": "my-bucket-c8045fcc-",
+        "force_destroy": false,
+      },
+    },
+    "aws_s3_bucket_notification": {
+      "my_bucket_S3BucketNotification_DDA29E8F": {
+        "bucket": "\${aws_s3_bucket.my_bucket.id}",
+        "depends_on": [
+          "aws_sns_topic_policy.my_bucket_my_bucket-oncreate_PublishPermission-c8045fccc85a7ef42d5391d87958e5ce36c53a401a_DC469583",
+          "aws_sns_topic_policy.my_bucket_my_bucket-onupdate_PublishPermission-c8045fccc85a7ef42d5391d87958e5ce36c53a401a_CDA9888A",
+          "aws_sns_topic_policy.my_bucket_my_bucket-ondelete_PublishPermission-c8045fccc85a7ef42d5391d87958e5ce36c53a401a_87361222",
         ],
-        \\"topic\\": [
+        "topic": [
           {
-            \\"events\\": [
-              \\"s3:ObjectCreated:Put\\"
+            "events": [
+              "s3:ObjectCreated:Put",
             ],
-            \\"id\\": \\"on-oncreate-notification\\",
-            \\"topic_arn\\": \\"\${aws_sns_topic.my_bucket_my_bucket-oncreate_820372FA.arn}\\"
+            "id": "on-oncreate-notification",
+            "topic_arn": "\${aws_sns_topic.my_bucket_my_bucket-oncreate_820372FA.arn}",
           },
           {
-            \\"events\\": [
-              \\"s3:ObjectCreated:Post\\"
+            "events": [
+              "s3:ObjectCreated:Post",
             ],
-            \\"id\\": \\"on-onupdate-notification\\",
-            \\"topic_arn\\": \\"\${aws_sns_topic.my_bucket_my_bucket-onupdate_ADC4AA5B.arn}\\"
+            "id": "on-onupdate-notification",
+            "topic_arn": "\${aws_sns_topic.my_bucket_my_bucket-onupdate_ADC4AA5B.arn}",
           },
           {
-            \\"events\\": [
-              \\"s3:ObjectRemoved:*\\"
+            "events": [
+              "s3:ObjectRemoved:*",
             ],
-            \\"id\\": \\"on-ondelete-notification\\",
-            \\"topic_arn\\": \\"\${aws_sns_topic.my_bucket_my_bucket-ondelete_D8AB43D6.arn}\\"
-          }
-        ]
-      }
-    },
-    \\"aws_s3_bucket_policy\\": {
-      \\"my_bucket_PublicPolicy_AF351571\\": {
-        \\"bucket\\": \\"\${aws_s3_bucket.my_bucket.bucket}\\",
-        \\"depends_on\\": [
-          \\"aws_s3_bucket_public_access_block.my_bucket_PublicAccessBlock_538547C0\\"
+            "id": "on-ondelete-notification",
+            "topic_arn": "\${aws_sns_topic.my_bucket_my_bucket-ondelete_D8AB43D6.arn}",
+          },
         ],
-        \\"policy\\": \\"{\\\\\\"Version\\\\\\":\\\\\\"2012-10-17\\\\\\",\\\\\\"Statement\\\\\\":[{\\\\\\"Effect\\\\\\":\\\\\\"Allow\\\\\\",\\\\\\"Principal\\\\\\":\\\\\\"*\\\\\\",\\\\\\"Action\\\\\\":[\\\\\\"s3:GetObject\\\\\\"],\\\\\\"Resource\\\\\\":[\\\\\\"\${aws_s3_bucket.my_bucket.arn}/*\\\\\\"]}]}\\"
-      }
+      },
     },
-    \\"aws_s3_bucket_public_access_block\\": {
-      \\"my_bucket_PublicAccessBlock_538547C0\\": {
-        \\"block_public_acls\\": false,
-        \\"block_public_policy\\": false,
-        \\"bucket\\": \\"\${aws_s3_bucket.my_bucket.bucket}\\",
-        \\"ignore_public_acls\\": false,
-        \\"restrict_public_buckets\\": false
-      }
+    "aws_s3_bucket_policy": {
+      "my_bucket_PublicPolicy_AF351571": {
+        "bucket": "\${aws_s3_bucket.my_bucket.bucket}",
+        "depends_on": [
+          "aws_s3_bucket_public_access_block.my_bucket_PublicAccessBlock_538547C0",
+        ],
+        "policy": "{\\"Version\\":\\"2012-10-17\\",\\"Statement\\":[{\\"Effect\\":\\"Allow\\",\\"Principal\\":\\"*\\",\\"Action\\":[\\"s3:GetObject\\"],\\"Resource\\":[\\"\${aws_s3_bucket.my_bucket.arn}/*\\"]}]}",
+      },
     },
-    \\"aws_s3_bucket_server_side_encryption_configuration\\": {
-      \\"my_bucket_Encryption_3B1569A4\\": {
-        \\"bucket\\": \\"\${aws_s3_bucket.my_bucket.bucket}\\",
-        \\"rule\\": [
+    "aws_s3_bucket_public_access_block": {
+      "my_bucket_PublicAccessBlock_538547C0": {
+        "block_public_acls": false,
+        "block_public_policy": false,
+        "bucket": "\${aws_s3_bucket.my_bucket.bucket}",
+        "ignore_public_acls": false,
+        "restrict_public_buckets": false,
+      },
+    },
+    "aws_s3_bucket_server_side_encryption_configuration": {
+      "my_bucket_Encryption_3B1569A4": {
+        "bucket": "\${aws_s3_bucket.my_bucket.bucket}",
+        "rule": [
           {
-            \\"apply_server_side_encryption_by_default\\": {
-              \\"sse_algorithm\\": \\"AES256\\"
-            }
-          }
-        ]
-      }
+            "apply_server_side_encryption_by_default": {
+              "sse_algorithm": "AES256",
+            },
+          },
+        ],
+      },
     },
-    \\"aws_s3_object\\": {
-      \\"my_bucket_my_bucket-oncreate-OnMessage-7b961f4d_S3Object_AA8B2734\\": {
-        \\"bucket\\": \\"\${aws_s3_bucket.Code.bucket}\\",
-        \\"key\\": \\"<key>\\",
-        \\"source\\": \\"<source>\\"
+    "aws_s3_object": {
+      "my_bucket_my_bucket-oncreate-OnMessage-7b961f4d_S3Object_AA8B2734": {
+        "bucket": "\${aws_s3_bucket.Code.bucket}",
+        "key": "<key>",
+        "source": "<source>",
       },
-      \\"my_bucket_my_bucket-ondelete-OnMessage-1de1a361_S3Object_2203B527\\": {
-        \\"bucket\\": \\"\${aws_s3_bucket.Code.bucket}\\",
-        \\"key\\": \\"<key>\\",
-        \\"source\\": \\"<source>\\"
+      "my_bucket_my_bucket-ondelete-OnMessage-1de1a361_S3Object_2203B527": {
+        "bucket": "\${aws_s3_bucket.Code.bucket}",
+        "key": "<key>",
+        "source": "<source>",
       },
-      \\"my_bucket_my_bucket-onupdate-OnMessage-46c07356_S3Object_0B6EDB66\\": {
-        \\"bucket\\": \\"\${aws_s3_bucket.Code.bucket}\\",
-        \\"key\\": \\"<key>\\",
-        \\"source\\": \\"<source>\\"
-      }
+      "my_bucket_my_bucket-onupdate-OnMessage-46c07356_S3Object_0B6EDB66": {
+        "bucket": "\${aws_s3_bucket.Code.bucket}",
+        "key": "<key>",
+        "source": "<source>",
+      },
     },
-    \\"aws_sns_topic\\": {
-      \\"my_bucket_my_bucket-oncreate_820372FA\\": {
-        \\"name\\": \\"my_bucket-oncreate-c81e8728\\"
+    "aws_sns_topic": {
+      "my_bucket_my_bucket-oncreate_820372FA": {
+        "name": "my_bucket-oncreate-c81e8728",
       },
-      \\"my_bucket_my_bucket-ondelete_D8AB43D6\\": {
-        \\"name\\": \\"my_bucket-ondelete-c804d947\\"
+      "my_bucket_my_bucket-ondelete_D8AB43D6": {
+        "name": "my_bucket-ondelete-c804d947",
       },
-      \\"my_bucket_my_bucket-onupdate_ADC4AA5B\\": {
-        \\"name\\": \\"my_bucket-onupdate-c85a0903\\"
-      }
+      "my_bucket_my_bucket-onupdate_ADC4AA5B": {
+        "name": "my_bucket-onupdate-c85a0903",
+      },
     },
-    \\"aws_sns_topic_policy\\": {
-      \\"my_bucket_my_bucket-oncreate_PublishPermission-c8045fccc85a7ef42d5391d87958e5ce36c53a401a_DC469583\\": {
-        \\"arn\\": \\"\${aws_sns_topic.my_bucket_my_bucket-oncreate_820372FA.arn}\\",
-        \\"policy\\": \\"{\\\\\\"Statement\\\\\\":[{\\\\\\"Effect\\\\\\":\\\\\\"Allow\\\\\\",\\\\\\"Principal\\\\\\":{\\\\\\"Service\\\\\\":\\\\\\"s3.amazonaws.com\\\\\\"},\\\\\\"Action\\\\\\":\\\\\\"sns:Publish\\\\\\",\\\\\\"Resource\\\\\\":\\\\\\"\${aws_sns_topic.my_bucket_my_bucket-oncreate_820372FA.arn}\\\\\\",\\\\\\"Condition\\\\\\":{\\\\\\"ArnEquals\\\\\\":{\\\\\\"aws:SourceArn\\\\\\":\\\\\\"\${aws_s3_bucket.my_bucket.arn}\\\\\\"}}}]}\\"
+    "aws_sns_topic_policy": {
+      "my_bucket_my_bucket-oncreate_PublishPermission-c8045fccc85a7ef42d5391d87958e5ce36c53a401a_DC469583": {
+        "arn": "\${aws_sns_topic.my_bucket_my_bucket-oncreate_820372FA.arn}",
+        "policy": "{\\"Statement\\":[{\\"Effect\\":\\"Allow\\",\\"Principal\\":{\\"Service\\":\\"s3.amazonaws.com\\"},\\"Action\\":\\"sns:Publish\\",\\"Resource\\":\\"\${aws_sns_topic.my_bucket_my_bucket-oncreate_820372FA.arn}\\",\\"Condition\\":{\\"ArnEquals\\":{\\"aws:SourceArn\\":\\"\${aws_s3_bucket.my_bucket.arn}\\"}}}]}",
       },
-      \\"my_bucket_my_bucket-ondelete_PublishPermission-c8045fccc85a7ef42d5391d87958e5ce36c53a401a_87361222\\": {
-        \\"arn\\": \\"\${aws_sns_topic.my_bucket_my_bucket-ondelete_D8AB43D6.arn}\\",
-        \\"policy\\": \\"{\\\\\\"Statement\\\\\\":[{\\\\\\"Effect\\\\\\":\\\\\\"Allow\\\\\\",\\\\\\"Principal\\\\\\":{\\\\\\"Service\\\\\\":\\\\\\"s3.amazonaws.com\\\\\\"},\\\\\\"Action\\\\\\":\\\\\\"sns:Publish\\\\\\",\\\\\\"Resource\\\\\\":\\\\\\"\${aws_sns_topic.my_bucket_my_bucket-ondelete_D8AB43D6.arn}\\\\\\",\\\\\\"Condition\\\\\\":{\\\\\\"ArnEquals\\\\\\":{\\\\\\"aws:SourceArn\\\\\\":\\\\\\"\${aws_s3_bucket.my_bucket.arn}\\\\\\"}}}]}\\"
+      "my_bucket_my_bucket-ondelete_PublishPermission-c8045fccc85a7ef42d5391d87958e5ce36c53a401a_87361222": {
+        "arn": "\${aws_sns_topic.my_bucket_my_bucket-ondelete_D8AB43D6.arn}",
+        "policy": "{\\"Statement\\":[{\\"Effect\\":\\"Allow\\",\\"Principal\\":{\\"Service\\":\\"s3.amazonaws.com\\"},\\"Action\\":\\"sns:Publish\\",\\"Resource\\":\\"\${aws_sns_topic.my_bucket_my_bucket-ondelete_D8AB43D6.arn}\\",\\"Condition\\":{\\"ArnEquals\\":{\\"aws:SourceArn\\":\\"\${aws_s3_bucket.my_bucket.arn}\\"}}}]}",
       },
-      \\"my_bucket_my_bucket-onupdate_PublishPermission-c8045fccc85a7ef42d5391d87958e5ce36c53a401a_CDA9888A\\": {
-        \\"arn\\": \\"\${aws_sns_topic.my_bucket_my_bucket-onupdate_ADC4AA5B.arn}\\",
-        \\"policy\\": \\"{\\\\\\"Statement\\\\\\":[{\\\\\\"Effect\\\\\\":\\\\\\"Allow\\\\\\",\\\\\\"Principal\\\\\\":{\\\\\\"Service\\\\\\":\\\\\\"s3.amazonaws.com\\\\\\"},\\\\\\"Action\\\\\\":\\\\\\"sns:Publish\\\\\\",\\\\\\"Resource\\\\\\":\\\\\\"\${aws_sns_topic.my_bucket_my_bucket-onupdate_ADC4AA5B.arn}\\\\\\",\\\\\\"Condition\\\\\\":{\\\\\\"ArnEquals\\\\\\":{\\\\\\"aws:SourceArn\\\\\\":\\\\\\"\${aws_s3_bucket.my_bucket.arn}\\\\\\"}}}]}\\"
-      }
+      "my_bucket_my_bucket-onupdate_PublishPermission-c8045fccc85a7ef42d5391d87958e5ce36c53a401a_CDA9888A": {
+        "arn": "\${aws_sns_topic.my_bucket_my_bucket-onupdate_ADC4AA5B.arn}",
+        "policy": "{\\"Statement\\":[{\\"Effect\\":\\"Allow\\",\\"Principal\\":{\\"Service\\":\\"s3.amazonaws.com\\"},\\"Action\\":\\"sns:Publish\\",\\"Resource\\":\\"\${aws_sns_topic.my_bucket_my_bucket-onupdate_ADC4AA5B.arn}\\",\\"Condition\\":{\\"ArnEquals\\":{\\"aws:SourceArn\\":\\"\${aws_s3_bucket.my_bucket.arn}\\"}}}]}",
+      },
     },
-    \\"aws_sns_topic_subscription\\": {
-      \\"my_bucket_my_bucket-oncreate_my_bucket-oncreate-TopicSubscription-7b961f4d_E00E14CE\\": {
-        \\"endpoint\\": \\"\${aws_lambda_function.my_bucket_my_bucket-oncreate-OnMessage-7b961f4d_8104FB90.arn}\\",
-        \\"protocol\\": \\"lambda\\",
-        \\"topic_arn\\": \\"\${aws_sns_topic.my_bucket_my_bucket-oncreate_820372FA.arn}\\"
+    "aws_sns_topic_subscription": {
+      "my_bucket_my_bucket-oncreate_my_bucket-oncreate-TopicSubscription-7b961f4d_E00E14CE": {
+        "endpoint": "\${aws_lambda_function.my_bucket_my_bucket-oncreate-OnMessage-7b961f4d_8104FB90.arn}",
+        "protocol": "lambda",
+        "topic_arn": "\${aws_sns_topic.my_bucket_my_bucket-oncreate_820372FA.arn}",
       },
-      \\"my_bucket_my_bucket-ondelete_my_bucket-ondelete-TopicSubscription-1de1a361_7E4EBD35\\": {
-        \\"endpoint\\": \\"\${aws_lambda_function.my_bucket_my_bucket-ondelete-OnMessage-1de1a361_37C9E1F7.arn}\\",
-        \\"protocol\\": \\"lambda\\",
-        \\"topic_arn\\": \\"\${aws_sns_topic.my_bucket_my_bucket-ondelete_D8AB43D6.arn}\\"
+      "my_bucket_my_bucket-ondelete_my_bucket-ondelete-TopicSubscription-1de1a361_7E4EBD35": {
+        "endpoint": "\${aws_lambda_function.my_bucket_my_bucket-ondelete-OnMessage-1de1a361_37C9E1F7.arn}",
+        "protocol": "lambda",
+        "topic_arn": "\${aws_sns_topic.my_bucket_my_bucket-ondelete_D8AB43D6.arn}",
       },
-      \\"my_bucket_my_bucket-onupdate_my_bucket-onupdate-TopicSubscription-46c07356_078EA64F\\": {
-        \\"endpoint\\": \\"\${aws_lambda_function.my_bucket_my_bucket-onupdate-OnMessage-46c07356_F3040BF9.arn}\\",
-        \\"protocol\\": \\"lambda\\",
-        \\"topic_arn\\": \\"\${aws_sns_topic.my_bucket_my_bucket-onupdate_ADC4AA5B.arn}\\"
-      }
-    }
-  }
-}"
+      "my_bucket_my_bucket-onupdate_my_bucket-onupdate-TopicSubscription-46c07356_078EA64F": {
+        "endpoint": "\${aws_lambda_function.my_bucket_my_bucket-onupdate-OnMessage-46c07356_F3040BF9.arn}",
+        "protocol": "lambda",
+        "topic_arn": "\${aws_sns_topic.my_bucket_my_bucket-onupdate_ADC4AA5B.arn}",
+      },
+    },
+  },
+}
 `;
 
 exports[`bucket with onEvent method 2`] = `
@@ -2599,142 +2599,142 @@ exports[`bucket with onEvent method 2`] = `
 `;
 
 exports[`bucket with onUpdate method 1`] = `
-"{
-  \\"output\\": {
-    \\"WING_TEST_RUNNER_FUNCTION_ARNS\\": {
-      \\"value\\": \\"[]\\"
-    }
+{
+  "output": {
+    "WING_TEST_RUNNER_FUNCTION_ARNS": {
+      "value": "[]",
+    },
   },
-  \\"resource\\": {
-    \\"aws_iam_role\\": {
-      \\"my_bucket_my_bucket-onupdate-OnMessage-46c07356_IamRole_4FC47AD3\\": {
-        \\"assume_role_policy\\": \\"{\\\\\\"Version\\\\\\":\\\\\\"2012-10-17\\\\\\",\\\\\\"Statement\\\\\\":[{\\\\\\"Action\\\\\\":\\\\\\"sts:AssumeRole\\\\\\",\\\\\\"Principal\\\\\\":{\\\\\\"Service\\\\\\":\\\\\\"lambda.amazonaws.com\\\\\\"},\\\\\\"Effect\\\\\\":\\\\\\"Allow\\\\\\"}]}\\"
-      }
-    },
-    \\"aws_iam_role_policy\\": {
-      \\"my_bucket_my_bucket-onupdate-OnMessage-46c07356_IamRolePolicy_4F7EE7F8\\": {
-        \\"policy\\": \\"{\\\\\\"Version\\\\\\":\\\\\\"2012-10-17\\\\\\",\\\\\\"Statement\\\\\\":[{\\\\\\"Effect\\\\\\":\\\\\\"Allow\\\\\\",\\\\\\"Action\\\\\\":\\\\\\"none:null\\\\\\",\\\\\\"Resource\\\\\\":\\\\\\"*\\\\\\"}]}\\",
-        \\"role\\": \\"\${aws_iam_role.my_bucket_my_bucket-onupdate-OnMessage-46c07356_IamRole_4FC47AD3.name}\\"
-      }
-    },
-    \\"aws_iam_role_policy_attachment\\": {
-      \\"my_bucket_my_bucket-onupdate-OnMessage-46c07356_IamRolePolicyAttachment_925666B1\\": {
-        \\"policy_arn\\": \\"arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole\\",
-        \\"role\\": \\"\${aws_iam_role.my_bucket_my_bucket-onupdate-OnMessage-46c07356_IamRole_4FC47AD3.name}\\"
-      }
-    },
-    \\"aws_lambda_function\\": {
-      \\"my_bucket_my_bucket-onupdate-OnMessage-46c07356_F3040BF9\\": {
-        \\"environment\\": {
-          \\"variables\\": {
-            \\"WING_FUNCTION_NAME\\": \\"my_bucket-onupdate-OnMessage-46c07356-c844b8ba\\"
-          }
-        },
-        \\"function_name\\": \\"my_bucket-onupdate-OnMessage-46c07356-c844b8ba\\",
-        \\"handler\\": \\"index.handler\\",
-        \\"publish\\": true,
-        \\"role\\": \\"\${aws_iam_role.my_bucket_my_bucket-onupdate-OnMessage-46c07356_IamRole_4FC47AD3.arn}\\",
-        \\"runtime\\": \\"nodejs18.x\\",
-        \\"s3_bucket\\": \\"\${aws_s3_bucket.Code.bucket}\\",
-        \\"s3_key\\": \\"\${aws_s3_object.my_bucket_my_bucket-onupdate-OnMessage-46c07356_S3Object_0B6EDB66.key}\\",
-        \\"timeout\\": 30,
-        \\"vpc_config\\": {
-          \\"security_group_ids\\": [],
-          \\"subnet_ids\\": []
-        }
-      }
-    },
-    \\"aws_lambda_permission\\": {
-      \\"my_bucket_my_bucket-onupdate-OnMessage-46c07356_InvokePermission-c85a09033744f6af2426f88e40823fbfd778fbdc16_84A15817\\": {
-        \\"action\\": \\"lambda:InvokeFunction\\",
-        \\"function_name\\": \\"\${aws_lambda_function.my_bucket_my_bucket-onupdate-OnMessage-46c07356_F3040BF9.function_name}\\",
-        \\"principal\\": \\"sns.amazonaws.com\\",
-        \\"source_arn\\": \\"\${aws_sns_topic.my_bucket_my_bucket-onupdate_ADC4AA5B.arn}\\"
-      }
-    },
-    \\"aws_s3_bucket\\": {
-      \\"Code\\": {
-        \\"bucket_prefix\\": \\"code-c84a50b1-\\"
+  "resource": {
+    "aws_iam_role": {
+      "my_bucket_my_bucket-onupdate-OnMessage-46c07356_IamRole_4FC47AD3": {
+        "assume_role_policy": "{\\"Version\\":\\"2012-10-17\\",\\"Statement\\":[{\\"Action\\":\\"sts:AssumeRole\\",\\"Principal\\":{\\"Service\\":\\"lambda.amazonaws.com\\"},\\"Effect\\":\\"Allow\\"}]}",
       },
-      \\"my_bucket\\": {
-        \\"bucket_prefix\\": \\"my-bucket-c8045fcc-\\",
-        \\"force_destroy\\": false
-      }
     },
-    \\"aws_s3_bucket_notification\\": {
-      \\"my_bucket_S3BucketNotification_DDA29E8F\\": {
-        \\"bucket\\": \\"\${aws_s3_bucket.my_bucket.id}\\",
-        \\"depends_on\\": [
-          \\"aws_sns_topic_policy.my_bucket_my_bucket-onupdate_PublishPermission-c8045fccc85a7ef42d5391d87958e5ce36c53a401a_CDA9888A\\"
+    "aws_iam_role_policy": {
+      "my_bucket_my_bucket-onupdate-OnMessage-46c07356_IamRolePolicy_4F7EE7F8": {
+        "policy": "{\\"Version\\":\\"2012-10-17\\",\\"Statement\\":[{\\"Effect\\":\\"Allow\\",\\"Action\\":\\"none:null\\",\\"Resource\\":\\"*\\"}]}",
+        "role": "\${aws_iam_role.my_bucket_my_bucket-onupdate-OnMessage-46c07356_IamRole_4FC47AD3.name}",
+      },
+    },
+    "aws_iam_role_policy_attachment": {
+      "my_bucket_my_bucket-onupdate-OnMessage-46c07356_IamRolePolicyAttachment_925666B1": {
+        "policy_arn": "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+        "role": "\${aws_iam_role.my_bucket_my_bucket-onupdate-OnMessage-46c07356_IamRole_4FC47AD3.name}",
+      },
+    },
+    "aws_lambda_function": {
+      "my_bucket_my_bucket-onupdate-OnMessage-46c07356_F3040BF9": {
+        "environment": {
+          "variables": {
+            "WING_FUNCTION_NAME": "my_bucket-onupdate-OnMessage-46c07356-c844b8ba",
+          },
+        },
+        "function_name": "my_bucket-onupdate-OnMessage-46c07356-c844b8ba",
+        "handler": "index.handler",
+        "publish": true,
+        "role": "\${aws_iam_role.my_bucket_my_bucket-onupdate-OnMessage-46c07356_IamRole_4FC47AD3.arn}",
+        "runtime": "nodejs18.x",
+        "s3_bucket": "\${aws_s3_bucket.Code.bucket}",
+        "s3_key": "\${aws_s3_object.my_bucket_my_bucket-onupdate-OnMessage-46c07356_S3Object_0B6EDB66.key}",
+        "timeout": 30,
+        "vpc_config": {
+          "security_group_ids": [],
+          "subnet_ids": [],
+        },
+      },
+    },
+    "aws_lambda_permission": {
+      "my_bucket_my_bucket-onupdate-OnMessage-46c07356_InvokePermission-c85a09033744f6af2426f88e40823fbfd778fbdc16_84A15817": {
+        "action": "lambda:InvokeFunction",
+        "function_name": "\${aws_lambda_function.my_bucket_my_bucket-onupdate-OnMessage-46c07356_F3040BF9.function_name}",
+        "principal": "sns.amazonaws.com",
+        "source_arn": "\${aws_sns_topic.my_bucket_my_bucket-onupdate_ADC4AA5B.arn}",
+      },
+    },
+    "aws_s3_bucket": {
+      "Code": {
+        "bucket_prefix": "code-c84a50b1-",
+      },
+      "my_bucket": {
+        "bucket_prefix": "my-bucket-c8045fcc-",
+        "force_destroy": false,
+      },
+    },
+    "aws_s3_bucket_notification": {
+      "my_bucket_S3BucketNotification_DDA29E8F": {
+        "bucket": "\${aws_s3_bucket.my_bucket.id}",
+        "depends_on": [
+          "aws_sns_topic_policy.my_bucket_my_bucket-onupdate_PublishPermission-c8045fccc85a7ef42d5391d87958e5ce36c53a401a_CDA9888A",
         ],
-        \\"topic\\": [
+        "topic": [
           {
-            \\"events\\": [
-              \\"s3:ObjectCreated:Post\\"
+            "events": [
+              "s3:ObjectCreated:Post",
             ],
-            \\"id\\": \\"on-onupdate-notification\\",
-            \\"topic_arn\\": \\"\${aws_sns_topic.my_bucket_my_bucket-onupdate_ADC4AA5B.arn}\\"
-          }
-        ]
-      }
-    },
-    \\"aws_s3_bucket_policy\\": {
-      \\"my_bucket_PublicPolicy_AF351571\\": {
-        \\"bucket\\": \\"\${aws_s3_bucket.my_bucket.bucket}\\",
-        \\"depends_on\\": [
-          \\"aws_s3_bucket_public_access_block.my_bucket_PublicAccessBlock_538547C0\\"
+            "id": "on-onupdate-notification",
+            "topic_arn": "\${aws_sns_topic.my_bucket_my_bucket-onupdate_ADC4AA5B.arn}",
+          },
         ],
-        \\"policy\\": \\"{\\\\\\"Version\\\\\\":\\\\\\"2012-10-17\\\\\\",\\\\\\"Statement\\\\\\":[{\\\\\\"Effect\\\\\\":\\\\\\"Allow\\\\\\",\\\\\\"Principal\\\\\\":\\\\\\"*\\\\\\",\\\\\\"Action\\\\\\":[\\\\\\"s3:GetObject\\\\\\"],\\\\\\"Resource\\\\\\":[\\\\\\"\${aws_s3_bucket.my_bucket.arn}/*\\\\\\"]}]}\\"
-      }
+      },
     },
-    \\"aws_s3_bucket_public_access_block\\": {
-      \\"my_bucket_PublicAccessBlock_538547C0\\": {
-        \\"block_public_acls\\": false,
-        \\"block_public_policy\\": false,
-        \\"bucket\\": \\"\${aws_s3_bucket.my_bucket.bucket}\\",
-        \\"ignore_public_acls\\": false,
-        \\"restrict_public_buckets\\": false
-      }
+    "aws_s3_bucket_policy": {
+      "my_bucket_PublicPolicy_AF351571": {
+        "bucket": "\${aws_s3_bucket.my_bucket.bucket}",
+        "depends_on": [
+          "aws_s3_bucket_public_access_block.my_bucket_PublicAccessBlock_538547C0",
+        ],
+        "policy": "{\\"Version\\":\\"2012-10-17\\",\\"Statement\\":[{\\"Effect\\":\\"Allow\\",\\"Principal\\":\\"*\\",\\"Action\\":[\\"s3:GetObject\\"],\\"Resource\\":[\\"\${aws_s3_bucket.my_bucket.arn}/*\\"]}]}",
+      },
     },
-    \\"aws_s3_bucket_server_side_encryption_configuration\\": {
-      \\"my_bucket_Encryption_3B1569A4\\": {
-        \\"bucket\\": \\"\${aws_s3_bucket.my_bucket.bucket}\\",
-        \\"rule\\": [
+    "aws_s3_bucket_public_access_block": {
+      "my_bucket_PublicAccessBlock_538547C0": {
+        "block_public_acls": false,
+        "block_public_policy": false,
+        "bucket": "\${aws_s3_bucket.my_bucket.bucket}",
+        "ignore_public_acls": false,
+        "restrict_public_buckets": false,
+      },
+    },
+    "aws_s3_bucket_server_side_encryption_configuration": {
+      "my_bucket_Encryption_3B1569A4": {
+        "bucket": "\${aws_s3_bucket.my_bucket.bucket}",
+        "rule": [
           {
-            \\"apply_server_side_encryption_by_default\\": {
-              \\"sse_algorithm\\": \\"AES256\\"
-            }
-          }
-        ]
-      }
+            "apply_server_side_encryption_by_default": {
+              "sse_algorithm": "AES256",
+            },
+          },
+        ],
+      },
     },
-    \\"aws_s3_object\\": {
-      \\"my_bucket_my_bucket-onupdate-OnMessage-46c07356_S3Object_0B6EDB66\\": {
-        \\"bucket\\": \\"\${aws_s3_bucket.Code.bucket}\\",
-        \\"key\\": \\"<key>\\",
-        \\"source\\": \\"<source>\\"
-      }
+    "aws_s3_object": {
+      "my_bucket_my_bucket-onupdate-OnMessage-46c07356_S3Object_0B6EDB66": {
+        "bucket": "\${aws_s3_bucket.Code.bucket}",
+        "key": "<key>",
+        "source": "<source>",
+      },
     },
-    \\"aws_sns_topic\\": {
-      \\"my_bucket_my_bucket-onupdate_ADC4AA5B\\": {
-        \\"name\\": \\"my_bucket-onupdate-c85a0903\\"
-      }
+    "aws_sns_topic": {
+      "my_bucket_my_bucket-onupdate_ADC4AA5B": {
+        "name": "my_bucket-onupdate-c85a0903",
+      },
     },
-    \\"aws_sns_topic_policy\\": {
-      \\"my_bucket_my_bucket-onupdate_PublishPermission-c8045fccc85a7ef42d5391d87958e5ce36c53a401a_CDA9888A\\": {
-        \\"arn\\": \\"\${aws_sns_topic.my_bucket_my_bucket-onupdate_ADC4AA5B.arn}\\",
-        \\"policy\\": \\"{\\\\\\"Statement\\\\\\":[{\\\\\\"Effect\\\\\\":\\\\\\"Allow\\\\\\",\\\\\\"Principal\\\\\\":{\\\\\\"Service\\\\\\":\\\\\\"s3.amazonaws.com\\\\\\"},\\\\\\"Action\\\\\\":\\\\\\"sns:Publish\\\\\\",\\\\\\"Resource\\\\\\":\\\\\\"\${aws_sns_topic.my_bucket_my_bucket-onupdate_ADC4AA5B.arn}\\\\\\",\\\\\\"Condition\\\\\\":{\\\\\\"ArnEquals\\\\\\":{\\\\\\"aws:SourceArn\\\\\\":\\\\\\"\${aws_s3_bucket.my_bucket.arn}\\\\\\"}}}]}\\"
-      }
+    "aws_sns_topic_policy": {
+      "my_bucket_my_bucket-onupdate_PublishPermission-c8045fccc85a7ef42d5391d87958e5ce36c53a401a_CDA9888A": {
+        "arn": "\${aws_sns_topic.my_bucket_my_bucket-onupdate_ADC4AA5B.arn}",
+        "policy": "{\\"Statement\\":[{\\"Effect\\":\\"Allow\\",\\"Principal\\":{\\"Service\\":\\"s3.amazonaws.com\\"},\\"Action\\":\\"sns:Publish\\",\\"Resource\\":\\"\${aws_sns_topic.my_bucket_my_bucket-onupdate_ADC4AA5B.arn}\\",\\"Condition\\":{\\"ArnEquals\\":{\\"aws:SourceArn\\":\\"\${aws_s3_bucket.my_bucket.arn}\\"}}}]}",
+      },
     },
-    \\"aws_sns_topic_subscription\\": {
-      \\"my_bucket_my_bucket-onupdate_my_bucket-onupdate-TopicSubscription-46c07356_078EA64F\\": {
-        \\"endpoint\\": \\"\${aws_lambda_function.my_bucket_my_bucket-onupdate-OnMessage-46c07356_F3040BF9.arn}\\",
-        \\"protocol\\": \\"lambda\\",
-        \\"topic_arn\\": \\"\${aws_sns_topic.my_bucket_my_bucket-onupdate_ADC4AA5B.arn}\\"
-      }
-    }
-  }
-}"
+    "aws_sns_topic_subscription": {
+      "my_bucket_my_bucket-onupdate_my_bucket-onupdate-TopicSubscription-46c07356_078EA64F": {
+        "endpoint": "\${aws_lambda_function.my_bucket_my_bucket-onupdate-OnMessage-46c07356_F3040BF9.arn}",
+        "protocol": "lambda",
+        "topic_arn": "\${aws_sns_topic.my_bucket_my_bucket-onupdate_ADC4AA5B.arn}",
+      },
+    },
+  },
+}
 `;
 
 exports[`bucket with onUpdate method 2`] = `
@@ -3116,63 +3116,63 @@ exports[`bucket with onUpdate method 2`] = `
 `;
 
 exports[`bucket with two preflight objects 1`] = `
-"{
-  \\"output\\": {
-    \\"WING_TEST_RUNNER_FUNCTION_ARNS\\": {
-      \\"value\\": \\"[]\\"
-    }
+{
+  "output": {
+    "WING_TEST_RUNNER_FUNCTION_ARNS": {
+      "value": "[]",
+    },
   },
-  \\"resource\\": {
-    \\"aws_s3_bucket\\": {
-      \\"my_bucket\\": {
-        \\"bucket_prefix\\": \\"my-bucket-c8045fcc-\\",
-        \\"force_destroy\\": false
-      }
-    },
-    \\"aws_s3_bucket_policy\\": {
-      \\"my_bucket_PublicPolicy_AF351571\\": {
-        \\"bucket\\": \\"\${aws_s3_bucket.my_bucket.bucket}\\",
-        \\"depends_on\\": [
-          \\"aws_s3_bucket_public_access_block.my_bucket_PublicAccessBlock_538547C0\\"
-        ],
-        \\"policy\\": \\"{\\\\\\"Version\\\\\\":\\\\\\"2012-10-17\\\\\\",\\\\\\"Statement\\\\\\":[{\\\\\\"Effect\\\\\\":\\\\\\"Allow\\\\\\",\\\\\\"Principal\\\\\\":\\\\\\"*\\\\\\",\\\\\\"Action\\\\\\":[\\\\\\"s3:GetObject\\\\\\"],\\\\\\"Resource\\\\\\":[\\\\\\"\${aws_s3_bucket.my_bucket.arn}/*\\\\\\"]}]}\\"
-      }
-    },
-    \\"aws_s3_bucket_public_access_block\\": {
-      \\"my_bucket_PublicAccessBlock_538547C0\\": {
-        \\"block_public_acls\\": false,
-        \\"block_public_policy\\": false,
-        \\"bucket\\": \\"\${aws_s3_bucket.my_bucket.bucket}\\",
-        \\"ignore_public_acls\\": false,
-        \\"restrict_public_buckets\\": false
-      }
-    },
-    \\"aws_s3_bucket_server_side_encryption_configuration\\": {
-      \\"my_bucket_Encryption_3B1569A4\\": {
-        \\"bucket\\": \\"\${aws_s3_bucket.my_bucket.bucket}\\",
-        \\"rule\\": [
-          {
-            \\"apply_server_side_encryption_by_default\\": {
-              \\"sse_algorithm\\": \\"AES256\\"
-            }
-          }
-        ]
-      }
-    },
-    \\"aws_s3_object\\": {
-      \\"my_bucket_S3Object-file1txt_7AFE54AE\\": {
-        \\"bucket\\": \\"\${aws_s3_bucket.my_bucket.bucket}\\",
-        \\"content\\": \\"hello world\\",
-        \\"key\\": \\"file1.txt\\"
+  "resource": {
+    "aws_s3_bucket": {
+      "my_bucket": {
+        "bucket_prefix": "my-bucket-c8045fcc-",
+        "force_destroy": false,
       },
-      \\"my_bucket_S3Object-file2txt_CB6BC703\\": {
-        \\"bucket\\": \\"\${aws_s3_bucket.my_bucket.bucket}\\",
-        \\"content\\": \\"boom bam\\",
-        \\"key\\": \\"file2.txt\\"
-      }
-    }
-  }
-}"
+    },
+    "aws_s3_bucket_policy": {
+      "my_bucket_PublicPolicy_AF351571": {
+        "bucket": "\${aws_s3_bucket.my_bucket.bucket}",
+        "depends_on": [
+          "aws_s3_bucket_public_access_block.my_bucket_PublicAccessBlock_538547C0",
+        ],
+        "policy": "{\\"Version\\":\\"2012-10-17\\",\\"Statement\\":[{\\"Effect\\":\\"Allow\\",\\"Principal\\":\\"*\\",\\"Action\\":[\\"s3:GetObject\\"],\\"Resource\\":[\\"\${aws_s3_bucket.my_bucket.arn}/*\\"]}]}",
+      },
+    },
+    "aws_s3_bucket_public_access_block": {
+      "my_bucket_PublicAccessBlock_538547C0": {
+        "block_public_acls": false,
+        "block_public_policy": false,
+        "bucket": "\${aws_s3_bucket.my_bucket.bucket}",
+        "ignore_public_acls": false,
+        "restrict_public_buckets": false,
+      },
+    },
+    "aws_s3_bucket_server_side_encryption_configuration": {
+      "my_bucket_Encryption_3B1569A4": {
+        "bucket": "\${aws_s3_bucket.my_bucket.bucket}",
+        "rule": [
+          {
+            "apply_server_side_encryption_by_default": {
+              "sse_algorithm": "AES256",
+            },
+          },
+        ],
+      },
+    },
+    "aws_s3_object": {
+      "my_bucket_S3Object-file1txt_7AFE54AE": {
+        "bucket": "\${aws_s3_bucket.my_bucket.bucket}",
+        "content": "hello world",
+        "key": "file1.txt",
+      },
+      "my_bucket_S3Object-file2txt_CB6BC703": {
+        "bucket": "\${aws_s3_bucket.my_bucket.bucket}",
+        "content": "boom bam",
+        "key": "file2.txt",
+      },
+    },
+  },
+}
 `;
 
 exports[`bucket with two preflight objects 2`] = `
@@ -3319,42 +3319,42 @@ exports[`bucket with two preflight objects 2`] = `
 `;
 
 exports[`create a bucket 1`] = `
-"{
-  \\"output\\": {
-    \\"WING_TEST_RUNNER_FUNCTION_ARNS\\": {
-      \\"value\\": \\"[]\\"
-    }
+{
+  "output": {
+    "WING_TEST_RUNNER_FUNCTION_ARNS": {
+      "value": "[]",
+    },
   },
-  \\"resource\\": {
-    \\"aws_s3_bucket\\": {
-      \\"my_bucket\\": {
-        \\"bucket_prefix\\": \\"my-bucket-c8045fcc-\\",
-        \\"force_destroy\\": false
-      }
+  "resource": {
+    "aws_s3_bucket": {
+      "my_bucket": {
+        "bucket_prefix": "my-bucket-c8045fcc-",
+        "force_destroy": false,
+      },
     },
-    \\"aws_s3_bucket_public_access_block\\": {
-      \\"my_bucket_PublicAccessBlock_538547C0\\": {
-        \\"block_public_acls\\": true,
-        \\"block_public_policy\\": true,
-        \\"bucket\\": \\"\${aws_s3_bucket.my_bucket.bucket}\\",
-        \\"ignore_public_acls\\": true,
-        \\"restrict_public_buckets\\": true
-      }
+    "aws_s3_bucket_public_access_block": {
+      "my_bucket_PublicAccessBlock_538547C0": {
+        "block_public_acls": true,
+        "block_public_policy": true,
+        "bucket": "\${aws_s3_bucket.my_bucket.bucket}",
+        "ignore_public_acls": true,
+        "restrict_public_buckets": true,
+      },
     },
-    \\"aws_s3_bucket_server_side_encryption_configuration\\": {
-      \\"my_bucket_Encryption_3B1569A4\\": {
-        \\"bucket\\": \\"\${aws_s3_bucket.my_bucket.bucket}\\",
-        \\"rule\\": [
+    "aws_s3_bucket_server_side_encryption_configuration": {
+      "my_bucket_Encryption_3B1569A4": {
+        "bucket": "\${aws_s3_bucket.my_bucket.bucket}",
+        "rule": [
           {
-            \\"apply_server_side_encryption_by_default\\": {
-              \\"sse_algorithm\\": \\"AES256\\"
-            }
-          }
-        ]
-      }
-    }
-  }
-}"
+            "apply_server_side_encryption_by_default": {
+              "sse_algorithm": "AES256",
+            },
+          },
+        ],
+      },
+    },
+  },
+}
 `;
 
 exports[`create a bucket 2`] = `

--- a/libs/wingsdk/test/target-tf-aws/__snapshots__/captures.test.ts.snap
+++ b/libs/wingsdk/test/target-tf-aws/__snapshots__/captures.test.ts.snap
@@ -34,101 +34,101 @@ function: new (require(\\"[REDACTED]/wingsdk/src/shared-aws/function.inflight\\"
 `;
 
 exports[`function with a function binding 3`] = `
-"{
-  \\"output\\": {
-    \\"WING_TEST_RUNNER_FUNCTION_ARNS\\": {
-      \\"value\\": \\"[]\\"
-    }
+{
+  "output": {
+    "WING_TEST_RUNNER_FUNCTION_ARNS": {
+      "value": "[]",
+    },
   },
-  \\"resource\\": {
-    \\"aws_iam_role\\": {
-      \\"Function1_IamRole_8B9BC80D\\": {
-        \\"assume_role_policy\\": \\"{\\\\\\"Version\\\\\\":\\\\\\"2012-10-17\\\\\\",\\\\\\"Statement\\\\\\":[{\\\\\\"Action\\\\\\":\\\\\\"sts:AssumeRole\\\\\\",\\\\\\"Principal\\\\\\":{\\\\\\"Service\\\\\\":\\\\\\"lambda.amazonaws.com\\\\\\"},\\\\\\"Effect\\\\\\":\\\\\\"Allow\\\\\\"}]}\\"
+  "resource": {
+    "aws_iam_role": {
+      "Function1_IamRole_8B9BC80D": {
+        "assume_role_policy": "{\\"Version\\":\\"2012-10-17\\",\\"Statement\\":[{\\"Action\\":\\"sts:AssumeRole\\",\\"Principal\\":{\\"Service\\":\\"lambda.amazonaws.com\\"},\\"Effect\\":\\"Allow\\"}]}",
       },
-      \\"Function2_IamRole_62EBED55\\": {
-        \\"assume_role_policy\\": \\"{\\\\\\"Version\\\\\\":\\\\\\"2012-10-17\\\\\\",\\\\\\"Statement\\\\\\":[{\\\\\\"Action\\\\\\":\\\\\\"sts:AssumeRole\\\\\\",\\\\\\"Principal\\\\\\":{\\\\\\"Service\\\\\\":\\\\\\"lambda.amazonaws.com\\\\\\"},\\\\\\"Effect\\\\\\":\\\\\\"Allow\\\\\\"}]}\\"
-      }
-    },
-    \\"aws_iam_role_policy\\": {
-      \\"Function1_IamRolePolicy_C0724D18\\": {
-        \\"policy\\": \\"{\\\\\\"Version\\\\\\":\\\\\\"2012-10-17\\\\\\",\\\\\\"Statement\\\\\\":[{\\\\\\"Effect\\\\\\":\\\\\\"Allow\\\\\\",\\\\\\"Action\\\\\\":\\\\\\"none:null\\\\\\",\\\\\\"Resource\\\\\\":\\\\\\"*\\\\\\"}]}\\",
-        \\"role\\": \\"\${aws_iam_role.Function1_IamRole_8B9BC80D.name}\\"
+      "Function2_IamRole_62EBED55": {
+        "assume_role_policy": "{\\"Version\\":\\"2012-10-17\\",\\"Statement\\":[{\\"Action\\":\\"sts:AssumeRole\\",\\"Principal\\":{\\"Service\\":\\"lambda.amazonaws.com\\"},\\"Effect\\":\\"Allow\\"}]}",
       },
-      \\"Function2_IamRolePolicy_E46C9D6B\\": {
-        \\"policy\\": \\"{\\\\\\"Version\\\\\\":\\\\\\"2012-10-17\\\\\\",\\\\\\"Statement\\\\\\":[{\\\\\\"Action\\\\\\":[\\\\\\"lambda:InvokeFunction\\\\\\"],\\\\\\"Resource\\\\\\":[\\\\\\"\${aws_lambda_function.Function1.arn}\\\\\\"],\\\\\\"Effect\\\\\\":\\\\\\"Allow\\\\\\"}]}\\",
-        \\"role\\": \\"\${aws_iam_role.Function2_IamRole_62EBED55.name}\\"
-      }
     },
-    \\"aws_iam_role_policy_attachment\\": {
-      \\"Function1_IamRolePolicyAttachment_0393C78B\\": {
-        \\"policy_arn\\": \\"arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole\\",
-        \\"role\\": \\"\${aws_iam_role.Function1_IamRole_8B9BC80D.name}\\"
+    "aws_iam_role_policy": {
+      "Function1_IamRolePolicy_C0724D18": {
+        "policy": "{\\"Version\\":\\"2012-10-17\\",\\"Statement\\":[{\\"Effect\\":\\"Allow\\",\\"Action\\":\\"none:null\\",\\"Resource\\":\\"*\\"}]}",
+        "role": "\${aws_iam_role.Function1_IamRole_8B9BC80D.name}",
       },
-      \\"Function2_IamRolePolicyAttachment_1D579508\\": {
-        \\"policy_arn\\": \\"arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole\\",
-        \\"role\\": \\"\${aws_iam_role.Function2_IamRole_62EBED55.name}\\"
-      }
+      "Function2_IamRolePolicy_E46C9D6B": {
+        "policy": "{\\"Version\\":\\"2012-10-17\\",\\"Statement\\":[{\\"Action\\":[\\"lambda:InvokeFunction\\"],\\"Resource\\":[\\"\${aws_lambda_function.Function1.arn}\\"],\\"Effect\\":\\"Allow\\"}]}",
+        "role": "\${aws_iam_role.Function2_IamRole_62EBED55.name}",
+      },
     },
-    \\"aws_lambda_function\\": {
-      \\"Function1\\": {
-        \\"environment\\": {
-          \\"variables\\": {
-            \\"WING_FUNCTION_NAME\\": \\"Function1-c87c16f1\\"
-          }
+    "aws_iam_role_policy_attachment": {
+      "Function1_IamRolePolicyAttachment_0393C78B": {
+        "policy_arn": "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+        "role": "\${aws_iam_role.Function1_IamRole_8B9BC80D.name}",
+      },
+      "Function2_IamRolePolicyAttachment_1D579508": {
+        "policy_arn": "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+        "role": "\${aws_iam_role.Function2_IamRole_62EBED55.name}",
+      },
+    },
+    "aws_lambda_function": {
+      "Function1": {
+        "environment": {
+          "variables": {
+            "WING_FUNCTION_NAME": "Function1-c87c16f1",
+          },
         },
-        \\"function_name\\": \\"Function1-c87c16f1\\",
-        \\"handler\\": \\"index.handler\\",
-        \\"publish\\": true,
-        \\"role\\": \\"\${aws_iam_role.Function1_IamRole_8B9BC80D.arn}\\",
-        \\"runtime\\": \\"nodejs18.x\\",
-        \\"s3_bucket\\": \\"\${aws_s3_bucket.Code.bucket}\\",
-        \\"s3_key\\": \\"\${aws_s3_object.Function1_S3Object_AFBA38E0.key}\\",
-        \\"timeout\\": 30,
-        \\"vpc_config\\": {
-          \\"security_group_ids\\": [],
-          \\"subnet_ids\\": []
-        }
-      },
-      \\"Function2\\": {
-        \\"environment\\": {
-          \\"variables\\": {
-            \\"FUNCTION_NAME_50735b21\\": \\"\${aws_lambda_function.Function1.arn}\\",
-            \\"WING_FUNCTION_NAME\\": \\"Function2-c827e998\\"
-          }
+        "function_name": "Function1-c87c16f1",
+        "handler": "index.handler",
+        "publish": true,
+        "role": "\${aws_iam_role.Function1_IamRole_8B9BC80D.arn}",
+        "runtime": "nodejs18.x",
+        "s3_bucket": "\${aws_s3_bucket.Code.bucket}",
+        "s3_key": "\${aws_s3_object.Function1_S3Object_AFBA38E0.key}",
+        "timeout": 30,
+        "vpc_config": {
+          "security_group_ids": [],
+          "subnet_ids": [],
         },
-        \\"function_name\\": \\"Function2-c827e998\\",
-        \\"handler\\": \\"index.handler\\",
-        \\"publish\\": true,
-        \\"role\\": \\"\${aws_iam_role.Function2_IamRole_62EBED55.arn}\\",
-        \\"runtime\\": \\"nodejs18.x\\",
-        \\"s3_bucket\\": \\"\${aws_s3_bucket.Code.bucket}\\",
-        \\"s3_key\\": \\"\${aws_s3_object.Function2_S3Object_6F3ED347.key}\\",
-        \\"timeout\\": 30,
-        \\"vpc_config\\": {
-          \\"security_group_ids\\": [],
-          \\"subnet_ids\\": []
-        }
-      }
-    },
-    \\"aws_s3_bucket\\": {
-      \\"Code\\": {
-        \\"bucket_prefix\\": \\"code-c84a50b1-\\"
-      }
-    },
-    \\"aws_s3_object\\": {
-      \\"Function1_S3Object_AFBA38E0\\": {
-        \\"bucket\\": \\"\${aws_s3_bucket.Code.bucket}\\",
-        \\"key\\": \\"<key>\\",
-        \\"source\\": \\"<source>\\"
       },
-      \\"Function2_S3Object_6F3ED347\\": {
-        \\"bucket\\": \\"\${aws_s3_bucket.Code.bucket}\\",
-        \\"key\\": \\"<key>\\",
-        \\"source\\": \\"<source>\\"
-      }
-    }
-  }
-}"
+      "Function2": {
+        "environment": {
+          "variables": {
+            "FUNCTION_NAME_50735b21": "\${aws_lambda_function.Function1.arn}",
+            "WING_FUNCTION_NAME": "Function2-c827e998",
+          },
+        },
+        "function_name": "Function2-c827e998",
+        "handler": "index.handler",
+        "publish": true,
+        "role": "\${aws_iam_role.Function2_IamRole_62EBED55.arn}",
+        "runtime": "nodejs18.x",
+        "s3_bucket": "\${aws_s3_bucket.Code.bucket}",
+        "s3_key": "\${aws_s3_object.Function2_S3Object_6F3ED347.key}",
+        "timeout": 30,
+        "vpc_config": {
+          "security_group_ids": [],
+          "subnet_ids": [],
+        },
+      },
+    },
+    "aws_s3_bucket": {
+      "Code": {
+        "bucket_prefix": "code-c84a50b1-",
+      },
+    },
+    "aws_s3_object": {
+      "Function1_S3Object_AFBA38E0": {
+        "bucket": "\${aws_s3_bucket.Code.bucket}",
+        "key": "<key>",
+        "source": "<source>",
+      },
+      "Function2_S3Object_6F3ED347": {
+        "bucket": "\${aws_s3_bucket.Code.bucket}",
+        "key": "<key>",
+        "source": "<source>",
+      },
+    },
+  },
+}
 `;
 
 exports[`function with a queue binding 1`] = `
@@ -162,113 +162,113 @@ return class Handler {
 `;
 
 exports[`function with a queue binding 3`] = `
-"{
-  \\"output\\": {
-    \\"WING_TEST_RUNNER_FUNCTION_ARNS\\": {
-      \\"value\\": \\"[]\\"
-    }
+{
+  "output": {
+    "WING_TEST_RUNNER_FUNCTION_ARNS": {
+      "value": "[]",
+    },
   },
-  \\"resource\\": {
-    \\"aws_iam_role\\": {
-      \\"Function_IamRole_678BE84C\\": {
-        \\"assume_role_policy\\": \\"{\\\\\\"Version\\\\\\":\\\\\\"2012-10-17\\\\\\",\\\\\\"Statement\\\\\\":[{\\\\\\"Action\\\\\\":\\\\\\"sts:AssumeRole\\\\\\",\\\\\\"Principal\\\\\\":{\\\\\\"Service\\\\\\":\\\\\\"lambda.amazonaws.com\\\\\\"},\\\\\\"Effect\\\\\\":\\\\\\"Allow\\\\\\"}]}\\"
+  "resource": {
+    "aws_iam_role": {
+      "Function_IamRole_678BE84C": {
+        "assume_role_policy": "{\\"Version\\":\\"2012-10-17\\",\\"Statement\\":[{\\"Action\\":\\"sts:AssumeRole\\",\\"Principal\\":{\\"Service\\":\\"lambda.amazonaws.com\\"},\\"Effect\\":\\"Allow\\"}]}",
       },
-      \\"Queue-SetConsumer-5cb7e554_IamRole_35925398\\": {
-        \\"assume_role_policy\\": \\"{\\\\\\"Version\\\\\\":\\\\\\"2012-10-17\\\\\\",\\\\\\"Statement\\\\\\":[{\\\\\\"Action\\\\\\":\\\\\\"sts:AssumeRole\\\\\\",\\\\\\"Principal\\\\\\":{\\\\\\"Service\\\\\\":\\\\\\"lambda.amazonaws.com\\\\\\"},\\\\\\"Effect\\\\\\":\\\\\\"Allow\\\\\\"}]}\\"
-      }
-    },
-    \\"aws_iam_role_policy\\": {
-      \\"Function_IamRolePolicy_E3B26607\\": {
-        \\"policy\\": \\"{\\\\\\"Version\\\\\\":\\\\\\"2012-10-17\\\\\\",\\\\\\"Statement\\\\\\":[{\\\\\\"Action\\\\\\":[\\\\\\"sqs:SendMessage\\\\\\"],\\\\\\"Resource\\\\\\":[\\\\\\"\${aws_sqs_queue.Queue.arn}\\\\\\"],\\\\\\"Effect\\\\\\":\\\\\\"Allow\\\\\\"}]}\\",
-        \\"role\\": \\"\${aws_iam_role.Function_IamRole_678BE84C.name}\\"
+      "Queue-SetConsumer-5cb7e554_IamRole_35925398": {
+        "assume_role_policy": "{\\"Version\\":\\"2012-10-17\\",\\"Statement\\":[{\\"Action\\":\\"sts:AssumeRole\\",\\"Principal\\":{\\"Service\\":\\"lambda.amazonaws.com\\"},\\"Effect\\":\\"Allow\\"}]}",
       },
-      \\"Queue-SetConsumer-5cb7e554_IamRolePolicy_8502FAE8\\": {
-        \\"policy\\": \\"{\\\\\\"Version\\\\\\":\\\\\\"2012-10-17\\\\\\",\\\\\\"Statement\\\\\\":[{\\\\\\"Action\\\\\\":[\\\\\\"sqs:ReceiveMessage\\\\\\",\\\\\\"sqs:ChangeMessageVisibility\\\\\\",\\\\\\"sqs:GetQueueUrl\\\\\\",\\\\\\"sqs:DeleteMessage\\\\\\",\\\\\\"sqs:GetQueueAttributes\\\\\\"],\\\\\\"Resource\\\\\\":[\\\\\\"\${aws_sqs_queue.Queue.arn}\\\\\\"],\\\\\\"Effect\\\\\\":\\\\\\"Allow\\\\\\"}]}\\",
-        \\"role\\": \\"\${aws_iam_role.Queue-SetConsumer-5cb7e554_IamRole_35925398.name}\\"
-      }
     },
-    \\"aws_iam_role_policy_attachment\\": {
-      \\"Function_IamRolePolicyAttachment_CACE1358\\": {
-        \\"policy_arn\\": \\"arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole\\",
-        \\"role\\": \\"\${aws_iam_role.Function_IamRole_678BE84C.name}\\"
+    "aws_iam_role_policy": {
+      "Function_IamRolePolicy_E3B26607": {
+        "policy": "{\\"Version\\":\\"2012-10-17\\",\\"Statement\\":[{\\"Action\\":[\\"sqs:SendMessage\\"],\\"Resource\\":[\\"\${aws_sqs_queue.Queue.arn}\\"],\\"Effect\\":\\"Allow\\"}]}",
+        "role": "\${aws_iam_role.Function_IamRole_678BE84C.name}",
       },
-      \\"Queue-SetConsumer-5cb7e554_IamRolePolicyAttachment_14162571\\": {
-        \\"policy_arn\\": \\"arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole\\",
-        \\"role\\": \\"\${aws_iam_role.Queue-SetConsumer-5cb7e554_IamRole_35925398.name}\\"
-      }
+      "Queue-SetConsumer-5cb7e554_IamRolePolicy_8502FAE8": {
+        "policy": "{\\"Version\\":\\"2012-10-17\\",\\"Statement\\":[{\\"Action\\":[\\"sqs:ReceiveMessage\\",\\"sqs:ChangeMessageVisibility\\",\\"sqs:GetQueueUrl\\",\\"sqs:DeleteMessage\\",\\"sqs:GetQueueAttributes\\"],\\"Resource\\":[\\"\${aws_sqs_queue.Queue.arn}\\"],\\"Effect\\":\\"Allow\\"}]}",
+        "role": "\${aws_iam_role.Queue-SetConsumer-5cb7e554_IamRole_35925398.name}",
+      },
     },
-    \\"aws_lambda_event_source_mapping\\": {
-      \\"Queue_EventSourceMapping_8332F7DC\\": {
-        \\"batch_size\\": 1,
-        \\"event_source_arn\\": \\"\${aws_sqs_queue.Queue.arn}\\",
-        \\"function_name\\": \\"\${aws_lambda_function.Queue-SetConsumer-5cb7e554.function_name}\\"
-      }
+    "aws_iam_role_policy_attachment": {
+      "Function_IamRolePolicyAttachment_CACE1358": {
+        "policy_arn": "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+        "role": "\${aws_iam_role.Function_IamRole_678BE84C.name}",
+      },
+      "Queue-SetConsumer-5cb7e554_IamRolePolicyAttachment_14162571": {
+        "policy_arn": "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+        "role": "\${aws_iam_role.Queue-SetConsumer-5cb7e554_IamRole_35925398.name}",
+      },
     },
-    \\"aws_lambda_function\\": {
-      \\"Function\\": {
-        \\"environment\\": {
-          \\"variables\\": {
-            \\"QUEUE_URL_1cfcc997\\": \\"\${aws_sqs_queue.Queue.url}\\",
-            \\"WING_FUNCTION_NAME\\": \\"Function-c852aba6\\"
-          }
+    "aws_lambda_event_source_mapping": {
+      "Queue_EventSourceMapping_8332F7DC": {
+        "batch_size": 1,
+        "event_source_arn": "\${aws_sqs_queue.Queue.arn}",
+        "function_name": "\${aws_lambda_function.Queue-SetConsumer-5cb7e554.function_name}",
+      },
+    },
+    "aws_lambda_function": {
+      "Function": {
+        "environment": {
+          "variables": {
+            "QUEUE_URL_1cfcc997": "\${aws_sqs_queue.Queue.url}",
+            "WING_FUNCTION_NAME": "Function-c852aba6",
+          },
         },
-        \\"function_name\\": \\"Function-c852aba6\\",
-        \\"handler\\": \\"index.handler\\",
-        \\"publish\\": true,
-        \\"role\\": \\"\${aws_iam_role.Function_IamRole_678BE84C.arn}\\",
-        \\"runtime\\": \\"nodejs18.x\\",
-        \\"s3_bucket\\": \\"\${aws_s3_bucket.Code.bucket}\\",
-        \\"s3_key\\": \\"\${aws_s3_object.Function_S3Object_C62A0C2D.key}\\",
-        \\"timeout\\": 30,
-        \\"vpc_config\\": {
-          \\"security_group_ids\\": [],
-          \\"subnet_ids\\": []
-        }
-      },
-      \\"Queue-SetConsumer-5cb7e554\\": {
-        \\"environment\\": {
-          \\"variables\\": {
-            \\"WING_FUNCTION_NAME\\": \\"Queue-SetConsumer-5cb7e554-c8f6c540\\"
-          }
+        "function_name": "Function-c852aba6",
+        "handler": "index.handler",
+        "publish": true,
+        "role": "\${aws_iam_role.Function_IamRole_678BE84C.arn}",
+        "runtime": "nodejs18.x",
+        "s3_bucket": "\${aws_s3_bucket.Code.bucket}",
+        "s3_key": "\${aws_s3_object.Function_S3Object_C62A0C2D.key}",
+        "timeout": 30,
+        "vpc_config": {
+          "security_group_ids": [],
+          "subnet_ids": [],
         },
-        \\"function_name\\": \\"Queue-SetConsumer-5cb7e554-c8f6c540\\",
-        \\"handler\\": \\"index.handler\\",
-        \\"publish\\": true,
-        \\"role\\": \\"\${aws_iam_role.Queue-SetConsumer-5cb7e554_IamRole_35925398.arn}\\",
-        \\"runtime\\": \\"nodejs18.x\\",
-        \\"s3_bucket\\": \\"\${aws_s3_bucket.Code.bucket}\\",
-        \\"s3_key\\": \\"\${aws_s3_object.Queue-SetConsumer-5cb7e554_S3Object_074547A5.key}\\",
-        \\"timeout\\": 30,
-        \\"vpc_config\\": {
-          \\"security_group_ids\\": [],
-          \\"subnet_ids\\": []
-        }
-      }
-    },
-    \\"aws_s3_bucket\\": {
-      \\"Code\\": {
-        \\"bucket_prefix\\": \\"code-c84a50b1-\\"
-      }
-    },
-    \\"aws_s3_object\\": {
-      \\"Function_S3Object_C62A0C2D\\": {
-        \\"bucket\\": \\"\${aws_s3_bucket.Code.bucket}\\",
-        \\"key\\": \\"<key>\\",
-        \\"source\\": \\"<source>\\"
       },
-      \\"Queue-SetConsumer-5cb7e554_S3Object_074547A5\\": {
-        \\"bucket\\": \\"\${aws_s3_bucket.Code.bucket}\\",
-        \\"key\\": \\"<key>\\",
-        \\"source\\": \\"<source>\\"
-      }
+      "Queue-SetConsumer-5cb7e554": {
+        "environment": {
+          "variables": {
+            "WING_FUNCTION_NAME": "Queue-SetConsumer-5cb7e554-c8f6c540",
+          },
+        },
+        "function_name": "Queue-SetConsumer-5cb7e554-c8f6c540",
+        "handler": "index.handler",
+        "publish": true,
+        "role": "\${aws_iam_role.Queue-SetConsumer-5cb7e554_IamRole_35925398.arn}",
+        "runtime": "nodejs18.x",
+        "s3_bucket": "\${aws_s3_bucket.Code.bucket}",
+        "s3_key": "\${aws_s3_object.Queue-SetConsumer-5cb7e554_S3Object_074547A5.key}",
+        "timeout": 30,
+        "vpc_config": {
+          "security_group_ids": [],
+          "subnet_ids": [],
+        },
+      },
     },
-    \\"aws_sqs_queue\\": {
-      \\"Queue\\": {
-        \\"name\\": \\"Queue-c822c726\\"
-      }
-    }
-  }
-}"
+    "aws_s3_bucket": {
+      "Code": {
+        "bucket_prefix": "code-c84a50b1-",
+      },
+    },
+    "aws_s3_object": {
+      "Function_S3Object_C62A0C2D": {
+        "bucket": "\${aws_s3_bucket.Code.bucket}",
+        "key": "<key>",
+        "source": "<source>",
+      },
+      "Queue-SetConsumer-5cb7e554_S3Object_074547A5": {
+        "bucket": "\${aws_s3_bucket.Code.bucket}",
+        "key": "<key>",
+        "source": "<source>",
+      },
+    },
+    "aws_sqs_queue": {
+      "Queue": {
+        "name": "Queue-c822c726",
+      },
+    },
+  },
+}
 `;
 
 exports[`function with bucket binding > put operation 1`] = `
@@ -287,186 +287,186 @@ bucket: new (require(\\"[REDACTED]/wingsdk/src/shared-aws/bucket.inflight\\")).B
 `;
 
 exports[`function with bucket binding > put operation 2`] = `
-"{
-  \\"output\\": {
-    \\"WING_TEST_RUNNER_FUNCTION_ARNS\\": {
-      \\"value\\": \\"[]\\"
-    }
+{
+  "output": {
+    "WING_TEST_RUNNER_FUNCTION_ARNS": {
+      "value": "[]",
+    },
   },
-  \\"resource\\": {
-    \\"aws_iam_role\\": {
-      \\"Function_IamRole_678BE84C\\": {
-        \\"assume_role_policy\\": \\"{\\\\\\"Version\\\\\\":\\\\\\"2012-10-17\\\\\\",\\\\\\"Statement\\\\\\":[{\\\\\\"Action\\\\\\":\\\\\\"sts:AssumeRole\\\\\\",\\\\\\"Principal\\\\\\":{\\\\\\"Service\\\\\\":\\\\\\"lambda.amazonaws.com\\\\\\"},\\\\\\"Effect\\\\\\":\\\\\\"Allow\\\\\\"}]}\\"
-      }
-    },
-    \\"aws_iam_role_policy\\": {
-      \\"Function_IamRolePolicy_E3B26607\\": {
-        \\"policy\\": \\"{\\\\\\"Version\\\\\\":\\\\\\"2012-10-17\\\\\\",\\\\\\"Statement\\\\\\":[{\\\\\\"Action\\\\\\":[\\\\\\"s3:PutObject*\\\\\\",\\\\\\"s3:Abort*\\\\\\"],\\\\\\"Resource\\\\\\":[\\\\\\"\${aws_s3_bucket.Bucket.arn}\\\\\\",\\\\\\"\${aws_s3_bucket.Bucket.arn}/*\\\\\\"],\\\\\\"Effect\\\\\\":\\\\\\"Allow\\\\\\"}]}\\",
-        \\"role\\": \\"\${aws_iam_role.Function_IamRole_678BE84C.name}\\"
-      }
-    },
-    \\"aws_iam_role_policy_attachment\\": {
-      \\"Function_IamRolePolicyAttachment_CACE1358\\": {
-        \\"policy_arn\\": \\"arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole\\",
-        \\"role\\": \\"\${aws_iam_role.Function_IamRole_678BE84C.name}\\"
-      }
-    },
-    \\"aws_lambda_function\\": {
-      \\"Function\\": {
-        \\"environment\\": {
-          \\"variables\\": {
-            \\"BUCKET_NAME_1357ca3a\\": \\"\${aws_s3_bucket.Bucket.bucket}\\",
-            \\"WING_FUNCTION_NAME\\": \\"Function-c852aba6\\"
-          }
-        },
-        \\"function_name\\": \\"Function-c852aba6\\",
-        \\"handler\\": \\"index.handler\\",
-        \\"publish\\": true,
-        \\"role\\": \\"\${aws_iam_role.Function_IamRole_678BE84C.arn}\\",
-        \\"runtime\\": \\"nodejs18.x\\",
-        \\"s3_bucket\\": \\"\${aws_s3_bucket.Code.bucket}\\",
-        \\"s3_key\\": \\"\${aws_s3_object.Function_S3Object_C62A0C2D.key}\\",
-        \\"timeout\\": 30,
-        \\"vpc_config\\": {
-          \\"security_group_ids\\": [],
-          \\"subnet_ids\\": []
-        }
-      }
-    },
-    \\"aws_s3_bucket\\": {
-      \\"Bucket\\": {
-        \\"bucket_prefix\\": \\"bucket-c88fdc5f-\\",
-        \\"force_destroy\\": false
+  "resource": {
+    "aws_iam_role": {
+      "Function_IamRole_678BE84C": {
+        "assume_role_policy": "{\\"Version\\":\\"2012-10-17\\",\\"Statement\\":[{\\"Action\\":\\"sts:AssumeRole\\",\\"Principal\\":{\\"Service\\":\\"lambda.amazonaws.com\\"},\\"Effect\\":\\"Allow\\"}]}",
       },
-      \\"Code\\": {
-        \\"bucket_prefix\\": \\"code-c84a50b1-\\"
-      }
     },
-    \\"aws_s3_bucket_public_access_block\\": {
-      \\"Bucket_PublicAccessBlock_A34F3B5C\\": {
-        \\"block_public_acls\\": true,
-        \\"block_public_policy\\": true,
-        \\"bucket\\": \\"\${aws_s3_bucket.Bucket.bucket}\\",
-        \\"ignore_public_acls\\": true,
-        \\"restrict_public_buckets\\": true
-      }
+    "aws_iam_role_policy": {
+      "Function_IamRolePolicy_E3B26607": {
+        "policy": "{\\"Version\\":\\"2012-10-17\\",\\"Statement\\":[{\\"Action\\":[\\"s3:PutObject*\\",\\"s3:Abort*\\"],\\"Resource\\":[\\"\${aws_s3_bucket.Bucket.arn}\\",\\"\${aws_s3_bucket.Bucket.arn}/*\\"],\\"Effect\\":\\"Allow\\"}]}",
+        "role": "\${aws_iam_role.Function_IamRole_678BE84C.name}",
+      },
     },
-    \\"aws_s3_bucket_server_side_encryption_configuration\\": {
-      \\"Bucket_Encryption_016FDA0C\\": {
-        \\"bucket\\": \\"\${aws_s3_bucket.Bucket.bucket}\\",
-        \\"rule\\": [
+    "aws_iam_role_policy_attachment": {
+      "Function_IamRolePolicyAttachment_CACE1358": {
+        "policy_arn": "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+        "role": "\${aws_iam_role.Function_IamRole_678BE84C.name}",
+      },
+    },
+    "aws_lambda_function": {
+      "Function": {
+        "environment": {
+          "variables": {
+            "BUCKET_NAME_1357ca3a": "\${aws_s3_bucket.Bucket.bucket}",
+            "WING_FUNCTION_NAME": "Function-c852aba6",
+          },
+        },
+        "function_name": "Function-c852aba6",
+        "handler": "index.handler",
+        "publish": true,
+        "role": "\${aws_iam_role.Function_IamRole_678BE84C.arn}",
+        "runtime": "nodejs18.x",
+        "s3_bucket": "\${aws_s3_bucket.Code.bucket}",
+        "s3_key": "\${aws_s3_object.Function_S3Object_C62A0C2D.key}",
+        "timeout": 30,
+        "vpc_config": {
+          "security_group_ids": [],
+          "subnet_ids": [],
+        },
+      },
+    },
+    "aws_s3_bucket": {
+      "Bucket": {
+        "bucket_prefix": "bucket-c88fdc5f-",
+        "force_destroy": false,
+      },
+      "Code": {
+        "bucket_prefix": "code-c84a50b1-",
+      },
+    },
+    "aws_s3_bucket_public_access_block": {
+      "Bucket_PublicAccessBlock_A34F3B5C": {
+        "block_public_acls": true,
+        "block_public_policy": true,
+        "bucket": "\${aws_s3_bucket.Bucket.bucket}",
+        "ignore_public_acls": true,
+        "restrict_public_buckets": true,
+      },
+    },
+    "aws_s3_bucket_server_side_encryption_configuration": {
+      "Bucket_Encryption_016FDA0C": {
+        "bucket": "\${aws_s3_bucket.Bucket.bucket}",
+        "rule": [
           {
-            \\"apply_server_side_encryption_by_default\\": {
-              \\"sse_algorithm\\": \\"AES256\\"
-            }
-          }
-        ]
-      }
+            "apply_server_side_encryption_by_default": {
+              "sse_algorithm": "AES256",
+            },
+          },
+        ],
+      },
     },
-    \\"aws_s3_object\\": {
-      \\"Function_S3Object_C62A0C2D\\": {
-        \\"bucket\\": \\"\${aws_s3_bucket.Code.bucket}\\",
-        \\"key\\": \\"<key>\\",
-        \\"source\\": \\"<source>\\"
-      }
-    }
-  }
-}"
+    "aws_s3_object": {
+      "Function_S3Object_C62A0C2D": {
+        "bucket": "\${aws_s3_bucket.Code.bucket}",
+        "key": "<key>",
+        "source": "<source>",
+      },
+    },
+  },
+}
 `;
 
 exports[`two functions reusing the same IFunctionHandler 1`] = `
-"{
-  \\"output\\": {
-    \\"WING_TEST_RUNNER_FUNCTION_ARNS\\": {
-      \\"value\\": \\"[]\\"
-    }
+{
+  "output": {
+    "WING_TEST_RUNNER_FUNCTION_ARNS": {
+      "value": "[]",
+    },
   },
-  \\"resource\\": {
-    \\"aws_iam_role\\": {
-      \\"Function1_IamRole_8B9BC80D\\": {
-        \\"assume_role_policy\\": \\"{\\\\\\"Version\\\\\\":\\\\\\"2012-10-17\\\\\\",\\\\\\"Statement\\\\\\":[{\\\\\\"Action\\\\\\":\\\\\\"sts:AssumeRole\\\\\\",\\\\\\"Principal\\\\\\":{\\\\\\"Service\\\\\\":\\\\\\"lambda.amazonaws.com\\\\\\"},\\\\\\"Effect\\\\\\":\\\\\\"Allow\\\\\\"}]}\\"
+  "resource": {
+    "aws_iam_role": {
+      "Function1_IamRole_8B9BC80D": {
+        "assume_role_policy": "{\\"Version\\":\\"2012-10-17\\",\\"Statement\\":[{\\"Action\\":\\"sts:AssumeRole\\",\\"Principal\\":{\\"Service\\":\\"lambda.amazonaws.com\\"},\\"Effect\\":\\"Allow\\"}]}",
       },
-      \\"Function2_IamRole_62EBED55\\": {
-        \\"assume_role_policy\\": \\"{\\\\\\"Version\\\\\\":\\\\\\"2012-10-17\\\\\\",\\\\\\"Statement\\\\\\":[{\\\\\\"Action\\\\\\":\\\\\\"sts:AssumeRole\\\\\\",\\\\\\"Principal\\\\\\":{\\\\\\"Service\\\\\\":\\\\\\"lambda.amazonaws.com\\\\\\"},\\\\\\"Effect\\\\\\":\\\\\\"Allow\\\\\\"}]}\\"
-      }
-    },
-    \\"aws_iam_role_policy\\": {
-      \\"Function1_IamRolePolicy_C0724D18\\": {
-        \\"policy\\": \\"{\\\\\\"Version\\\\\\":\\\\\\"2012-10-17\\\\\\",\\\\\\"Statement\\\\\\":[{\\\\\\"Effect\\\\\\":\\\\\\"Allow\\\\\\",\\\\\\"Action\\\\\\":\\\\\\"none:null\\\\\\",\\\\\\"Resource\\\\\\":\\\\\\"*\\\\\\"}]}\\",
-        \\"role\\": \\"\${aws_iam_role.Function1_IamRole_8B9BC80D.name}\\"
+      "Function2_IamRole_62EBED55": {
+        "assume_role_policy": "{\\"Version\\":\\"2012-10-17\\",\\"Statement\\":[{\\"Action\\":\\"sts:AssumeRole\\",\\"Principal\\":{\\"Service\\":\\"lambda.amazonaws.com\\"},\\"Effect\\":\\"Allow\\"}]}",
       },
-      \\"Function2_IamRolePolicy_E46C9D6B\\": {
-        \\"policy\\": \\"{\\\\\\"Version\\\\\\":\\\\\\"2012-10-17\\\\\\",\\\\\\"Statement\\\\\\":[{\\\\\\"Effect\\\\\\":\\\\\\"Allow\\\\\\",\\\\\\"Action\\\\\\":\\\\\\"none:null\\\\\\",\\\\\\"Resource\\\\\\":\\\\\\"*\\\\\\"}]}\\",
-        \\"role\\": \\"\${aws_iam_role.Function2_IamRole_62EBED55.name}\\"
-      }
     },
-    \\"aws_iam_role_policy_attachment\\": {
-      \\"Function1_IamRolePolicyAttachment_0393C78B\\": {
-        \\"policy_arn\\": \\"arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole\\",
-        \\"role\\": \\"\${aws_iam_role.Function1_IamRole_8B9BC80D.name}\\"
+    "aws_iam_role_policy": {
+      "Function1_IamRolePolicy_C0724D18": {
+        "policy": "{\\"Version\\":\\"2012-10-17\\",\\"Statement\\":[{\\"Effect\\":\\"Allow\\",\\"Action\\":\\"none:null\\",\\"Resource\\":\\"*\\"}]}",
+        "role": "\${aws_iam_role.Function1_IamRole_8B9BC80D.name}",
       },
-      \\"Function2_IamRolePolicyAttachment_1D579508\\": {
-        \\"policy_arn\\": \\"arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole\\",
-        \\"role\\": \\"\${aws_iam_role.Function2_IamRole_62EBED55.name}\\"
-      }
+      "Function2_IamRolePolicy_E46C9D6B": {
+        "policy": "{\\"Version\\":\\"2012-10-17\\",\\"Statement\\":[{\\"Effect\\":\\"Allow\\",\\"Action\\":\\"none:null\\",\\"Resource\\":\\"*\\"}]}",
+        "role": "\${aws_iam_role.Function2_IamRole_62EBED55.name}",
+      },
     },
-    \\"aws_lambda_function\\": {
-      \\"Function1\\": {
-        \\"environment\\": {
-          \\"variables\\": {
-            \\"WING_FUNCTION_NAME\\": \\"Function1-c87c16f1\\"
-          }
+    "aws_iam_role_policy_attachment": {
+      "Function1_IamRolePolicyAttachment_0393C78B": {
+        "policy_arn": "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+        "role": "\${aws_iam_role.Function1_IamRole_8B9BC80D.name}",
+      },
+      "Function2_IamRolePolicyAttachment_1D579508": {
+        "policy_arn": "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+        "role": "\${aws_iam_role.Function2_IamRole_62EBED55.name}",
+      },
+    },
+    "aws_lambda_function": {
+      "Function1": {
+        "environment": {
+          "variables": {
+            "WING_FUNCTION_NAME": "Function1-c87c16f1",
+          },
         },
-        \\"function_name\\": \\"Function1-c87c16f1\\",
-        \\"handler\\": \\"index.handler\\",
-        \\"publish\\": true,
-        \\"role\\": \\"\${aws_iam_role.Function1_IamRole_8B9BC80D.arn}\\",
-        \\"runtime\\": \\"nodejs18.x\\",
-        \\"s3_bucket\\": \\"\${aws_s3_bucket.Code.bucket}\\",
-        \\"s3_key\\": \\"\${aws_s3_object.Function1_S3Object_AFBA38E0.key}\\",
-        \\"timeout\\": 30,
-        \\"vpc_config\\": {
-          \\"security_group_ids\\": [],
-          \\"subnet_ids\\": []
-        }
-      },
-      \\"Function2\\": {
-        \\"environment\\": {
-          \\"variables\\": {
-            \\"WING_FUNCTION_NAME\\": \\"Function2-c827e998\\"
-          }
+        "function_name": "Function1-c87c16f1",
+        "handler": "index.handler",
+        "publish": true,
+        "role": "\${aws_iam_role.Function1_IamRole_8B9BC80D.arn}",
+        "runtime": "nodejs18.x",
+        "s3_bucket": "\${aws_s3_bucket.Code.bucket}",
+        "s3_key": "\${aws_s3_object.Function1_S3Object_AFBA38E0.key}",
+        "timeout": 30,
+        "vpc_config": {
+          "security_group_ids": [],
+          "subnet_ids": [],
         },
-        \\"function_name\\": \\"Function2-c827e998\\",
-        \\"handler\\": \\"index.handler\\",
-        \\"publish\\": true,
-        \\"role\\": \\"\${aws_iam_role.Function2_IamRole_62EBED55.arn}\\",
-        \\"runtime\\": \\"nodejs18.x\\",
-        \\"s3_bucket\\": \\"\${aws_s3_bucket.Code.bucket}\\",
-        \\"s3_key\\": \\"\${aws_s3_object.Function2_S3Object_6F3ED347.key}\\",
-        \\"timeout\\": 30,
-        \\"vpc_config\\": {
-          \\"security_group_ids\\": [],
-          \\"subnet_ids\\": []
-        }
-      }
-    },
-    \\"aws_s3_bucket\\": {
-      \\"Code\\": {
-        \\"bucket_prefix\\": \\"code-c84a50b1-\\"
-      }
-    },
-    \\"aws_s3_object\\": {
-      \\"Function1_S3Object_AFBA38E0\\": {
-        \\"bucket\\": \\"\${aws_s3_bucket.Code.bucket}\\",
-        \\"key\\": \\"<key>\\",
-        \\"source\\": \\"<source>\\"
       },
-      \\"Function2_S3Object_6F3ED347\\": {
-        \\"bucket\\": \\"\${aws_s3_bucket.Code.bucket}\\",
-        \\"key\\": \\"<key>\\",
-        \\"source\\": \\"<source>\\"
-      }
-    }
-  }
-}"
+      "Function2": {
+        "environment": {
+          "variables": {
+            "WING_FUNCTION_NAME": "Function2-c827e998",
+          },
+        },
+        "function_name": "Function2-c827e998",
+        "handler": "index.handler",
+        "publish": true,
+        "role": "\${aws_iam_role.Function2_IamRole_62EBED55.arn}",
+        "runtime": "nodejs18.x",
+        "s3_bucket": "\${aws_s3_bucket.Code.bucket}",
+        "s3_key": "\${aws_s3_object.Function2_S3Object_6F3ED347.key}",
+        "timeout": 30,
+        "vpc_config": {
+          "security_group_ids": [],
+          "subnet_ids": [],
+        },
+      },
+    },
+    "aws_s3_bucket": {
+      "Code": {
+        "bucket_prefix": "code-c84a50b1-",
+      },
+    },
+    "aws_s3_object": {
+      "Function1_S3Object_AFBA38E0": {
+        "bucket": "\${aws_s3_bucket.Code.bucket}",
+        "key": "<key>",
+        "source": "<source>",
+      },
+      "Function2_S3Object_6F3ED347": {
+        "bucket": "\${aws_s3_bucket.Code.bucket}",
+        "key": "<key>",
+        "source": "<source>",
+      },
+    },
+  },
+}
 `;

--- a/libs/wingsdk/test/target-tf-aws/__snapshots__/counter.test.ts.snap
+++ b/libs/wingsdk/test/target-tf-aws/__snapshots__/counter.test.ts.snap
@@ -1,28 +1,28 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`counter name valid 1`] = `
-"{
-  \\"output\\": {
-    \\"WING_TEST_RUNNER_FUNCTION_ARNS\\": {
-      \\"value\\": \\"[]\\"
-    }
+{
+  "output": {
+    "WING_TEST_RUNNER_FUNCTION_ARNS": {
+      "value": "[]",
+    },
   },
-  \\"resource\\": {
-    \\"aws_dynamodb_table\\": {
-      \\"TheAmazing-Counter_01\\": {
-        \\"attribute\\": [
+  "resource": {
+    "aws_dynamodb_table": {
+      "TheAmazing-Counter_01": {
+        "attribute": [
           {
-            \\"name\\": \\"id\\",
-            \\"type\\": \\"S\\"
-          }
+            "name": "id",
+            "type": "S",
+          },
         ],
-        \\"billing_mode\\": \\"PAY_PER_REQUEST\\",
-        \\"hash_key\\": \\"id\\",
-        \\"name\\": \\"wing-counter-The.Amazing-Counter_01-c83e5bd8\\"
-      }
-    }
-  }
-}"
+        "billing_mode": "PAY_PER_REQUEST",
+        "hash_key": "id",
+        "name": "wing-counter-The.Amazing-Counter_01-c83e5bd8",
+      },
+    },
+  },
+}
 `;
 
 exports[`counter name valid 2`] = `
@@ -129,28 +129,28 @@ exports[`counter name valid 2`] = `
 `;
 
 exports[`counter with initial value 1`] = `
-"{
-  \\"output\\": {
-    \\"WING_TEST_RUNNER_FUNCTION_ARNS\\": {
-      \\"value\\": \\"[]\\"
-    }
+{
+  "output": {
+    "WING_TEST_RUNNER_FUNCTION_ARNS": {
+      "value": "[]",
+    },
   },
-  \\"resource\\": {
-    \\"aws_dynamodb_table\\": {
-      \\"Counter\\": {
-        \\"attribute\\": [
+  "resource": {
+    "aws_dynamodb_table": {
+      "Counter": {
+        "attribute": [
           {
-            \\"name\\": \\"id\\",
-            \\"type\\": \\"S\\"
-          }
+            "name": "id",
+            "type": "S",
+          },
         ],
-        \\"billing_mode\\": \\"PAY_PER_REQUEST\\",
-        \\"hash_key\\": \\"id\\",
-        \\"name\\": \\"wing-counter-Counter-c824ef62\\"
-      }
-    }
-  }
-}"
+        "billing_mode": "PAY_PER_REQUEST",
+        "hash_key": "id",
+        "name": "wing-counter-Counter-c824ef62",
+      },
+    },
+  },
+}
 `;
 
 exports[`counter with initial value 2`] = `
@@ -257,79 +257,79 @@ exports[`counter with initial value 2`] = `
 `;
 
 exports[`dec() policy statement 1`] = `
-"{
-  \\"output\\": {
-    \\"WING_TEST_RUNNER_FUNCTION_ARNS\\": {
-      \\"value\\": \\"[]\\"
-    }
+{
+  "output": {
+    "WING_TEST_RUNNER_FUNCTION_ARNS": {
+      "value": "[]",
+    },
   },
-  \\"resource\\": {
-    \\"aws_dynamodb_table\\": {
-      \\"Counter\\": {
-        \\"attribute\\": [
+  "resource": {
+    "aws_dynamodb_table": {
+      "Counter": {
+        "attribute": [
           {
-            \\"name\\": \\"id\\",
-            \\"type\\": \\"S\\"
-          }
+            "name": "id",
+            "type": "S",
+          },
         ],
-        \\"billing_mode\\": \\"PAY_PER_REQUEST\\",
-        \\"hash_key\\": \\"id\\",
-        \\"name\\": \\"wing-counter-Counter-c824ef62\\"
-      }
+        "billing_mode": "PAY_PER_REQUEST",
+        "hash_key": "id",
+        "name": "wing-counter-Counter-c824ef62",
+      },
     },
-    \\"aws_iam_role\\": {
-      \\"Function_IamRole_678BE84C\\": {
-        \\"assume_role_policy\\": \\"{\\\\\\"Version\\\\\\":\\\\\\"2012-10-17\\\\\\",\\\\\\"Statement\\\\\\":[{\\\\\\"Action\\\\\\":\\\\\\"sts:AssumeRole\\\\\\",\\\\\\"Principal\\\\\\":{\\\\\\"Service\\\\\\":\\\\\\"lambda.amazonaws.com\\\\\\"},\\\\\\"Effect\\\\\\":\\\\\\"Allow\\\\\\"}]}\\"
-      }
+    "aws_iam_role": {
+      "Function_IamRole_678BE84C": {
+        "assume_role_policy": "{\\"Version\\":\\"2012-10-17\\",\\"Statement\\":[{\\"Action\\":\\"sts:AssumeRole\\",\\"Principal\\":{\\"Service\\":\\"lambda.amazonaws.com\\"},\\"Effect\\":\\"Allow\\"}]}",
+      },
     },
-    \\"aws_iam_role_policy\\": {
-      \\"Function_IamRolePolicy_E3B26607\\": {
-        \\"policy\\": \\"{\\\\\\"Version\\\\\\":\\\\\\"2012-10-17\\\\\\",\\\\\\"Statement\\\\\\":[{\\\\\\"Action\\\\\\":[\\\\\\"dynamodb:UpdateItem\\\\\\"],\\\\\\"Resource\\\\\\":[\\\\\\"\${aws_dynamodb_table.Counter.arn}\\\\\\"],\\\\\\"Effect\\\\\\":\\\\\\"Allow\\\\\\"}]}\\",
-        \\"role\\": \\"\${aws_iam_role.Function_IamRole_678BE84C.name}\\"
-      }
+    "aws_iam_role_policy": {
+      "Function_IamRolePolicy_E3B26607": {
+        "policy": "{\\"Version\\":\\"2012-10-17\\",\\"Statement\\":[{\\"Action\\":[\\"dynamodb:UpdateItem\\"],\\"Resource\\":[\\"\${aws_dynamodb_table.Counter.arn}\\"],\\"Effect\\":\\"Allow\\"}]}",
+        "role": "\${aws_iam_role.Function_IamRole_678BE84C.name}",
+      },
     },
-    \\"aws_iam_role_policy_attachment\\": {
-      \\"Function_IamRolePolicyAttachment_CACE1358\\": {
-        \\"policy_arn\\": \\"arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole\\",
-        \\"role\\": \\"\${aws_iam_role.Function_IamRole_678BE84C.name}\\"
-      }
+    "aws_iam_role_policy_attachment": {
+      "Function_IamRolePolicyAttachment_CACE1358": {
+        "policy_arn": "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+        "role": "\${aws_iam_role.Function_IamRole_678BE84C.name}",
+      },
     },
-    \\"aws_lambda_function\\": {
-      \\"Function\\": {
-        \\"environment\\": {
-          \\"variables\\": {
-            \\"DYNAMODB_TABLE_NAME_6cb5a3a4\\": \\"\${aws_dynamodb_table.Counter.name}\\",
-            \\"WING_FUNCTION_NAME\\": \\"Function-c852aba6\\"
-          }
+    "aws_lambda_function": {
+      "Function": {
+        "environment": {
+          "variables": {
+            "DYNAMODB_TABLE_NAME_6cb5a3a4": "\${aws_dynamodb_table.Counter.name}",
+            "WING_FUNCTION_NAME": "Function-c852aba6",
+          },
         },
-        \\"function_name\\": \\"Function-c852aba6\\",
-        \\"handler\\": \\"index.handler\\",
-        \\"publish\\": true,
-        \\"role\\": \\"\${aws_iam_role.Function_IamRole_678BE84C.arn}\\",
-        \\"runtime\\": \\"nodejs18.x\\",
-        \\"s3_bucket\\": \\"\${aws_s3_bucket.Code.bucket}\\",
-        \\"s3_key\\": \\"\${aws_s3_object.Function_S3Object_C62A0C2D.key}\\",
-        \\"timeout\\": 30,
-        \\"vpc_config\\": {
-          \\"security_group_ids\\": [],
-          \\"subnet_ids\\": []
-        }
-      }
+        "function_name": "Function-c852aba6",
+        "handler": "index.handler",
+        "publish": true,
+        "role": "\${aws_iam_role.Function_IamRole_678BE84C.arn}",
+        "runtime": "nodejs18.x",
+        "s3_bucket": "\${aws_s3_bucket.Code.bucket}",
+        "s3_key": "\${aws_s3_object.Function_S3Object_C62A0C2D.key}",
+        "timeout": 30,
+        "vpc_config": {
+          "security_group_ids": [],
+          "subnet_ids": [],
+        },
+      },
     },
-    \\"aws_s3_bucket\\": {
-      \\"Code\\": {
-        \\"bucket_prefix\\": \\"code-c84a50b1-\\"
-      }
+    "aws_s3_bucket": {
+      "Code": {
+        "bucket_prefix": "code-c84a50b1-",
+      },
     },
-    \\"aws_s3_object\\": {
-      \\"Function_S3Object_C62A0C2D\\": {
-        \\"bucket\\": \\"\${aws_s3_bucket.Code.bucket}\\",
-        \\"key\\": \\"<key>\\",
-        \\"source\\": \\"<source>\\"
-      }
-    }
-  }
-}"
+    "aws_s3_object": {
+      "Function_S3Object_C62A0C2D": {
+        "bucket": "\${aws_s3_bucket.Code.bucket}",
+        "key": "<key>",
+        "source": "<source>",
+      },
+    },
+  },
+}
 `;
 
 exports[`dec() policy statement 2`] = `
@@ -551,28 +551,28 @@ exports[`dec() policy statement 2`] = `
 `;
 
 exports[`default counter behavior 1`] = `
-"{
-  \\"output\\": {
-    \\"WING_TEST_RUNNER_FUNCTION_ARNS\\": {
-      \\"value\\": \\"[]\\"
-    }
+{
+  "output": {
+    "WING_TEST_RUNNER_FUNCTION_ARNS": {
+      "value": "[]",
+    },
   },
-  \\"resource\\": {
-    \\"aws_dynamodb_table\\": {
-      \\"Counter\\": {
-        \\"attribute\\": [
+  "resource": {
+    "aws_dynamodb_table": {
+      "Counter": {
+        "attribute": [
           {
-            \\"name\\": \\"id\\",
-            \\"type\\": \\"S\\"
-          }
+            "name": "id",
+            "type": "S",
+          },
         ],
-        \\"billing_mode\\": \\"PAY_PER_REQUEST\\",
-        \\"hash_key\\": \\"id\\",
-        \\"name\\": \\"wing-counter-Counter-c824ef62\\"
-      }
-    }
-  }
-}"
+        "billing_mode": "PAY_PER_REQUEST",
+        "hash_key": "id",
+        "name": "wing-counter-Counter-c824ef62",
+      },
+    },
+  },
+}
 `;
 
 exports[`function with a counter binding 1`] = `
@@ -594,79 +594,79 @@ my_counter: new (require(\\"[REDACTED]/wingsdk/src/shared-aws/counter.inflight\\
 `;
 
 exports[`function with a counter binding 2`] = `
-"{
-  \\"output\\": {
-    \\"WING_TEST_RUNNER_FUNCTION_ARNS\\": {
-      \\"value\\": \\"[]\\"
-    }
+{
+  "output": {
+    "WING_TEST_RUNNER_FUNCTION_ARNS": {
+      "value": "[]",
+    },
   },
-  \\"resource\\": {
-    \\"aws_dynamodb_table\\": {
-      \\"Counter\\": {
-        \\"attribute\\": [
+  "resource": {
+    "aws_dynamodb_table": {
+      "Counter": {
+        "attribute": [
           {
-            \\"name\\": \\"id\\",
-            \\"type\\": \\"S\\"
-          }
+            "name": "id",
+            "type": "S",
+          },
         ],
-        \\"billing_mode\\": \\"PAY_PER_REQUEST\\",
-        \\"hash_key\\": \\"id\\",
-        \\"name\\": \\"wing-counter-Counter-c824ef62\\"
-      }
+        "billing_mode": "PAY_PER_REQUEST",
+        "hash_key": "id",
+        "name": "wing-counter-Counter-c824ef62",
+      },
     },
-    \\"aws_iam_role\\": {
-      \\"Function_IamRole_678BE84C\\": {
-        \\"assume_role_policy\\": \\"{\\\\\\"Version\\\\\\":\\\\\\"2012-10-17\\\\\\",\\\\\\"Statement\\\\\\":[{\\\\\\"Action\\\\\\":\\\\\\"sts:AssumeRole\\\\\\",\\\\\\"Principal\\\\\\":{\\\\\\"Service\\\\\\":\\\\\\"lambda.amazonaws.com\\\\\\"},\\\\\\"Effect\\\\\\":\\\\\\"Allow\\\\\\"}]}\\"
-      }
+    "aws_iam_role": {
+      "Function_IamRole_678BE84C": {
+        "assume_role_policy": "{\\"Version\\":\\"2012-10-17\\",\\"Statement\\":[{\\"Action\\":\\"sts:AssumeRole\\",\\"Principal\\":{\\"Service\\":\\"lambda.amazonaws.com\\"},\\"Effect\\":\\"Allow\\"}]}",
+      },
     },
-    \\"aws_iam_role_policy\\": {
-      \\"Function_IamRolePolicy_E3B26607\\": {
-        \\"policy\\": \\"{\\\\\\"Version\\\\\\":\\\\\\"2012-10-17\\\\\\",\\\\\\"Statement\\\\\\":[{\\\\\\"Action\\\\\\":[\\\\\\"dynamodb:UpdateItem\\\\\\"],\\\\\\"Resource\\\\\\":[\\\\\\"\${aws_dynamodb_table.Counter.arn}\\\\\\"],\\\\\\"Effect\\\\\\":\\\\\\"Allow\\\\\\"}]}\\",
-        \\"role\\": \\"\${aws_iam_role.Function_IamRole_678BE84C.name}\\"
-      }
+    "aws_iam_role_policy": {
+      "Function_IamRolePolicy_E3B26607": {
+        "policy": "{\\"Version\\":\\"2012-10-17\\",\\"Statement\\":[{\\"Action\\":[\\"dynamodb:UpdateItem\\"],\\"Resource\\":[\\"\${aws_dynamodb_table.Counter.arn}\\"],\\"Effect\\":\\"Allow\\"}]}",
+        "role": "\${aws_iam_role.Function_IamRole_678BE84C.name}",
+      },
     },
-    \\"aws_iam_role_policy_attachment\\": {
-      \\"Function_IamRolePolicyAttachment_CACE1358\\": {
-        \\"policy_arn\\": \\"arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole\\",
-        \\"role\\": \\"\${aws_iam_role.Function_IamRole_678BE84C.name}\\"
-      }
+    "aws_iam_role_policy_attachment": {
+      "Function_IamRolePolicyAttachment_CACE1358": {
+        "policy_arn": "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+        "role": "\${aws_iam_role.Function_IamRole_678BE84C.name}",
+      },
     },
-    \\"aws_lambda_function\\": {
-      \\"Function\\": {
-        \\"environment\\": {
-          \\"variables\\": {
-            \\"DYNAMODB_TABLE_NAME_6cb5a3a4\\": \\"\${aws_dynamodb_table.Counter.name}\\",
-            \\"WING_FUNCTION_NAME\\": \\"Function-c852aba6\\"
-          }
+    "aws_lambda_function": {
+      "Function": {
+        "environment": {
+          "variables": {
+            "DYNAMODB_TABLE_NAME_6cb5a3a4": "\${aws_dynamodb_table.Counter.name}",
+            "WING_FUNCTION_NAME": "Function-c852aba6",
+          },
         },
-        \\"function_name\\": \\"Function-c852aba6\\",
-        \\"handler\\": \\"index.handler\\",
-        \\"publish\\": true,
-        \\"role\\": \\"\${aws_iam_role.Function_IamRole_678BE84C.arn}\\",
-        \\"runtime\\": \\"nodejs18.x\\",
-        \\"s3_bucket\\": \\"\${aws_s3_bucket.Code.bucket}\\",
-        \\"s3_key\\": \\"\${aws_s3_object.Function_S3Object_C62A0C2D.key}\\",
-        \\"timeout\\": 30,
-        \\"vpc_config\\": {
-          \\"security_group_ids\\": [],
-          \\"subnet_ids\\": []
-        }
-      }
+        "function_name": "Function-c852aba6",
+        "handler": "index.handler",
+        "publish": true,
+        "role": "\${aws_iam_role.Function_IamRole_678BE84C.arn}",
+        "runtime": "nodejs18.x",
+        "s3_bucket": "\${aws_s3_bucket.Code.bucket}",
+        "s3_key": "\${aws_s3_object.Function_S3Object_C62A0C2D.key}",
+        "timeout": 30,
+        "vpc_config": {
+          "security_group_ids": [],
+          "subnet_ids": [],
+        },
+      },
     },
-    \\"aws_s3_bucket\\": {
-      \\"Code\\": {
-        \\"bucket_prefix\\": \\"code-c84a50b1-\\"
-      }
+    "aws_s3_bucket": {
+      "Code": {
+        "bucket_prefix": "code-c84a50b1-",
+      },
     },
-    \\"aws_s3_object\\": {
-      \\"Function_S3Object_C62A0C2D\\": {
-        \\"bucket\\": \\"\${aws_s3_bucket.Code.bucket}\\",
-        \\"key\\": \\"<key>\\",
-        \\"source\\": \\"<source>\\"
-      }
-    }
-  }
-}"
+    "aws_s3_object": {
+      "Function_S3Object_C62A0C2D": {
+        "bucket": "\${aws_s3_bucket.Code.bucket}",
+        "key": "<key>",
+        "source": "<source>",
+      },
+    },
+  },
+}
 `;
 
 exports[`function with a counter binding 3`] = `
@@ -888,79 +888,79 @@ exports[`function with a counter binding 3`] = `
 `;
 
 exports[`inc() policy statement 1`] = `
-"{
-  \\"output\\": {
-    \\"WING_TEST_RUNNER_FUNCTION_ARNS\\": {
-      \\"value\\": \\"[]\\"
-    }
+{
+  "output": {
+    "WING_TEST_RUNNER_FUNCTION_ARNS": {
+      "value": "[]",
+    },
   },
-  \\"resource\\": {
-    \\"aws_dynamodb_table\\": {
-      \\"Counter\\": {
-        \\"attribute\\": [
+  "resource": {
+    "aws_dynamodb_table": {
+      "Counter": {
+        "attribute": [
           {
-            \\"name\\": \\"id\\",
-            \\"type\\": \\"S\\"
-          }
+            "name": "id",
+            "type": "S",
+          },
         ],
-        \\"billing_mode\\": \\"PAY_PER_REQUEST\\",
-        \\"hash_key\\": \\"id\\",
-        \\"name\\": \\"wing-counter-Counter-c824ef62\\"
-      }
+        "billing_mode": "PAY_PER_REQUEST",
+        "hash_key": "id",
+        "name": "wing-counter-Counter-c824ef62",
+      },
     },
-    \\"aws_iam_role\\": {
-      \\"Function_IamRole_678BE84C\\": {
-        \\"assume_role_policy\\": \\"{\\\\\\"Version\\\\\\":\\\\\\"2012-10-17\\\\\\",\\\\\\"Statement\\\\\\":[{\\\\\\"Action\\\\\\":\\\\\\"sts:AssumeRole\\\\\\",\\\\\\"Principal\\\\\\":{\\\\\\"Service\\\\\\":\\\\\\"lambda.amazonaws.com\\\\\\"},\\\\\\"Effect\\\\\\":\\\\\\"Allow\\\\\\"}]}\\"
-      }
+    "aws_iam_role": {
+      "Function_IamRole_678BE84C": {
+        "assume_role_policy": "{\\"Version\\":\\"2012-10-17\\",\\"Statement\\":[{\\"Action\\":\\"sts:AssumeRole\\",\\"Principal\\":{\\"Service\\":\\"lambda.amazonaws.com\\"},\\"Effect\\":\\"Allow\\"}]}",
+      },
     },
-    \\"aws_iam_role_policy\\": {
-      \\"Function_IamRolePolicy_E3B26607\\": {
-        \\"policy\\": \\"{\\\\\\"Version\\\\\\":\\\\\\"2012-10-17\\\\\\",\\\\\\"Statement\\\\\\":[{\\\\\\"Action\\\\\\":[\\\\\\"dynamodb:UpdateItem\\\\\\"],\\\\\\"Resource\\\\\\":[\\\\\\"\${aws_dynamodb_table.Counter.arn}\\\\\\"],\\\\\\"Effect\\\\\\":\\\\\\"Allow\\\\\\"}]}\\",
-        \\"role\\": \\"\${aws_iam_role.Function_IamRole_678BE84C.name}\\"
-      }
+    "aws_iam_role_policy": {
+      "Function_IamRolePolicy_E3B26607": {
+        "policy": "{\\"Version\\":\\"2012-10-17\\",\\"Statement\\":[{\\"Action\\":[\\"dynamodb:UpdateItem\\"],\\"Resource\\":[\\"\${aws_dynamodb_table.Counter.arn}\\"],\\"Effect\\":\\"Allow\\"}]}",
+        "role": "\${aws_iam_role.Function_IamRole_678BE84C.name}",
+      },
     },
-    \\"aws_iam_role_policy_attachment\\": {
-      \\"Function_IamRolePolicyAttachment_CACE1358\\": {
-        \\"policy_arn\\": \\"arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole\\",
-        \\"role\\": \\"\${aws_iam_role.Function_IamRole_678BE84C.name}\\"
-      }
+    "aws_iam_role_policy_attachment": {
+      "Function_IamRolePolicyAttachment_CACE1358": {
+        "policy_arn": "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+        "role": "\${aws_iam_role.Function_IamRole_678BE84C.name}",
+      },
     },
-    \\"aws_lambda_function\\": {
-      \\"Function\\": {
-        \\"environment\\": {
-          \\"variables\\": {
-            \\"DYNAMODB_TABLE_NAME_6cb5a3a4\\": \\"\${aws_dynamodb_table.Counter.name}\\",
-            \\"WING_FUNCTION_NAME\\": \\"Function-c852aba6\\"
-          }
+    "aws_lambda_function": {
+      "Function": {
+        "environment": {
+          "variables": {
+            "DYNAMODB_TABLE_NAME_6cb5a3a4": "\${aws_dynamodb_table.Counter.name}",
+            "WING_FUNCTION_NAME": "Function-c852aba6",
+          },
         },
-        \\"function_name\\": \\"Function-c852aba6\\",
-        \\"handler\\": \\"index.handler\\",
-        \\"publish\\": true,
-        \\"role\\": \\"\${aws_iam_role.Function_IamRole_678BE84C.arn}\\",
-        \\"runtime\\": \\"nodejs18.x\\",
-        \\"s3_bucket\\": \\"\${aws_s3_bucket.Code.bucket}\\",
-        \\"s3_key\\": \\"\${aws_s3_object.Function_S3Object_C62A0C2D.key}\\",
-        \\"timeout\\": 30,
-        \\"vpc_config\\": {
-          \\"security_group_ids\\": [],
-          \\"subnet_ids\\": []
-        }
-      }
+        "function_name": "Function-c852aba6",
+        "handler": "index.handler",
+        "publish": true,
+        "role": "\${aws_iam_role.Function_IamRole_678BE84C.arn}",
+        "runtime": "nodejs18.x",
+        "s3_bucket": "\${aws_s3_bucket.Code.bucket}",
+        "s3_key": "\${aws_s3_object.Function_S3Object_C62A0C2D.key}",
+        "timeout": 30,
+        "vpc_config": {
+          "security_group_ids": [],
+          "subnet_ids": [],
+        },
+      },
     },
-    \\"aws_s3_bucket\\": {
-      \\"Code\\": {
-        \\"bucket_prefix\\": \\"code-c84a50b1-\\"
-      }
+    "aws_s3_bucket": {
+      "Code": {
+        "bucket_prefix": "code-c84a50b1-",
+      },
     },
-    \\"aws_s3_object\\": {
-      \\"Function_S3Object_C62A0C2D\\": {
-        \\"bucket\\": \\"\${aws_s3_bucket.Code.bucket}\\",
-        \\"key\\": \\"<key>\\",
-        \\"source\\": \\"<source>\\"
-      }
-    }
-  }
-}"
+    "aws_s3_object": {
+      "Function_S3Object_C62A0C2D": {
+        "bucket": "\${aws_s3_bucket.Code.bucket}",
+        "key": "<key>",
+        "source": "<source>",
+      },
+    },
+  },
+}
 `;
 
 exports[`inc() policy statement 2`] = `
@@ -1182,79 +1182,79 @@ exports[`inc() policy statement 2`] = `
 `;
 
 exports[`peek() policy statement 1`] = `
-"{
-  \\"output\\": {
-    \\"WING_TEST_RUNNER_FUNCTION_ARNS\\": {
-      \\"value\\": \\"[]\\"
-    }
+{
+  "output": {
+    "WING_TEST_RUNNER_FUNCTION_ARNS": {
+      "value": "[]",
+    },
   },
-  \\"resource\\": {
-    \\"aws_dynamodb_table\\": {
-      \\"Counter\\": {
-        \\"attribute\\": [
+  "resource": {
+    "aws_dynamodb_table": {
+      "Counter": {
+        "attribute": [
           {
-            \\"name\\": \\"id\\",
-            \\"type\\": \\"S\\"
-          }
+            "name": "id",
+            "type": "S",
+          },
         ],
-        \\"billing_mode\\": \\"PAY_PER_REQUEST\\",
-        \\"hash_key\\": \\"id\\",
-        \\"name\\": \\"wing-counter-Counter-c824ef62\\"
-      }
+        "billing_mode": "PAY_PER_REQUEST",
+        "hash_key": "id",
+        "name": "wing-counter-Counter-c824ef62",
+      },
     },
-    \\"aws_iam_role\\": {
-      \\"Function_IamRole_678BE84C\\": {
-        \\"assume_role_policy\\": \\"{\\\\\\"Version\\\\\\":\\\\\\"2012-10-17\\\\\\",\\\\\\"Statement\\\\\\":[{\\\\\\"Action\\\\\\":\\\\\\"sts:AssumeRole\\\\\\",\\\\\\"Principal\\\\\\":{\\\\\\"Service\\\\\\":\\\\\\"lambda.amazonaws.com\\\\\\"},\\\\\\"Effect\\\\\\":\\\\\\"Allow\\\\\\"}]}\\"
-      }
+    "aws_iam_role": {
+      "Function_IamRole_678BE84C": {
+        "assume_role_policy": "{\\"Version\\":\\"2012-10-17\\",\\"Statement\\":[{\\"Action\\":\\"sts:AssumeRole\\",\\"Principal\\":{\\"Service\\":\\"lambda.amazonaws.com\\"},\\"Effect\\":\\"Allow\\"}]}",
+      },
     },
-    \\"aws_iam_role_policy\\": {
-      \\"Function_IamRolePolicy_E3B26607\\": {
-        \\"policy\\": \\"{\\\\\\"Version\\\\\\":\\\\\\"2012-10-17\\\\\\",\\\\\\"Statement\\\\\\":[{\\\\\\"Action\\\\\\":[\\\\\\"dynamodb:GetItem\\\\\\"],\\\\\\"Resource\\\\\\":[\\\\\\"\${aws_dynamodb_table.Counter.arn}\\\\\\"],\\\\\\"Effect\\\\\\":\\\\\\"Allow\\\\\\"}]}\\",
-        \\"role\\": \\"\${aws_iam_role.Function_IamRole_678BE84C.name}\\"
-      }
+    "aws_iam_role_policy": {
+      "Function_IamRolePolicy_E3B26607": {
+        "policy": "{\\"Version\\":\\"2012-10-17\\",\\"Statement\\":[{\\"Action\\":[\\"dynamodb:GetItem\\"],\\"Resource\\":[\\"\${aws_dynamodb_table.Counter.arn}\\"],\\"Effect\\":\\"Allow\\"}]}",
+        "role": "\${aws_iam_role.Function_IamRole_678BE84C.name}",
+      },
     },
-    \\"aws_iam_role_policy_attachment\\": {
-      \\"Function_IamRolePolicyAttachment_CACE1358\\": {
-        \\"policy_arn\\": \\"arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole\\",
-        \\"role\\": \\"\${aws_iam_role.Function_IamRole_678BE84C.name}\\"
-      }
+    "aws_iam_role_policy_attachment": {
+      "Function_IamRolePolicyAttachment_CACE1358": {
+        "policy_arn": "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+        "role": "\${aws_iam_role.Function_IamRole_678BE84C.name}",
+      },
     },
-    \\"aws_lambda_function\\": {
-      \\"Function\\": {
-        \\"environment\\": {
-          \\"variables\\": {
-            \\"DYNAMODB_TABLE_NAME_6cb5a3a4\\": \\"\${aws_dynamodb_table.Counter.name}\\",
-            \\"WING_FUNCTION_NAME\\": \\"Function-c852aba6\\"
-          }
+    "aws_lambda_function": {
+      "Function": {
+        "environment": {
+          "variables": {
+            "DYNAMODB_TABLE_NAME_6cb5a3a4": "\${aws_dynamodb_table.Counter.name}",
+            "WING_FUNCTION_NAME": "Function-c852aba6",
+          },
         },
-        \\"function_name\\": \\"Function-c852aba6\\",
-        \\"handler\\": \\"index.handler\\",
-        \\"publish\\": true,
-        \\"role\\": \\"\${aws_iam_role.Function_IamRole_678BE84C.arn}\\",
-        \\"runtime\\": \\"nodejs18.x\\",
-        \\"s3_bucket\\": \\"\${aws_s3_bucket.Code.bucket}\\",
-        \\"s3_key\\": \\"\${aws_s3_object.Function_S3Object_C62A0C2D.key}\\",
-        \\"timeout\\": 30,
-        \\"vpc_config\\": {
-          \\"security_group_ids\\": [],
-          \\"subnet_ids\\": []
-        }
-      }
+        "function_name": "Function-c852aba6",
+        "handler": "index.handler",
+        "publish": true,
+        "role": "\${aws_iam_role.Function_IamRole_678BE84C.arn}",
+        "runtime": "nodejs18.x",
+        "s3_bucket": "\${aws_s3_bucket.Code.bucket}",
+        "s3_key": "\${aws_s3_object.Function_S3Object_C62A0C2D.key}",
+        "timeout": 30,
+        "vpc_config": {
+          "security_group_ids": [],
+          "subnet_ids": [],
+        },
+      },
     },
-    \\"aws_s3_bucket\\": {
-      \\"Code\\": {
-        \\"bucket_prefix\\": \\"code-c84a50b1-\\"
-      }
+    "aws_s3_bucket": {
+      "Code": {
+        "bucket_prefix": "code-c84a50b1-",
+      },
     },
-    \\"aws_s3_object\\": {
-      \\"Function_S3Object_C62A0C2D\\": {
-        \\"bucket\\": \\"\${aws_s3_bucket.Code.bucket}\\",
-        \\"key\\": \\"<key>\\",
-        \\"source\\": \\"<source>\\"
-      }
-    }
-  }
-}"
+    "aws_s3_object": {
+      "Function_S3Object_C62A0C2D": {
+        "bucket": "\${aws_s3_bucket.Code.bucket}",
+        "key": "<key>",
+        "source": "<source>",
+      },
+    },
+  },
+}
 `;
 
 exports[`peek() policy statement 2`] = `
@@ -1476,28 +1476,28 @@ exports[`peek() policy statement 2`] = `
 `;
 
 exports[`replace invalid character from counter name 1`] = `
-"{
-  \\"output\\": {
-    \\"WING_TEST_RUNNER_FUNCTION_ARNS\\": {
-      \\"value\\": \\"[]\\"
-    }
+{
+  "output": {
+    "WING_TEST_RUNNER_FUNCTION_ARNS": {
+      "value": "[]",
+    },
   },
-  \\"resource\\": {
-    \\"aws_dynamodb_table\\": {
-      \\"TheAmazingCounter01\\": {
-        \\"attribute\\": [
+  "resource": {
+    "aws_dynamodb_table": {
+      "TheAmazingCounter01": {
+        "attribute": [
           {
-            \\"name\\": \\"id\\",
-            \\"type\\": \\"S\\"
-          }
+            "name": "id",
+            "type": "S",
+          },
         ],
-        \\"billing_mode\\": \\"PAY_PER_REQUEST\\",
-        \\"hash_key\\": \\"id\\",
-        \\"name\\": \\"wing-counter-The-Amazing-Counter-01-c848151b\\"
-      }
-    }
-  }
-}"
+        "billing_mode": "PAY_PER_REQUEST",
+        "hash_key": "id",
+        "name": "wing-counter-The-Amazing-Counter-01-c848151b",
+      },
+    },
+  },
+}
 `;
 
 exports[`replace invalid character from counter name 2`] = `
@@ -1604,79 +1604,79 @@ exports[`replace invalid character from counter name 2`] = `
 `;
 
 exports[`set() policy statement 1`] = `
-"{
-  \\"output\\": {
-    \\"WING_TEST_RUNNER_FUNCTION_ARNS\\": {
-      \\"value\\": \\"[]\\"
-    }
+{
+  "output": {
+    "WING_TEST_RUNNER_FUNCTION_ARNS": {
+      "value": "[]",
+    },
   },
-  \\"resource\\": {
-    \\"aws_dynamodb_table\\": {
-      \\"Counter\\": {
-        \\"attribute\\": [
+  "resource": {
+    "aws_dynamodb_table": {
+      "Counter": {
+        "attribute": [
           {
-            \\"name\\": \\"id\\",
-            \\"type\\": \\"S\\"
-          }
+            "name": "id",
+            "type": "S",
+          },
         ],
-        \\"billing_mode\\": \\"PAY_PER_REQUEST\\",
-        \\"hash_key\\": \\"id\\",
-        \\"name\\": \\"wing-counter-Counter-c824ef62\\"
-      }
+        "billing_mode": "PAY_PER_REQUEST",
+        "hash_key": "id",
+        "name": "wing-counter-Counter-c824ef62",
+      },
     },
-    \\"aws_iam_role\\": {
-      \\"Function_IamRole_678BE84C\\": {
-        \\"assume_role_policy\\": \\"{\\\\\\"Version\\\\\\":\\\\\\"2012-10-17\\\\\\",\\\\\\"Statement\\\\\\":[{\\\\\\"Action\\\\\\":\\\\\\"sts:AssumeRole\\\\\\",\\\\\\"Principal\\\\\\":{\\\\\\"Service\\\\\\":\\\\\\"lambda.amazonaws.com\\\\\\"},\\\\\\"Effect\\\\\\":\\\\\\"Allow\\\\\\"}]}\\"
-      }
+    "aws_iam_role": {
+      "Function_IamRole_678BE84C": {
+        "assume_role_policy": "{\\"Version\\":\\"2012-10-17\\",\\"Statement\\":[{\\"Action\\":\\"sts:AssumeRole\\",\\"Principal\\":{\\"Service\\":\\"lambda.amazonaws.com\\"},\\"Effect\\":\\"Allow\\"}]}",
+      },
     },
-    \\"aws_iam_role_policy\\": {
-      \\"Function_IamRolePolicy_E3B26607\\": {
-        \\"policy\\": \\"{\\\\\\"Version\\\\\\":\\\\\\"2012-10-17\\\\\\",\\\\\\"Statement\\\\\\":[{\\\\\\"Action\\\\\\":[\\\\\\"dynamodb:UpdateItem\\\\\\"],\\\\\\"Resource\\\\\\":[\\\\\\"\${aws_dynamodb_table.Counter.arn}\\\\\\"],\\\\\\"Effect\\\\\\":\\\\\\"Allow\\\\\\"}]}\\",
-        \\"role\\": \\"\${aws_iam_role.Function_IamRole_678BE84C.name}\\"
-      }
+    "aws_iam_role_policy": {
+      "Function_IamRolePolicy_E3B26607": {
+        "policy": "{\\"Version\\":\\"2012-10-17\\",\\"Statement\\":[{\\"Action\\":[\\"dynamodb:UpdateItem\\"],\\"Resource\\":[\\"\${aws_dynamodb_table.Counter.arn}\\"],\\"Effect\\":\\"Allow\\"}]}",
+        "role": "\${aws_iam_role.Function_IamRole_678BE84C.name}",
+      },
     },
-    \\"aws_iam_role_policy_attachment\\": {
-      \\"Function_IamRolePolicyAttachment_CACE1358\\": {
-        \\"policy_arn\\": \\"arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole\\",
-        \\"role\\": \\"\${aws_iam_role.Function_IamRole_678BE84C.name}\\"
-      }
+    "aws_iam_role_policy_attachment": {
+      "Function_IamRolePolicyAttachment_CACE1358": {
+        "policy_arn": "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+        "role": "\${aws_iam_role.Function_IamRole_678BE84C.name}",
+      },
     },
-    \\"aws_lambda_function\\": {
-      \\"Function\\": {
-        \\"environment\\": {
-          \\"variables\\": {
-            \\"DYNAMODB_TABLE_NAME_6cb5a3a4\\": \\"\${aws_dynamodb_table.Counter.name}\\",
-            \\"WING_FUNCTION_NAME\\": \\"Function-c852aba6\\"
-          }
+    "aws_lambda_function": {
+      "Function": {
+        "environment": {
+          "variables": {
+            "DYNAMODB_TABLE_NAME_6cb5a3a4": "\${aws_dynamodb_table.Counter.name}",
+            "WING_FUNCTION_NAME": "Function-c852aba6",
+          },
         },
-        \\"function_name\\": \\"Function-c852aba6\\",
-        \\"handler\\": \\"index.handler\\",
-        \\"publish\\": true,
-        \\"role\\": \\"\${aws_iam_role.Function_IamRole_678BE84C.arn}\\",
-        \\"runtime\\": \\"nodejs18.x\\",
-        \\"s3_bucket\\": \\"\${aws_s3_bucket.Code.bucket}\\",
-        \\"s3_key\\": \\"\${aws_s3_object.Function_S3Object_C62A0C2D.key}\\",
-        \\"timeout\\": 30,
-        \\"vpc_config\\": {
-          \\"security_group_ids\\": [],
-          \\"subnet_ids\\": []
-        }
-      }
+        "function_name": "Function-c852aba6",
+        "handler": "index.handler",
+        "publish": true,
+        "role": "\${aws_iam_role.Function_IamRole_678BE84C.arn}",
+        "runtime": "nodejs18.x",
+        "s3_bucket": "\${aws_s3_bucket.Code.bucket}",
+        "s3_key": "\${aws_s3_object.Function_S3Object_C62A0C2D.key}",
+        "timeout": 30,
+        "vpc_config": {
+          "security_group_ids": [],
+          "subnet_ids": [],
+        },
+      },
     },
-    \\"aws_s3_bucket\\": {
-      \\"Code\\": {
-        \\"bucket_prefix\\": \\"code-c84a50b1-\\"
-      }
+    "aws_s3_bucket": {
+      "Code": {
+        "bucket_prefix": "code-c84a50b1-",
+      },
     },
-    \\"aws_s3_object\\": {
-      \\"Function_S3Object_C62A0C2D\\": {
-        \\"bucket\\": \\"\${aws_s3_bucket.Code.bucket}\\",
-        \\"key\\": \\"<key>\\",
-        \\"source\\": \\"<source>\\"
-      }
-    }
-  }
-}"
+    "aws_s3_object": {
+      "Function_S3Object_C62A0C2D": {
+        "bucket": "\${aws_s3_bucket.Code.bucket}",
+        "key": "<key>",
+        "source": "<source>",
+      },
+    },
+  },
+}
 `;
 
 exports[`set() policy statement 2`] = `

--- a/libs/wingsdk/test/target-tf-aws/__snapshots__/function.test.ts.snap
+++ b/libs/wingsdk/test/target-tf-aws/__snapshots__/function.test.ts.snap
@@ -1,65 +1,65 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`basic function 1`] = `
-"{
-  \\"output\\": {
-    \\"WING_TEST_RUNNER_FUNCTION_ARNS\\": {
-      \\"value\\": \\"[]\\"
-    }
+{
+  "output": {
+    "WING_TEST_RUNNER_FUNCTION_ARNS": {
+      "value": "[]",
+    },
   },
-  \\"resource\\": {
-    \\"aws_iam_role\\": {
-      \\"Function_IamRole_678BE84C\\": {
-        \\"assume_role_policy\\": \\"{\\\\\\"Version\\\\\\":\\\\\\"2012-10-17\\\\\\",\\\\\\"Statement\\\\\\":[{\\\\\\"Action\\\\\\":\\\\\\"sts:AssumeRole\\\\\\",\\\\\\"Principal\\\\\\":{\\\\\\"Service\\\\\\":\\\\\\"lambda.amazonaws.com\\\\\\"},\\\\\\"Effect\\\\\\":\\\\\\"Allow\\\\\\"}]}\\"
-      }
+  "resource": {
+    "aws_iam_role": {
+      "Function_IamRole_678BE84C": {
+        "assume_role_policy": "{\\"Version\\":\\"2012-10-17\\",\\"Statement\\":[{\\"Action\\":\\"sts:AssumeRole\\",\\"Principal\\":{\\"Service\\":\\"lambda.amazonaws.com\\"},\\"Effect\\":\\"Allow\\"}]}",
+      },
     },
-    \\"aws_iam_role_policy\\": {
-      \\"Function_IamRolePolicy_E3B26607\\": {
-        \\"policy\\": \\"{\\\\\\"Version\\\\\\":\\\\\\"2012-10-17\\\\\\",\\\\\\"Statement\\\\\\":[{\\\\\\"Effect\\\\\\":\\\\\\"Allow\\\\\\",\\\\\\"Action\\\\\\":\\\\\\"none:null\\\\\\",\\\\\\"Resource\\\\\\":\\\\\\"*\\\\\\"}]}\\",
-        \\"role\\": \\"\${aws_iam_role.Function_IamRole_678BE84C.name}\\"
-      }
+    "aws_iam_role_policy": {
+      "Function_IamRolePolicy_E3B26607": {
+        "policy": "{\\"Version\\":\\"2012-10-17\\",\\"Statement\\":[{\\"Effect\\":\\"Allow\\",\\"Action\\":\\"none:null\\",\\"Resource\\":\\"*\\"}]}",
+        "role": "\${aws_iam_role.Function_IamRole_678BE84C.name}",
+      },
     },
-    \\"aws_iam_role_policy_attachment\\": {
-      \\"Function_IamRolePolicyAttachment_CACE1358\\": {
-        \\"policy_arn\\": \\"arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole\\",
-        \\"role\\": \\"\${aws_iam_role.Function_IamRole_678BE84C.name}\\"
-      }
+    "aws_iam_role_policy_attachment": {
+      "Function_IamRolePolicyAttachment_CACE1358": {
+        "policy_arn": "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+        "role": "\${aws_iam_role.Function_IamRole_678BE84C.name}",
+      },
     },
-    \\"aws_lambda_function\\": {
-      \\"Function\\": {
-        \\"environment\\": {
-          \\"variables\\": {
-            \\"WING_FUNCTION_NAME\\": \\"Function-c852aba6\\"
-          }
+    "aws_lambda_function": {
+      "Function": {
+        "environment": {
+          "variables": {
+            "WING_FUNCTION_NAME": "Function-c852aba6",
+          },
         },
-        \\"function_name\\": \\"Function-c852aba6\\",
-        \\"handler\\": \\"index.handler\\",
-        \\"publish\\": true,
-        \\"role\\": \\"\${aws_iam_role.Function_IamRole_678BE84C.arn}\\",
-        \\"runtime\\": \\"nodejs18.x\\",
-        \\"s3_bucket\\": \\"\${aws_s3_bucket.Code.bucket}\\",
-        \\"s3_key\\": \\"\${aws_s3_object.Function_S3Object_C62A0C2D.key}\\",
-        \\"timeout\\": 30,
-        \\"vpc_config\\": {
-          \\"security_group_ids\\": [],
-          \\"subnet_ids\\": []
-        }
-      }
+        "function_name": "Function-c852aba6",
+        "handler": "index.handler",
+        "publish": true,
+        "role": "\${aws_iam_role.Function_IamRole_678BE84C.arn}",
+        "runtime": "nodejs18.x",
+        "s3_bucket": "\${aws_s3_bucket.Code.bucket}",
+        "s3_key": "\${aws_s3_object.Function_S3Object_C62A0C2D.key}",
+        "timeout": 30,
+        "vpc_config": {
+          "security_group_ids": [],
+          "subnet_ids": [],
+        },
+      },
     },
-    \\"aws_s3_bucket\\": {
-      \\"Code\\": {
-        \\"bucket_prefix\\": \\"code-c84a50b1-\\"
-      }
+    "aws_s3_bucket": {
+      "Code": {
+        "bucket_prefix": "code-c84a50b1-",
+      },
     },
-    \\"aws_s3_object\\": {
-      \\"Function_S3Object_C62A0C2D\\": {
-        \\"bucket\\": \\"\${aws_s3_bucket.Code.bucket}\\",
-        \\"key\\": \\"<key>\\",
-        \\"source\\": \\"<source>\\"
-      }
-    }
-  }
-}"
+    "aws_s3_object": {
+      "Function_S3Object_C62A0C2D": {
+        "bucket": "\${aws_s3_bucket.Code.bucket}",
+        "key": "<key>",
+        "source": "<source>",
+      },
+    },
+  },
+}
 `;
 
 exports[`basic function 2`] = `
@@ -230,67 +230,67 @@ exports[`basic function 2`] = `
 `;
 
 exports[`basic function with environment variables 1`] = `
-"{
-  \\"output\\": {
-    \\"WING_TEST_RUNNER_FUNCTION_ARNS\\": {
-      \\"value\\": \\"[]\\"
-    }
+{
+  "output": {
+    "WING_TEST_RUNNER_FUNCTION_ARNS": {
+      "value": "[]",
+    },
   },
-  \\"resource\\": {
-    \\"aws_iam_role\\": {
-      \\"Function_IamRole_678BE84C\\": {
-        \\"assume_role_policy\\": \\"{\\\\\\"Version\\\\\\":\\\\\\"2012-10-17\\\\\\",\\\\\\"Statement\\\\\\":[{\\\\\\"Action\\\\\\":\\\\\\"sts:AssumeRole\\\\\\",\\\\\\"Principal\\\\\\":{\\\\\\"Service\\\\\\":\\\\\\"lambda.amazonaws.com\\\\\\"},\\\\\\"Effect\\\\\\":\\\\\\"Allow\\\\\\"}]}\\"
-      }
+  "resource": {
+    "aws_iam_role": {
+      "Function_IamRole_678BE84C": {
+        "assume_role_policy": "{\\"Version\\":\\"2012-10-17\\",\\"Statement\\":[{\\"Action\\":\\"sts:AssumeRole\\",\\"Principal\\":{\\"Service\\":\\"lambda.amazonaws.com\\"},\\"Effect\\":\\"Allow\\"}]}",
+      },
     },
-    \\"aws_iam_role_policy\\": {
-      \\"Function_IamRolePolicy_E3B26607\\": {
-        \\"policy\\": \\"{\\\\\\"Version\\\\\\":\\\\\\"2012-10-17\\\\\\",\\\\\\"Statement\\\\\\":[{\\\\\\"Effect\\\\\\":\\\\\\"Allow\\\\\\",\\\\\\"Action\\\\\\":\\\\\\"none:null\\\\\\",\\\\\\"Resource\\\\\\":\\\\\\"*\\\\\\"}]}\\",
-        \\"role\\": \\"\${aws_iam_role.Function_IamRole_678BE84C.name}\\"
-      }
+    "aws_iam_role_policy": {
+      "Function_IamRolePolicy_E3B26607": {
+        "policy": "{\\"Version\\":\\"2012-10-17\\",\\"Statement\\":[{\\"Effect\\":\\"Allow\\",\\"Action\\":\\"none:null\\",\\"Resource\\":\\"*\\"}]}",
+        "role": "\${aws_iam_role.Function_IamRole_678BE84C.name}",
+      },
     },
-    \\"aws_iam_role_policy_attachment\\": {
-      \\"Function_IamRolePolicyAttachment_CACE1358\\": {
-        \\"policy_arn\\": \\"arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole\\",
-        \\"role\\": \\"\${aws_iam_role.Function_IamRole_678BE84C.name}\\"
-      }
+    "aws_iam_role_policy_attachment": {
+      "Function_IamRolePolicyAttachment_CACE1358": {
+        "policy_arn": "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+        "role": "\${aws_iam_role.Function_IamRole_678BE84C.name}",
+      },
     },
-    \\"aws_lambda_function\\": {
-      \\"Function\\": {
-        \\"environment\\": {
-          \\"variables\\": {
-            \\"BOOM\\": \\"BAM\\",
-            \\"FOO\\": \\"BAR\\",
-            \\"WING_FUNCTION_NAME\\": \\"Function-c852aba6\\"
-          }
+    "aws_lambda_function": {
+      "Function": {
+        "environment": {
+          "variables": {
+            "BOOM": "BAM",
+            "FOO": "BAR",
+            "WING_FUNCTION_NAME": "Function-c852aba6",
+          },
         },
-        \\"function_name\\": \\"Function-c852aba6\\",
-        \\"handler\\": \\"index.handler\\",
-        \\"publish\\": true,
-        \\"role\\": \\"\${aws_iam_role.Function_IamRole_678BE84C.arn}\\",
-        \\"runtime\\": \\"nodejs18.x\\",
-        \\"s3_bucket\\": \\"\${aws_s3_bucket.Code.bucket}\\",
-        \\"s3_key\\": \\"\${aws_s3_object.Function_S3Object_C62A0C2D.key}\\",
-        \\"timeout\\": 30,
-        \\"vpc_config\\": {
-          \\"security_group_ids\\": [],
-          \\"subnet_ids\\": []
-        }
-      }
+        "function_name": "Function-c852aba6",
+        "handler": "index.handler",
+        "publish": true,
+        "role": "\${aws_iam_role.Function_IamRole_678BE84C.arn}",
+        "runtime": "nodejs18.x",
+        "s3_bucket": "\${aws_s3_bucket.Code.bucket}",
+        "s3_key": "\${aws_s3_object.Function_S3Object_C62A0C2D.key}",
+        "timeout": 30,
+        "vpc_config": {
+          "security_group_ids": [],
+          "subnet_ids": [],
+        },
+      },
     },
-    \\"aws_s3_bucket\\": {
-      \\"Code\\": {
-        \\"bucket_prefix\\": \\"code-c84a50b1-\\"
-      }
+    "aws_s3_bucket": {
+      "Code": {
+        "bucket_prefix": "code-c84a50b1-",
+      },
     },
-    \\"aws_s3_object\\": {
-      \\"Function_S3Object_C62A0C2D\\": {
-        \\"bucket\\": \\"\${aws_s3_bucket.Code.bucket}\\",
-        \\"key\\": \\"<key>\\",
-        \\"source\\": \\"<source>\\"
-      }
-    }
-  }
-}"
+    "aws_s3_object": {
+      "Function_S3Object_C62A0C2D": {
+        "bucket": "\${aws_s3_bucket.Code.bucket}",
+        "key": "<key>",
+        "source": "<source>",
+      },
+    },
+  },
+}
 `;
 
 exports[`basic function with environment variables 2`] = `
@@ -461,66 +461,66 @@ exports[`basic function with environment variables 2`] = `
 `;
 
 exports[`basic function with memory size specified 1`] = `
-"{
-  \\"output\\": {
-    \\"WING_TEST_RUNNER_FUNCTION_ARNS\\": {
-      \\"value\\": \\"[]\\"
-    }
+{
+  "output": {
+    "WING_TEST_RUNNER_FUNCTION_ARNS": {
+      "value": "[]",
+    },
   },
-  \\"resource\\": {
-    \\"aws_iam_role\\": {
-      \\"Function_IamRole_678BE84C\\": {
-        \\"assume_role_policy\\": \\"{\\\\\\"Version\\\\\\":\\\\\\"2012-10-17\\\\\\",\\\\\\"Statement\\\\\\":[{\\\\\\"Action\\\\\\":\\\\\\"sts:AssumeRole\\\\\\",\\\\\\"Principal\\\\\\":{\\\\\\"Service\\\\\\":\\\\\\"lambda.amazonaws.com\\\\\\"},\\\\\\"Effect\\\\\\":\\\\\\"Allow\\\\\\"}]}\\"
-      }
+  "resource": {
+    "aws_iam_role": {
+      "Function_IamRole_678BE84C": {
+        "assume_role_policy": "{\\"Version\\":\\"2012-10-17\\",\\"Statement\\":[{\\"Action\\":\\"sts:AssumeRole\\",\\"Principal\\":{\\"Service\\":\\"lambda.amazonaws.com\\"},\\"Effect\\":\\"Allow\\"}]}",
+      },
     },
-    \\"aws_iam_role_policy\\": {
-      \\"Function_IamRolePolicy_E3B26607\\": {
-        \\"policy\\": \\"{\\\\\\"Version\\\\\\":\\\\\\"2012-10-17\\\\\\",\\\\\\"Statement\\\\\\":[{\\\\\\"Effect\\\\\\":\\\\\\"Allow\\\\\\",\\\\\\"Action\\\\\\":\\\\\\"none:null\\\\\\",\\\\\\"Resource\\\\\\":\\\\\\"*\\\\\\"}]}\\",
-        \\"role\\": \\"\${aws_iam_role.Function_IamRole_678BE84C.name}\\"
-      }
+    "aws_iam_role_policy": {
+      "Function_IamRolePolicy_E3B26607": {
+        "policy": "{\\"Version\\":\\"2012-10-17\\",\\"Statement\\":[{\\"Effect\\":\\"Allow\\",\\"Action\\":\\"none:null\\",\\"Resource\\":\\"*\\"}]}",
+        "role": "\${aws_iam_role.Function_IamRole_678BE84C.name}",
+      },
     },
-    \\"aws_iam_role_policy_attachment\\": {
-      \\"Function_IamRolePolicyAttachment_CACE1358\\": {
-        \\"policy_arn\\": \\"arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole\\",
-        \\"role\\": \\"\${aws_iam_role.Function_IamRole_678BE84C.name}\\"
-      }
+    "aws_iam_role_policy_attachment": {
+      "Function_IamRolePolicyAttachment_CACE1358": {
+        "policy_arn": "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+        "role": "\${aws_iam_role.Function_IamRole_678BE84C.name}",
+      },
     },
-    \\"aws_lambda_function\\": {
-      \\"Function\\": {
-        \\"environment\\": {
-          \\"variables\\": {
-            \\"WING_FUNCTION_NAME\\": \\"Function-c852aba6\\"
-          }
+    "aws_lambda_function": {
+      "Function": {
+        "environment": {
+          "variables": {
+            "WING_FUNCTION_NAME": "Function-c852aba6",
+          },
         },
-        \\"function_name\\": \\"Function-c852aba6\\",
-        \\"handler\\": \\"index.handler\\",
-        \\"memory_size\\": 512,
-        \\"publish\\": true,
-        \\"role\\": \\"\${aws_iam_role.Function_IamRole_678BE84C.arn}\\",
-        \\"runtime\\": \\"nodejs18.x\\",
-        \\"s3_bucket\\": \\"\${aws_s3_bucket.Code.bucket}\\",
-        \\"s3_key\\": \\"\${aws_s3_object.Function_S3Object_C62A0C2D.key}\\",
-        \\"timeout\\": 30,
-        \\"vpc_config\\": {
-          \\"security_group_ids\\": [],
-          \\"subnet_ids\\": []
-        }
-      }
+        "function_name": "Function-c852aba6",
+        "handler": "index.handler",
+        "memory_size": 512,
+        "publish": true,
+        "role": "\${aws_iam_role.Function_IamRole_678BE84C.arn}",
+        "runtime": "nodejs18.x",
+        "s3_bucket": "\${aws_s3_bucket.Code.bucket}",
+        "s3_key": "\${aws_s3_object.Function_S3Object_C62A0C2D.key}",
+        "timeout": 30,
+        "vpc_config": {
+          "security_group_ids": [],
+          "subnet_ids": [],
+        },
+      },
     },
-    \\"aws_s3_bucket\\": {
-      \\"Code\\": {
-        \\"bucket_prefix\\": \\"code-c84a50b1-\\"
-      }
+    "aws_s3_bucket": {
+      "Code": {
+        "bucket_prefix": "code-c84a50b1-",
+      },
     },
-    \\"aws_s3_object\\": {
-      \\"Function_S3Object_C62A0C2D\\": {
-        \\"bucket\\": \\"\${aws_s3_bucket.Code.bucket}\\",
-        \\"key\\": \\"<key>\\",
-        \\"source\\": \\"<source>\\"
-      }
-    }
-  }
-}"
+    "aws_s3_object": {
+      "Function_S3Object_C62A0C2D": {
+        "bucket": "\${aws_s3_bucket.Code.bucket}",
+        "key": "<key>",
+        "source": "<source>",
+      },
+    },
+  },
+}
 `;
 
 exports[`basic function with memory size specified 2`] = `
@@ -691,65 +691,65 @@ exports[`basic function with memory size specified 2`] = `
 `;
 
 exports[`basic function with timeout explicitly set 1`] = `
-"{
-  \\"output\\": {
-    \\"WING_TEST_RUNNER_FUNCTION_ARNS\\": {
-      \\"value\\": \\"[]\\"
-    }
+{
+  "output": {
+    "WING_TEST_RUNNER_FUNCTION_ARNS": {
+      "value": "[]",
+    },
   },
-  \\"resource\\": {
-    \\"aws_iam_role\\": {
-      \\"Function_IamRole_678BE84C\\": {
-        \\"assume_role_policy\\": \\"{\\\\\\"Version\\\\\\":\\\\\\"2012-10-17\\\\\\",\\\\\\"Statement\\\\\\":[{\\\\\\"Action\\\\\\":\\\\\\"sts:AssumeRole\\\\\\",\\\\\\"Principal\\\\\\":{\\\\\\"Service\\\\\\":\\\\\\"lambda.amazonaws.com\\\\\\"},\\\\\\"Effect\\\\\\":\\\\\\"Allow\\\\\\"}]}\\"
-      }
+  "resource": {
+    "aws_iam_role": {
+      "Function_IamRole_678BE84C": {
+        "assume_role_policy": "{\\"Version\\":\\"2012-10-17\\",\\"Statement\\":[{\\"Action\\":\\"sts:AssumeRole\\",\\"Principal\\":{\\"Service\\":\\"lambda.amazonaws.com\\"},\\"Effect\\":\\"Allow\\"}]}",
+      },
     },
-    \\"aws_iam_role_policy\\": {
-      \\"Function_IamRolePolicy_E3B26607\\": {
-        \\"policy\\": \\"{\\\\\\"Version\\\\\\":\\\\\\"2012-10-17\\\\\\",\\\\\\"Statement\\\\\\":[{\\\\\\"Effect\\\\\\":\\\\\\"Allow\\\\\\",\\\\\\"Action\\\\\\":\\\\\\"none:null\\\\\\",\\\\\\"Resource\\\\\\":\\\\\\"*\\\\\\"}]}\\",
-        \\"role\\": \\"\${aws_iam_role.Function_IamRole_678BE84C.name}\\"
-      }
+    "aws_iam_role_policy": {
+      "Function_IamRolePolicy_E3B26607": {
+        "policy": "{\\"Version\\":\\"2012-10-17\\",\\"Statement\\":[{\\"Effect\\":\\"Allow\\",\\"Action\\":\\"none:null\\",\\"Resource\\":\\"*\\"}]}",
+        "role": "\${aws_iam_role.Function_IamRole_678BE84C.name}",
+      },
     },
-    \\"aws_iam_role_policy_attachment\\": {
-      \\"Function_IamRolePolicyAttachment_CACE1358\\": {
-        \\"policy_arn\\": \\"arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole\\",
-        \\"role\\": \\"\${aws_iam_role.Function_IamRole_678BE84C.name}\\"
-      }
+    "aws_iam_role_policy_attachment": {
+      "Function_IamRolePolicyAttachment_CACE1358": {
+        "policy_arn": "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+        "role": "\${aws_iam_role.Function_IamRole_678BE84C.name}",
+      },
     },
-    \\"aws_lambda_function\\": {
-      \\"Function\\": {
-        \\"environment\\": {
-          \\"variables\\": {
-            \\"WING_FUNCTION_NAME\\": \\"Function-c852aba6\\"
-          }
+    "aws_lambda_function": {
+      "Function": {
+        "environment": {
+          "variables": {
+            "WING_FUNCTION_NAME": "Function-c852aba6",
+          },
         },
-        \\"function_name\\": \\"Function-c852aba6\\",
-        \\"handler\\": \\"index.handler\\",
-        \\"publish\\": true,
-        \\"role\\": \\"\${aws_iam_role.Function_IamRole_678BE84C.arn}\\",
-        \\"runtime\\": \\"nodejs18.x\\",
-        \\"s3_bucket\\": \\"\${aws_s3_bucket.Code.bucket}\\",
-        \\"s3_key\\": \\"\${aws_s3_object.Function_S3Object_C62A0C2D.key}\\",
-        \\"timeout\\": 30,
-        \\"vpc_config\\": {
-          \\"security_group_ids\\": [],
-          \\"subnet_ids\\": []
-        }
-      }
+        "function_name": "Function-c852aba6",
+        "handler": "index.handler",
+        "publish": true,
+        "role": "\${aws_iam_role.Function_IamRole_678BE84C.arn}",
+        "runtime": "nodejs18.x",
+        "s3_bucket": "\${aws_s3_bucket.Code.bucket}",
+        "s3_key": "\${aws_s3_object.Function_S3Object_C62A0C2D.key}",
+        "timeout": 30,
+        "vpc_config": {
+          "security_group_ids": [],
+          "subnet_ids": [],
+        },
+      },
     },
-    \\"aws_s3_bucket\\": {
-      \\"Code\\": {
-        \\"bucket_prefix\\": \\"code-c84a50b1-\\"
-      }
+    "aws_s3_bucket": {
+      "Code": {
+        "bucket_prefix": "code-c84a50b1-",
+      },
     },
-    \\"aws_s3_object\\": {
-      \\"Function_S3Object_C62A0C2D\\": {
-        \\"bucket\\": \\"\${aws_s3_bucket.Code.bucket}\\",
-        \\"key\\": \\"<key>\\",
-        \\"source\\": \\"<source>\\"
-      }
-    }
-  }
-}"
+    "aws_s3_object": {
+      "Function_S3Object_C62A0C2D": {
+        "bucket": "\${aws_s3_bucket.Code.bucket}",
+        "key": "<key>",
+        "source": "<source>",
+      },
+    },
+  },
+}
 `;
 
 exports[`basic function with timeout explicitly set 2`] = `
@@ -920,65 +920,65 @@ exports[`basic function with timeout explicitly set 2`] = `
 `;
 
 exports[`function name valid 1`] = `
-"{
-  \\"output\\": {
-    \\"WING_TEST_RUNNER_FUNCTION_ARNS\\": {
-      \\"value\\": \\"[]\\"
-    }
+{
+  "output": {
+    "WING_TEST_RUNNER_FUNCTION_ARNS": {
+      "value": "[]",
+    },
   },
-  \\"resource\\": {
-    \\"aws_iam_role\\": {
-      \\"The-Mighty_Function-01_IamRole_590EA29B\\": {
-        \\"assume_role_policy\\": \\"{\\\\\\"Version\\\\\\":\\\\\\"2012-10-17\\\\\\",\\\\\\"Statement\\\\\\":[{\\\\\\"Action\\\\\\":\\\\\\"sts:AssumeRole\\\\\\",\\\\\\"Principal\\\\\\":{\\\\\\"Service\\\\\\":\\\\\\"lambda.amazonaws.com\\\\\\"},\\\\\\"Effect\\\\\\":\\\\\\"Allow\\\\\\"}]}\\"
-      }
+  "resource": {
+    "aws_iam_role": {
+      "The-Mighty_Function-01_IamRole_590EA29B": {
+        "assume_role_policy": "{\\"Version\\":\\"2012-10-17\\",\\"Statement\\":[{\\"Action\\":\\"sts:AssumeRole\\",\\"Principal\\":{\\"Service\\":\\"lambda.amazonaws.com\\"},\\"Effect\\":\\"Allow\\"}]}",
+      },
     },
-    \\"aws_iam_role_policy\\": {
-      \\"The-Mighty_Function-01_IamRolePolicy_506506FA\\": {
-        \\"policy\\": \\"{\\\\\\"Version\\\\\\":\\\\\\"2012-10-17\\\\\\",\\\\\\"Statement\\\\\\":[{\\\\\\"Effect\\\\\\":\\\\\\"Allow\\\\\\",\\\\\\"Action\\\\\\":\\\\\\"none:null\\\\\\",\\\\\\"Resource\\\\\\":\\\\\\"*\\\\\\"}]}\\",
-        \\"role\\": \\"\${aws_iam_role.The-Mighty_Function-01_IamRole_590EA29B.name}\\"
-      }
+    "aws_iam_role_policy": {
+      "The-Mighty_Function-01_IamRolePolicy_506506FA": {
+        "policy": "{\\"Version\\":\\"2012-10-17\\",\\"Statement\\":[{\\"Effect\\":\\"Allow\\",\\"Action\\":\\"none:null\\",\\"Resource\\":\\"*\\"}]}",
+        "role": "\${aws_iam_role.The-Mighty_Function-01_IamRole_590EA29B.name}",
+      },
     },
-    \\"aws_iam_role_policy_attachment\\": {
-      \\"The-Mighty_Function-01_IamRolePolicyAttachment_63D2B658\\": {
-        \\"policy_arn\\": \\"arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole\\",
-        \\"role\\": \\"\${aws_iam_role.The-Mighty_Function-01_IamRole_590EA29B.name}\\"
-      }
+    "aws_iam_role_policy_attachment": {
+      "The-Mighty_Function-01_IamRolePolicyAttachment_63D2B658": {
+        "policy_arn": "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+        "role": "\${aws_iam_role.The-Mighty_Function-01_IamRole_590EA29B.name}",
+      },
     },
-    \\"aws_lambda_function\\": {
-      \\"The-Mighty_Function-01\\": {
-        \\"environment\\": {
-          \\"variables\\": {
-            \\"WING_FUNCTION_NAME\\": \\"The-Mighty_Function-01-c86057f3\\"
-          }
+    "aws_lambda_function": {
+      "The-Mighty_Function-01": {
+        "environment": {
+          "variables": {
+            "WING_FUNCTION_NAME": "The-Mighty_Function-01-c86057f3",
+          },
         },
-        \\"function_name\\": \\"The-Mighty_Function-01-c86057f3\\",
-        \\"handler\\": \\"index.handler\\",
-        \\"publish\\": true,
-        \\"role\\": \\"\${aws_iam_role.The-Mighty_Function-01_IamRole_590EA29B.arn}\\",
-        \\"runtime\\": \\"nodejs18.x\\",
-        \\"s3_bucket\\": \\"\${aws_s3_bucket.Code.bucket}\\",
-        \\"s3_key\\": \\"\${aws_s3_object.The-Mighty_Function-01_S3Object_4181DCAE.key}\\",
-        \\"timeout\\": 30,
-        \\"vpc_config\\": {
-          \\"security_group_ids\\": [],
-          \\"subnet_ids\\": []
-        }
-      }
+        "function_name": "The-Mighty_Function-01-c86057f3",
+        "handler": "index.handler",
+        "publish": true,
+        "role": "\${aws_iam_role.The-Mighty_Function-01_IamRole_590EA29B.arn}",
+        "runtime": "nodejs18.x",
+        "s3_bucket": "\${aws_s3_bucket.Code.bucket}",
+        "s3_key": "\${aws_s3_object.The-Mighty_Function-01_S3Object_4181DCAE.key}",
+        "timeout": 30,
+        "vpc_config": {
+          "security_group_ids": [],
+          "subnet_ids": [],
+        },
+      },
     },
-    \\"aws_s3_bucket\\": {
-      \\"Code\\": {
-        \\"bucket_prefix\\": \\"code-c84a50b1-\\"
-      }
+    "aws_s3_bucket": {
+      "Code": {
+        "bucket_prefix": "code-c84a50b1-",
+      },
     },
-    \\"aws_s3_object\\": {
-      \\"The-Mighty_Function-01_S3Object_4181DCAE\\": {
-        \\"bucket\\": \\"\${aws_s3_bucket.Code.bucket}\\",
-        \\"key\\": \\"<key>\\",
-        \\"source\\": \\"<source>\\"
-      }
-    }
-  }
-}"
+    "aws_s3_object": {
+      "The-Mighty_Function-01_S3Object_4181DCAE": {
+        "bucket": "\${aws_s3_bucket.Code.bucket}",
+        "key": "<key>",
+        "source": "<source>",
+      },
+    },
+  },
+}
 `;
 
 exports[`function name valid 2`] = `
@@ -1149,65 +1149,65 @@ exports[`function name valid 2`] = `
 `;
 
 exports[`replace invalid character from function name 1`] = `
-"{
-  \\"output\\": {
-    \\"WING_TEST_RUNNER_FUNCTION_ARNS\\": {
-      \\"value\\": \\"[]\\"
-    }
+{
+  "output": {
+    "WING_TEST_RUNNER_FUNCTION_ARNS": {
+      "value": "[]",
+    },
   },
-  \\"resource\\": {
-    \\"aws_iam_role\\": {
-      \\"TheMightyFunction_IamRole_5421E649\\": {
-        \\"assume_role_policy\\": \\"{\\\\\\"Version\\\\\\":\\\\\\"2012-10-17\\\\\\",\\\\\\"Statement\\\\\\":[{\\\\\\"Action\\\\\\":\\\\\\"sts:AssumeRole\\\\\\",\\\\\\"Principal\\\\\\":{\\\\\\"Service\\\\\\":\\\\\\"lambda.amazonaws.com\\\\\\"},\\\\\\"Effect\\\\\\":\\\\\\"Allow\\\\\\"}]}\\"
-      }
+  "resource": {
+    "aws_iam_role": {
+      "TheMightyFunction_IamRole_5421E649": {
+        "assume_role_policy": "{\\"Version\\":\\"2012-10-17\\",\\"Statement\\":[{\\"Action\\":\\"sts:AssumeRole\\",\\"Principal\\":{\\"Service\\":\\"lambda.amazonaws.com\\"},\\"Effect\\":\\"Allow\\"}]}",
+      },
     },
-    \\"aws_iam_role_policy\\": {
-      \\"TheMightyFunction_IamRolePolicy_B7246118\\": {
-        \\"policy\\": \\"{\\\\\\"Version\\\\\\":\\\\\\"2012-10-17\\\\\\",\\\\\\"Statement\\\\\\":[{\\\\\\"Effect\\\\\\":\\\\\\"Allow\\\\\\",\\\\\\"Action\\\\\\":\\\\\\"none:null\\\\\\",\\\\\\"Resource\\\\\\":\\\\\\"*\\\\\\"}]}\\",
-        \\"role\\": \\"\${aws_iam_role.TheMightyFunction_IamRole_5421E649.name}\\"
-      }
+    "aws_iam_role_policy": {
+      "TheMightyFunction_IamRolePolicy_B7246118": {
+        "policy": "{\\"Version\\":\\"2012-10-17\\",\\"Statement\\":[{\\"Effect\\":\\"Allow\\",\\"Action\\":\\"none:null\\",\\"Resource\\":\\"*\\"}]}",
+        "role": "\${aws_iam_role.TheMightyFunction_IamRole_5421E649.name}",
+      },
     },
-    \\"aws_iam_role_policy_attachment\\": {
-      \\"TheMightyFunction_IamRolePolicyAttachment_FD664B8E\\": {
-        \\"policy_arn\\": \\"arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole\\",
-        \\"role\\": \\"\${aws_iam_role.TheMightyFunction_IamRole_5421E649.name}\\"
-      }
+    "aws_iam_role_policy_attachment": {
+      "TheMightyFunction_IamRolePolicyAttachment_FD664B8E": {
+        "policy_arn": "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+        "role": "\${aws_iam_role.TheMightyFunction_IamRole_5421E649.name}",
+      },
     },
-    \\"aws_lambda_function\\": {
-      \\"TheMightyFunction\\": {
-        \\"environment\\": {
-          \\"variables\\": {
-            \\"WING_FUNCTION_NAME\\": \\"The-Mighty-Function-c86ccf73\\"
-          }
+    "aws_lambda_function": {
+      "TheMightyFunction": {
+        "environment": {
+          "variables": {
+            "WING_FUNCTION_NAME": "The-Mighty-Function-c86ccf73",
+          },
         },
-        \\"function_name\\": \\"The-Mighty-Function-c86ccf73\\",
-        \\"handler\\": \\"index.handler\\",
-        \\"publish\\": true,
-        \\"role\\": \\"\${aws_iam_role.TheMightyFunction_IamRole_5421E649.arn}\\",
-        \\"runtime\\": \\"nodejs18.x\\",
-        \\"s3_bucket\\": \\"\${aws_s3_bucket.Code.bucket}\\",
-        \\"s3_key\\": \\"\${aws_s3_object.TheMightyFunction_S3Object_51333814.key}\\",
-        \\"timeout\\": 30,
-        \\"vpc_config\\": {
-          \\"security_group_ids\\": [],
-          \\"subnet_ids\\": []
-        }
-      }
+        "function_name": "The-Mighty-Function-c86ccf73",
+        "handler": "index.handler",
+        "publish": true,
+        "role": "\${aws_iam_role.TheMightyFunction_IamRole_5421E649.arn}",
+        "runtime": "nodejs18.x",
+        "s3_bucket": "\${aws_s3_bucket.Code.bucket}",
+        "s3_key": "\${aws_s3_object.TheMightyFunction_S3Object_51333814.key}",
+        "timeout": 30,
+        "vpc_config": {
+          "security_group_ids": [],
+          "subnet_ids": [],
+        },
+      },
     },
-    \\"aws_s3_bucket\\": {
-      \\"Code\\": {
-        \\"bucket_prefix\\": \\"code-c84a50b1-\\"
-      }
+    "aws_s3_bucket": {
+      "Code": {
+        "bucket_prefix": "code-c84a50b1-",
+      },
     },
-    \\"aws_s3_object\\": {
-      \\"TheMightyFunction_S3Object_51333814\\": {
-        \\"bucket\\": \\"\${aws_s3_bucket.Code.bucket}\\",
-        \\"key\\": \\"<key>\\",
-        \\"source\\": \\"<source>\\"
-      }
-    }
-  }
-}"
+    "aws_s3_object": {
+      "TheMightyFunction_S3Object_51333814": {
+        "bucket": "\${aws_s3_bucket.Code.bucket}",
+        "key": "<key>",
+        "source": "<source>",
+      },
+    },
+  },
+}
 `;
 
 exports[`replace invalid character from function name 2`] = `

--- a/libs/wingsdk/test/target-tf-aws/__snapshots__/logger.test.ts.snap
+++ b/libs/wingsdk/test/target-tf-aws/__snapshots__/logger.test.ts.snap
@@ -18,63 +18,63 @@ return class Handler {
 `;
 
 exports[`inflight function uses a logger 2`] = `
-"{
-  \\"output\\": {
-    \\"WING_TEST_RUNNER_FUNCTION_ARNS\\": {
-      \\"value\\": \\"[]\\"
-    }
+{
+  "output": {
+    "WING_TEST_RUNNER_FUNCTION_ARNS": {
+      "value": "[]",
+    },
   },
-  \\"resource\\": {
-    \\"aws_iam_role\\": {
-      \\"Function_IamRole_678BE84C\\": {
-        \\"assume_role_policy\\": \\"{\\\\\\"Version\\\\\\":\\\\\\"2012-10-17\\\\\\",\\\\\\"Statement\\\\\\":[{\\\\\\"Action\\\\\\":\\\\\\"sts:AssumeRole\\\\\\",\\\\\\"Principal\\\\\\":{\\\\\\"Service\\\\\\":\\\\\\"lambda.amazonaws.com\\\\\\"},\\\\\\"Effect\\\\\\":\\\\\\"Allow\\\\\\"}]}\\"
-      }
+  "resource": {
+    "aws_iam_role": {
+      "Function_IamRole_678BE84C": {
+        "assume_role_policy": "{\\"Version\\":\\"2012-10-17\\",\\"Statement\\":[{\\"Action\\":\\"sts:AssumeRole\\",\\"Principal\\":{\\"Service\\":\\"lambda.amazonaws.com\\"},\\"Effect\\":\\"Allow\\"}]}",
+      },
     },
-    \\"aws_iam_role_policy\\": {
-      \\"Function_IamRolePolicy_E3B26607\\": {
-        \\"policy\\": \\"{\\\\\\"Version\\\\\\":\\\\\\"2012-10-17\\\\\\",\\\\\\"Statement\\\\\\":[{\\\\\\"Effect\\\\\\":\\\\\\"Allow\\\\\\",\\\\\\"Action\\\\\\":\\\\\\"none:null\\\\\\",\\\\\\"Resource\\\\\\":\\\\\\"*\\\\\\"}]}\\",
-        \\"role\\": \\"\${aws_iam_role.Function_IamRole_678BE84C.name}\\"
-      }
+    "aws_iam_role_policy": {
+      "Function_IamRolePolicy_E3B26607": {
+        "policy": "{\\"Version\\":\\"2012-10-17\\",\\"Statement\\":[{\\"Effect\\":\\"Allow\\",\\"Action\\":\\"none:null\\",\\"Resource\\":\\"*\\"}]}",
+        "role": "\${aws_iam_role.Function_IamRole_678BE84C.name}",
+      },
     },
-    \\"aws_iam_role_policy_attachment\\": {
-      \\"Function_IamRolePolicyAttachment_CACE1358\\": {
-        \\"policy_arn\\": \\"arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole\\",
-        \\"role\\": \\"\${aws_iam_role.Function_IamRole_678BE84C.name}\\"
-      }
+    "aws_iam_role_policy_attachment": {
+      "Function_IamRolePolicyAttachment_CACE1358": {
+        "policy_arn": "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+        "role": "\${aws_iam_role.Function_IamRole_678BE84C.name}",
+      },
     },
-    \\"aws_lambda_function\\": {
-      \\"Function\\": {
-        \\"environment\\": {
-          \\"variables\\": {
-            \\"WING_FUNCTION_NAME\\": \\"Function-c852aba6\\"
-          }
+    "aws_lambda_function": {
+      "Function": {
+        "environment": {
+          "variables": {
+            "WING_FUNCTION_NAME": "Function-c852aba6",
+          },
         },
-        \\"function_name\\": \\"Function-c852aba6\\",
-        \\"handler\\": \\"index.handler\\",
-        \\"publish\\": true,
-        \\"role\\": \\"\${aws_iam_role.Function_IamRole_678BE84C.arn}\\",
-        \\"runtime\\": \\"nodejs18.x\\",
-        \\"s3_bucket\\": \\"\${aws_s3_bucket.Code.bucket}\\",
-        \\"s3_key\\": \\"\${aws_s3_object.Function_S3Object_C62A0C2D.key}\\",
-        \\"timeout\\": 30,
-        \\"vpc_config\\": {
-          \\"security_group_ids\\": [],
-          \\"subnet_ids\\": []
-        }
-      }
+        "function_name": "Function-c852aba6",
+        "handler": "index.handler",
+        "publish": true,
+        "role": "\${aws_iam_role.Function_IamRole_678BE84C.arn}",
+        "runtime": "nodejs18.x",
+        "s3_bucket": "\${aws_s3_bucket.Code.bucket}",
+        "s3_key": "\${aws_s3_object.Function_S3Object_C62A0C2D.key}",
+        "timeout": 30,
+        "vpc_config": {
+          "security_group_ids": [],
+          "subnet_ids": [],
+        },
+      },
     },
-    \\"aws_s3_bucket\\": {
-      \\"Code\\": {
-        \\"bucket_prefix\\": \\"code-c84a50b1-\\"
-      }
+    "aws_s3_bucket": {
+      "Code": {
+        "bucket_prefix": "code-c84a50b1-",
+      },
     },
-    \\"aws_s3_object\\": {
-      \\"Function_S3Object_C62A0C2D\\": {
-        \\"bucket\\": \\"\${aws_s3_bucket.Code.bucket}\\",
-        \\"key\\": \\"<key>\\",
-        \\"source\\": \\"<source>\\"
-      }
-    }
-  }
-}"
+    "aws_s3_object": {
+      "Function_S3Object_C62A0C2D": {
+        "bucket": "\${aws_s3_bucket.Code.bucket}",
+        "key": "<key>",
+        "source": "<source>",
+      },
+    },
+  },
+}
 `;

--- a/libs/wingsdk/test/target-tf-aws/__snapshots__/on-deploy.test.ts.snap
+++ b/libs/wingsdk/test/target-tf-aws/__snapshots__/on-deploy.test.ts.snap
@@ -1,74 +1,74 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`create an OnDeploy 1`] = `
-"{
-  \\"data\\": {
-    \\"aws_lambda_invocation\\": {
-      \\"my_on_deploy_Invocation_1A26E3B9\\": {
-        \\"depends_on\\": [],
-        \\"function_name\\": \\"\${aws_lambda_function.my_on_deploy_Function_59669FC0.function_name}\\",
-        \\"input\\": \\"{}\\"
-      }
-    }
+{
+  "data": {
+    "aws_lambda_invocation": {
+      "my_on_deploy_Invocation_1A26E3B9": {
+        "depends_on": [],
+        "function_name": "\${aws_lambda_function.my_on_deploy_Function_59669FC0.function_name}",
+        "input": "{}",
+      },
+    },
   },
-  \\"output\\": {
-    \\"WING_TEST_RUNNER_FUNCTION_ARNS\\": {
-      \\"value\\": \\"[]\\"
-    }
+  "output": {
+    "WING_TEST_RUNNER_FUNCTION_ARNS": {
+      "value": "[]",
+    },
   },
-  \\"resource\\": {
-    \\"aws_iam_role\\": {
-      \\"my_on_deploy_Function_IamRole_76DF13CA\\": {
-        \\"assume_role_policy\\": \\"{\\\\\\"Version\\\\\\":\\\\\\"2012-10-17\\\\\\",\\\\\\"Statement\\\\\\":[{\\\\\\"Action\\\\\\":\\\\\\"sts:AssumeRole\\\\\\",\\\\\\"Principal\\\\\\":{\\\\\\"Service\\\\\\":\\\\\\"lambda.amazonaws.com\\\\\\"},\\\\\\"Effect\\\\\\":\\\\\\"Allow\\\\\\"}]}\\"
-      }
+  "resource": {
+    "aws_iam_role": {
+      "my_on_deploy_Function_IamRole_76DF13CA": {
+        "assume_role_policy": "{\\"Version\\":\\"2012-10-17\\",\\"Statement\\":[{\\"Action\\":\\"sts:AssumeRole\\",\\"Principal\\":{\\"Service\\":\\"lambda.amazonaws.com\\"},\\"Effect\\":\\"Allow\\"}]}",
+      },
     },
-    \\"aws_iam_role_policy\\": {
-      \\"my_on_deploy_Function_IamRolePolicy_AA6273E9\\": {
-        \\"policy\\": \\"{\\\\\\"Version\\\\\\":\\\\\\"2012-10-17\\\\\\",\\\\\\"Statement\\\\\\":[{\\\\\\"Effect\\\\\\":\\\\\\"Allow\\\\\\",\\\\\\"Action\\\\\\":\\\\\\"none:null\\\\\\",\\\\\\"Resource\\\\\\":\\\\\\"*\\\\\\"}]}\\",
-        \\"role\\": \\"\${aws_iam_role.my_on_deploy_Function_IamRole_76DF13CA.name}\\"
-      }
+    "aws_iam_role_policy": {
+      "my_on_deploy_Function_IamRolePolicy_AA6273E9": {
+        "policy": "{\\"Version\\":\\"2012-10-17\\",\\"Statement\\":[{\\"Effect\\":\\"Allow\\",\\"Action\\":\\"none:null\\",\\"Resource\\":\\"*\\"}]}",
+        "role": "\${aws_iam_role.my_on_deploy_Function_IamRole_76DF13CA.name}",
+      },
     },
-    \\"aws_iam_role_policy_attachment\\": {
-      \\"my_on_deploy_Function_IamRolePolicyAttachment_505E5C37\\": {
-        \\"policy_arn\\": \\"arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole\\",
-        \\"role\\": \\"\${aws_iam_role.my_on_deploy_Function_IamRole_76DF13CA.name}\\"
-      }
+    "aws_iam_role_policy_attachment": {
+      "my_on_deploy_Function_IamRolePolicyAttachment_505E5C37": {
+        "policy_arn": "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+        "role": "\${aws_iam_role.my_on_deploy_Function_IamRole_76DF13CA.name}",
+      },
     },
-    \\"aws_lambda_function\\": {
-      \\"my_on_deploy_Function_59669FC0\\": {
-        \\"environment\\": {
-          \\"variables\\": {
-            \\"WING_FUNCTION_NAME\\": \\"Function-c88c90bc\\"
-          }
+    "aws_lambda_function": {
+      "my_on_deploy_Function_59669FC0": {
+        "environment": {
+          "variables": {
+            "WING_FUNCTION_NAME": "Function-c88c90bc",
+          },
         },
-        \\"function_name\\": \\"Function-c88c90bc\\",
-        \\"handler\\": \\"index.handler\\",
-        \\"publish\\": true,
-        \\"role\\": \\"\${aws_iam_role.my_on_deploy_Function_IamRole_76DF13CA.arn}\\",
-        \\"runtime\\": \\"nodejs18.x\\",
-        \\"s3_bucket\\": \\"\${aws_s3_bucket.Code.bucket}\\",
-        \\"s3_key\\": \\"\${aws_s3_object.my_on_deploy_Function_S3Object_69D52AC4.key}\\",
-        \\"timeout\\": 30,
-        \\"vpc_config\\": {
-          \\"security_group_ids\\": [],
-          \\"subnet_ids\\": []
-        }
-      }
+        "function_name": "Function-c88c90bc",
+        "handler": "index.handler",
+        "publish": true,
+        "role": "\${aws_iam_role.my_on_deploy_Function_IamRole_76DF13CA.arn}",
+        "runtime": "nodejs18.x",
+        "s3_bucket": "\${aws_s3_bucket.Code.bucket}",
+        "s3_key": "\${aws_s3_object.my_on_deploy_Function_S3Object_69D52AC4.key}",
+        "timeout": 30,
+        "vpc_config": {
+          "security_group_ids": [],
+          "subnet_ids": [],
+        },
+      },
     },
-    \\"aws_s3_bucket\\": {
-      \\"Code\\": {
-        \\"bucket_prefix\\": \\"code-c84a50b1-\\"
-      }
+    "aws_s3_bucket": {
+      "Code": {
+        "bucket_prefix": "code-c84a50b1-",
+      },
     },
-    \\"aws_s3_object\\": {
-      \\"my_on_deploy_Function_S3Object_69D52AC4\\": {
-        \\"bucket\\": \\"\${aws_s3_bucket.Code.bucket}\\",
-        \\"key\\": \\"<key>\\",
-        \\"source\\": \\"<source>\\"
-      }
-    }
-  }
-}"
+    "aws_s3_object": {
+      "my_on_deploy_Function_S3Object_69D52AC4": {
+        "bucket": "\${aws_s3_bucket.Code.bucket}",
+        "key": "<key>",
+        "source": "<source>",
+      },
+    },
+  },
+}
 `;
 
 exports[`create an OnDeploy 2`] = `
@@ -264,103 +264,103 @@ exports[`create an OnDeploy 2`] = `
 `;
 
 exports[`execute OnDeploy after other resources 1`] = `
-"{
-  \\"data\\": {
-    \\"aws_lambda_invocation\\": {
-      \\"my_on_deploy_Invocation_1A26E3B9\\": {
-        \\"depends_on\\": [
-          \\"aws_s3_bucket.my_bucket\\",
-          \\"aws_s3_bucket_server_side_encryption_configuration.my_bucket_Encryption_3B1569A4\\",
-          \\"aws_s3_bucket_public_access_block.my_bucket_PublicAccessBlock_538547C0\\"
+{
+  "data": {
+    "aws_lambda_invocation": {
+      "my_on_deploy_Invocation_1A26E3B9": {
+        "depends_on": [
+          "aws_s3_bucket.my_bucket",
+          "aws_s3_bucket_server_side_encryption_configuration.my_bucket_Encryption_3B1569A4",
+          "aws_s3_bucket_public_access_block.my_bucket_PublicAccessBlock_538547C0",
         ],
-        \\"function_name\\": \\"\${aws_lambda_function.my_on_deploy_Function_59669FC0.function_name}\\",
-        \\"input\\": \\"{}\\"
-      }
-    }
-  },
-  \\"output\\": {
-    \\"WING_TEST_RUNNER_FUNCTION_ARNS\\": {
-      \\"value\\": \\"[]\\"
-    }
-  },
-  \\"resource\\": {
-    \\"aws_iam_role\\": {
-      \\"my_on_deploy_Function_IamRole_76DF13CA\\": {
-        \\"assume_role_policy\\": \\"{\\\\\\"Version\\\\\\":\\\\\\"2012-10-17\\\\\\",\\\\\\"Statement\\\\\\":[{\\\\\\"Action\\\\\\":\\\\\\"sts:AssumeRole\\\\\\",\\\\\\"Principal\\\\\\":{\\\\\\"Service\\\\\\":\\\\\\"lambda.amazonaws.com\\\\\\"},\\\\\\"Effect\\\\\\":\\\\\\"Allow\\\\\\"}]}\\"
-      }
-    },
-    \\"aws_iam_role_policy\\": {
-      \\"my_on_deploy_Function_IamRolePolicy_AA6273E9\\": {
-        \\"policy\\": \\"{\\\\\\"Version\\\\\\":\\\\\\"2012-10-17\\\\\\",\\\\\\"Statement\\\\\\":[{\\\\\\"Effect\\\\\\":\\\\\\"Allow\\\\\\",\\\\\\"Action\\\\\\":\\\\\\"none:null\\\\\\",\\\\\\"Resource\\\\\\":\\\\\\"*\\\\\\"}]}\\",
-        \\"role\\": \\"\${aws_iam_role.my_on_deploy_Function_IamRole_76DF13CA.name}\\"
-      }
-    },
-    \\"aws_iam_role_policy_attachment\\": {
-      \\"my_on_deploy_Function_IamRolePolicyAttachment_505E5C37\\": {
-        \\"policy_arn\\": \\"arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole\\",
-        \\"role\\": \\"\${aws_iam_role.my_on_deploy_Function_IamRole_76DF13CA.name}\\"
-      }
-    },
-    \\"aws_lambda_function\\": {
-      \\"my_on_deploy_Function_59669FC0\\": {
-        \\"environment\\": {
-          \\"variables\\": {
-            \\"WING_FUNCTION_NAME\\": \\"Function-c88c90bc\\"
-          }
-        },
-        \\"function_name\\": \\"Function-c88c90bc\\",
-        \\"handler\\": \\"index.handler\\",
-        \\"publish\\": true,
-        \\"role\\": \\"\${aws_iam_role.my_on_deploy_Function_IamRole_76DF13CA.arn}\\",
-        \\"runtime\\": \\"nodejs18.x\\",
-        \\"s3_bucket\\": \\"\${aws_s3_bucket.Code.bucket}\\",
-        \\"s3_key\\": \\"\${aws_s3_object.my_on_deploy_Function_S3Object_69D52AC4.key}\\",
-        \\"timeout\\": 30,
-        \\"vpc_config\\": {
-          \\"security_group_ids\\": [],
-          \\"subnet_ids\\": []
-        }
-      }
-    },
-    \\"aws_s3_bucket\\": {
-      \\"Code\\": {
-        \\"bucket_prefix\\": \\"code-c84a50b1-\\"
+        "function_name": "\${aws_lambda_function.my_on_deploy_Function_59669FC0.function_name}",
+        "input": "{}",
       },
-      \\"my_bucket\\": {
-        \\"bucket_prefix\\": \\"my-bucket-c8045fcc-\\",
-        \\"force_destroy\\": false
-      }
     },
-    \\"aws_s3_bucket_public_access_block\\": {
-      \\"my_bucket_PublicAccessBlock_538547C0\\": {
-        \\"block_public_acls\\": true,
-        \\"block_public_policy\\": true,
-        \\"bucket\\": \\"\${aws_s3_bucket.my_bucket.bucket}\\",
-        \\"ignore_public_acls\\": true,
-        \\"restrict_public_buckets\\": true
-      }
+  },
+  "output": {
+    "WING_TEST_RUNNER_FUNCTION_ARNS": {
+      "value": "[]",
     },
-    \\"aws_s3_bucket_server_side_encryption_configuration\\": {
-      \\"my_bucket_Encryption_3B1569A4\\": {
-        \\"bucket\\": \\"\${aws_s3_bucket.my_bucket.bucket}\\",
-        \\"rule\\": [
+  },
+  "resource": {
+    "aws_iam_role": {
+      "my_on_deploy_Function_IamRole_76DF13CA": {
+        "assume_role_policy": "{\\"Version\\":\\"2012-10-17\\",\\"Statement\\":[{\\"Action\\":\\"sts:AssumeRole\\",\\"Principal\\":{\\"Service\\":\\"lambda.amazonaws.com\\"},\\"Effect\\":\\"Allow\\"}]}",
+      },
+    },
+    "aws_iam_role_policy": {
+      "my_on_deploy_Function_IamRolePolicy_AA6273E9": {
+        "policy": "{\\"Version\\":\\"2012-10-17\\",\\"Statement\\":[{\\"Effect\\":\\"Allow\\",\\"Action\\":\\"none:null\\",\\"Resource\\":\\"*\\"}]}",
+        "role": "\${aws_iam_role.my_on_deploy_Function_IamRole_76DF13CA.name}",
+      },
+    },
+    "aws_iam_role_policy_attachment": {
+      "my_on_deploy_Function_IamRolePolicyAttachment_505E5C37": {
+        "policy_arn": "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+        "role": "\${aws_iam_role.my_on_deploy_Function_IamRole_76DF13CA.name}",
+      },
+    },
+    "aws_lambda_function": {
+      "my_on_deploy_Function_59669FC0": {
+        "environment": {
+          "variables": {
+            "WING_FUNCTION_NAME": "Function-c88c90bc",
+          },
+        },
+        "function_name": "Function-c88c90bc",
+        "handler": "index.handler",
+        "publish": true,
+        "role": "\${aws_iam_role.my_on_deploy_Function_IamRole_76DF13CA.arn}",
+        "runtime": "nodejs18.x",
+        "s3_bucket": "\${aws_s3_bucket.Code.bucket}",
+        "s3_key": "\${aws_s3_object.my_on_deploy_Function_S3Object_69D52AC4.key}",
+        "timeout": 30,
+        "vpc_config": {
+          "security_group_ids": [],
+          "subnet_ids": [],
+        },
+      },
+    },
+    "aws_s3_bucket": {
+      "Code": {
+        "bucket_prefix": "code-c84a50b1-",
+      },
+      "my_bucket": {
+        "bucket_prefix": "my-bucket-c8045fcc-",
+        "force_destroy": false,
+      },
+    },
+    "aws_s3_bucket_public_access_block": {
+      "my_bucket_PublicAccessBlock_538547C0": {
+        "block_public_acls": true,
+        "block_public_policy": true,
+        "bucket": "\${aws_s3_bucket.my_bucket.bucket}",
+        "ignore_public_acls": true,
+        "restrict_public_buckets": true,
+      },
+    },
+    "aws_s3_bucket_server_side_encryption_configuration": {
+      "my_bucket_Encryption_3B1569A4": {
+        "bucket": "\${aws_s3_bucket.my_bucket.bucket}",
+        "rule": [
           {
-            \\"apply_server_side_encryption_by_default\\": {
-              \\"sse_algorithm\\": \\"AES256\\"
-            }
-          }
-        ]
-      }
+            "apply_server_side_encryption_by_default": {
+              "sse_algorithm": "AES256",
+            },
+          },
+        ],
+      },
     },
-    \\"aws_s3_object\\": {
-      \\"my_on_deploy_Function_S3Object_69D52AC4\\": {
-        \\"bucket\\": \\"\${aws_s3_bucket.Code.bucket}\\",
-        \\"key\\": \\"<key>\\",
-        \\"source\\": \\"<source>\\"
-      }
-    }
-  }
-}"
+    "aws_s3_object": {
+      "my_on_deploy_Function_S3Object_69D52AC4": {
+        "bucket": "\${aws_s3_bucket.Code.bucket}",
+        "key": "<key>",
+        "source": "<source>",
+      },
+    },
+  },
+}
 `;
 
 exports[`execute OnDeploy after other resources 2`] = `
@@ -597,108 +597,108 @@ exports[`execute OnDeploy after other resources 2`] = `
 `;
 
 exports[`execute OnDeploy before other resources 1`] = `
-"{
-  \\"data\\": {
-    \\"aws_lambda_invocation\\": {
-      \\"my_on_deploy_Invocation_1A26E3B9\\": {
-        \\"depends_on\\": [],
-        \\"function_name\\": \\"\${aws_lambda_function.my_on_deploy_Function_59669FC0.function_name}\\",
-        \\"input\\": \\"{}\\"
-      }
-    }
-  },
-  \\"output\\": {
-    \\"WING_TEST_RUNNER_FUNCTION_ARNS\\": {
-      \\"value\\": \\"[]\\"
-    }
-  },
-  \\"resource\\": {
-    \\"aws_iam_role\\": {
-      \\"my_on_deploy_Function_IamRole_76DF13CA\\": {
-        \\"assume_role_policy\\": \\"{\\\\\\"Version\\\\\\":\\\\\\"2012-10-17\\\\\\",\\\\\\"Statement\\\\\\":[{\\\\\\"Action\\\\\\":\\\\\\"sts:AssumeRole\\\\\\",\\\\\\"Principal\\\\\\":{\\\\\\"Service\\\\\\":\\\\\\"lambda.amazonaws.com\\\\\\"},\\\\\\"Effect\\\\\\":\\\\\\"Allow\\\\\\"}]}\\"
-      }
-    },
-    \\"aws_iam_role_policy\\": {
-      \\"my_on_deploy_Function_IamRolePolicy_AA6273E9\\": {
-        \\"policy\\": \\"{\\\\\\"Version\\\\\\":\\\\\\"2012-10-17\\\\\\",\\\\\\"Statement\\\\\\":[{\\\\\\"Effect\\\\\\":\\\\\\"Allow\\\\\\",\\\\\\"Action\\\\\\":\\\\\\"none:null\\\\\\",\\\\\\"Resource\\\\\\":\\\\\\"*\\\\\\"}]}\\",
-        \\"role\\": \\"\${aws_iam_role.my_on_deploy_Function_IamRole_76DF13CA.name}\\"
-      }
-    },
-    \\"aws_iam_role_policy_attachment\\": {
-      \\"my_on_deploy_Function_IamRolePolicyAttachment_505E5C37\\": {
-        \\"policy_arn\\": \\"arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole\\",
-        \\"role\\": \\"\${aws_iam_role.my_on_deploy_Function_IamRole_76DF13CA.name}\\"
-      }
-    },
-    \\"aws_lambda_function\\": {
-      \\"my_on_deploy_Function_59669FC0\\": {
-        \\"environment\\": {
-          \\"variables\\": {
-            \\"WING_FUNCTION_NAME\\": \\"Function-c88c90bc\\"
-          }
-        },
-        \\"function_name\\": \\"Function-c88c90bc\\",
-        \\"handler\\": \\"index.handler\\",
-        \\"publish\\": true,
-        \\"role\\": \\"\${aws_iam_role.my_on_deploy_Function_IamRole_76DF13CA.arn}\\",
-        \\"runtime\\": \\"nodejs18.x\\",
-        \\"s3_bucket\\": \\"\${aws_s3_bucket.Code.bucket}\\",
-        \\"s3_key\\": \\"\${aws_s3_object.my_on_deploy_Function_S3Object_69D52AC4.key}\\",
-        \\"timeout\\": 30,
-        \\"vpc_config\\": {
-          \\"security_group_ids\\": [],
-          \\"subnet_ids\\": []
-        }
-      }
-    },
-    \\"aws_s3_bucket\\": {
-      \\"Code\\": {
-        \\"bucket_prefix\\": \\"code-c84a50b1-\\"
+{
+  "data": {
+    "aws_lambda_invocation": {
+      "my_on_deploy_Invocation_1A26E3B9": {
+        "depends_on": [],
+        "function_name": "\${aws_lambda_function.my_on_deploy_Function_59669FC0.function_name}",
+        "input": "{}",
       },
-      \\"my_bucket\\": {
-        \\"bucket_prefix\\": \\"my-bucket-c8045fcc-\\",
-        \\"depends_on\\": [
-          \\"\${data.aws_lambda_invocation.my_on_deploy_Invocation_1A26E3B9}\\"
-        ],
-        \\"force_destroy\\": false
-      }
     },
-    \\"aws_s3_bucket_public_access_block\\": {
-      \\"my_bucket_PublicAccessBlock_538547C0\\": {
-        \\"block_public_acls\\": true,
-        \\"block_public_policy\\": true,
-        \\"bucket\\": \\"\${aws_s3_bucket.my_bucket.bucket}\\",
-        \\"depends_on\\": [
-          \\"\${data.aws_lambda_invocation.my_on_deploy_Invocation_1A26E3B9}\\"
-        ],
-        \\"ignore_public_acls\\": true,
-        \\"restrict_public_buckets\\": true
-      }
+  },
+  "output": {
+    "WING_TEST_RUNNER_FUNCTION_ARNS": {
+      "value": "[]",
     },
-    \\"aws_s3_bucket_server_side_encryption_configuration\\": {
-      \\"my_bucket_Encryption_3B1569A4\\": {
-        \\"bucket\\": \\"\${aws_s3_bucket.my_bucket.bucket}\\",
-        \\"depends_on\\": [
-          \\"\${data.aws_lambda_invocation.my_on_deploy_Invocation_1A26E3B9}\\"
+  },
+  "resource": {
+    "aws_iam_role": {
+      "my_on_deploy_Function_IamRole_76DF13CA": {
+        "assume_role_policy": "{\\"Version\\":\\"2012-10-17\\",\\"Statement\\":[{\\"Action\\":\\"sts:AssumeRole\\",\\"Principal\\":{\\"Service\\":\\"lambda.amazonaws.com\\"},\\"Effect\\":\\"Allow\\"}]}",
+      },
+    },
+    "aws_iam_role_policy": {
+      "my_on_deploy_Function_IamRolePolicy_AA6273E9": {
+        "policy": "{\\"Version\\":\\"2012-10-17\\",\\"Statement\\":[{\\"Effect\\":\\"Allow\\",\\"Action\\":\\"none:null\\",\\"Resource\\":\\"*\\"}]}",
+        "role": "\${aws_iam_role.my_on_deploy_Function_IamRole_76DF13CA.name}",
+      },
+    },
+    "aws_iam_role_policy_attachment": {
+      "my_on_deploy_Function_IamRolePolicyAttachment_505E5C37": {
+        "policy_arn": "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+        "role": "\${aws_iam_role.my_on_deploy_Function_IamRole_76DF13CA.name}",
+      },
+    },
+    "aws_lambda_function": {
+      "my_on_deploy_Function_59669FC0": {
+        "environment": {
+          "variables": {
+            "WING_FUNCTION_NAME": "Function-c88c90bc",
+          },
+        },
+        "function_name": "Function-c88c90bc",
+        "handler": "index.handler",
+        "publish": true,
+        "role": "\${aws_iam_role.my_on_deploy_Function_IamRole_76DF13CA.arn}",
+        "runtime": "nodejs18.x",
+        "s3_bucket": "\${aws_s3_bucket.Code.bucket}",
+        "s3_key": "\${aws_s3_object.my_on_deploy_Function_S3Object_69D52AC4.key}",
+        "timeout": 30,
+        "vpc_config": {
+          "security_group_ids": [],
+          "subnet_ids": [],
+        },
+      },
+    },
+    "aws_s3_bucket": {
+      "Code": {
+        "bucket_prefix": "code-c84a50b1-",
+      },
+      "my_bucket": {
+        "bucket_prefix": "my-bucket-c8045fcc-",
+        "depends_on": [
+          "\${data.aws_lambda_invocation.my_on_deploy_Invocation_1A26E3B9}",
         ],
-        \\"rule\\": [
+        "force_destroy": false,
+      },
+    },
+    "aws_s3_bucket_public_access_block": {
+      "my_bucket_PublicAccessBlock_538547C0": {
+        "block_public_acls": true,
+        "block_public_policy": true,
+        "bucket": "\${aws_s3_bucket.my_bucket.bucket}",
+        "depends_on": [
+          "\${data.aws_lambda_invocation.my_on_deploy_Invocation_1A26E3B9}",
+        ],
+        "ignore_public_acls": true,
+        "restrict_public_buckets": true,
+      },
+    },
+    "aws_s3_bucket_server_side_encryption_configuration": {
+      "my_bucket_Encryption_3B1569A4": {
+        "bucket": "\${aws_s3_bucket.my_bucket.bucket}",
+        "depends_on": [
+          "\${data.aws_lambda_invocation.my_on_deploy_Invocation_1A26E3B9}",
+        ],
+        "rule": [
           {
-            \\"apply_server_side_encryption_by_default\\": {
-              \\"sse_algorithm\\": \\"AES256\\"
-            }
-          }
-        ]
-      }
+            "apply_server_side_encryption_by_default": {
+              "sse_algorithm": "AES256",
+            },
+          },
+        ],
+      },
     },
-    \\"aws_s3_object\\": {
-      \\"my_on_deploy_Function_S3Object_69D52AC4\\": {
-        \\"bucket\\": \\"\${aws_s3_bucket.Code.bucket}\\",
-        \\"key\\": \\"<key>\\",
-        \\"source\\": \\"<source>\\"
-      }
-    }
-  }
-}"
+    "aws_s3_object": {
+      "my_on_deploy_Function_S3Object_69D52AC4": {
+        "bucket": "\${aws_s3_bucket.Code.bucket}",
+        "key": "<key>",
+        "source": "<source>",
+      },
+    },
+  },
+}
 `;
 
 exports[`execute OnDeploy before other resources 2`] = `

--- a/libs/wingsdk/test/target-tf-aws/__snapshots__/queue.test.ts.snap
+++ b/libs/wingsdk/test/target-tf-aws/__snapshots__/queue.test.ts.snap
@@ -1,20 +1,20 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`default queue behavior 1`] = `
-"{
-  \\"output\\": {
-    \\"WING_TEST_RUNNER_FUNCTION_ARNS\\": {
-      \\"value\\": \\"[]\\"
-    }
+{
+  "output": {
+    "WING_TEST_RUNNER_FUNCTION_ARNS": {
+      "value": "[]",
+    },
   },
-  \\"resource\\": {
-    \\"aws_sqs_queue\\": {
-      \\"Queue\\": {
-        \\"name\\": \\"Queue-c822c726\\"
-      }
-    }
-  }
-}"
+  "resource": {
+    "aws_sqs_queue": {
+      "Queue": {
+        "name": "Queue-c822c726",
+      },
+    },
+  },
+}
 `;
 
 exports[`default queue behavior 2`] = `
@@ -121,20 +121,20 @@ exports[`default queue behavior 2`] = `
 `;
 
 exports[`queue name valid 1`] = `
-"{
-  \\"output\\": {
-    \\"WING_TEST_RUNNER_FUNCTION_ARNS\\": {
-      \\"value\\": \\"[]\\"
-    }
+{
+  "output": {
+    "WING_TEST_RUNNER_FUNCTION_ARNS": {
+      "value": "[]",
+    },
   },
-  \\"resource\\": {
-    \\"aws_sqs_queue\\": {
-      \\"The-Incredible_Queue-01\\": {
-        \\"name\\": \\"The-Incredible_Queue-01-c8d1a14d\\"
-      }
-    }
-  }
-}"
+  "resource": {
+    "aws_sqs_queue": {
+      "The-Incredible_Queue-01": {
+        "name": "The-Incredible_Queue-01-c8d1a14d",
+      },
+    },
+  },
+}
 `;
 
 exports[`queue name valid 2`] = `
@@ -243,78 +243,78 @@ exports[`queue name valid 2`] = `
 exports[`queue with a consumer function 1`] = `"new (require(\\"[REDACTED]/wingsdk/src/shared-aws/function.inflight\\")).FunctionClient(process.env[\\"FUNCTION_NAME_75ee4dfb\\"], \\"root/Default/Queue-SetConsumer-c5395e41\\")"`;
 
 exports[`queue with a consumer function 2`] = `
-"{
-  \\"output\\": {
-    \\"WING_TEST_RUNNER_FUNCTION_ARNS\\": {
-      \\"value\\": \\"[]\\"
-    }
+{
+  "output": {
+    "WING_TEST_RUNNER_FUNCTION_ARNS": {
+      "value": "[]",
+    },
   },
-  \\"resource\\": {
-    \\"aws_iam_role\\": {
-      \\"Queue-SetConsumer-c5395e41_IamRole_75E61A87\\": {
-        \\"assume_role_policy\\": \\"{\\\\\\"Version\\\\\\":\\\\\\"2012-10-17\\\\\\",\\\\\\"Statement\\\\\\":[{\\\\\\"Action\\\\\\":\\\\\\"sts:AssumeRole\\\\\\",\\\\\\"Principal\\\\\\":{\\\\\\"Service\\\\\\":\\\\\\"lambda.amazonaws.com\\\\\\"},\\\\\\"Effect\\\\\\":\\\\\\"Allow\\\\\\"}]}\\"
-      }
+  "resource": {
+    "aws_iam_role": {
+      "Queue-SetConsumer-c5395e41_IamRole_75E61A87": {
+        "assume_role_policy": "{\\"Version\\":\\"2012-10-17\\",\\"Statement\\":[{\\"Action\\":\\"sts:AssumeRole\\",\\"Principal\\":{\\"Service\\":\\"lambda.amazonaws.com\\"},\\"Effect\\":\\"Allow\\"}]}",
+      },
     },
-    \\"aws_iam_role_policy\\": {
-      \\"Queue-SetConsumer-c5395e41_IamRolePolicy_489AB5A9\\": {
-        \\"policy\\": \\"{\\\\\\"Version\\\\\\":\\\\\\"2012-10-17\\\\\\",\\\\\\"Statement\\\\\\":[{\\\\\\"Action\\\\\\":[\\\\\\"sqs:ReceiveMessage\\\\\\",\\\\\\"sqs:ChangeMessageVisibility\\\\\\",\\\\\\"sqs:GetQueueUrl\\\\\\",\\\\\\"sqs:DeleteMessage\\\\\\",\\\\\\"sqs:GetQueueAttributes\\\\\\"],\\\\\\"Resource\\\\\\":[\\\\\\"\${aws_sqs_queue.Queue.arn}\\\\\\"],\\\\\\"Effect\\\\\\":\\\\\\"Allow\\\\\\"}]}\\",
-        \\"role\\": \\"\${aws_iam_role.Queue-SetConsumer-c5395e41_IamRole_75E61A87.name}\\"
-      }
+    "aws_iam_role_policy": {
+      "Queue-SetConsumer-c5395e41_IamRolePolicy_489AB5A9": {
+        "policy": "{\\"Version\\":\\"2012-10-17\\",\\"Statement\\":[{\\"Action\\":[\\"sqs:ReceiveMessage\\",\\"sqs:ChangeMessageVisibility\\",\\"sqs:GetQueueUrl\\",\\"sqs:DeleteMessage\\",\\"sqs:GetQueueAttributes\\"],\\"Resource\\":[\\"\${aws_sqs_queue.Queue.arn}\\"],\\"Effect\\":\\"Allow\\"}]}",
+        "role": "\${aws_iam_role.Queue-SetConsumer-c5395e41_IamRole_75E61A87.name}",
+      },
     },
-    \\"aws_iam_role_policy_attachment\\": {
-      \\"Queue-SetConsumer-c5395e41_IamRolePolicyAttachment_FD666537\\": {
-        \\"policy_arn\\": \\"arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole\\",
-        \\"role\\": \\"\${aws_iam_role.Queue-SetConsumer-c5395e41_IamRole_75E61A87.name}\\"
-      }
+    "aws_iam_role_policy_attachment": {
+      "Queue-SetConsumer-c5395e41_IamRolePolicyAttachment_FD666537": {
+        "policy_arn": "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+        "role": "\${aws_iam_role.Queue-SetConsumer-c5395e41_IamRole_75E61A87.name}",
+      },
     },
-    \\"aws_lambda_event_source_mapping\\": {
-      \\"Queue_EventSourceMapping_8332F7DC\\": {
-        \\"batch_size\\": 1,
-        \\"event_source_arn\\": \\"\${aws_sqs_queue.Queue.arn}\\",
-        \\"function_name\\": \\"\${aws_lambda_function.Queue-SetConsumer-c5395e41.function_name}\\"
-      }
+    "aws_lambda_event_source_mapping": {
+      "Queue_EventSourceMapping_8332F7DC": {
+        "batch_size": 1,
+        "event_source_arn": "\${aws_sqs_queue.Queue.arn}",
+        "function_name": "\${aws_lambda_function.Queue-SetConsumer-c5395e41.function_name}",
+      },
     },
-    \\"aws_lambda_function\\": {
-      \\"Queue-SetConsumer-c5395e41\\": {
-        \\"environment\\": {
-          \\"variables\\": {
-            \\"WING_FUNCTION_NAME\\": \\"Queue-SetConsumer-c5395e41-c80c3bf7\\"
-          }
+    "aws_lambda_function": {
+      "Queue-SetConsumer-c5395e41": {
+        "environment": {
+          "variables": {
+            "WING_FUNCTION_NAME": "Queue-SetConsumer-c5395e41-c80c3bf7",
+          },
         },
-        \\"function_name\\": \\"Queue-SetConsumer-c5395e41-c80c3bf7\\",
-        \\"handler\\": \\"index.handler\\",
-        \\"publish\\": true,
-        \\"role\\": \\"\${aws_iam_role.Queue-SetConsumer-c5395e41_IamRole_75E61A87.arn}\\",
-        \\"runtime\\": \\"nodejs18.x\\",
-        \\"s3_bucket\\": \\"\${aws_s3_bucket.Code.bucket}\\",
-        \\"s3_key\\": \\"\${aws_s3_object.Queue-SetConsumer-c5395e41_S3Object_D8D7B631.key}\\",
-        \\"timeout\\": 30,
-        \\"vpc_config\\": {
-          \\"security_group_ids\\": [],
-          \\"subnet_ids\\": []
-        }
-      }
+        "function_name": "Queue-SetConsumer-c5395e41-c80c3bf7",
+        "handler": "index.handler",
+        "publish": true,
+        "role": "\${aws_iam_role.Queue-SetConsumer-c5395e41_IamRole_75E61A87.arn}",
+        "runtime": "nodejs18.x",
+        "s3_bucket": "\${aws_s3_bucket.Code.bucket}",
+        "s3_key": "\${aws_s3_object.Queue-SetConsumer-c5395e41_S3Object_D8D7B631.key}",
+        "timeout": 30,
+        "vpc_config": {
+          "security_group_ids": [],
+          "subnet_ids": [],
+        },
+      },
     },
-    \\"aws_s3_bucket\\": {
-      \\"Code\\": {
-        \\"bucket_prefix\\": \\"code-c84a50b1-\\"
-      }
+    "aws_s3_bucket": {
+      "Code": {
+        "bucket_prefix": "code-c84a50b1-",
+      },
     },
-    \\"aws_s3_object\\": {
-      \\"Queue-SetConsumer-c5395e41_S3Object_D8D7B631\\": {
-        \\"bucket\\": \\"\${aws_s3_bucket.Code.bucket}\\",
-        \\"key\\": \\"<key>\\",
-        \\"source\\": \\"<source>\\"
-      }
+    "aws_s3_object": {
+      "Queue-SetConsumer-c5395e41_S3Object_D8D7B631": {
+        "bucket": "\${aws_s3_bucket.Code.bucket}",
+        "key": "<key>",
+        "source": "<source>",
+      },
     },
-    \\"aws_sqs_queue\\": {
-      \\"Queue\\": {
-        \\"name\\": \\"Queue-c822c726\\",
-        \\"visibility_timeout_seconds\\": 30
-      }
-    }
-  }
-}"
+    "aws_sqs_queue": {
+      "Queue": {
+        "name": "Queue-c822c726",
+        "visibility_timeout_seconds": 30,
+      },
+    },
+  },
+}
 `;
 
 exports[`queue with a consumer function 3`] = `
@@ -571,21 +571,21 @@ exports[`queue with a consumer function 3`] = `
 `;
 
 exports[`queue with custom retention 1`] = `
-"{
-  \\"output\\": {
-    \\"WING_TEST_RUNNER_FUNCTION_ARNS\\": {
-      \\"value\\": \\"[]\\"
-    }
+{
+  "output": {
+    "WING_TEST_RUNNER_FUNCTION_ARNS": {
+      "value": "[]",
+    },
   },
-  \\"resource\\": {
-    \\"aws_sqs_queue\\": {
-      \\"Queue\\": {
-        \\"message_retention_seconds\\": 1800,
-        \\"name\\": \\"Queue-c822c726\\"
-      }
-    }
-  }
-}"
+  "resource": {
+    "aws_sqs_queue": {
+      "Queue": {
+        "message_retention_seconds": 1800,
+        "name": "Queue-c822c726",
+      },
+    },
+  },
+}
 `;
 
 exports[`queue with custom retention 2`] = `
@@ -692,21 +692,21 @@ exports[`queue with custom retention 2`] = `
 `;
 
 exports[`queue with custom timeout 1`] = `
-"{
-  \\"output\\": {
-    \\"WING_TEST_RUNNER_FUNCTION_ARNS\\": {
-      \\"value\\": \\"[]\\"
-    }
+{
+  "output": {
+    "WING_TEST_RUNNER_FUNCTION_ARNS": {
+      "value": "[]",
+    },
   },
-  \\"resource\\": {
-    \\"aws_sqs_queue\\": {
-      \\"Queue\\": {
-        \\"name\\": \\"Queue-c822c726\\",
-        \\"visibility_timeout_seconds\\": 30
-      }
-    }
-  }
-}"
+  "resource": {
+    "aws_sqs_queue": {
+      "Queue": {
+        "name": "Queue-c822c726",
+        "visibility_timeout_seconds": 30,
+      },
+    },
+  },
+}
 `;
 
 exports[`queue with custom timeout 2`] = `
@@ -813,20 +813,20 @@ exports[`queue with custom timeout 2`] = `
 `;
 
 exports[`replace invalid character from queue name 1`] = `
-"{
-  \\"output\\": {
-    \\"WING_TEST_RUNNER_FUNCTION_ARNS\\": {
-      \\"value\\": \\"[]\\"
-    }
+{
+  "output": {
+    "WING_TEST_RUNNER_FUNCTION_ARNS": {
+      "value": "[]",
+    },
   },
-  \\"resource\\": {
-    \\"aws_sqs_queue\\": {
-      \\"TheIncredibleQueue\\": {
-        \\"name\\": \\"The-Incredible-Queue-c8305287\\"
-      }
-    }
-  }
-}"
+  "resource": {
+    "aws_sqs_queue": {
+      "TheIncredibleQueue": {
+        "name": "The-Incredible-Queue-c8305287",
+      },
+    },
+  },
+}
 `;
 
 exports[`replace invalid character from queue name 2`] = `

--- a/libs/wingsdk/test/target-tf-aws/__snapshots__/redis.test.ts.snap
+++ b/libs/wingsdk/test/target-tf-aws/__snapshots__/redis.test.ts.snap
@@ -1,178 +1,178 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`When creating a Redis resource > should create an elasticache cluster and required vpc networking resources 1`] = `
-"{
-  \\"output\\": {
-    \\"WING_TEST_RUNNER_FUNCTION_ARNS\\": {
-      \\"value\\": \\"[]\\"
-    }
+{
+  "output": {
+    "WING_TEST_RUNNER_FUNCTION_ARNS": {
+      "value": "[]",
+    },
   },
-  \\"resource\\": {
-    \\"aws_eip\\": {
-      \\"EIP\\": {}
+  "resource": {
+    "aws_eip": {
+      "EIP": {},
     },
-    \\"aws_elasticache_cluster\\": {
-      \\"Redis_RedisCluster_F55D8A3B\\": {
-        \\"availability_zone\\": \\"\${aws_subnet.PrivateSubnet.availability_zone}\\",
-        \\"cluster_id\\": \\"redis-c8cdb969\\",
-        \\"engine\\": \\"redis\\",
-        \\"engine_version\\": \\"6.2\\",
-        \\"node_type\\": \\"cache.t4g.small\\",
-        \\"num_cache_nodes\\": 1,
-        \\"parameter_group_name\\": \\"default.redis6.x\\",
-        \\"security_group_ids\\": [
-          \\"\${aws_security_group.Redis_securityGroup_BE4B8855.id}\\"
+    "aws_elasticache_cluster": {
+      "Redis_RedisCluster_F55D8A3B": {
+        "availability_zone": "\${aws_subnet.PrivateSubnet.availability_zone}",
+        "cluster_id": "redis-c8cdb969",
+        "engine": "redis",
+        "engine_version": "6.2",
+        "node_type": "cache.t4g.small",
+        "num_cache_nodes": 1,
+        "parameter_group_name": "default.redis6.x",
+        "security_group_ids": [
+          "\${aws_security_group.Redis_securityGroup_BE4B8855.id}",
         ],
-        \\"subnet_group_name\\": \\"\${aws_elasticache_subnet_group.Redis_RedisSubnetGroup_E7D796E2.name}\\"
-      }
-    },
-    \\"aws_elasticache_subnet_group\\": {
-      \\"Redis_RedisSubnetGroup_E7D796E2\\": {
-        \\"name\\": \\"redis-c8cdb969-subnetGroup\\",
-        \\"subnet_ids\\": [
-          \\"\${aws_subnet.PrivateSubnet.id}\\"
-        ]
-      }
-    },
-    \\"aws_internet_gateway\\": {
-      \\"InternetGateway\\": {
-        \\"tags\\": {
-          \\"Name\\": \\"Default-c82bf964-internet-gateway\\"
-        },
-        \\"vpc_id\\": \\"\${aws_vpc.VPC.id}\\"
-      }
-    },
-    \\"aws_nat_gateway\\": {
-      \\"NATGateway\\": {
-        \\"allocation_id\\": \\"\${aws_eip.EIP.id}\\",
-        \\"subnet_id\\": \\"\${aws_subnet.PublicSubnet.id}\\",
-        \\"tags\\": {
-          \\"Name\\": \\"Default-c82bf964-nat-gateway\\"
-        }
-      }
-    },
-    \\"aws_route_table\\": {
-      \\"PrivateRouteTable\\": {
-        \\"route\\": [
-          {
-            \\"carrier_gateway_id\\": null,
-            \\"cidr_block\\": \\"0.0.0.0/0\\",
-            \\"core_network_arn\\": null,
-            \\"destination_prefix_list_id\\": null,
-            \\"egress_only_gateway_id\\": null,
-            \\"gateway_id\\": null,
-            \\"instance_id\\": null,
-            \\"ipv6_cidr_block\\": null,
-            \\"local_gateway_id\\": null,
-            \\"nat_gateway_id\\": \\"\${aws_nat_gateway.NATGateway.id}\\",
-            \\"network_interface_id\\": null,
-            \\"transit_gateway_id\\": null,
-            \\"vpc_endpoint_id\\": null,
-            \\"vpc_peering_connection_id\\": null
-          }
-        ],
-        \\"tags\\": {
-          \\"Name\\": \\"Default-c82bf964-private-route-table-1\\"
-        },
-        \\"vpc_id\\": \\"\${aws_vpc.VPC.id}\\"
+        "subnet_group_name": "\${aws_elasticache_subnet_group.Redis_RedisSubnetGroup_E7D796E2.name}",
       },
-      \\"PublicRouteTable\\": {
-        \\"route\\": [
-          {
-            \\"carrier_gateway_id\\": null,
-            \\"cidr_block\\": \\"0.0.0.0/0\\",
-            \\"core_network_arn\\": null,
-            \\"destination_prefix_list_id\\": null,
-            \\"egress_only_gateway_id\\": null,
-            \\"gateway_id\\": \\"\${aws_internet_gateway.InternetGateway.id}\\",
-            \\"instance_id\\": null,
-            \\"ipv6_cidr_block\\": null,
-            \\"local_gateway_id\\": null,
-            \\"nat_gateway_id\\": null,
-            \\"network_interface_id\\": null,
-            \\"transit_gateway_id\\": null,
-            \\"vpc_endpoint_id\\": null,
-            \\"vpc_peering_connection_id\\": null
-          }
+    },
+    "aws_elasticache_subnet_group": {
+      "Redis_RedisSubnetGroup_E7D796E2": {
+        "name": "redis-c8cdb969-subnetGroup",
+        "subnet_ids": [
+          "\${aws_subnet.PrivateSubnet.id}",
         ],
-        \\"tags\\": {
-          \\"Name\\": \\"Default-c82bf964-public-route-table-1\\"
-        },
-        \\"vpc_id\\": \\"\${aws_vpc.VPC.id}\\"
-      }
-    },
-    \\"aws_route_table_association\\": {
-      \\"PrivateRouteTableAssociation\\": {
-        \\"route_table_id\\": \\"\${aws_route_table.PrivateRouteTable.id}\\",
-        \\"subnet_id\\": \\"\${aws_subnet.PrivateSubnet.id}\\"
       },
-      \\"PublicRouteTableAssociation\\": {
-        \\"route_table_id\\": \\"\${aws_route_table.PublicRouteTable.id}\\",
-        \\"subnet_id\\": \\"\${aws_subnet.PublicSubnet.id}\\"
-      }
     },
-    \\"aws_security_group\\": {
-      \\"Redis_securityGroup_BE4B8855\\": {
-        \\"egress\\": [
+    "aws_internet_gateway": {
+      "InternetGateway": {
+        "tags": {
+          "Name": "Default-c82bf964-internet-gateway",
+        },
+        "vpc_id": "\${aws_vpc.VPC.id}",
+      },
+    },
+    "aws_nat_gateway": {
+      "NATGateway": {
+        "allocation_id": "\${aws_eip.EIP.id}",
+        "subnet_id": "\${aws_subnet.PublicSubnet.id}",
+        "tags": {
+          "Name": "Default-c82bf964-nat-gateway",
+        },
+      },
+    },
+    "aws_route_table": {
+      "PrivateRouteTable": {
+        "route": [
           {
-            \\"cidr_blocks\\": [
-              \\"0.0.0.0/0\\"
+            "carrier_gateway_id": null,
+            "cidr_block": "0.0.0.0/0",
+            "core_network_arn": null,
+            "destination_prefix_list_id": null,
+            "egress_only_gateway_id": null,
+            "gateway_id": null,
+            "instance_id": null,
+            "ipv6_cidr_block": null,
+            "local_gateway_id": null,
+            "nat_gateway_id": "\${aws_nat_gateway.NATGateway.id}",
+            "network_interface_id": null,
+            "transit_gateway_id": null,
+            "vpc_endpoint_id": null,
+            "vpc_peering_connection_id": null,
+          },
+        ],
+        "tags": {
+          "Name": "Default-c82bf964-private-route-table-1",
+        },
+        "vpc_id": "\${aws_vpc.VPC.id}",
+      },
+      "PublicRouteTable": {
+        "route": [
+          {
+            "carrier_gateway_id": null,
+            "cidr_block": "0.0.0.0/0",
+            "core_network_arn": null,
+            "destination_prefix_list_id": null,
+            "egress_only_gateway_id": null,
+            "gateway_id": "\${aws_internet_gateway.InternetGateway.id}",
+            "instance_id": null,
+            "ipv6_cidr_block": null,
+            "local_gateway_id": null,
+            "nat_gateway_id": null,
+            "network_interface_id": null,
+            "transit_gateway_id": null,
+            "vpc_endpoint_id": null,
+            "vpc_peering_connection_id": null,
+          },
+        ],
+        "tags": {
+          "Name": "Default-c82bf964-public-route-table-1",
+        },
+        "vpc_id": "\${aws_vpc.VPC.id}",
+      },
+    },
+    "aws_route_table_association": {
+      "PrivateRouteTableAssociation": {
+        "route_table_id": "\${aws_route_table.PrivateRouteTable.id}",
+        "subnet_id": "\${aws_subnet.PrivateSubnet.id}",
+      },
+      "PublicRouteTableAssociation": {
+        "route_table_id": "\${aws_route_table.PublicRouteTable.id}",
+        "subnet_id": "\${aws_subnet.PublicSubnet.id}",
+      },
+    },
+    "aws_security_group": {
+      "Redis_securityGroup_BE4B8855": {
+        "egress": [
+          {
+            "cidr_blocks": [
+              "0.0.0.0/0",
             ],
-            \\"description\\": null,
-            \\"from_port\\": 0,
-            \\"ipv6_cidr_blocks\\": null,
-            \\"prefix_list_ids\\": null,
-            \\"protocol\\": \\"-1\\",
-            \\"security_groups\\": null,
-            \\"self\\": null,
-            \\"to_port\\": 0
-          }
+            "description": null,
+            "from_port": 0,
+            "ipv6_cidr_blocks": null,
+            "prefix_list_ids": null,
+            "protocol": "-1",
+            "security_groups": null,
+            "self": null,
+            "to_port": 0,
+          },
         ],
-        \\"ingress\\": [
+        "ingress": [
           {
-            \\"cidr_blocks\\": [
-              \\"\${aws_subnet.PrivateSubnet.cidr_block}\\"
+            "cidr_blocks": [
+              "\${aws_subnet.PrivateSubnet.cidr_block}",
             ],
-            \\"description\\": null,
-            \\"from_port\\": 6379,
-            \\"ipv6_cidr_blocks\\": null,
-            \\"prefix_list_ids\\": null,
-            \\"protocol\\": \\"tcp\\",
-            \\"security_groups\\": null,
-            \\"self\\": true,
-            \\"to_port\\": 6379
-          }
+            "description": null,
+            "from_port": 6379,
+            "ipv6_cidr_blocks": null,
+            "prefix_list_ids": null,
+            "protocol": "tcp",
+            "security_groups": null,
+            "self": true,
+            "to_port": 6379,
+          },
         ],
-        \\"name\\": \\"3542402a-securityGroup\\",
-        \\"vpc_id\\": \\"\${aws_vpc.VPC.id}\\"
-      }
-    },
-    \\"aws_subnet\\": {
-      \\"PrivateSubnet\\": {
-        \\"cidr_block\\": \\"10.0.4.0/22\\",
-        \\"tags\\": {
-          \\"Name\\": \\"Default-c82bf964-private-subnet-1\\"
-        },
-        \\"vpc_id\\": \\"\${aws_vpc.VPC.id}\\"
+        "name": "3542402a-securityGroup",
+        "vpc_id": "\${aws_vpc.VPC.id}",
       },
-      \\"PublicSubnet\\": {
-        \\"cidr_block\\": \\"10.0.0.0/24\\",
-        \\"tags\\": {
-          \\"Name\\": \\"Default-c82bf964-public-subnet-1\\"
-        },
-        \\"vpc_id\\": \\"\${aws_vpc.VPC.id}\\"
-      }
     },
-    \\"aws_vpc\\": {
-      \\"VPC\\": {
-        \\"cidr_block\\": \\"10.0.0.0/16\\",
-        \\"enable_dns_hostnames\\": true,
-        \\"enable_dns_support\\": true,
-        \\"tags\\": {
-          \\"Name\\": \\"Default-c82bf964-vpc\\"
-        }
-      }
-    }
-  }
-}"
+    "aws_subnet": {
+      "PrivateSubnet": {
+        "cidr_block": "10.0.4.0/22",
+        "tags": {
+          "Name": "Default-c82bf964-private-subnet-1",
+        },
+        "vpc_id": "\${aws_vpc.VPC.id}",
+      },
+      "PublicSubnet": {
+        "cidr_block": "10.0.0.0/24",
+        "tags": {
+          "Name": "Default-c82bf964-public-subnet-1",
+        },
+        "vpc_id": "\${aws_vpc.VPC.id}",
+      },
+    },
+    "aws_vpc": {
+      "VPC": {
+        "cidr_block": "10.0.0.0/16",
+        "enable_dns_hostnames": true,
+        "enable_dns_support": true,
+        "tags": {
+          "Name": "Default-c82bf964-vpc",
+        },
+      },
+    },
+  },
+}
 `;

--- a/libs/wingsdk/test/target-tf-aws/__snapshots__/schedule.test.ts.snap
+++ b/libs/wingsdk/test/target-tf-aws/__snapshots__/schedule.test.ts.snap
@@ -1,86 +1,86 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`schedule behavior with cron 1`] = `
-"{
-  \\"output\\": {
-    \\"WING_TEST_RUNNER_FUNCTION_ARNS\\": {
-      \\"value\\": \\"[]\\"
-    }
+{
+  "output": {
+    "WING_TEST_RUNNER_FUNCTION_ARNS": {
+      "value": "[]",
+    },
   },
-  \\"resource\\": {
-    \\"aws_cloudwatch_event_rule\\": {
-      \\"Schedule_15669BF1\\": {
-        \\"is_enabled\\": true,
-        \\"schedule_expression\\": \\"cron(0/1 * ? * * *)\\"
-      }
+  "resource": {
+    "aws_cloudwatch_event_rule": {
+      "Schedule_15669BF1": {
+        "is_enabled": true,
+        "schedule_expression": "cron(0/1 * ? * * *)",
+      },
     },
-    \\"aws_cloudwatch_event_target\\": {
-      \\"Schedule_ScheduleTarget-c5395e41_BF97AE46\\": {
-        \\"arn\\": \\"\${aws_lambda_function.Schedule-OnTick-c5395e41.qualified_arn}\\",
-        \\"rule\\": \\"\${aws_cloudwatch_event_rule.Schedule_15669BF1.name}\\"
-      }
+    "aws_cloudwatch_event_target": {
+      "Schedule_ScheduleTarget-c5395e41_BF97AE46": {
+        "arn": "\${aws_lambda_function.Schedule-OnTick-c5395e41.qualified_arn}",
+        "rule": "\${aws_cloudwatch_event_rule.Schedule_15669BF1.name}",
+      },
     },
-    \\"aws_iam_role\\": {
-      \\"Schedule-OnTick-c5395e41_IamRole_014E0D2D\\": {
-        \\"assume_role_policy\\": \\"{\\\\\\"Version\\\\\\":\\\\\\"2012-10-17\\\\\\",\\\\\\"Statement\\\\\\":[{\\\\\\"Action\\\\\\":\\\\\\"sts:AssumeRole\\\\\\",\\\\\\"Principal\\\\\\":{\\\\\\"Service\\\\\\":\\\\\\"lambda.amazonaws.com\\\\\\"},\\\\\\"Effect\\\\\\":\\\\\\"Allow\\\\\\"}]}\\"
-      }
+    "aws_iam_role": {
+      "Schedule-OnTick-c5395e41_IamRole_014E0D2D": {
+        "assume_role_policy": "{\\"Version\\":\\"2012-10-17\\",\\"Statement\\":[{\\"Action\\":\\"sts:AssumeRole\\",\\"Principal\\":{\\"Service\\":\\"lambda.amazonaws.com\\"},\\"Effect\\":\\"Allow\\"}]}",
+      },
     },
-    \\"aws_iam_role_policy\\": {
-      \\"Schedule-OnTick-c5395e41_IamRolePolicy_8E955645\\": {
-        \\"policy\\": \\"{\\\\\\"Version\\\\\\":\\\\\\"2012-10-17\\\\\\",\\\\\\"Statement\\\\\\":[{\\\\\\"Effect\\\\\\":\\\\\\"Allow\\\\\\",\\\\\\"Action\\\\\\":\\\\\\"none:null\\\\\\",\\\\\\"Resource\\\\\\":\\\\\\"*\\\\\\"}]}\\",
-        \\"role\\": \\"\${aws_iam_role.Schedule-OnTick-c5395e41_IamRole_014E0D2D.name}\\"
-      }
+    "aws_iam_role_policy": {
+      "Schedule-OnTick-c5395e41_IamRolePolicy_8E955645": {
+        "policy": "{\\"Version\\":\\"2012-10-17\\",\\"Statement\\":[{\\"Effect\\":\\"Allow\\",\\"Action\\":\\"none:null\\",\\"Resource\\":\\"*\\"}]}",
+        "role": "\${aws_iam_role.Schedule-OnTick-c5395e41_IamRole_014E0D2D.name}",
+      },
     },
-    \\"aws_iam_role_policy_attachment\\": {
-      \\"Schedule-OnTick-c5395e41_IamRolePolicyAttachment_55B6C17D\\": {
-        \\"policy_arn\\": \\"arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole\\",
-        \\"role\\": \\"\${aws_iam_role.Schedule-OnTick-c5395e41_IamRole_014E0D2D.name}\\"
-      }
+    "aws_iam_role_policy_attachment": {
+      "Schedule-OnTick-c5395e41_IamRolePolicyAttachment_55B6C17D": {
+        "policy_arn": "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+        "role": "\${aws_iam_role.Schedule-OnTick-c5395e41_IamRole_014E0D2D.name}",
+      },
     },
-    \\"aws_lambda_function\\": {
-      \\"Schedule-OnTick-c5395e41\\": {
-        \\"environment\\": {
-          \\"variables\\": {
-            \\"WING_FUNCTION_NAME\\": \\"Schedule-OnTick-c5395e41-c861b8f8\\"
-          }
+    "aws_lambda_function": {
+      "Schedule-OnTick-c5395e41": {
+        "environment": {
+          "variables": {
+            "WING_FUNCTION_NAME": "Schedule-OnTick-c5395e41-c861b8f8",
+          },
         },
-        \\"function_name\\": \\"Schedule-OnTick-c5395e41-c861b8f8\\",
-        \\"handler\\": \\"index.handler\\",
-        \\"publish\\": true,
-        \\"role\\": \\"\${aws_iam_role.Schedule-OnTick-c5395e41_IamRole_014E0D2D.arn}\\",
-        \\"runtime\\": \\"nodejs18.x\\",
-        \\"s3_bucket\\": \\"\${aws_s3_bucket.Code.bucket}\\",
-        \\"s3_key\\": \\"\${aws_s3_object.Schedule-OnTick-c5395e41_S3Object_70645C21.key}\\",
-        \\"timeout\\": 30,
-        \\"vpc_config\\": {
-          \\"security_group_ids\\": [],
-          \\"subnet_ids\\": []
-        }
-      }
+        "function_name": "Schedule-OnTick-c5395e41-c861b8f8",
+        "handler": "index.handler",
+        "publish": true,
+        "role": "\${aws_iam_role.Schedule-OnTick-c5395e41_IamRole_014E0D2D.arn}",
+        "runtime": "nodejs18.x",
+        "s3_bucket": "\${aws_s3_bucket.Code.bucket}",
+        "s3_key": "\${aws_s3_object.Schedule-OnTick-c5395e41_S3Object_70645C21.key}",
+        "timeout": 30,
+        "vpc_config": {
+          "security_group_ids": [],
+          "subnet_ids": [],
+        },
+      },
     },
-    \\"aws_lambda_permission\\": {
-      \\"Schedule-OnTick-c5395e41_InvokePermission-c8b3fc394731d07e61c00e422c6b234372c09bc3b3_BC18A455\\": {
-        \\"action\\": \\"lambda:InvokeFunction\\",
-        \\"function_name\\": \\"\${aws_lambda_function.Schedule-OnTick-c5395e41.function_name}\\",
-        \\"principal\\": \\"events.amazonaws.com\\",
-        \\"qualifier\\": \\"\${aws_lambda_function.Schedule-OnTick-c5395e41.version}\\",
-        \\"source_arn\\": \\"\${aws_cloudwatch_event_rule.Schedule_15669BF1.arn}\\"
-      }
+    "aws_lambda_permission": {
+      "Schedule-OnTick-c5395e41_InvokePermission-c8b3fc394731d07e61c00e422c6b234372c09bc3b3_BC18A455": {
+        "action": "lambda:InvokeFunction",
+        "function_name": "\${aws_lambda_function.Schedule-OnTick-c5395e41.function_name}",
+        "principal": "events.amazonaws.com",
+        "qualifier": "\${aws_lambda_function.Schedule-OnTick-c5395e41.version}",
+        "source_arn": "\${aws_cloudwatch_event_rule.Schedule_15669BF1.arn}",
+      },
     },
-    \\"aws_s3_bucket\\": {
-      \\"Code\\": {
-        \\"bucket_prefix\\": \\"code-c84a50b1-\\"
-      }
+    "aws_s3_bucket": {
+      "Code": {
+        "bucket_prefix": "code-c84a50b1-",
+      },
     },
-    \\"aws_s3_object\\": {
-      \\"Schedule-OnTick-c5395e41_S3Object_70645C21\\": {
-        \\"bucket\\": \\"\${aws_s3_bucket.Code.bucket}\\",
-        \\"key\\": \\"<key>\\",
-        \\"source\\": \\"<source>\\"
-      }
-    }
-  }
-}"
+    "aws_s3_object": {
+      "Schedule-OnTick-c5395e41_S3Object_70645C21": {
+        "bucket": "\${aws_s3_bucket.Code.bucket}",
+        "key": "<key>",
+        "source": "<source>",
+      },
+    },
+  },
+}
 `;
 
 exports[`schedule behavior with cron 2`] = `
@@ -345,86 +345,86 @@ exports[`schedule behavior with cron 2`] = `
 `;
 
 exports[`schedule behavior with rate 1`] = `
-"{
-  \\"output\\": {
-    \\"WING_TEST_RUNNER_FUNCTION_ARNS\\": {
-      \\"value\\": \\"[]\\"
-    }
+{
+  "output": {
+    "WING_TEST_RUNNER_FUNCTION_ARNS": {
+      "value": "[]",
+    },
   },
-  \\"resource\\": {
-    \\"aws_cloudwatch_event_rule\\": {
-      \\"Schedule_15669BF1\\": {
-        \\"is_enabled\\": true,
-        \\"schedule_expression\\": \\"rate(2 minutes)\\"
-      }
+  "resource": {
+    "aws_cloudwatch_event_rule": {
+      "Schedule_15669BF1": {
+        "is_enabled": true,
+        "schedule_expression": "rate(2 minutes)",
+      },
     },
-    \\"aws_cloudwatch_event_target\\": {
-      \\"Schedule_ScheduleTarget-c5395e41_BF97AE46\\": {
-        \\"arn\\": \\"\${aws_lambda_function.Schedule-OnTick-c5395e41.qualified_arn}\\",
-        \\"rule\\": \\"\${aws_cloudwatch_event_rule.Schedule_15669BF1.name}\\"
-      }
+    "aws_cloudwatch_event_target": {
+      "Schedule_ScheduleTarget-c5395e41_BF97AE46": {
+        "arn": "\${aws_lambda_function.Schedule-OnTick-c5395e41.qualified_arn}",
+        "rule": "\${aws_cloudwatch_event_rule.Schedule_15669BF1.name}",
+      },
     },
-    \\"aws_iam_role\\": {
-      \\"Schedule-OnTick-c5395e41_IamRole_014E0D2D\\": {
-        \\"assume_role_policy\\": \\"{\\\\\\"Version\\\\\\":\\\\\\"2012-10-17\\\\\\",\\\\\\"Statement\\\\\\":[{\\\\\\"Action\\\\\\":\\\\\\"sts:AssumeRole\\\\\\",\\\\\\"Principal\\\\\\":{\\\\\\"Service\\\\\\":\\\\\\"lambda.amazonaws.com\\\\\\"},\\\\\\"Effect\\\\\\":\\\\\\"Allow\\\\\\"}]}\\"
-      }
+    "aws_iam_role": {
+      "Schedule-OnTick-c5395e41_IamRole_014E0D2D": {
+        "assume_role_policy": "{\\"Version\\":\\"2012-10-17\\",\\"Statement\\":[{\\"Action\\":\\"sts:AssumeRole\\",\\"Principal\\":{\\"Service\\":\\"lambda.amazonaws.com\\"},\\"Effect\\":\\"Allow\\"}]}",
+      },
     },
-    \\"aws_iam_role_policy\\": {
-      \\"Schedule-OnTick-c5395e41_IamRolePolicy_8E955645\\": {
-        \\"policy\\": \\"{\\\\\\"Version\\\\\\":\\\\\\"2012-10-17\\\\\\",\\\\\\"Statement\\\\\\":[{\\\\\\"Effect\\\\\\":\\\\\\"Allow\\\\\\",\\\\\\"Action\\\\\\":\\\\\\"none:null\\\\\\",\\\\\\"Resource\\\\\\":\\\\\\"*\\\\\\"}]}\\",
-        \\"role\\": \\"\${aws_iam_role.Schedule-OnTick-c5395e41_IamRole_014E0D2D.name}\\"
-      }
+    "aws_iam_role_policy": {
+      "Schedule-OnTick-c5395e41_IamRolePolicy_8E955645": {
+        "policy": "{\\"Version\\":\\"2012-10-17\\",\\"Statement\\":[{\\"Effect\\":\\"Allow\\",\\"Action\\":\\"none:null\\",\\"Resource\\":\\"*\\"}]}",
+        "role": "\${aws_iam_role.Schedule-OnTick-c5395e41_IamRole_014E0D2D.name}",
+      },
     },
-    \\"aws_iam_role_policy_attachment\\": {
-      \\"Schedule-OnTick-c5395e41_IamRolePolicyAttachment_55B6C17D\\": {
-        \\"policy_arn\\": \\"arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole\\",
-        \\"role\\": \\"\${aws_iam_role.Schedule-OnTick-c5395e41_IamRole_014E0D2D.name}\\"
-      }
+    "aws_iam_role_policy_attachment": {
+      "Schedule-OnTick-c5395e41_IamRolePolicyAttachment_55B6C17D": {
+        "policy_arn": "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+        "role": "\${aws_iam_role.Schedule-OnTick-c5395e41_IamRole_014E0D2D.name}",
+      },
     },
-    \\"aws_lambda_function\\": {
-      \\"Schedule-OnTick-c5395e41\\": {
-        \\"environment\\": {
-          \\"variables\\": {
-            \\"WING_FUNCTION_NAME\\": \\"Schedule-OnTick-c5395e41-c861b8f8\\"
-          }
+    "aws_lambda_function": {
+      "Schedule-OnTick-c5395e41": {
+        "environment": {
+          "variables": {
+            "WING_FUNCTION_NAME": "Schedule-OnTick-c5395e41-c861b8f8",
+          },
         },
-        \\"function_name\\": \\"Schedule-OnTick-c5395e41-c861b8f8\\",
-        \\"handler\\": \\"index.handler\\",
-        \\"publish\\": true,
-        \\"role\\": \\"\${aws_iam_role.Schedule-OnTick-c5395e41_IamRole_014E0D2D.arn}\\",
-        \\"runtime\\": \\"nodejs18.x\\",
-        \\"s3_bucket\\": \\"\${aws_s3_bucket.Code.bucket}\\",
-        \\"s3_key\\": \\"\${aws_s3_object.Schedule-OnTick-c5395e41_S3Object_70645C21.key}\\",
-        \\"timeout\\": 30,
-        \\"vpc_config\\": {
-          \\"security_group_ids\\": [],
-          \\"subnet_ids\\": []
-        }
-      }
+        "function_name": "Schedule-OnTick-c5395e41-c861b8f8",
+        "handler": "index.handler",
+        "publish": true,
+        "role": "\${aws_iam_role.Schedule-OnTick-c5395e41_IamRole_014E0D2D.arn}",
+        "runtime": "nodejs18.x",
+        "s3_bucket": "\${aws_s3_bucket.Code.bucket}",
+        "s3_key": "\${aws_s3_object.Schedule-OnTick-c5395e41_S3Object_70645C21.key}",
+        "timeout": 30,
+        "vpc_config": {
+          "security_group_ids": [],
+          "subnet_ids": [],
+        },
+      },
     },
-    \\"aws_lambda_permission\\": {
-      \\"Schedule-OnTick-c5395e41_InvokePermission-c8b3fc394731d07e61c00e422c6b234372c09bc3b3_BC18A455\\": {
-        \\"action\\": \\"lambda:InvokeFunction\\",
-        \\"function_name\\": \\"\${aws_lambda_function.Schedule-OnTick-c5395e41.function_name}\\",
-        \\"principal\\": \\"events.amazonaws.com\\",
-        \\"qualifier\\": \\"\${aws_lambda_function.Schedule-OnTick-c5395e41.version}\\",
-        \\"source_arn\\": \\"\${aws_cloudwatch_event_rule.Schedule_15669BF1.arn}\\"
-      }
+    "aws_lambda_permission": {
+      "Schedule-OnTick-c5395e41_InvokePermission-c8b3fc394731d07e61c00e422c6b234372c09bc3b3_BC18A455": {
+        "action": "lambda:InvokeFunction",
+        "function_name": "\${aws_lambda_function.Schedule-OnTick-c5395e41.function_name}",
+        "principal": "events.amazonaws.com",
+        "qualifier": "\${aws_lambda_function.Schedule-OnTick-c5395e41.version}",
+        "source_arn": "\${aws_cloudwatch_event_rule.Schedule_15669BF1.arn}",
+      },
     },
-    \\"aws_s3_bucket\\": {
-      \\"Code\\": {
-        \\"bucket_prefix\\": \\"code-c84a50b1-\\"
-      }
+    "aws_s3_bucket": {
+      "Code": {
+        "bucket_prefix": "code-c84a50b1-",
+      },
     },
-    \\"aws_s3_object\\": {
-      \\"Schedule-OnTick-c5395e41_S3Object_70645C21\\": {
-        \\"bucket\\": \\"\${aws_s3_bucket.Code.bucket}\\",
-        \\"key\\": \\"<key>\\",
-        \\"source\\": \\"<source>\\"
-      }
-    }
-  }
-}"
+    "aws_s3_object": {
+      "Schedule-OnTick-c5395e41_S3Object_70645C21": {
+        "bucket": "\${aws_s3_bucket.Code.bucket}",
+        "key": "<key>",
+        "source": "<source>",
+      },
+    },
+  },
+}
 `;
 
 exports[`schedule behavior with rate 2`] = `
@@ -689,132 +689,132 @@ exports[`schedule behavior with rate 2`] = `
 `;
 
 exports[`schedule with two functions 1`] = `
-"{
-  \\"output\\": {
-    \\"WING_TEST_RUNNER_FUNCTION_ARNS\\": {
-      \\"value\\": \\"[]\\"
-    }
+{
+  "output": {
+    "WING_TEST_RUNNER_FUNCTION_ARNS": {
+      "value": "[]",
+    },
   },
-  \\"resource\\": {
-    \\"aws_cloudwatch_event_rule\\": {
-      \\"Schedule_15669BF1\\": {
-        \\"is_enabled\\": true,
-        \\"schedule_expression\\": \\"cron(0/1 * ? * * *)\\"
-      }
-    },
-    \\"aws_cloudwatch_event_target\\": {
-      \\"Schedule_ScheduleTarget-0a615500_52695350\\": {
-        \\"arn\\": \\"\${aws_lambda_function.Schedule-OnTick-0a615500.qualified_arn}\\",
-        \\"rule\\": \\"\${aws_cloudwatch_event_rule.Schedule_15669BF1.name}\\"
+  "resource": {
+    "aws_cloudwatch_event_rule": {
+      "Schedule_15669BF1": {
+        "is_enabled": true,
+        "schedule_expression": "cron(0/1 * ? * * *)",
       },
-      \\"Schedule_ScheduleTarget-7b33bcba_A92DF656\\": {
-        \\"arn\\": \\"\${aws_lambda_function.Schedule-OnTick-7b33bcba.qualified_arn}\\",
-        \\"rule\\": \\"\${aws_cloudwatch_event_rule.Schedule_15669BF1.name}\\"
-      }
     },
-    \\"aws_iam_role\\": {
-      \\"Schedule-OnTick-0a615500_IamRole_92CE809F\\": {
-        \\"assume_role_policy\\": \\"{\\\\\\"Version\\\\\\":\\\\\\"2012-10-17\\\\\\",\\\\\\"Statement\\\\\\":[{\\\\\\"Action\\\\\\":\\\\\\"sts:AssumeRole\\\\\\",\\\\\\"Principal\\\\\\":{\\\\\\"Service\\\\\\":\\\\\\"lambda.amazonaws.com\\\\\\"},\\\\\\"Effect\\\\\\":\\\\\\"Allow\\\\\\"}]}\\"
+    "aws_cloudwatch_event_target": {
+      "Schedule_ScheduleTarget-0a615500_52695350": {
+        "arn": "\${aws_lambda_function.Schedule-OnTick-0a615500.qualified_arn}",
+        "rule": "\${aws_cloudwatch_event_rule.Schedule_15669BF1.name}",
       },
-      \\"Schedule-OnTick-7b33bcba_IamRole_C04DD603\\": {
-        \\"assume_role_policy\\": \\"{\\\\\\"Version\\\\\\":\\\\\\"2012-10-17\\\\\\",\\\\\\"Statement\\\\\\":[{\\\\\\"Action\\\\\\":\\\\\\"sts:AssumeRole\\\\\\",\\\\\\"Principal\\\\\\":{\\\\\\"Service\\\\\\":\\\\\\"lambda.amazonaws.com\\\\\\"},\\\\\\"Effect\\\\\\":\\\\\\"Allow\\\\\\"}]}\\"
-      }
-    },
-    \\"aws_iam_role_policy\\": {
-      \\"Schedule-OnTick-0a615500_IamRolePolicy_E8D3C496\\": {
-        \\"policy\\": \\"{\\\\\\"Version\\\\\\":\\\\\\"2012-10-17\\\\\\",\\\\\\"Statement\\\\\\":[{\\\\\\"Effect\\\\\\":\\\\\\"Allow\\\\\\",\\\\\\"Action\\\\\\":\\\\\\"none:null\\\\\\",\\\\\\"Resource\\\\\\":\\\\\\"*\\\\\\"}]}\\",
-        \\"role\\": \\"\${aws_iam_role.Schedule-OnTick-0a615500_IamRole_92CE809F.name}\\"
+      "Schedule_ScheduleTarget-7b33bcba_A92DF656": {
+        "arn": "\${aws_lambda_function.Schedule-OnTick-7b33bcba.qualified_arn}",
+        "rule": "\${aws_cloudwatch_event_rule.Schedule_15669BF1.name}",
       },
-      \\"Schedule-OnTick-7b33bcba_IamRolePolicy_D2C8C96D\\": {
-        \\"policy\\": \\"{\\\\\\"Version\\\\\\":\\\\\\"2012-10-17\\\\\\",\\\\\\"Statement\\\\\\":[{\\\\\\"Effect\\\\\\":\\\\\\"Allow\\\\\\",\\\\\\"Action\\\\\\":\\\\\\"none:null\\\\\\",\\\\\\"Resource\\\\\\":\\\\\\"*\\\\\\"}]}\\",
-        \\"role\\": \\"\${aws_iam_role.Schedule-OnTick-7b33bcba_IamRole_C04DD603.name}\\"
-      }
     },
-    \\"aws_iam_role_policy_attachment\\": {
-      \\"Schedule-OnTick-0a615500_IamRolePolicyAttachment_00C5D4B2\\": {
-        \\"policy_arn\\": \\"arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole\\",
-        \\"role\\": \\"\${aws_iam_role.Schedule-OnTick-0a615500_IamRole_92CE809F.name}\\"
+    "aws_iam_role": {
+      "Schedule-OnTick-0a615500_IamRole_92CE809F": {
+        "assume_role_policy": "{\\"Version\\":\\"2012-10-17\\",\\"Statement\\":[{\\"Action\\":\\"sts:AssumeRole\\",\\"Principal\\":{\\"Service\\":\\"lambda.amazonaws.com\\"},\\"Effect\\":\\"Allow\\"}]}",
       },
-      \\"Schedule-OnTick-7b33bcba_IamRolePolicyAttachment_7CE94FAE\\": {
-        \\"policy_arn\\": \\"arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole\\",
-        \\"role\\": \\"\${aws_iam_role.Schedule-OnTick-7b33bcba_IamRole_C04DD603.name}\\"
-      }
+      "Schedule-OnTick-7b33bcba_IamRole_C04DD603": {
+        "assume_role_policy": "{\\"Version\\":\\"2012-10-17\\",\\"Statement\\":[{\\"Action\\":\\"sts:AssumeRole\\",\\"Principal\\":{\\"Service\\":\\"lambda.amazonaws.com\\"},\\"Effect\\":\\"Allow\\"}]}",
+      },
     },
-    \\"aws_lambda_function\\": {
-      \\"Schedule-OnTick-0a615500\\": {
-        \\"environment\\": {
-          \\"variables\\": {
-            \\"WING_FUNCTION_NAME\\": \\"Schedule-OnTick-0a615500-c8fd8480\\"
-          }
+    "aws_iam_role_policy": {
+      "Schedule-OnTick-0a615500_IamRolePolicy_E8D3C496": {
+        "policy": "{\\"Version\\":\\"2012-10-17\\",\\"Statement\\":[{\\"Effect\\":\\"Allow\\",\\"Action\\":\\"none:null\\",\\"Resource\\":\\"*\\"}]}",
+        "role": "\${aws_iam_role.Schedule-OnTick-0a615500_IamRole_92CE809F.name}",
+      },
+      "Schedule-OnTick-7b33bcba_IamRolePolicy_D2C8C96D": {
+        "policy": "{\\"Version\\":\\"2012-10-17\\",\\"Statement\\":[{\\"Effect\\":\\"Allow\\",\\"Action\\":\\"none:null\\",\\"Resource\\":\\"*\\"}]}",
+        "role": "\${aws_iam_role.Schedule-OnTick-7b33bcba_IamRole_C04DD603.name}",
+      },
+    },
+    "aws_iam_role_policy_attachment": {
+      "Schedule-OnTick-0a615500_IamRolePolicyAttachment_00C5D4B2": {
+        "policy_arn": "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+        "role": "\${aws_iam_role.Schedule-OnTick-0a615500_IamRole_92CE809F.name}",
+      },
+      "Schedule-OnTick-7b33bcba_IamRolePolicyAttachment_7CE94FAE": {
+        "policy_arn": "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+        "role": "\${aws_iam_role.Schedule-OnTick-7b33bcba_IamRole_C04DD603.name}",
+      },
+    },
+    "aws_lambda_function": {
+      "Schedule-OnTick-0a615500": {
+        "environment": {
+          "variables": {
+            "WING_FUNCTION_NAME": "Schedule-OnTick-0a615500-c8fd8480",
+          },
         },
-        \\"function_name\\": \\"Schedule-OnTick-0a615500-c8fd8480\\",
-        \\"handler\\": \\"index.handler\\",
-        \\"publish\\": true,
-        \\"role\\": \\"\${aws_iam_role.Schedule-OnTick-0a615500_IamRole_92CE809F.arn}\\",
-        \\"runtime\\": \\"nodejs18.x\\",
-        \\"s3_bucket\\": \\"\${aws_s3_bucket.Code.bucket}\\",
-        \\"s3_key\\": \\"\${aws_s3_object.Schedule-OnTick-0a615500_S3Object_587833FB.key}\\",
-        \\"timeout\\": 30,
-        \\"vpc_config\\": {
-          \\"security_group_ids\\": [],
-          \\"subnet_ids\\": []
-        }
-      },
-      \\"Schedule-OnTick-7b33bcba\\": {
-        \\"environment\\": {
-          \\"variables\\": {
-            \\"WING_FUNCTION_NAME\\": \\"Schedule-OnTick-7b33bcba-c86000d7\\"
-          }
+        "function_name": "Schedule-OnTick-0a615500-c8fd8480",
+        "handler": "index.handler",
+        "publish": true,
+        "role": "\${aws_iam_role.Schedule-OnTick-0a615500_IamRole_92CE809F.arn}",
+        "runtime": "nodejs18.x",
+        "s3_bucket": "\${aws_s3_bucket.Code.bucket}",
+        "s3_key": "\${aws_s3_object.Schedule-OnTick-0a615500_S3Object_587833FB.key}",
+        "timeout": 30,
+        "vpc_config": {
+          "security_group_ids": [],
+          "subnet_ids": [],
         },
-        \\"function_name\\": \\"Schedule-OnTick-7b33bcba-c86000d7\\",
-        \\"handler\\": \\"index.handler\\",
-        \\"publish\\": true,
-        \\"role\\": \\"\${aws_iam_role.Schedule-OnTick-7b33bcba_IamRole_C04DD603.arn}\\",
-        \\"runtime\\": \\"nodejs18.x\\",
-        \\"s3_bucket\\": \\"\${aws_s3_bucket.Code.bucket}\\",
-        \\"s3_key\\": \\"\${aws_s3_object.Schedule-OnTick-7b33bcba_S3Object_4D57889B.key}\\",
-        \\"timeout\\": 30,
-        \\"vpc_config\\": {
-          \\"security_group_ids\\": [],
-          \\"subnet_ids\\": []
-        }
-      }
-    },
-    \\"aws_lambda_permission\\": {
-      \\"Schedule-OnTick-0a615500_InvokePermission-c8b3fc394731d07e61c00e422c6b234372c09bc3b3_67BEC9AD\\": {
-        \\"action\\": \\"lambda:InvokeFunction\\",
-        \\"function_name\\": \\"\${aws_lambda_function.Schedule-OnTick-0a615500.function_name}\\",
-        \\"principal\\": \\"events.amazonaws.com\\",
-        \\"qualifier\\": \\"\${aws_lambda_function.Schedule-OnTick-0a615500.version}\\",
-        \\"source_arn\\": \\"\${aws_cloudwatch_event_rule.Schedule_15669BF1.arn}\\"
       },
-      \\"Schedule-OnTick-7b33bcba_InvokePermission-c8b3fc394731d07e61c00e422c6b234372c09bc3b3_D6BACA03\\": {
-        \\"action\\": \\"lambda:InvokeFunction\\",
-        \\"function_name\\": \\"\${aws_lambda_function.Schedule-OnTick-7b33bcba.function_name}\\",
-        \\"principal\\": \\"events.amazonaws.com\\",
-        \\"qualifier\\": \\"\${aws_lambda_function.Schedule-OnTick-7b33bcba.version}\\",
-        \\"source_arn\\": \\"\${aws_cloudwatch_event_rule.Schedule_15669BF1.arn}\\"
-      }
-    },
-    \\"aws_s3_bucket\\": {
-      \\"Code\\": {
-        \\"bucket_prefix\\": \\"code-c84a50b1-\\"
-      }
-    },
-    \\"aws_s3_object\\": {
-      \\"Schedule-OnTick-0a615500_S3Object_587833FB\\": {
-        \\"bucket\\": \\"\${aws_s3_bucket.Code.bucket}\\",
-        \\"key\\": \\"<key>\\",
-        \\"source\\": \\"<source>\\"
+      "Schedule-OnTick-7b33bcba": {
+        "environment": {
+          "variables": {
+            "WING_FUNCTION_NAME": "Schedule-OnTick-7b33bcba-c86000d7",
+          },
+        },
+        "function_name": "Schedule-OnTick-7b33bcba-c86000d7",
+        "handler": "index.handler",
+        "publish": true,
+        "role": "\${aws_iam_role.Schedule-OnTick-7b33bcba_IamRole_C04DD603.arn}",
+        "runtime": "nodejs18.x",
+        "s3_bucket": "\${aws_s3_bucket.Code.bucket}",
+        "s3_key": "\${aws_s3_object.Schedule-OnTick-7b33bcba_S3Object_4D57889B.key}",
+        "timeout": 30,
+        "vpc_config": {
+          "security_group_ids": [],
+          "subnet_ids": [],
+        },
       },
-      \\"Schedule-OnTick-7b33bcba_S3Object_4D57889B\\": {
-        \\"bucket\\": \\"\${aws_s3_bucket.Code.bucket}\\",
-        \\"key\\": \\"<key>\\",
-        \\"source\\": \\"<source>\\"
-      }
-    }
-  }
-}"
+    },
+    "aws_lambda_permission": {
+      "Schedule-OnTick-0a615500_InvokePermission-c8b3fc394731d07e61c00e422c6b234372c09bc3b3_67BEC9AD": {
+        "action": "lambda:InvokeFunction",
+        "function_name": "\${aws_lambda_function.Schedule-OnTick-0a615500.function_name}",
+        "principal": "events.amazonaws.com",
+        "qualifier": "\${aws_lambda_function.Schedule-OnTick-0a615500.version}",
+        "source_arn": "\${aws_cloudwatch_event_rule.Schedule_15669BF1.arn}",
+      },
+      "Schedule-OnTick-7b33bcba_InvokePermission-c8b3fc394731d07e61c00e422c6b234372c09bc3b3_D6BACA03": {
+        "action": "lambda:InvokeFunction",
+        "function_name": "\${aws_lambda_function.Schedule-OnTick-7b33bcba.function_name}",
+        "principal": "events.amazonaws.com",
+        "qualifier": "\${aws_lambda_function.Schedule-OnTick-7b33bcba.version}",
+        "source_arn": "\${aws_cloudwatch_event_rule.Schedule_15669BF1.arn}",
+      },
+    },
+    "aws_s3_bucket": {
+      "Code": {
+        "bucket_prefix": "code-c84a50b1-",
+      },
+    },
+    "aws_s3_object": {
+      "Schedule-OnTick-0a615500_S3Object_587833FB": {
+        "bucket": "\${aws_s3_bucket.Code.bucket}",
+        "key": "<key>",
+        "source": "<source>",
+      },
+      "Schedule-OnTick-7b33bcba_S3Object_4D57889B": {
+        "bucket": "\${aws_s3_bucket.Code.bucket}",
+        "key": "<key>",
+        "source": "<source>",
+      },
+    },
+  },
+}
 `;
 
 exports[`schedule with two functions 2`] = `

--- a/libs/wingsdk/test/target-tf-aws/__snapshots__/secret.test.ts.snap
+++ b/libs/wingsdk/test/target-tf-aws/__snapshots__/secret.test.ts.snap
@@ -1,23 +1,23 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`default secret behavior 1`] = `
-"{
-  \\"output\\": {
-    \\"Secret_SecretArn_C6DFE868\\": {
-      \\"value\\": \\"\${aws_secretsmanager_secret.Secret.arn}\\"
+{
+  "output": {
+    "Secret_SecretArn_C6DFE868": {
+      "value": "\${aws_secretsmanager_secret.Secret.arn}",
     },
-    \\"WING_TEST_RUNNER_FUNCTION_ARNS\\": {
-      \\"value\\": \\"[]\\"
-    }
+    "WING_TEST_RUNNER_FUNCTION_ARNS": {
+      "value": "[]",
+    },
   },
-  \\"resource\\": {
-    \\"aws_secretsmanager_secret\\": {
-      \\"Secret\\": {
-        \\"name\\": \\"Secret-c8e3aab7\\"
-      }
-    }
-  }
-}"
+  "resource": {
+    "aws_secretsmanager_secret": {
+      "Secret": {
+        "name": "Secret-c8e3aab7",
+      },
+    },
+  },
+}
 `;
 
 exports[`default secret behavior 2`] = `
@@ -132,18 +132,18 @@ exports[`default secret behavior 2`] = `
 `;
 
 exports[`secret with a name 1`] = `
-"{
-  \\"data\\": {
-    \\"aws_secretsmanager_secret\\": {
-      \\"Secret\\": {
-        \\"name\\": \\"my-secret\\"
-      }
-    }
+{
+  "data": {
+    "aws_secretsmanager_secret": {
+      "Secret": {
+        "name": "my-secret",
+      },
+    },
   },
-  \\"output\\": {
-    \\"WING_TEST_RUNNER_FUNCTION_ARNS\\": {
-      \\"value\\": \\"[]\\"
-    }
-  }
-}"
+  "output": {
+    "WING_TEST_RUNNER_FUNCTION_ARNS": {
+      "value": "[]",
+    },
+  },
+}
 `;

--- a/libs/wingsdk/test/target-tf-aws/__snapshots__/table.test.ts.snap
+++ b/libs/wingsdk/test/target-tf-aws/__snapshots__/table.test.ts.snap
@@ -1,28 +1,28 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`default table behavior 1`] = `
-"{
-  \\"output\\": {
-    \\"WING_TEST_RUNNER_FUNCTION_ARNS\\": {
-      \\"value\\": \\"[]\\"
-    }
+{
+  "output": {
+    "WING_TEST_RUNNER_FUNCTION_ARNS": {
+      "value": "[]",
+    },
   },
-  \\"resource\\": {
-    \\"aws_dynamodb_table\\": {
-      \\"Table\\": {
-        \\"attribute\\": [
+  "resource": {
+    "aws_dynamodb_table": {
+      "Table": {
+        "attribute": [
           {
-            \\"name\\": \\"id\\",
-            \\"type\\": \\"S\\"
-          }
+            "name": "id",
+            "type": "S",
+          },
         ],
-        \\"billing_mode\\": \\"PAY_PER_REQUEST\\",
-        \\"hash_key\\": \\"id\\",
-        \\"name\\": \\"my-wing-tableTable-c89b2d37\\"
-      }
-    }
-  }
-}"
+        "billing_mode": "PAY_PER_REQUEST",
+        "hash_key": "id",
+        "name": "my-wing-tableTable-c89b2d37",
+      },
+    },
+  },
+}
 `;
 
 exports[`function with a table binding 1`] = `
@@ -43,81 +43,81 @@ my_table: new (require(\\"[REDACTED]/wingsdk/src/shared-aws/table.inflight\\")).
 `;
 
 exports[`function with a table binding 2`] = `
-"{
-  \\"output\\": {
-    \\"WING_TEST_RUNNER_FUNCTION_ARNS\\": {
-      \\"value\\": \\"[]\\"
-    }
+{
+  "output": {
+    "WING_TEST_RUNNER_FUNCTION_ARNS": {
+      "value": "[]",
+    },
   },
-  \\"resource\\": {
-    \\"aws_dynamodb_table\\": {
-      \\"Table\\": {
-        \\"attribute\\": [
+  "resource": {
+    "aws_dynamodb_table": {
+      "Table": {
+        "attribute": [
           {
-            \\"name\\": \\"id\\",
-            \\"type\\": \\"S\\"
-          }
+            "name": "id",
+            "type": "S",
+          },
         ],
-        \\"billing_mode\\": \\"PAY_PER_REQUEST\\",
-        \\"hash_key\\": \\"id\\",
-        \\"name\\": \\"my-wing-tableTable-c89b2d37\\"
-      }
+        "billing_mode": "PAY_PER_REQUEST",
+        "hash_key": "id",
+        "name": "my-wing-tableTable-c89b2d37",
+      },
     },
-    \\"aws_iam_role\\": {
-      \\"Function_IamRole_678BE84C\\": {
-        \\"assume_role_policy\\": \\"{\\\\\\"Version\\\\\\":\\\\\\"2012-10-17\\\\\\",\\\\\\"Statement\\\\\\":[{\\\\\\"Action\\\\\\":\\\\\\"sts:AssumeRole\\\\\\",\\\\\\"Principal\\\\\\":{\\\\\\"Service\\\\\\":\\\\\\"lambda.amazonaws.com\\\\\\"},\\\\\\"Effect\\\\\\":\\\\\\"Allow\\\\\\"}]}\\"
-      }
+    "aws_iam_role": {
+      "Function_IamRole_678BE84C": {
+        "assume_role_policy": "{\\"Version\\":\\"2012-10-17\\",\\"Statement\\":[{\\"Action\\":\\"sts:AssumeRole\\",\\"Principal\\":{\\"Service\\":\\"lambda.amazonaws.com\\"},\\"Effect\\":\\"Allow\\"}]}",
+      },
     },
-    \\"aws_iam_role_policy\\": {
-      \\"Function_IamRolePolicy_E3B26607\\": {
-        \\"policy\\": \\"{\\\\\\"Version\\\\\\":\\\\\\"2012-10-17\\\\\\",\\\\\\"Statement\\\\\\":[{\\\\\\"Action\\\\\\":[\\\\\\"dynamodb:PutItem\\\\\\"],\\\\\\"Resource\\\\\\":[\\\\\\"\${aws_dynamodb_table.Table.arn}\\\\\\"],\\\\\\"Effect\\\\\\":\\\\\\"Allow\\\\\\"}]}\\",
-        \\"role\\": \\"\${aws_iam_role.Function_IamRole_678BE84C.name}\\"
-      }
+    "aws_iam_role_policy": {
+      "Function_IamRolePolicy_E3B26607": {
+        "policy": "{\\"Version\\":\\"2012-10-17\\",\\"Statement\\":[{\\"Action\\":[\\"dynamodb:PutItem\\"],\\"Resource\\":[\\"\${aws_dynamodb_table.Table.arn}\\"],\\"Effect\\":\\"Allow\\"}]}",
+        "role": "\${aws_iam_role.Function_IamRole_678BE84C.name}",
+      },
     },
-    \\"aws_iam_role_policy_attachment\\": {
-      \\"Function_IamRolePolicyAttachment_CACE1358\\": {
-        \\"policy_arn\\": \\"arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole\\",
-        \\"role\\": \\"\${aws_iam_role.Function_IamRole_678BE84C.name}\\"
-      }
+    "aws_iam_role_policy_attachment": {
+      "Function_IamRolePolicyAttachment_CACE1358": {
+        "policy_arn": "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+        "role": "\${aws_iam_role.Function_IamRole_678BE84C.name}",
+      },
     },
-    \\"aws_lambda_function\\": {
-      \\"Function\\": {
-        \\"environment\\": {
-          \\"variables\\": {
-            \\"DYNAMODB_TABLE_NAME_e7245baa\\": \\"\${aws_dynamodb_table.Table.name}\\",
-            \\"DYNAMODB_TABLE_NAME_e7245baa_COLUMNS\\": \\"{\\\\\\"name\\\\\\":0}\\",
-            \\"DYNAMODB_TABLE_NAME_e7245baa_PRIMARY_KEY\\": \\"id\\",
-            \\"WING_FUNCTION_NAME\\": \\"Function-c852aba6\\"
-          }
+    "aws_lambda_function": {
+      "Function": {
+        "environment": {
+          "variables": {
+            "DYNAMODB_TABLE_NAME_e7245baa": "\${aws_dynamodb_table.Table.name}",
+            "DYNAMODB_TABLE_NAME_e7245baa_COLUMNS": "{\\"name\\":0}",
+            "DYNAMODB_TABLE_NAME_e7245baa_PRIMARY_KEY": "id",
+            "WING_FUNCTION_NAME": "Function-c852aba6",
+          },
         },
-        \\"function_name\\": \\"Function-c852aba6\\",
-        \\"handler\\": \\"index.handler\\",
-        \\"publish\\": true,
-        \\"role\\": \\"\${aws_iam_role.Function_IamRole_678BE84C.arn}\\",
-        \\"runtime\\": \\"nodejs18.x\\",
-        \\"s3_bucket\\": \\"\${aws_s3_bucket.Code.bucket}\\",
-        \\"s3_key\\": \\"\${aws_s3_object.Function_S3Object_C62A0C2D.key}\\",
-        \\"timeout\\": 30,
-        \\"vpc_config\\": {
-          \\"security_group_ids\\": [],
-          \\"subnet_ids\\": []
-        }
-      }
+        "function_name": "Function-c852aba6",
+        "handler": "index.handler",
+        "publish": true,
+        "role": "\${aws_iam_role.Function_IamRole_678BE84C.arn}",
+        "runtime": "nodejs18.x",
+        "s3_bucket": "\${aws_s3_bucket.Code.bucket}",
+        "s3_key": "\${aws_s3_object.Function_S3Object_C62A0C2D.key}",
+        "timeout": 30,
+        "vpc_config": {
+          "security_group_ids": [],
+          "subnet_ids": [],
+        },
+      },
     },
-    \\"aws_s3_bucket\\": {
-      \\"Code\\": {
-        \\"bucket_prefix\\": \\"code-c84a50b1-\\"
-      }
+    "aws_s3_bucket": {
+      "Code": {
+        "bucket_prefix": "code-c84a50b1-",
+      },
     },
-    \\"aws_s3_object\\": {
-      \\"Function_S3Object_C62A0C2D\\": {
-        \\"bucket\\": \\"\${aws_s3_bucket.Code.bucket}\\",
-        \\"key\\": \\"<key>\\",
-        \\"source\\": \\"<source>\\"
-      }
-    }
-  }
-}"
+    "aws_s3_object": {
+      "Function_S3Object_C62A0C2D": {
+        "bucket": "\${aws_s3_bucket.Code.bucket}",
+        "key": "<key>",
+        "source": "<source>",
+      },
+    },
+  },
+}
 `;
 
 exports[`function with a table binding 3`] = `

--- a/libs/wingsdk/test/target-tf-aws/__snapshots__/tokens.test.ts.snap
+++ b/libs/wingsdk/test/target-tf-aws/__snapshots__/tokens.test.ts.snap
@@ -20,118 +20,118 @@ list: JSON.parse(process.env[\\"WING_TOKEN_TFTOKEN_TOKEN_9\\"])
 `;
 
 exports[`captures tokens 2`] = `
-"{
-  \\"data\\": {
-    \\"aws_region\\": {
-      \\"Region\\": {}
-    }
+{
+  "data": {
+    "aws_region": {
+      "Region": {},
+    },
   },
-  \\"output\\": {
-    \\"WING_TEST_RUNNER_FUNCTION_ARNS\\": {
-      \\"value\\": \\"[]\\"
-    }
+  "output": {
+    "WING_TEST_RUNNER_FUNCTION_ARNS": {
+      "value": "[]",
+    },
   },
-  \\"resource\\": {
-    \\"aws_api_gateway_deployment\\": {
-      \\"Api_api_deployment_7FB64CC4\\": {
-        \\"lifecycle\\": {
-          \\"create_before_destroy\\": true
+  "resource": {
+    "aws_api_gateway_deployment": {
+      "Api_api_deployment_7FB64CC4": {
+        "lifecycle": {
+          "create_before_destroy": true,
         },
-        \\"rest_api_id\\": \\"\${aws_api_gateway_rest_api.Api_api_91C07D84.id}\\",
-        \\"triggers\\": {
-          \\"redeployment\\": \\"5c0f11f0478884e3d7859fa987b8b7ecf8f2f6bc\\"
-        }
-      }
-    },
-    \\"aws_api_gateway_rest_api\\": {
-      \\"Api_api_91C07D84\\": {
-        \\"body\\": \\"{\\\\\\"openapi\\\\\\":\\\\\\"3.0.3\\\\\\",\\\\\\"paths\\\\\\":{\\\\\\"/\\\\\\":{\\\\\\"get\\\\\\":{\\\\\\"operationId\\\\\\":\\\\\\"get\\\\\\",\\\\\\"responses\\\\\\":{\\\\\\"200\\\\\\":{\\\\\\"description\\\\\\":\\\\\\"200 response\\\\\\",\\\\\\"content\\\\\\":{}}},\\\\\\"parameters\\\\\\":[],\\\\\\"x-amazon-apigateway-integration\\\\\\":{\\\\\\"uri\\\\\\":\\\\\\"arn:aws:apigateway:\${data.aws_region.Region.name}:lambda:path/2015-03-31/functions/\${aws_lambda_function.Api_Api-OnRequest-c5395e41_37F21C2B.arn}/invocations\\\\\\",\\\\\\"type\\\\\\":\\\\\\"aws_proxy\\\\\\",\\\\\\"httpMethod\\\\\\":\\\\\\"POST\\\\\\",\\\\\\"responses\\\\\\":{\\\\\\"default\\\\\\":{\\\\\\"statusCode\\\\\\":\\\\\\"200\\\\\\"}},\\\\\\"passthroughBehavior\\\\\\":\\\\\\"when_no_match\\\\\\",\\\\\\"contentHandling\\\\\\":\\\\\\"CONVERT_TO_TEXT\\\\\\"}}}}}\\",
-        \\"name\\": \\"api-c8f613f0\\"
-      }
-    },
-    \\"aws_api_gateway_stage\\": {
-      \\"Api_api_stage_E0FA39D6\\": {
-        \\"deployment_id\\": \\"\${aws_api_gateway_deployment.Api_api_deployment_7FB64CC4.id}\\",
-        \\"rest_api_id\\": \\"\${aws_api_gateway_rest_api.Api_api_91C07D84.id}\\",
-        \\"stage_name\\": \\"prod\\"
-      }
-    },
-    \\"aws_iam_role\\": {
-      \\"Api_Api-OnRequest-c5395e41_IamRole_9427E0ED\\": {
-        \\"assume_role_policy\\": \\"{\\\\\\"Version\\\\\\":\\\\\\"2012-10-17\\\\\\",\\\\\\"Statement\\\\\\":[{\\\\\\"Action\\\\\\":\\\\\\"sts:AssumeRole\\\\\\",\\\\\\"Principal\\\\\\":{\\\\\\"Service\\\\\\":\\\\\\"lambda.amazonaws.com\\\\\\"},\\\\\\"Effect\\\\\\":\\\\\\"Allow\\\\\\"}]}\\"
-      }
-    },
-    \\"aws_iam_role_policy\\": {
-      \\"Api_Api-OnRequest-c5395e41_IamRolePolicy_7C0B6530\\": {
-        \\"policy\\": \\"{\\\\\\"Version\\\\\\":\\\\\\"2012-10-17\\\\\\",\\\\\\"Statement\\\\\\":[{\\\\\\"Effect\\\\\\":\\\\\\"Allow\\\\\\",\\\\\\"Action\\\\\\":\\\\\\"none:null\\\\\\",\\\\\\"Resource\\\\\\":\\\\\\"*\\\\\\"}]}\\",
-        \\"role\\": \\"\${aws_iam_role.Api_Api-OnRequest-c5395e41_IamRole_9427E0ED.name}\\"
-      }
-    },
-    \\"aws_iam_role_policy_attachment\\": {
-      \\"Api_Api-OnRequest-c5395e41_IamRolePolicyAttachment_60C1AF18\\": {
-        \\"policy_arn\\": \\"arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole\\",
-        \\"role\\": \\"\${aws_iam_role.Api_Api-OnRequest-c5395e41_IamRole_9427E0ED.name}\\"
-      }
-    },
-    \\"aws_lambda_function\\": {
-      \\"Api_Api-OnRequest-c5395e41_37F21C2B\\": {
-        \\"environment\\": {
-          \\"variables\\": {
-            \\"WING_FUNCTION_NAME\\": \\"Api-OnRequest-c5395e41-c8f26cae\\",
-            \\"WING_TOKEN_8_109562212591386E_298\\": \\"\${jsonencode(var.Number)}\\",
-            \\"WING_TOKEN_TFTOKEN_TOKEN_7\\": \\"\${jsonencode(aws_api_gateway_stage.Api_api_stage_E0FA39D6.invoke_url)}\\",
-            \\"WING_TOKEN_TFTOKEN_TOKEN_9\\": \\"\${jsonencode(var.List)}\\"
-          }
+        "rest_api_id": "\${aws_api_gateway_rest_api.Api_api_91C07D84.id}",
+        "triggers": {
+          "redeployment": "5c0f11f0478884e3d7859fa987b8b7ecf8f2f6bc",
         },
-        \\"function_name\\": \\"Api-OnRequest-c5395e41-c8f26cae\\",
-        \\"handler\\": \\"index.handler\\",
-        \\"publish\\": true,
-        \\"role\\": \\"\${aws_iam_role.Api_Api-OnRequest-c5395e41_IamRole_9427E0ED.arn}\\",
-        \\"runtime\\": \\"nodejs18.x\\",
-        \\"s3_bucket\\": \\"\${aws_s3_bucket.Code.bucket}\\",
-        \\"s3_key\\": \\"\${aws_s3_object.Api_Api-OnRequest-c5395e41_S3Object_D564F39C.key}\\",
-        \\"timeout\\": 30,
-        \\"vpc_config\\": {
-          \\"security_group_ids\\": [],
-          \\"subnet_ids\\": []
-        }
-      }
+      },
     },
-    \\"aws_lambda_permission\\": {
-      \\"Api_api_permission-GET-c2e3ffa8_5BF93889\\": {
-        \\"action\\": \\"lambda:InvokeFunction\\",
-        \\"function_name\\": \\"\${aws_lambda_function.Api_Api-OnRequest-c5395e41_37F21C2B.function_name}\\",
-        \\"principal\\": \\"apigateway.amazonaws.com\\",
-        \\"source_arn\\": \\"\${aws_api_gateway_rest_api.Api_api_91C07D84.execution_arn}/*/GET/\\",
-        \\"statement_id\\": \\"AllowExecutionFromAPIGateway-GET-c2e3ffa8\\"
-      }
+    "aws_api_gateway_rest_api": {
+      "Api_api_91C07D84": {
+        "body": "{\\"openapi\\":\\"3.0.3\\",\\"paths\\":{\\"/\\":{\\"get\\":{\\"operationId\\":\\"get\\",\\"responses\\":{\\"200\\":{\\"description\\":\\"200 response\\",\\"content\\":{}}},\\"parameters\\":[],\\"x-amazon-apigateway-integration\\":{\\"uri\\":\\"arn:aws:apigateway:\${data.aws_region.Region.name}:lambda:path/2015-03-31/functions/\${aws_lambda_function.Api_Api-OnRequest-c5395e41_37F21C2B.arn}/invocations\\",\\"type\\":\\"aws_proxy\\",\\"httpMethod\\":\\"POST\\",\\"responses\\":{\\"default\\":{\\"statusCode\\":\\"200\\"}},\\"passthroughBehavior\\":\\"when_no_match\\",\\"contentHandling\\":\\"CONVERT_TO_TEXT\\"}}}}}",
+        "name": "api-c8f613f0",
+      },
     },
-    \\"aws_s3_bucket\\": {
-      \\"Code\\": {
-        \\"bucket_prefix\\": \\"code-c84a50b1-\\"
-      }
+    "aws_api_gateway_stage": {
+      "Api_api_stage_E0FA39D6": {
+        "deployment_id": "\${aws_api_gateway_deployment.Api_api_deployment_7FB64CC4.id}",
+        "rest_api_id": "\${aws_api_gateway_rest_api.Api_api_91C07D84.id}",
+        "stage_name": "prod",
+      },
     },
-    \\"aws_s3_object\\": {
-      \\"Api_Api-OnRequest-c5395e41_S3Object_D564F39C\\": {
-        \\"bucket\\": \\"\${aws_s3_bucket.Code.bucket}\\",
-        \\"key\\": \\"<key>\\",
-        \\"source\\": \\"<source>\\"
-      }
-    }
+    "aws_iam_role": {
+      "Api_Api-OnRequest-c5395e41_IamRole_9427E0ED": {
+        "assume_role_policy": "{\\"Version\\":\\"2012-10-17\\",\\"Statement\\":[{\\"Action\\":\\"sts:AssumeRole\\",\\"Principal\\":{\\"Service\\":\\"lambda.amazonaws.com\\"},\\"Effect\\":\\"Allow\\"}]}",
+      },
+    },
+    "aws_iam_role_policy": {
+      "Api_Api-OnRequest-c5395e41_IamRolePolicy_7C0B6530": {
+        "policy": "{\\"Version\\":\\"2012-10-17\\",\\"Statement\\":[{\\"Effect\\":\\"Allow\\",\\"Action\\":\\"none:null\\",\\"Resource\\":\\"*\\"}]}",
+        "role": "\${aws_iam_role.Api_Api-OnRequest-c5395e41_IamRole_9427E0ED.name}",
+      },
+    },
+    "aws_iam_role_policy_attachment": {
+      "Api_Api-OnRequest-c5395e41_IamRolePolicyAttachment_60C1AF18": {
+        "policy_arn": "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+        "role": "\${aws_iam_role.Api_Api-OnRequest-c5395e41_IamRole_9427E0ED.name}",
+      },
+    },
+    "aws_lambda_function": {
+      "Api_Api-OnRequest-c5395e41_37F21C2B": {
+        "environment": {
+          "variables": {
+            "WING_FUNCTION_NAME": "Api-OnRequest-c5395e41-c8f26cae",
+            "WING_TOKEN_8_109562212591386E_298": "\${jsonencode(var.Number)}",
+            "WING_TOKEN_TFTOKEN_TOKEN_7": "\${jsonencode(aws_api_gateway_stage.Api_api_stage_E0FA39D6.invoke_url)}",
+            "WING_TOKEN_TFTOKEN_TOKEN_9": "\${jsonencode(var.List)}",
+          },
+        },
+        "function_name": "Api-OnRequest-c5395e41-c8f26cae",
+        "handler": "index.handler",
+        "publish": true,
+        "role": "\${aws_iam_role.Api_Api-OnRequest-c5395e41_IamRole_9427E0ED.arn}",
+        "runtime": "nodejs18.x",
+        "s3_bucket": "\${aws_s3_bucket.Code.bucket}",
+        "s3_key": "\${aws_s3_object.Api_Api-OnRequest-c5395e41_S3Object_D564F39C.key}",
+        "timeout": 30,
+        "vpc_config": {
+          "security_group_ids": [],
+          "subnet_ids": [],
+        },
+      },
+    },
+    "aws_lambda_permission": {
+      "Api_api_permission-GET-c2e3ffa8_5BF93889": {
+        "action": "lambda:InvokeFunction",
+        "function_name": "\${aws_lambda_function.Api_Api-OnRequest-c5395e41_37F21C2B.function_name}",
+        "principal": "apigateway.amazonaws.com",
+        "source_arn": "\${aws_api_gateway_rest_api.Api_api_91C07D84.execution_arn}/*/GET/",
+        "statement_id": "AllowExecutionFromAPIGateway-GET-c2e3ffa8",
+      },
+    },
+    "aws_s3_bucket": {
+      "Code": {
+        "bucket_prefix": "code-c84a50b1-",
+      },
+    },
+    "aws_s3_object": {
+      "Api_Api-OnRequest-c5395e41_S3Object_D564F39C": {
+        "bucket": "\${aws_s3_bucket.Code.bucket}",
+        "key": "<key>",
+        "source": "<source>",
+      },
+    },
   },
-  \\"variable\\": {
-    \\"List\\": {
-      \\"default\\": [
+  "variable": {
+    "List": {
+      "default": [
         1,
         2,
-        3
+        3,
       ],
-      \\"type\\": \\"List<Number>\\"
+      "type": "List<Number>",
     },
-    \\"Number\\": {
-      \\"default\\": 123,
-      \\"type\\": \\"Number\\"
-    }
-  }
-}"
+    "Number": {
+      "default": 123,
+      "type": "Number",
+    },
+  },
+}
 `;

--- a/libs/wingsdk/test/target-tf-aws/__snapshots__/topic.test.ts.snap
+++ b/libs/wingsdk/test/target-tf-aws/__snapshots__/topic.test.ts.snap
@@ -1,20 +1,20 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`default topic behavior 1`] = `
-"{
-  \\"output\\": {
-    \\"WING_TEST_RUNNER_FUNCTION_ARNS\\": {
-      \\"value\\": \\"[]\\"
-    }
+{
+  "output": {
+    "WING_TEST_RUNNER_FUNCTION_ARNS": {
+      "value": "[]",
+    },
   },
-  \\"resource\\": {
-    \\"aws_sns_topic\\": {
-      \\"Topic\\": {
-        \\"name\\": \\"Topic-c8228fb7\\"
-      }
-    }
-  }
-}"
+  "resource": {
+    "aws_sns_topic": {
+      "Topic": {
+        "name": "Topic-c8228fb7",
+      },
+    },
+  },
+}
 `;
 
 exports[`default topic behavior 2`] = `
@@ -121,20 +121,20 @@ exports[`default topic behavior 2`] = `
 `;
 
 exports[`replace invalid character from queue name 1`] = `
-"{
-  \\"output\\": {
-    \\"WING_TEST_RUNNER_FUNCTION_ARNS\\": {
-      \\"value\\": \\"[]\\"
-    }
+{
+  "output": {
+    "WING_TEST_RUNNER_FUNCTION_ARNS": {
+      "value": "[]",
+    },
   },
-  \\"resource\\": {
-    \\"aws_sns_topic\\": {
-      \\"TheSpectacularTopic\\": {
-        \\"name\\": \\"The-Spectacular-Topic-c8252318\\"
-      }
-    }
-  }
-}"
+  "resource": {
+    "aws_sns_topic": {
+      "TheSpectacularTopic": {
+        "name": "The-Spectacular-Topic-c8252318",
+      },
+    },
+  },
+}
 `;
 
 exports[`replace invalid character from queue name 2`] = `
@@ -241,20 +241,20 @@ exports[`replace invalid character from queue name 2`] = `
 `;
 
 exports[`topic name valid 1`] = `
-"{
-  \\"output\\": {
-    \\"WING_TEST_RUNNER_FUNCTION_ARNS\\": {
-      \\"value\\": \\"[]\\"
-    }
+{
+  "output": {
+    "WING_TEST_RUNNER_FUNCTION_ARNS": {
+      "value": "[]",
+    },
   },
-  \\"resource\\": {
-    \\"aws_sns_topic\\": {
-      \\"The-Spectacular_Topic-01\\": {
-        \\"name\\": \\"The-Spectacular_Topic-01-c828760a\\"
-      }
-    }
-  }
-}"
+  "resource": {
+    "aws_sns_topic": {
+      "The-Spectacular_Topic-01": {
+        "name": "The-Spectacular_Topic-01-c828760a",
+      },
+    },
+  },
+}
 `;
 
 exports[`topic name valid 2`] = `
@@ -376,85 +376,85 @@ return class Handler {
 `;
 
 exports[`topic with subscriber function 2`] = `
-"{
-  \\"output\\": {
-    \\"WING_TEST_RUNNER_FUNCTION_ARNS\\": {
-      \\"value\\": \\"[]\\"
-    }
+{
+  "output": {
+    "WING_TEST_RUNNER_FUNCTION_ARNS": {
+      "value": "[]",
+    },
   },
-  \\"resource\\": {
-    \\"aws_iam_role\\": {
-      \\"Topic-OnMessage-c5395e41_IamRole_6C4D2D29\\": {
-        \\"assume_role_policy\\": \\"{\\\\\\"Version\\\\\\":\\\\\\"2012-10-17\\\\\\",\\\\\\"Statement\\\\\\":[{\\\\\\"Action\\\\\\":\\\\\\"sts:AssumeRole\\\\\\",\\\\\\"Principal\\\\\\":{\\\\\\"Service\\\\\\":\\\\\\"lambda.amazonaws.com\\\\\\"},\\\\\\"Effect\\\\\\":\\\\\\"Allow\\\\\\"}]}\\"
-      }
+  "resource": {
+    "aws_iam_role": {
+      "Topic-OnMessage-c5395e41_IamRole_6C4D2D29": {
+        "assume_role_policy": "{\\"Version\\":\\"2012-10-17\\",\\"Statement\\":[{\\"Action\\":\\"sts:AssumeRole\\",\\"Principal\\":{\\"Service\\":\\"lambda.amazonaws.com\\"},\\"Effect\\":\\"Allow\\"}]}",
+      },
     },
-    \\"aws_iam_role_policy\\": {
-      \\"Topic-OnMessage-c5395e41_IamRolePolicy_E008396D\\": {
-        \\"policy\\": \\"{\\\\\\"Version\\\\\\":\\\\\\"2012-10-17\\\\\\",\\\\\\"Statement\\\\\\":[{\\\\\\"Effect\\\\\\":\\\\\\"Allow\\\\\\",\\\\\\"Action\\\\\\":\\\\\\"none:null\\\\\\",\\\\\\"Resource\\\\\\":\\\\\\"*\\\\\\"}]}\\",
-        \\"role\\": \\"\${aws_iam_role.Topic-OnMessage-c5395e41_IamRole_6C4D2D29.name}\\"
-      }
+    "aws_iam_role_policy": {
+      "Topic-OnMessage-c5395e41_IamRolePolicy_E008396D": {
+        "policy": "{\\"Version\\":\\"2012-10-17\\",\\"Statement\\":[{\\"Effect\\":\\"Allow\\",\\"Action\\":\\"none:null\\",\\"Resource\\":\\"*\\"}]}",
+        "role": "\${aws_iam_role.Topic-OnMessage-c5395e41_IamRole_6C4D2D29.name}",
+      },
     },
-    \\"aws_iam_role_policy_attachment\\": {
-      \\"Topic-OnMessage-c5395e41_IamRolePolicyAttachment_936AE21F\\": {
-        \\"policy_arn\\": \\"arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole\\",
-        \\"role\\": \\"\${aws_iam_role.Topic-OnMessage-c5395e41_IamRole_6C4D2D29.name}\\"
-      }
+    "aws_iam_role_policy_attachment": {
+      "Topic-OnMessage-c5395e41_IamRolePolicyAttachment_936AE21F": {
+        "policy_arn": "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+        "role": "\${aws_iam_role.Topic-OnMessage-c5395e41_IamRole_6C4D2D29.name}",
+      },
     },
-    \\"aws_lambda_function\\": {
-      \\"Topic-OnMessage-c5395e41\\": {
-        \\"environment\\": {
-          \\"variables\\": {
-            \\"WING_FUNCTION_NAME\\": \\"Topic-OnMessage-c5395e41-c8eb4431\\"
-          }
+    "aws_lambda_function": {
+      "Topic-OnMessage-c5395e41": {
+        "environment": {
+          "variables": {
+            "WING_FUNCTION_NAME": "Topic-OnMessage-c5395e41-c8eb4431",
+          },
         },
-        \\"function_name\\": \\"Topic-OnMessage-c5395e41-c8eb4431\\",
-        \\"handler\\": \\"index.handler\\",
-        \\"publish\\": true,
-        \\"role\\": \\"\${aws_iam_role.Topic-OnMessage-c5395e41_IamRole_6C4D2D29.arn}\\",
-        \\"runtime\\": \\"nodejs18.x\\",
-        \\"s3_bucket\\": \\"\${aws_s3_bucket.Code.bucket}\\",
-        \\"s3_key\\": \\"\${aws_s3_object.Topic-OnMessage-c5395e41_S3Object_7A3438DE.key}\\",
-        \\"timeout\\": 30,
-        \\"vpc_config\\": {
-          \\"security_group_ids\\": [],
-          \\"subnet_ids\\": []
-        }
-      }
+        "function_name": "Topic-OnMessage-c5395e41-c8eb4431",
+        "handler": "index.handler",
+        "publish": true,
+        "role": "\${aws_iam_role.Topic-OnMessage-c5395e41_IamRole_6C4D2D29.arn}",
+        "runtime": "nodejs18.x",
+        "s3_bucket": "\${aws_s3_bucket.Code.bucket}",
+        "s3_key": "\${aws_s3_object.Topic-OnMessage-c5395e41_S3Object_7A3438DE.key}",
+        "timeout": 30,
+        "vpc_config": {
+          "security_group_ids": [],
+          "subnet_ids": [],
+        },
+      },
     },
-    \\"aws_lambda_permission\\": {
-      \\"Topic-OnMessage-c5395e41_InvokePermission-c8228fb70d825c2a5610c610e5246d5313ea6bd1a2_DC3A27DA\\": {
-        \\"action\\": \\"lambda:InvokeFunction\\",
-        \\"function_name\\": \\"\${aws_lambda_function.Topic-OnMessage-c5395e41.function_name}\\",
-        \\"principal\\": \\"sns.amazonaws.com\\",
-        \\"source_arn\\": \\"\${aws_sns_topic.Topic.arn}\\"
-      }
+    "aws_lambda_permission": {
+      "Topic-OnMessage-c5395e41_InvokePermission-c8228fb70d825c2a5610c610e5246d5313ea6bd1a2_DC3A27DA": {
+        "action": "lambda:InvokeFunction",
+        "function_name": "\${aws_lambda_function.Topic-OnMessage-c5395e41.function_name}",
+        "principal": "sns.amazonaws.com",
+        "source_arn": "\${aws_sns_topic.Topic.arn}",
+      },
     },
-    \\"aws_s3_bucket\\": {
-      \\"Code\\": {
-        \\"bucket_prefix\\": \\"code-c84a50b1-\\"
-      }
+    "aws_s3_bucket": {
+      "Code": {
+        "bucket_prefix": "code-c84a50b1-",
+      },
     },
-    \\"aws_s3_object\\": {
-      \\"Topic-OnMessage-c5395e41_S3Object_7A3438DE\\": {
-        \\"bucket\\": \\"\${aws_s3_bucket.Code.bucket}\\",
-        \\"key\\": \\"<key>\\",
-        \\"source\\": \\"<source>\\"
-      }
+    "aws_s3_object": {
+      "Topic-OnMessage-c5395e41_S3Object_7A3438DE": {
+        "bucket": "\${aws_s3_bucket.Code.bucket}",
+        "key": "<key>",
+        "source": "<source>",
+      },
     },
-    \\"aws_sns_topic\\": {
-      \\"Topic\\": {
-        \\"name\\": \\"Topic-c8228fb7\\"
-      }
+    "aws_sns_topic": {
+      "Topic": {
+        "name": "Topic-c8228fb7",
+      },
     },
-    \\"aws_sns_topic_subscription\\": {
-      \\"Topic_Topic-TopicSubscription-c5395e41_5CA277EA\\": {
-        \\"endpoint\\": \\"\${aws_lambda_function.Topic-OnMessage-c5395e41.arn}\\",
-        \\"protocol\\": \\"lambda\\",
-        \\"topic_arn\\": \\"\${aws_sns_topic.Topic.arn}\\"
-      }
-    }
-  }
-}"
+    "aws_sns_topic_subscription": {
+      "Topic_Topic-TopicSubscription-c5395e41_5CA277EA": {
+        "endpoint": "\${aws_lambda_function.Topic-OnMessage-c5395e41.arn}",
+        "protocol": "lambda",
+        "topic_arn": "\${aws_sns_topic.Topic.arn}",
+      },
+    },
+  },
+}
 `;
 
 exports[`topic with subscriber function 3`] = `

--- a/libs/wingsdk/test/target-tf-aws/__snapshots__/website.test.ts.snap
+++ b/libs/wingsdk/test/target-tf-aws/__snapshots__/website.test.ts.snap
@@ -1,164 +1,164 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`default website behavior 1`] = `
-"{
-  \\"data\\": {
-    \\"aws_iam_policy_document\\": {
-      \\"Website_AllowDistributionReadOnly_24CFF6C0\\": {
-        \\"statement\\": [
+{
+  "data": {
+    "aws_iam_policy_document": {
+      "Website_AllowDistributionReadOnly_24CFF6C0": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"s3:GetObject\\"
+            "actions": [
+              "s3:GetObject",
             ],
-            \\"condition\\": [
+            "condition": [
               {
-                \\"test\\": \\"StringEquals\\",
-                \\"values\\": [
-                  \\"\${aws_cloudfront_distribution.Website_Distribution_5E840E42.arn}\\"
+                "test": "StringEquals",
+                "values": [
+                  "\${aws_cloudfront_distribution.Website_Distribution_5E840E42.arn}",
                 ],
-                \\"variable\\": \\"AWS:SourceArn\\"
-              }
+                "variable": "AWS:SourceArn",
+              },
             ],
-            \\"principals\\": [
+            "principals": [
               {
-                \\"identifiers\\": [
-                  \\"cloudfront.amazonaws.com\\"
+                "identifiers": [
+                  "cloudfront.amazonaws.com",
                 ],
-                \\"type\\": \\"Service\\"
-              }
+                "type": "Service",
+              },
             ],
-            \\"resources\\": [
-              \\"\${aws_s3_bucket.Website_WebsiteBucket_3C0321F0.arn}/*\\"
-            ]
-          }
-        ]
-      }
-    }
-  },
-  \\"output\\": {
-    \\"WING_TEST_RUNNER_FUNCTION_ARNS\\": {
-      \\"value\\": \\"[]\\"
-    }
-  },
-  \\"resource\\": {
-    \\"aws_cloudfront_distribution\\": {
-      \\"Website_Distribution_5E840E42\\": {
-        \\"default_cache_behavior\\": {
-          \\"allowed_methods\\": [
-            \\"GET\\",
-            \\"HEAD\\"
-          ],
-          \\"cached_methods\\": [
-            \\"GET\\",
-            \\"HEAD\\"
-          ],
-          \\"compress\\": true,
-          \\"default_ttl\\": 3600,
-          \\"forwarded_values\\": {
-            \\"cookies\\": {
-              \\"forward\\": \\"none\\"
-            },
-            \\"query_string\\": false
+            "resources": [
+              "\${aws_s3_bucket.Website_WebsiteBucket_3C0321F0.arn}/*",
+            ],
           },
-          \\"max_ttl\\": 86400,
-          \\"min_ttl\\": 0,
-          \\"target_origin_id\\": \\"s3Origin\\",
-          \\"viewer_protocol_policy\\": \\"redirect-to-https\\"
-        },
-        \\"default_root_object\\": \\"index.html\\",
-        \\"enabled\\": true,
-        \\"origin\\": [
-          {
-            \\"domain_name\\": \\"\${aws_s3_bucket.Website_WebsiteBucket_3C0321F0.bucket_regional_domain_name}\\",
-            \\"origin_access_control_id\\": \\"\${aws_cloudfront_origin_access_control.Website_CloudfrontOac_756836A4.id}\\",
-            \\"origin_id\\": \\"s3Origin\\"
-          }
         ],
-        \\"price_class\\": \\"PriceClass_100\\",
-        \\"restrictions\\": {
-          \\"geo_restriction\\": {
-            \\"locations\\": [],
-            \\"restriction_type\\": \\"none\\"
-          }
-        },
-        \\"viewer_certificate\\": {
-          \\"cloudfront_default_certificate\\": true
-        }
-      }
-    },
-    \\"aws_cloudfront_origin_access_control\\": {
-      \\"Website_CloudfrontOac_756836A4\\": {
-        \\"name\\": \\"Website-c80d509a-cloudfront-oac\\",
-        \\"origin_access_control_origin_type\\": \\"s3\\",
-        \\"signing_behavior\\": \\"always\\",
-        \\"signing_protocol\\": \\"sigv4\\"
-      }
-    },
-    \\"aws_s3_bucket\\": {
-      \\"Website_WebsiteBucket_3C0321F0\\": {
-        \\"bucket_prefix\\": \\"website-c80d509a-\\",
-        \\"force_destroy\\": false
-      }
-    },
-    \\"aws_s3_bucket_policy\\": {
-      \\"Website_DistributionS3BucketPolicy_09AE0BCA\\": {
-        \\"bucket\\": \\"\${aws_s3_bucket.Website_WebsiteBucket_3C0321F0.id}\\",
-        \\"policy\\": \\"\${data.aws_iam_policy_document.Website_AllowDistributionReadOnly_24CFF6C0.json}\\"
-      }
-    },
-    \\"aws_s3_bucket_public_access_block\\": {
-      \\"Website_PublicAccessBlock_C196C11D\\": {
-        \\"block_public_acls\\": true,
-        \\"block_public_policy\\": true,
-        \\"bucket\\": \\"\${aws_s3_bucket.Website_WebsiteBucket_3C0321F0.bucket}\\",
-        \\"ignore_public_acls\\": true,
-        \\"restrict_public_buckets\\": true
-      }
-    },
-    \\"aws_s3_bucket_server_side_encryption_configuration\\": {
-      \\"Website_Encryption_5BBFE612\\": {
-        \\"bucket\\": \\"\${aws_s3_bucket.Website_WebsiteBucket_3C0321F0.bucket}\\",
-        \\"rule\\": [
-          {
-            \\"apply_server_side_encryption_by_default\\": {
-              \\"sse_algorithm\\": \\"AES256\\"
-            }
-          }
-        ]
-      }
-    },
-    \\"aws_s3_bucket_website_configuration\\": {
-      \\"Website_BucketWebsiteConfiguration_58F891B4\\": {
-        \\"bucket\\": \\"\${aws_s3_bucket.Website_WebsiteBucket_3C0321F0.bucket}\\",
-        \\"index_document\\": {
-          \\"suffix\\": \\"index.html\\"
-        }
-      }
-    },
-    \\"aws_s3_object\\": {
-      \\"Website_File--bhtml_6ACC0793\\": {
-        \\"bucket\\": \\"\${aws_s3_bucket.Website_WebsiteBucket_3C0321F0.bucket}\\",
-        \\"content_type\\": \\"text/html; charset=utf-8\\",
-        \\"depends_on\\": [
-          \\"aws_s3_bucket.Website_WebsiteBucket_3C0321F0\\"
-        ],
-        \\"key\\": \\"/b.html\\",
-        \\"source\\": \\"<source>\\",
-        \\"source_hash\\": \\"\${filemd5(<source>)}\\"
       },
-      \\"Website_File--inner-folder--ahtml_7D20A7EF\\": {
-        \\"bucket\\": \\"\${aws_s3_bucket.Website_WebsiteBucket_3C0321F0.bucket}\\",
-        \\"content_type\\": \\"text/html; charset=utf-8\\",
-        \\"depends_on\\": [
-          \\"aws_s3_bucket.Website_WebsiteBucket_3C0321F0\\"
+    },
+  },
+  "output": {
+    "WING_TEST_RUNNER_FUNCTION_ARNS": {
+      "value": "[]",
+    },
+  },
+  "resource": {
+    "aws_cloudfront_distribution": {
+      "Website_Distribution_5E840E42": {
+        "default_cache_behavior": {
+          "allowed_methods": [
+            "GET",
+            "HEAD",
+          ],
+          "cached_methods": [
+            "GET",
+            "HEAD",
+          ],
+          "compress": true,
+          "default_ttl": 3600,
+          "forwarded_values": {
+            "cookies": {
+              "forward": "none",
+            },
+            "query_string": false,
+          },
+          "max_ttl": 86400,
+          "min_ttl": 0,
+          "target_origin_id": "s3Origin",
+          "viewer_protocol_policy": "redirect-to-https",
+        },
+        "default_root_object": "index.html",
+        "enabled": true,
+        "origin": [
+          {
+            "domain_name": "\${aws_s3_bucket.Website_WebsiteBucket_3C0321F0.bucket_regional_domain_name}",
+            "origin_access_control_id": "\${aws_cloudfront_origin_access_control.Website_CloudfrontOac_756836A4.id}",
+            "origin_id": "s3Origin",
+          },
         ],
-        \\"key\\": \\"/inner-folder/a.html\\",
-        \\"source\\": \\"<source>\\",
-        \\"source_hash\\": \\"\${filemd5(<source>)}\\"
-      }
-    }
-  }
-}"
+        "price_class": "PriceClass_100",
+        "restrictions": {
+          "geo_restriction": {
+            "locations": [],
+            "restriction_type": "none",
+          },
+        },
+        "viewer_certificate": {
+          "cloudfront_default_certificate": true,
+        },
+      },
+    },
+    "aws_cloudfront_origin_access_control": {
+      "Website_CloudfrontOac_756836A4": {
+        "name": "Website-c80d509a-cloudfront-oac",
+        "origin_access_control_origin_type": "s3",
+        "signing_behavior": "always",
+        "signing_protocol": "sigv4",
+      },
+    },
+    "aws_s3_bucket": {
+      "Website_WebsiteBucket_3C0321F0": {
+        "bucket_prefix": "website-c80d509a-",
+        "force_destroy": false,
+      },
+    },
+    "aws_s3_bucket_policy": {
+      "Website_DistributionS3BucketPolicy_09AE0BCA": {
+        "bucket": "\${aws_s3_bucket.Website_WebsiteBucket_3C0321F0.id}",
+        "policy": "\${data.aws_iam_policy_document.Website_AllowDistributionReadOnly_24CFF6C0.json}",
+      },
+    },
+    "aws_s3_bucket_public_access_block": {
+      "Website_PublicAccessBlock_C196C11D": {
+        "block_public_acls": true,
+        "block_public_policy": true,
+        "bucket": "\${aws_s3_bucket.Website_WebsiteBucket_3C0321F0.bucket}",
+        "ignore_public_acls": true,
+        "restrict_public_buckets": true,
+      },
+    },
+    "aws_s3_bucket_server_side_encryption_configuration": {
+      "Website_Encryption_5BBFE612": {
+        "bucket": "\${aws_s3_bucket.Website_WebsiteBucket_3C0321F0.bucket}",
+        "rule": [
+          {
+            "apply_server_side_encryption_by_default": {
+              "sse_algorithm": "AES256",
+            },
+          },
+        ],
+      },
+    },
+    "aws_s3_bucket_website_configuration": {
+      "Website_BucketWebsiteConfiguration_58F891B4": {
+        "bucket": "\${aws_s3_bucket.Website_WebsiteBucket_3C0321F0.bucket}",
+        "index_document": {
+          "suffix": "index.html",
+        },
+      },
+    },
+    "aws_s3_object": {
+      "Website_File--bhtml_6ACC0793": {
+        "bucket": "\${aws_s3_bucket.Website_WebsiteBucket_3C0321F0.bucket}",
+        "content_type": "text/html; charset=utf-8",
+        "depends_on": [
+          "aws_s3_bucket.Website_WebsiteBucket_3C0321F0",
+        ],
+        "key": "/b.html",
+        "source": "<source>",
+        "source_hash": "\${filemd5(<source>)}",
+      },
+      "Website_File--inner-folder--ahtml_7D20A7EF": {
+        "bucket": "\${aws_s3_bucket.Website_WebsiteBucket_3C0321F0.bucket}",
+        "content_type": "text/html; charset=utf-8",
+        "depends_on": [
+          "aws_s3_bucket.Website_WebsiteBucket_3C0321F0",
+        ],
+        "key": "/inner-folder/a.html",
+        "source": "<source>",
+        "source_hash": "\${filemd5(<source>)}",
+      },
+    },
+  },
+}
 `;
 
 exports[`default website behavior 2`] = `
@@ -337,173 +337,173 @@ exports[`default website behavior 2`] = `
 `;
 
 exports[`website with add_json 1`] = `
-"{
-  \\"data\\": {
-    \\"aws_iam_policy_document\\": {
-      \\"Website_AllowDistributionReadOnly_24CFF6C0\\": {
-        \\"statement\\": [
+{
+  "data": {
+    "aws_iam_policy_document": {
+      "Website_AllowDistributionReadOnly_24CFF6C0": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"s3:GetObject\\"
+            "actions": [
+              "s3:GetObject",
             ],
-            \\"condition\\": [
+            "condition": [
               {
-                \\"test\\": \\"StringEquals\\",
-                \\"values\\": [
-                  \\"\${aws_cloudfront_distribution.Website_Distribution_5E840E42.arn}\\"
+                "test": "StringEquals",
+                "values": [
+                  "\${aws_cloudfront_distribution.Website_Distribution_5E840E42.arn}",
                 ],
-                \\"variable\\": \\"AWS:SourceArn\\"
-              }
+                "variable": "AWS:SourceArn",
+              },
             ],
-            \\"principals\\": [
+            "principals": [
               {
-                \\"identifiers\\": [
-                  \\"cloudfront.amazonaws.com\\"
+                "identifiers": [
+                  "cloudfront.amazonaws.com",
                 ],
-                \\"type\\": \\"Service\\"
-              }
+                "type": "Service",
+              },
             ],
-            \\"resources\\": [
-              \\"\${aws_s3_bucket.Website_WebsiteBucket_3C0321F0.arn}/*\\"
-            ]
-          }
-        ]
-      }
-    }
-  },
-  \\"output\\": {
-    \\"WING_TEST_RUNNER_FUNCTION_ARNS\\": {
-      \\"value\\": \\"[]\\"
-    }
-  },
-  \\"resource\\": {
-    \\"aws_cloudfront_distribution\\": {
-      \\"Website_Distribution_5E840E42\\": {
-        \\"default_cache_behavior\\": {
-          \\"allowed_methods\\": [
-            \\"GET\\",
-            \\"HEAD\\"
-          ],
-          \\"cached_methods\\": [
-            \\"GET\\",
-            \\"HEAD\\"
-          ],
-          \\"compress\\": true,
-          \\"default_ttl\\": 3600,
-          \\"forwarded_values\\": {
-            \\"cookies\\": {
-              \\"forward\\": \\"none\\"
-            },
-            \\"query_string\\": false
+            "resources": [
+              "\${aws_s3_bucket.Website_WebsiteBucket_3C0321F0.arn}/*",
+            ],
           },
-          \\"max_ttl\\": 86400,
-          \\"min_ttl\\": 0,
-          \\"target_origin_id\\": \\"s3Origin\\",
-          \\"viewer_protocol_policy\\": \\"redirect-to-https\\"
-        },
-        \\"default_root_object\\": \\"index.html\\",
-        \\"enabled\\": true,
-        \\"origin\\": [
-          {
-            \\"domain_name\\": \\"\${aws_s3_bucket.Website_WebsiteBucket_3C0321F0.bucket_regional_domain_name}\\",
-            \\"origin_access_control_id\\": \\"\${aws_cloudfront_origin_access_control.Website_CloudfrontOac_756836A4.id}\\",
-            \\"origin_id\\": \\"s3Origin\\"
-          }
         ],
-        \\"price_class\\": \\"PriceClass_100\\",
-        \\"restrictions\\": {
-          \\"geo_restriction\\": {
-            \\"locations\\": [],
-            \\"restriction_type\\": \\"none\\"
-          }
-        },
-        \\"viewer_certificate\\": {
-          \\"cloudfront_default_certificate\\": true
-        }
-      }
-    },
-    \\"aws_cloudfront_origin_access_control\\": {
-      \\"Website_CloudfrontOac_756836A4\\": {
-        \\"name\\": \\"Website-c80d509a-cloudfront-oac\\",
-        \\"origin_access_control_origin_type\\": \\"s3\\",
-        \\"signing_behavior\\": \\"always\\",
-        \\"signing_protocol\\": \\"sigv4\\"
-      }
-    },
-    \\"aws_s3_bucket\\": {
-      \\"Website_WebsiteBucket_3C0321F0\\": {
-        \\"bucket_prefix\\": \\"website-c80d509a-\\",
-        \\"force_destroy\\": false
-      }
-    },
-    \\"aws_s3_bucket_policy\\": {
-      \\"Website_DistributionS3BucketPolicy_09AE0BCA\\": {
-        \\"bucket\\": \\"\${aws_s3_bucket.Website_WebsiteBucket_3C0321F0.id}\\",
-        \\"policy\\": \\"\${data.aws_iam_policy_document.Website_AllowDistributionReadOnly_24CFF6C0.json}\\"
-      }
-    },
-    \\"aws_s3_bucket_public_access_block\\": {
-      \\"Website_PublicAccessBlock_C196C11D\\": {
-        \\"block_public_acls\\": true,
-        \\"block_public_policy\\": true,
-        \\"bucket\\": \\"\${aws_s3_bucket.Website_WebsiteBucket_3C0321F0.bucket}\\",
-        \\"ignore_public_acls\\": true,
-        \\"restrict_public_buckets\\": true
-      }
-    },
-    \\"aws_s3_bucket_server_side_encryption_configuration\\": {
-      \\"Website_Encryption_5BBFE612\\": {
-        \\"bucket\\": \\"\${aws_s3_bucket.Website_WebsiteBucket_3C0321F0.bucket}\\",
-        \\"rule\\": [
-          {
-            \\"apply_server_side_encryption_by_default\\": {
-              \\"sse_algorithm\\": \\"AES256\\"
-            }
-          }
-        ]
-      }
-    },
-    \\"aws_s3_bucket_website_configuration\\": {
-      \\"Website_BucketWebsiteConfiguration_58F891B4\\": {
-        \\"bucket\\": \\"\${aws_s3_bucket.Website_WebsiteBucket_3C0321F0.bucket}\\",
-        \\"index_document\\": {
-          \\"suffix\\": \\"index.html\\"
-        }
-      }
-    },
-    \\"aws_s3_object\\": {
-      \\"Website_File--bhtml_6ACC0793\\": {
-        \\"bucket\\": \\"\${aws_s3_bucket.Website_WebsiteBucket_3C0321F0.bucket}\\",
-        \\"content_type\\": \\"text/html; charset=utf-8\\",
-        \\"depends_on\\": [
-          \\"aws_s3_bucket.Website_WebsiteBucket_3C0321F0\\"
-        ],
-        \\"key\\": \\"/b.html\\",
-        \\"source\\": \\"<source>\\",
-        \\"source_hash\\": \\"\${filemd5(<source>)}\\"
       },
-      \\"Website_File--inner-folder--ahtml_7D20A7EF\\": {
-        \\"bucket\\": \\"\${aws_s3_bucket.Website_WebsiteBucket_3C0321F0.bucket}\\",
-        \\"content_type\\": \\"text/html; charset=utf-8\\",
-        \\"depends_on\\": [
-          \\"aws_s3_bucket.Website_WebsiteBucket_3C0321F0\\"
+    },
+  },
+  "output": {
+    "WING_TEST_RUNNER_FUNCTION_ARNS": {
+      "value": "[]",
+    },
+  },
+  "resource": {
+    "aws_cloudfront_distribution": {
+      "Website_Distribution_5E840E42": {
+        "default_cache_behavior": {
+          "allowed_methods": [
+            "GET",
+            "HEAD",
+          ],
+          "cached_methods": [
+            "GET",
+            "HEAD",
+          ],
+          "compress": true,
+          "default_ttl": 3600,
+          "forwarded_values": {
+            "cookies": {
+              "forward": "none",
+            },
+            "query_string": false,
+          },
+          "max_ttl": 86400,
+          "min_ttl": 0,
+          "target_origin_id": "s3Origin",
+          "viewer_protocol_policy": "redirect-to-https",
+        },
+        "default_root_object": "index.html",
+        "enabled": true,
+        "origin": [
+          {
+            "domain_name": "\${aws_s3_bucket.Website_WebsiteBucket_3C0321F0.bucket_regional_domain_name}",
+            "origin_access_control_id": "\${aws_cloudfront_origin_access_control.Website_CloudfrontOac_756836A4.id}",
+            "origin_id": "s3Origin",
+          },
         ],
-        \\"key\\": \\"/inner-folder/a.html\\",
-        \\"source\\": \\"<source>\\",
-        \\"source_hash\\": \\"\${filemd5(<source>)}\\"
+        "price_class": "PriceClass_100",
+        "restrictions": {
+          "geo_restriction": {
+            "locations": [],
+            "restriction_type": "none",
+          },
+        },
+        "viewer_certificate": {
+          "cloudfront_default_certificate": true,
+        },
       },
-      \\"Website_File-configjson_1F1498B9\\": {
-        \\"bucket\\": \\"\${aws_s3_bucket.Website_WebsiteBucket_3C0321F0.bucket}\\",
-        \\"content\\": \\"{\\\\\\"version\\\\\\":\\\\\\"8.31.0\\\\\\"}\\",
-        \\"content_type\\": \\"application/json\\",
-        \\"depends_on\\": [
-          \\"aws_s3_bucket.Website_WebsiteBucket_3C0321F0\\"
+    },
+    "aws_cloudfront_origin_access_control": {
+      "Website_CloudfrontOac_756836A4": {
+        "name": "Website-c80d509a-cloudfront-oac",
+        "origin_access_control_origin_type": "s3",
+        "signing_behavior": "always",
+        "signing_protocol": "sigv4",
+      },
+    },
+    "aws_s3_bucket": {
+      "Website_WebsiteBucket_3C0321F0": {
+        "bucket_prefix": "website-c80d509a-",
+        "force_destroy": false,
+      },
+    },
+    "aws_s3_bucket_policy": {
+      "Website_DistributionS3BucketPolicy_09AE0BCA": {
+        "bucket": "\${aws_s3_bucket.Website_WebsiteBucket_3C0321F0.id}",
+        "policy": "\${data.aws_iam_policy_document.Website_AllowDistributionReadOnly_24CFF6C0.json}",
+      },
+    },
+    "aws_s3_bucket_public_access_block": {
+      "Website_PublicAccessBlock_C196C11D": {
+        "block_public_acls": true,
+        "block_public_policy": true,
+        "bucket": "\${aws_s3_bucket.Website_WebsiteBucket_3C0321F0.bucket}",
+        "ignore_public_acls": true,
+        "restrict_public_buckets": true,
+      },
+    },
+    "aws_s3_bucket_server_side_encryption_configuration": {
+      "Website_Encryption_5BBFE612": {
+        "bucket": "\${aws_s3_bucket.Website_WebsiteBucket_3C0321F0.bucket}",
+        "rule": [
+          {
+            "apply_server_side_encryption_by_default": {
+              "sse_algorithm": "AES256",
+            },
+          },
         ],
-        \\"key\\": \\"config.json\\"
-      }
-    }
-  }
-}"
+      },
+    },
+    "aws_s3_bucket_website_configuration": {
+      "Website_BucketWebsiteConfiguration_58F891B4": {
+        "bucket": "\${aws_s3_bucket.Website_WebsiteBucket_3C0321F0.bucket}",
+        "index_document": {
+          "suffix": "index.html",
+        },
+      },
+    },
+    "aws_s3_object": {
+      "Website_File--bhtml_6ACC0793": {
+        "bucket": "\${aws_s3_bucket.Website_WebsiteBucket_3C0321F0.bucket}",
+        "content_type": "text/html; charset=utf-8",
+        "depends_on": [
+          "aws_s3_bucket.Website_WebsiteBucket_3C0321F0",
+        ],
+        "key": "/b.html",
+        "source": "<source>",
+        "source_hash": "\${filemd5(<source>)}",
+      },
+      "Website_File--inner-folder--ahtml_7D20A7EF": {
+        "bucket": "\${aws_s3_bucket.Website_WebsiteBucket_3C0321F0.bucket}",
+        "content_type": "text/html; charset=utf-8",
+        "depends_on": [
+          "aws_s3_bucket.Website_WebsiteBucket_3C0321F0",
+        ],
+        "key": "/inner-folder/a.html",
+        "source": "<source>",
+        "source_hash": "\${filemd5(<source>)}",
+      },
+      "Website_File-configjson_1F1498B9": {
+        "bucket": "\${aws_s3_bucket.Website_WebsiteBucket_3C0321F0.bucket}",
+        "content": "{\\"version\\":\\"8.31.0\\"}",
+        "content_type": "application/json",
+        "depends_on": [
+          "aws_s3_bucket.Website_WebsiteBucket_3C0321F0",
+        ],
+        "key": "config.json",
+      },
+    },
+  },
+}
 `;
 
 exports[`website with add_json 2`] = `

--- a/libs/wingsdk/test/target-tf-aws/counter.test.ts
+++ b/libs/wingsdk/test/target-tf-aws/counter.test.ts
@@ -12,7 +12,7 @@ import {
 } from "../util";
 
 test("default counter behavior", () => {
-  const app = new tfaws.App({ outdir: mkdtemp() });
+  const app = new tfaws.App({ outdir: mkdtemp(), entrypointDir: __dirname });
   cloud.Counter._newCounter(app, "Counter");
   const output = app.synth();
 
@@ -21,7 +21,7 @@ test("default counter behavior", () => {
 });
 
 test("counter with initial value", () => {
-  const app = new tfaws.App({ outdir: mkdtemp() });
+  const app = new tfaws.App({ outdir: mkdtemp(), entrypointDir: __dirname });
   cloud.Counter._newCounter(app, "Counter", {
     initial: 9991,
   });
@@ -33,7 +33,7 @@ test("counter with initial value", () => {
 });
 
 test("function with a counter binding", () => {
-  const app = new tfaws.App({ outdir: mkdtemp() });
+  const app = new tfaws.App({ outdir: mkdtemp(), entrypointDir: __dirname });
   const counter = cloud.Counter._newCounter(app, "Counter");
   const inflight = Testing.makeHandler(
     app,
@@ -86,7 +86,7 @@ test("inc() policy statement", () => {
   cloud.Function._newFunction(app, "Function", inflight);
   const output = app.synth();
 
-  expect(tfSanitize(output)).toContain("dynamodb:UpdateItem");
+  expect(output).toContain("dynamodb:UpdateItem");
   expect(tfSanitize(output)).toMatchSnapshot();
   expect(treeJsonOf(app.outdir)).toMatchSnapshot();
 });
@@ -111,7 +111,7 @@ test("dec() policy statement", () => {
   cloud.Function._newFunction(app, "Function", inflight);
   const output = app.synth();
 
-  expect(tfSanitize(output)).toContain("dynamodb:UpdateItem");
+  expect(output).toContain("dynamodb:UpdateItem");
   expect(tfSanitize(output)).toMatchSnapshot();
   expect(treeJsonOf(app.outdir)).toMatchSnapshot();
 });
@@ -136,7 +136,7 @@ test("peek() policy statement", () => {
   cloud.Function._newFunction(app, "Function", inflight);
   const output = app.synth();
 
-  expect(tfSanitize(output)).toContain("dynamodb:GetItem");
+  expect(output).toContain("dynamodb:GetItem");
   expect(tfSanitize(output)).toMatchSnapshot();
   expect(treeJsonOf(app.outdir)).toMatchSnapshot();
 });
@@ -160,8 +160,7 @@ test("set() policy statement", () => {
   );
   cloud.Function._newFunction(app, "Function", inflight);
   const output = app.synth();
-
-  expect(tfSanitize(output)).toContain("dynamodb:UpdateItem");
+  expect(output).toContain("dynamodb:UpdateItem");
   expect(tfSanitize(output)).toMatchSnapshot();
   expect(treeJsonOf(app.outdir)).toMatchSnapshot();
 });

--- a/libs/wingsdk/test/target-tf-azure/__snapshots__/bucket.test.ts.snap
+++ b/libs/wingsdk/test/target-tf-azure/__snapshots__/bucket.test.ts.snap
@@ -1,32 +1,32 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`bucket is public 1`] = `
-"{
-  \\"resource\\": {
-    \\"azurerm_resource_group\\": {
-      \\"ResourceGroup\\": {
-        \\"location\\": \\"East US\\",
-        \\"name\\": \\"Default-c82bf964\\"
-      }
+{
+  "resource": {
+    "azurerm_resource_group": {
+      "ResourceGroup": {
+        "location": "East US",
+        "name": "Default-c82bf964",
+      },
     },
-    \\"azurerm_storage_account\\": {
-      \\"StorageAccount\\": {
-        \\"account_replication_type\\": \\"LRS\\",
-        \\"account_tier\\": \\"Standard\\",
-        \\"location\\": \\"\${azurerm_resource_group.ResourceGroup.location}\\",
-        \\"name\\": \\"defaultc82bf964\\",
-        \\"resource_group_name\\": \\"\${azurerm_resource_group.ResourceGroup.name}\\"
-      }
+    "azurerm_storage_account": {
+      "StorageAccount": {
+        "account_replication_type": "LRS",
+        "account_tier": "Standard",
+        "location": "\${azurerm_resource_group.ResourceGroup.location}",
+        "name": "defaultc82bf964",
+        "resource_group_name": "\${azurerm_resource_group.ResourceGroup.name}",
+      },
     },
-    \\"azurerm_storage_container\\": {
-      \\"my_bucket_Bucket_50609D70\\": {
-        \\"container_access_type\\": \\"public\\",
-        \\"name\\": \\"my-bucket-c8045fcc\\",
-        \\"storage_account_name\\": \\"\${azurerm_storage_account.StorageAccount.name}\\"
-      }
-    }
-  }
-}"
+    "azurerm_storage_container": {
+      "my_bucket_Bucket_50609D70": {
+        "container_access_type": "public",
+        "name": "my-bucket-c8045fcc",
+        "storage_account_name": "\${azurerm_storage_account.StorageAccount.name}",
+      },
+    },
+  },
+}
 `;
 
 exports[`bucket is public 2`] = `
@@ -123,32 +123,32 @@ exports[`bucket is public 2`] = `
 `;
 
 exports[`bucket name valid 1`] = `
-"{
-  \\"resource\\": {
-    \\"azurerm_resource_group\\": {
-      \\"ResourceGroup\\": {
-        \\"location\\": \\"East US\\",
-        \\"name\\": \\"Default-c82bf964\\"
-      }
+{
+  "resource": {
+    "azurerm_resource_group": {
+      "ResourceGroup": {
+        "location": "East US",
+        "name": "Default-c82bf964",
+      },
     },
-    \\"azurerm_storage_account\\": {
-      \\"StorageAccount\\": {
-        \\"account_replication_type\\": \\"LRS\\",
-        \\"account_tier\\": \\"Standard\\",
-        \\"location\\": \\"\${azurerm_resource_group.ResourceGroup.location}\\",
-        \\"name\\": \\"defaultc82bf964\\",
-        \\"resource_group_name\\": \\"\${azurerm_resource_group.ResourceGroup.name}\\"
-      }
+    "azurerm_storage_account": {
+      "StorageAccount": {
+        "account_replication_type": "LRS",
+        "account_tier": "Standard",
+        "location": "\${azurerm_resource_group.ResourceGroup.location}",
+        "name": "defaultc82bf964",
+        "resource_group_name": "\${azurerm_resource_group.ResourceGroup.name}",
+      },
     },
-    \\"azurerm_storage_container\\": {
-      \\"The-Uncanny-Bucket_61E10229\\": {
-        \\"container_access_type\\": \\"private\\",
-        \\"name\\": \\"the-uncanny-bucket-c8ac4720\\",
-        \\"storage_account_name\\": \\"\${azurerm_storage_account.StorageAccount.name}\\"
-      }
-    }
-  }
-}"
+    "azurerm_storage_container": {
+      "The-Uncanny-Bucket_61E10229": {
+        "container_access_type": "private",
+        "name": "the-uncanny-bucket-c8ac4720",
+        "storage_account_name": "\${azurerm_storage_account.StorageAccount.name}",
+      },
+    },
+  },
+}
 `;
 
 exports[`bucket name valid 2`] = `
@@ -245,48 +245,48 @@ exports[`bucket name valid 2`] = `
 `;
 
 exports[`bucket with two preflight objects 1`] = `
-"{
-  \\"resource\\": {
-    \\"azurerm_resource_group\\": {
-      \\"ResourceGroup\\": {
-        \\"location\\": \\"East US\\",
-        \\"name\\": \\"Default-c82bf964\\"
-      }
-    },
-    \\"azurerm_storage_account\\": {
-      \\"StorageAccount\\": {
-        \\"account_replication_type\\": \\"LRS\\",
-        \\"account_tier\\": \\"Standard\\",
-        \\"location\\": \\"\${azurerm_resource_group.ResourceGroup.location}\\",
-        \\"name\\": \\"defaultc82bf964\\",
-        \\"resource_group_name\\": \\"\${azurerm_resource_group.ResourceGroup.name}\\"
-      }
-    },
-    \\"azurerm_storage_blob\\": {
-      \\"my_bucket_Blob-file1txt_2FA447D8\\": {
-        \\"name\\": \\"file1.txt\\",
-        \\"source_content\\": \\"hello world\\",
-        \\"storage_account_name\\": \\"\${azurerm_storage_account.StorageAccount.name}\\",
-        \\"storage_container_name\\": \\"\${azurerm_storage_container.my_bucket_Bucket_50609D70.name}\\",
-        \\"type\\": \\"Block\\"
+{
+  "resource": {
+    "azurerm_resource_group": {
+      "ResourceGroup": {
+        "location": "East US",
+        "name": "Default-c82bf964",
       },
-      \\"my_bucket_Blob-file2txt_8F904E31\\": {
-        \\"name\\": \\"file2.txt\\",
-        \\"source_content\\": \\"boom bam\\",
-        \\"storage_account_name\\": \\"\${azurerm_storage_account.StorageAccount.name}\\",
-        \\"storage_container_name\\": \\"\${azurerm_storage_container.my_bucket_Bucket_50609D70.name}\\",
-        \\"type\\": \\"Block\\"
-      }
     },
-    \\"azurerm_storage_container\\": {
-      \\"my_bucket_Bucket_50609D70\\": {
-        \\"container_access_type\\": \\"public\\",
-        \\"name\\": \\"my-bucket-c8045fcc\\",
-        \\"storage_account_name\\": \\"\${azurerm_storage_account.StorageAccount.name}\\"
-      }
-    }
-  }
-}"
+    "azurerm_storage_account": {
+      "StorageAccount": {
+        "account_replication_type": "LRS",
+        "account_tier": "Standard",
+        "location": "\${azurerm_resource_group.ResourceGroup.location}",
+        "name": "defaultc82bf964",
+        "resource_group_name": "\${azurerm_resource_group.ResourceGroup.name}",
+      },
+    },
+    "azurerm_storage_blob": {
+      "my_bucket_Blob-file1txt_2FA447D8": {
+        "name": "file1.txt",
+        "source_content": "hello world",
+        "storage_account_name": "\${azurerm_storage_account.StorageAccount.name}",
+        "storage_container_name": "\${azurerm_storage_container.my_bucket_Bucket_50609D70.name}",
+        "type": "Block",
+      },
+      "my_bucket_Blob-file2txt_8F904E31": {
+        "name": "file2.txt",
+        "source_content": "boom bam",
+        "storage_account_name": "\${azurerm_storage_account.StorageAccount.name}",
+        "storage_container_name": "\${azurerm_storage_container.my_bucket_Bucket_50609D70.name}",
+        "type": "Block",
+      },
+    },
+    "azurerm_storage_container": {
+      "my_bucket_Bucket_50609D70": {
+        "container_access_type": "public",
+        "name": "my-bucket-c8045fcc",
+        "storage_account_name": "\${azurerm_storage_account.StorageAccount.name}",
+      },
+    },
+  },
+}
 `;
 
 exports[`bucket with two preflight objects 2`] = `
@@ -399,32 +399,32 @@ exports[`bucket with two preflight objects 2`] = `
 `;
 
 exports[`create a bucket 1`] = `
-"{
-  \\"resource\\": {
-    \\"azurerm_resource_group\\": {
-      \\"ResourceGroup\\": {
-        \\"location\\": \\"East US\\",
-        \\"name\\": \\"Default-c82bf964\\"
-      }
+{
+  "resource": {
+    "azurerm_resource_group": {
+      "ResourceGroup": {
+        "location": "East US",
+        "name": "Default-c82bf964",
+      },
     },
-    \\"azurerm_storage_account\\": {
-      \\"StorageAccount\\": {
-        \\"account_replication_type\\": \\"LRS\\",
-        \\"account_tier\\": \\"Standard\\",
-        \\"location\\": \\"\${azurerm_resource_group.ResourceGroup.location}\\",
-        \\"name\\": \\"defaultc82bf964\\",
-        \\"resource_group_name\\": \\"\${azurerm_resource_group.ResourceGroup.name}\\"
-      }
+    "azurerm_storage_account": {
+      "StorageAccount": {
+        "account_replication_type": "LRS",
+        "account_tier": "Standard",
+        "location": "\${azurerm_resource_group.ResourceGroup.location}",
+        "name": "defaultc82bf964",
+        "resource_group_name": "\${azurerm_resource_group.ResourceGroup.name}",
+      },
     },
-    \\"azurerm_storage_container\\": {
-      \\"my_bucket_Bucket_50609D70\\": {
-        \\"container_access_type\\": \\"private\\",
-        \\"name\\": \\"my-bucket-c8045fcc\\",
-        \\"storage_account_name\\": \\"\${azurerm_storage_account.StorageAccount.name}\\"
-      }
-    }
-  }
-}"
+    "azurerm_storage_container": {
+      "my_bucket_Bucket_50609D70": {
+        "container_access_type": "private",
+        "name": "my-bucket-c8045fcc",
+        "storage_account_name": "\${azurerm_storage_account.StorageAccount.name}",
+      },
+    },
+  },
+}
 `;
 
 exports[`create a bucket 2`] = `
@@ -521,37 +521,37 @@ exports[`create a bucket 2`] = `
 `;
 
 exports[`create multiple buckets 1`] = `
-"{
-  \\"resource\\": {
-    \\"azurerm_resource_group\\": {
-      \\"ResourceGroup\\": {
-        \\"location\\": \\"East US\\",
-        \\"name\\": \\"Default-c82bf964\\"
-      }
-    },
-    \\"azurerm_storage_account\\": {
-      \\"StorageAccount\\": {
-        \\"account_replication_type\\": \\"LRS\\",
-        \\"account_tier\\": \\"Standard\\",
-        \\"location\\": \\"\${azurerm_resource_group.ResourceGroup.location}\\",
-        \\"name\\": \\"defaultc82bf964\\",
-        \\"resource_group_name\\": \\"\${azurerm_resource_group.ResourceGroup.name}\\"
-      }
-    },
-    \\"azurerm_storage_container\\": {
-      \\"my_bucket2_Bucket_9E34665C\\": {
-        \\"container_access_type\\": \\"private\\",
-        \\"name\\": \\"my-bucket2-c87f4817\\",
-        \\"storage_account_name\\": \\"\${azurerm_storage_account.StorageAccount.name}\\"
+{
+  "resource": {
+    "azurerm_resource_group": {
+      "ResourceGroup": {
+        "location": "East US",
+        "name": "Default-c82bf964",
       },
-      \\"my_bucket_Bucket_50609D70\\": {
-        \\"container_access_type\\": \\"private\\",
-        \\"name\\": \\"my-bucket-c8045fcc\\",
-        \\"storage_account_name\\": \\"\${azurerm_storage_account.StorageAccount.name}\\"
-      }
-    }
-  }
-}"
+    },
+    "azurerm_storage_account": {
+      "StorageAccount": {
+        "account_replication_type": "LRS",
+        "account_tier": "Standard",
+        "location": "\${azurerm_resource_group.ResourceGroup.location}",
+        "name": "defaultc82bf964",
+        "resource_group_name": "\${azurerm_resource_group.ResourceGroup.name}",
+      },
+    },
+    "azurerm_storage_container": {
+      "my_bucket2_Bucket_9E34665C": {
+        "container_access_type": "private",
+        "name": "my-bucket2-c87f4817",
+        "storage_account_name": "\${azurerm_storage_account.StorageAccount.name}",
+      },
+      "my_bucket_Bucket_50609D70": {
+        "container_access_type": "private",
+        "name": "my-bucket-c8045fcc",
+        "storage_account_name": "\${azurerm_storage_account.StorageAccount.name}",
+      },
+    },
+  },
+}
 `;
 
 exports[`create multiple buckets 2`] = `

--- a/libs/wingsdk/test/target-tf-azure/__snapshots__/captures.test.ts.snap
+++ b/libs/wingsdk/test/target-tf-azure/__snapshots__/captures.test.ts.snap
@@ -16,93 +16,93 @@ bucket: new (require(\\"[REDACTED]/wingsdk/src/target-tf-azure/bucket.inflight\\
 `;
 
 exports[`function with a bucket binding requiring only read 2`] = `
-"{
-  \\"resource\\": {
-    \\"azurerm_linux_function_app\\": {
-      \\"Function_042596DC\\": {
-        \\"app_settings\\": {
-          \\"BUCKET_NAME_e51fbb13\\": \\"\${azurerm_storage_container.Bucket_DC7D6F65.name}\\",
-          \\"BUCKET_NAME_e51fbb13_IS_PUBLIC\\": \\"false\\",
-          \\"FUNCTIONS_WORKER_RUNTIME\\": \\"node\\",
-          \\"STORAGE_ACCOUNT_e51fbb13\\": \\"\${azurerm_storage_account.StorageAccount.name}\\",
-          \\"WEBSITE_RUN_FROM_PACKAGE\\": \\"https://\${azurerm_storage_account.StorageAccount.name}.blob.core.windows.net/\${azurerm_storage_container.Function_FunctionBucket_0F705EF9.name}/\${azurerm_storage_blob.Function_CodeBlob_8A9705C9.name}\\"
+{
+  "resource": {
+    "azurerm_linux_function_app": {
+      "Function_042596DC": {
+        "app_settings": {
+          "BUCKET_NAME_e51fbb13": "\${azurerm_storage_container.Bucket_DC7D6F65.name}",
+          "BUCKET_NAME_e51fbb13_IS_PUBLIC": "false",
+          "FUNCTIONS_WORKER_RUNTIME": "node",
+          "STORAGE_ACCOUNT_e51fbb13": "\${azurerm_storage_account.StorageAccount.name}",
+          "WEBSITE_RUN_FROM_PACKAGE": "https://\${azurerm_storage_account.StorageAccount.name}.blob.core.windows.net/\${azurerm_storage_container.Function_FunctionBucket_0F705EF9.name}/\${azurerm_storage_blob.Function_CodeBlob_8A9705C9.name}",
         },
-        \\"https_only\\": true,
-        \\"identity\\": {
-          \\"type\\": \\"SystemAssigned\\"
+        "https_only": true,
+        "identity": {
+          "type": "SystemAssigned",
         },
-        \\"location\\": \\"\${azurerm_resource_group.ResourceGroup.location}\\",
-        \\"name\\": \\"function-c852aba6\\",
-        \\"resource_group_name\\": \\"\${azurerm_resource_group.ResourceGroup.name}\\",
-        \\"service_plan_id\\": \\"\${azurerm_service_plan.ServicePlan.id}\\",
-        \\"site_config\\": {
-          \\"application_stack\\": {
-            \\"node_version\\": \\"16\\"
-          }
+        "location": "\${azurerm_resource_group.ResourceGroup.location}",
+        "name": "function-c852aba6",
+        "resource_group_name": "\${azurerm_resource_group.ResourceGroup.name}",
+        "service_plan_id": "\${azurerm_service_plan.ServicePlan.id}",
+        "site_config": {
+          "application_stack": {
+            "node_version": "16",
+          },
         },
-        \\"storage_account_access_key\\": \\"\${azurerm_storage_account.StorageAccount.primary_access_key}\\",
-        \\"storage_account_name\\": \\"\${azurerm_storage_account.StorageAccount.name}\\"
-      }
-    },
-    \\"azurerm_resource_group\\": {
-      \\"ResourceGroup\\": {
-        \\"location\\": \\"East US\\",
-        \\"name\\": \\"Default-c82bf964\\"
-      }
-    },
-    \\"azurerm_role_assignment\\": {
-      \\"Function_ReadLambdaCodeAssignment_75049D5E\\": {
-        \\"principal_id\\": \\"\${azurerm_linux_function_app.Function_042596DC.identity[0].principal_id}\\",
-        \\"role_definition_name\\": \\"Storage Blob Data Reader\\",
-        \\"scope\\": \\"\${azurerm_storage_account.StorageAccount.id}\\"
+        "storage_account_access_key": "\${azurerm_storage_account.StorageAccount.primary_access_key}",
+        "storage_account_name": "\${azurerm_storage_account.StorageAccount.name}",
       },
-      \\"Function_RoleAssignmentc88fdc5f491a51d8438235500a4821fbc31357ca3aStorageBlobDataReader_57069DF9\\": {
-        \\"principal_id\\": \\"\${azurerm_linux_function_app.Function_042596DC.identity[0].principal_id}\\",
-        \\"role_definition_name\\": \\"Storage Blob Data Reader\\",
-        \\"scope\\": \\"\${azurerm_storage_account.StorageAccount.id}\\"
-      }
     },
-    \\"azurerm_service_plan\\": {
-      \\"ServicePlan\\": {
-        \\"location\\": \\"\${azurerm_resource_group.ResourceGroup.location}\\",
-        \\"name\\": \\"Default-c82bf964\\",
-        \\"os_type\\": \\"Linux\\",
-        \\"resource_group_name\\": \\"\${azurerm_resource_group.ResourceGroup.name}\\",
-        \\"sku_name\\": \\"Y1\\"
-      }
-    },
-    \\"azurerm_storage_account\\": {
-      \\"StorageAccount\\": {
-        \\"account_replication_type\\": \\"LRS\\",
-        \\"account_tier\\": \\"Standard\\",
-        \\"location\\": \\"\${azurerm_resource_group.ResourceGroup.location}\\",
-        \\"name\\": \\"defaultc82bf964\\",
-        \\"resource_group_name\\": \\"\${azurerm_resource_group.ResourceGroup.name}\\"
-      }
-    },
-    \\"azurerm_storage_blob\\": {
-      \\"Function_CodeBlob_8A9705C9\\": {
-        \\"name\\": \\"function-c852aba6.zip\\",
-        \\"source\\": \\"<source>\\",
-        \\"storage_account_name\\": \\"\${azurerm_storage_account.StorageAccount.name}\\",
-        \\"storage_container_name\\": \\"\${azurerm_storage_container.Function_FunctionBucket_0F705EF9.name}\\",
-        \\"type\\": \\"Block\\"
-      }
-    },
-    \\"azurerm_storage_container\\": {
-      \\"Bucket_DC7D6F65\\": {
-        \\"container_access_type\\": \\"private\\",
-        \\"name\\": \\"bucket-c88fdc5f\\",
-        \\"storage_account_name\\": \\"\${azurerm_storage_account.StorageAccount.name}\\"
+    "azurerm_resource_group": {
+      "ResourceGroup": {
+        "location": "East US",
+        "name": "Default-c82bf964",
       },
-      \\"Function_FunctionBucket_0F705EF9\\": {
-        \\"container_access_type\\": \\"private\\",
-        \\"name\\": \\"functionbucket-c8ccf7e8\\",
-        \\"storage_account_name\\": \\"\${azurerm_storage_account.StorageAccount.name}\\"
-      }
-    }
-  }
-}"
+    },
+    "azurerm_role_assignment": {
+      "Function_ReadLambdaCodeAssignment_75049D5E": {
+        "principal_id": "\${azurerm_linux_function_app.Function_042596DC.identity[0].principal_id}",
+        "role_definition_name": "Storage Blob Data Reader",
+        "scope": "\${azurerm_storage_account.StorageAccount.id}",
+      },
+      "Function_RoleAssignmentc88fdc5f491a51d8438235500a4821fbc31357ca3aStorageBlobDataReader_57069DF9": {
+        "principal_id": "\${azurerm_linux_function_app.Function_042596DC.identity[0].principal_id}",
+        "role_definition_name": "Storage Blob Data Reader",
+        "scope": "\${azurerm_storage_account.StorageAccount.id}",
+      },
+    },
+    "azurerm_service_plan": {
+      "ServicePlan": {
+        "location": "\${azurerm_resource_group.ResourceGroup.location}",
+        "name": "Default-c82bf964",
+        "os_type": "Linux",
+        "resource_group_name": "\${azurerm_resource_group.ResourceGroup.name}",
+        "sku_name": "Y1",
+      },
+    },
+    "azurerm_storage_account": {
+      "StorageAccount": {
+        "account_replication_type": "LRS",
+        "account_tier": "Standard",
+        "location": "\${azurerm_resource_group.ResourceGroup.location}",
+        "name": "defaultc82bf964",
+        "resource_group_name": "\${azurerm_resource_group.ResourceGroup.name}",
+      },
+    },
+    "azurerm_storage_blob": {
+      "Function_CodeBlob_8A9705C9": {
+        "name": "function-c852aba6.zip",
+        "source": "<source>",
+        "storage_account_name": "\${azurerm_storage_account.StorageAccount.name}",
+        "storage_container_name": "\${azurerm_storage_container.Function_FunctionBucket_0F705EF9.name}",
+        "type": "Block",
+      },
+    },
+    "azurerm_storage_container": {
+      "Bucket_DC7D6F65": {
+        "container_access_type": "private",
+        "name": "bucket-c88fdc5f",
+        "storage_account_name": "\${azurerm_storage_account.StorageAccount.name}",
+      },
+      "Function_FunctionBucket_0F705EF9": {
+        "container_access_type": "private",
+        "name": "functionbucket-c8ccf7e8",
+        "storage_account_name": "\${azurerm_storage_account.StorageAccount.name}",
+      },
+    },
+  },
+}
 `;
 
 exports[`function with a bucket binding requiring read_write 1`] = `
@@ -121,91 +121,91 @@ bucket: new (require(\\"[REDACTED]/wingsdk/src/target-tf-azure/bucket.inflight\\
 `;
 
 exports[`function with a bucket binding requiring read_write 2`] = `
-"{
-  \\"resource\\": {
-    \\"azurerm_linux_function_app\\": {
-      \\"Function_042596DC\\": {
-        \\"app_settings\\": {
-          \\"BUCKET_NAME_e51fbb13\\": \\"\${azurerm_storage_container.Bucket_DC7D6F65.name}\\",
-          \\"BUCKET_NAME_e51fbb13_IS_PUBLIC\\": \\"false\\",
-          \\"FUNCTIONS_WORKER_RUNTIME\\": \\"node\\",
-          \\"STORAGE_ACCOUNT_e51fbb13\\": \\"\${azurerm_storage_account.StorageAccount.name}\\",
-          \\"WEBSITE_RUN_FROM_PACKAGE\\": \\"https://\${azurerm_storage_account.StorageAccount.name}.blob.core.windows.net/\${azurerm_storage_container.Function_FunctionBucket_0F705EF9.name}/\${azurerm_storage_blob.Function_CodeBlob_8A9705C9.name}\\"
+{
+  "resource": {
+    "azurerm_linux_function_app": {
+      "Function_042596DC": {
+        "app_settings": {
+          "BUCKET_NAME_e51fbb13": "\${azurerm_storage_container.Bucket_DC7D6F65.name}",
+          "BUCKET_NAME_e51fbb13_IS_PUBLIC": "false",
+          "FUNCTIONS_WORKER_RUNTIME": "node",
+          "STORAGE_ACCOUNT_e51fbb13": "\${azurerm_storage_account.StorageAccount.name}",
+          "WEBSITE_RUN_FROM_PACKAGE": "https://\${azurerm_storage_account.StorageAccount.name}.blob.core.windows.net/\${azurerm_storage_container.Function_FunctionBucket_0F705EF9.name}/\${azurerm_storage_blob.Function_CodeBlob_8A9705C9.name}",
         },
-        \\"https_only\\": true,
-        \\"identity\\": {
-          \\"type\\": \\"SystemAssigned\\"
+        "https_only": true,
+        "identity": {
+          "type": "SystemAssigned",
         },
-        \\"location\\": \\"\${azurerm_resource_group.ResourceGroup.location}\\",
-        \\"name\\": \\"function-c852aba6\\",
-        \\"resource_group_name\\": \\"\${azurerm_resource_group.ResourceGroup.name}\\",
-        \\"service_plan_id\\": \\"\${azurerm_service_plan.ServicePlan.id}\\",
-        \\"site_config\\": {
-          \\"application_stack\\": {
-            \\"node_version\\": \\"16\\"
-          }
+        "location": "\${azurerm_resource_group.ResourceGroup.location}",
+        "name": "function-c852aba6",
+        "resource_group_name": "\${azurerm_resource_group.ResourceGroup.name}",
+        "service_plan_id": "\${azurerm_service_plan.ServicePlan.id}",
+        "site_config": {
+          "application_stack": {
+            "node_version": "16",
+          },
         },
-        \\"storage_account_access_key\\": \\"\${azurerm_storage_account.StorageAccount.primary_access_key}\\",
-        \\"storage_account_name\\": \\"\${azurerm_storage_account.StorageAccount.name}\\"
-      }
-    },
-    \\"azurerm_resource_group\\": {
-      \\"ResourceGroup\\": {
-        \\"location\\": \\"East US\\",
-        \\"name\\": \\"Default-c82bf964\\"
-      }
-    },
-    \\"azurerm_role_assignment\\": {
-      \\"Function_ReadLambdaCodeAssignment_75049D5E\\": {
-        \\"principal_id\\": \\"\${azurerm_linux_function_app.Function_042596DC.identity[0].principal_id}\\",
-        \\"role_definition_name\\": \\"Storage Blob Data Reader\\",
-        \\"scope\\": \\"\${azurerm_storage_account.StorageAccount.id}\\"
+        "storage_account_access_key": "\${azurerm_storage_account.StorageAccount.primary_access_key}",
+        "storage_account_name": "\${azurerm_storage_account.StorageAccount.name}",
       },
-      \\"Function_RoleAssignmentc88fdc5f491a51d8438235500a4821fbc31357ca3aStorageBlobDataContributor_8C0A9D1B\\": {
-        \\"principal_id\\": \\"\${azurerm_linux_function_app.Function_042596DC.identity[0].principal_id}\\",
-        \\"role_definition_name\\": \\"Storage Blob Data Contributor\\",
-        \\"scope\\": \\"\${azurerm_storage_account.StorageAccount.id}\\"
-      }
     },
-    \\"azurerm_service_plan\\": {
-      \\"ServicePlan\\": {
-        \\"location\\": \\"\${azurerm_resource_group.ResourceGroup.location}\\",
-        \\"name\\": \\"Default-c82bf964\\",
-        \\"os_type\\": \\"Linux\\",
-        \\"resource_group_name\\": \\"\${azurerm_resource_group.ResourceGroup.name}\\",
-        \\"sku_name\\": \\"Y1\\"
-      }
-    },
-    \\"azurerm_storage_account\\": {
-      \\"StorageAccount\\": {
-        \\"account_replication_type\\": \\"LRS\\",
-        \\"account_tier\\": \\"Standard\\",
-        \\"location\\": \\"\${azurerm_resource_group.ResourceGroup.location}\\",
-        \\"name\\": \\"defaultc82bf964\\",
-        \\"resource_group_name\\": \\"\${azurerm_resource_group.ResourceGroup.name}\\"
-      }
-    },
-    \\"azurerm_storage_blob\\": {
-      \\"Function_CodeBlob_8A9705C9\\": {
-        \\"name\\": \\"function-c852aba6.zip\\",
-        \\"source\\": \\"<source>\\",
-        \\"storage_account_name\\": \\"\${azurerm_storage_account.StorageAccount.name}\\",
-        \\"storage_container_name\\": \\"\${azurerm_storage_container.Function_FunctionBucket_0F705EF9.name}\\",
-        \\"type\\": \\"Block\\"
-      }
-    },
-    \\"azurerm_storage_container\\": {
-      \\"Bucket_DC7D6F65\\": {
-        \\"container_access_type\\": \\"private\\",
-        \\"name\\": \\"bucket-c88fdc5f\\",
-        \\"storage_account_name\\": \\"\${azurerm_storage_account.StorageAccount.name}\\"
+    "azurerm_resource_group": {
+      "ResourceGroup": {
+        "location": "East US",
+        "name": "Default-c82bf964",
       },
-      \\"Function_FunctionBucket_0F705EF9\\": {
-        \\"container_access_type\\": \\"private\\",
-        \\"name\\": \\"functionbucket-c8ccf7e8\\",
-        \\"storage_account_name\\": \\"\${azurerm_storage_account.StorageAccount.name}\\"
-      }
-    }
-  }
-}"
+    },
+    "azurerm_role_assignment": {
+      "Function_ReadLambdaCodeAssignment_75049D5E": {
+        "principal_id": "\${azurerm_linux_function_app.Function_042596DC.identity[0].principal_id}",
+        "role_definition_name": "Storage Blob Data Reader",
+        "scope": "\${azurerm_storage_account.StorageAccount.id}",
+      },
+      "Function_RoleAssignmentc88fdc5f491a51d8438235500a4821fbc31357ca3aStorageBlobDataContributor_8C0A9D1B": {
+        "principal_id": "\${azurerm_linux_function_app.Function_042596DC.identity[0].principal_id}",
+        "role_definition_name": "Storage Blob Data Contributor",
+        "scope": "\${azurerm_storage_account.StorageAccount.id}",
+      },
+    },
+    "azurerm_service_plan": {
+      "ServicePlan": {
+        "location": "\${azurerm_resource_group.ResourceGroup.location}",
+        "name": "Default-c82bf964",
+        "os_type": "Linux",
+        "resource_group_name": "\${azurerm_resource_group.ResourceGroup.name}",
+        "sku_name": "Y1",
+      },
+    },
+    "azurerm_storage_account": {
+      "StorageAccount": {
+        "account_replication_type": "LRS",
+        "account_tier": "Standard",
+        "location": "\${azurerm_resource_group.ResourceGroup.location}",
+        "name": "defaultc82bf964",
+        "resource_group_name": "\${azurerm_resource_group.ResourceGroup.name}",
+      },
+    },
+    "azurerm_storage_blob": {
+      "Function_CodeBlob_8A9705C9": {
+        "name": "function-c852aba6.zip",
+        "source": "<source>",
+        "storage_account_name": "\${azurerm_storage_account.StorageAccount.name}",
+        "storage_container_name": "\${azurerm_storage_container.Function_FunctionBucket_0F705EF9.name}",
+        "type": "Block",
+      },
+    },
+    "azurerm_storage_container": {
+      "Bucket_DC7D6F65": {
+        "container_access_type": "private",
+        "name": "bucket-c88fdc5f",
+        "storage_account_name": "\${azurerm_storage_account.StorageAccount.name}",
+      },
+      "Function_FunctionBucket_0F705EF9": {
+        "container_access_type": "private",
+        "name": "functionbucket-c8ccf7e8",
+        "storage_account_name": "\${azurerm_storage_account.StorageAccount.name}",
+      },
+    },
+  },
+}
 `;

--- a/libs/wingsdk/test/target-tf-azure/__snapshots__/function.test.ts.snap
+++ b/libs/wingsdk/test/target-tf-azure/__snapshots__/function.test.ts.snap
@@ -1,80 +1,80 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`basic function 1`] = `
-"{
-  \\"resource\\": {
-    \\"azurerm_linux_function_app\\": {
-      \\"Function_042596DC\\": {
-        \\"app_settings\\": {
-          \\"FUNCTIONS_WORKER_RUNTIME\\": \\"node\\",
-          \\"WEBSITE_RUN_FROM_PACKAGE\\": \\"https://\${azurerm_storage_account.StorageAccount.name}.blob.core.windows.net/\${azurerm_storage_container.Function_FunctionBucket_0F705EF9.name}/\${azurerm_storage_blob.Function_CodeBlob_8A9705C9.name}\\"
+{
+  "resource": {
+    "azurerm_linux_function_app": {
+      "Function_042596DC": {
+        "app_settings": {
+          "FUNCTIONS_WORKER_RUNTIME": "node",
+          "WEBSITE_RUN_FROM_PACKAGE": "https://\${azurerm_storage_account.StorageAccount.name}.blob.core.windows.net/\${azurerm_storage_container.Function_FunctionBucket_0F705EF9.name}/\${azurerm_storage_blob.Function_CodeBlob_8A9705C9.name}",
         },
-        \\"https_only\\": true,
-        \\"identity\\": {
-          \\"type\\": \\"SystemAssigned\\"
+        "https_only": true,
+        "identity": {
+          "type": "SystemAssigned",
         },
-        \\"location\\": \\"\${azurerm_resource_group.ResourceGroup.location}\\",
-        \\"name\\": \\"function-c852aba6\\",
-        \\"resource_group_name\\": \\"\${azurerm_resource_group.ResourceGroup.name}\\",
-        \\"service_plan_id\\": \\"\${azurerm_service_plan.ServicePlan.id}\\",
-        \\"site_config\\": {
-          \\"application_stack\\": {
-            \\"node_version\\": \\"16\\"
-          }
+        "location": "\${azurerm_resource_group.ResourceGroup.location}",
+        "name": "function-c852aba6",
+        "resource_group_name": "\${azurerm_resource_group.ResourceGroup.name}",
+        "service_plan_id": "\${azurerm_service_plan.ServicePlan.id}",
+        "site_config": {
+          "application_stack": {
+            "node_version": "16",
+          },
         },
-        \\"storage_account_access_key\\": \\"\${azurerm_storage_account.StorageAccount.primary_access_key}\\",
-        \\"storage_account_name\\": \\"\${azurerm_storage_account.StorageAccount.name}\\"
-      }
+        "storage_account_access_key": "\${azurerm_storage_account.StorageAccount.primary_access_key}",
+        "storage_account_name": "\${azurerm_storage_account.StorageAccount.name}",
+      },
     },
-    \\"azurerm_resource_group\\": {
-      \\"ResourceGroup\\": {
-        \\"location\\": \\"East US\\",
-        \\"name\\": \\"Default-c82bf964\\"
-      }
+    "azurerm_resource_group": {
+      "ResourceGroup": {
+        "location": "East US",
+        "name": "Default-c82bf964",
+      },
     },
-    \\"azurerm_role_assignment\\": {
-      \\"Function_ReadLambdaCodeAssignment_75049D5E\\": {
-        \\"principal_id\\": \\"\${azurerm_linux_function_app.Function_042596DC.identity[0].principal_id}\\",
-        \\"role_definition_name\\": \\"Storage Blob Data Reader\\",
-        \\"scope\\": \\"\${azurerm_storage_account.StorageAccount.id}\\"
-      }
+    "azurerm_role_assignment": {
+      "Function_ReadLambdaCodeAssignment_75049D5E": {
+        "principal_id": "\${azurerm_linux_function_app.Function_042596DC.identity[0].principal_id}",
+        "role_definition_name": "Storage Blob Data Reader",
+        "scope": "\${azurerm_storage_account.StorageAccount.id}",
+      },
     },
-    \\"azurerm_service_plan\\": {
-      \\"ServicePlan\\": {
-        \\"location\\": \\"\${azurerm_resource_group.ResourceGroup.location}\\",
-        \\"name\\": \\"Default-c82bf964\\",
-        \\"os_type\\": \\"Linux\\",
-        \\"resource_group_name\\": \\"\${azurerm_resource_group.ResourceGroup.name}\\",
-        \\"sku_name\\": \\"Y1\\"
-      }
+    "azurerm_service_plan": {
+      "ServicePlan": {
+        "location": "\${azurerm_resource_group.ResourceGroup.location}",
+        "name": "Default-c82bf964",
+        "os_type": "Linux",
+        "resource_group_name": "\${azurerm_resource_group.ResourceGroup.name}",
+        "sku_name": "Y1",
+      },
     },
-    \\"azurerm_storage_account\\": {
-      \\"StorageAccount\\": {
-        \\"account_replication_type\\": \\"LRS\\",
-        \\"account_tier\\": \\"Standard\\",
-        \\"location\\": \\"\${azurerm_resource_group.ResourceGroup.location}\\",
-        \\"name\\": \\"defaultc82bf964\\",
-        \\"resource_group_name\\": \\"\${azurerm_resource_group.ResourceGroup.name}\\"
-      }
+    "azurerm_storage_account": {
+      "StorageAccount": {
+        "account_replication_type": "LRS",
+        "account_tier": "Standard",
+        "location": "\${azurerm_resource_group.ResourceGroup.location}",
+        "name": "defaultc82bf964",
+        "resource_group_name": "\${azurerm_resource_group.ResourceGroup.name}",
+      },
     },
-    \\"azurerm_storage_blob\\": {
-      \\"Function_CodeBlob_8A9705C9\\": {
-        \\"name\\": \\"function-c852aba6.zip\\",
-        \\"source\\": \\"<source>\\",
-        \\"storage_account_name\\": \\"\${azurerm_storage_account.StorageAccount.name}\\",
-        \\"storage_container_name\\": \\"\${azurerm_storage_container.Function_FunctionBucket_0F705EF9.name}\\",
-        \\"type\\": \\"Block\\"
-      }
+    "azurerm_storage_blob": {
+      "Function_CodeBlob_8A9705C9": {
+        "name": "function-c852aba6.zip",
+        "source": "<source>",
+        "storage_account_name": "\${azurerm_storage_account.StorageAccount.name}",
+        "storage_container_name": "\${azurerm_storage_container.Function_FunctionBucket_0F705EF9.name}",
+        "type": "Block",
+      },
     },
-    \\"azurerm_storage_container\\": {
-      \\"Function_FunctionBucket_0F705EF9\\": {
-        \\"container_access_type\\": \\"private\\",
-        \\"name\\": \\"functionbucket-c8ccf7e8\\",
-        \\"storage_account_name\\": \\"\${azurerm_storage_account.StorageAccount.name}\\"
-      }
-    }
-  }
-}"
+    "azurerm_storage_container": {
+      "Function_FunctionBucket_0F705EF9": {
+        "container_access_type": "private",
+        "name": "functionbucket-c8ccf7e8",
+        "storage_account_name": "\${azurerm_storage_account.StorageAccount.name}",
+      },
+    },
+  },
+}
 `;
 
 exports[`basic function 2`] = `
@@ -244,82 +244,82 @@ exports[`basic function 2`] = `
 `;
 
 exports[`basic function with environment variables 1`] = `
-"{
-  \\"resource\\": {
-    \\"azurerm_linux_function_app\\": {
-      \\"Function_042596DC\\": {
-        \\"app_settings\\": {
-          \\"BOOM\\": \\"BAM\\",
-          \\"FOO\\": \\"BAR\\",
-          \\"FUNCTIONS_WORKER_RUNTIME\\": \\"node\\",
-          \\"WEBSITE_RUN_FROM_PACKAGE\\": \\"https://\${azurerm_storage_account.StorageAccount.name}.blob.core.windows.net/\${azurerm_storage_container.Function_FunctionBucket_0F705EF9.name}/\${azurerm_storage_blob.Function_CodeBlob_8A9705C9.name}\\"
+{
+  "resource": {
+    "azurerm_linux_function_app": {
+      "Function_042596DC": {
+        "app_settings": {
+          "BOOM": "BAM",
+          "FOO": "BAR",
+          "FUNCTIONS_WORKER_RUNTIME": "node",
+          "WEBSITE_RUN_FROM_PACKAGE": "https://\${azurerm_storage_account.StorageAccount.name}.blob.core.windows.net/\${azurerm_storage_container.Function_FunctionBucket_0F705EF9.name}/\${azurerm_storage_blob.Function_CodeBlob_8A9705C9.name}",
         },
-        \\"https_only\\": true,
-        \\"identity\\": {
-          \\"type\\": \\"SystemAssigned\\"
+        "https_only": true,
+        "identity": {
+          "type": "SystemAssigned",
         },
-        \\"location\\": \\"\${azurerm_resource_group.ResourceGroup.location}\\",
-        \\"name\\": \\"function-c852aba6\\",
-        \\"resource_group_name\\": \\"\${azurerm_resource_group.ResourceGroup.name}\\",
-        \\"service_plan_id\\": \\"\${azurerm_service_plan.ServicePlan.id}\\",
-        \\"site_config\\": {
-          \\"application_stack\\": {
-            \\"node_version\\": \\"16\\"
-          }
+        "location": "\${azurerm_resource_group.ResourceGroup.location}",
+        "name": "function-c852aba6",
+        "resource_group_name": "\${azurerm_resource_group.ResourceGroup.name}",
+        "service_plan_id": "\${azurerm_service_plan.ServicePlan.id}",
+        "site_config": {
+          "application_stack": {
+            "node_version": "16",
+          },
         },
-        \\"storage_account_access_key\\": \\"\${azurerm_storage_account.StorageAccount.primary_access_key}\\",
-        \\"storage_account_name\\": \\"\${azurerm_storage_account.StorageAccount.name}\\"
-      }
+        "storage_account_access_key": "\${azurerm_storage_account.StorageAccount.primary_access_key}",
+        "storage_account_name": "\${azurerm_storage_account.StorageAccount.name}",
+      },
     },
-    \\"azurerm_resource_group\\": {
-      \\"ResourceGroup\\": {
-        \\"location\\": \\"East US\\",
-        \\"name\\": \\"Default-c82bf964\\"
-      }
+    "azurerm_resource_group": {
+      "ResourceGroup": {
+        "location": "East US",
+        "name": "Default-c82bf964",
+      },
     },
-    \\"azurerm_role_assignment\\": {
-      \\"Function_ReadLambdaCodeAssignment_75049D5E\\": {
-        \\"principal_id\\": \\"\${azurerm_linux_function_app.Function_042596DC.identity[0].principal_id}\\",
-        \\"role_definition_name\\": \\"Storage Blob Data Reader\\",
-        \\"scope\\": \\"\${azurerm_storage_account.StorageAccount.id}\\"
-      }
+    "azurerm_role_assignment": {
+      "Function_ReadLambdaCodeAssignment_75049D5E": {
+        "principal_id": "\${azurerm_linux_function_app.Function_042596DC.identity[0].principal_id}",
+        "role_definition_name": "Storage Blob Data Reader",
+        "scope": "\${azurerm_storage_account.StorageAccount.id}",
+      },
     },
-    \\"azurerm_service_plan\\": {
-      \\"ServicePlan\\": {
-        \\"location\\": \\"\${azurerm_resource_group.ResourceGroup.location}\\",
-        \\"name\\": \\"Default-c82bf964\\",
-        \\"os_type\\": \\"Linux\\",
-        \\"resource_group_name\\": \\"\${azurerm_resource_group.ResourceGroup.name}\\",
-        \\"sku_name\\": \\"Y1\\"
-      }
+    "azurerm_service_plan": {
+      "ServicePlan": {
+        "location": "\${azurerm_resource_group.ResourceGroup.location}",
+        "name": "Default-c82bf964",
+        "os_type": "Linux",
+        "resource_group_name": "\${azurerm_resource_group.ResourceGroup.name}",
+        "sku_name": "Y1",
+      },
     },
-    \\"azurerm_storage_account\\": {
-      \\"StorageAccount\\": {
-        \\"account_replication_type\\": \\"LRS\\",
-        \\"account_tier\\": \\"Standard\\",
-        \\"location\\": \\"\${azurerm_resource_group.ResourceGroup.location}\\",
-        \\"name\\": \\"defaultc82bf964\\",
-        \\"resource_group_name\\": \\"\${azurerm_resource_group.ResourceGroup.name}\\"
-      }
+    "azurerm_storage_account": {
+      "StorageAccount": {
+        "account_replication_type": "LRS",
+        "account_tier": "Standard",
+        "location": "\${azurerm_resource_group.ResourceGroup.location}",
+        "name": "defaultc82bf964",
+        "resource_group_name": "\${azurerm_resource_group.ResourceGroup.name}",
+      },
     },
-    \\"azurerm_storage_blob\\": {
-      \\"Function_CodeBlob_8A9705C9\\": {
-        \\"name\\": \\"function-c852aba6.zip\\",
-        \\"source\\": \\"<source>\\",
-        \\"storage_account_name\\": \\"\${azurerm_storage_account.StorageAccount.name}\\",
-        \\"storage_container_name\\": \\"\${azurerm_storage_container.Function_FunctionBucket_0F705EF9.name}\\",
-        \\"type\\": \\"Block\\"
-      }
+    "azurerm_storage_blob": {
+      "Function_CodeBlob_8A9705C9": {
+        "name": "function-c852aba6.zip",
+        "source": "<source>",
+        "storage_account_name": "\${azurerm_storage_account.StorageAccount.name}",
+        "storage_container_name": "\${azurerm_storage_container.Function_FunctionBucket_0F705EF9.name}",
+        "type": "Block",
+      },
     },
-    \\"azurerm_storage_container\\": {
-      \\"Function_FunctionBucket_0F705EF9\\": {
-        \\"container_access_type\\": \\"private\\",
-        \\"name\\": \\"functionbucket-c8ccf7e8\\",
-        \\"storage_account_name\\": \\"\${azurerm_storage_account.StorageAccount.name}\\"
-      }
-    }
-  }
-}"
+    "azurerm_storage_container": {
+      "Function_FunctionBucket_0F705EF9": {
+        "container_access_type": "private",
+        "name": "functionbucket-c8ccf7e8",
+        "storage_account_name": "\${azurerm_storage_account.StorageAccount.name}",
+      },
+    },
+  },
+}
 `;
 
 exports[`basic function with environment variables 2`] = `
@@ -489,80 +489,80 @@ exports[`basic function with environment variables 2`] = `
 `;
 
 exports[`replace invalid character from function name 1`] = `
-"{
-  \\"resource\\": {
-    \\"azurerm_linux_function_app\\": {
-      \\"someFunction01_Function_83CF4008\\": {
-        \\"app_settings\\": {
-          \\"FUNCTIONS_WORKER_RUNTIME\\": \\"node\\",
-          \\"WEBSITE_RUN_FROM_PACKAGE\\": \\"https://\${azurerm_storage_account.StorageAccount.name}.blob.core.windows.net/\${azurerm_storage_container.someFunction01_FunctionBucket_BDC04946.name}/\${azurerm_storage_blob.someFunction01_CodeBlob_D6CD3DCE.name}\\"
+{
+  "resource": {
+    "azurerm_linux_function_app": {
+      "someFunction01_Function_83CF4008": {
+        "app_settings": {
+          "FUNCTIONS_WORKER_RUNTIME": "node",
+          "WEBSITE_RUN_FROM_PACKAGE": "https://\${azurerm_storage_account.StorageAccount.name}.blob.core.windows.net/\${azurerm_storage_container.someFunction01_FunctionBucket_BDC04946.name}/\${azurerm_storage_blob.someFunction01_CodeBlob_D6CD3DCE.name}",
         },
-        \\"https_only\\": true,
-        \\"identity\\": {
-          \\"type\\": \\"SystemAssigned\\"
+        "https_only": true,
+        "identity": {
+          "type": "SystemAssigned",
         },
-        \\"location\\": \\"\${azurerm_resource_group.ResourceGroup.location}\\",
-        \\"name\\": \\"somefunction01-c8eb4882\\",
-        \\"resource_group_name\\": \\"\${azurerm_resource_group.ResourceGroup.name}\\",
-        \\"service_plan_id\\": \\"\${azurerm_service_plan.ServicePlan.id}\\",
-        \\"site_config\\": {
-          \\"application_stack\\": {
-            \\"node_version\\": \\"16\\"
-          }
+        "location": "\${azurerm_resource_group.ResourceGroup.location}",
+        "name": "somefunction01-c8eb4882",
+        "resource_group_name": "\${azurerm_resource_group.ResourceGroup.name}",
+        "service_plan_id": "\${azurerm_service_plan.ServicePlan.id}",
+        "site_config": {
+          "application_stack": {
+            "node_version": "16",
+          },
         },
-        \\"storage_account_access_key\\": \\"\${azurerm_storage_account.StorageAccount.primary_access_key}\\",
-        \\"storage_account_name\\": \\"\${azurerm_storage_account.StorageAccount.name}\\"
-      }
+        "storage_account_access_key": "\${azurerm_storage_account.StorageAccount.primary_access_key}",
+        "storage_account_name": "\${azurerm_storage_account.StorageAccount.name}",
+      },
     },
-    \\"azurerm_resource_group\\": {
-      \\"ResourceGroup\\": {
-        \\"location\\": \\"East US\\",
-        \\"name\\": \\"Default-c82bf964\\"
-      }
+    "azurerm_resource_group": {
+      "ResourceGroup": {
+        "location": "East US",
+        "name": "Default-c82bf964",
+      },
     },
-    \\"azurerm_role_assignment\\": {
-      \\"someFunction01_ReadLambdaCodeAssignment_639B8FD1\\": {
-        \\"principal_id\\": \\"\${azurerm_linux_function_app.someFunction01_Function_83CF4008.identity[0].principal_id}\\",
-        \\"role_definition_name\\": \\"Storage Blob Data Reader\\",
-        \\"scope\\": \\"\${azurerm_storage_account.StorageAccount.id}\\"
-      }
+    "azurerm_role_assignment": {
+      "someFunction01_ReadLambdaCodeAssignment_639B8FD1": {
+        "principal_id": "\${azurerm_linux_function_app.someFunction01_Function_83CF4008.identity[0].principal_id}",
+        "role_definition_name": "Storage Blob Data Reader",
+        "scope": "\${azurerm_storage_account.StorageAccount.id}",
+      },
     },
-    \\"azurerm_service_plan\\": {
-      \\"ServicePlan\\": {
-        \\"location\\": \\"\${azurerm_resource_group.ResourceGroup.location}\\",
-        \\"name\\": \\"Default-c82bf964\\",
-        \\"os_type\\": \\"Linux\\",
-        \\"resource_group_name\\": \\"\${azurerm_resource_group.ResourceGroup.name}\\",
-        \\"sku_name\\": \\"Y1\\"
-      }
+    "azurerm_service_plan": {
+      "ServicePlan": {
+        "location": "\${azurerm_resource_group.ResourceGroup.location}",
+        "name": "Default-c82bf964",
+        "os_type": "Linux",
+        "resource_group_name": "\${azurerm_resource_group.ResourceGroup.name}",
+        "sku_name": "Y1",
+      },
     },
-    \\"azurerm_storage_account\\": {
-      \\"StorageAccount\\": {
-        \\"account_replication_type\\": \\"LRS\\",
-        \\"account_tier\\": \\"Standard\\",
-        \\"location\\": \\"\${azurerm_resource_group.ResourceGroup.location}\\",
-        \\"name\\": \\"defaultc82bf964\\",
-        \\"resource_group_name\\": \\"\${azurerm_resource_group.ResourceGroup.name}\\"
-      }
+    "azurerm_storage_account": {
+      "StorageAccount": {
+        "account_replication_type": "LRS",
+        "account_tier": "Standard",
+        "location": "\${azurerm_resource_group.ResourceGroup.location}",
+        "name": "defaultc82bf964",
+        "resource_group_name": "\${azurerm_resource_group.ResourceGroup.name}",
+      },
     },
-    \\"azurerm_storage_blob\\": {
-      \\"someFunction01_CodeBlob_D6CD3DCE\\": {
-        \\"name\\": \\"somefunction01-c8eb4882.zip\\",
-        \\"source\\": \\"<source>\\",
-        \\"storage_account_name\\": \\"\${azurerm_storage_account.StorageAccount.name}\\",
-        \\"storage_container_name\\": \\"\${azurerm_storage_container.someFunction01_FunctionBucket_BDC04946.name}\\",
-        \\"type\\": \\"Block\\"
-      }
+    "azurerm_storage_blob": {
+      "someFunction01_CodeBlob_D6CD3DCE": {
+        "name": "somefunction01-c8eb4882.zip",
+        "source": "<source>",
+        "storage_account_name": "\${azurerm_storage_account.StorageAccount.name}",
+        "storage_container_name": "\${azurerm_storage_container.someFunction01_FunctionBucket_BDC04946.name}",
+        "type": "Block",
+      },
     },
-    \\"azurerm_storage_container\\": {
-      \\"someFunction01_FunctionBucket_BDC04946\\": {
-        \\"container_access_type\\": \\"private\\",
-        \\"name\\": \\"functionbucket-c84280f4\\",
-        \\"storage_account_name\\": \\"\${azurerm_storage_account.StorageAccount.name}\\"
-      }
-    }
-  }
-}"
+    "azurerm_storage_container": {
+      "someFunction01_FunctionBucket_BDC04946": {
+        "container_access_type": "private",
+        "name": "functionbucket-c84280f4",
+        "storage_account_name": "\${azurerm_storage_account.StorageAccount.name}",
+      },
+    },
+  },
+}
 `;
 
 exports[`replace invalid character from function name 2`] = `

--- a/libs/wingsdk/test/target-tf-gcp/__snapshots__/bucket.test.ts.snap
+++ b/libs/wingsdk/test/target-tf-gcp/__snapshots__/bucket.test.ts.snap
@@ -1,30 +1,30 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`bucket is public 1`] = `
-"{
-  \\"resource\\": {
-    \\"google_storage_bucket\\": {
-      \\"my_bucket\\": {
-        \\"location\\": \\"US\\",
-        \\"name\\": \\"my_bucket-\${random_id.my_bucket_Id_50F73A6B.hex}\\",
-        \\"public_access_prevention\\": \\"inherited\\",
-        \\"uniform_bucket_level_access\\": true
-      }
+{
+  "resource": {
+    "google_storage_bucket": {
+      "my_bucket": {
+        "location": "US",
+        "name": "my_bucket-\${random_id.my_bucket_Id_50F73A6B.hex}",
+        "public_access_prevention": "inherited",
+        "uniform_bucket_level_access": true,
+      },
     },
-    \\"google_storage_bucket_iam_member\\": {
-      \\"my_bucket_PublicAccessIamMember_F45C9FFA\\": {
-        \\"bucket\\": \\"\${google_storage_bucket.my_bucket.name}\\",
-        \\"member\\": \\"allUsers\\",
-        \\"role\\": \\"roles/storage.objectViewer\\"
-      }
+    "google_storage_bucket_iam_member": {
+      "my_bucket_PublicAccessIamMember_F45C9FFA": {
+        "bucket": "\${google_storage_bucket.my_bucket.name}",
+        "member": "allUsers",
+        "role": "roles/storage.objectViewer",
+      },
     },
-    \\"random_id\\": {
-      \\"my_bucket_Id_50F73A6B\\": {
-        \\"byte_length\\": 4
-      }
-    }
-  }
-}"
+    "random_id": {
+      "my_bucket_Id_50F73A6B": {
+        "byte_length": 4,
+      },
+    },
+  },
+}
 `;
 
 exports[`bucket is public 2`] = `
@@ -129,35 +129,35 @@ exports[`bucket is public 2`] = `
 `;
 
 exports[`bucket with two preflight objects 1`] = `
-"{
-  \\"resource\\": {
-    \\"google_storage_bucket\\": {
-      \\"my_bucket\\": {
-        \\"location\\": \\"US\\",
-        \\"name\\": \\"my_bucket-\${random_id.my_bucket_Id_50F73A6B.hex}\\",
-        \\"public_access_prevention\\": \\"enforced\\",
-        \\"uniform_bucket_level_access\\": true
-      }
-    },
-    \\"google_storage_bucket_object\\": {
-      \\"my_bucket_Object-file1txt_F3CECCDA\\": {
-        \\"bucket\\": \\"\${google_storage_bucket.my_bucket.id}\\",
-        \\"content\\": \\"hello world\\",
-        \\"name\\": \\"file1.txt\\"
+{
+  "resource": {
+    "google_storage_bucket": {
+      "my_bucket": {
+        "location": "US",
+        "name": "my_bucket-\${random_id.my_bucket_Id_50F73A6B.hex}",
+        "public_access_prevention": "enforced",
+        "uniform_bucket_level_access": true,
       },
-      \\"my_bucket_Object-file2txt_DA15A080\\": {
-        \\"bucket\\": \\"\${google_storage_bucket.my_bucket.id}\\",
-        \\"content\\": \\"boom bam\\",
-        \\"name\\": \\"file2.txt\\"
-      }
     },
-    \\"random_id\\": {
-      \\"my_bucket_Id_50F73A6B\\": {
-        \\"byte_length\\": 4
-      }
-    }
-  }
-}"
+    "google_storage_bucket_object": {
+      "my_bucket_Object-file1txt_F3CECCDA": {
+        "bucket": "\${google_storage_bucket.my_bucket.id}",
+        "content": "hello world",
+        "name": "file1.txt",
+      },
+      "my_bucket_Object-file2txt_DA15A080": {
+        "bucket": "\${google_storage_bucket.my_bucket.id}",
+        "content": "boom bam",
+        "name": "file2.txt",
+      },
+    },
+    "random_id": {
+      "my_bucket_Id_50F73A6B": {
+        "byte_length": 4,
+      },
+    },
+  },
+}
 `;
 
 exports[`bucket with two preflight objects 2`] = `
@@ -270,23 +270,23 @@ exports[`bucket with two preflight objects 2`] = `
 `;
 
 exports[`create a bucket 1`] = `
-"{
-  \\"resource\\": {
-    \\"google_storage_bucket\\": {
-      \\"my_bucket\\": {
-        \\"location\\": \\"US\\",
-        \\"name\\": \\"my_bucket-\${random_id.my_bucket_Id_50F73A6B.hex}\\",
-        \\"public_access_prevention\\": \\"enforced\\",
-        \\"uniform_bucket_level_access\\": true
-      }
+{
+  "resource": {
+    "google_storage_bucket": {
+      "my_bucket": {
+        "location": "US",
+        "name": "my_bucket-\${random_id.my_bucket_Id_50F73A6B.hex}",
+        "public_access_prevention": "enforced",
+        "uniform_bucket_level_access": true,
+      },
     },
-    \\"random_id\\": {
-      \\"my_bucket_Id_50F73A6B\\": {
-        \\"byte_length\\": 4
-      }
-    }
-  }
-}"
+    "random_id": {
+      "my_bucket_Id_50F73A6B": {
+        "byte_length": 4,
+      },
+    },
+  },
+}
 `;
 
 exports[`create a bucket 2`] = `
@@ -383,32 +383,32 @@ exports[`create a bucket 2`] = `
 `;
 
 exports[`two buckets 1`] = `
-"{
-  \\"resource\\": {
-    \\"google_storage_bucket\\": {
-      \\"my_bucket1\\": {
-        \\"location\\": \\"US\\",
-        \\"name\\": \\"my_bucket1-\${random_id.my_bucket1_Id_D79FE240.hex}\\",
-        \\"public_access_prevention\\": \\"enforced\\",
-        \\"uniform_bucket_level_access\\": true
+{
+  "resource": {
+    "google_storage_bucket": {
+      "my_bucket1": {
+        "location": "US",
+        "name": "my_bucket1-\${random_id.my_bucket1_Id_D79FE240.hex}",
+        "public_access_prevention": "enforced",
+        "uniform_bucket_level_access": true,
       },
-      \\"my_bucket2\\": {
-        \\"location\\": \\"US\\",
-        \\"name\\": \\"my_bucket2-\${random_id.my_bucket2_Id_0AB96F49.hex}\\",
-        \\"public_access_prevention\\": \\"enforced\\",
-        \\"uniform_bucket_level_access\\": true
-      }
+      "my_bucket2": {
+        "location": "US",
+        "name": "my_bucket2-\${random_id.my_bucket2_Id_0AB96F49.hex}",
+        "public_access_prevention": "enforced",
+        "uniform_bucket_level_access": true,
+      },
     },
-    \\"random_id\\": {
-      \\"my_bucket1_Id_D79FE240\\": {
-        \\"byte_length\\": 4
+    "random_id": {
+      "my_bucket1_Id_D79FE240": {
+        "byte_length": 4,
       },
-      \\"my_bucket2_Id_0AB96F49\\": {
-        \\"byte_length\\": 4
-      }
-    }
-  }
-}"
+      "my_bucket2_Id_0AB96F49": {
+        "byte_length": 4,
+      },
+    },
+  },
+}
 `;
 
 exports[`two buckets 2`] = `

--- a/libs/wingsdk/test/util.ts
+++ b/libs/wingsdk/test/util.ts
@@ -1,6 +1,7 @@
 import { mkdtempSync, readFileSync, readdirSync, statSync } from "fs";
 import { tmpdir } from "os";
 import { extname, isAbsolute, join } from "path";
+import { Template } from "aws-cdk-lib/assertions";
 import { App, Code } from "../src/core";
 
 export function treeJsonOf(outdir: string): any {
@@ -85,39 +86,46 @@ export function getTfDataSource(
   return dataSources[key];
 }
 
-export function tfSanitize(templateStr: string): string {
-  const template = JSON.parse(templateStr);
+export function awscdkSanitize(template: Template): any {
+  let json = template.toJSON();
 
-  // remove names of assets whose hashes are sensitive to changes based
-  // on the file system layout
-  return JSON.stringify(
-    template,
-    (key, value) => {
-      if (
-        key === "key" &&
-        typeof value === "string" &&
-        value.match(/^asset\..*\.zip$/)
-      ) {
-        return "<key>";
-      }
-      if (
-        key === "source" &&
-        typeof value === "string" &&
-        (value.match(/^assets\/.*\/archive.zip$/) || isAbsolute(value))
-      ) {
-        return "<source>";
-      }
-      if (
-        key === "source_hash" &&
-        typeof value === "string" &&
-        value.startsWith("${filemd5")
-      ) {
-        return "${filemd5(<source>)}";
+  return JSON.parse(
+    JSON.stringify(json, (key, value) => {
+      if (key === "S3Key" && value.endsWith(".zip")) {
+        return "<S3Key>";
       }
       return value;
-    },
-    2
+    })
   );
+}
+
+export function tfSanitize(templateStr: string): any {
+  // remove names of assets whose hashes are sensitive to changes based
+  // on the file system layout
+  return JSON.parse(templateStr, (key, value) => {
+    if (
+      key === "key" &&
+      typeof value === "string" &&
+      value.match(/^asset\..*\.zip$/)
+    ) {
+      return "<key>";
+    }
+    if (
+      key === "source" &&
+      typeof value === "string" &&
+      (value.match(/^assets\/.*\/archive.zip$/) || isAbsolute(value))
+    ) {
+      return "<source>";
+    }
+    if (
+      key === "source_hash" &&
+      typeof value === "string" &&
+      value.startsWith("${filemd5")
+    ) {
+      return "${filemd5(<source>)}";
+    }
+    return value;
+  });
 }
 
 export function appSnapshot(app: App): Record<string, any> {


### PR DESCRIPTION
fixes #3812 

- remove path-dependent hashes for awscdk like we do for cdktf tests
- change tfSanitize to return an object instead of a string, this results in much nicer looking snapshots for cdktf snapshots (less escapes)

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
