### PR TITLE
feat(sdk): use arm64 for `awscdk` and `tf-aws` functions

### DIFF
--- a/libs/wingsdk/src/target-awscdk/function.ts
+++ b/libs/wingsdk/src/target-awscdk/function.ts
@@ -2,6 +2,7 @@ import { resolve } from "path";
 import { Duration } from "aws-cdk-lib";
 import { PolicyStatement as CdkPolicyStatement } from "aws-cdk-lib/aws-iam";
 import {
+  Architecture,
   Function as CdkFunction,
   Code,
   IEventSource,
@@ -44,6 +45,7 @@ export class Function extends cloud.Function implements IAwsFunction {
         ? Duration.seconds(props.timeout.seconds)
         : Duration.minutes(0.5),
       memorySize: props.memory ? props.memory : undefined,
+      architecture: Architecture.ARM_64,
     });
 
     this.arn = this.function.functionArn;

--- a/libs/wingsdk/src/target-tf-aws/function.ts
+++ b/libs/wingsdk/src/target-tf-aws/function.ts
@@ -208,6 +208,7 @@ export class Function extends cloud.Function implements IAwsFunction {
         ? props.timeout.seconds
         : Duration.fromMinutes(0.5).seconds,
       memorySize: props.memory ? props.memory : undefined,
+      architectures: ["arm64"],
     });
 
     this.arn = this.function.arn;

--- a/libs/wingsdk/test/target-awscdk/__snapshots__/bucket.test.ts.snap
+++ b/libs/wingsdk/test/target-awscdk/__snapshots__/bucket.test.ts.snap
@@ -367,6 +367,9 @@ def submit_response(event: dict, context, response_status: str, error_message: s
         "mybucketOnCreatec185c7e3ServiceRoleE5FE1BDD",
       ],
       "Properties": {
+        "Architectures": [
+          "arm64",
+        ],
         "Code": {
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
@@ -718,6 +721,9 @@ def submit_response(event: dict, context, response_status: str, error_message: s
         "mybucketOnDeletec185c7e3ServiceRole113BE170",
       ],
       "Properties": {
+        "Architectures": [
+          "arm64",
+        ],
         "Code": {
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
@@ -1091,6 +1097,9 @@ def submit_response(event: dict, context, response_status: str, error_message: s
         "mybucketOnEventc185c7e3ServiceRole3C4A0154",
       ],
       "Properties": {
+        "Architectures": [
+          "arm64",
+        ],
         "Code": {
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
@@ -1442,6 +1451,9 @@ def submit_response(event: dict, context, response_status: str, error_message: s
         "mybucketOnUpdatec185c7e3ServiceRoleA530B9CD",
       ],
       "Properties": {
+        "Architectures": [
+          "arm64",
+        ],
         "Code": {
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",

--- a/libs/wingsdk/test/target-awscdk/__snapshots__/counter.test.ts.snap
+++ b/libs/wingsdk/test/target-awscdk/__snapshots__/counter.test.ts.snap
@@ -125,6 +125,9 @@ exports[`dec() policy statement 2`] = `
         "FunctionServiceRole675BB04A",
       ],
       "Properties": {
+        "Architectures": [
+          "arm64",
+        ],
         "Code": {
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
@@ -363,6 +366,9 @@ exports[`function with a counter binding 2`] = `
         "FunctionServiceRole675BB04A",
       ],
       "Properties": {
+        "Architectures": [
+          "arm64",
+        ],
         "Code": {
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
@@ -535,6 +541,9 @@ exports[`inc() policy statement 2`] = `
         "FunctionServiceRole675BB04A",
       ],
       "Properties": {
+        "Architectures": [
+          "arm64",
+        ],
         "Code": {
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
@@ -707,6 +716,9 @@ exports[`peek() policy statement 2`] = `
         "FunctionServiceRole675BB04A",
       ],
       "Properties": {
+        "Architectures": [
+          "arm64",
+        ],
         "Code": {
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
@@ -879,6 +891,9 @@ exports[`set() policy statement 2`] = `
         "FunctionServiceRole675BB04A",
       ],
       "Properties": {
+        "Architectures": [
+          "arm64",
+        ],
         "Code": {
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",

--- a/libs/wingsdk/test/target-awscdk/__snapshots__/function.test.ts.snap
+++ b/libs/wingsdk/test/target-awscdk/__snapshots__/function.test.ts.snap
@@ -20,6 +20,9 @@ exports[`basic function 1`] = `
         "FunctionServiceRole675BB04A",
       ],
       "Properties": {
+        "Architectures": [
+          "arm64",
+        ],
         "Code": {
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
@@ -120,6 +123,9 @@ exports[`basic function with environment variables 1`] = `
         "FunctionServiceRole675BB04A",
       ],
       "Properties": {
+        "Architectures": [
+          "arm64",
+        ],
         "Code": {
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
@@ -226,6 +232,9 @@ exports[`basic function with memory size specified 1`] = `
         "FunctionServiceRole675BB04A",
       ],
       "Properties": {
+        "Architectures": [
+          "arm64",
+        ],
         "Code": {
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
@@ -327,6 +336,9 @@ exports[`basic function with timeout explicitly set 1`] = `
         "FunctionServiceRole675BB04A",
       ],
       "Properties": {
+        "Architectures": [
+          "arm64",
+        ],
         "Code": {
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",

--- a/libs/wingsdk/test/target-awscdk/__snapshots__/on-deploy.test.ts.snap
+++ b/libs/wingsdk/test/target-awscdk/__snapshots__/on-deploy.test.ts.snap
@@ -98,6 +98,9 @@ exports[`create an OnDeploy 1`] = `
         "myondeployFunctionServiceRole7277F8BB",
       ],
       "Properties": {
+        "Architectures": [
+          "arm64",
+        ],
         "Code": {
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
@@ -116,7 +119,7 @@ exports[`create an OnDeploy 1`] = `
       },
       "Type": "AWS::Lambda::Function",
     },
-    "myondeployFunctionCurrentVersion6BC23754dc8a690e8db1c57e1302de9438f9dfa2": {
+    "myondeployFunctionCurrentVersion6BC23754495ffbfe7093f6d76e062790f78856b0": {
       "Properties": {
         "FunctionName": {
           "Ref": "myondeployFunction47551748",
@@ -159,7 +162,7 @@ exports[`create an OnDeploy 1`] = `
       "DeletionPolicy": "Delete",
       "Properties": {
         "HandlerArn": {
-          "Ref": "myondeployFunctionCurrentVersion6BC23754dc8a690e8db1c57e1302de9438f9dfa2",
+          "Ref": "myondeployFunctionCurrentVersion6BC23754495ffbfe7093f6d76e062790f78856b0",
         },
         "ServiceToken": {
           "Fn::GetAtt": [
@@ -322,6 +325,9 @@ exports[`execute OnDeploy after other resources 1`] = `
         "myondeployFunctionServiceRole7277F8BB",
       ],
       "Properties": {
+        "Architectures": [
+          "arm64",
+        ],
         "Code": {
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
@@ -340,7 +346,7 @@ exports[`execute OnDeploy after other resources 1`] = `
       },
       "Type": "AWS::Lambda::Function",
     },
-    "myondeployFunctionCurrentVersion6BC23754dc8a690e8db1c57e1302de9438f9dfa2": {
+    "myondeployFunctionCurrentVersion6BC23754495ffbfe7093f6d76e062790f78856b0": {
       "Properties": {
         "FunctionName": {
           "Ref": "myondeployFunction47551748",
@@ -386,7 +392,7 @@ exports[`execute OnDeploy after other resources 1`] = `
       ],
       "Properties": {
         "HandlerArn": {
-          "Ref": "myondeployFunctionCurrentVersion6BC23754dc8a690e8db1c57e1302de9438f9dfa2",
+          "Ref": "myondeployFunctionCurrentVersion6BC23754495ffbfe7093f6d76e062790f78856b0",
         },
         "ServiceToken": {
           "Fn::GetAtt": [
@@ -552,6 +558,9 @@ exports[`execute OnDeploy before other resources 1`] = `
         "myondeployFunctionServiceRole7277F8BB",
       ],
       "Properties": {
+        "Architectures": [
+          "arm64",
+        ],
         "Code": {
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
@@ -570,7 +579,7 @@ exports[`execute OnDeploy before other resources 1`] = `
       },
       "Type": "AWS::Lambda::Function",
     },
-    "myondeployFunctionCurrentVersion6BC23754dc8a690e8db1c57e1302de9438f9dfa2": {
+    "myondeployFunctionCurrentVersion6BC23754495ffbfe7093f6d76e062790f78856b0": {
       "Properties": {
         "FunctionName": {
           "Ref": "myondeployFunction47551748",
@@ -613,7 +622,7 @@ exports[`execute OnDeploy before other resources 1`] = `
       "DeletionPolicy": "Delete",
       "Properties": {
         "HandlerArn": {
-          "Ref": "myondeployFunctionCurrentVersion6BC23754dc8a690e8db1c57e1302de9438f9dfa2",
+          "Ref": "myondeployFunctionCurrentVersion6BC23754495ffbfe7093f6d76e062790f78856b0",
         },
         "ServiceToken": {
           "Fn::GetAtt": [

--- a/libs/wingsdk/test/target-awscdk/__snapshots__/queue.test.ts.snap
+++ b/libs/wingsdk/test/target-awscdk/__snapshots__/queue.test.ts.snap
@@ -82,6 +82,9 @@ exports[`queue with a consumer function 2`] = `
         "QueueSetConsumerc185c7e3ServiceRole98E9022D",
       ],
       "Properties": {
+        "Architectures": [
+          "arm64",
+        ],
         "Code": {
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",

--- a/libs/wingsdk/test/target-awscdk/__snapshots__/schedule.test.ts.snap
+++ b/libs/wingsdk/test/target-awscdk/__snapshots__/schedule.test.ts.snap
@@ -57,6 +57,9 @@ exports[`schedule behavior with cron 1`] = `
         "ScheduleSetConsumerc185c7e3ServiceRoleAA894847",
       ],
       "Properties": {
+        "Architectures": [
+          "arm64",
+        ],
         "Code": {
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
@@ -194,6 +197,9 @@ exports[`schedule behavior with rate 1`] = `
         "ScheduleSetConsumerc185c7e3ServiceRoleAA894847",
       ],
       "Properties": {
+        "Architectures": [
+          "arm64",
+        ],
         "Code": {
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
@@ -359,6 +365,9 @@ exports[`schedule with two functions 1`] = `
         "ScheduleSetConsumer6e1b4252ServiceRole88F787AF",
       ],
       "Properties": {
+        "Architectures": [
+          "arm64",
+        ],
         "Code": {
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
@@ -413,6 +422,9 @@ exports[`schedule with two functions 1`] = `
         "ScheduleSetConsumerc185c7e3ServiceRoleAA894847",
       ],
       "Properties": {
+        "Architectures": [
+          "arm64",
+        ],
         "Code": {
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",

--- a/libs/wingsdk/test/target-awscdk/__snapshots__/topic.test.ts.snap
+++ b/libs/wingsdk/test/target-awscdk/__snapshots__/topic.test.ts.snap
@@ -102,6 +102,9 @@ exports[`topic with multiple subscribers 3`] = `
         "TopicOnMessage6e1b4252ServiceRoleEC336C6C",
       ],
       "Properties": {
+        "Architectures": [
+          "arm64",
+        ],
         "Code": {
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
@@ -187,6 +190,9 @@ exports[`topic with multiple subscribers 3`] = `
         "TopicOnMessagee967ab9dServiceRole111B1D6D",
       ],
       "Properties": {
+        "Architectures": [
+          "arm64",
+        ],
         "Code": {
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
@@ -336,6 +342,9 @@ exports[`topic with subscriber function 2`] = `
         "TopicOnMessagec185c7e3ServiceRole9266A390",
       ],
       "Properties": {
+        "Architectures": [
+          "arm64",
+        ],
         "Code": {
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",

--- a/libs/wingsdk/test/target-tf-aws/__snapshots__/bucket.test.ts.snap
+++ b/libs/wingsdk/test/target-tf-aws/__snapshots__/bucket.test.ts.snap
@@ -466,6 +466,9 @@ exports[`bucket with onCreate method 1`] = `
     },
     "aws_lambda_function": {
       "my_bucket_my_bucket-oncreate-OnMessage-7b961f4d_8104FB90": {
+        "architectures": [
+          "arm64",
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "my_bucket-oncreate-OnMessage-7b961f4d-c81311dd",
@@ -885,6 +888,9 @@ exports[`bucket with onDelete method 1`] = `
     },
     "aws_lambda_function": {
       "my_bucket_my_bucket-ondelete-OnMessage-1de1a361_37C9E1F7": {
+        "architectures": [
+          "arm64",
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "my_bucket-ondelete-OnMessage-1de1a361-c89e08bf",
@@ -1326,6 +1332,9 @@ exports[`bucket with onEvent method 1`] = `
     },
     "aws_lambda_function": {
       "my_bucket_my_bucket-oncreate-OnMessage-7b961f4d_8104FB90": {
+        "architectures": [
+          "arm64",
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "my_bucket-oncreate-OnMessage-7b961f4d-c81311dd",
@@ -1345,6 +1354,9 @@ exports[`bucket with onEvent method 1`] = `
         },
       },
       "my_bucket_my_bucket-ondelete-OnMessage-1de1a361_37C9E1F7": {
+        "architectures": [
+          "arm64",
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "my_bucket-ondelete-OnMessage-1de1a361-c89e08bf",
@@ -1364,6 +1376,9 @@ exports[`bucket with onEvent method 1`] = `
         },
       },
       "my_bucket_my_bucket-onupdate-OnMessage-46c07356_F3040BF9": {
+        "architectures": [
+          "arm64",
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "my_bucket-onupdate-OnMessage-46c07356-c844b8ba",
@@ -2105,6 +2120,9 @@ exports[`bucket with onUpdate method 1`] = `
     },
     "aws_lambda_function": {
       "my_bucket_my_bucket-onupdate-OnMessage-46c07356_F3040BF9": {
+        "architectures": [
+          "arm64",
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "my_bucket-onupdate-OnMessage-46c07356-c844b8ba",

--- a/libs/wingsdk/test/target-tf-aws/__snapshots__/captures.test.ts.snap
+++ b/libs/wingsdk/test/target-tf-aws/__snapshots__/captures.test.ts.snap
@@ -71,6 +71,9 @@ exports[`function with a function binding 3`] = `
     },
     "aws_lambda_function": {
       "Function1": {
+        "architectures": [
+          "arm64",
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Function1-c87c16f1",
@@ -90,6 +93,9 @@ exports[`function with a function binding 3`] = `
         },
       },
       "Function2": {
+        "architectures": [
+          "arm64",
+        ],
         "environment": {
           "variables": {
             "FUNCTION_NAME_50735b21": "\${aws_lambda_function.Function1.arn}",
@@ -206,6 +212,9 @@ exports[`function with a queue binding 3`] = `
     },
     "aws_lambda_function": {
       "Function": {
+        "architectures": [
+          "arm64",
+        ],
         "environment": {
           "variables": {
             "QUEUE_URL_1cfcc997": "\${aws_sqs_queue.Queue.url}",
@@ -226,6 +235,9 @@ exports[`function with a queue binding 3`] = `
         },
       },
       "Queue-SetConsumer-5cb7e554": {
+        "architectures": [
+          "arm64",
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Queue-SetConsumer-5cb7e554-c8f6c540",
@@ -313,6 +325,9 @@ exports[`function with bucket binding > put operation 2`] = `
     },
     "aws_lambda_function": {
       "Function": {
+        "architectures": [
+          "arm64",
+        ],
         "environment": {
           "variables": {
             "BUCKET_NAME_1357ca3a": "\${aws_s3_bucket.Bucket.bucket}",
@@ -403,6 +418,9 @@ exports[`two functions reusing the same IFunctionHandler 1`] = `
     },
     "aws_lambda_function": {
       "Function1": {
+        "architectures": [
+          "arm64",
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Function1-c87c16f1",
@@ -422,6 +440,9 @@ exports[`two functions reusing the same IFunctionHandler 1`] = `
         },
       },
       "Function2": {
+        "architectures": [
+          "arm64",
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Function2-c827e998",

--- a/libs/wingsdk/test/target-tf-aws/__snapshots__/counter.test.ts.snap
+++ b/libs/wingsdk/test/target-tf-aws/__snapshots__/counter.test.ts.snap
@@ -284,6 +284,9 @@ exports[`dec() policy statement 1`] = `
     },
     "aws_lambda_function": {
       "Function": {
+        "architectures": [
+          "arm64",
+        ],
         "environment": {
           "variables": {
             "DYNAMODB_TABLE_NAME_6cb5a3a4": "\${aws_dynamodb_table.Counter.name}",
@@ -583,6 +586,9 @@ exports[`function with a counter binding 2`] = `
     },
     "aws_lambda_function": {
       "Function": {
+        "architectures": [
+          "arm64",
+        ],
         "environment": {
           "variables": {
             "DYNAMODB_TABLE_NAME_6cb5a3a4": "\${aws_dynamodb_table.Counter.name}",
@@ -839,6 +845,9 @@ exports[`inc() policy statement 1`] = `
     },
     "aws_lambda_function": {
       "Function": {
+        "architectures": [
+          "arm64",
+        ],
         "environment": {
           "variables": {
             "DYNAMODB_TABLE_NAME_6cb5a3a4": "\${aws_dynamodb_table.Counter.name}",
@@ -1095,6 +1104,9 @@ exports[`peek() policy statement 1`] = `
     },
     "aws_lambda_function": {
       "Function": {
+        "architectures": [
+          "arm64",
+        ],
         "environment": {
           "variables": {
             "DYNAMODB_TABLE_NAME_6cb5a3a4": "\${aws_dynamodb_table.Counter.name}",
@@ -1473,6 +1485,9 @@ exports[`set() policy statement 1`] = `
     },
     "aws_lambda_function": {
       "Function": {
+        "architectures": [
+          "arm64",
+        ],
         "environment": {
           "variables": {
             "DYNAMODB_TABLE_NAME_6cb5a3a4": "\${aws_dynamodb_table.Counter.name}",

--- a/libs/wingsdk/test/target-tf-aws/__snapshots__/function.test.ts.snap
+++ b/libs/wingsdk/test/target-tf-aws/__snapshots__/function.test.ts.snap
@@ -27,6 +27,9 @@ exports[`basic function 1`] = `
     },
     "aws_lambda_function": {
       "Function": {
+        "architectures": [
+          "arm64",
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Function-c852aba6",
@@ -247,6 +250,9 @@ exports[`basic function with environment variables 1`] = `
     },
     "aws_lambda_function": {
       "Function": {
+        "architectures": [
+          "arm64",
+        ],
         "environment": {
           "variables": {
             "BOOM": "BAM",
@@ -469,6 +475,9 @@ exports[`basic function with memory size specified 1`] = `
     },
     "aws_lambda_function": {
       "Function": {
+        "architectures": [
+          "arm64",
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Function-c852aba6",
@@ -690,6 +699,9 @@ exports[`basic function with timeout explicitly set 1`] = `
     },
     "aws_lambda_function": {
       "Function": {
+        "architectures": [
+          "arm64",
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Function-c852aba6",
@@ -910,6 +922,9 @@ exports[`function name valid 1`] = `
     },
     "aws_lambda_function": {
       "The-Mighty_Function-01": {
+        "architectures": [
+          "arm64",
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "The-Mighty_Function-01-c86057f3",
@@ -1130,6 +1145,9 @@ exports[`replace invalid character from function name 1`] = `
     },
     "aws_lambda_function": {
       "TheMightyFunction": {
+        "architectures": [
+          "arm64",
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "The-Mighty-Function-c86ccf73",

--- a/libs/wingsdk/test/target-tf-aws/__snapshots__/logger.test.ts.snap
+++ b/libs/wingsdk/test/target-tf-aws/__snapshots__/logger.test.ts.snap
@@ -44,6 +44,9 @@ exports[`inflight function uses a logger 2`] = `
     },
     "aws_lambda_function": {
       "Function": {
+        "architectures": [
+          "arm64",
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Function-c852aba6",

--- a/libs/wingsdk/test/target-tf-aws/__snapshots__/on-deploy.test.ts.snap
+++ b/libs/wingsdk/test/target-tf-aws/__snapshots__/on-deploy.test.ts.snap
@@ -36,6 +36,9 @@ exports[`create an OnDeploy 1`] = `
     },
     "aws_lambda_function": {
       "my_on_deploy_Function_59669FC0": {
+        "architectures": [
+          "arm64",
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Function-c88c90bc",
@@ -290,6 +293,9 @@ exports[`execute OnDeploy after other resources 1`] = `
     },
     "aws_lambda_function": {
       "my_on_deploy_Function_59669FC0": {
+        "architectures": [
+          "arm64",
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Function-c88c90bc",
@@ -587,6 +593,9 @@ exports[`execute OnDeploy before other resources 1`] = `
     },
     "aws_lambda_function": {
       "my_on_deploy_Function_59669FC0": {
+        "architectures": [
+          "arm64",
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Function-c88c90bc",

--- a/libs/wingsdk/test/target-tf-aws/__snapshots__/queue.test.ts.snap
+++ b/libs/wingsdk/test/target-tf-aws/__snapshots__/queue.test.ts.snap
@@ -264,6 +264,9 @@ exports[`queue with a consumer function 2`] = `
     },
     "aws_lambda_function": {
       "Queue-SetConsumer-c5395e41": {
+        "architectures": [
+          "arm64",
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Queue-SetConsumer-c5395e41-c80c3bf7",

--- a/libs/wingsdk/test/target-tf-aws/__snapshots__/schedule.test.ts.snap
+++ b/libs/wingsdk/test/target-tf-aws/__snapshots__/schedule.test.ts.snap
@@ -39,6 +39,9 @@ exports[`schedule behavior with cron 1`] = `
     },
     "aws_lambda_function": {
       "Schedule-OnTick-c5395e41": {
+        "architectures": [
+          "arm64",
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Schedule-OnTick-c5395e41-c861b8f8",
@@ -329,6 +332,9 @@ exports[`schedule behavior with rate 1`] = `
     },
     "aws_lambda_function": {
       "Schedule-OnTick-c5395e41": {
+        "architectures": [
+          "arm64",
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Schedule-OnTick-c5395e41-c861b8f8",
@@ -634,6 +640,9 @@ exports[`schedule with two functions 1`] = `
     },
     "aws_lambda_function": {
       "Schedule-OnTick-0a615500": {
+        "architectures": [
+          "arm64",
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Schedule-OnTick-0a615500-c8fd8480",
@@ -653,6 +662,9 @@ exports[`schedule with two functions 1`] = `
         },
       },
       "Schedule-OnTick-7b33bcba": {
+        "architectures": [
+          "arm64",
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Schedule-OnTick-7b33bcba-c86000d7",

--- a/libs/wingsdk/test/target-tf-aws/__snapshots__/table.test.ts.snap
+++ b/libs/wingsdk/test/target-tf-aws/__snapshots__/table.test.ts.snap
@@ -82,6 +82,9 @@ exports[`function with a table binding 2`] = `
     },
     "aws_lambda_function": {
       "Function": {
+        "architectures": [
+          "arm64",
+        ],
         "environment": {
           "variables": {
             "DYNAMODB_TABLE_NAME_e7245baa": "\${aws_dynamodb_table.Table.name}",

--- a/libs/wingsdk/test/target-tf-aws/__snapshots__/tokens.test.ts.snap
+++ b/libs/wingsdk/test/target-tf-aws/__snapshots__/tokens.test.ts.snap
@@ -75,6 +75,9 @@ exports[`captures tokens 2`] = `
     },
     "aws_lambda_function": {
       "Api_Api-OnRequest-c5395e41_37F21C2B": {
+        "architectures": [
+          "arm64",
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Api-OnRequest-c5395e41-c8f26cae",

--- a/libs/wingsdk/test/target-tf-aws/__snapshots__/topic.test.ts.snap
+++ b/libs/wingsdk/test/target-tf-aws/__snapshots__/topic.test.ts.snap
@@ -384,6 +384,9 @@ exports[`topic with subscriber function 2`] = `
     },
     "aws_lambda_function": {
       "Topic-OnMessage-c5395e41": {
+        "architectures": [
+          "arm64",
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Topic-OnMessage-c5395e41-c8eb4431",

--- a/tools/hangar/__snapshots__/plugins.ts.snap
+++ b/tools/hangar/__snapshots__/plugins.ts.snap
@@ -86,6 +86,9 @@ exports[`Plugin examples > AWS target plugins > permission-boundary.js 1`] = `
             "uniqueId": "cloudQueue-SetConsumer-cdafee6e",
           },
         },
+        "architectures": [
+          "arm64",
+        ],
         "environment": {
           "variables": {
             "BUCKET_NAME_d755b447": "\${aws_s3_bucket.cloudBucket.bucket}",
@@ -329,6 +332,9 @@ exports[`Plugin examples > AWS target plugins > replicate-s3.js 1`] = `
             "uniqueId": "cloudQueue-SetConsumer-cdafee6e",
           },
         },
+        "architectures": [
+          "arm64",
+        ],
         "environment": {
           "variables": {
             "BUCKET_NAME_d755b447": "\${aws_s3_bucket.cloudBucket.bucket}",
@@ -620,6 +626,9 @@ exports[`Plugin examples > AWS target plugins > tf-backend.js > azurerm backend 
             "uniqueId": "cloudQueue-SetConsumer-cdafee6e",
           },
         },
+        "architectures": [
+          "arm64",
+        ],
         "environment": {
           "variables": {
             "BUCKET_NAME_d755b447": "\${aws_s3_bucket.cloudBucket.bucket}",
@@ -793,6 +802,9 @@ exports[`Plugin examples > AWS target plugins > tf-backend.js > gcp backend 1`] 
             "uniqueId": "cloudQueue-SetConsumer-cdafee6e",
           },
         },
+        "architectures": [
+          "arm64",
+        ],
         "environment": {
           "variables": {
             "BUCKET_NAME_d755b447": "\${aws_s3_bucket.cloudBucket.bucket}",
@@ -966,6 +978,9 @@ exports[`Plugin examples > AWS target plugins > tf-backend.js > s3 backend 1`] =
             "uniqueId": "cloudQueue-SetConsumer-cdafee6e",
           },
         },
+        "architectures": [
+          "arm64",
+        ],
         "environment": {
           "variables": {
             "BUCKET_NAME_d755b447": "\${aws_s3_bucket.cloudBucket.bucket}",

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/api/delete.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/api/delete.w_compile_tf-aws.md
@@ -204,6 +204,9 @@ module.exports = function({ $api_url, $http_HttpMethod, $http_Util }) {
             "uniqueId": "cloudApi_cloudApi-OnRequest-cdafee6e_A6C8366F"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "cloud-Api-OnRequest-cdafee6e-c8147384",
@@ -230,6 +233,9 @@ module.exports = function({ $api_url, $http_HttpMethod, $http_Util }) {
             "uniqueId": "testhttpdeleteandhttpfetchcanpreformacalltoanapi_Handler_98044CDF"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c897cd38",

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/api/get.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/api/get.w_compile_tf-aws.md
@@ -208,6 +208,9 @@ module.exports = function({ $api_url, $body, $http_HttpMethod, $http_Util }) {
             "uniqueId": "cloudApi_cloudApi-OnRequest-cdafee6e_A6C8366F"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "cloud-Api-OnRequest-cdafee6e-c8147384",
@@ -234,6 +237,9 @@ module.exports = function({ $api_url, $body, $http_HttpMethod, $http_Util }) {
             "uniqueId": "testhttpgetandhttpfetchcanpreformacalltoanapi_Handler_9FEA2521"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c838ce37",

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/api/options.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/api/options.w_compile_tf-aws.md
@@ -296,6 +296,9 @@ module.exports = function({ $api_url, $http_HttpMethod, $http_Util, $path }) {
             "uniqueId": "cloudApi_cloudApi-OnRequest-3fc9280c_5DA20E7A"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "cloud-Api-OnRequest-3fc9280c-c8d3ecf9",
@@ -322,6 +325,9 @@ module.exports = function({ $api_url, $http_HttpMethod, $http_Util, $path }) {
             "uniqueId": "cloudApi_cloudApi-OnRequest-86898773_701F5CA7"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "cloud-Api-OnRequest-86898773-c8ed6547",
@@ -348,6 +354,9 @@ module.exports = function({ $api_url, $http_HttpMethod, $http_Util, $path }) {
             "uniqueId": "cloudApi_cloudApi-OnRequest-cdafee6e_A6C8366F"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "cloud-Api-OnRequest-cdafee6e-c8147384",
@@ -374,6 +383,9 @@ module.exports = function({ $api_url, $http_HttpMethod, $http_Util, $path }) {
             "uniqueId": "testhttpfetchcanpreformacalltoanapitoCONNECTHEADandOPTIONS_Handler_E8EF5111"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c8f5c667",

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/api/patch.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/api/patch.w_compile_tf-aws.md
@@ -205,6 +205,9 @@ module.exports = function({ $_id, $api_url, $body, $http_HttpMethod, $http_Util,
             "uniqueId": "cloudApi_cloudApi-OnRequest-cdafee6e_A6C8366F"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "cloud-Api-OnRequest-cdafee6e-c8147384",
@@ -231,6 +234,9 @@ module.exports = function({ $_id, $api_url, $body, $http_HttpMethod, $http_Util,
             "uniqueId": "testhttppatchandhttpfetchcanpreformacalltoanapi_Handler_185CBA02"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c89df580",

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/api/post.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/api/post.w_compile_tf-aws.md
@@ -204,6 +204,9 @@ module.exports = function({ $api_url, $body, $http_HttpMethod, $http_Util, $std_
             "uniqueId": "cloudApi_cloudApi-OnRequest-cdafee6e_A6C8366F"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "cloud-Api-OnRequest-cdafee6e-c8147384",
@@ -230,6 +233,9 @@ module.exports = function({ $api_url, $body, $http_HttpMethod, $http_Util, $std_
             "uniqueId": "testhttppostandhttpfetchcanpreformacalltoanapi_Handler_C4853DBD"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c88947b5",

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/api/put.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/api/put.w_compile_tf-aws.md
@@ -209,6 +209,9 @@ module.exports = function({ $_id, $api_url, $body, $http_HttpMethod, $http_Util,
             "uniqueId": "cloudApi_cloudApi-OnRequest-cdafee6e_A6C8366F"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "cloud-Api-OnRequest-cdafee6e-c8147384",
@@ -235,6 +238,9 @@ module.exports = function({ $_id, $api_url, $body, $http_HttpMethod, $http_Util,
             "uniqueId": "testhttpputandhttpfetchcanpreformacalltoanapi_Handler_2B7157C1"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c8e4b12f",

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/add_file.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/add_file.w_compile_tf-aws.md
@@ -93,6 +93,9 @@ module.exports = function({ $b }) {
             "uniqueId": "testaddObject_Handler_44ECC49C"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "BUCKET_NAME_d755b447": "${aws_s3_bucket.cloudBucket.bucket}",

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/add_object.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/add_object.w_compile_tf-aws.md
@@ -93,6 +93,9 @@ module.exports = function({ $b, $jsonObj1, $std_Json }) {
             "uniqueId": "testaddObject_Handler_44ECC49C"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "BUCKET_NAME_d755b447": "${aws_s3_bucket.cloudBucket.bucket}",

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/bucket_list.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/bucket_list.w_compile_tf-aws.md
@@ -107,6 +107,9 @@ module.exports = function({ $b }) {
             "uniqueId": "testlist_Handler_58856559"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "BUCKET_NAME_d755b447": "${aws_s3_bucket.cloudBucket.bucket}",

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/delete.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/delete.w_compile_tf-aws.md
@@ -108,6 +108,9 @@ module.exports = function({ $b }) {
             "uniqueId": "testdelete_Handler_3DFCE06A"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "BUCKET_NAME_d755b447": "${aws_s3_bucket.cloudBucket.bucket}",

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/events.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/events.w_compile_tf-aws.md
@@ -497,6 +497,9 @@ module.exports = function({ $Source, $b, $checkHitCount, $util_Util, $wait }) {
             "uniqueId": "cloudBucket_cloudBucket-oncreate-OnMessage-42558af0_C94BBC24"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "DYNAMODB_TABLE_NAME_49baa65c": "${aws_dynamodb_table.cloudCounter.name}",
@@ -527,6 +530,9 @@ module.exports = function({ $Source, $b, $checkHitCount, $util_Util, $wait }) {
             "uniqueId": "cloudBucket_cloudBucket-oncreate-OnMessage-47274dc3_A5F9D3AA"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "DYNAMODB_TABLE_NAME_49baa65c": "${aws_dynamodb_table.cloudCounter.name}",
@@ -557,6 +563,9 @@ module.exports = function({ $Source, $b, $checkHitCount, $util_Util, $wait }) {
             "uniqueId": "cloudBucket_cloudBucket-ondelete-OnMessage-4b0506cb_9EE796E8"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "DYNAMODB_TABLE_NAME_49baa65c": "${aws_dynamodb_table.cloudCounter.name}",
@@ -587,6 +596,9 @@ module.exports = function({ $Source, $b, $checkHitCount, $util_Util, $wait }) {
             "uniqueId": "cloudBucket_cloudBucket-ondelete-OnMessage-cd5c55f4_57A0B983"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "DYNAMODB_TABLE_NAME_49baa65c": "${aws_dynamodb_table.cloudCounter.name}",
@@ -617,6 +629,9 @@ module.exports = function({ $Source, $b, $checkHitCount, $util_Util, $wait }) {
             "uniqueId": "cloudBucket_cloudBucket-onupdate-OnMessage-39d17a37_8E8F6CE8"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "DYNAMODB_TABLE_NAME_49baa65c": "${aws_dynamodb_table.cloudCounter.name}",
@@ -647,6 +662,9 @@ module.exports = function({ $Source, $b, $checkHitCount, $util_Util, $wait }) {
             "uniqueId": "cloudBucket_cloudBucket-onupdate-OnMessage-ff1f5e53_791EE56B"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "DYNAMODB_TABLE_NAME_49baa65c": "${aws_dynamodb_table.cloudCounter.name}",
@@ -677,6 +695,9 @@ module.exports = function({ $Source, $b, $checkHitCount, $util_Util, $wait }) {
             "uniqueId": "hitCountisincrementedaccordingtothebucketevent_Handler_29DEB1F6"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "BUCKET_NAME_d755b447": "${aws_s3_bucket.cloudBucket.bucket}",

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/exists.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/exists.w_compile_tf-aws.md
@@ -97,6 +97,9 @@ module.exports = function({ $b }) {
             "uniqueId": "testexists_Handler_D37905B7"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "BUCKET_NAME_d755b447": "${aws_s3_bucket.cloudBucket.bucket}",

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/public_url.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/public_url.w_compile_tf-aws.md
@@ -106,6 +106,9 @@ module.exports = function({ $http_Util, $privateBucket, $publicBucket, $util_Uti
             "uniqueId": "testpublicUrl_Handler_E965919F"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "BUCKET_NAME_7c320eda": "${aws_s3_bucket.publicBucket.bucket}",

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/put.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/put.w_compile_tf-aws.md
@@ -103,6 +103,9 @@ module.exports = function({ $b }) {
             "uniqueId": "testput_Handler_724F92D5"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "BUCKET_NAME_d755b447": "${aws_s3_bucket.cloudBucket.bucket}",

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/put_json.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/put_json.w_compile_tf-aws.md
@@ -106,6 +106,9 @@ module.exports = function({ $b }) {
             "uniqueId": "testputJson_Handler_08BF437F"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "BUCKET_NAME_d755b447": "${aws_s3_bucket.cloudBucket.bucket}",

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/try_delete.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/try_delete.w_compile_tf-aws.md
@@ -101,6 +101,9 @@ module.exports = function({ $b }) {
             "uniqueId": "testtryDelete_Handler_C4052A94"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "BUCKET_NAME_d755b447": "${aws_s3_bucket.cloudBucket.bucket}",

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/try_get.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/try_get.w_compile_tf-aws.md
@@ -97,6 +97,9 @@ module.exports = function({ $b }) {
             "uniqueId": "testtryGet_Handler_EE8DDBD9"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "BUCKET_NAME_d755b447": "${aws_s3_bucket.cloudBucket.bucket}",

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/try_get_json.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/try_get_json.w_compile_tf-aws.md
@@ -101,6 +101,9 @@ module.exports = function({ $b, $std_Json }) {
             "uniqueId": "testtryGetJson_Handler_A244DB7C"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "BUCKET_NAME_d755b447": "${aws_s3_bucket.cloudBucket.bucket}",

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/counter/dec.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/counter/dec.w_compile_tf-aws.md
@@ -170,6 +170,9 @@ module.exports = function({ $counter }) {
             "uniqueId": "testdec_Handler_BE7C58D4"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "DYNAMODB_TABLE_NAME_49baa65c": "${aws_dynamodb_table.cloudCounter.name}",
@@ -197,6 +200,9 @@ module.exports = function({ $counter }) {
             "uniqueId": "testkeydec_Handler_4A8C3A6B"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "DYNAMODB_TABLE_NAME_49baa65c": "${aws_dynamodb_table.cloudCounter.name}",

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/counter/inc.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/counter/inc.w_compile_tf-aws.md
@@ -180,6 +180,9 @@ module.exports = function({ $counter }) {
             "uniqueId": "testinc_Handler_5C48B863"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "DYNAMODB_TABLE_NAME_49baa65c": "${aws_dynamodb_table.cloudCounter.name}",
@@ -207,6 +210,9 @@ module.exports = function({ $counter }) {
             "uniqueId": "testkeyinc_Handler_15600574"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "DYNAMODB_TABLE_NAME_49baa65c": "${aws_dynamodb_table.cloudCounter.name}",

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/counter/initial.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/counter/initial.w_compile_tf-aws.md
@@ -238,6 +238,9 @@ module.exports = function({ $counterC }) {
             "uniqueId": "testinitialdefault_Handler_CE963B96"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "DYNAMODB_TABLE_NAME_220d28dd": "${aws_dynamodb_table.counterA.name}",
@@ -265,6 +268,9 @@ module.exports = function({ $counterC }) {
             "uniqueId": "testinitialnegative-value_Handler_C5E9E480"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "DYNAMODB_TABLE_NAME_4795370d": "${aws_dynamodb_table.counterC.name}",
@@ -292,6 +298,9 @@ module.exports = function({ $counterC }) {
             "uniqueId": "testinitialpositive-value_Handler_473ACDB1"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "DYNAMODB_TABLE_NAME_96df6c3c": "${aws_dynamodb_table.counterB.name}",

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/counter/peek.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/counter/peek.w_compile_tf-aws.md
@@ -164,6 +164,9 @@ module.exports = function({ $c }) {
             "uniqueId": "testkeypeek_Handler_03F3EFDE"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "DYNAMODB_TABLE_NAME_49baa65c": "${aws_dynamodb_table.cloudCounter.name}",
@@ -191,6 +194,9 @@ module.exports = function({ $c }) {
             "uniqueId": "testpeek_Handler_70E78480"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "DYNAMODB_TABLE_NAME_49baa65c": "${aws_dynamodb_table.cloudCounter.name}",

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/counter/set.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/counter/set.w_compile_tf-aws.md
@@ -174,6 +174,9 @@ module.exports = function({ $counter }) {
             "uniqueId": "testkeyset_Handler_33945E34"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "DYNAMODB_TABLE_NAME_49baa65c": "${aws_dynamodb_table.cloudCounter.name}",
@@ -201,6 +204,9 @@ module.exports = function({ $counter }) {
             "uniqueId": "testset_Handler_62442DF2"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "DYNAMODB_TABLE_NAME_49baa65c": "${aws_dynamodb_table.cloudCounter.name}",

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/function/invoke.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/function/invoke.w_compile_tf-aws.md
@@ -143,6 +143,9 @@ module.exports = function({ $f }) {
             "uniqueId": "cloudFunction"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "cloud-Function-c8d2eca1",
@@ -169,6 +172,9 @@ module.exports = function({ $f }) {
             "uniqueId": "testinvoke_Handler_A47C4946"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "FUNCTION_NAME_5bb84dfa": "${aws_lambda_function.cloudFunction.arn}",

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/function/logging.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/function/logging.w_compile_tf-aws.md
@@ -205,6 +205,9 @@ module.exports = function({  }) {
             "uniqueId": "f1"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "f1-c8545025",
@@ -231,6 +234,9 @@ module.exports = function({  }) {
             "uniqueId": "f2"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "FUNCTION_NAME_09b8c606": "${aws_lambda_function.f1.arn}",
@@ -258,6 +264,9 @@ module.exports = function({  }) {
             "uniqueId": "testlogging_Handler_2002EF98"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "FUNCTION_NAME_0300817a": "${aws_lambda_function.f2.arn}",

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/function/memory_and_env.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/function/memory_and_env.w_compile_tf-aws.md
@@ -209,6 +209,9 @@ module.exports = function({ $c, $f1, $f2 }) {
             "uniqueId": "envfn"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "DYNAMODB_TABLE_NAME_49baa65c": "${aws_dynamodb_table.cloudCounter.name}",
@@ -238,6 +241,9 @@ module.exports = function({ $c, $f1, $f2 }) {
             "uniqueId": "memoryfn"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "DYNAMODB_TABLE_NAME_49baa65c": "${aws_dynamodb_table.cloudCounter.name}",
@@ -266,6 +272,9 @@ module.exports = function({ $c, $f1, $f2 }) {
             "uniqueId": "testfunctionwithmemoryandfunctionwithenvcanbeinvoked_Handler_BE0A518F"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "DYNAMODB_TABLE_NAME_49baa65c": "${aws_dynamodb_table.cloudCounter.name}",

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/abs.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/abs.w_compile_tf-aws.md
@@ -92,6 +92,9 @@ module.exports = function({ $math_Util, $x, $y }) {
             "uniqueId": "testinflightabsolute_Handler_DB051761"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c84ad0c4",

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/acos.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/acos.w_compile_tf-aws.md
@@ -109,6 +109,9 @@ module.exports = function({ $math_Util }) {
             "uniqueId": "testinflightarccosine_Handler_506E61C9"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c853dd3e",

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/acot.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/acot.w_compile_tf-aws.md
@@ -95,6 +95,9 @@ module.exports = function({ $math_Util }) {
             "uniqueId": "testinflightarccotgent_Handler_E7A125FF"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c8e6e1b8",

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/acsc.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/acsc.w_compile_tf-aws.md
@@ -102,6 +102,9 @@ module.exports = function({ $math_Util }) {
             "uniqueId": "testinflightarccosecant_Handler_B1D46C37"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c850f94d",

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/angular_conversion.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/angular_conversion.w_compile_tf-aws.md
@@ -102,6 +102,9 @@ module.exports = function({ $math_Util }) {
             "uniqueId": "testinflightangularconversions_Handler_70CD171D"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c85ddda6",

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/asec.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/asec.w_compile_tf-aws.md
@@ -103,6 +103,9 @@ module.exports = function({ $math_Util }) {
             "uniqueId": "testinflightarccosecant_Handler_B1D46C37"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c850f94d",

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/asin.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/asin.w_compile_tf-aws.md
@@ -109,6 +109,9 @@ module.exports = function({ $math_Util }) {
             "uniqueId": "testinflightarcsine_Handler_7B606063"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c8343dcd",

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/atan.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/atan.w_compile_tf-aws.md
@@ -94,6 +94,9 @@ module.exports = function({ $math_Util }) {
             "uniqueId": "testinflightarctangent_Handler_85128CD1"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c8657687",

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/atan2.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/atan2.w_compile_tf-aws.md
@@ -97,6 +97,9 @@ module.exports = function({ $math_Util }) {
             "uniqueId": "testinflightarctangent2_Handler_412D0A11"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c88af4a6",

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/combinations.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/combinations.w_compile_tf-aws.md
@@ -91,6 +91,9 @@ module.exports = function({ $math_Util, $population, $subset }) {
             "uniqueId": "testinflightcombinations_Handler_B89BE656"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c8a6ff13",

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/cos.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/cos.w_compile_tf-aws.md
@@ -96,6 +96,9 @@ module.exports = function({ $math_Util }) {
             "uniqueId": "testinflightcosine_Handler_8C1A066C"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c81ebe2a",

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/cot.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/cot.w_compile_tf-aws.md
@@ -94,6 +94,9 @@ module.exports = function({ $math_Util }) {
             "uniqueId": "testinflightcotangent_Handler_93C199E4"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c8fc3a88",

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/csc.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/csc.w_compile_tf-aws.md
@@ -98,6 +98,9 @@ module.exports = function({ $math_Util }) {
             "uniqueId": "testinflightcosecant_Handler_0491DCB0"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c8baaa0a",

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/euler.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/euler.w_compile_tf-aws.md
@@ -109,6 +109,9 @@ module.exports = function({ $compoundOneYear, $interest, $math_Util, $value }) {
             "uniqueId": "testEULER_Handler_7DE24200"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c80e7a9d",

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/factorial.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/factorial.w_compile_tf-aws.md
@@ -96,6 +96,9 @@ module.exports = function({ $math_Util }) {
             "uniqueId": "testinflightfactorial_Handler_23BDFAA4"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c818ed07",

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/fibonacci.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/fibonacci.w_compile_tf-aws.md
@@ -101,6 +101,9 @@ module.exports = function({ $math_Util }) {
             "uniqueId": "testinflightfibonacci_Handler_5DF5857A"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c87dfd42",

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/floor_ceil_round.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/floor_ceil_round.w_compile_tf-aws.md
@@ -101,6 +101,9 @@ module.exports = function({ $__x_, $__y_, $math_Util, $x, $y }) {
             "uniqueId": "testinflightfloor--ceil--round_Handler_90E85A3F"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c8bf255a",

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/hypot.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/hypot.w_compile_tf-aws.md
@@ -94,6 +94,9 @@ module.exports = function({ $math_Util }) {
             "uniqueId": "testinflighthypot_Handler_892C5ACF"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c8289cd0",

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/median_mode_mean.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/median_mode_mean.w_compile_tf-aws.md
@@ -193,6 +193,9 @@ module.exports = function({ $math_Util, $mean_arr }) {
             "uniqueId": "testinflightmean_Handler_8EC47095"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c81bc5c0",
@@ -219,6 +222,9 @@ module.exports = function({ $math_Util, $mean_arr }) {
             "uniqueId": "testinflightmedian_Handler_B978E173"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c8d95514",
@@ -245,6 +251,9 @@ module.exports = function({ $math_Util, $mean_arr }) {
             "uniqueId": "testinflightmode_Handler_72A19270"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c8c7e996",

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/min_max.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/min_max.w_compile_tf-aws.md
@@ -92,6 +92,9 @@ module.exports = function({ $math_Util, $myArray }) {
             "uniqueId": "testinflightmin--max_Handler_7896C0CC"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c88f3f4b",

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/pi.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/pi.w_compile_tf-aws.md
@@ -109,6 +109,9 @@ module.exports = function({ $circumference, $math_Util, $r }) {
             "uniqueId": "testPI_Handler_129F22B0"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c8f48054",

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/prime.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/prime.w_compile_tf-aws.md
@@ -97,6 +97,9 @@ module.exports = function({ $math_Util }) {
             "uniqueId": "testinflightprimenumbers_Handler_E7E982CC"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c80a9be6",

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/random.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/random.w_compile_tf-aws.md
@@ -92,6 +92,9 @@ module.exports = function({ $math_Util }) {
             "uniqueId": "testinflightabsolute_Handler_DB051761"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c84ad0c4",

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/sec.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/sec.w_compile_tf-aws.md
@@ -96,6 +96,9 @@ module.exports = function({ $math_Util }) {
             "uniqueId": "testinflightsecant_Handler_72888816"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c8dc1a66",

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/sin.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/sin.w_compile_tf-aws.md
@@ -95,6 +95,9 @@ module.exports = function({ $math_Util }) {
             "uniqueId": "testinflightsine_Handler_C32FE4B8"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c8977bb8",

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/sqrt.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/sqrt.w_compile_tf-aws.md
@@ -103,6 +103,9 @@ module.exports = function({ $math_Util }) {
             "uniqueId": "testinflightsquareroot_Handler_2121E9F7"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c88a288d",

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/tan.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/tan.w_compile_tf-aws.md
@@ -94,6 +94,9 @@ module.exports = function({ $math_Util }) {
             "uniqueId": "testinflighttangent_Handler_C5A37FFB"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c8879d07",

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/tau.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/tau.w_compile_tf-aws.md
@@ -94,6 +94,9 @@ module.exports = function({ $math_Util }) {
             "uniqueId": "testTAU_Handler_FB9BAA33"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c86e3343",

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/on_deploy/execute_after.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/on_deploy/execute_after.w_compile_tf-aws.md
@@ -237,6 +237,9 @@ module.exports = function({ $counter }) {
             "uniqueId": "init1_Function_9744E65A"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "DYNAMODB_TABLE_NAME_49baa65c": "${aws_dynamodb_table.cloudCounter.name}",
@@ -264,6 +267,9 @@ module.exports = function({ $counter }) {
             "uniqueId": "init2_Function_C6177D5D"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "DYNAMODB_TABLE_NAME_49baa65c": "${aws_dynamodb_table.cloudCounter.name}",
@@ -291,6 +297,9 @@ module.exports = function({ $counter }) {
             "uniqueId": "testcounter_Handler_9843F4E3"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "DYNAMODB_TABLE_NAME_49baa65c": "${aws_dynamodb_table.cloudCounter.name}",

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/queue/pop.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/queue/pop.w_compile_tf-aws.md
@@ -97,6 +97,9 @@ module.exports = function({ $q }) {
             "uniqueId": "testpop_Handler_595175BF"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "QUEUE_URL_31e95cbd": "${aws_sqs_queue.cloudQueue.url}",

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/queue/purge.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/queue/purge.w_compile_tf-aws.md
@@ -114,6 +114,9 @@ module.exports = function({ $q, $std_Duration, $util_Util }) {
             "uniqueId": "testpurge_Handler_F7A5D0E5"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "QUEUE_URL_31e95cbd": "${aws_sqs_queue.cloudQueue.url}",

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/queue/set_consumer.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/queue/set_consumer.w_compile_tf-aws.md
@@ -197,6 +197,9 @@ module.exports = function({  }) {
             "uniqueId": "cloudQueue-SetConsumer-cdafee6e"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "DYNAMODB_TABLE_NAME_49baa65c": "${aws_dynamodb_table.cloudCounter.name}",
@@ -224,6 +227,9 @@ module.exports = function({  }) {
             "uniqueId": "testsetConsumer_Handler_A97FE23F"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "DYNAMODB_TABLE_NAME_49baa65c": "${aws_dynamodb_table.cloudCounter.name}",

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/schedule/on_tick.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/schedule/on_tick.w_compile_tf-aws.md
@@ -269,6 +269,9 @@ module.exports = function({ $c1, $c2, $std_Duration, $util_Util }) {
             "uniqueId": "from_cron-OnTick-cdafee6e"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "DYNAMODB_TABLE_NAME_bca69a1d": "${aws_dynamodb_table.c1.name}",
@@ -296,6 +299,9 @@ module.exports = function({ $c1, $c2, $std_Duration, $util_Util }) {
             "uniqueId": "from_rate-OnTick-86898773"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "DYNAMODB_TABLE_NAME_7ba9f967": "${aws_dynamodb_table.c2.name}",
@@ -323,6 +329,9 @@ module.exports = function({ $c1, $c2, $std_Duration, $util_Util }) {
             "uniqueId": "ontickiscalledbothforrateandcronschedules_Handler_B4B8DF58"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "DYNAMODB_TABLE_NAME_7ba9f967": "${aws_dynamodb_table.c2.name}",

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/std/array.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/std/array.w_compile_tf-aws.md
@@ -854,6 +854,9 @@ module.exports = function({  }) {
             "uniqueId": "testat_Handler_E4F013BC"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c858faac",
@@ -880,6 +883,9 @@ module.exports = function({  }) {
             "uniqueId": "testconcatArray_Handler_F66848AE"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c8ba9aa0",
@@ -906,6 +912,9 @@ module.exports = function({  }) {
             "uniqueId": "testconcatMutArray_Handler_40D88E89"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c8e5a138",
@@ -932,6 +941,9 @@ module.exports = function({  }) {
             "uniqueId": "testcontains_Handler_F60865D9"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c8e953a0",
@@ -958,6 +970,9 @@ module.exports = function({  }) {
             "uniqueId": "testcopyMut_Handler_851E24B4"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c8b1cc09",
@@ -984,6 +999,9 @@ module.exports = function({  }) {
             "uniqueId": "testcopy_Handler_27A14A0E"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c802a3d7",
@@ -1010,6 +1028,9 @@ module.exports = function({  }) {
             "uniqueId": "testindexOfArray_Handler_DB3A81F5"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c88fa7a3",
@@ -1036,6 +1057,9 @@ module.exports = function({  }) {
             "uniqueId": "testindexOf_Handler_BD91EA6F"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c80be453",
@@ -1062,6 +1086,9 @@ module.exports = function({  }) {
             "uniqueId": "testinsert_Handler_20BB87F8"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c8bd9541",
@@ -1088,6 +1115,9 @@ module.exports = function({  }) {
             "uniqueId": "testjoinWithDefaultSeparator_Handler_7AE1258D"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c833ed71",
@@ -1114,6 +1144,9 @@ module.exports = function({  }) {
             "uniqueId": "testjoin_Handler_6AC62A8E"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c8a46f15",
@@ -1140,6 +1173,9 @@ module.exports = function({  }) {
             "uniqueId": "testlastIndexOf_Handler_FFB2061F"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c84609d0",
@@ -1166,6 +1202,9 @@ module.exports = function({  }) {
             "uniqueId": "testlength_Handler_BFD8933F"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c8e0ccbd",
@@ -1192,6 +1231,9 @@ module.exports = function({  }) {
             "uniqueId": "testpushAndPop_Handler_EAC0C8FF"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c8b6e896",
@@ -1218,6 +1260,9 @@ module.exports = function({  }) {
             "uniqueId": "testset_Handler_ADDF1A01"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c8240bc7",

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/std/bool.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/std/bool.w_compile_tf-aws.md
@@ -101,6 +101,9 @@ module.exports = function({ $PARSE_ERROR, $std_Boolean, $std_Json }) {
             "uniqueId": "testfromJson_Handler_ACD6C987"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c8d3ce6e",

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/std/datetime.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/std/datetime.w_compile_tf-aws.md
@@ -112,6 +112,9 @@ module.exports = function({ $_d4_toUtc____hours, $d4_hours, $d4_timezone, $math_
             "uniqueId": "testinflightdatetime_Handler_CCA19CA1"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c8211bab",

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/std/duration.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/std/duration.w_compile_tf-aws.md
@@ -110,6 +110,9 @@ module.exports = function({ $std_Duration }) {
             "uniqueId": "testduration_Handler_50E6E252"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c8eae108",

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/std/json.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/std/json.w_compile_tf-aws.md
@@ -196,6 +196,9 @@ module.exports = function({ $std_Json }) {
             "uniqueId": "testsetAt_Handler_51015029"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c841d86c",
@@ -222,6 +225,9 @@ module.exports = function({ $std_Json }) {
             "uniqueId": "testset_Handler_ADDF1A01"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c8240bc7",
@@ -248,6 +254,9 @@ module.exports = function({ $std_Json }) {
             "uniqueId": "teststringify_Handler_2E93A8A7"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c84b217d",

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/std/number.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/std/number.w_compile_tf-aws.md
@@ -138,6 +138,9 @@ module.exports = function({ $std_Number }) {
             "uniqueId": "testfromJson_Handler_CA86BEEA"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c89f3277",
@@ -164,6 +167,9 @@ module.exports = function({ $std_Number }) {
             "uniqueId": "testfromStr_Handler_03ACB5A8"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c8fdb1d1",

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/std/string.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/std/string.w_compile_tf-aws.md
@@ -752,6 +752,9 @@ module.exports = function({  }) {
             "uniqueId": "testat_Handler_E4F013BC"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c858faac",
@@ -778,6 +781,9 @@ module.exports = function({  }) {
             "uniqueId": "testconcat_Handler_E184D86A"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c869963c",
@@ -804,6 +810,9 @@ module.exports = function({  }) {
             "uniqueId": "testcontains_Handler_F60865D9"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c8e953a0",
@@ -830,6 +839,9 @@ module.exports = function({  }) {
             "uniqueId": "testendsWith_Handler_9BA42993"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c8465c4f",
@@ -856,6 +868,9 @@ module.exports = function({  }) {
             "uniqueId": "testfromJson_Handler_CA86BEEA"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c89f3277",
@@ -882,6 +897,9 @@ module.exports = function({  }) {
             "uniqueId": "testindexOf_Handler_BD91EA6F"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c80be453",
@@ -908,6 +926,9 @@ module.exports = function({  }) {
             "uniqueId": "testlength_Handler_BFD8933F"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c8e0ccbd",
@@ -934,6 +955,9 @@ module.exports = function({  }) {
             "uniqueId": "testlowercase_Handler_EAADE79D"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c86ac32a",
@@ -960,6 +984,9 @@ module.exports = function({  }) {
             "uniqueId": "testreplace_Handler_83836186"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c876baf0",
@@ -986,6 +1013,9 @@ module.exports = function({  }) {
             "uniqueId": "testsplit_Handler_4FAF6D9E"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c8e87cf7",
@@ -1012,6 +1042,9 @@ module.exports = function({  }) {
             "uniqueId": "teststartsWith_Handler_C8752245"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c8f6a537",
@@ -1038,6 +1071,9 @@ module.exports = function({  }) {
             "uniqueId": "testsubstring_Handler_E6617207"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c803a722",
@@ -1064,6 +1100,9 @@ module.exports = function({  }) {
             "uniqueId": "testtrim_Handler_403ED8AD"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c81cc785",
@@ -1090,6 +1129,9 @@ module.exports = function({  }) {
             "uniqueId": "testuppercase_Handler_352FFA2E"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c882dfb8",

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/table/add_row.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/table/add_row.w_compile_tf-aws.md
@@ -139,6 +139,9 @@ module.exports = function({ $_marioInfo___gender__, $_marioInfo___role__, $_peac
             "uniqueId": "testaddRow_Handler_2806A65E"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "DYNAMODB_TABLE_NAME_d5d44f18": "${aws_dynamodb_table.exTable.name}",

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/table/list.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/table/list.w_compile_tf-aws.md
@@ -121,6 +121,9 @@ module.exports = function({ $std_String, $table }) {
             "uniqueId": "testlist_Handler_58856559"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "DYNAMODB_TABLE_NAME_d5d44f18": "${aws_dynamodb_table.exTable.name}",

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/topic/on_message.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/topic/on_message.w_compile_tf-aws.md
@@ -232,6 +232,9 @@ module.exports = function({  }) {
             "uniqueId": "cloudTopic-OnMessage-86898773"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "DYNAMODB_TABLE_NAME_49baa65c": "${aws_dynamodb_table.cloudCounter.name}",
@@ -259,6 +262,9 @@ module.exports = function({  }) {
             "uniqueId": "cloudTopic-OnMessage-cdafee6e"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "DYNAMODB_TABLE_NAME_49baa65c": "${aws_dynamodb_table.cloudCounter.name}",
@@ -286,6 +292,9 @@ module.exports = function({  }) {
             "uniqueId": "testonMessage_Handler_1EC8F213"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "DYNAMODB_TABLE_NAME_49baa65c": "${aws_dynamodb_table.cloudCounter.name}",

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/util/base64.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/util/base64.w_compile_tf-aws.md
@@ -99,6 +99,9 @@ module.exports = function({ $util_Util }) {
             "uniqueId": "testinflightbase64_Handler_31E9772F"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c853d8cf",

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/util/env.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/util/env.w_compile_tf-aws.md
@@ -93,6 +93,9 @@ module.exports = function({ $NIL, $RANDOM, $util_Util }) {
             "uniqueId": "testuseutilfrominflight_Handler_6C871F39"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c8904ffd",

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/util/nanoid.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/util/nanoid.w_compile_tf-aws.md
@@ -104,6 +104,9 @@ module.exports = function({ $util_Util }) {
             "uniqueId": "testinflightnanoid_Handler_154ED1B9"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c864f292",

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/util/sha256.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/util/sha256.w_compile_tf-aws.md
@@ -92,6 +92,9 @@ module.exports = function({ $util_Util }) {
             "uniqueId": "testinflightsha256_Handler_A03FE0BD"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c8b74430",

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/util/sleep.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/util/sleep.w_compile_tf-aws.md
@@ -110,6 +110,9 @@ module.exports = function({  }) {
             "uniqueId": "testsleep100miliseconds_Handler_F390CA22"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c8e32fa2",

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/util/uuidv4.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/util/uuidv4.w_compile_tf-aws.md
@@ -119,6 +119,9 @@ module.exports = function({  }) {
             "uniqueId": "testinflightuuidv4_Handler_3A34A54F"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c86b3dcf",

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/util/wait-until.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/util/wait-until.w_compile_tf-aws.md
@@ -365,6 +365,9 @@ module.exports = function({  }) {
             "uniqueId": "testreturnsaftersometimewaiting_Handler_436A90C3"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "DYNAMODB_TABLE_NAME_49baa65c": "${aws_dynamodb_table.cloudCounter.name}",
@@ -392,6 +395,9 @@ module.exports = function({  }) {
             "uniqueId": "testreturnsfalsegoestotimeout_Handler_A7F9DD9D"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c857ac6d",
@@ -418,6 +424,9 @@ module.exports = function({  }) {
             "uniqueId": "testreturnstrueimmediately_Handler_0210037F"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c85e05f6",
@@ -444,6 +453,9 @@ module.exports = function({  }) {
             "uniqueId": "testsettingprops_Handler_8BB7DC9B"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "DYNAMODB_TABLE_NAME_49baa65c": "${aws_dynamodb_table.cloudCounter.name}",
@@ -471,6 +483,9 @@ module.exports = function({  }) {
             "uniqueId": "testthrowingexceptionfrompredicateshouldthrowimmediately_Handler_B4BADFD9"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "DYNAMODB_TABLE_NAME_49baa65c": "${aws_dynamodb_table.cloudCounter.name}",

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/website/two_websites.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/website/two_websites.w_compile_tf-aws.md
@@ -292,6 +292,9 @@ module.exports = function({ $http_Util, $w1_url, $w2_url }) {
             "uniqueId": "testdeployingtwowebsites_Handler_DDBE7E21"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c8683851",

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/website/website.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/website/website.w_compile_tf-aws.md
@@ -209,6 +209,9 @@ module.exports = function({  }) {
             "uniqueId": "testaccessfilesonthewebsite_Handler_B4D12109"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c867c4e0",

--- a/tools/hangar/__snapshots__/test_corpus/valid/api.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/api.w_compile_tf-aws.md
@@ -311,6 +311,9 @@ module.exports = function({  }) {
             "uniqueId": "A_cloudApi_cloudApi-OnRequest-73c5308f_E645B0BE"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "cloud-Api-OnRequest-73c5308f-c85168bb",
@@ -338,6 +341,9 @@ module.exports = function({  }) {
             "uniqueId": "cloudApi_cloudApi-OnRequest-cdafee6e_A6C8366F"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "DYNAMODB_TABLE_NAME_49baa65c": "${aws_dynamodb_table.cloudCounter.name}",
@@ -365,6 +371,9 @@ module.exports = function({  }) {
             "uniqueId": "testapiurl_Handler_7D451301"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c8315524",

--- a/tools/hangar/__snapshots__/test_corpus/valid/api_path_vars.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/api_path_vars.w_compile_tf-aws.md
@@ -195,6 +195,9 @@ module.exports = function({ $api_url, $http_Util, $std_Json }) {
             "uniqueId": "cloudApi_cloudApi-OnRequest-cdafee6e_A6C8366F"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "cloud-Api-OnRequest-cdafee6e-c8147384",
@@ -221,6 +224,9 @@ module.exports = function({ $api_url, $http_Util, $std_Json }) {
             "uniqueId": "testtest_Handler_295107CC"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c8f4f2a1",

--- a/tools/hangar/__snapshots__/test_corpus/valid/api_valid_path.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/api_valid_path.w_compile_tf-aws.md
@@ -145,6 +145,9 @@ module.exports = function({  }) {
             "uniqueId": "cloudApi_cloudApi-OnRequest-cdafee6e_A6C8366F"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "cloud-Api-OnRequest-cdafee6e-c8147384",

--- a/tools/hangar/__snapshots__/test_corpus/valid/assert.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/assert.w_compile_tf-aws.md
@@ -105,6 +105,9 @@ module.exports = function({ $s1, $s2 }) {
             "uniqueId": "testassertworksinflight_Handler_915EA51A"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c8a7b0b3",

--- a/tools/hangar/__snapshots__/test_corpus/valid/asynchronous_model_implicit_await_in_functions.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/asynchronous_model_implicit_await_in_functions.w_compile_tf-aws.md
@@ -138,6 +138,9 @@ module.exports = function({ $strToStr }) {
             "uniqueId": "func"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "FUNCTION_NAME_bc9a3a6d": "${aws_lambda_function.strToStr.arn}",
@@ -165,6 +168,9 @@ module.exports = function({ $strToStr }) {
             "uniqueId": "strToStr"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "strToStr-c8d5081f",

--- a/tools/hangar/__snapshots__/test_corpus/valid/bring_jsii.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/bring_jsii.w_compile_tf-aws.md
@@ -91,6 +91,9 @@ module.exports = function({ $greeting }) {
             "uniqueId": "testsayHello_Handler_98B5E136"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c887876f",

--- a/tools/hangar/__snapshots__/test_corpus/valid/bring_jsii_path.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/bring_jsii_path.w_compile_tf-aws.md
@@ -91,6 +91,9 @@ module.exports = function({ $greeting }) {
             "uniqueId": "testsayHello_Handler_98B5E136"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c887876f",

--- a/tools/hangar/__snapshots__/test_corpus/valid/bring_local.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/bring_local.w_compile_tf-aws.md
@@ -249,6 +249,9 @@ module.exports = function({  }) {
             "uniqueId": "file1Store_cloudOnDeploy_Function_9539541F"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "BUCKET_NAME_94dc4b3e": "${aws_s3_bucket.file1Store_cloudBucket_86CE87B1.bucket}",
@@ -276,6 +279,9 @@ module.exports = function({  }) {
             "uniqueId": "testadddatatostore_Handler_19066842"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "BUCKET_NAME_94dc4b3e": "${aws_s3_bucket.file1Store_cloudBucket_86CE87B1.bucket}",

--- a/tools/hangar/__snapshots__/test_corpus/valid/bucket_events.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/bucket_events.w_compile_tf-aws.md
@@ -446,6 +446,9 @@ module.exports = function({ $b }) {
             "uniqueId": "b_b-oncreate-OnMessage-1d3b2039_20E46F00"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "b-oncreate-OnMessage-1d3b2039-c8a821e7",
@@ -472,6 +475,9 @@ module.exports = function({ $b }) {
             "uniqueId": "b_b-oncreate-OnMessage-a729fee3_49378F05"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "BUCKET_NAME_73fd1ead": "${aws_s3_bucket.other.bucket}",
@@ -499,6 +505,9 @@ module.exports = function({ $b }) {
             "uniqueId": "b_b-ondelete-OnMessage-4b2cd998_0DD64A53"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "BUCKET_NAME_73fd1ead": "${aws_s3_bucket.other.bucket}",
@@ -526,6 +535,9 @@ module.exports = function({ $b }) {
             "uniqueId": "b_b-ondelete-OnMessage-b83da9f8_75B42E31"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "b-ondelete-OnMessage-b83da9f8-c80fdb5a",
@@ -552,6 +564,9 @@ module.exports = function({ $b }) {
             "uniqueId": "b_b-onupdate-OnMessage-2dce4026_5DC58D89"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "b-onupdate-OnMessage-2dce4026-c8164eef",
@@ -578,6 +593,9 @@ module.exports = function({ $b }) {
             "uniqueId": "b_b-onupdate-OnMessage-b03e6c67_09F5FCDD"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "BUCKET_NAME_73fd1ead": "${aws_s3_bucket.other.bucket}",
@@ -605,6 +623,9 @@ module.exports = function({ $b }) {
             "uniqueId": "other_other-oncreate-OnMessage-2b1e14fd_9EE2200F"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "other-oncreate-OnMessage-2b1e14fd-c8a9cff0",
@@ -631,6 +652,9 @@ module.exports = function({ $b }) {
             "uniqueId": "other_other-ondelete-OnMessage-9bef38d2_7F9E1372"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "other-ondelete-OnMessage-9bef38d2-c8c0555a",
@@ -657,6 +681,9 @@ module.exports = function({ $b }) {
             "uniqueId": "other_other-onupdate-OnMessage-bffa2a20_0A9CE94D"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "other-onupdate-OnMessage-bffa2a20-c85595aa",
@@ -683,6 +710,9 @@ module.exports = function({ $b }) {
             "uniqueId": "testputtinganddeletingfromabuckettotriggerbucketevents_Handler_31F6B48C"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "BUCKET_NAME_34279ead": "${aws_s3_bucket.b.bucket}",

--- a/tools/hangar/__snapshots__/test_corpus/valid/bucket_keys.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/bucket_keys.w_compile_tf-aws.md
@@ -101,6 +101,9 @@ module.exports = function({ $b }) {
             "uniqueId": "testtest_Handler_295107CC"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "BUCKET_NAME_d755b447": "${aws_s3_bucket.cloudBucket.bucket}",

--- a/tools/hangar/__snapshots__/test_corpus/valid/call_static_of_myself.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/call_static_of_myself.w_compile_tf-aws.md
@@ -138,6 +138,9 @@ module.exports = function({  }) {
             "uniqueId": "testtest_Handler_295107CC"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c8f4f2a1",

--- a/tools/hangar/__snapshots__/test_corpus/valid/calling_inflight_variants.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/calling_inflight_variants.w_compile_tf-aws.md
@@ -150,6 +150,9 @@ module.exports = function({  }) {
             "uniqueId": "testcallingdifferenttypesofinflights_Handler_F0BAE661"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c8f324e0",

--- a/tools/hangar/__snapshots__/test_corpus/valid/capture_containers.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/capture_containers.w_compile_tf-aws.md
@@ -99,6 +99,9 @@ module.exports = function({ $Object_keys_myMap__length, $__bang__in___arrOfMap_a
             "uniqueId": "testcapture_containers_Handler_C1B42BA9"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c876b763",

--- a/tools/hangar/__snapshots__/test_corpus/valid/capture_in_binary.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/capture_in_binary.w_compile_tf-aws.md
@@ -93,6 +93,9 @@ module.exports = function({ $b, $x }) {
             "uniqueId": "testbinaryexpressions_Handler_BDFD91F0"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "BUCKET_NAME_d755b447": "${aws_s3_bucket.cloudBucket.bucket}",

--- a/tools/hangar/__snapshots__/test_corpus/valid/capture_mutables.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/capture_mutables.w_compile_tf-aws.md
@@ -112,6 +112,9 @@ module.exports = function({ $handler }) {
             "uniqueId": "testmain_Handler_242B2607"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c8d10438",

--- a/tools/hangar/__snapshots__/test_corpus/valid/capture_primitives.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/capture_primitives.w_compile_tf-aws.md
@@ -105,6 +105,9 @@ module.exports = function({ $myBool, $myDur_hours, $myDur_minutes, $myDur_second
             "uniqueId": "cloudFunction"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "cloud-Function-c8d2eca1",

--- a/tools/hangar/__snapshots__/test_corpus/valid/capture_reassigable_class_field.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/capture_reassigable_class_field.w_compile_tf-aws.md
@@ -178,6 +178,9 @@ module.exports = function({  }) {
             "uniqueId": "testmain_Handler_242B2607"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "BUCKET_NAME_ce72b88b": "${aws_s3_bucket.KeyValueStore_cloudBucket_D9D365FD.bucket}",

--- a/tools/hangar/__snapshots__/test_corpus/valid/capture_reassignable.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/capture_reassignable.w_compile_tf-aws.md
@@ -109,6 +109,9 @@ module.exports = function({ $handler }) {
             "uniqueId": "testmain_Handler_242B2607"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c8d10438",

--- a/tools/hangar/__snapshots__/test_corpus/valid/capture_resource_and_data.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/capture_resource_and_data.w_compile_tf-aws.md
@@ -94,6 +94,9 @@ module.exports = function({ $data_size, $queue, $res }) {
             "uniqueId": "testresourceanddata_Handler_1086F74C"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "BUCKET_NAME_d755b447": "${aws_s3_bucket.cloudBucket.bucket}",

--- a/tools/hangar/__snapshots__/test_corpus/valid/capture_resource_with_no_inflight.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/capture_resource_with_no_inflight.w_compile_tf-aws.md
@@ -129,6 +129,9 @@ module.exports = function({  }) {
             "uniqueId": "testtest_Handler_295107CC"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "DYNAMODB_TABLE_NAME_5b05aa10": "${aws_dynamodb_table.A_cloudCounter_1CAB7DAD.name}",

--- a/tools/hangar/__snapshots__/test_corpus/valid/capture_tokens.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/capture_tokens.w_compile_tf-aws.md
@@ -250,6 +250,9 @@ module.exports = function({  }) {
             "uniqueId": "testinflightclass_Handler_F51916C9"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c8ed8f29",
@@ -277,6 +280,9 @@ module.exports = function({  }) {
             "uniqueId": "testinflightglobals_Handler_386DF115"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c8ecc6d5",

--- a/tools/hangar/__snapshots__/test_corpus/valid/captures.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/captures.w_compile_tf-aws.md
@@ -277,6 +277,9 @@ module.exports = function({ $headers }) {
             "uniqueId": "AnotherFunction"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "BUCKET_NAME_0c557d45": "${aws_s3_bucket.PrivateBucket.bucket}",
@@ -306,6 +309,9 @@ module.exports = function({ $headers }) {
             "uniqueId": "cloudApi_cloudApi-OnRequest-86898773_701F5CA7"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "cloud-Api-OnRequest-86898773-c8ed6547",
@@ -332,6 +338,9 @@ module.exports = function({ $headers }) {
             "uniqueId": "cloudFunction"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "BUCKET_NAME_0c557d45": "${aws_s3_bucket.PrivateBucket.bucket}",
@@ -361,6 +370,9 @@ module.exports = function({ $headers }) {
             "uniqueId": "cloudQueue-SetConsumer-cdafee6e"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "BUCKET_NAME_0c557d45": "${aws_s3_bucket.PrivateBucket.bucket}",

--- a/tools/hangar/__snapshots__/test_corpus/valid/class.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/class.w_compile_tf-aws.md
@@ -447,6 +447,9 @@ module.exports = function({ $PaidStudent }) {
             "uniqueId": "testaccessinflightfield_Handler_39158E6E"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c84be49a",
@@ -473,6 +476,9 @@ module.exports = function({ $PaidStudent }) {
             "uniqueId": "testcheckderivedclassinstancevariables_Handler_6847A085"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c87bcb74",
@@ -499,6 +505,9 @@ module.exports = function({ $PaidStudent }) {
             "uniqueId": "testdevivedclassinitbodyhappensaftersuper_Handler_8CA21B73"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c8edbb48",
@@ -525,6 +534,9 @@ module.exports = function({ $PaidStudent }) {
             "uniqueId": "testinflightsuperconstructor_Handler_C698F98B"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c81ddf4a",

--- a/tools/hangar/__snapshots__/test_corpus/valid/closure_class.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/closure_class.w_compile_tf-aws.md
@@ -113,6 +113,9 @@ module.exports = function({  }) {
             "uniqueId": "testtest_Handler_295107CC"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c8f4f2a1",

--- a/tools/hangar/__snapshots__/test_corpus/valid/deep_equality.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/deep_equality.w_compile_tf-aws.md
@@ -654,6 +654,9 @@ module.exports = function({ $arrayA, $arrayB }) {
             "uniqueId": "testArraywithdifferentvalues_Handler_2422390C"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c804987d",
@@ -680,6 +683,9 @@ module.exports = function({ $arrayA, $arrayB }) {
             "uniqueId": "testArraywiththesamevalue_Handler_7A26272F"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c85bde80",
@@ -706,6 +712,9 @@ module.exports = function({ $arrayA, $arrayB }) {
             "uniqueId": "testJsonwithdifferentvalues_Handler_7CBC98A6"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c81ffded",
@@ -732,6 +741,9 @@ module.exports = function({ $arrayA, $arrayB }) {
             "uniqueId": "testJsonwiththesamevalue_Handler_0A930AF7"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c8a70f75",
@@ -758,6 +770,9 @@ module.exports = function({ $arrayA, $arrayB }) {
             "uniqueId": "testMapwithdifferentvalues_Handler_E889ADD0"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c8bfa9fd",
@@ -784,6 +799,9 @@ module.exports = function({ $arrayA, $arrayB }) {
             "uniqueId": "testMapwiththesamevalue_Handler_74DC4830"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c8e1f849",
@@ -810,6 +828,9 @@ module.exports = function({ $arrayA, $arrayB }) {
             "uniqueId": "testPrimitivetypeswithdifferentvalues_Handler_1CD5AE77"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c8339af6",
@@ -836,6 +857,9 @@ module.exports = function({ $arrayA, $arrayB }) {
             "uniqueId": "testPrimitivetypeswiththesamevalue_Handler_E7430682"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c8c80713",
@@ -862,6 +886,9 @@ module.exports = function({ $arrayA, $arrayB }) {
             "uniqueId": "testSettypeswithdifferentvalues_Handler_827F38F3"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c8f9b754",
@@ -888,6 +915,9 @@ module.exports = function({ $arrayA, $arrayB }) {
             "uniqueId": "testSettypeswiththesamevalue_Handler_16147212"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c80c25d8",
@@ -914,6 +944,9 @@ module.exports = function({ $arrayA, $arrayB }) {
             "uniqueId": "testStructwithdifferentvalues_Handler_A8DC5651"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c8546ffd",
@@ -940,6 +973,9 @@ module.exports = function({ $arrayA, $arrayB }) {
             "uniqueId": "testStructwiththesamevalue_Handler_4436CF3A"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c8c23fc1",

--- a/tools/hangar/__snapshots__/test_corpus/valid/double_reference.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/double_reference.w_compile_tf-aws.md
@@ -145,6 +145,9 @@ module.exports = function({ $initCount }) {
             "uniqueId": "testhello_Handler_549C38EE"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "DYNAMODB_TABLE_NAME_49baa65c": "${aws_dynamodb_table.cloudCounter.name}",

--- a/tools/hangar/__snapshots__/test_corpus/valid/doubler.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/doubler.w_compile_tf-aws.md
@@ -207,6 +207,9 @@ module.exports = function({  }) {
             "uniqueId": "Doubler2_cloudFunction_402CDAA3"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "cloud-Function-c8d4b6f0",
@@ -233,6 +236,9 @@ module.exports = function({  }) {
             "uniqueId": "testf28_Handler_DBBFD2BC"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "FUNCTION_NAME_f7db7b1d": "${aws_lambda_function.Doubler2_cloudFunction_402CDAA3.arn}",

--- a/tools/hangar/__snapshots__/test_corpus/valid/enums.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/enums.w_compile_tf-aws.md
@@ -92,6 +92,9 @@ module.exports = function({ $SomeEnum, $one, $two }) {
             "uniqueId": "testinflight_Handler_93A83C5E"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c85726ab",

--- a/tools/hangar/__snapshots__/test_corpus/valid/extern_implementation.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/extern_implementation.w_compile_tf-aws.md
@@ -168,6 +168,9 @@ module.exports = function({  }) {
             "uniqueId": "testcall_Handler_7902F7E6"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c8074088",
@@ -194,6 +197,9 @@ module.exports = function({  }) {
             "uniqueId": "testconsole_Handler_057D9B4E"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c8fb077d",

--- a/tools/hangar/__snapshots__/test_corpus/valid/file_counter.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/file_counter.w_compile_tf-aws.md
@@ -125,6 +125,9 @@ module.exports = function({ $bucket, $counter }) {
             "uniqueId": "cloudQueue-SetConsumer-cdafee6e"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "BUCKET_NAME_d755b447": "${aws_s3_bucket.cloudBucket.bucket}",

--- a/tools/hangar/__snapshots__/test_corpus/valid/for_loop.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/for_loop.w_compile_tf-aws.md
@@ -112,6 +112,9 @@ module.exports = function({  }) {
             "uniqueId": "cloudFunction"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "cloud-Function-c8d2eca1",

--- a/tools/hangar/__snapshots__/test_corpus/valid/function_returns_function.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/function_returns_function.w_compile_tf-aws.md
@@ -101,6 +101,9 @@ module.exports = function({  }) {
             "uniqueId": "testinflightfunctionscanreturnotherinflightfunctions_Handler_7EBEFDAA"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c8801592",

--- a/tools/hangar/__snapshots__/test_corpus/valid/hello.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/hello.w_compile_tf-aws.md
@@ -104,6 +104,9 @@ module.exports = function({ $bucket }) {
             "uniqueId": "cloudQueue-SetConsumer-cdafee6e"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "BUCKET_NAME_d755b447": "${aws_s3_bucket.cloudBucket.bucket}",

--- a/tools/hangar/__snapshots__/test_corpus/valid/inference.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/inference.w_compile_tf-aws.md
@@ -145,6 +145,9 @@ module.exports = function({  }) {
             "uniqueId": "cloudApi_cloudApi-OnRequest-cdafee6e_A6C8366F"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "cloud-Api-OnRequest-cdafee6e-c8147384",

--- a/tools/hangar/__snapshots__/test_corpus/valid/inflight-subscribers.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/inflight-subscribers.w_compile_tf-aws.md
@@ -151,6 +151,9 @@ module.exports = function({  }) {
             "uniqueId": "cloudQueue-SetConsumer-86898773"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "cloud-Queue-SetConsumer-86898773-c8cecfb3",
@@ -177,6 +180,9 @@ module.exports = function({  }) {
             "uniqueId": "cloudTopic-OnMessage-cdafee6e"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "cloud-Topic-OnMessage-cdafee6e-c814de3f",

--- a/tools/hangar/__snapshots__/test_corpus/valid/inflight_capture_static.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/inflight_capture_static.w_compile_tf-aws.md
@@ -274,6 +274,9 @@ module.exports = function({  }) {
             "uniqueId": "testcallstaticmethodofanamespacedtype_Handler_482915F1"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c808c556",
@@ -300,6 +303,9 @@ module.exports = function({  }) {
             "uniqueId": "testcallstaticmethodofaninnerinflightclass_Handler_2C5AF32C"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c8d913d8",
@@ -326,6 +332,9 @@ module.exports = function({  }) {
             "uniqueId": "testcallstaticmethodofanouterinflightclass_Handler_2DD5B79F"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c8dbdf1b",
@@ -352,6 +361,9 @@ module.exports = function({  }) {
             "uniqueId": "testcallstaticmethodofpreflight_Handler_8B40B9DA"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c8e286c0",

--- a/tools/hangar/__snapshots__/test_corpus/valid/inflight_class_as_struct_members.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/inflight_class_as_struct_members.w_compile_tf-aws.md
@@ -154,6 +154,9 @@ module.exports = function({  }) {
             "uniqueId": "testtest_Handler_295107CC"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c8f4f2a1",

--- a/tools/hangar/__snapshots__/test_corpus/valid/inflight_class_capture_const.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/inflight_class_capture_const.w_compile_tf-aws.md
@@ -105,6 +105,9 @@ module.exports = function({ $myConst }) {
             "uniqueId": "testinflightclasscapturesconst_Handler_17207FA8"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c8e53a58",

--- a/tools/hangar/__snapshots__/test_corpus/valid/inflight_class_definitions.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/inflight_class_definitions.w_compile_tf-aws.md
@@ -207,6 +207,9 @@ module.exports = function({  }) {
             "uniqueId": "testtest_Handler_295107CC"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c8f4f2a1",

--- a/tools/hangar/__snapshots__/test_corpus/valid/inflight_class_inner_capture_mutable.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/inflight_class_inner_capture_mutable.w_compile_tf-aws.md
@@ -102,6 +102,9 @@ module.exports = function({  }) {
             "uniqueId": "testinnerinflightclasscaptureimmutable_Handler_8A6A0444"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c88a8b71",

--- a/tools/hangar/__snapshots__/test_corpus/valid/inflight_class_inside_inflight_closure.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/inflight_class_inside_inflight_closure.w_compile_tf-aws.md
@@ -215,6 +215,9 @@ module.exports = function({  }) {
             "uniqueId": "PreflightClass_cloudFunction_9F7C6688"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "BUCKET_NAME_70ca4fed": "${aws_s3_bucket.PreflightClass_cloudBucket_05421049.bucket}",
@@ -242,6 +245,9 @@ module.exports = function({  }) {
             "uniqueId": "testinflightclassinsideclosurecapturesfromclosure_Handler_9491D6BF"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c866c5da",
@@ -268,6 +274,9 @@ module.exports = function({  }) {
             "uniqueId": "testitworks_Handler_FCB0C220"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "FUNCTION_NAME_31bff872": "${aws_lambda_function.PreflightClass_cloudFunction_9F7C6688.arn}",

--- a/tools/hangar/__snapshots__/test_corpus/valid/inflight_class_outside_inflight_closure.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/inflight_class_outside_inflight_closure.w_compile_tf-aws.md
@@ -109,6 +109,9 @@ module.exports = function({  }) {
             "uniqueId": "testinflightclassoutsideinflightclosure_Handler_D7A68A3D"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c8046c38",

--- a/tools/hangar/__snapshots__/test_corpus/valid/inflight_class_structural_interace_handler.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/inflight_class_structural_interace_handler.w_compile_tf-aws.md
@@ -115,6 +115,9 @@ module.exports = function({  }) {
             "uniqueId": "teststructureinterfacetypesforhandle_Handler_2DA6D9F8"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c83718d0",

--- a/tools/hangar/__snapshots__/test_corpus/valid/inflight_class_without_init.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/inflight_class_without_init.w_compile_tf-aws.md
@@ -101,6 +101,9 @@ module.exports = function({  }) {
             "uniqueId": "testinflightclasswithoutinit_Handler_26AF0424"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c8459d32",

--- a/tools/hangar/__snapshots__/test_corpus/valid/inflights_calling_inflights.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/inflights_calling_inflights.w_compile_tf-aws.md
@@ -240,6 +240,9 @@ module.exports = function({  }) {
             "uniqueId": "func1"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "BUCKET_NAME_d755b447": "${aws_s3_bucket.cloudBucket.bucket}",
@@ -267,6 +270,9 @@ module.exports = function({  }) {
             "uniqueId": "testinflightscancallotherinflights_Handler_90705AE1"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "BUCKET_NAME_d755b447": "${aws_s3_bucket.cloudBucket.bucket}",
@@ -295,6 +301,9 @@ module.exports = function({  }) {
             "uniqueId": "testvariablecanbeaninflightclosure_Handler_E55D136A"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "BUCKET_NAME_d755b447": "${aws_s3_bucket.cloudBucket.bucket}",

--- a/tools/hangar/__snapshots__/test_corpus/valid/issue_2889.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/issue_2889.w_compile_tf-aws.md
@@ -196,6 +196,9 @@ module.exports = function({ $api_url, $http_Util, $std_Json }) {
             "uniqueId": "cloudApi_cloudApi-OnRequest-cdafee6e_A6C8366F"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "cloud-Api-OnRequest-cdafee6e-c8147384",
@@ -222,6 +225,9 @@ module.exports = function({ $api_url, $http_Util, $std_Json }) {
             "uniqueId": "testapishouldreturnavalidstringifiedjson_Handler_DCAABCD2"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c88c3aa2",

--- a/tools/hangar/__snapshots__/test_corpus/valid/json_bucket.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/json_bucket.w_compile_tf-aws.md
@@ -140,6 +140,9 @@ module.exports = function({ $b, $fileName, $getJson, $j }) {
             "uniqueId": "cloudFunction"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "BUCKET_NAME_d755b447": "${aws_s3_bucket.cloudBucket.bucket}",
@@ -167,6 +170,9 @@ module.exports = function({ $b, $fileName, $getJson, $j }) {
             "uniqueId": "testput_Handler_724F92D5"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "BUCKET_NAME_d755b447": "${aws_s3_bucket.cloudBucket.bucket}",

--- a/tools/hangar/__snapshots__/test_corpus/valid/json_static.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/json_static.w_compile_tf-aws.md
@@ -141,6 +141,9 @@ module.exports = function({ $std_Json }) {
             "uniqueId": "testAccessJsonstaticinflight_Handler_E1606978"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c8867497",
@@ -167,6 +170,9 @@ module.exports = function({ $std_Json }) {
             "uniqueId": "testhaskeyornot_Handler_3209D975"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c8ecbdc2",

--- a/tools/hangar/__snapshots__/test_corpus/valid/lift_expr_with_this.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/lift_expr_with_this.w_compile_tf-aws.md
@@ -104,6 +104,9 @@ module.exports = function({  }) {
             "uniqueId": "testtest_Handler_295107CC"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c8f4f2a1",

--- a/tools/hangar/__snapshots__/test_corpus/valid/lift_redefinition.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/lift_redefinition.w_compile_tf-aws.md
@@ -93,6 +93,9 @@ module.exports = function({ $y }) {
             "uniqueId": "testtest_Handler_295107CC"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c8f4f2a1",

--- a/tools/hangar/__snapshots__/test_corpus/valid/lift_this.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/lift_this.w_compile_tf-aws.md
@@ -112,6 +112,9 @@ module.exports = function({  }) {
             "uniqueId": "testtest_Handler_295107CC"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c8f4f2a1",

--- a/tools/hangar/__snapshots__/test_corpus/valid/lift_via_closure.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/lift_via_closure.w_compile_tf-aws.md
@@ -187,6 +187,9 @@ module.exports = function({ $bucket2 }) {
             "uniqueId": "testcallnon-syntheticclosureasafunction_Handler_8C8F5E97"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "BUCKET_NAME_bbe94f63": "${aws_s3_bucket.MyClosure_cloudBucket_4DAD12C0.bucket}",
@@ -215,6 +218,9 @@ module.exports = function({ $bucket2 }) {
             "uniqueId": "testcallsyntheticclosureclassasafunction_Handler_577F53A9"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "BUCKET_NAME_d755b447": "${aws_s3_bucket.cloudBucket.bucket}",

--- a/tools/hangar/__snapshots__/test_corpus/valid/lift_via_closure_explicit.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/lift_via_closure_explicit.w_compile_tf-aws.md
@@ -110,6 +110,9 @@ module.exports = function({  }) {
             "uniqueId": "testtest_Handler_295107CC"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "QUEUE_URL_6ec5b2e4": "${aws_sqs_queue.MyClosure_cloudQueue_465FD228.url}",

--- a/tools/hangar/__snapshots__/test_corpus/valid/nil.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/nil.w_compile_tf-aws.md
@@ -172,6 +172,9 @@ module.exports = function({  }) {
             "uniqueId": "testnilreturn_Handler_C1CE87DB"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c8668556",
@@ -198,6 +201,9 @@ module.exports = function({  }) {
             "uniqueId": "testoptionalinstancevariable_Handler_CA8A00DB"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c8a1de9c",

--- a/tools/hangar/__snapshots__/test_corpus/valid/optionals.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/optionals.w_compile_tf-aws.md
@@ -208,6 +208,9 @@ module.exports = function({  }) {
             "uniqueId": "testt_Handler_FF112F5E"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "BUCKET_NAME_c1491ba5": "${aws_s3_bucket.orangebucket.bucket}",

--- a/tools/hangar/__snapshots__/test_corpus/valid/print.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/print.w_compile_tf-aws.md
@@ -140,6 +140,9 @@ module.exports = function({  }) {
             "uniqueId": "testlog1_Handler_EDBEC34F"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c82c13b7",
@@ -166,6 +169,9 @@ module.exports = function({  }) {
             "uniqueId": "testlog2_Handler_C5C192A7"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c87c0241",

--- a/tools/hangar/__snapshots__/test_corpus/valid/redis.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/redis.w_compile_tf-aws.md
@@ -253,6 +253,9 @@ module.exports = function({ $queue, $r, $r2, $util_Util }) {
             "uniqueId": "cloudQueue-SetConsumer-cdafee6e"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "REDIS_CLUSTER_ID_89baf91f": "${aws_elasticache_cluster.exRedis_RedisCluster_3C9A5882.cluster_id}",
@@ -284,6 +287,9 @@ module.exports = function({ $queue, $r, $r2, $util_Util }) {
             "uniqueId": "testtestingRedis_Handler_7678DD27"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "QUEUE_URL_31e95cbd": "${aws_sqs_queue.cloudQueue.url}",

--- a/tools/hangar/__snapshots__/test_corpus/valid/resource.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/resource.w_compile_tf-aws.md
@@ -423,6 +423,9 @@ module.exports = function({  }) {
             "uniqueId": "BigPublisher_b2_b2-oncreate-OnMessage-59543b60_93D04CBC"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "QUEUE_URL_b0ba884c": "${aws_sqs_queue.BigPublisher_cloudQueue_2EE8871A.url}",
@@ -450,6 +453,9 @@ module.exports = function({  }) {
             "uniqueId": "BigPublisher_cloudQueue-SetConsumer-c50bc9ef_67ECF75E"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "BUCKET_NAME_7ef741f5": "${aws_s3_bucket.BigPublisher_cloudBucket_ABF95118.bucket}",
@@ -477,6 +483,9 @@ module.exports = function({  }) {
             "uniqueId": "BigPublisher_cloudTopic-OnMessage-113c9059_12D15502"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "BUCKET_NAME_7ef741f5": "${aws_s3_bucket.BigPublisher_cloudBucket_ABF95118.bucket}",
@@ -504,6 +513,9 @@ module.exports = function({  }) {
             "uniqueId": "testdependencycycles_Handler_2DD0D3F7"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "BUCKET_NAME_584271ad": "${aws_s3_bucket.BigPublisher_b2_702AC841.bucket}",
@@ -534,6 +546,9 @@ module.exports = function({  }) {
             "uniqueId": "testtest_Handler_295107CC"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "BUCKET_NAME_d755b447": "${aws_s3_bucket.cloudBucket.bucket}",

--- a/tools/hangar/__snapshots__/test_corpus/valid/resource_as_inflight_literal.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/resource_as_inflight_literal.w_compile_tf-aws.md
@@ -138,6 +138,9 @@ module.exports = function({  }) {
             "uniqueId": "cloudFunction"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "cloud-Function-c8d2eca1",
@@ -164,6 +167,9 @@ module.exports = function({  }) {
             "uniqueId": "testtest_Handler_295107CC"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "FUNCTION_NAME_5bb84dfa": "${aws_lambda_function.cloudFunction.arn}",

--- a/tools/hangar/__snapshots__/test_corpus/valid/resource_call_static.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/resource_call_static.w_compile_tf-aws.md
@@ -125,6 +125,9 @@ module.exports = function({ $globalCounter }) {
             "uniqueId": "testaccesscloudresourcethroughstaticmethodsonly_Handler_BC0E7705"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "DYNAMODB_TABLE_NAME_49baa65c": "${aws_dynamodb_table.cloudCounter.name}",

--- a/tools/hangar/__snapshots__/test_corpus/valid/resource_captures.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/resource_captures.w_compile_tf-aws.md
@@ -235,6 +235,9 @@ module.exports = function({  }) {
             "uniqueId": "testtest_Handler_295107CC"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "BUCKET_NAME_51ee81c0": "${aws_s3_bucket.MyResource_cloudBucket_B5E6C951.bucket}",

--- a/tools/hangar/__snapshots__/test_corpus/valid/resource_captures_globals.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/resource_captures_globals.w_compile_tf-aws.md
@@ -283,6 +283,9 @@ module.exports = function({ $_parentThis_localCounter, $globalCounter }) {
             "uniqueId": "MyResource_cloudTopic-OnMessage-f10eb240_23BCEE41"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "DYNAMODB_TABLE_NAME_49baa65c": "${aws_dynamodb_table.cloudCounter.name}",
@@ -311,6 +314,9 @@ module.exports = function({ $_parentThis_localCounter, $globalCounter }) {
             "uniqueId": "testaccesscloudresourcethroughstaticmethodsonly_Handler_BC0E7705"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "DYNAMODB_TABLE_NAME_49baa65c": "${aws_dynamodb_table.cloudCounter.name}",
@@ -338,6 +344,9 @@ module.exports = function({ $_parentThis_localCounter, $globalCounter }) {
             "uniqueId": "testtest_Handler_295107CC"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "BUCKET_NAME_ae5b06c6": "${aws_s3_bucket.Another_First_cloudBucket_DB822B7C.bucket}",

--- a/tools/hangar/__snapshots__/test_corpus/valid/shadowing.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/shadowing.w_compile_tf-aws.md
@@ -121,6 +121,9 @@ module.exports = function({ $fn }) {
             "uniqueId": "testcaptureshadowinteraction_Handler_9B768E38"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c8807c1f",

--- a/tools/hangar/__snapshots__/test_corpus/valid/statements_if.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/statements_if.w_compile_tf-aws.md
@@ -110,6 +110,9 @@ module.exports = function({  }) {
             "uniqueId": "testtest_Handler_295107CC"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c8f4f2a1",

--- a/tools/hangar/__snapshots__/test_corpus/valid/static_members.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/static_members.w_compile_tf-aws.md
@@ -116,6 +116,9 @@ module.exports = function({  }) {
             "uniqueId": "testtest_Handler_295107CC"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c8f4f2a1",

--- a/tools/hangar/__snapshots__/test_corpus/valid/std_string.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/std_string.w_compile_tf-aws.md
@@ -93,6 +93,9 @@ module.exports = function({ $__s1_split_______at_1__, $_s1_concat_s2__, $s1_inde
             "uniqueId": "teststring_Handler_2FEE704D"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c8a1f7f0",

--- a/tools/hangar/__snapshots__/test_corpus/valid/struct_from_json.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/struct_from_json.w_compile_tf-aws.md
@@ -531,6 +531,9 @@ module.exports = function({ $Student, $jStudent1 }) {
             "uniqueId": "testflightschoolstudent_Handler_8BE7AA78"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c85c011b",
@@ -557,6 +560,9 @@ module.exports = function({ $Student, $jStudent1 }) {
             "uniqueId": "testliftingastudent_Handler_30A43B55"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c82f8661",

--- a/tools/hangar/__snapshots__/test_corpus/valid/structs.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/structs.w_compile_tf-aws.md
@@ -313,6 +313,9 @@ module.exports = function(stdStruct) {
             "uniqueId": "teststructdefinitionsarephaseindependant_Handler_F8CACE9E"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c8158c42",

--- a/tools/hangar/__snapshots__/test_corpus/valid/super_call.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/super_call.w_compile_tf-aws.md
@@ -261,6 +261,9 @@ module.exports = function({ $InflightA }) {
             "uniqueId": "testsupercallinflight_Handler_8BA833E3"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c83c6423",
@@ -287,6 +290,9 @@ module.exports = function({ $InflightA }) {
             "uniqueId": "testsupercallsetsbindingpermissions_Handler_094D9398"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "BUCKET_NAME_d755b447": "${aws_s3_bucket.cloudBucket.bucket}",

--- a/tools/hangar/__snapshots__/test_corpus/valid/symbol_shadow.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/symbol_shadow.w_compile_tf-aws.md
@@ -245,6 +245,9 @@ module.exports = function({  }) {
             "uniqueId": "A_testinflightinresourceshouldcapturetherightscopedvar_Handler_B24941AC"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c83cf74f",
@@ -271,6 +274,9 @@ module.exports = function({  }) {
             "uniqueId": "testinflightnestedshouldnotcapturetheshadowedvar_Handler_B6B64A92"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c85de384",
@@ -297,6 +303,9 @@ module.exports = function({  }) {
             "uniqueId": "testinflightontopshouldcapturetop_Handler_2FA69946"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c859340a",
@@ -323,6 +332,9 @@ module.exports = function({  }) {
             "uniqueId": "testinsideInflightshouldcapturetherightscope_Handler_B6CD7A27"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c83ad462",

--- a/tools/hangar/__snapshots__/test_corpus/valid/test_bucket.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/test_bucket.w_compile_tf-aws.md
@@ -141,6 +141,9 @@ module.exports = function({ $b }) {
             "uniqueId": "testget_Handler_67989B36"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "BUCKET_NAME_d755b447": "${aws_s3_bucket.cloudBucket.bucket}",
@@ -168,6 +171,9 @@ module.exports = function({ $b }) {
             "uniqueId": "testput_Handler_724F92D5"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "BUCKET_NAME_d755b447": "${aws_s3_bucket.cloudBucket.bucket}",

--- a/tools/hangar/__snapshots__/test_corpus/valid/test_without_bring.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/test_without_bring.w_compile_tf-aws.md
@@ -91,6 +91,9 @@ module.exports = function({  }) {
             "uniqueId": "testhellotest_Handler_388AC021"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c8123dd7",

--- a/tools/hangar/__snapshots__/test_corpus/valid/use_inflight_method_inside_init_closure.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/use_inflight_method_inside_init_closure.w_compile_tf-aws.md
@@ -105,6 +105,9 @@ module.exports = function({  }) {
             "uniqueId": "Foo_cloudFunction_E4309ED7"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "cloud-Function-c8858302",

--- a/tools/hangar/__snapshots__/test_corpus/valid/website_with_api.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/website_with_api.w_compile_tf-aws.md
@@ -365,6 +365,9 @@ module.exports = function({  }) {
             "uniqueId": "cloudApi_cloudApi-OnRequest-3fc9280c_5DA20E7A"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "cloud-Api-OnRequest-3fc9280c-c8d3ecf9",
@@ -391,6 +394,9 @@ module.exports = function({  }) {
             "uniqueId": "cloudApi_cloudApi-OnRequest-86898773_701F5CA7"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "DYNAMODB_TABLE_NAME_d5d44f18": "${aws_dynamodb_table.exTable.name}",
@@ -420,6 +426,9 @@ module.exports = function({  }) {
             "uniqueId": "cloudApi_cloudApi-OnRequest-cdafee6e_A6C8366F"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "DYNAMODB_TABLE_NAME_d5d44f18": "${aws_dynamodb_table.exTable.name}",

--- a/tools/hangar/__snapshots__/test_corpus/valid/while_loop_await.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/while_loop_await.w_compile_tf-aws.md
@@ -111,6 +111,9 @@ module.exports = function({  }) {
             "uniqueId": "cloudQueue-SetConsumer-cdafee6e"
           }
         },
+        "architectures": [
+          "arm64"
+        ],
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "cloud-Queue-SetConsumer-cdafee6e-c8eb6a09",


### PR DESCRIPTION
This change should give better price/performance for most workloads, and not have any effect on runtime behavior since all cloud functions are using the AWS-provided NodeJS runtimes.

## Checklist

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [x] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
