### PR TITLE
chore(compiler): make preflight.js more self-contained

### DIFF
--- a/libs/wingc/src/jsify/snapshots/access_methods_and_properties_on_collections.snap
+++ b/libs/wingc/src/jsify/snapshots/access_methods_and_properties_on_collections.snap
@@ -38,6 +38,7 @@ module.exports = function({ $_y_at_0__, $x_length }) {
 
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/libs/wingc/src/jsify/snapshots/access_property_on_primitive.snap
+++ b/libs/wingc/src/jsify/snapshots/access_property_on_primitive.snap
@@ -35,6 +35,7 @@ module.exports = function({ $s_length }) {
 
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/libs/wingc/src/jsify/snapshots/access_property_on_value_returned_from_collection.snap
+++ b/libs/wingc/src/jsify/snapshots/access_property_on_value_returned_from_collection.snap
@@ -35,6 +35,7 @@ module.exports = function({ $_s___hello___length }) {
 
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/libs/wingc/src/jsify/snapshots/base_class_captures_inflight.snap
+++ b/libs/wingc/src/jsify/snapshots/base_class_captures_inflight.snap
@@ -56,6 +56,7 @@ module.exports = function({ $Base }) {
 
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/libs/wingc/src/jsify/snapshots/base_class_captures_preflight.snap
+++ b/libs/wingc/src/jsify/snapshots/base_class_captures_preflight.snap
@@ -50,6 +50,7 @@ module.exports = function({ $Base }) {
 
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/libs/wingc/src/jsify/snapshots/base_class_lift_indirect.snap
+++ b/libs/wingc/src/jsify/snapshots/base_class_lift_indirect.snap
@@ -64,6 +64,7 @@ module.exports = function({ $Base }) {
 
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/libs/wingc/src/jsify/snapshots/base_class_with_fields_inflight.snap
+++ b/libs/wingc/src/jsify/snapshots/base_class_with_fields_inflight.snap
@@ -65,6 +65,7 @@ module.exports = function({ $Base }) {
 
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/libs/wingc/src/jsify/snapshots/base_class_with_fields_preflight.snap
+++ b/libs/wingc/src/jsify/snapshots/base_class_with_fields_preflight.snap
@@ -55,6 +55,7 @@ module.exports = function({ $Base }) {
 
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/libs/wingc/src/jsify/snapshots/base_class_with_lifted_field_object.snap
+++ b/libs/wingc/src/jsify/snapshots/base_class_with_lifted_field_object.snap
@@ -55,6 +55,7 @@ module.exports = function({ $Base }) {
 
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/libs/wingc/src/jsify/snapshots/base_class_with_lifted_fields.snap
+++ b/libs/wingc/src/jsify/snapshots/base_class_with_lifted_fields.snap
@@ -55,6 +55,7 @@ module.exports = function({ $Base }) {
 
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/libs/wingc/src/jsify/snapshots/builtins.snap
+++ b/libs/wingc/src/jsify/snapshots/builtins.snap
@@ -33,6 +33,7 @@ module.exports = function({  }) {
 
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/libs/wingc/src/jsify/snapshots/call_static_inflight_from_static_inflight.snap
+++ b/libs/wingc/src/jsify/snapshots/call_static_inflight_from_static_inflight.snap
@@ -49,6 +49,7 @@ module.exports = function({ $A }) {
 
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/libs/wingc/src/jsify/snapshots/calls_methods_on_preflight_object.snap
+++ b/libs/wingc/src/jsify/snapshots/calls_methods_on_preflight_object.snap
@@ -38,6 +38,7 @@ module.exports = function({ $b }) {
 
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/libs/wingc/src/jsify/snapshots/capture_from_inside_an_inflight_closure.snap
+++ b/libs/wingc/src/jsify/snapshots/capture_from_inside_an_inflight_closure.snap
@@ -39,6 +39,7 @@ module.exports = function({ $foo }) {
 
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/libs/wingc/src/jsify/snapshots/capture_identifier_closure_from_preflight_scope.snap
+++ b/libs/wingc/src/jsify/snapshots/capture_identifier_closure_from_preflight_scope.snap
@@ -51,6 +51,7 @@ module.exports = function({ $foo }) {
 
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/libs/wingc/src/jsify/snapshots/capture_identifier_from_preflight_scope.snap
+++ b/libs/wingc/src/jsify/snapshots/capture_identifier_from_preflight_scope.snap
@@ -34,6 +34,7 @@ module.exports = function({ $x }) {
 
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/libs/wingc/src/jsify/snapshots/capture_identifier_from_preflight_scope_with_method_call.snap
+++ b/libs/wingc/src/jsify/snapshots/capture_identifier_from_preflight_scope_with_method_call.snap
@@ -52,6 +52,7 @@ module.exports = function({  }) {
 
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/libs/wingc/src/jsify/snapshots/capture_identifier_from_preflight_scope_with_nested_object.snap
+++ b/libs/wingc/src/jsify/snapshots/capture_identifier_from_preflight_scope_with_nested_object.snap
@@ -55,6 +55,7 @@ module.exports = function({  }) {
 
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/libs/wingc/src/jsify/snapshots/capture_identifier_from_preflight_scope_with_property.snap
+++ b/libs/wingc/src/jsify/snapshots/capture_identifier_from_preflight_scope_with_property.snap
@@ -34,6 +34,7 @@ module.exports = function({ $x_length }) {
 
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/libs/wingc/src/jsify/snapshots/capture_in_keyword_args.snap
+++ b/libs/wingc/src/jsify/snapshots/capture_in_keyword_args.snap
@@ -39,6 +39,7 @@ module.exports = function({ $util_Util, $x }) {
 
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/libs/wingc/src/jsify/snapshots/capture_object_with_this_in_name.snap
+++ b/libs/wingc/src/jsify/snapshots/capture_object_with_this_in_name.snap
@@ -35,6 +35,7 @@ module.exports = function({ $bucket_this }) {
 
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/libs/wingc/src/jsify/snapshots/capture_token.snap
+++ b/libs/wingc/src/jsify/snapshots/capture_token.snap
@@ -34,6 +34,7 @@ module.exports = function({ $api_url }) {
 
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/libs/wingc/src/jsify/snapshots/capture_type_inflight_class_sibling_from_init.snap
+++ b/libs/wingc/src/jsify/snapshots/capture_type_inflight_class_sibling_from_init.snap
@@ -56,6 +56,7 @@ module.exports = function({  }) {
 
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/libs/wingc/src/jsify/snapshots/capture_type_inflight_class_sibling_from_method.snap
+++ b/libs/wingc/src/jsify/snapshots/capture_type_inflight_class_sibling_from_method.snap
@@ -44,6 +44,7 @@ module.exports = function({  }) {
 
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/libs/wingc/src/jsify/snapshots/capture_type_new_inflight_class_inner_no_capture.snap
+++ b/libs/wingc/src/jsify/snapshots/capture_type_new_inflight_class_inner_no_capture.snap
@@ -36,6 +36,7 @@ module.exports = function({  }) {
 
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/libs/wingc/src/jsify/snapshots/capture_type_new_inflight_class_outer.snap
+++ b/libs/wingc/src/jsify/snapshots/capture_type_new_inflight_class_outer.snap
@@ -45,6 +45,7 @@ module.exports = function({  }) {
 
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/libs/wingc/src/jsify/snapshots/capture_type_static_method.snap
+++ b/libs/wingc/src/jsify/snapshots/capture_type_static_method.snap
@@ -52,6 +52,7 @@ module.exports = function({  }) {
 
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/libs/wingc/src/jsify/snapshots/capture_type_static_method_inflight_class.snap
+++ b/libs/wingc/src/jsify/snapshots/capture_type_static_method_inflight_class.snap
@@ -50,6 +50,7 @@ module.exports = function({  }) {
 
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/libs/wingc/src/jsify/snapshots/capture_var_from_method_inflight.snap
+++ b/libs/wingc/src/jsify/snapshots/capture_var_from_method_inflight.snap
@@ -41,6 +41,7 @@ module.exports = function({  }) {
 
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/libs/wingc/src/jsify/snapshots/closed_inflight_class_extends_outer_inflight_class.snap
+++ b/libs/wingc/src/jsify/snapshots/closed_inflight_class_extends_outer_inflight_class.snap
@@ -48,6 +48,7 @@ module.exports = function({  }) {
 
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/libs/wingc/src/jsify/snapshots/closure_field.snap
+++ b/libs/wingc/src/jsify/snapshots/closure_field.snap
@@ -90,6 +90,7 @@ module.exports = function({  }) {
 
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/libs/wingc/src/jsify/snapshots/enum_value.snap
+++ b/libs/wingc/src/jsify/snapshots/enum_value.snap
@@ -38,6 +38,7 @@ module.exports = function({ $MyEnum, $x }) {
 
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/libs/wingc/src/jsify/snapshots/free_inflight_obj_from_inflight.snap
+++ b/libs/wingc/src/jsify/snapshots/free_inflight_obj_from_inflight.snap
@@ -44,6 +44,7 @@ module.exports = function({  }) {
 
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/libs/wingc/src/jsify/snapshots/free_preflight_object_from_preflight.snap
+++ b/libs/wingc/src/jsify/snapshots/free_preflight_object_from_preflight.snap
@@ -29,6 +29,7 @@ module.exports = function({  }) {
 
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/libs/wingc/src/jsify/snapshots/func_returns_func.snap
+++ b/libs/wingc/src/jsify/snapshots/func_returns_func.snap
@@ -43,6 +43,7 @@ module.exports = function({  }) {
 
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/libs/wingc/src/jsify/snapshots/identify_field.snap
+++ b/libs/wingc/src/jsify/snapshots/identify_field.snap
@@ -38,6 +38,7 @@ module.exports = function({  }) {
 
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/libs/wingc/src/jsify/snapshots/implicit_lift_inflight_init.snap
+++ b/libs/wingc/src/jsify/snapshots/implicit_lift_inflight_init.snap
@@ -56,6 +56,7 @@ module.exports = function({  }) {
 
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/libs/wingc/src/jsify/snapshots/indirect_capture.snap
+++ b/libs/wingc/src/jsify/snapshots/indirect_capture.snap
@@ -68,6 +68,7 @@ module.exports = function({ $b }) {
 
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/libs/wingc/src/jsify/snapshots/inflight_class_extends_both_inside_inflight_closure.snap
+++ b/libs/wingc/src/jsify/snapshots/inflight_class_extends_both_inside_inflight_closure.snap
@@ -37,6 +37,7 @@ module.exports = function({  }) {
 
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/libs/wingc/src/jsify/snapshots/inflight_class_extends_inflight_class.snap
+++ b/libs/wingc/src/jsify/snapshots/inflight_class_extends_inflight_class.snap
@@ -34,6 +34,7 @@ module.exports = function({ $A }) {
 
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/libs/wingc/src/jsify/snapshots/inflight_constructor.snap
+++ b/libs/wingc/src/jsify/snapshots/inflight_constructor.snap
@@ -41,6 +41,7 @@ module.exports = function({  }) {
 
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/libs/wingc/src/jsify/snapshots/inflight_field.snap
+++ b/libs/wingc/src/jsify/snapshots/inflight_field.snap
@@ -40,6 +40,7 @@ module.exports = function({  }) {
 
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/libs/wingc/src/jsify/snapshots/inflight_field_from_inflight.snap
+++ b/libs/wingc/src/jsify/snapshots/inflight_field_from_inflight.snap
@@ -39,6 +39,7 @@ module.exports = function({  }) {
 
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/libs/wingc/src/jsify/snapshots/inflight_field_from_inflight_class.snap
+++ b/libs/wingc/src/jsify/snapshots/inflight_field_from_inflight_class.snap
@@ -36,6 +36,7 @@ module.exports = function({  }) {
 
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/libs/wingc/src/jsify/snapshots/inline_inflight_class.snap
+++ b/libs/wingc/src/jsify/snapshots/inline_inflight_class.snap
@@ -56,6 +56,7 @@ module.exports = function({  }) {
 
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/libs/wingc/src/jsify/snapshots/json_object.snap
+++ b/libs/wingc/src/jsify/snapshots/json_object.snap
@@ -35,6 +35,7 @@ module.exports = function({ $jsonObj1, $std_Json }) {
 
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/libs/wingc/src/jsify/snapshots/lift_binary_preflight_and_inflight_expression.snap
+++ b/libs/wingc/src/jsify/snapshots/lift_binary_preflight_and_inflight_expression.snap
@@ -36,6 +36,7 @@ module.exports = function({ $x }) {
 
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/libs/wingc/src/jsify/snapshots/lift_binary_preflight_expression.snap
+++ b/libs/wingc/src/jsify/snapshots/lift_binary_preflight_expression.snap
@@ -35,6 +35,7 @@ module.exports = function({ $x, $y }) {
 
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/libs/wingc/src/jsify/snapshots/lift_element_from_collection_as_field.snap
+++ b/libs/wingc/src/jsify/snapshots/lift_element_from_collection_as_field.snap
@@ -39,6 +39,7 @@ module.exports = function({  }) {
 
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/libs/wingc/src/jsify/snapshots/lift_element_from_collection_of_objects.snap
+++ b/libs/wingc/src/jsify/snapshots/lift_element_from_collection_of_objects.snap
@@ -36,6 +36,7 @@ module.exports = function({ $_a_at_0__ }) {
 
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/libs/wingc/src/jsify/snapshots/lift_inflight_closure.snap
+++ b/libs/wingc/src/jsify/snapshots/lift_inflight_closure.snap
@@ -52,6 +52,7 @@ module.exports = function({ $f }) {
 
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/libs/wingc/src/jsify/snapshots/lift_inside_preflight_method.snap
+++ b/libs/wingc/src/jsify/snapshots/lift_inside_preflight_method.snap
@@ -57,6 +57,7 @@ module.exports = function({  }) {
 
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/libs/wingc/src/jsify/snapshots/lift_string.snap
+++ b/libs/wingc/src/jsify/snapshots/lift_string.snap
@@ -34,6 +34,7 @@ module.exports = function({ $b }) {
 
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/libs/wingc/src/jsify/snapshots/lift_this.snap
+++ b/libs/wingc/src/jsify/snapshots/lift_this.snap
@@ -69,6 +69,7 @@ module.exports = function({  }) {
 
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/libs/wingc/src/jsify/snapshots/lift_var_with_this.snap
+++ b/libs/wingc/src/jsify/snapshots/lift_var_with_this.snap
@@ -52,6 +52,7 @@ module.exports = function({  }) {
 
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/libs/wingc/src/jsify/snapshots/lift_via_closure.snap
+++ b/libs/wingc/src/jsify/snapshots/lift_via_closure.snap
@@ -59,6 +59,7 @@ module.exports = function({ $fn }) {
 
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/libs/wingc/src/jsify/snapshots/lift_via_closure_class_explicit.snap
+++ b/libs/wingc/src/jsify/snapshots/lift_via_closure_class_explicit.snap
@@ -74,6 +74,7 @@ module.exports = function({  }) {
 
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/libs/wingc/src/jsify/snapshots/namespaced_static_from_inflight.snap
+++ b/libs/wingc/src/jsify/snapshots/namespaced_static_from_inflight.snap
@@ -34,6 +34,7 @@ module.exports = function({ $util_Util }) {
 
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/libs/wingc/src/jsify/snapshots/nested_inflight_after_preflight_operation.snap
+++ b/libs/wingc/src/jsify/snapshots/nested_inflight_after_preflight_operation.snap
@@ -58,6 +58,7 @@ module.exports = function({  }) {
 
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/libs/wingc/src/jsify/snapshots/nested_preflight_operation.snap
+++ b/libs/wingc/src/jsify/snapshots/nested_preflight_operation.snap
@@ -73,6 +73,7 @@ module.exports = function({  }) {
 
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/libs/wingc/src/jsify/snapshots/new_inflight_object.snap
+++ b/libs/wingc/src/jsify/snapshots/new_inflight_object.snap
@@ -45,6 +45,7 @@ module.exports = function({  }) {
 
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/libs/wingc/src/jsify/snapshots/no_capture_inside_methods.snap
+++ b/libs/wingc/src/jsify/snapshots/no_capture_inside_methods.snap
@@ -39,6 +39,7 @@ module.exports = function({  }) {
 
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/libs/wingc/src/jsify/snapshots/no_capture_of_identifier_from_inner_scope.snap
+++ b/libs/wingc/src/jsify/snapshots/no_capture_of_identifier_from_inner_scope.snap
@@ -39,6 +39,7 @@ module.exports = function({  }) {
 
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/libs/wingc/src/jsify/snapshots/no_capture_of_identifier_from_same_scope.snap
+++ b/libs/wingc/src/jsify/snapshots/no_capture_of_identifier_from_same_scope.snap
@@ -35,6 +35,7 @@ module.exports = function({  }) {
 
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/libs/wingc/src/jsify/snapshots/no_capture_shadow_inside_inner_scopes.snap
+++ b/libs/wingc/src/jsify/snapshots/no_capture_shadow_inside_inner_scopes.snap
@@ -47,6 +47,7 @@ module.exports = function({  }) {
 
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/libs/wingc/src/jsify/snapshots/no_lift_shadow_inside_inner_scopes.snap
+++ b/libs/wingc/src/jsify/snapshots/no_lift_shadow_inside_inner_scopes.snap
@@ -45,6 +45,7 @@ module.exports = function({ $i }) {
 
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/libs/wingc/src/jsify/snapshots/preflight_class_extends_preflight_class.snap
+++ b/libs/wingc/src/jsify/snapshots/preflight_class_extends_preflight_class.snap
@@ -39,6 +39,7 @@ module.exports = function({ $Base }) {
 
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/libs/wingc/src/jsify/snapshots/preflight_collection.snap
+++ b/libs/wingc/src/jsify/snapshots/preflight_collection.snap
@@ -36,6 +36,7 @@ module.exports = function({ $_a_at_0__, $a_length }) {
 
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/libs/wingc/src/jsify/snapshots/preflight_collection_of_preflight_objects.snap
+++ b/libs/wingc/src/jsify/snapshots/preflight_collection_of_preflight_objects.snap
@@ -40,6 +40,7 @@ module.exports = function({ $_arr_at_0__, $arr_length }) {
 
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/libs/wingc/src/jsify/snapshots/preflight_nested_object_with_operations.snap
+++ b/libs/wingc/src/jsify/snapshots/preflight_nested_object_with_operations.snap
@@ -55,6 +55,7 @@ module.exports = function({  }) {
 
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/libs/wingc/src/jsify/snapshots/preflight_object.snap
+++ b/libs/wingc/src/jsify/snapshots/preflight_object.snap
@@ -56,6 +56,7 @@ module.exports = function({  }) {
 
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/libs/wingc/src/jsify/snapshots/preflight_object_through_property.snap
+++ b/libs/wingc/src/jsify/snapshots/preflight_object_through_property.snap
@@ -56,6 +56,7 @@ module.exports = function({  }) {
 
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/libs/wingc/src/jsify/snapshots/preflight_object_with_operations.snap
+++ b/libs/wingc/src/jsify/snapshots/preflight_object_with_operations.snap
@@ -37,6 +37,7 @@ module.exports = function({ $b }) {
 
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/libs/wingc/src/jsify/snapshots/preflight_object_with_operations_multiple_methods.snap
+++ b/libs/wingc/src/jsify/snapshots/preflight_object_with_operations_multiple_methods.snap
@@ -42,6 +42,7 @@ module.exports = function({ $b }) {
 
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/libs/wingc/src/jsify/snapshots/preflight_value_field.snap
+++ b/libs/wingc/src/jsify/snapshots/preflight_value_field.snap
@@ -61,6 +61,7 @@ module.exports = function({  }) {
 
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/libs/wingc/src/jsify/snapshots/read_primitive_value.snap
+++ b/libs/wingc/src/jsify/snapshots/read_primitive_value.snap
@@ -35,6 +35,7 @@ module.exports = function({ $x }) {
 
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/libs/wingc/src/jsify/snapshots/reassign_captured_variable.snap
+++ b/libs/wingc/src/jsify/snapshots/reassign_captured_variable.snap
@@ -44,6 +44,7 @@ module.exports = function({  }) {
 
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/libs/wingc/src/jsify/snapshots/reassigned_captured_variable_preflight.snap
+++ b/libs/wingc/src/jsify/snapshots/reassigned_captured_variable_preflight.snap
@@ -16,6 +16,7 @@ source: libs/wingc/src/jsify/tests.rs
 
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/libs/wingc/src/jsify/snapshots/ref_std_macro.snap
+++ b/libs/wingc/src/jsify/snapshots/ref_std_macro.snap
@@ -35,6 +35,7 @@ module.exports = function({ $arr_length }) {
 
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/libs/wingc/src/jsify/snapshots/reference_from_static_inflight.snap
+++ b/libs/wingc/src/jsify/snapshots/reference_from_static_inflight.snap
@@ -34,6 +34,7 @@ module.exports = function({ $s }) {
 
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/libs/wingc/src/jsify/snapshots/reference_inflight_class.snap
+++ b/libs/wingc/src/jsify/snapshots/reference_inflight_class.snap
@@ -50,6 +50,7 @@ module.exports = function({  }) {
 
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/libs/wingc/src/jsify/snapshots/reference_inflight_field.snap
+++ b/libs/wingc/src/jsify/snapshots/reference_inflight_field.snap
@@ -41,6 +41,7 @@ module.exports = function({  }) {
 
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/libs/wingc/src/jsify/snapshots/reference_inflight_from_inflight.snap
+++ b/libs/wingc/src/jsify/snapshots/reference_inflight_from_inflight.snap
@@ -62,6 +62,7 @@ module.exports = function({ $s }) {
 
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/libs/wingc/src/jsify/snapshots/reference_preflight_field.snap
+++ b/libs/wingc/src/jsify/snapshots/reference_preflight_field.snap
@@ -39,6 +39,7 @@ module.exports = function({  }) {
 
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/libs/wingc/src/jsify/snapshots/reference_preflight_field_call_independent_method.snap
+++ b/libs/wingc/src/jsify/snapshots/reference_preflight_field_call_independent_method.snap
@@ -39,6 +39,7 @@ module.exports = function({  }) {
 
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/libs/wingc/src/jsify/snapshots/reference_preflight_fields.snap
+++ b/libs/wingc/src/jsify/snapshots/reference_preflight_fields.snap
@@ -55,6 +55,7 @@ module.exports = function({  }) {
 
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/libs/wingc/src/jsify/snapshots/reference_preflight_free_variable_with_this_in_the_expression.snap
+++ b/libs/wingc/src/jsify/snapshots/reference_preflight_free_variable_with_this_in_the_expression.snap
@@ -42,6 +42,7 @@ module.exports = function({ $b }) {
 
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/libs/wingc/src/jsify/snapshots/reference_preflight_object_from_static_inflight.snap
+++ b/libs/wingc/src/jsify/snapshots/reference_preflight_object_from_static_inflight.snap
@@ -36,6 +36,7 @@ module.exports = function({ $q }) {
 
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/libs/wingc/src/jsify/snapshots/reference_static_inflight.snap
+++ b/libs/wingc/src/jsify/snapshots/reference_static_inflight.snap
@@ -51,6 +51,7 @@ module.exports = function({  }) {
 
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/libs/wingc/src/jsify/snapshots/reference_static_inflight_which_references_preflight_object.snap
+++ b/libs/wingc/src/jsify/snapshots/reference_static_inflight_which_references_preflight_object.snap
@@ -60,6 +60,7 @@ module.exports = function({ $b }) {
 
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/libs/wingc/src/jsify/snapshots/static_external_inflight_class.snap
+++ b/libs/wingc/src/jsify/snapshots/static_external_inflight_class.snap
@@ -61,6 +61,7 @@ module.exports = function({  }) {
 
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/libs/wingc/src/jsify/snapshots/static_external_preflight_class.snap
+++ b/libs/wingc/src/jsify/snapshots/static_external_preflight_class.snap
@@ -60,6 +60,7 @@ module.exports = function({  }) {
 
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/libs/wingc/src/jsify/snapshots/static_inflight_operation.snap
+++ b/libs/wingc/src/jsify/snapshots/static_inflight_operation.snap
@@ -57,6 +57,7 @@ module.exports = function({ $b }) {
 
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/libs/wingc/src/jsify/snapshots/static_local_inflight_class.snap
+++ b/libs/wingc/src/jsify/snapshots/static_local_inflight_class.snap
@@ -53,6 +53,7 @@ module.exports = function({  }) {
 
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/libs/wingc/src/jsify/snapshots/static_on_std_type.snap
+++ b/libs/wingc/src/jsify/snapshots/static_on_std_type.snap
@@ -35,6 +35,7 @@ module.exports = function({ $std_Json, $std_String }) {
 
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/libs/wingc/src/jsify/snapshots/transitive_reference.snap
+++ b/libs/wingc/src/jsify/snapshots/transitive_reference.snap
@@ -75,6 +75,7 @@ module.exports = function({  }) {
 
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/libs/wingc/src/jsify/snapshots/transitive_reference_via_inflight_class.snap
+++ b/libs/wingc/src/jsify/snapshots/transitive_reference_via_inflight_class.snap
@@ -58,6 +58,7 @@ module.exports = function({ $b }) {
 
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/libs/wingc/src/jsify/snapshots/transitive_reference_via_static.snap
+++ b/libs/wingc/src/jsify/snapshots/transitive_reference_via_static.snap
@@ -80,6 +80,7 @@ module.exports = function({ $MyType }) {
 
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/libs/wingc/src/jsify/snapshots/two_identical_lifts.snap
+++ b/libs/wingc/src/jsify/snapshots/two_identical_lifts.snap
@@ -44,6 +44,7 @@ module.exports = function({ $b }) {
 
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/libs/wingc/src/jsify/snapshots/unqualified_lift_of_collection.snap
+++ b/libs/wingc/src/jsify/snapshots/unqualified_lift_of_collection.snap
@@ -35,6 +35,7 @@ module.exports = function({ $a }) {
 
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/libs/wingc/src/jsify/snapshots/use_util_functions.snap
+++ b/libs/wingc/src/jsify/snapshots/use_util_functions.snap
@@ -33,6 +33,7 @@ module.exports = function({ $util_Util }) {
 
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/libs/wingc/src/jsify/snapshots/var_inflight_field_from_inflight.snap
+++ b/libs/wingc/src/jsify/snapshots/var_inflight_field_from_inflight.snap
@@ -41,6 +41,7 @@ module.exports = function({  }) {
 
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/libs/wingc/src/jsify/snapshots/wait_util.snap
+++ b/libs/wingc/src/jsify/snapshots/wait_util.snap
@@ -41,6 +41,7 @@ module.exports = function({ $util_Util }) {
 
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/libs/wingcompiler/src/compile.ts
+++ b/libs/wingcompiler/src/compile.ts
@@ -101,6 +101,7 @@ export async function compile(entrypoint: string, options: CompileOptions): Prom
   // in the future we may look for a unified approach
   process.env["WING_TARGET"] = options.target;
   process.env["WING_IS_TEST"] = testing.toString();
+  process.env["WING_PLUGIN_PATHS"] = resolvePluginPaths(options.plugins ?? []);
 
   const tempProcess: { env: Record<string, string | undefined> } = { env: { ...process.env } };
 
@@ -197,7 +198,6 @@ export async function compile(entrypoint: string, options: CompileOptions): Prom
     console,
     __dirname: workDir,
     __filename: artifactPath,
-    $plugins: resolvePluginPaths(options.plugins ?? []),
     // since the SDK is loaded in the outer VM, we need these to be the same class instance,
     // otherwise "instanceof" won't work between preflight code and the SDK. this is needed e.g. in
     // `serializeImmutableData` which has special cases for serializing these types.
@@ -240,12 +240,12 @@ export async function compile(entrypoint: string, options: CompileOptions): Prom
  * if absolute path is not provided.
  *
  * @param plugins list of plugin paths (absolute or relative)
- * @returns list of absolute plugin paths or relative to cwd
+ * @returns list of absolute plugin paths or relative to cwd, joined by ";"
  */
-function resolvePluginPaths(plugins: string[]): string[] {
+function resolvePluginPaths(plugins: string[]): string {
   const resolvedPluginPaths: string[] = [];
   for (const plugin of plugins) {
     resolvedPluginPaths.push(resolve(process.cwd(), plugin));
   }
-  return resolvedPluginPaths;
+  return resolvedPluginPaths.join(";");
 }

--- a/tools/hangar/__snapshots__/error.ts.snap
+++ b/tools/hangar/__snapshots__/error.ts.snap
@@ -3,7 +3,7 @@
 exports[`bool_from_json.w 1`] = `
 "ERROR: unable to parse number 123 as a boolean
 
-../../../examples/tests/error/target/test/bool_from_json.wsim.[REDACTED].tmp/.wing/preflight.js:8
+../../../examples/tests/error/target/test/bool_from_json.wsim.[REDACTED].tmp/.wing/preflight.js:9
        super(scope, id);
        const j = ({\\"a\\": 123});
 >>     const a = (std.Boolean.fromJson((j)[\\"a\\"]));
@@ -20,7 +20,7 @@ Duration <DURATION>"
 exports[`num_from_str.w 1`] = `
 "ERROR: unable to parse \\"123a\\" as a number
 
-../../../examples/tests/error/target/test/num_from_str.wsim.[REDACTED].tmp/.wing/preflight.js:7
+../../../examples/tests/error/target/test/num_from_str.wsim.[REDACTED].tmp/.wing/preflight.js:8
      constructor(scope, id) {
        super(scope, id);
 >>     const a = ((args) => { if (isNaN(args)) {throw new Error(\\"unable to parse /\\"\\" + args + \\"/\\" as a number\\")}; return parseInt(args) })(\\"123a\\");
@@ -37,7 +37,7 @@ Duration <DURATION>"
 exports[`number_from_json.w 1`] = `
 "ERROR: unable to parse string apples as a number
 
-../../../examples/tests/error/target/test/number_from_json.wsim.[REDACTED].tmp/.wing/preflight.js:8
+../../../examples/tests/error/target/test/number_from_json.wsim.[REDACTED].tmp/.wing/preflight.js:9
        super(scope, id);
        const j = ({\\"a\\": \\"apples\\"});
 >>     const a = ((args) => { if (typeof args !== \\"number\\") {throw new Error(\\"unable to parse \\" + typeof args + \\" \\" + args + \\" as a number\\")}; return JSON.parse(JSON.stringify(args)) })((j)[\\"a\\"]);
@@ -60,7 +60,7 @@ hint: Every preflight object needs a unique identifier within its scope. You can
 
 For more information, see https://www.winglang.io/docs/language-guide/language-reference#33-preflight-classes
 
-../../../examples/tests/error/target/test/repeat_construct_id.wsim.[REDACTED].tmp/.wing/preflight.js:9
+../../../examples/tests/error/target/test/repeat_construct_id.wsim.[REDACTED].tmp/.wing/preflight.js:10
        super(scope, id);
        const bucket1 = this.node.root.newAbstract(\\"@winglang/sdk.cloud.Bucket\\",this,\\"cloud.Bucket\\");
 >>     const bucket2 = this.node.root.newAbstract(\\"@winglang/sdk.cloud.Bucket\\",this,\\"cloud.Bucket\\");
@@ -83,7 +83,7 @@ hint: Every preflight object needs a unique identifier within its scope. You can
 
 For more information, see https://www.winglang.io/docs/language-guide/language-reference#33-preflight-classes
 
-../../../examples/tests/error/target/test/repeat_construct_id2.wsim.[REDACTED].tmp/.wing/preflight.js:12
+../../../examples/tests/error/target/test/repeat_construct_id2.wsim.[REDACTED].tmp/.wing/preflight.js:13
        });
        const bucket1 = this.node.root.newAbstract(\\"@winglang/sdk.cloud.Bucket\\",this,String.raw({ raw: [\\"\\", \\"\\"] }, (make_name())));
 >>     const bucket2 = this.node.root.newAbstract(\\"@winglang/sdk.cloud.Bucket\\",this,String.raw({ raw: [\\"\\", \\"\\"] }, (make_name())));
@@ -100,7 +100,7 @@ Duration <DURATION>"
 exports[`string_from_json.w 1`] = `
 "ERROR: unable to parse number 123 as a string
 
-../../../examples/tests/error/target/test/string_from_json.wsim.[REDACTED].tmp/.wing/preflight.js:8
+../../../examples/tests/error/target/test/string_from_json.wsim.[REDACTED].tmp/.wing/preflight.js:9
        super(scope, id);
        const j = ({\\"a\\": 123});
 >>     const a = ((args) => { if (typeof args !== \\"string\\") {throw new Error(\\"unable to parse \\" + typeof args + \\" \\" + args + \\" as a string\\")}; return JSON.parse(JSON.stringify(args)) })((j)[\\"a\\"]);
@@ -118,7 +118,7 @@ exports[`struct_from_json_1.w 1`] = `
 "ERROR: unable to parse Person:
 - instance.age is not of a type(s) number
 
-../../../examples/tests/error/target/test/struct_from_json_1.wsim.[REDACTED].tmp/.wing/preflight.js:9
+../../../examples/tests/error/target/test/struct_from_json_1.wsim.[REDACTED].tmp/.wing/preflight.js:10
        const Person = require(\\"./Person.Struct.js\\")($stdlib.std.Struct);
        const j = ({\\"name\\": \\"cool\\",\\"age\\": \\"not a number\\"});
 >>     (Person.fromJson(j));
@@ -137,7 +137,7 @@ exports[`struct_from_json_2.w 1`] = `
 - instance.age is not of a type(s) number
 - instance requires property \\"advisor\\"
 
-../../../examples/tests/error/target/test/struct_from_json_2.wsim.[REDACTED].tmp/.wing/preflight.js:11
+../../../examples/tests/error/target/test/struct_from_json_2.wsim.[REDACTED].tmp/.wing/preflight.js:12
        const Student = require(\\"./Student.Struct.js\\")($stdlib.std.Struct);
        const missingAdvisor = ({\\"name\\": \\"cool\\",\\"age\\": \\"not a number\\"});
 >>     (Student.fromJson(missingAdvisor));
@@ -156,7 +156,7 @@ exports[`struct_from_json_3.w 1`] = `
 - instance.age is not of a type(s) number
 - instance.advisors[1].id is not of a type(s) string
 
-../../../examples/tests/error/target/test/struct_from_json_3.wsim.[REDACTED].tmp/.wing/preflight.js:11
+../../../examples/tests/error/target/test/struct_from_json_3.wsim.[REDACTED].tmp/.wing/preflight.js:12
        const Student = require(\\"./Student.Struct.js\\")($stdlib.std.Struct);
        const invalidAdvisorInArray = ({\\"name\\": \\"cool\\",\\"age\\": \\"not a number\\",\\"advisors\\": [({\\"id\\": \\"advisor1\\",\\"name\\": \\"Bob\\",\\"age\\": 34}), ({\\"id\\": 10,\\"name\\": \\"Jacob\\",\\"age\\": 45})]});
 >>     (Student.fromJson(invalidAdvisorInArray));
@@ -174,7 +174,7 @@ exports[`struct_from_json_4.w 1`] = `
 "ERROR: unable to parse Student:
 - instance.advisors contains duplicate item
 
-../../../examples/tests/error/target/test/struct_from_json_4.wsim.[REDACTED].tmp/.wing/preflight.js:11
+../../../examples/tests/error/target/test/struct_from_json_4.wsim.[REDACTED].tmp/.wing/preflight.js:12
        const Student = require(\\"./Student.Struct.js\\")($stdlib.std.Struct);
        const invalidAdvisorInArray = ({\\"name\\": \\"cool\\",\\"age\\": 22,\\"advisors\\": [({\\"id\\": \\"advisor1\\",\\"name\\": \\"Bob\\",\\"age\\": 34}), ({\\"id\\": \\"advisor1\\",\\"name\\": \\"Bob\\",\\"age\\": 34})]});
 >>     (Student.fromJson(invalidAdvisorInArray));
@@ -192,7 +192,7 @@ exports[`struct_from_json_5.w 1`] = `
 "ERROR: unable to parse Foo:
 - instance.names.c is not of a type(s) string
 
-../../../examples/tests/error/target/test/struct_from_json_5.wsim.[REDACTED].tmp/.wing/preflight.js:9
+../../../examples/tests/error/target/test/struct_from_json_5.wsim.[REDACTED].tmp/.wing/preflight.js:10
        const Foo = require(\\"./Foo.Struct.js\\")($stdlib.std.Struct);
        const jFoo = ({\\"names\\": ({\\"a\\": \\"Amanda\\",\\"b\\": \\"Barry\\",\\"c\\": 10})});
 >>     (Foo.fromJson(jFoo));
@@ -209,7 +209,7 @@ Duration <DURATION>"
 exports[`utilities.w 1`] = `
 "ERROR: assertion failed: false
 
-../../../examples/tests/error/target/test/utilities.wsim.[REDACTED].tmp/.wing/preflight.js:7
+../../../examples/tests/error/target/test/utilities.wsim.[REDACTED].tmp/.wing/preflight.js:8
      constructor(scope, id) {
        super(scope, id);
 >>     {((cond) => {if (!cond) throw new Error(\\"assertion failed: false\\")})(false)};

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/api/delete.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/api/delete.w_compile_tf-aws.md
@@ -314,6 +314,7 @@ module.exports = function({ $api_url, $http_HttpMethod, $http_Util }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/api/get.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/api/get.w_compile_tf-aws.md
@@ -318,6 +318,7 @@ module.exports = function({ $api_url, $body, $http_HttpMethod, $http_Util }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/api/options.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/api/options.w_compile_tf-aws.md
@@ -512,6 +512,7 @@ module.exports = function({ $api_url, $http_HttpMethod, $http_Util, $path }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/api/patch.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/api/patch.w_compile_tf-aws.md
@@ -315,6 +315,7 @@ module.exports = function({ $_id, $api_url, $body, $http_HttpMethod, $http_Util,
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/api/post.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/api/post.w_compile_tf-aws.md
@@ -314,6 +314,7 @@ module.exports = function({ $api_url, $body, $http_HttpMethod, $http_Util, $std_
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/api/put.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/api/put.w_compile_tf-aws.md
@@ -319,6 +319,7 @@ module.exports = function({ $_id, $api_url, $body, $http_HttpMethod, $http_Util,
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/add_file.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/add_file.w_compile_tf-aws.md
@@ -198,6 +198,7 @@ module.exports = function({ $b }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/add_object.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/add_object.w_compile_tf-aws.md
@@ -198,6 +198,7 @@ module.exports = function({ $b, $jsonObj1, $std_Json }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/bucket_list.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/bucket_list.w_compile_tf-aws.md
@@ -201,6 +201,7 @@ module.exports = function({ $b }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/delete.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/delete.w_compile_tf-aws.md
@@ -202,6 +202,7 @@ module.exports = function({ $b }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/events.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/events.w_compile_tf-aws.md
@@ -1089,6 +1089,7 @@ module.exports = function({ $Source, $b, $checkHitCount, $util_Util, $wait }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/exists.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/exists.w_compile_tf-aws.md
@@ -180,6 +180,7 @@ module.exports = function({ $b }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/public_url.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/public_url.w_compile_tf-aws.md
@@ -246,6 +246,7 @@ module.exports = function({ $http_Util, $privateBucket, $publicBucket, $util_Uti
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/put.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/put.w_compile_tf-aws.md
@@ -186,6 +186,7 @@ module.exports = function({ $b }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/put_json.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/put_json.w_compile_tf-aws.md
@@ -189,6 +189,7 @@ module.exports = function({ $b }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/try_delete.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/try_delete.w_compile_tf-aws.md
@@ -184,6 +184,7 @@ module.exports = function({ $b }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/try_get.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/try_get.w_compile_tf-aws.md
@@ -180,6 +180,7 @@ module.exports = function({ $b }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/try_get_json.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/try_get_json.w_compile_tf-aws.md
@@ -184,6 +184,7 @@ module.exports = function({ $b, $std_Json }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/counter/dec.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/counter/dec.w_compile_tf-aws.md
@@ -266,6 +266,7 @@ module.exports = function({ $counter }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/counter/inc.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/counter/inc.w_compile_tf-aws.md
@@ -276,6 +276,7 @@ module.exports = function({ $counter }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/counter/initial.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/counter/initial.w_compile_tf-aws.md
@@ -375,6 +375,7 @@ module.exports = function({ $counterC }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/counter/peek.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/counter/peek.w_compile_tf-aws.md
@@ -260,6 +260,7 @@ module.exports = function({ $c }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/counter/set.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/counter/set.w_compile_tf-aws.md
@@ -270,6 +270,7 @@ module.exports = function({ $counter }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/function/invoke.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/function/invoke.w_compile_tf-aws.md
@@ -238,6 +238,7 @@ module.exports = function({ $f }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/function/logging.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/function/logging.w_compile_tf-aws.md
@@ -341,6 +341,7 @@ module.exports = function({  }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/function/memory_and_env.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/function/memory_and_env.w_compile_tf-aws.md
@@ -379,6 +379,7 @@ module.exports = function({ $c, $f1, $f2 }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/abs.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/abs.w_compile_tf-aws.md
@@ -146,6 +146,7 @@ module.exports = function({ $math_Util, $x, $y }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/acos.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/acos.w_compile_tf-aws.md
@@ -163,6 +163,7 @@ module.exports = function({ $math_Util }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/acot.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/acot.w_compile_tf-aws.md
@@ -149,6 +149,7 @@ module.exports = function({ $math_Util }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/acsc.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/acsc.w_compile_tf-aws.md
@@ -156,6 +156,7 @@ module.exports = function({ $math_Util }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/angular_conversion.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/angular_conversion.w_compile_tf-aws.md
@@ -156,6 +156,7 @@ module.exports = function({ $math_Util }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/asec.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/asec.w_compile_tf-aws.md
@@ -157,6 +157,7 @@ module.exports = function({ $math_Util }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/asin.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/asin.w_compile_tf-aws.md
@@ -163,6 +163,7 @@ module.exports = function({ $math_Util }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/atan.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/atan.w_compile_tf-aws.md
@@ -148,6 +148,7 @@ module.exports = function({ $math_Util }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/atan2.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/atan2.w_compile_tf-aws.md
@@ -151,6 +151,7 @@ module.exports = function({ $math_Util }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/combinations.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/combinations.w_compile_tf-aws.md
@@ -145,6 +145,7 @@ module.exports = function({ $math_Util, $population, $subset }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/cos.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/cos.w_compile_tf-aws.md
@@ -150,6 +150,7 @@ module.exports = function({ $math_Util }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/cot.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/cot.w_compile_tf-aws.md
@@ -148,6 +148,7 @@ module.exports = function({ $math_Util }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/csc.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/csc.w_compile_tf-aws.md
@@ -152,6 +152,7 @@ module.exports = function({ $math_Util }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/euler.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/euler.w_compile_tf-aws.md
@@ -163,6 +163,7 @@ module.exports = function({ $compoundOneYear, $interest, $math_Util, $value }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/factorial.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/factorial.w_compile_tf-aws.md
@@ -150,6 +150,7 @@ module.exports = function({ $math_Util }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/fibonacci.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/fibonacci.w_compile_tf-aws.md
@@ -155,6 +155,7 @@ module.exports = function({ $math_Util }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/floor_ceil_round.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/floor_ceil_round.w_compile_tf-aws.md
@@ -155,6 +155,7 @@ module.exports = function({ $__x_, $__y_, $math_Util, $x, $y }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/hypot.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/hypot.w_compile_tf-aws.md
@@ -148,6 +148,7 @@ module.exports = function({ $math_Util }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/median_mode_mean.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/median_mode_mean.w_compile_tf-aws.md
@@ -327,6 +327,7 @@ module.exports = function({ $math_Util, $mean_arr }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/min_max.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/min_max.w_compile_tf-aws.md
@@ -146,6 +146,7 @@ module.exports = function({ $math_Util, $myArray }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/pi.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/pi.w_compile_tf-aws.md
@@ -163,6 +163,7 @@ module.exports = function({ $circumference, $math_Util, $r }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/prime.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/prime.w_compile_tf-aws.md
@@ -151,6 +151,7 @@ module.exports = function({ $math_Util }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/random.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/random.w_compile_tf-aws.md
@@ -146,6 +146,7 @@ module.exports = function({ $math_Util }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/sec.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/sec.w_compile_tf-aws.md
@@ -150,6 +150,7 @@ module.exports = function({ $math_Util }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/sin.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/sin.w_compile_tf-aws.md
@@ -149,6 +149,7 @@ module.exports = function({ $math_Util }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/sqrt.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/sqrt.w_compile_tf-aws.md
@@ -157,6 +157,7 @@ module.exports = function({ $math_Util }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/tan.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/tan.w_compile_tf-aws.md
@@ -148,6 +148,7 @@ module.exports = function({ $math_Util }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/tau.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/tau.w_compile_tf-aws.md
@@ -148,6 +148,7 @@ module.exports = function({ $math_Util }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/on_deploy/execute_after.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/on_deploy/execute_after.w_compile_tf-aws.md
@@ -374,6 +374,7 @@ module.exports = function({ $counter }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/queue/pop.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/queue/pop.w_compile_tf-aws.md
@@ -163,6 +163,7 @@ module.exports = function({ $q }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/queue/purge.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/queue/purge.w_compile_tf-aws.md
@@ -180,6 +180,7 @@ module.exports = function({ $q, $std_Duration, $util_Util }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/queue/set_consumer.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/queue/set_consumer.w_compile_tf-aws.md
@@ -305,6 +305,7 @@ module.exports = function({  }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/schedule/on_tick.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/schedule/on_tick.w_compile_tf-aws.md
@@ -435,6 +435,7 @@ module.exports = function({ $c1, $c2, $std_Duration, $util_Util }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/std/array.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/std/array.w_compile_tf-aws.md
@@ -1548,6 +1548,7 @@ module.exports = function({  }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/std/bool.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/std/bool.w_compile_tf-aws.md
@@ -155,6 +155,7 @@ module.exports = function({ $PARSE_ERROR, $std_Boolean, $std_Json }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/std/datetime.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/std/datetime.w_compile_tf-aws.md
@@ -166,6 +166,7 @@ module.exports = function({ $_d4_toUtc____hours, $d4_hours, $d4_timezone, $math_
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/std/duration.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/std/duration.w_compile_tf-aws.md
@@ -164,6 +164,7 @@ module.exports = function({ $std_Duration }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/std/json.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/std/json.w_compile_tf-aws.md
@@ -330,6 +330,7 @@ module.exports = function({ $std_Json }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/std/map.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/std/map.w_compile_tf-aws.md
@@ -35,6 +35,7 @@
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/std/number.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/std/number.w_compile_tf-aws.md
@@ -232,6 +232,7 @@ module.exports = function({ $std_Number }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/std/range.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/std/range.w_compile_tf-aws.md
@@ -35,6 +35,7 @@
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/std/set.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/std/set.w_compile_tf-aws.md
@@ -35,6 +35,7 @@
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/std/string.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/std/string.w_compile_tf-aws.md
@@ -1326,6 +1326,7 @@ module.exports = function({  }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/table/add_row.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/table/add_row.w_compile_tf-aws.md
@@ -196,6 +196,7 @@ module.exports = function({ $_marioInfo___gender__, $_marioInfo___role__, $_peac
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/table/list.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/table/list.w_compile_tf-aws.md
@@ -178,6 +178,7 @@ module.exports = function({ $std_String, $table }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/topic/on_message.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/topic/on_message.w_compile_tf-aws.md
@@ -431,6 +431,7 @@ module.exports = function({  }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/util/base64.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/util/base64.w_compile_tf-aws.md
@@ -153,6 +153,7 @@ module.exports = function({ $util_Util }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/util/env.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/util/env.w_compile_tf-aws.md
@@ -147,6 +147,7 @@ module.exports = function({ $NIL, $RANDOM, $util_Util }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/util/nanoid.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/util/nanoid.w_compile_tf-aws.md
@@ -158,6 +158,7 @@ module.exports = function({ $util_Util }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/util/sha256.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/util/sha256.w_compile_tf-aws.md
@@ -146,6 +146,7 @@ module.exports = function({ $util_Util }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/util/sleep.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/util/sleep.w_compile_tf-aws.md
@@ -164,6 +164,7 @@ module.exports = function({  }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/util/uuidv4.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/util/uuidv4.w_compile_tf-aws.md
@@ -173,6 +173,7 @@ module.exports = function({  }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/util/wait-until.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/util/wait-until.w_compile_tf-aws.md
@@ -582,6 +582,7 @@ module.exports = function({  }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/website/two_websites.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/website/two_websites.w_compile_tf-aws.md
@@ -514,6 +514,7 @@ module.exports = function({ $http_Util, $w1_url, $w2_url }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/website/website.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/website/website.w_compile_tf-aws.md
@@ -365,6 +365,7 @@ module.exports = function({  }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/valid/anon_function.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/anon_function.w_compile_tf-aws.md
@@ -35,6 +35,7 @@
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/valid/api.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/api.w_compile_tf-aws.md
@@ -476,6 +476,7 @@ module.exports = function({  }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/valid/api_path_vars.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/api_path_vars.w_compile_tf-aws.md
@@ -305,6 +305,7 @@ module.exports = function({ $api_url, $http_Util, $std_Json }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/valid/api_valid_path.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/api_valid_path.w_compile_tf-aws.md
@@ -266,6 +266,7 @@ module.exports = function({  }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/valid/assert.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/assert.w_compile_tf-aws.md
@@ -159,6 +159,7 @@ module.exports = function({ $s1, $s2 }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/valid/asynchronous_model_implicit_await_in_functions.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/asynchronous_model_implicit_await_in_functions.w_compile_tf-aws.md
@@ -244,6 +244,7 @@ module.exports = function({ $strToStr }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/valid/baz.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/baz.w_compile_tf-aws.md
@@ -47,6 +47,7 @@ module.exports = function({  }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/valid/bring_awscdk.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/bring_awscdk.w_compile_tf-aws.md
@@ -47,6 +47,7 @@ module.exports = function({  }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/valid/bring_cdktf.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/bring_cdktf.w_compile_tf-aws.md
@@ -64,6 +64,7 @@ module.exports = function({  }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/valid/bring_jsii.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/bring_jsii.w_compile_tf-aws.md
@@ -145,6 +145,7 @@ module.exports = function({ $greeting }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/valid/bring_jsii_path.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/bring_jsii_path.w_compile_tf-aws.md
@@ -145,6 +145,7 @@ module.exports = function({ $greeting }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/valid/bring_local.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/bring_local.w_compile_tf-aws.md
@@ -382,6 +382,7 @@ module.exports = function({ $stdlib }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/valid/bring_local_normalization.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/bring_local_normalization.w_compile_tf-aws.md
@@ -190,6 +190,7 @@ module.exports = function({ $stdlib }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/valid/bring_projen.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/bring_projen.w_compile_tf-aws.md
@@ -35,6 +35,7 @@
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/valid/bucket_events.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/bucket_events.w_compile_tf-aws.md
@@ -1323,6 +1323,7 @@ module.exports = function({ $b }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/valid/bucket_keys.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/bucket_keys.w_compile_tf-aws.md
@@ -184,6 +184,7 @@ module.exports = function({ $b }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/valid/call_static_of_myself.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/call_static_of_myself.w_compile_tf-aws.md
@@ -192,6 +192,7 @@ module.exports = function({  }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/valid/calling_inflight_variants.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/calling_inflight_variants.w_compile_tf-aws.md
@@ -204,6 +204,7 @@ module.exports = function({  }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/valid/capture_containers.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/capture_containers.w_compile_tf-aws.md
@@ -153,6 +153,7 @@ module.exports = function({ $Object_keys_myMap__length, $__bang__in___arrOfMap_a
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/valid/capture_in_binary.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/capture_in_binary.w_compile_tf-aws.md
@@ -176,6 +176,7 @@ module.exports = function({ $b, $x }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/valid/capture_mutables.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/capture_mutables.w_compile_tf-aws.md
@@ -166,6 +166,7 @@ module.exports = function({ $handler }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/valid/capture_primitives.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/capture_primitives.w_compile_tf-aws.md
@@ -159,6 +159,7 @@ module.exports = function({ $myBool, $myDur_hours, $myDur_minutes, $myDur_second
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/valid/capture_reassigable_class_field.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/capture_reassigable_class_field.w_compile_tf-aws.md
@@ -262,6 +262,7 @@ module.exports = function({  }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/valid/capture_reassignable.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/capture_reassignable.w_compile_tf-aws.md
@@ -163,6 +163,7 @@ module.exports = function({ $handler }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/valid/capture_resource_and_data.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/capture_resource_and_data.w_compile_tf-aws.md
@@ -189,6 +189,7 @@ module.exports = function({ $data_size, $queue, $res }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/valid/capture_resource_with_no_inflight.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/capture_resource_with_no_inflight.w_compile_tf-aws.md
@@ -184,6 +184,7 @@ module.exports = function({  }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/valid/capture_tokens.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/capture_tokens.w_compile_tf-aws.md
@@ -346,6 +346,7 @@ module.exports = function({  }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/valid/captures.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/captures.w_compile_tf-aws.md
@@ -596,6 +596,7 @@ module.exports = function({ $headers }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/valid/class.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/class.w_compile_tf-aws.md
@@ -621,6 +621,7 @@ module.exports = function({ $PaidStudent }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/valid/closure_class.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/closure_class.w_compile_tf-aws.md
@@ -167,6 +167,7 @@ module.exports = function({  }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/valid/construct-base.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/construct-base.w_compile_tf-aws.md
@@ -59,6 +59,7 @@ module.exports = function({  }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/valid/container_types.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/container_types.w_compile_tf-aws.md
@@ -119,6 +119,7 @@
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/valid/custom_obj_id.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/custom_obj_id.w_compile_tf-aws.md
@@ -47,6 +47,7 @@ module.exports = function({  }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/valid/debug_env.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/debug_env.w_compile_tf-aws.md
@@ -47,6 +47,7 @@ module.exports = function({  }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/valid/deep_equality.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/deep_equality.w_compile_tf-aws.md
@@ -1148,6 +1148,7 @@ module.exports = function({ $arrayA, $arrayB }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/valid/double_reference.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/double_reference.w_compile_tf-aws.md
@@ -200,6 +200,7 @@ module.exports = function({ $initCount }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/valid/doubler.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/doubler.w_compile_tf-aws.md
@@ -302,6 +302,7 @@ module.exports = function({  }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/valid/enums.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/enums.w_compile_tf-aws.md
@@ -146,6 +146,7 @@ module.exports = function({ $SomeEnum, $one, $two }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/valid/expressions_binary_operators.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/expressions_binary_operators.w_compile_tf-aws.md
@@ -35,6 +35,7 @@
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/valid/expressions_string_interpolation.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/expressions_string_interpolation.w_compile_tf-aws.md
@@ -35,6 +35,7 @@
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/valid/extern_implementation.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/extern_implementation.w_compile_tf-aws.md
@@ -262,6 +262,7 @@ module.exports = function({  }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/valid/file_counter.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/file_counter.w_compile_tf-aws.md
@@ -221,6 +221,7 @@ module.exports = function({ $bucket, $counter }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/valid/for_loop.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/for_loop.w_compile_tf-aws.md
@@ -166,6 +166,7 @@ module.exports = function({  }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/valid/forward_decl.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/forward_decl.w_compile_tf-aws.md
@@ -47,6 +47,7 @@ module.exports = function({  }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/valid/function_returns_function.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/function_returns_function.w_compile_tf-aws.md
@@ -155,6 +155,7 @@ module.exports = function({  }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/valid/function_type.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/function_type.w_compile_tf-aws.md
@@ -85,6 +85,7 @@ module.exports = function({  }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/valid/function_variadic_arguments.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/function_variadic_arguments.w_compile_tf-aws.md
@@ -119,6 +119,7 @@
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/valid/hello.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/hello.w_compile_tf-aws.md
@@ -198,6 +198,7 @@ module.exports = function({ $bucket }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/valid/identical_inflights.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/identical_inflights.w_compile_tf-aws.md
@@ -69,6 +69,7 @@ module.exports = function({  }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/valid/impl_interface.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/impl_interface.w_compile_tf-aws.md
@@ -117,6 +117,7 @@ module.exports = function({  }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/valid/implicit_std.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/implicit_std.w_compile_tf-aws.md
@@ -35,6 +35,7 @@
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/valid/inference.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/inference.w_compile_tf-aws.md
@@ -214,6 +214,7 @@ module.exports = function({  }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/valid/inflight-subscribers.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/inflight-subscribers.w_compile_tf-aws.md
@@ -294,6 +294,7 @@ module.exports = function({  }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/valid/inflight_capture_static.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/inflight_capture_static.w_compile_tf-aws.md
@@ -448,6 +448,7 @@ module.exports = function({  }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/valid/inflight_class_as_struct_members.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/inflight_class_as_struct_members.w_compile_tf-aws.md
@@ -208,6 +208,7 @@ module.exports = function({  }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/valid/inflight_class_capture_const.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/inflight_class_capture_const.w_compile_tf-aws.md
@@ -159,6 +159,7 @@ module.exports = function({ $myConst }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/valid/inflight_class_capture_preflight_object.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/inflight_class_capture_preflight_object.w_compile_tf-aws.md
@@ -35,6 +35,7 @@
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/valid/inflight_class_definitions.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/inflight_class_definitions.w_compile_tf-aws.md
@@ -261,6 +261,7 @@ module.exports = function({  }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/valid/inflight_class_inner_capture_mutable.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/inflight_class_inner_capture_mutable.w_compile_tf-aws.md
@@ -156,6 +156,7 @@ module.exports = function({  }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/valid/inflight_class_inside_inflight_closure.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/inflight_class_inside_inflight_closure.w_compile_tf-aws.md
@@ -379,6 +379,7 @@ module.exports = function({  }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/valid/inflight_class_modifiers.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/inflight_class_modifiers.w_compile_tf-aws.md
@@ -50,6 +50,7 @@ module.exports = function({  }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/valid/inflight_class_outside_inflight_closure.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/inflight_class_outside_inflight_closure.w_compile_tf-aws.md
@@ -163,6 +163,7 @@ module.exports = function({  }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/valid/inflight_class_structural_interace_handler.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/inflight_class_structural_interace_handler.w_compile_tf-aws.md
@@ -169,6 +169,7 @@ module.exports = function({  }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/valid/inflight_class_without_init.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/inflight_class_without_init.w_compile_tf-aws.md
@@ -155,6 +155,7 @@ module.exports = function({  }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/valid/inflight_concat.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/inflight_concat.w_compile_tf-aws.md
@@ -51,6 +51,7 @@ module.exports = function({  }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/valid/inflights_calling_inflights.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/inflights_calling_inflights.w_compile_tf-aws.md
@@ -406,6 +406,7 @@ module.exports = function({  }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/valid/interface.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/interface.w_compile_tf-aws.md
@@ -35,6 +35,7 @@
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/valid/issue_2889.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/issue_2889.w_compile_tf-aws.md
@@ -306,6 +306,7 @@ module.exports = function({ $api_url, $http_Util, $std_Json }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/valid/json.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/json.w_compile_tf-aws.md
@@ -271,6 +271,7 @@ module.exports = function({  }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/valid/json_bucket.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/json_bucket.w_compile_tf-aws.md
@@ -265,6 +265,7 @@ module.exports = function({ $b, $fileName, $getJson, $j }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/valid/json_static.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/json_static.w_compile_tf-aws.md
@@ -235,6 +235,7 @@ module.exports = function({ $std_Json }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/valid/json_string_interpolation.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/json_string_interpolation.w_compile_tf-aws.md
@@ -35,6 +35,7 @@
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/valid/lift_expr_with_this.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/lift_expr_with_this.w_compile_tf-aws.md
@@ -158,6 +158,7 @@ module.exports = function({  }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/valid/lift_redefinition.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/lift_redefinition.w_compile_tf-aws.md
@@ -147,6 +147,7 @@ module.exports = function({ $y }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/valid/lift_this.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/lift_this.w_compile_tf-aws.md
@@ -166,6 +166,7 @@ module.exports = function({  }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/valid/lift_via_closure.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/lift_via_closure.w_compile_tf-aws.md
@@ -338,6 +338,7 @@ module.exports = function({ $bucket2 }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/valid/lift_via_closure_explicit.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/lift_via_closure_explicit.w_compile_tf-aws.md
@@ -176,6 +176,7 @@ module.exports = function({  }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/valid/mut_container_types.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/mut_container_types.w_compile_tf-aws.md
@@ -119,6 +119,7 @@
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/valid/nil.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/nil.w_compile_tf-aws.md
@@ -266,6 +266,7 @@ module.exports = function({  }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/valid/optionals.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/optionals.w_compile_tf-aws.md
@@ -291,6 +291,7 @@ module.exports = function({  }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/valid/primitive_methods.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/primitive_methods.w_compile_tf-aws.md
@@ -35,6 +35,7 @@
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/valid/print.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/print.w_compile_tf-aws.md
@@ -234,6 +234,7 @@ module.exports = function({  }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/valid/reassignment.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/reassignment.w_compile_tf-aws.md
@@ -47,6 +47,7 @@ module.exports = function({  }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/valid/redis.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/redis.w_compile_tf-aws.md
@@ -597,6 +597,7 @@ module.exports = function({ $queue, $r, $r2, $util_Util }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/valid/resource.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/resource.w_compile_tf-aws.md
@@ -842,6 +842,7 @@ module.exports = function({  }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/valid/resource_as_inflight_literal.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/resource_as_inflight_literal.w_compile_tf-aws.md
@@ -233,6 +233,7 @@ module.exports = function({  }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/valid/resource_call_static.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/resource_call_static.w_compile_tf-aws.md
@@ -180,6 +180,7 @@ module.exports = function({ $globalCounter }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/valid/resource_captures.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/resource_captures.w_compile_tf-aws.md
@@ -384,6 +384,7 @@ module.exports = function({  }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/valid/resource_captures_globals.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/resource_captures_globals.w_compile_tf-aws.md
@@ -516,6 +516,7 @@ module.exports = function({ $_parentThis_localCounter, $globalCounter }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/valid/service.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/service.w_compile_tf-aws.md
@@ -35,6 +35,7 @@
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/valid/shadowing.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/shadowing.w_compile_tf-aws.md
@@ -175,6 +175,7 @@ module.exports = function({ $fn }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/valid/statements_if.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/statements_if.w_compile_tf-aws.md
@@ -164,6 +164,7 @@ module.exports = function({  }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/valid/statements_variable_declarations.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/statements_variable_declarations.w_compile_tf-aws.md
@@ -35,6 +35,7 @@
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/valid/static_members.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/static_members.w_compile_tf-aws.md
@@ -170,6 +170,7 @@ module.exports = function({  }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/valid/std_containers.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/std_containers.w_compile_tf-aws.md
@@ -73,6 +73,7 @@ module.exports = function({ $Animal }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/valid/std_string.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/std_string.w_compile_tf-aws.md
@@ -147,6 +147,7 @@ module.exports = function({ $__s1_split_______at_1__, $_s1_concat_s2__, $s1_inde
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/valid/store.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/store.w_compile_tf-aws.md
@@ -122,6 +122,7 @@ module.exports = function({ $stdlib }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/valid/struct_from_json.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/struct_from_json.w_compile_tf-aws.md
@@ -625,6 +625,7 @@ module.exports = function({ $Student, $jStudent1 }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/valid/structs.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/structs.w_compile_tf-aws.md
@@ -367,6 +367,7 @@ module.exports = function(stdStruct) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/valid/super_call.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/super_call.w_compile_tf-aws.md
@@ -384,6 +384,7 @@ module.exports = function({ $InflightA }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/valid/symbol_shadow.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/symbol_shadow.w_compile_tf-aws.md
@@ -419,6 +419,7 @@ module.exports = function({  }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/valid/table.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/table.w_compile_tf-aws.md
@@ -56,6 +56,7 @@
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/valid/test_bucket.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/test_bucket.w_compile_tf-aws.md
@@ -265,6 +265,7 @@ module.exports = function({ $b }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/valid/test_without_bring.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/test_without_bring.w_compile_tf-aws.md
@@ -145,6 +145,7 @@ module.exports = function({  }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/valid/try_catch.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/try_catch.w_compile_tf-aws.md
@@ -35,6 +35,7 @@
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/valid/use_inflight_method_inside_init_closure.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/use_inflight_method_inside_init_closure.w_compile_tf-aws.md
@@ -159,6 +159,7 @@ module.exports = function({  }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/valid/website_with_api.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/website_with_api.w_compile_tf-aws.md
@@ -631,6 +631,7 @@ module.exports = function({  }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/valid/while.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/while.w_compile_tf-aws.md
@@ -35,6 +35,7 @@
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/__snapshots__/test_corpus/valid/while_loop_await.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/while_loop_await.w_compile_tf-aws.md
@@ -176,6 +176,7 @@ module.exports = function({  }) {
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
+const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;

--- a/tools/hangar/src/unsupported.test.ts
+++ b/tools/hangar/src/unsupported.test.ts
@@ -32,7 +32,7 @@ test("unsupported resource in target", async ({ expect }) => {
   expect(sanitizeOutput(result.stderr)).toMatchInlineSnapshot(`
     "ERROR: Unable to create an instance of abstract type \\"@winglang/sdk.cloud.Schedule\\" for this target
 
-    target/test.tfgcp.[REDACTED].tmp/.wing/preflight.js:8
+    target/test.tfgcp.[REDACTED].tmp/.wing/preflight.js:9
          constructor(scope, id) {
            super(scope, id);
     >>     this.node.root.newAbstract(\\"@winglang/sdk.cloud.Schedule\\",this,\\"cloud.Schedule\\");


### PR DESCRIPTION
Currently the `preflight.js` files generated by Wing contain a reference to a value named `$plugins` which has to be injected by a NodeJS VM. Because of this, it's not possible to run `node path/to/.wing/preflight.js` for debugging purposes without manually editing the file to stub in a fake value.

I've removed the need to inject this value by passing the list of plugin paths through an environment variable instead.

## Checklist

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [ ] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
