### PR TITLE
fix(sdk): defer hash calculation of api spec to terraform

### DIFF
--- a/libs/wingsdk/src/target-tf-aws/api.ts
+++ b/libs/wingsdk/src/target-tf-aws/api.ts
@@ -1,7 +1,7 @@
 import { createHash } from "crypto";
 import { join } from "path";
 
-import { Lazy } from "cdktf/lib/tokens";
+import { Fn, Lazy } from "cdktf";
 import { Construct } from "constructs";
 import { App } from "./app";
 import { Function } from "./function";
@@ -398,14 +398,7 @@ class WingRestApi extends Construct {
       },
       triggers: {
         // Trigger redeployment when the api spec changes
-        redeployment: Lazy.stringValue({
-          produce: () => {
-            const value = createHash("sha1")
-              .update(JSON.stringify(props.apiSpec))
-              .digest("hex");
-            return value;
-          },
-        }),
+        redeployment: Fn.sha256(this.api.body),
       },
     });
 

--- a/libs/wingsdk/test/target-tf-aws/__snapshots__/tokens.test.ts.snap
+++ b/libs/wingsdk/test/target-tf-aws/__snapshots__/tokens.test.ts.snap
@@ -13,9 +13,9 @@ return class Handler {
   }
 };
 })())({
-str: JSON.parse(process.env[\\"WING_TOKEN_TFTOKEN_TOKEN_7\\"]),
-num: JSON.parse(process.env[\\"WING_TOKEN_8_109562212591386E_298\\"]),
-list: JSON.parse(process.env[\\"WING_TOKEN_TFTOKEN_TOKEN_9\\"])
+str: JSON.parse(process.env[\\"WING_TOKEN_TFTOKEN_TOKEN_8\\"]),
+num: JSON.parse(process.env[\\"WING_TOKEN_8_109562212591387E_298\\"]),
+list: JSON.parse(process.env[\\"WING_TOKEN_TFTOKEN_TOKEN_10\\"])
 })"
 `;
 
@@ -39,7 +39,7 @@ exports[`captures tokens 2`] = `
         },
         "rest_api_id": "\${aws_api_gateway_rest_api.Api_api_91C07D84.id}",
         "triggers": {
-          "redeployment": "5c0f11f0478884e3d7859fa987b8b7ecf8f2f6bc",
+          "redeployment": "\${sha256(aws_api_gateway_rest_api.Api_api_91C07D84.body)}",
         },
       },
     },
@@ -81,9 +81,9 @@ exports[`captures tokens 2`] = `
         "environment": {
           "variables": {
             "WING_FUNCTION_NAME": "Api-OnRequest-c5395e41-c8f26cae",
-            "WING_TOKEN_8_109562212591386E_298": "\${jsonencode(var.Number)}",
-            "WING_TOKEN_TFTOKEN_TOKEN_7": "\${jsonencode(aws_api_gateway_stage.Api_api_stage_E0FA39D6.invoke_url)}",
-            "WING_TOKEN_TFTOKEN_TOKEN_9": "\${jsonencode(var.List)}",
+            "WING_TOKEN_8_109562212591387E_298": "\${jsonencode(var.Number)}",
+            "WING_TOKEN_TFTOKEN_TOKEN_10": "\${jsonencode(var.List)}",
+            "WING_TOKEN_TFTOKEN_TOKEN_8": "\${jsonencode(aws_api_gateway_stage.Api_api_stage_E0FA39D6.invoke_url)}",
           },
         },
         "function_name": "Api-OnRequest-c5395e41-c8f26cae",

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/api/delete.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/api/delete.w_compile_tf-aws.md
@@ -103,7 +103,7 @@ module.exports = function({ $api_url, $http_HttpMethod, $http_Util }) {
         },
         "rest_api_id": "${aws_api_gateway_rest_api.cloudApi_api_2B334D75.id}",
         "triggers": {
-          "redeployment": "3f2ed3e388571f5b15cbc06ba1b47979abe75776"
+          "redeployment": "${sha256(aws_api_gateway_rest_api.cloudApi_api_2B334D75.body)}"
         }
       }
     },
@@ -240,7 +240,7 @@ module.exports = function({ $api_url, $http_HttpMethod, $http_Util }) {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c897cd38",
             "WING_TARGET": "tf-aws",
-            "WING_TOKEN_TFTOKEN_TOKEN_7": "${jsonencode(aws_api_gateway_stage.cloudApi_api_stage_BBB283E4.invoke_url)}"
+            "WING_TOKEN_TFTOKEN_TOKEN_8": "${jsonencode(aws_api_gateway_stage.cloudApi_api_stage_BBB283E4.invoke_url)}"
           }
         },
         "function_name": "Handler-c897cd38",

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/api/get.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/api/get.w_compile_tf-aws.md
@@ -107,7 +107,7 @@ module.exports = function({ $api_url, $body, $http_HttpMethod, $http_Util }) {
         },
         "rest_api_id": "${aws_api_gateway_rest_api.cloudApi_api_2B334D75.id}",
         "triggers": {
-          "redeployment": "10bb301799b13187f97edf464edbfe465c48a11e"
+          "redeployment": "${sha256(aws_api_gateway_rest_api.cloudApi_api_2B334D75.body)}"
         }
       }
     },
@@ -244,7 +244,7 @@ module.exports = function({ $api_url, $body, $http_HttpMethod, $http_Util }) {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c838ce37",
             "WING_TARGET": "tf-aws",
-            "WING_TOKEN_TFTOKEN_TOKEN_7": "${jsonencode(aws_api_gateway_stage.cloudApi_api_stage_BBB283E4.invoke_url)}"
+            "WING_TOKEN_TFTOKEN_TOKEN_8": "${jsonencode(aws_api_gateway_stage.cloudApi_api_stage_BBB283E4.invoke_url)}"
           }
         },
         "function_name": "Handler-c838ce37",

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/api/options.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/api/options.w_compile_tf-aws.md
@@ -137,7 +137,7 @@ module.exports = function({ $api_url, $http_HttpMethod, $http_Util, $path }) {
         },
         "rest_api_id": "${aws_api_gateway_rest_api.cloudApi_api_2B334D75.id}",
         "triggers": {
-          "redeployment": "9bcd95d1a951f5b01da431cbc7b3eb0ab691fdeb"
+          "redeployment": "${sha256(aws_api_gateway_rest_api.cloudApi_api_2B334D75.body)}"
         }
       }
     },
@@ -390,7 +390,7 @@ module.exports = function({ $api_url, $http_HttpMethod, $http_Util, $path }) {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c8f5c667",
             "WING_TARGET": "tf-aws",
-            "WING_TOKEN_TFTOKEN_TOKEN_7": "${jsonencode(aws_api_gateway_stage.cloudApi_api_stage_BBB283E4.invoke_url)}"
+            "WING_TOKEN_TFTOKEN_TOKEN_8": "${jsonencode(aws_api_gateway_stage.cloudApi_api_stage_BBB283E4.invoke_url)}"
           }
         },
         "function_name": "Handler-c8f5c667",

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/api/patch.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/api/patch.w_compile_tf-aws.md
@@ -104,7 +104,7 @@ module.exports = function({ $_id, $api_url, $body, $http_HttpMethod, $http_Util,
         },
         "rest_api_id": "${aws_api_gateway_rest_api.cloudApi_api_2B334D75.id}",
         "triggers": {
-          "redeployment": "2afd05beaf27bcecd099e20f65c2990011bdae48"
+          "redeployment": "${sha256(aws_api_gateway_rest_api.cloudApi_api_2B334D75.body)}"
         }
       }
     },
@@ -241,7 +241,7 @@ module.exports = function({ $_id, $api_url, $body, $http_HttpMethod, $http_Util,
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c89df580",
             "WING_TARGET": "tf-aws",
-            "WING_TOKEN_TFTOKEN_TOKEN_7": "${jsonencode(aws_api_gateway_stage.cloudApi_api_stage_BBB283E4.invoke_url)}"
+            "WING_TOKEN_TFTOKEN_TOKEN_8": "${jsonencode(aws_api_gateway_stage.cloudApi_api_stage_BBB283E4.invoke_url)}"
           }
         },
         "function_name": "Handler-c89df580",

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/api/post.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/api/post.w_compile_tf-aws.md
@@ -103,7 +103,7 @@ module.exports = function({ $api_url, $body, $http_HttpMethod, $http_Util, $std_
         },
         "rest_api_id": "${aws_api_gateway_rest_api.cloudApi_api_2B334D75.id}",
         "triggers": {
-          "redeployment": "afb250682538f14812af9e01ecd4d6310c8cfb87"
+          "redeployment": "${sha256(aws_api_gateway_rest_api.cloudApi_api_2B334D75.body)}"
         }
       }
     },
@@ -240,7 +240,7 @@ module.exports = function({ $api_url, $body, $http_HttpMethod, $http_Util, $std_
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c88947b5",
             "WING_TARGET": "tf-aws",
-            "WING_TOKEN_TFTOKEN_TOKEN_7": "${jsonencode(aws_api_gateway_stage.cloudApi_api_stage_BBB283E4.invoke_url)}"
+            "WING_TOKEN_TFTOKEN_TOKEN_8": "${jsonencode(aws_api_gateway_stage.cloudApi_api_stage_BBB283E4.invoke_url)}"
           }
         },
         "function_name": "Handler-c88947b5",

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/api/put.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/api/put.w_compile_tf-aws.md
@@ -108,7 +108,7 @@ module.exports = function({ $_id, $api_url, $body, $http_HttpMethod, $http_Util,
         },
         "rest_api_id": "${aws_api_gateway_rest_api.cloudApi_api_2B334D75.id}",
         "triggers": {
-          "redeployment": "4c47cf4383648e8878b273255efa16fb8e65ec18"
+          "redeployment": "${sha256(aws_api_gateway_rest_api.cloudApi_api_2B334D75.body)}"
         }
       }
     },
@@ -245,7 +245,7 @@ module.exports = function({ $_id, $api_url, $body, $http_HttpMethod, $http_Util,
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c8e4b12f",
             "WING_TARGET": "tf-aws",
-            "WING_TOKEN_TFTOKEN_TOKEN_7": "${jsonencode(aws_api_gateway_stage.cloudApi_api_stage_BBB283E4.invoke_url)}"
+            "WING_TOKEN_TFTOKEN_TOKEN_8": "${jsonencode(aws_api_gateway_stage.cloudApi_api_stage_BBB283E4.invoke_url)}"
           }
         },
         "function_name": "Handler-c8e4b12f",

--- a/tools/hangar/__snapshots__/test_corpus/valid/api.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/api.w_compile_tf-aws.md
@@ -126,7 +126,7 @@ module.exports = function({  }) {
         },
         "rest_api_id": "${aws_api_gateway_rest_api.A_cloudApi_api_37FCEF91.id}",
         "triggers": {
-          "redeployment": "66f9e4b69146527e1951e6308dc9128a3ca41abb"
+          "redeployment": "${sha256(aws_api_gateway_rest_api.A_cloudApi_api_37FCEF91.body)}"
         }
       },
       "cloudApi_api_deployment_545514BF": {
@@ -141,7 +141,7 @@ module.exports = function({  }) {
         },
         "rest_api_id": "${aws_api_gateway_rest_api.cloudApi_api_2B334D75.id}",
         "triggers": {
-          "redeployment": "d4a66f49086c55ef3890317ca607c501380327bb"
+          "redeployment": "${sha256(aws_api_gateway_rest_api.cloudApi_api_2B334D75.body)}"
         }
       }
     },
@@ -318,7 +318,7 @@ module.exports = function({  }) {
           "variables": {
             "WING_FUNCTION_NAME": "cloud-Api-OnRequest-73c5308f-c85168bb",
             "WING_TARGET": "tf-aws",
-            "WING_TOKEN_TFTOKEN_TOKEN_41": "${jsonencode(aws_api_gateway_stage.A_cloudApi_api_stage_6D822CCE.invoke_url)}"
+            "WING_TOKEN_TFTOKEN_TOKEN_43": "${jsonencode(aws_api_gateway_stage.A_cloudApi_api_stage_6D822CCE.invoke_url)}"
           }
         },
         "function_name": "cloud-Api-OnRequest-73c5308f-c85168bb",
@@ -378,7 +378,7 @@ module.exports = function({  }) {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c8315524",
             "WING_TARGET": "tf-aws",
-            "WING_TOKEN_TFTOKEN_TOKEN_7": "${jsonencode(aws_api_gateway_stage.cloudApi_api_stage_BBB283E4.invoke_url)}"
+            "WING_TOKEN_TFTOKEN_TOKEN_8": "${jsonencode(aws_api_gateway_stage.cloudApi_api_stage_BBB283E4.invoke_url)}"
           }
         },
         "function_name": "Handler-c8315524",

--- a/tools/hangar/__snapshots__/test_corpus/valid/api_path_vars.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/api_path_vars.w_compile_tf-aws.md
@@ -94,7 +94,7 @@ module.exports = function({ $api_url, $http_Util, $std_Json }) {
         },
         "rest_api_id": "${aws_api_gateway_rest_api.cloudApi_api_2B334D75.id}",
         "triggers": {
-          "redeployment": "4ae1656762ef65f98b4b2e240588f473cd4e9469"
+          "redeployment": "${sha256(aws_api_gateway_rest_api.cloudApi_api_2B334D75.body)}"
         }
       }
     },
@@ -231,7 +231,7 @@ module.exports = function({ $api_url, $http_Util, $std_Json }) {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c8f4f2a1",
             "WING_TARGET": "tf-aws",
-            "WING_TOKEN_TFTOKEN_TOKEN_7": "${jsonencode(aws_api_gateway_stage.cloudApi_api_stage_BBB283E4.invoke_url)}"
+            "WING_TOKEN_TFTOKEN_TOKEN_8": "${jsonencode(aws_api_gateway_stage.cloudApi_api_stage_BBB283E4.invoke_url)}"
           }
         },
         "function_name": "Handler-c8f4f2a1",

--- a/tools/hangar/__snapshots__/test_corpus/valid/api_valid_path.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/api_valid_path.w_compile_tf-aws.md
@@ -73,7 +73,7 @@ module.exports = function({  }) {
         },
         "rest_api_id": "${aws_api_gateway_rest_api.cloudApi_api_2B334D75.id}",
         "triggers": {
-          "redeployment": "ca397382abb9ec6fa6cdfa8a96c26d44013057ba"
+          "redeployment": "${sha256(aws_api_gateway_rest_api.cloudApi_api_2B334D75.body)}"
         }
       }
     },

--- a/tools/hangar/__snapshots__/test_corpus/valid/capture_tokens.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/capture_tokens.w_compile_tf-aws.md
@@ -113,7 +113,7 @@ module.exports = function({  }) {
         },
         "rest_api_id": "${aws_api_gateway_rest_api.MyResource_cloudApi_api_4CB9B8E3.id}",
         "triggers": {
-          "redeployment": "6eb5a41974a89ebc5d63af9e7fe3ce6e1d6619c7"
+          "redeployment": "${sha256(aws_api_gateway_rest_api.MyResource_cloudApi_api_4CB9B8E3.body)}"
         }
       },
       "cloudApi_api_deployment_545514BF": {
@@ -128,7 +128,7 @@ module.exports = function({  }) {
         },
         "rest_api_id": "${aws_api_gateway_rest_api.cloudApi_api_2B334D75.id}",
         "triggers": {
-          "redeployment": "6eb5a41974a89ebc5d63af9e7fe3ce6e1d6619c7"
+          "redeployment": "${sha256(aws_api_gateway_rest_api.cloudApi_api_2B334D75.body)}"
         }
       }
     },
@@ -257,7 +257,7 @@ module.exports = function({  }) {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c8ed8f29",
             "WING_TARGET": "tf-aws",
-            "WING_TOKEN_TFTOKEN_TOKEN_7": "${jsonencode(aws_api_gateway_stage.MyResource_cloudApi_api_stage_A26656F9.invoke_url)}"
+            "WING_TOKEN_TFTOKEN_TOKEN_8": "${jsonencode(aws_api_gateway_stage.MyResource_cloudApi_api_stage_A26656F9.invoke_url)}"
           }
         },
         "function_name": "Handler-c8ed8f29",
@@ -287,7 +287,7 @@ module.exports = function({  }) {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c8ecc6d5",
             "WING_TARGET": "tf-aws",
-            "WING_TOKEN_TFTOKEN_TOKEN_30": "${jsonencode(aws_api_gateway_stage.cloudApi_api_stage_BBB283E4.invoke_url)}"
+            "WING_TOKEN_TFTOKEN_TOKEN_32": "${jsonencode(aws_api_gateway_stage.cloudApi_api_stage_BBB283E4.invoke_url)}"
           }
         },
         "function_name": "Handler-c8ecc6d5",

--- a/tools/hangar/__snapshots__/test_corpus/valid/captures.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/captures.w_compile_tf-aws.md
@@ -105,7 +105,7 @@ module.exports = function({ $headers }) {
         },
         "rest_api_id": "${aws_api_gateway_rest_api.cloudApi_api_2B334D75.id}",
         "triggers": {
-          "redeployment": "273d559c5171243e931678d9387d60465c3b99de"
+          "redeployment": "${sha256(aws_api_gateway_rest_api.cloudApi_api_2B334D75.body)}"
         }
       }
     },

--- a/tools/hangar/__snapshots__/test_corpus/valid/inference.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/inference.w_compile_tf-aws.md
@@ -73,7 +73,7 @@ module.exports = function({  }) {
         },
         "rest_api_id": "${aws_api_gateway_rest_api.cloudApi_api_2B334D75.id}",
         "triggers": {
-          "redeployment": "d4a66f49086c55ef3890317ca607c501380327bb"
+          "redeployment": "${sha256(aws_api_gateway_rest_api.cloudApi_api_2B334D75.body)}"
         }
       }
     },

--- a/tools/hangar/__snapshots__/test_corpus/valid/issue_2889.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/issue_2889.w_compile_tf-aws.md
@@ -95,7 +95,7 @@ module.exports = function({ $api_url, $http_Util, $std_Json }) {
         },
         "rest_api_id": "${aws_api_gateway_rest_api.cloudApi_api_2B334D75.id}",
         "triggers": {
-          "redeployment": "ca2771f24c2978f810a5a1a5c3373f4ac9d7d88c"
+          "redeployment": "${sha256(aws_api_gateway_rest_api.cloudApi_api_2B334D75.body)}"
         }
       }
     },
@@ -232,7 +232,7 @@ module.exports = function({ $api_url, $http_Util, $std_Json }) {
           "variables": {
             "WING_FUNCTION_NAME": "Handler-c88c3aa2",
             "WING_TARGET": "tf-aws",
-            "WING_TOKEN_TFTOKEN_TOKEN_7": "${jsonencode(aws_api_gateway_stage.cloudApi_api_stage_BBB283E4.invoke_url)}"
+            "WING_TOKEN_TFTOKEN_TOKEN_8": "${jsonencode(aws_api_gateway_stage.cloudApi_api_stage_BBB283E4.invoke_url)}"
           }
         },
         "function_name": "Handler-c88c3aa2",

--- a/tools/hangar/__snapshots__/test_corpus/valid/website_with_api.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/website_with_api.w_compile_tf-aws.md
@@ -151,7 +151,7 @@ module.exports = function({  }) {
         },
         "rest_api_id": "${aws_api_gateway_rest_api.cloudApi_api_2B334D75.id}",
         "triggers": {
-          "redeployment": "53d34a77ebc006529cbee88240e663619396c753"
+          "redeployment": "${sha256(aws_api_gateway_rest_api.cloudApi_api_2B334D75.body)}"
         }
       }
     },


### PR DESCRIPTION
Makes the code simpler and doesn't require to build keep two identical versions of the openapi spec

## Checklist

- [ ] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [ ] Description explains motivation and solution
- [ ] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
