### PR TITLE
chore(compiler)!: remove panic built-in method

### DIFF
--- a/docs/docs/02-concepts/01-preflight-and-inflight.md
+++ b/docs/docs/02-concepts/01-preflight-and-inflight.md
@@ -266,7 +266,7 @@ inflight () => {
 
 ## Phase-independent code
 
-The global functions `log`, `assert`, `throw`, and `panic` can all be used in both preflight and inflight code.
+The global functions `log`, `assert`, and `throw` can all be used in both preflight and inflight code.
 
 Issue [#435](https://github.com/winglang/wing/issues/435) is tracking support for the capability to define phase-independent functions.
 

--- a/docs/docs/03-language-reference.md
+++ b/docs/docs/03-language-reference.md
@@ -517,17 +517,11 @@ log("UTC: ${t1.utc.toIso())}");            // output: 2023-02-09T06:21:03.000Z
 | -------- | -------------------------------------------------------- |
 | `log`    | logs str                                                 |
 | `throw`  | creates and throws an instance of an exception           |
-| `panic`  | exits with a serializable, dumps the trace + a core dump |
-| `assert` | checks a condition and _panics_ if evaluated to false    |
-
-`panic` is a fatal call by design. If the intention is error handling, panic is the
-last resort. Exceptions are non fatal and should be used instead for effectively
-communicating errors to the user.
+| `assert` | checks a condition and _throws_ if evaluated to false    |
 
 > ```TS
 > log("Hello ${name}");
 > throw("a recoverable error occurred");
-> panic("a fatal error encountered");
 > assert(x > 0);
 > ```
 
@@ -969,12 +963,7 @@ translate to JavaScript. You can create a new exception with a `throw` call.
 In the presence of `try`, both `catch` and `finally` are optional but at least one of them must be present.
 In the presence of `catch` the variable holding the exception (`e` in the example below) is optional.
 
-`panic` is meant to be fatal error handling.  
 `throw` is meant to be recoverable error handling.
-
-An uncaught exception is considered user error but a panic call is not. Compiler
-guarantees exception safety by throwing a compile error if an exception is
-expected from a call and it is not being caught.
 
 > ```TS
 > try {

--- a/examples/tests/error/utilities.w
+++ b/examples/tests/error/utilities.w
@@ -1,4 +1,3 @@
 assert(false);
 log("W");
 throw("me");
-panic("L");

--- a/libs/wingc/src/ast.rs
+++ b/libs/wingc/src/ast.rs
@@ -304,7 +304,6 @@ pub struct Stmt {
 #[derive(Debug)]
 pub enum UtilityFunctions {
 	Log,
-	Panic,
 	Throw,
 	Assert,
 }
@@ -312,12 +311,7 @@ pub enum UtilityFunctions {
 impl UtilityFunctions {
 	/// Returns all utility functions.
 	pub fn all() -> Vec<UtilityFunctions> {
-		vec![
-			UtilityFunctions::Log,
-			UtilityFunctions::Panic,
-			UtilityFunctions::Throw,
-			UtilityFunctions::Assert,
-		]
+		vec![UtilityFunctions::Log, UtilityFunctions::Throw, UtilityFunctions::Assert]
 	}
 }
 
@@ -325,7 +319,6 @@ impl Display for UtilityFunctions {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		match self {
 			UtilityFunctions::Log => write!(f, "log"),
-			UtilityFunctions::Panic => write!(f, "panic"),
 			UtilityFunctions::Throw => write!(f, "throw"),
 			UtilityFunctions::Assert => write!(f, "assert"),
 		}

--- a/libs/wingc/src/lib.rs
+++ b/libs/wingc/src/lib.rs
@@ -141,7 +141,7 @@ pub unsafe extern "C" fn wingc_free(ptr: *mut u8, size: usize) {
 /// should be called before any other function
 #[no_mangle]
 pub unsafe extern "C" fn wingc_init() {
-	// Setup a custom panic hook to report panics as complitation diagnostics
+	// Setup a custom panic hook to report panics as compilation diagnostics
 	set_custom_panic_hook();
 }
 
@@ -256,24 +256,6 @@ pub fn type_check(
 			phase: Phase::Independent,
 			js_override: Some("{((msg) => {throw new Error(msg)})($args$)}".to_string()),
 			docs: Docs::with_summary("throws an error"),
-		}),
-		scope,
-		types,
-	);
-	add_builtin(
-		UtilityFunctions::Panic.to_string().as_str(),
-		Type::Function(FunctionSignature {
-			this_type: None,
-			parameters: vec![FunctionParameter {
-				typeref: types.string(),
-				name: "message".into(),
-				docs: Docs::with_summary("The message to panic with"),
-				variadic: false,
-			}],
-			return_type: types.void(),
-			phase: Phase::Independent,
-			js_override: Some("{((msg) => {console.error(msg, (new Error()).stack);process.exit(1)})($args$)}".to_string()),
-			docs: Docs::with_summary("panics with an error"),
 		}),
 		scope,
 		types,

--- a/libs/wingc/src/lsp/snapshots/completions/call_struct_expansion.snap
+++ b/libs/wingc/src/lsp/snapshots/completions/call_struct_expansion.snap
@@ -37,18 +37,6 @@ source: libs/wingc/src/lsp/completions.rs
   command:
     title: triggerParameterHints
     command: editor.action.triggerParameterHints
-- label: panic
-  kind: 3
-  detail: "(message: str): void"
-  documentation:
-    kind: markdown
-    value: "```wing\npanic: (message: str): void\n```\n---\npanics with an error\n\n### Parameters\n- `message` — The message to panic with"
-  sortText: cc|panic
-  insertText: panic($0)
-  insertTextFormat: 2
-  command:
-    title: triggerParameterHints
-    command: editor.action.triggerParameterHints
 - label: throw
   kind: 3
   detail: "(message: str): void"

--- a/libs/wingc/src/lsp/snapshots/completions/call_struct_expansion_partial.snap
+++ b/libs/wingc/src/lsp/snapshots/completions/call_struct_expansion_partial.snap
@@ -37,18 +37,6 @@ source: libs/wingc/src/lsp/completions.rs
   command:
     title: triggerParameterHints
     command: editor.action.triggerParameterHints
-- label: panic
-  kind: 3
-  detail: "(message: str): void"
-  documentation:
-    kind: markdown
-    value: "```wing\npanic: (message: str): void\n```\n---\npanics with an error\n\n### Parameters\n- `message` — The message to panic with"
-  sortText: cc|panic
-  insertText: panic($0)
-  insertTextFormat: 2
-  command:
-    title: triggerParameterHints
-    command: editor.action.triggerParameterHints
 - label: throw
   kind: 3
   detail: "(message: str): void"

--- a/libs/wingc/src/lsp/snapshots/completions/empty.snap
+++ b/libs/wingc/src/lsp/snapshots/completions/empty.snap
@@ -25,18 +25,6 @@ source: libs/wingc/src/lsp/completions.rs
   command:
     title: triggerParameterHints
     command: editor.action.triggerParameterHints
-- label: panic
-  kind: 3
-  detail: "(message: str): void"
-  documentation:
-    kind: markdown
-    value: "```wing\npanic: (message: str): void\n```\n---\npanics with an error\n\n### Parameters\n- `message` — The message to panic with"
-  sortText: cc|panic
-  insertText: panic($0)
-  insertTextFormat: 2
-  command:
-    title: triggerParameterHints
-    command: editor.action.triggerParameterHints
 - label: throw
   kind: 3
   detail: "(message: str): void"

--- a/libs/wingc/src/lsp/snapshots/completions/only_show_symbols_in_scope.snap
+++ b/libs/wingc/src/lsp/snapshots/completions/only_show_symbols_in_scope.snap
@@ -39,18 +39,6 @@ source: libs/wingc/src/lsp/completions.rs
   command:
     title: triggerParameterHints
     command: editor.action.triggerParameterHints
-- label: panic
-  kind: 3
-  detail: "(message: str): void"
-  documentation:
-    kind: markdown
-    value: "```wing\npanic: (message: str): void\n```\n---\npanics with an error\n\n### Parameters\n- `message` — The message to panic with"
-  sortText: cc|panic
-  insertText: panic($0)
-  insertTextFormat: 2
-  command:
-    title: triggerParameterHints
-    command: editor.action.triggerParameterHints
 - label: throw
   kind: 3
   detail: "(message: str): void"

--- a/libs/wingc/src/lsp/snapshots/completions/struct_literal_value.snap
+++ b/libs/wingc/src/lsp/snapshots/completions/struct_literal_value.snap
@@ -25,18 +25,6 @@ source: libs/wingc/src/lsp/completions.rs
   command:
     title: triggerParameterHints
     command: editor.action.triggerParameterHints
-- label: panic
-  kind: 3
-  detail: "(message: str): void"
-  documentation:
-    kind: markdown
-    value: "```wing\npanic: (message: str): void\n```\n---\npanics with an error\n\n### Parameters\n- `message` — The message to panic with"
-  sortText: cc|panic
-  insertText: panic($0)
-  insertTextFormat: 2
-  command:
-    title: triggerParameterHints
-    command: editor.action.triggerParameterHints
 - label: throw
   kind: 3
   detail: "(message: str): void"

--- a/tools/hangar/__snapshots__/test_corpus/valid/debug_env.w_test_sim.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/debug_env.w_test_sim.md
@@ -4,7 +4,7 @@
 ```log
 [symbol environment at ../../../../examples/tests/valid/debug_env.w:7:5]
 level 0: { this => A }
-level 1: { A => A [type], assert => (condition: bool): void, cloud => cloud [namespace], log => (message: str): void, panic => (message: str): void, std => std [namespace], throw => (message: str): void }
+level 1: { A => A [type], assert => (condition: bool): void, cloud => cloud [namespace], log => (message: str): void, std => std [namespace], throw => (message: str): void }
 pass ─ debug_env.wsim (no tests)
  
  


### PR DESCRIPTION
> Don't panic! Stay cool...

This minor breaking change was staring at me for too long - better remove `panic()` before anyone starts using it.

Closes #2055

## Checklist

- [ ] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [ ] Description explains motivation and solution
- [ ] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
