### PR TITLE
chore(sdk): improve bucket tests readability with `assertThrows`

### DIFF
--- a/examples/tests/sdk_tests/bucket/delete.w
+++ b/examples/tests/sdk_tests/bucket/delete.w
@@ -4,7 +4,18 @@ let b = new cloud.Bucket();
 b.addObject("file2.txt", "Bar");
 
 test "delete" {
-  let var error = "";
+  let assertThrows = (expected: str, block: (): void) => {
+    let var error = false;
+    try {
+      block();
+    } catch actual {
+      assert(actual == expected);
+      error = true;
+    }
+    assert(error);
+  };
+
+  let OBJECT_DOES_NOT_EXIST_ERROR = "Object does not exist (key=file1.json).";
   let jsonObj1 = Json { key1: "value1" };
 
   b.putJson("file1.json", jsonObj1);
@@ -14,13 +25,10 @@ test "delete" {
   assert(b.exists("file2.txt"));
 
   b.delete("file1.json", mustExist: true);
-  try {
-    b.delete("file1.json", mustExist: true);
-  } catch e {
-    error = e;
-  }
 
-  assert(error == "Object does not exist (key=file1.json).");
+  assertThrows(OBJECT_DOES_NOT_EXIST_ERROR, () => {
+    b.delete("file1.json", mustExist: true);
+  });
   assert(b.exists("file2.txt"));
 
   b.delete("file2.txt");

--- a/examples/tests/sdk_tests/bucket/public_url.w
+++ b/examples/tests/sdk_tests/bucket/public_url.w
@@ -6,7 +6,19 @@ let publicBucket = new cloud.Bucket(public: true) as "publicBucket";
 let privateBucket = new cloud.Bucket() as "privateBucket";
 
 test "publicUrl" {
-  let var error = "";
+  let assertThrows = (expected: str, block: (): void) => {
+    let var error = false;
+    try {
+      block();
+    } catch actual {
+      assert(actual == expected);
+      error = true;
+    }
+    assert(error);
+  };
+
+  let BUCKET_NOT_PUBLIC_ERROR = "Cannot provide public url for a non-public bucket";
+
   publicBucket.put("file1.txt", "Foo");
   privateBucket.put("file2.txt", "Bar");
 
@@ -18,10 +30,7 @@ test "publicUrl" {
     assert(http.get(publicUrl).body ==  "Foo");
   }
 
-  try {
+  assertThrows(BUCKET_NOT_PUBLIC_ERROR, () => {
     privateBucket.publicUrl("file2.txt");
-  } catch e {
-    error = e;
-  }
-  assert(error == "Cannot provide public url for a non-public bucket");
+  });
 }

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/delete.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/delete.w_compile_tf-aws.md
@@ -10,21 +10,30 @@ module.exports = function({ $b }) {
       return $obj;
     }
     async handle() {
-      let error = "";
+      const assertThrows = async (expected, block) => {
+        let error = false;
+        try {
+          (await block());
+        }
+        catch ($error_actual) {
+          const actual = $error_actual.message;
+          {((cond) => {if (!cond) throw new Error("assertion failed: actual == expected")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(actual,expected)))};
+          error = true;
+        }
+        {((cond) => {if (!cond) throw new Error("assertion failed: error")})(error)};
+      }
+      ;
+      const OBJECT_DOES_NOT_EXIST_ERROR = "Object does not exist (key=file1.json).";
       const jsonObj1 = ({"key1": "value1"});
       (await $b.putJson("file1.json",jsonObj1));
       (await $b.delete("file1.txt"));
       {((cond) => {if (!cond) throw new Error("assertion failed: b.exists(\"file1.json\")")})((await $b.exists("file1.json")))};
       {((cond) => {if (!cond) throw new Error("assertion failed: b.exists(\"file2.txt\")")})((await $b.exists("file2.txt")))};
       (await $b.delete("file1.json",{ mustExist: true }));
-      try {
+      (await assertThrows(OBJECT_DOES_NOT_EXIST_ERROR,async () => {
         (await $b.delete("file1.json",{ mustExist: true }));
       }
-      catch ($error_e) {
-        const e = $error_e.message;
-        error = e;
-      }
-      {((cond) => {if (!cond) throw new Error("assertion failed: error == \"Object does not exist (key=file1.json).\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(error,"Object does not exist (key=file1.json).")))};
+      ));
       {((cond) => {if (!cond) throw new Error("assertion failed: b.exists(\"file2.txt\")")})((await $b.exists("file2.txt")))};
       (await $b.delete("file2.txt"));
       {((cond) => {if (!cond) throw new Error("assertion failed: !b.exists(\"file2.txt\")")})((!(await $b.exists("file2.txt"))))};

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/public_url.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/public_url.w_compile_tf-aws.md
@@ -10,7 +10,20 @@ module.exports = function({ $http_Util, $privateBucket, $publicBucket, $util_Uti
       return $obj;
     }
     async handle() {
-      let error = "";
+      const assertThrows = async (expected, block) => {
+        let error = false;
+        try {
+          (await block());
+        }
+        catch ($error_actual) {
+          const actual = $error_actual.message;
+          {((cond) => {if (!cond) throw new Error("assertion failed: actual == expected")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(actual,expected)))};
+          error = true;
+        }
+        {((cond) => {if (!cond) throw new Error("assertion failed: error")})(error)};
+      }
+      ;
+      const BUCKET_NOT_PUBLIC_ERROR = "Cannot provide public url for a non-public bucket";
       (await $publicBucket.put("file1.txt","Foo"));
       (await $privateBucket.put("file2.txt","Bar"));
       const publicUrl = (await $publicBucket.publicUrl("file1.txt"));
@@ -18,14 +31,10 @@ module.exports = function({ $http_Util, $privateBucket, $publicBucket, $util_Uti
       if ((((a,b) => { try { return require('assert').notDeepStrictEqual(a,b) === undefined; } catch { return false; } })((await $util_Util.env("WING_TARGET")),"sim"))) {
         {((cond) => {if (!cond) throw new Error("assertion failed: http.get(publicUrl).body ==  \"Foo\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $http_Util.get(publicUrl)).body,"Foo")))};
       }
-      try {
+      (await assertThrows(BUCKET_NOT_PUBLIC_ERROR,async () => {
         (await $privateBucket.publicUrl("file2.txt"));
       }
-      catch ($error_e) {
-        const e = $error_e.message;
-        error = e;
-      }
-      {((cond) => {if (!cond) throw new Error("assertion failed: error == \"Cannot provide public url for a non-public bucket\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(error,"Cannot provide public url for a non-public bucket")))};
+      ));
     }
   }
   return $Closure1;


### PR DESCRIPTION
Updating the bucket tests following the same standard used in the other resources.

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
