### PR TITLE
fix(sdk): remove unnecessary s3 bucket policy

### DIFF
--- a/libs/wingc/src/jsify/snapshots/json_object.snap
+++ b/libs/wingc/src/jsify/snapshots/json_object.snap
@@ -24,7 +24,7 @@ module.exports = function({ $jsonObj1, $std_Json }) {
       return $obj;
     }
     async handle() {
-      {console.log(((args) => { return JSON.stringify(args[0], null, args[1]) })([$jsonObj1]))};
+      {console.log(((args) => { return JSON.stringify(args[0], null, args[1]?.indent) })([$jsonObj1]))};
     }
   }
   return $Closure1;

--- a/libs/wingc/src/lsp/snapshots/completions/json_statics.snap
+++ b/libs/wingc/src/lsp/snapshots/completions/json_statics.snap
@@ -75,10 +75,10 @@ source: libs/wingc/src/lsp/completions.rs
     command: editor.action.triggerParameterHints
 - label: stringify
   kind: 2
-  detail: "(json: any, indent: num?): str"
+  detail: "(json: any, options: JsonStringifyOptions?): str"
   documentation:
     kind: markdown
-    value: "```wing\nstatic stringify: (json: any, indent: num?): str\n```\n---\nFormats Json as string.\n\n\n### Returns\nstring representation of the Json\n\n### Remarks\n(JSON.stringify($args$))"
+    value: "```wing\nstatic stringify: (json: any, options: JsonStringifyOptions?): str\n```\n---\nFormats Json as string.\n\n\n### Returns\nstring representation of the Json"
   sortText: ff|stringify
   insertText: stringify($0)
   insertTextFormat: 2

--- a/libs/wingc/src/lsp/snapshots/completions/static_completions_after_expression.snap
+++ b/libs/wingc/src/lsp/snapshots/completions/static_completions_after_expression.snap
@@ -75,10 +75,10 @@ source: libs/wingc/src/lsp/completions.rs
     command: editor.action.triggerParameterHints
 - label: stringify
   kind: 2
-  detail: "(json: any, indent: num?): str"
+  detail: "(json: any, options: JsonStringifyOptions?): str"
   documentation:
     kind: markdown
-    value: "```wing\nstatic stringify: (json: any, indent: num?): str\n```\n---\nFormats Json as string.\n\n\n### Returns\nstring representation of the Json\n\n### Remarks\n(JSON.stringify($args$))"
+    value: "```wing\nstatic stringify: (json: any, options: JsonStringifyOptions?): str\n```\n---\nFormats Json as string.\n\n\n### Returns\nstring representation of the Json"
   sortText: ff|stringify
   insertText: stringify($0)
   insertTextFormat: 2

--- a/libs/wingc/src/lsp/snapshots/completions/static_json_after_expression.snap
+++ b/libs/wingc/src/lsp/snapshots/completions/static_json_after_expression.snap
@@ -75,10 +75,10 @@ source: libs/wingc/src/lsp/completions.rs
     command: editor.action.triggerParameterHints
 - label: stringify
   kind: 2
-  detail: "(json: any, indent: num?): str"
+  detail: "(json: any, options: JsonStringifyOptions?): str"
   documentation:
     kind: markdown
-    value: "```wing\nstatic stringify: (json: any, indent: num?): str\n```\n---\nFormats Json as string.\n\n\n### Returns\nstring representation of the Json\n\n### Remarks\n(JSON.stringify($args$))"
+    value: "```wing\nstatic stringify: (json: any, options: JsonStringifyOptions?): str\n```\n---\nFormats Json as string.\n\n\n### Returns\nstring representation of the Json"
   sortText: ff|stringify
   insertText: stringify($0)
   insertTextFormat: 2

--- a/libs/wingc/src/lsp/snapshots/completions/static_json_after_expression_statement.snap
+++ b/libs/wingc/src/lsp/snapshots/completions/static_json_after_expression_statement.snap
@@ -75,10 +75,10 @@ source: libs/wingc/src/lsp/completions.rs
     command: editor.action.triggerParameterHints
 - label: stringify
   kind: 2
-  detail: "(json: any, indent: num?): str"
+  detail: "(json: any, options: JsonStringifyOptions?): str"
   documentation:
     kind: markdown
-    value: "```wing\nstatic stringify: (json: any, indent: num?): str\n```\n---\nFormats Json as string.\n\n\n### Returns\nstring representation of the Json\n\n### Remarks\n(JSON.stringify($args$))"
+    value: "```wing\nstatic stringify: (json: any, options: JsonStringifyOptions?): str\n```\n---\nFormats Json as string.\n\n\n### Returns\nstring representation of the Json"
   sortText: ff|stringify
   insertText: stringify($0)
   insertTextFormat: 2

--- a/libs/wingc/src/lsp/snapshots/hovers/static_stdtype_method.snap
+++ b/libs/wingc/src/lsp/snapshots/hovers/static_stdtype_method.snap
@@ -3,7 +3,7 @@ source: libs/wingc/src/lsp/hover.rs
 ---
 contents:
   kind: markdown
-  value: "```wing\nstatic stringify: (json: any, indent: num?): str\n```\n---\nFormats Json as string.\n\n\n### Returns\nstring representation of the Json\n\n### Remarks\n(JSON.stringify($args$))"
+  value: "```wing\nstatic stringify: (json: any, options: JsonStringifyOptions?): str\n```\n---\nFormats Json as string.\n\n\n### Returns\nstring representation of the Json"
 range:
   start:
     line: 1

--- a/libs/wingsdk/src/target-tf-aws/bucket.ts
+++ b/libs/wingsdk/src/target-tf-aws/bucket.ts
@@ -206,14 +206,6 @@ export function createEncryptedBucket(
       policy: JSON.stringify(policy),
       dependsOn: [publicAccessBlock],
     });
-  } else {
-    new S3BucketPublicAccessBlock(scope, "PublicAccessBlock", {
-      bucket: bucket.bucket,
-      blockPublicAcls: true,
-      blockPublicPolicy: true,
-      ignorePublicAcls: true,
-      restrictPublicBuckets: true,
-    });
   }
 
   return bucket;

--- a/libs/wingsdk/test/target-tf-aws/__snapshots__/bucket.test.ts.snap
+++ b/libs/wingsdk/test/target-tf-aws/__snapshots__/bucket.test.ts.snap
@@ -183,15 +183,6 @@ exports[`bucket prefix must be lowercase 1`] = `
         "force_destroy": false,
       },
     },
-    "aws_s3_bucket_public_access_block": {
-      "The-UncannyBucket_PublicAccessBlock_88AA9BF7": {
-        "block_public_acls": true,
-        "block_public_policy": true,
-        "bucket": "\${aws_s3_bucket.The-UncannyBucket.bucket}",
-        "ignore_public_acls": true,
-        "restrict_public_buckets": true,
-      },
-    },
     "aws_s3_bucket_server_side_encryption_configuration": {
       "The-UncannyBucket_Encryption_4CFC1E98": {
         "bucket": "\${aws_s3_bucket.The-UncannyBucket.bucket}",
@@ -233,14 +224,6 @@ exports[`bucket prefix must be lowercase 2`] = `
                     },
                     "id": "Encryption",
                     "path": "root/Default/The-Uncanny.Bucket/Encryption",
-                  },
-                  "PublicAccessBlock": {
-                    "constructInfo": {
-                      "fqn": "cdktf.TerraformResource",
-                      "version": "0.17.0",
-                    },
-                    "id": "PublicAccessBlock",
-                    "path": "root/Default/The-Uncanny.Bucket/PublicAccessBlock",
                   },
                 },
                 "constructInfo": {
@@ -335,15 +318,6 @@ exports[`bucket prefix valid 1`] = `
         "force_destroy": false,
       },
     },
-    "aws_s3_bucket_public_access_block": {
-      "the-uncannybucket_PublicAccessBlock_AC5BC68C": {
-        "block_public_acls": true,
-        "block_public_policy": true,
-        "bucket": "\${aws_s3_bucket.the-uncannybucket.bucket}",
-        "ignore_public_acls": true,
-        "restrict_public_buckets": true,
-      },
-    },
     "aws_s3_bucket_server_side_encryption_configuration": {
       "the-uncannybucket_Encryption_78D02B71": {
         "bucket": "\${aws_s3_bucket.the-uncannybucket.bucket}",
@@ -416,14 +390,6 @@ exports[`bucket prefix valid 2`] = `
                     },
                     "id": "Encryption",
                     "path": "root/Default/the-uncanny.bucket/Encryption",
-                  },
-                  "PublicAccessBlock": {
-                    "constructInfo": {
-                      "fqn": "cdktf.TerraformResource",
-                      "version": "0.17.0",
-                    },
-                    "id": "PublicAccessBlock",
-                    "path": "root/Default/the-uncanny.bucket/PublicAccessBlock",
                   },
                 },
                 "constructInfo": {
@@ -2939,15 +2905,6 @@ exports[`create a bucket 1`] = `
         "force_destroy": false,
       },
     },
-    "aws_s3_bucket_public_access_block": {
-      "my_bucket_PublicAccessBlock_538547C0": {
-        "block_public_acls": true,
-        "block_public_policy": true,
-        "bucket": "\${aws_s3_bucket.my_bucket.bucket}",
-        "ignore_public_acls": true,
-        "restrict_public_buckets": true,
-      },
-    },
     "aws_s3_bucket_server_side_encryption_configuration": {
       "my_bucket_Encryption_3B1569A4": {
         "bucket": "\${aws_s3_bucket.my_bucket.bucket}",
@@ -3020,14 +2977,6 @@ exports[`create a bucket 2`] = `
                     },
                     "id": "Encryption",
                     "path": "root/Default/my_bucket/Encryption",
-                  },
-                  "PublicAccessBlock": {
-                    "constructInfo": {
-                      "fqn": "cdktf.TerraformResource",
-                      "version": "0.17.0",
-                    },
-                    "id": "PublicAccessBlock",
-                    "path": "root/Default/my_bucket/PublicAccessBlock",
                   },
                 },
                 "constructInfo": {

--- a/libs/wingsdk/test/target-tf-aws/__snapshots__/captures.test.ts.snap
+++ b/libs/wingsdk/test/target-tf-aws/__snapshots__/captures.test.ts.snap
@@ -342,15 +342,6 @@ exports[`function with bucket binding > put operation 2`] = `
         "bucket_prefix": "code-c84a50b1-",
       },
     },
-    "aws_s3_bucket_public_access_block": {
-      "Bucket_PublicAccessBlock_A34F3B5C": {
-        "block_public_acls": true,
-        "block_public_policy": true,
-        "bucket": "\${aws_s3_bucket.Bucket.bucket}",
-        "ignore_public_acls": true,
-        "restrict_public_buckets": true,
-      },
-    },
     "aws_s3_bucket_server_side_encryption_configuration": {
       "Bucket_Encryption_016FDA0C": {
         "bucket": "\${aws_s3_bucket.Bucket.bucket}",

--- a/libs/wingsdk/test/target-tf-aws/__snapshots__/on-deploy.test.ts.snap
+++ b/libs/wingsdk/test/target-tf-aws/__snapshots__/on-deploy.test.ts.snap
@@ -259,7 +259,6 @@ exports[`execute OnDeploy after other resources 1`] = `
         "depends_on": [
           "aws_s3_bucket.my_bucket",
           "aws_s3_bucket_server_side_encryption_configuration.my_bucket_Encryption_3B1569A4",
-          "aws_s3_bucket_public_access_block.my_bucket_PublicAccessBlock_538547C0",
         ],
         "function_name": "\${aws_lambda_function.my_on_deploy_Function_59669FC0.function_name}",
         "input": "{}",
@@ -317,15 +316,6 @@ exports[`execute OnDeploy after other resources 1`] = `
       "my_bucket": {
         "bucket_prefix": "my-bucket-c8045fcc-",
         "force_destroy": false,
-      },
-    },
-    "aws_s3_bucket_public_access_block": {
-      "my_bucket_PublicAccessBlock_538547C0": {
-        "block_public_acls": true,
-        "block_public_policy": true,
-        "bucket": "\${aws_s3_bucket.my_bucket.bucket}",
-        "ignore_public_acls": true,
-        "restrict_public_buckets": true,
       },
     },
     "aws_s3_bucket_server_side_encryption_configuration": {
@@ -428,14 +418,6 @@ exports[`execute OnDeploy after other resources 2`] = `
                     },
                     "id": "Encryption",
                     "path": "root/Default/my_bucket/Encryption",
-                  },
-                  "PublicAccessBlock": {
-                    "constructInfo": {
-                      "fqn": "cdktf.TerraformResource",
-                      "version": "0.17.0",
-                    },
-                    "id": "PublicAccessBlock",
-                    "path": "root/Default/my_bucket/PublicAccessBlock",
                   },
                 },
                 "constructInfo": {
@@ -636,18 +618,6 @@ exports[`execute OnDeploy before other resources 1`] = `
         "force_destroy": false,
       },
     },
-    "aws_s3_bucket_public_access_block": {
-      "my_bucket_PublicAccessBlock_538547C0": {
-        "block_public_acls": true,
-        "block_public_policy": true,
-        "bucket": "\${aws_s3_bucket.my_bucket.bucket}",
-        "depends_on": [
-          "\${data.aws_lambda_invocation.my_on_deploy_Invocation_1A26E3B9}",
-        ],
-        "ignore_public_acls": true,
-        "restrict_public_buckets": true,
-      },
-    },
     "aws_s3_bucket_server_side_encryption_configuration": {
       "my_bucket_Encryption_3B1569A4": {
         "bucket": "\${aws_s3_bucket.my_bucket.bucket}",
@@ -751,14 +721,6 @@ exports[`execute OnDeploy before other resources 2`] = `
                     },
                     "id": "Encryption",
                     "path": "root/Default/my_bucket/Encryption",
-                  },
-                  "PublicAccessBlock": {
-                    "constructInfo": {
-                      "fqn": "cdktf.TerraformResource",
-                      "version": "0.17.0",
-                    },
-                    "id": "PublicAccessBlock",
-                    "path": "root/Default/my_bucket/PublicAccessBlock",
                   },
                 },
                 "constructInfo": {

--- a/libs/wingsdk/test/target-tf-aws/__snapshots__/website.test.ts.snap
+++ b/libs/wingsdk/test/target-tf-aws/__snapshots__/website.test.ts.snap
@@ -106,15 +106,6 @@ exports[`default website behavior 1`] = `
         "policy": "\${data.aws_iam_policy_document.Website_AllowDistributionReadOnly_24CFF6C0.json}",
       },
     },
-    "aws_s3_bucket_public_access_block": {
-      "Website_PublicAccessBlock_C196C11D": {
-        "block_public_acls": true,
-        "block_public_policy": true,
-        "bucket": "\${aws_s3_bucket.Website_WebsiteBucket_3C0321F0.bucket}",
-        "ignore_public_acls": true,
-        "restrict_public_buckets": true,
-      },
-    },
     "aws_s3_bucket_server_side_encryption_configuration": {
       "Website_Encryption_5BBFE612": {
         "bucket": "\${aws_s3_bucket.Website_WebsiteBucket_3C0321F0.bucket}",
@@ -234,14 +225,6 @@ exports[`default website behavior 2`] = `
                     },
                     "id": "File--inner-folder--a.html",
                     "path": "root/Default/Website/File--inner-folder--a.html",
-                  },
-                  "PublicAccessBlock": {
-                    "constructInfo": {
-                      "fqn": "cdktf.TerraformResource",
-                      "version": "0.17.0",
-                    },
-                    "id": "PublicAccessBlock",
-                    "path": "root/Default/Website/PublicAccessBlock",
                   },
                   "WebsiteBucket": {
                     "constructInfo": {
@@ -436,15 +419,6 @@ exports[`website with add_json 1`] = `
         "policy": "\${data.aws_iam_policy_document.Website_AllowDistributionReadOnly_24CFF6C0.json}",
       },
     },
-    "aws_s3_bucket_public_access_block": {
-      "Website_PublicAccessBlock_C196C11D": {
-        "block_public_acls": true,
-        "block_public_policy": true,
-        "bucket": "\${aws_s3_bucket.Website_WebsiteBucket_3C0321F0.bucket}",
-        "ignore_public_acls": true,
-        "restrict_public_buckets": true,
-      },
-    },
     "aws_s3_bucket_server_side_encryption_configuration": {
       "Website_Encryption_5BBFE612": {
         "bucket": "\${aws_s3_bucket.Website_WebsiteBucket_3C0321F0.bucket}",
@@ -581,14 +555,6 @@ exports[`website with add_json 2`] = `
                     },
                     "id": "File-config.json",
                     "path": "root/Default/Website/File-config.json",
-                  },
-                  "PublicAccessBlock": {
-                    "constructInfo": {
-                      "fqn": "cdktf.TerraformResource",
-                      "version": "0.17.0",
-                    },
-                    "id": "PublicAccessBlock",
-                    "path": "root/Default/Website/PublicAccessBlock",
                   },
                   "WebsiteBucket": {
                     "constructInfo": {

--- a/libs/wingsdk/test/target-tf-aws/bucket.test.ts
+++ b/libs/wingsdk/test/target-tf-aws/bucket.test.ts
@@ -21,7 +21,6 @@ test("create a bucket", () => {
   // THEN
   expect(tfResourcesOf(output)).toEqual([
     "aws_s3_bucket", // main bucket
-    "aws_s3_bucket_public_access_block", // ensure bucket is private
     "aws_s3_bucket_server_side_encryption_configuration", // server side encryption
   ]);
   expect(tfSanitize(output)).toMatchSnapshot();

--- a/libs/wingsdk/test/target-tf-aws/captures.test.ts
+++ b/libs/wingsdk/test/target-tf-aws/captures.test.ts
@@ -55,7 +55,6 @@ describe("function with bucket binding", () => {
       "aws_iam_role_policy_attachment",
       "aws_lambda_function",
       "aws_s3_bucket",
-      "aws_s3_bucket_public_access_block",
       "aws_s3_bucket_server_side_encryption_configuration",
       "aws_s3_object",
     ]);

--- a/libs/wingsdk/test/target-tf-aws/website.test.ts
+++ b/libs/wingsdk/test/target-tf-aws/website.test.ts
@@ -25,7 +25,6 @@ test("default website behavior", () => {
     "aws_cloudfront_origin_access_control",
     "aws_s3_bucket",
     "aws_s3_bucket_policy",
-    "aws_s3_bucket_public_access_block", // allow public access to an s3 bucket
     "aws_s3_bucket_server_side_encryption_configuration",
     "aws_s3_bucket_website_configuration",
     "aws_s3_object",
@@ -73,7 +72,6 @@ test("website with add_json", () => {
     "aws_cloudfront_origin_access_control",
     "aws_s3_bucket",
     "aws_s3_bucket_policy",
-    "aws_s3_bucket_public_access_block", // allow public access to an s3 bucket
     "aws_s3_bucket_server_side_encryption_configuration",
     "aws_s3_bucket_website_configuration",
     "aws_s3_object",

--- a/tools/hangar/__snapshots__/plugins.ts.snap
+++ b/tools/hangar/__snapshots__/plugins.ts.snap
@@ -128,21 +128,6 @@ exports[`Plugin examples > AWS target plugins > permission-boundary.js 1`] = `
         "force_destroy": false,
       },
     },
-    "aws_s3_bucket_public_access_block": {
-      "cloudBucket_PublicAccessBlock_5946CCE8": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/cloud.Bucket/PublicAccessBlock",
-            "uniqueId": "cloudBucket_PublicAccessBlock_5946CCE8",
-          },
-        },
-        "block_public_acls": true,
-        "block_public_policy": true,
-        "bucket": "\${aws_s3_bucket.cloudBucket.bucket}",
-        "ignore_public_acls": true,
-        "restrict_public_buckets": true,
-      },
-    },
     "aws_s3_bucket_server_side_encryption_configuration": {
       "cloudBucket_Encryption_77B6AEEF": {
         "//": {
@@ -402,21 +387,6 @@ exports[`Plugin examples > AWS target plugins > replicate-s3.js 1`] = `
           },
         },
         "bucket": "some-prefix\${aws_s3_bucket.cloudBucket.bucket}",
-      },
-    },
-    "aws_s3_bucket_public_access_block": {
-      "cloudBucket_PublicAccessBlock_5946CCE8": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/cloud.Bucket/PublicAccessBlock",
-            "uniqueId": "cloudBucket_PublicAccessBlock_5946CCE8",
-          },
-        },
-        "block_public_acls": true,
-        "block_public_policy": true,
-        "bucket": "\${aws_s3_bucket.cloudBucket.bucket}",
-        "ignore_public_acls": true,
-        "restrict_public_buckets": true,
       },
     },
     "aws_s3_bucket_replication_configuration": {
@@ -692,21 +662,6 @@ exports[`Plugin examples > AWS target plugins > tf-backend.js > azurerm backend 
         "force_destroy": false,
       },
     },
-    "aws_s3_bucket_public_access_block": {
-      "cloudBucket_PublicAccessBlock_5946CCE8": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/cloud.Bucket/PublicAccessBlock",
-            "uniqueId": "cloudBucket_PublicAccessBlock_5946CCE8",
-          },
-        },
-        "block_public_acls": true,
-        "block_public_policy": true,
-        "bucket": "\${aws_s3_bucket.cloudBucket.bucket}",
-        "ignore_public_acls": true,
-        "restrict_public_buckets": true,
-      },
-    },
     "aws_s3_bucket_server_side_encryption_configuration": {
       "cloudBucket_Encryption_77B6AEEF": {
         "//": {
@@ -880,21 +835,6 @@ exports[`Plugin examples > AWS target plugins > tf-backend.js > gcp backend 1`] 
         "force_destroy": false,
       },
     },
-    "aws_s3_bucket_public_access_block": {
-      "cloudBucket_PublicAccessBlock_5946CCE8": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/cloud.Bucket/PublicAccessBlock",
-            "uniqueId": "cloudBucket_PublicAccessBlock_5946CCE8",
-          },
-        },
-        "block_public_acls": true,
-        "block_public_policy": true,
-        "bucket": "\${aws_s3_bucket.cloudBucket.bucket}",
-        "ignore_public_acls": true,
-        "restrict_public_buckets": true,
-      },
-    },
     "aws_s3_bucket_server_side_encryption_configuration": {
       "cloudBucket_Encryption_77B6AEEF": {
         "//": {
@@ -1066,21 +1006,6 @@ exports[`Plugin examples > AWS target plugins > tf-backend.js > s3 backend 1`] =
         },
         "bucket_prefix": "cloud-bucket-c87175e7-",
         "force_destroy": false,
-      },
-    },
-    "aws_s3_bucket_public_access_block": {
-      "cloudBucket_PublicAccessBlock_5946CCE8": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/cloud.Bucket/PublicAccessBlock",
-            "uniqueId": "cloudBucket_PublicAccessBlock_5946CCE8",
-          },
-        },
-        "block_public_acls": true,
-        "block_public_policy": true,
-        "bucket": "\${aws_s3_bucket.cloudBucket.bucket}",
-        "ignore_public_acls": true,
-        "restrict_public_buckets": true,
       },
     },
     "aws_s3_bucket_server_side_encryption_configuration": {

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/add_file.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/add_file.w_compile_tf-aws.md
@@ -135,21 +135,6 @@ module.exports = function({ $b }) {
         "force_destroy": false
       }
     },
-    "aws_s3_bucket_public_access_block": {
-      "cloudBucket_PublicAccessBlock_5946CCE8": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/cloud.Bucket/PublicAccessBlock",
-            "uniqueId": "cloudBucket_PublicAccessBlock_5946CCE8"
-          }
-        },
-        "block_public_acls": true,
-        "block_public_policy": true,
-        "bucket": "${aws_s3_bucket.cloudBucket.bucket}",
-        "ignore_public_acls": true,
-        "restrict_public_buckets": true
-      }
-    },
     "aws_s3_bucket_server_side_encryption_configuration": {
       "cloudBucket_Encryption_77B6AEEF": {
         "//": {

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/add_object.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/add_object.w_compile_tf-aws.md
@@ -135,21 +135,6 @@ module.exports = function({ $b, $jsonObj1, $std_Json }) {
         "force_destroy": false
       }
     },
-    "aws_s3_bucket_public_access_block": {
-      "cloudBucket_PublicAccessBlock_5946CCE8": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/cloud.Bucket/PublicAccessBlock",
-            "uniqueId": "cloudBucket_PublicAccessBlock_5946CCE8"
-          }
-        },
-        "block_public_acls": true,
-        "block_public_policy": true,
-        "bucket": "${aws_s3_bucket.cloudBucket.bucket}",
-        "ignore_public_acls": true,
-        "restrict_public_buckets": true
-      }
-    },
     "aws_s3_bucket_server_side_encryption_configuration": {
       "cloudBucket_Encryption_77B6AEEF": {
         "//": {

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/bucket_list.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/bucket_list.w_compile_tf-aws.md
@@ -149,21 +149,6 @@ module.exports = function({ $b }) {
         "force_destroy": false
       }
     },
-    "aws_s3_bucket_public_access_block": {
-      "cloudBucket_PublicAccessBlock_5946CCE8": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/cloud.Bucket/PublicAccessBlock",
-            "uniqueId": "cloudBucket_PublicAccessBlock_5946CCE8"
-          }
-        },
-        "block_public_acls": true,
-        "block_public_policy": true,
-        "bucket": "${aws_s3_bucket.cloudBucket.bucket}",
-        "ignore_public_acls": true,
-        "restrict_public_buckets": true
-      }
-    },
     "aws_s3_bucket_server_side_encryption_configuration": {
       "cloudBucket_Encryption_77B6AEEF": {
         "//": {

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/delete.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/delete.w_compile_tf-aws.md
@@ -150,21 +150,6 @@ module.exports = function({ $b }) {
         "force_destroy": false
       }
     },
-    "aws_s3_bucket_public_access_block": {
-      "cloudBucket_PublicAccessBlock_5946CCE8": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/cloud.Bucket/PublicAccessBlock",
-            "uniqueId": "cloudBucket_PublicAccessBlock_5946CCE8"
-          }
-        },
-        "block_public_acls": true,
-        "block_public_policy": true,
-        "bucket": "${aws_s3_bucket.cloudBucket.bucket}",
-        "ignore_public_acls": true,
-        "restrict_public_buckets": true
-      }
-    },
     "aws_s3_bucket_server_side_encryption_configuration": {
       "cloudBucket_Encryption_77B6AEEF": {
         "//": {

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/events.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/events.w_compile_tf-aws.md
@@ -835,21 +835,6 @@ module.exports = function({ $Source, $b, $checkHitCount, $util_Util, $wait }) {
         ]
       }
     },
-    "aws_s3_bucket_public_access_block": {
-      "cloudBucket_PublicAccessBlock_5946CCE8": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/cloud.Bucket/PublicAccessBlock",
-            "uniqueId": "cloudBucket_PublicAccessBlock_5946CCE8"
-          }
-        },
-        "block_public_acls": true,
-        "block_public_policy": true,
-        "bucket": "${aws_s3_bucket.cloudBucket.bucket}",
-        "ignore_public_acls": true,
-        "restrict_public_buckets": true
-      }
-    },
     "aws_s3_bucket_server_side_encryption_configuration": {
       "cloudBucket_Encryption_77B6AEEF": {
         "//": {

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/exists.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/exists.w_compile_tf-aws.md
@@ -139,21 +139,6 @@ module.exports = function({ $b }) {
         "force_destroy": false
       }
     },
-    "aws_s3_bucket_public_access_block": {
-      "cloudBucket_PublicAccessBlock_5946CCE8": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/cloud.Bucket/PublicAccessBlock",
-            "uniqueId": "cloudBucket_PublicAccessBlock_5946CCE8"
-          }
-        },
-        "block_public_acls": true,
-        "block_public_policy": true,
-        "bucket": "${aws_s3_bucket.cloudBucket.bucket}",
-        "ignore_public_acls": true,
-        "restrict_public_buckets": true
-      }
-    },
     "aws_s3_bucket_server_side_encryption_configuration": {
       "cloudBucket_Encryption_77B6AEEF": {
         "//": {

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/public_url.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/public_url.w_compile_tf-aws.md
@@ -175,19 +175,6 @@ module.exports = function({ $http_Util, $privateBucket, $publicBucket, $util_Uti
       }
     },
     "aws_s3_bucket_public_access_block": {
-      "privateBucket_PublicAccessBlock_BF0F9FC6": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/privateBucket/PublicAccessBlock",
-            "uniqueId": "privateBucket_PublicAccessBlock_BF0F9FC6"
-          }
-        },
-        "block_public_acls": true,
-        "block_public_policy": true,
-        "bucket": "${aws_s3_bucket.privateBucket.bucket}",
-        "ignore_public_acls": true,
-        "restrict_public_buckets": true
-      },
       "publicBucket_PublicAccessBlock_54D9EFBA": {
         "//": {
           "metadata": {

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/put.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/put.w_compile_tf-aws.md
@@ -145,21 +145,6 @@ module.exports = function({ $b }) {
         "force_destroy": false
       }
     },
-    "aws_s3_bucket_public_access_block": {
-      "cloudBucket_PublicAccessBlock_5946CCE8": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/cloud.Bucket/PublicAccessBlock",
-            "uniqueId": "cloudBucket_PublicAccessBlock_5946CCE8"
-          }
-        },
-        "block_public_acls": true,
-        "block_public_policy": true,
-        "bucket": "${aws_s3_bucket.cloudBucket.bucket}",
-        "ignore_public_acls": true,
-        "restrict_public_buckets": true
-      }
-    },
     "aws_s3_bucket_server_side_encryption_configuration": {
       "cloudBucket_Encryption_77B6AEEF": {
         "//": {

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/put_json.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/put_json.w_compile_tf-aws.md
@@ -148,21 +148,6 @@ module.exports = function({ $b }) {
         "force_destroy": false
       }
     },
-    "aws_s3_bucket_public_access_block": {
-      "cloudBucket_PublicAccessBlock_5946CCE8": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/cloud.Bucket/PublicAccessBlock",
-            "uniqueId": "cloudBucket_PublicAccessBlock_5946CCE8"
-          }
-        },
-        "block_public_acls": true,
-        "block_public_policy": true,
-        "bucket": "${aws_s3_bucket.cloudBucket.bucket}",
-        "ignore_public_acls": true,
-        "restrict_public_buckets": true
-      }
-    },
     "aws_s3_bucket_server_side_encryption_configuration": {
       "cloudBucket_Encryption_77B6AEEF": {
         "//": {

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/try_delete.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/try_delete.w_compile_tf-aws.md
@@ -143,21 +143,6 @@ module.exports = function({ $b }) {
         "force_destroy": false
       }
     },
-    "aws_s3_bucket_public_access_block": {
-      "cloudBucket_PublicAccessBlock_5946CCE8": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/cloud.Bucket/PublicAccessBlock",
-            "uniqueId": "cloudBucket_PublicAccessBlock_5946CCE8"
-          }
-        },
-        "block_public_acls": true,
-        "block_public_policy": true,
-        "bucket": "${aws_s3_bucket.cloudBucket.bucket}",
-        "ignore_public_acls": true,
-        "restrict_public_buckets": true
-      }
-    },
     "aws_s3_bucket_server_side_encryption_configuration": {
       "cloudBucket_Encryption_77B6AEEF": {
         "//": {

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/try_get.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/try_get.w_compile_tf-aws.md
@@ -139,21 +139,6 @@ module.exports = function({ $b }) {
         "force_destroy": false
       }
     },
-    "aws_s3_bucket_public_access_block": {
-      "cloudBucket_PublicAccessBlock_5946CCE8": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/cloud.Bucket/PublicAccessBlock",
-            "uniqueId": "cloudBucket_PublicAccessBlock_5946CCE8"
-          }
-        },
-        "block_public_acls": true,
-        "block_public_policy": true,
-        "bucket": "${aws_s3_bucket.cloudBucket.bucket}",
-        "ignore_public_acls": true,
-        "restrict_public_buckets": true
-      }
-    },
     "aws_s3_bucket_server_side_encryption_configuration": {
       "cloudBucket_Encryption_77B6AEEF": {
         "//": {

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/try_get_json.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/try_get_json.w_compile_tf-aws.md
@@ -143,21 +143,6 @@ module.exports = function({ $b, $std_Json }) {
         "force_destroy": false
       }
     },
-    "aws_s3_bucket_public_access_block": {
-      "cloudBucket_PublicAccessBlock_5946CCE8": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/cloud.Bucket/PublicAccessBlock",
-            "uniqueId": "cloudBucket_PublicAccessBlock_5946CCE8"
-          }
-        },
-        "block_public_acls": true,
-        "block_public_policy": true,
-        "bucket": "${aws_s3_bucket.cloudBucket.bucket}",
-        "ignore_public_acls": true,
-        "restrict_public_buckets": true
-      }
-    },
     "aws_s3_bucket_server_side_encryption_configuration": {
       "cloudBucket_Encryption_77B6AEEF": {
         "//": {

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/function/memory_and_env.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/function/memory_and_env.w_compile_tf-aws.md
@@ -310,21 +310,6 @@ module.exports = function({ $c, $f1, $f2 }) {
         "force_destroy": false
       }
     },
-    "aws_s3_bucket_public_access_block": {
-      "cloudBucket_PublicAccessBlock_5946CCE8": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/cloud.Bucket/PublicAccessBlock",
-            "uniqueId": "cloudBucket_PublicAccessBlock_5946CCE8"
-          }
-        },
-        "block_public_acls": true,
-        "block_public_policy": true,
-        "bucket": "${aws_s3_bucket.cloudBucket.bucket}",
-        "ignore_public_acls": true,
-        "restrict_public_buckets": true
-      }
-    },
     "aws_s3_bucket_server_side_encryption_configuration": {
       "cloudBucket_Encryption_77B6AEEF": {
         "//": {

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/std/array.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/std/array.w_compile_tf-aws.md
@@ -1279,47 +1279,6 @@ module.exports = function({  }) {
         "force_destroy": false
       }
     },
-    "aws_s3_bucket_public_access_block": {
-      "cloudBucket_PublicAccessBlock_5946CCE8": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/cloud.Bucket/PublicAccessBlock",
-            "uniqueId": "cloudBucket_PublicAccessBlock_5946CCE8"
-          }
-        },
-        "block_public_acls": true,
-        "block_public_policy": true,
-        "bucket": "${aws_s3_bucket.cloudBucket.bucket}",
-        "ignore_public_acls": true,
-        "restrict_public_buckets": true
-      },
-      "myBucket_PublicAccessBlock_7A6E4A40": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/myBucket/PublicAccessBlock",
-            "uniqueId": "myBucket_PublicAccessBlock_7A6E4A40"
-          }
-        },
-        "block_public_acls": true,
-        "block_public_policy": true,
-        "bucket": "${aws_s3_bucket.myBucket.bucket}",
-        "ignore_public_acls": true,
-        "restrict_public_buckets": true
-      },
-      "mySecondBucket_PublicAccessBlock_54DA86BC": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/mySecondBucket/PublicAccessBlock",
-            "uniqueId": "mySecondBucket_PublicAccessBlock_54DA86BC"
-          }
-        },
-        "block_public_acls": true,
-        "block_public_policy": true,
-        "bucket": "${aws_s3_bucket.mySecondBucket.bucket}",
-        "ignore_public_acls": true,
-        "restrict_public_buckets": true
-      }
-    },
     "aws_s3_bucket_server_side_encryption_configuration": {
       "cloudBucket_Encryption_77B6AEEF": {
         "//": {

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/website/two_websites.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/website/two_websites.w_compile_tf-aws.md
@@ -296,8 +296,8 @@ module.exports = function({ $http_Util, $w1_url, $w2_url }) {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c8683851",
             "WING_TARGET": "tf-aws",
-            "WING_TOKEN_HTTPS_TFTOKEN_TOKEN_16": "${jsonencode(\"https://${aws_cloudfront_distribution.cloudWebsite_Distribution_083B5AF9.domain_name}\")}",
-            "WING_TOKEN_HTTPS_TFTOKEN_TOKEN_32": "${jsonencode(\"https://${aws_cloudfront_distribution.website-2_Distribution_F1FA4680.domain_name}\")}"
+            "WING_TOKEN_HTTPS_TFTOKEN_TOKEN_15": "${jsonencode(\"https://${aws_cloudfront_distribution.cloudWebsite_Distribution_083B5AF9.domain_name}\")}",
+            "WING_TOKEN_HTTPS_TFTOKEN_TOKEN_30": "${jsonencode(\"https://${aws_cloudfront_distribution.website-2_Distribution_F1FA4680.domain_name}\")}"
           }
         },
         "function_name": "Handler-c8683851",
@@ -365,34 +365,6 @@ module.exports = function({ $http_Util, $w1_url, $w2_url }) {
         },
         "bucket": "${aws_s3_bucket.website-2_WebsiteBucket_59576A0C.id}",
         "policy": "${data.aws_iam_policy_document.website-2_AllowDistributionReadOnly_994269D9.json}"
-      }
-    },
-    "aws_s3_bucket_public_access_block": {
-      "cloudWebsite_PublicAccessBlock_18A70311": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/cloud.Website/PublicAccessBlock",
-            "uniqueId": "cloudWebsite_PublicAccessBlock_18A70311"
-          }
-        },
-        "block_public_acls": true,
-        "block_public_policy": true,
-        "bucket": "${aws_s3_bucket.cloudWebsite_WebsiteBucket_EB03D355.bucket}",
-        "ignore_public_acls": true,
-        "restrict_public_buckets": true
-      },
-      "website-2_PublicAccessBlock_304A3A16": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/website-2/PublicAccessBlock",
-            "uniqueId": "website-2_PublicAccessBlock_304A3A16"
-          }
-        },
-        "block_public_acls": true,
-        "block_public_policy": true,
-        "bucket": "${aws_s3_bucket.website-2_WebsiteBucket_59576A0C.bucket}",
-        "ignore_public_acls": true,
-        "restrict_public_buckets": true
       }
     },
     "aws_s3_bucket_server_side_encryption_configuration": {

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/website/website.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/website/website.w_compile_tf-aws.md
@@ -213,7 +213,7 @@ module.exports = function({  }) {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c867c4e0",
             "WING_TARGET": "tf-aws",
-            "WING_TOKEN_HTTPS_TFTOKEN_TOKEN_16": "${jsonencode(\"https://${aws_cloudfront_distribution.cloudWebsite_Distribution_083B5AF9.domain_name}\")}"
+            "WING_TOKEN_HTTPS_TFTOKEN_TOKEN_15": "${jsonencode(\"https://${aws_cloudfront_distribution.cloudWebsite_Distribution_083B5AF9.domain_name}\")}"
           }
         },
         "function_name": "Handler-c867c4e0",
@@ -261,21 +261,6 @@ module.exports = function({  }) {
         },
         "bucket": "${aws_s3_bucket.cloudWebsite_WebsiteBucket_EB03D355.id}",
         "policy": "${data.aws_iam_policy_document.cloudWebsite_AllowDistributionReadOnly_89DC4FD0.json}"
-      }
-    },
-    "aws_s3_bucket_public_access_block": {
-      "cloudWebsite_PublicAccessBlock_18A70311": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/cloud.Website/PublicAccessBlock",
-            "uniqueId": "cloudWebsite_PublicAccessBlock_18A70311"
-          }
-        },
-        "block_public_acls": true,
-        "block_public_policy": true,
-        "bucket": "${aws_s3_bucket.cloudWebsite_WebsiteBucket_EB03D355.bucket}",
-        "ignore_public_acls": true,
-        "restrict_public_buckets": true
       }
     },
     "aws_s3_bucket_server_side_encryption_configuration": {

--- a/tools/hangar/__snapshots__/test_corpus/valid/bring_local.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/bring_local.w_compile_tf-aws.md
@@ -318,21 +318,6 @@ module.exports = function({  }) {
         "force_destroy": false
       }
     },
-    "aws_s3_bucket_public_access_block": {
-      "file1Store_cloudBucket_PublicAccessBlock_542A96A5": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/file1.Store/cloud.Bucket/PublicAccessBlock",
-            "uniqueId": "file1Store_cloudBucket_PublicAccessBlock_542A96A5"
-          }
-        },
-        "block_public_acls": true,
-        "block_public_policy": true,
-        "bucket": "${aws_s3_bucket.file1Store_cloudBucket_86CE87B1.bucket}",
-        "ignore_public_acls": true,
-        "restrict_public_buckets": true
-      }
-    },
     "aws_s3_bucket_server_side_encryption_configuration": {
       "file1Store_cloudBucket_Encryption_387D9114": {
         "//": {

--- a/tools/hangar/__snapshots__/test_corpus/valid/bucket_events.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/bucket_events.w_compile_tf-aws.md
@@ -921,34 +921,6 @@ module.exports = function({ $b }) {
         ]
       }
     },
-    "aws_s3_bucket_public_access_block": {
-      "b_PublicAccessBlock_D351EBD6": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/b/PublicAccessBlock",
-            "uniqueId": "b_PublicAccessBlock_D351EBD6"
-          }
-        },
-        "block_public_acls": true,
-        "block_public_policy": true,
-        "bucket": "${aws_s3_bucket.b.bucket}",
-        "ignore_public_acls": true,
-        "restrict_public_buckets": true
-      },
-      "other_PublicAccessBlock_6FF8D942": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/other/PublicAccessBlock",
-            "uniqueId": "other_PublicAccessBlock_6FF8D942"
-          }
-        },
-        "block_public_acls": true,
-        "block_public_policy": true,
-        "bucket": "${aws_s3_bucket.other.bucket}",
-        "ignore_public_acls": true,
-        "restrict_public_buckets": true
-      }
-    },
     "aws_s3_bucket_server_side_encryption_configuration": {
       "b_Encryption_AF1DCBD9": {
         "//": {

--- a/tools/hangar/__snapshots__/test_corpus/valid/bucket_keys.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/bucket_keys.w_compile_tf-aws.md
@@ -143,21 +143,6 @@ module.exports = function({ $b }) {
         "force_destroy": false
       }
     },
-    "aws_s3_bucket_public_access_block": {
-      "cloudBucket_PublicAccessBlock_5946CCE8": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/cloud.Bucket/PublicAccessBlock",
-            "uniqueId": "cloudBucket_PublicAccessBlock_5946CCE8"
-          }
-        },
-        "block_public_acls": true,
-        "block_public_policy": true,
-        "bucket": "${aws_s3_bucket.cloudBucket.bucket}",
-        "ignore_public_acls": true,
-        "restrict_public_buckets": true
-      }
-    },
     "aws_s3_bucket_server_side_encryption_configuration": {
       "cloudBucket_Encryption_77B6AEEF": {
         "//": {

--- a/tools/hangar/__snapshots__/test_corpus/valid/capture_in_binary.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/capture_in_binary.w_compile_tf-aws.md
@@ -135,21 +135,6 @@ module.exports = function({ $b, $x }) {
         "force_destroy": false
       }
     },
-    "aws_s3_bucket_public_access_block": {
-      "cloudBucket_PublicAccessBlock_5946CCE8": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/cloud.Bucket/PublicAccessBlock",
-            "uniqueId": "cloudBucket_PublicAccessBlock_5946CCE8"
-          }
-        },
-        "block_public_acls": true,
-        "block_public_policy": true,
-        "bucket": "${aws_s3_bucket.cloudBucket.bucket}",
-        "ignore_public_acls": true,
-        "restrict_public_buckets": true
-      }
-    },
     "aws_s3_bucket_server_side_encryption_configuration": {
       "cloudBucket_Encryption_77B6AEEF": {
         "//": {

--- a/tools/hangar/__snapshots__/test_corpus/valid/capture_reassigable_class_field.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/capture_reassigable_class_field.w_compile_tf-aws.md
@@ -221,21 +221,6 @@ module.exports = function({  }) {
         "force_destroy": false
       }
     },
-    "aws_s3_bucket_public_access_block": {
-      "KeyValueStore_cloudBucket_PublicAccessBlock_A373F90E": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/KeyValueStore/cloud.Bucket/PublicAccessBlock",
-            "uniqueId": "KeyValueStore_cloudBucket_PublicAccessBlock_A373F90E"
-          }
-        },
-        "block_public_acls": true,
-        "block_public_policy": true,
-        "bucket": "${aws_s3_bucket.KeyValueStore_cloudBucket_D9D365FD.bucket}",
-        "ignore_public_acls": true,
-        "restrict_public_buckets": true
-      }
-    },
     "aws_s3_bucket_server_side_encryption_configuration": {
       "KeyValueStore_cloudBucket_Encryption_D3F8A987": {
         "//": {

--- a/tools/hangar/__snapshots__/test_corpus/valid/capture_resource_and_data.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/capture_resource_and_data.w_compile_tf-aws.md
@@ -137,21 +137,6 @@ module.exports = function({ $data_size, $queue, $res }) {
         "force_destroy": false
       }
     },
-    "aws_s3_bucket_public_access_block": {
-      "cloudBucket_PublicAccessBlock_5946CCE8": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/cloud.Bucket/PublicAccessBlock",
-            "uniqueId": "cloudBucket_PublicAccessBlock_5946CCE8"
-          }
-        },
-        "block_public_acls": true,
-        "block_public_policy": true,
-        "bucket": "${aws_s3_bucket.cloudBucket.bucket}",
-        "ignore_public_acls": true,
-        "restrict_public_buckets": true
-      }
-    },
     "aws_s3_bucket_server_side_encryption_configuration": {
       "cloudBucket_Encryption_77B6AEEF": {
         "//": {

--- a/tools/hangar/__snapshots__/test_corpus/valid/captures.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/captures.w_compile_tf-aws.md
@@ -105,7 +105,7 @@ module.exports = function({ $headers }) {
         },
         "rest_api_id": "${aws_api_gateway_rest_api.cloudApi_api_2B334D75.id}",
         "triggers": {
-          "redeployment": "996be997492f7193f147683623ec3ca01a8e752f"
+          "redeployment": "273d559c5171243e931678d9387d60465c3b99de"
         }
       }
     },
@@ -456,19 +456,6 @@ module.exports = function({ $headers }) {
       }
     },
     "aws_s3_bucket_public_access_block": {
-      "PrivateBucket_PublicAccessBlock_BE4B4C0B": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/PrivateBucket/PublicAccessBlock",
-            "uniqueId": "PrivateBucket_PublicAccessBlock_BE4B4C0B"
-          }
-        },
-        "block_public_acls": true,
-        "block_public_policy": true,
-        "bucket": "${aws_s3_bucket.PrivateBucket.bucket}",
-        "ignore_public_acls": true,
-        "restrict_public_buckets": true
-      },
       "PublicBucket_PublicAccessBlock_4FE1A1A3": {
         "//": {
           "metadata": {
@@ -481,19 +468,6 @@ module.exports = function({ $headers }) {
         "bucket": "${aws_s3_bucket.PublicBucket.bucket}",
         "ignore_public_acls": false,
         "restrict_public_buckets": false
-      },
-      "cloudBucket_PublicAccessBlock_5946CCE8": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/cloud.Bucket/PublicAccessBlock",
-            "uniqueId": "cloudBucket_PublicAccessBlock_5946CCE8"
-          }
-        },
-        "block_public_acls": true,
-        "block_public_policy": true,
-        "bucket": "${aws_s3_bucket.cloudBucket.bucket}",
-        "ignore_public_acls": true,
-        "restrict_public_buckets": true
       }
     },
     "aws_s3_bucket_server_side_encryption_configuration": {

--- a/tools/hangar/__snapshots__/test_corpus/valid/container_types.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/container_types.w_compile_tf-aws.md
@@ -62,47 +62,6 @@
         "force_destroy": false
       }
     },
-    "aws_s3_bucket_public_access_block": {
-      "bucket1_PublicAccessBlock_01FA69AD": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/bucket1/PublicAccessBlock",
-            "uniqueId": "bucket1_PublicAccessBlock_01FA69AD"
-          }
-        },
-        "block_public_acls": true,
-        "block_public_policy": true,
-        "bucket": "${aws_s3_bucket.bucket1.bucket}",
-        "ignore_public_acls": true,
-        "restrict_public_buckets": true
-      },
-      "bucket2_PublicAccessBlock_063D91B9": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/bucket2/PublicAccessBlock",
-            "uniqueId": "bucket2_PublicAccessBlock_063D91B9"
-          }
-        },
-        "block_public_acls": true,
-        "block_public_policy": true,
-        "bucket": "${aws_s3_bucket.bucket2.bucket}",
-        "ignore_public_acls": true,
-        "restrict_public_buckets": true
-      },
-      "bucket3_PublicAccessBlock_D66B79BF": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/bucket3/PublicAccessBlock",
-            "uniqueId": "bucket3_PublicAccessBlock_D66B79BF"
-          }
-        },
-        "block_public_acls": true,
-        "block_public_policy": true,
-        "bucket": "${aws_s3_bucket.bucket3.bucket}",
-        "ignore_public_acls": true,
-        "restrict_public_buckets": true
-      }
-    },
     "aws_s3_bucket_server_side_encryption_configuration": {
       "bucket1_Encryption_4417F366": {
         "//": {

--- a/tools/hangar/__snapshots__/test_corpus/valid/file_counter.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/file_counter.w_compile_tf-aws.md
@@ -168,21 +168,6 @@ module.exports = function({ $bucket, $counter }) {
         "force_destroy": false
       }
     },
-    "aws_s3_bucket_public_access_block": {
-      "cloudBucket_PublicAccessBlock_5946CCE8": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/cloud.Bucket/PublicAccessBlock",
-            "uniqueId": "cloudBucket_PublicAccessBlock_5946CCE8"
-          }
-        },
-        "block_public_acls": true,
-        "block_public_policy": true,
-        "bucket": "${aws_s3_bucket.cloudBucket.bucket}",
-        "ignore_public_acls": true,
-        "restrict_public_buckets": true
-      }
-    },
     "aws_s3_bucket_server_side_encryption_configuration": {
       "cloudBucket_Encryption_77B6AEEF": {
         "//": {

--- a/tools/hangar/__snapshots__/test_corpus/valid/function_variadic_arguments.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/function_variadic_arguments.w_compile_tf-aws.md
@@ -62,47 +62,6 @@
         "force_destroy": false
       }
     },
-    "aws_s3_bucket_public_access_block": {
-      "bucket1_PublicAccessBlock_01FA69AD": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/bucket1/PublicAccessBlock",
-            "uniqueId": "bucket1_PublicAccessBlock_01FA69AD"
-          }
-        },
-        "block_public_acls": true,
-        "block_public_policy": true,
-        "bucket": "${aws_s3_bucket.bucket1.bucket}",
-        "ignore_public_acls": true,
-        "restrict_public_buckets": true
-      },
-      "bucket2_PublicAccessBlock_063D91B9": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/bucket2/PublicAccessBlock",
-            "uniqueId": "bucket2_PublicAccessBlock_063D91B9"
-          }
-        },
-        "block_public_acls": true,
-        "block_public_policy": true,
-        "bucket": "${aws_s3_bucket.bucket2.bucket}",
-        "ignore_public_acls": true,
-        "restrict_public_buckets": true
-      },
-      "bucket3_PublicAccessBlock_D66B79BF": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/bucket3/PublicAccessBlock",
-            "uniqueId": "bucket3_PublicAccessBlock_D66B79BF"
-          }
-        },
-        "block_public_acls": true,
-        "block_public_policy": true,
-        "bucket": "${aws_s3_bucket.bucket3.bucket}",
-        "ignore_public_acls": true,
-        "restrict_public_buckets": true
-      }
-    },
     "aws_s3_bucket_server_side_encryption_configuration": {
       "bucket1_Encryption_4417F366": {
         "//": {

--- a/tools/hangar/__snapshots__/test_corpus/valid/hello.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/hello.w_compile_tf-aws.md
@@ -146,21 +146,6 @@ module.exports = function({ $bucket }) {
         "force_destroy": false
       }
     },
-    "aws_s3_bucket_public_access_block": {
-      "cloudBucket_PublicAccessBlock_5946CCE8": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/cloud.Bucket/PublicAccessBlock",
-            "uniqueId": "cloudBucket_PublicAccessBlock_5946CCE8"
-          }
-        },
-        "block_public_acls": true,
-        "block_public_policy": true,
-        "bucket": "${aws_s3_bucket.cloudBucket.bucket}",
-        "ignore_public_acls": true,
-        "restrict_public_buckets": true
-      }
-    },
     "aws_s3_bucket_server_side_encryption_configuration": {
       "cloudBucket_Encryption_77B6AEEF": {
         "//": {

--- a/tools/hangar/__snapshots__/test_corpus/valid/inflight_class_inside_inflight_closure.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/inflight_class_inside_inflight_closure.w_compile_tf-aws.md
@@ -310,21 +310,6 @@ module.exports = function({  }) {
         "force_destroy": false
       }
     },
-    "aws_s3_bucket_public_access_block": {
-      "PreflightClass_cloudBucket_PublicAccessBlock_0331EFEC": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/PreflightClass/cloud.Bucket/PublicAccessBlock",
-            "uniqueId": "PreflightClass_cloudBucket_PublicAccessBlock_0331EFEC"
-          }
-        },
-        "block_public_acls": true,
-        "block_public_policy": true,
-        "bucket": "${aws_s3_bucket.PreflightClass_cloudBucket_05421049.bucket}",
-        "ignore_public_acls": true,
-        "restrict_public_buckets": true
-      }
-    },
     "aws_s3_bucket_server_side_encryption_configuration": {
       "PreflightClass_cloudBucket_Encryption_30FD2B0E": {
         "//": {

--- a/tools/hangar/__snapshots__/test_corpus/valid/inflights_calling_inflights.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/inflights_calling_inflights.w_compile_tf-aws.md
@@ -337,21 +337,6 @@ module.exports = function({  }) {
         "force_destroy": false
       }
     },
-    "aws_s3_bucket_public_access_block": {
-      "cloudBucket_PublicAccessBlock_5946CCE8": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/cloud.Bucket/PublicAccessBlock",
-            "uniqueId": "cloudBucket_PublicAccessBlock_5946CCE8"
-          }
-        },
-        "block_public_acls": true,
-        "block_public_policy": true,
-        "bucket": "${aws_s3_bucket.cloudBucket.bucket}",
-        "ignore_public_acls": true,
-        "restrict_public_buckets": true
-      }
-    },
     "aws_s3_bucket_server_side_encryption_configuration": {
       "cloudBucket_Encryption_77B6AEEF": {
         "//": {

--- a/tools/hangar/__snapshots__/test_corpus/valid/json.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/json.w_compile_tf-aws.md
@@ -246,21 +246,6 @@ module.exports = function({  }) {
         "force_destroy": false
       }
     },
-    "aws_s3_bucket_public_access_block": {
-      "cloudBucket_PublicAccessBlock_5946CCE8": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/cloud.Bucket/PublicAccessBlock",
-            "uniqueId": "cloudBucket_PublicAccessBlock_5946CCE8"
-          }
-        },
-        "block_public_acls": true,
-        "block_public_policy": true,
-        "bucket": "${aws_s3_bucket.cloudBucket.bucket}",
-        "ignore_public_acls": true,
-        "restrict_public_buckets": true
-      }
-    },
     "aws_s3_bucket_server_side_encryption_configuration": {
       "cloudBucket_Encryption_77B6AEEF": {
         "//": {

--- a/tools/hangar/__snapshots__/test_corpus/valid/json_bucket.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/json_bucket.w_compile_tf-aws.md
@@ -210,21 +210,6 @@ module.exports = function({ $b, $fileName, $getJson, $j }) {
         "force_destroy": false
       }
     },
-    "aws_s3_bucket_public_access_block": {
-      "cloudBucket_PublicAccessBlock_5946CCE8": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/cloud.Bucket/PublicAccessBlock",
-            "uniqueId": "cloudBucket_PublicAccessBlock_5946CCE8"
-          }
-        },
-        "block_public_acls": true,
-        "block_public_policy": true,
-        "bucket": "${aws_s3_bucket.cloudBucket.bucket}",
-        "ignore_public_acls": true,
-        "restrict_public_buckets": true
-      }
-    },
     "aws_s3_bucket_server_side_encryption_configuration": {
       "cloudBucket_Encryption_77B6AEEF": {
         "//": {

--- a/tools/hangar/__snapshots__/test_corpus/valid/lift_via_closure.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/lift_via_closure.w_compile_tf-aws.md
@@ -267,34 +267,6 @@ module.exports = function({ $bucket2 }) {
         "force_destroy": false
       }
     },
-    "aws_s3_bucket_public_access_block": {
-      "MyClosure_cloudBucket_PublicAccessBlock_EFF6E688": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/MyClosure/cloud.Bucket/PublicAccessBlock",
-            "uniqueId": "MyClosure_cloudBucket_PublicAccessBlock_EFF6E688"
-          }
-        },
-        "block_public_acls": true,
-        "block_public_policy": true,
-        "bucket": "${aws_s3_bucket.MyClosure_cloudBucket_4DAD12C0.bucket}",
-        "ignore_public_acls": true,
-        "restrict_public_buckets": true
-      },
-      "cloudBucket_PublicAccessBlock_5946CCE8": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/cloud.Bucket/PublicAccessBlock",
-            "uniqueId": "cloudBucket_PublicAccessBlock_5946CCE8"
-          }
-        },
-        "block_public_acls": true,
-        "block_public_policy": true,
-        "bucket": "${aws_s3_bucket.cloudBucket.bucket}",
-        "ignore_public_acls": true,
-        "restrict_public_buckets": true
-      }
-    },
     "aws_s3_bucket_server_side_encryption_configuration": {
       "MyClosure_cloudBucket_Encryption_31C1B5A0": {
         "//": {

--- a/tools/hangar/__snapshots__/test_corpus/valid/mut_container_types.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/mut_container_types.w_compile_tf-aws.md
@@ -62,47 +62,6 @@
         "force_destroy": false
       }
     },
-    "aws_s3_bucket_public_access_block": {
-      "bucket1_PublicAccessBlock_01FA69AD": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/bucket1/PublicAccessBlock",
-            "uniqueId": "bucket1_PublicAccessBlock_01FA69AD"
-          }
-        },
-        "block_public_acls": true,
-        "block_public_policy": true,
-        "bucket": "${aws_s3_bucket.bucket1.bucket}",
-        "ignore_public_acls": true,
-        "restrict_public_buckets": true
-      },
-      "bucket2_PublicAccessBlock_063D91B9": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/bucket2/PublicAccessBlock",
-            "uniqueId": "bucket2_PublicAccessBlock_063D91B9"
-          }
-        },
-        "block_public_acls": true,
-        "block_public_policy": true,
-        "bucket": "${aws_s3_bucket.bucket2.bucket}",
-        "ignore_public_acls": true,
-        "restrict_public_buckets": true
-      },
-      "bucket3_PublicAccessBlock_D66B79BF": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/bucket3/PublicAccessBlock",
-            "uniqueId": "bucket3_PublicAccessBlock_D66B79BF"
-          }
-        },
-        "block_public_acls": true,
-        "block_public_policy": true,
-        "bucket": "${aws_s3_bucket.bucket3.bucket}",
-        "ignore_public_acls": true,
-        "restrict_public_buckets": true
-      }
-    },
     "aws_s3_bucket_server_side_encryption_configuration": {
       "bucket1_Encryption_4417F366": {
         "//": {

--- a/tools/hangar/__snapshots__/test_corpus/valid/optionals.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/optionals.w_compile_tf-aws.md
@@ -250,21 +250,6 @@ module.exports = function({  }) {
         "force_destroy": false
       }
     },
-    "aws_s3_bucket_public_access_block": {
-      "orangebucket_PublicAccessBlock_E0BEAC90": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/orange bucket/PublicAccessBlock",
-            "uniqueId": "orangebucket_PublicAccessBlock_E0BEAC90"
-          }
-        },
-        "block_public_acls": true,
-        "block_public_policy": true,
-        "bucket": "${aws_s3_bucket.orangebucket.bucket}",
-        "ignore_public_acls": true,
-        "restrict_public_buckets": true
-      }
-    },
     "aws_s3_bucket_server_side_encryption_configuration": {
       "orangebucket_Encryption_F338E6D4": {
         "//": {

--- a/tools/hangar/__snapshots__/test_corpus/valid/resource.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/resource.w_compile_tf-aws.md
@@ -646,47 +646,6 @@ module.exports = function({  }) {
         ]
       }
     },
-    "aws_s3_bucket_public_access_block": {
-      "BigPublisher_b2_PublicAccessBlock_AB982F06": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/BigPublisher/b2/PublicAccessBlock",
-            "uniqueId": "BigPublisher_b2_PublicAccessBlock_AB982F06"
-          }
-        },
-        "block_public_acls": true,
-        "block_public_policy": true,
-        "bucket": "${aws_s3_bucket.BigPublisher_b2_702AC841.bucket}",
-        "ignore_public_acls": true,
-        "restrict_public_buckets": true
-      },
-      "BigPublisher_cloudBucket_PublicAccessBlock_6DB1CA1E": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/BigPublisher/cloud.Bucket/PublicAccessBlock",
-            "uniqueId": "BigPublisher_cloudBucket_PublicAccessBlock_6DB1CA1E"
-          }
-        },
-        "block_public_acls": true,
-        "block_public_policy": true,
-        "bucket": "${aws_s3_bucket.BigPublisher_cloudBucket_ABF95118.bucket}",
-        "ignore_public_acls": true,
-        "restrict_public_buckets": true
-      },
-      "cloudBucket_PublicAccessBlock_5946CCE8": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/cloud.Bucket/PublicAccessBlock",
-            "uniqueId": "cloudBucket_PublicAccessBlock_5946CCE8"
-          }
-        },
-        "block_public_acls": true,
-        "block_public_policy": true,
-        "bucket": "${aws_s3_bucket.cloudBucket.bucket}",
-        "ignore_public_acls": true,
-        "restrict_public_buckets": true
-      }
-    },
     "aws_s3_bucket_server_side_encryption_configuration": {
       "BigPublisher_b2_Encryption_24266321": {
         "//": {

--- a/tools/hangar/__snapshots__/test_corpus/valid/resource_captures.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/resource_captures.w_compile_tf-aws.md
@@ -300,47 +300,6 @@ module.exports = function({  }) {
         "force_destroy": false
       }
     },
-    "aws_s3_bucket_public_access_block": {
-      "MyResource_Another_First_cloudBucket_PublicAccessBlock_58B6E544": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/MyResource/Another/First/cloud.Bucket/PublicAccessBlock",
-            "uniqueId": "MyResource_Another_First_cloudBucket_PublicAccessBlock_58B6E544"
-          }
-        },
-        "block_public_acls": true,
-        "block_public_policy": true,
-        "bucket": "${aws_s3_bucket.MyResource_Another_First_cloudBucket_5C44A510.bucket}",
-        "ignore_public_acls": true,
-        "restrict_public_buckets": true
-      },
-      "MyResource_cloudBucket_PublicAccessBlock_2087472B": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/MyResource/cloud.Bucket/PublicAccessBlock",
-            "uniqueId": "MyResource_cloudBucket_PublicAccessBlock_2087472B"
-          }
-        },
-        "block_public_acls": true,
-        "block_public_policy": true,
-        "bucket": "${aws_s3_bucket.MyResource_cloudBucket_B5E6C951.bucket}",
-        "ignore_public_acls": true,
-        "restrict_public_buckets": true
-      },
-      "cloudBucket_PublicAccessBlock_5946CCE8": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/cloud.Bucket/PublicAccessBlock",
-            "uniqueId": "cloudBucket_PublicAccessBlock_5946CCE8"
-          }
-        },
-        "block_public_acls": true,
-        "block_public_policy": true,
-        "bucket": "${aws_s3_bucket.cloudBucket.bucket}",
-        "ignore_public_acls": true,
-        "restrict_public_buckets": true
-      }
-    },
     "aws_s3_bucket_server_side_encryption_configuration": {
       "MyResource_Another_First_cloudBucket_Encryption_0413154A": {
         "//": {

--- a/tools/hangar/__snapshots__/test_corpus/valid/resource_captures_globals.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/resource_captures_globals.w_compile_tf-aws.md
@@ -407,34 +407,6 @@ module.exports = function({ $_parentThis_localCounter, $globalCounter }) {
         "force_destroy": false
       }
     },
-    "aws_s3_bucket_public_access_block": {
-      "Another_First_cloudBucket_PublicAccessBlock_BB475ACE": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/Another/First/cloud.Bucket/PublicAccessBlock",
-            "uniqueId": "Another_First_cloudBucket_PublicAccessBlock_BB475ACE"
-          }
-        },
-        "block_public_acls": true,
-        "block_public_policy": true,
-        "bucket": "${aws_s3_bucket.Another_First_cloudBucket_DB822B7C.bucket}",
-        "ignore_public_acls": true,
-        "restrict_public_buckets": true
-      },
-      "cloudBucket_PublicAccessBlock_5946CCE8": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/cloud.Bucket/PublicAccessBlock",
-            "uniqueId": "cloudBucket_PublicAccessBlock_5946CCE8"
-          }
-        },
-        "block_public_acls": true,
-        "block_public_policy": true,
-        "bucket": "${aws_s3_bucket.cloudBucket.bucket}",
-        "ignore_public_acls": true,
-        "restrict_public_buckets": true
-      }
-    },
     "aws_s3_bucket_server_side_encryption_configuration": {
       "Another_First_cloudBucket_Encryption_C22274BF": {
         "//": {

--- a/tools/hangar/__snapshots__/test_corpus/valid/super_call.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/super_call.w_compile_tf-aws.md
@@ -329,21 +329,6 @@ module.exports = function({ $InflightA }) {
         "force_destroy": false
       }
     },
-    "aws_s3_bucket_public_access_block": {
-      "cloudBucket_PublicAccessBlock_5946CCE8": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/cloud.Bucket/PublicAccessBlock",
-            "uniqueId": "cloudBucket_PublicAccessBlock_5946CCE8"
-          }
-        },
-        "block_public_acls": true,
-        "block_public_policy": true,
-        "bucket": "${aws_s3_bucket.cloudBucket.bucket}",
-        "ignore_public_acls": true,
-        "restrict_public_buckets": true
-      }
-    },
     "aws_s3_bucket_server_side_encryption_configuration": {
       "cloudBucket_Encryption_77B6AEEF": {
         "//": {

--- a/tools/hangar/__snapshots__/test_corpus/valid/test_bucket.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/test_bucket.w_compile_tf-aws.md
@@ -210,21 +210,6 @@ module.exports = function({ $b }) {
         "force_destroy": false
       }
     },
-    "aws_s3_bucket_public_access_block": {
-      "cloudBucket_PublicAccessBlock_5946CCE8": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/cloud.Bucket/PublicAccessBlock",
-            "uniqueId": "cloudBucket_PublicAccessBlock_5946CCE8"
-          }
-        },
-        "block_public_acls": true,
-        "block_public_policy": true,
-        "bucket": "${aws_s3_bucket.cloudBucket.bucket}",
-        "ignore_public_acls": true,
-        "restrict_public_buckets": true
-      }
-    },
     "aws_s3_bucket_server_side_encryption_configuration": {
       "cloudBucket_Encryption_77B6AEEF": {
         "//": {

--- a/tools/hangar/__snapshots__/test_corpus/valid/website_with_api.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/website_with_api.w_compile_tf-aws.md
@@ -151,7 +151,7 @@ module.exports = function({  }) {
         },
         "rest_api_id": "${aws_api_gateway_rest_api.cloudApi_api_2B334D75.id}",
         "triggers": {
-          "redeployment": "968b3a7209054cfcc312829735646935481807e4"
+          "redeployment": "53d34a77ebc006529cbee88240e663619396c753"
         }
       }
     },
@@ -515,21 +515,6 @@ module.exports = function({  }) {
         },
         "bucket": "${aws_s3_bucket.cloudWebsite_WebsiteBucket_EB03D355.id}",
         "policy": "${data.aws_iam_policy_document.cloudWebsite_AllowDistributionReadOnly_89DC4FD0.json}"
-      }
-    },
-    "aws_s3_bucket_public_access_block": {
-      "cloudWebsite_PublicAccessBlock_18A70311": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/cloud.Website/PublicAccessBlock",
-            "uniqueId": "cloudWebsite_PublicAccessBlock_18A70311"
-          }
-        },
-        "block_public_acls": true,
-        "block_public_policy": true,
-        "bucket": "${aws_s3_bucket.cloudWebsite_WebsiteBucket_EB03D355.bucket}",
-        "ignore_public_acls": true,
-        "restrict_public_buckets": true
       }
     },
     "aws_s3_bucket_server_side_encryption_configuration": {

--- a/tools/hangar/__snapshots__/tree_json.ts.snap
+++ b/tools/hangar/__snapshots__/tree_json.ts.snap
@@ -135,14 +135,6 @@ exports[`tree.json for an app with many resources 1`] = `
                             "id": "Encryption",
                             "path": "root/Default/Default/BigPublisher/b2/Encryption",
                           },
-                          "PublicAccessBlock": {
-                            "constructInfo": {
-                              "fqn": "cdktf.TerraformResource",
-                              "version": "0.17.0",
-                            },
-                            "id": "PublicAccessBlock",
-                            "path": "root/Default/Default/BigPublisher/b2/PublicAccessBlock",
-                          },
                           "S3BucketNotification": {
                             "constructInfo": {
                               "fqn": "cdktf.TerraformResource",
@@ -310,14 +302,6 @@ exports[`tree.json for an app with many resources 1`] = `
                             },
                             "id": "Encryption",
                             "path": "root/Default/Default/BigPublisher/cloud.Bucket/Encryption",
-                          },
-                          "PublicAccessBlock": {
-                            "constructInfo": {
-                              "fqn": "cdktf.TerraformResource",
-                              "version": "0.17.0",
-                            },
-                            "id": "PublicAccessBlock",
-                            "path": "root/Default/Default/BigPublisher/cloud.Bucket/PublicAccessBlock",
                           },
                         },
                         "constructInfo": {
@@ -622,14 +606,6 @@ exports[`tree.json for an app with many resources 1`] = `
                         },
                         "id": "Encryption",
                         "path": "root/Default/Default/cloud.Bucket/Encryption",
-                      },
-                      "PublicAccessBlock": {
-                        "constructInfo": {
-                          "fqn": "cdktf.TerraformResource",
-                          "version": "0.17.0",
-                        },
-                        "id": "PublicAccessBlock",
-                        "path": "root/Default/Default/cloud.Bucket/PublicAccessBlock",
                       },
                     },
                     "constructInfo": {


### PR DESCRIPTION
S3 Block Public Access is enabled by default for all new buckets created after April 2023 (see [HERE](https://aws.amazon.com/about-aws/whats-new/2023/04/amazon-s3-security-best-practices-buckets-default/)).

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
