### PR TITLE
fix: publish job not publishing all npm packages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -352,7 +352,7 @@ jobs:
           PACKAGE_VERSION: ${{ needs.build.outputs.version }}
         run: |
           PACKAGES=("winglang-sdk" "winglang-compiler" "wingconsole-design-system" "wingconsole-ui" "wingconsole-server" "wingconsole-app")
-          for PACKAGE in $PACKAGES; do
+          for PACKAGE in "${PACKAGES[@]}"; do
             npm publish "$PACKAGE-$PACKAGE_VERSION.tgz" --access public
           done
 


### PR DESCRIPTION
Seems the array was not being expanded properly and instead of iterating over each element it was treated as a single string. This syntax does work is zsh shells but probably is not bash compliant. This fix hopefully fixes the issue of only sdk package being uploaded to npm.
## Checklist

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [ ] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
