### PR TITLE
fix(sdk): connections are kept alive in api/website simulator

### DIFF
--- a/apps/wing-console/console/app/test/describe.ts
+++ b/apps/wing-console/console/app/test/describe.ts
@@ -36,8 +36,6 @@ export const describe = (wingfile: string, callback: () => void) => {
 
     await page.goto(`http://localhost:${server.port}/`);
 
-    await page.getByTestId("loading-overlay").waitFor({ state: "hidden" });
-
     await page.waitForLoadState("domcontentloaded");
   });
 

--- a/libs/wingsdk/src/target-sim/api.inflight.ts
+++ b/libs/wingsdk/src/target-sim/api.inflight.ts
@@ -155,6 +155,7 @@ export class Api
   public async cleanup(): Promise<void> {
     this.addTrace(`Closing server on ${this.url}`);
     this.server?.close();
+    this.server?.closeAllConnections();
   }
 
   private addTrace(message: string): void {

--- a/libs/wingsdk/src/target-sim/website.inflight.ts
+++ b/libs/wingsdk/src/target-sim/website.inflight.ts
@@ -62,6 +62,7 @@ export class Website implements IWebsiteClient, ISimulatorResourceInstance {
   public async cleanup(): Promise<void> {
     this.addTrace(`Closing server on ${this.url}`);
     this.server?.close();
+    this.server?.closeAllConnections();
   }
 
   private addTrace(message: string): void {


### PR DESCRIPTION
Fixes #3709

`.close()` keeps existing connections alive, and those connections prevent the node process from closing.

Misc:
 - https://github.com/winglang/wing/pull/3964 Caused a failure in the playwright tests. I'm not sure why it would only fail sometimes, but I don't think there's a need to wait for the loading animation, regardless.


*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
