### PR TITLE
chore(repo): typo in mergify queue message

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -16,7 +16,7 @@ pull_request_rules:
     actions:
       comment:
         message: |
-          Thanks for contributing, @{{author}}! This PR will now be added to the [merge queue](https://mergify.com/merge-queue), or immediately merged if @{{head}} is up-to-date with @{{base}} and the queue is empty.
+          Thanks for contributing, @{{author}}! This PR will now be added to the [merge queue](https://mergify.com/merge-queue), or immediately merged if `{{head}}` is up-to-date with `{{base}}` and the queue is empty.
       queue:
         name: default
         method: squash


### PR DESCRIPTION
idk why I thought the `@` was part of the interpolation syntax

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
