### PR TITLE
chore(docs):  add push batch to `cloud.queue` example in the docs

### DIFF
--- a/docs/docs/04-standard-library/01-cloud/queue.md
+++ b/docs/docs/04-standard-library/01-cloud/queue.md
@@ -51,9 +51,7 @@ let q = new cloud.Queue();
 
 new cloud.Function(inflight () => {
   q.push("message a");
-  q.push("message b");
-  q.push("message c");
-  q.push("message d");
+  q.push("message b", "message c", "message d");
   log("approxSize is ${q.approxSize()}");
   log("popping message ${q.pop()}");
   log("popping message ${q.pop()}");

--- a/libs/wingsdk/src/cloud/queue.md
+++ b/libs/wingsdk/src/cloud/queue.md
@@ -51,9 +51,7 @@ let q = new cloud.Queue();
 
 new cloud.Function(inflight () => {
   q.push("message a");
-  q.push("message b");
-  q.push("message c");
-  q.push("message d");
+  q.push("message b", "message c", "message d");
   log("approxSize is ${q.approxSize()}");
   log("popping message ${q.pop()}");
   log("popping message ${q.pop()}");


### PR DESCRIPTION
Show in the `cloud.Queue` example that you can push multiple messages at once if you want.

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
