### PR TITLE
feat(console): remove theme toggle for playground

### DIFF
--- a/apps/wing-console/console/ui/src/layout/layout-provider.tsx
+++ b/apps/wing-console/console/ui/src/layout/layout-provider.tsx
@@ -39,6 +39,9 @@ export function LayoutProvider({
             },
           ],
         },
+        statusBar: {
+          showThemeToggle: false,
+        },
         panels: {
           rounded: false,
         },


### PR DESCRIPTION
Removes the theme toggle from the footer for the playground layout.

Before
<img width="1512" alt="image" src="https://github.com/winglang/wing/assets/5547636/7989f3c1-b1ad-4453-81db-ebb14a9eb03b">

After
<img width="1512" alt="image" src="https://github.com/winglang/wing/assets/5547636/a3c2b310-b3d4-4d5a-adea-25ae91437526">


*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
