### PR TITLE
fix(sdk): missing sourceModule info

### DIFF
--- a/libs/wingsdk/src/core/tree.ts
+++ b/libs/wingsdk/src/core/tree.ts
@@ -62,6 +62,12 @@ export interface DisplayInfo {
    * @default false (visible)
    */
   readonly hidden?: boolean;
+
+  /**
+   * The source file or library where the construct was defined.
+   * @default - no source information
+   */
+  readonly sourceModule?: string;
 }
 
 /**
@@ -159,6 +165,7 @@ function synthDisplay(construct: IConstruct): DisplayInfo | undefined {
       title: display.title,
       description: display.description,
       hidden: display.hidden,
+      sourceModule: display.sourceModule,
     };
   }
   return;

--- a/libs/wingsdk/test/target-sim/__snapshots__/api.test.ts.snap
+++ b/libs/wingsdk/test/target-sim/__snapshots__/api.test.ts.snap
@@ -158,6 +158,7 @@ return class Handler {
               },
               "display": {
                 "description": "A cloud function (FaaS)",
+                "sourceModule": "@winglang/sdk",
                 "title": "get()",
               },
               "id": "OnRequestHandler-e645076f",
@@ -346,6 +347,7 @@ return class Handler {
               },
               "display": {
                 "description": "A cloud function (FaaS)",
+                "sourceModule": "@winglang/sdk",
                 "title": "get()",
               },
               "id": "OnRequestHandler-e645076f",
@@ -534,6 +536,7 @@ return class Handler {
               },
               "display": {
                 "description": "A cloud function (FaaS)",
+                "sourceModule": "@winglang/sdk",
                 "title": "get()",
               },
               "id": "OnRequestHandler-e645076f",
@@ -722,6 +725,7 @@ return class Handler {
               },
               "display": {
                 "description": "A cloud function (FaaS)",
+                "sourceModule": "@winglang/sdk",
                 "title": "get()",
               },
               "id": "OnRequestHandler-e645076f",
@@ -910,6 +914,7 @@ return class Handler {
               },
               "display": {
                 "description": "A cloud function (FaaS)",
+                "sourceModule": "@winglang/sdk",
                 "title": "get()",
               },
               "id": "OnRequestHandler-e645076f",
@@ -1230,6 +1235,7 @@ return class Handler {
               },
               "display": {
                 "description": "A cloud function (FaaS)",
+                "sourceModule": "@winglang/sdk",
                 "title": "get()",
               },
               "id": "OnRequestHandler-e645076f",
@@ -1416,6 +1422,7 @@ return class Handler {
               },
               "display": {
                 "description": "A cloud function (FaaS)",
+                "sourceModule": "@winglang/sdk",
                 "title": "get()",
               },
               "id": "OnRequestHandler-e645076f",
@@ -1692,6 +1699,7 @@ return class Handler {
               },
               "display": {
                 "description": "A cloud function (FaaS)",
+                "sourceModule": "@winglang/sdk",
                 "title": "get()",
               },
               "id": "OnRequestHandler-7c48a9f0",
@@ -1704,6 +1712,7 @@ return class Handler {
               },
               "display": {
                 "description": "A cloud function (FaaS)",
+                "sourceModule": "@winglang/sdk",
                 "title": "post()",
               },
               "id": "OnRequestHandler-f6d90a7f",
@@ -1982,6 +1991,7 @@ return class Handler {
               },
               "display": {
                 "description": "A cloud function (FaaS)",
+                "sourceModule": "@winglang/sdk",
                 "title": "get()",
               },
               "id": "OnRequestHandler-7c48a9f0",
@@ -1994,6 +2004,7 @@ return class Handler {
               },
               "display": {
                 "description": "A cloud function (FaaS)",
+                "sourceModule": "@winglang/sdk",
                 "title": "get()",
               },
               "id": "OnRequestHandler-f6d90a7f",
@@ -2182,6 +2193,7 @@ return class Handler {
               },
               "display": {
                 "description": "A cloud function (FaaS)",
+                "sourceModule": "@winglang/sdk",
                 "title": "get()",
               },
               "id": "OnRequestHandler-e645076f",
@@ -2379,6 +2391,7 @@ return class Handler {
               },
               "display": {
                 "description": "A cloud function (FaaS)",
+                "sourceModule": "@winglang/sdk",
                 "title": "get()",
               },
               "id": "OnRequestHandler-e645076f",
@@ -2567,6 +2580,7 @@ return class Handler {
               },
               "display": {
                 "description": "A cloud function (FaaS)",
+                "sourceModule": "@winglang/sdk",
                 "title": "post()",
               },
               "id": "OnRequestHandler-e645076f",

--- a/libs/wingsdk/test/target-sim/__snapshots__/file-counter.test.ts.snap
+++ b/libs/wingsdk/test/target-sim/__snapshots__/file-counter.test.ts.snap
@@ -201,6 +201,7 @@ bucket: (function(env) {
                   },
                   "display": {
                     "description": "A cloud function (FaaS)",
+                    "sourceModule": "@winglang/sdk",
                     "title": "setConsumer()",
                   },
                   "id": "Queue-SetConsumer-401ee792",

--- a/libs/wingsdk/test/target-sim/__snapshots__/on-deploy.test.ts.snap
+++ b/libs/wingsdk/test/target-sim/__snapshots__/on-deploy.test.ts.snap
@@ -90,6 +90,7 @@ return class Handler {
               },
               "display": {
                 "description": "A cloud function (FaaS)",
+                "sourceModule": "@winglang/sdk",
                 "title": "Function",
               },
               "id": "Function",

--- a/libs/wingsdk/test/target-sim/__snapshots__/queue.test.ts.snap
+++ b/libs/wingsdk/test/target-sim/__snapshots__/queue.test.ts.snap
@@ -221,6 +221,7 @@ async handle(message) {
               },
               "display": {
                 "description": "A cloud function (FaaS)",
+                "sourceModule": "@winglang/sdk",
                 "title": "setConsumer()",
               },
               "id": "my_queue-SetConsumer-e645076f",
@@ -414,6 +415,7 @@ async handle(message) {
               },
               "display": {
                 "description": "A cloud function (FaaS)",
+                "sourceModule": "@winglang/sdk",
                 "title": "setConsumer()",
               },
               "id": "my_queue-SetConsumer-e645076f",
@@ -608,6 +610,7 @@ async handle(message) {
               },
               "display": {
                 "description": "A cloud function (FaaS)",
+                "sourceModule": "@winglang/sdk",
                 "title": "setConsumer()",
               },
               "id": "my_queue-SetConsumer-e645076f",
@@ -938,6 +941,7 @@ async handle(message) {
               },
               "display": {
                 "description": "A cloud function (FaaS)",
+                "sourceModule": "@winglang/sdk",
                 "title": "setConsumer()",
               },
               "id": "my_queue-SetConsumer-e645076f",
@@ -975,6 +979,7 @@ async handle(message) {
               },
               "display": {
                 "description": "A cloud function (FaaS)",
+                "sourceModule": "@winglang/sdk",
                 "title": "Function",
               },
               "id": "Function",
@@ -1156,6 +1161,7 @@ async handle(message) {
               },
               "display": {
                 "description": "A cloud function (FaaS)",
+                "sourceModule": "@winglang/sdk",
                 "title": "setConsumer()",
               },
               "id": "my_queue-SetConsumer-e645076f",

--- a/libs/wingsdk/test/target-sim/__snapshots__/schedule.test.ts.snap
+++ b/libs/wingsdk/test/target-sim/__snapshots__/schedule.test.ts.snap
@@ -187,6 +187,7 @@ console.log(\\"Hello from schedule!\\");
               },
               "display": {
                 "description": "A cloud function (FaaS)",
+                "sourceModule": "@winglang/sdk",
                 "title": "onTick()",
               },
               "id": "my_schedule-OnTick-e645076f",
@@ -358,6 +359,7 @@ console.log(\\"Hello from schedule!\\");
               },
               "display": {
                 "description": "A cloud function (FaaS)",
+                "sourceModule": "@winglang/sdk",
                 "title": "onTick()",
               },
               "id": "my_schedule-OnTick-e645076f",
@@ -529,6 +531,7 @@ console.log(\\"Hello from schedule!\\");
               },
               "display": {
                 "description": "A cloud function (FaaS)",
+                "sourceModule": "@winglang/sdk",
                 "title": "onTick()",
               },
               "id": "my_schedule-OnTick-e645076f",

--- a/libs/wingsdk/test/target-sim/__snapshots__/service.test.ts.snap
+++ b/libs/wingsdk/test/target-sim/__snapshots__/service.test.ts.snap
@@ -121,6 +121,7 @@ async handle(message) {
               },
               "display": {
                 "description": "A cloud function (FaaS)",
+                "sourceModule": "@winglang/sdk",
                 "title": "onStart()",
               },
               "id": "my_service-ServiceOnStartef2b13b9",


### PR DESCRIPTION
Fixes a regression from https://github.com/winglang/wing/pull/3884 - tree.json was no longer being emitted with `sourceModule` information, causing some issues in the Wing Console. Thanks @polamoros for catching this 🙏 

## Checklist

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [x] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
