### PR TITLE
chore(repo): pr title linter must run on synchronize

### DIFF
--- a/.github/workflows/pull-request-lint.yml
+++ b/.github/workflows/pull-request-lint.yml
@@ -4,6 +4,7 @@ on:
   pull_request_target:
     types:
       - opened
+      - synchronize
       - reopened
       - edited
     branches-ignore:


### PR DESCRIPTION
I removed synchronize since it didn't make sense at first, the PR title didn't change so why rerun? Well now I know the answer is because otherwise a new status won't be created for the new commit.

## Checklist

- [ ] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [ ] Description explains motivation and solution
- [ ] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
