### PR TITLE
fix(compiler): error when more than one space is placed between `if` and `let`

### DIFF
--- a/examples/tests/valid/optionals.w
+++ b/examples/tests/valid/optionals.w
@@ -66,6 +66,12 @@ if let var z = a {
   assert(z == 2);
 }
 
+// extra space between if and let
+let b: num? = 1;
+if    let z = b {
+  assert(z == 1);
+}
+
 // Nested if lets
 if let parsedName = tryParseName("Good Name") {
   assert(parsedName.first == "Good");

--- a/libs/tree-sitter-wing/grammar.js
+++ b/libs/tree-sitter-wing/grammar.js
@@ -274,7 +274,8 @@ module.exports = grammar({
 
     if_let_statement: ($) =>
       seq(
-        "if let",
+        "if",
+        "let",
         optional(field("reassignable", $.reassignable)),
         field("name", $.identifier),
         "=",

--- a/tools/hangar/__snapshots__/test_corpus/valid/optionals.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/optionals.w_compile_tf-aws.md
@@ -476,6 +476,14 @@ class $Root extends $stdlib.std.Resource {
         {((cond) => {if (!cond) throw new Error("assertion failed: z == 2")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(z,2)))};
       }
     }
+    const b = 1;
+    {
+      const $IF_LET_VALUE = b;
+      if ($IF_LET_VALUE != undefined) {
+        const z = $IF_LET_VALUE;
+        {((cond) => {if (!cond) throw new Error("assertion failed: z == 1")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(z,1)))};
+      }
+    }
     {
       const $IF_LET_VALUE = (tryParseName("Good Name"));
       if ($IF_LET_VALUE != undefined) {


### PR DESCRIPTION
@MarkMcCulloh, your review on PR #3888 made me realize that if I put more than one space between `if let`, it generates errors.

I've updated the `if let` to work even with extra spaces.

Closes #3959 

## Checklist

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [x] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
