### PR TITLE
fix(docs): wing filename in comparison pages

### DIFF
--- a/docs/docs/src/examples/function-upload-to-bucket/wing.js
+++ b/docs/docs/src/examples/function-upload-to-bucket/wing.js
@@ -1,4 +1,4 @@
 // We cannot parse the folder structure at runtime because of Docusaurus and webpack limitations
 
 import wingHelloPath from '!file-loader?outputPath=docs!./wing/hello.w';
-export default { name: "hello.js", path: wingHelloPath };
+export default { name: "hello.w", path: wingHelloPath };


### PR DESCRIPTION
The comparison to other solution pages shows `hello.js` file with wing code inside.

![](https://github.com/winglang/wing/assets/5693018/b2f7657b-1170-4410-9d33-cab8838715c4)


I believe it's by mistake and it should by `hello.w`


## Checklist

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [ ] Tests added (always) - It's docs change
- [x] Docs updated (only required for features)
- [x] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
