### PR TITLE
feat(console): improve vs-code theme sync

### DIFF
--- a/apps/wing-console/console/ui/src/ui/edge-metadata.tsx
+++ b/apps/wing-console/console/ui/src/ui/edge-metadata.tsx
@@ -89,7 +89,7 @@ export const EdgeMetadata = ({
             "border-t",
             theme.border4,
             "px-2 py-1.5 flex flex-col gap-y-1 gap-x-4",
-            "bg-slate-100 dark:bg-slate-700 text-slate-900 dark:text-slate-250",
+            "text-slate-900 dark:text-slate-250",
           )}
         >
           <Attribute name="Source">


### PR DESCRIPTION
Edge metadata panel  is not showing the correct background color.

<img width="1495" alt="image" src="https://github.com/winglang/wing/assets/5547636/e47e9a89-7400-467c-b6de-a44146e5d1e9">

vs

<img width="1013" alt="image" src="https://github.com/winglang/wing/assets/5547636/9da1d8c2-6302-47a3-b195-293ce0272b2c">


*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
