### PR TITLE
feat(compiler)!: `throw` becomes a keyword

### DIFF
--- a/apps/vscode-wing/syntaxes/wing.tmLanguage.json
+++ b/apps/vscode-wing/syntaxes/wing.tmLanguage.json
@@ -109,7 +109,7 @@
       "patterns": [
         {
           "name": "keyword.control.flow.wing",
-          "match": "\\b(else|elif|if|return|try|catch|finally|bring|as)\\b"
+          "match": "\\b(else|elif|if|return|throw|try|catch|finally|bring|as)\\b"
         },
         {
           "name": "keyword.control.loop.wing",

--- a/docs/docs/03-language-reference.md
+++ b/docs/docs/03-language-reference.md
@@ -516,12 +516,10 @@ log("UTC: ${t1.utc.toIso())}");            // output: 2023-02-09T06:21:03.000Z
 | Name     | Extra information                                        |
 | -------- | -------------------------------------------------------- |
 | `log`    | logs str                                                 |
-| `throw`  | creates and throws an instance of an exception           |
 | `assert` | checks a condition and _throws_ if evaluated to false    |
 
 > ```TS
 > log("Hello ${name}");
-> throw("a recoverable error occurred");
 > assert(x > 0);
 > ```
 
@@ -1173,7 +1171,7 @@ The loop invariant in for loops is implicitly re-assignable (`var`).
 
 ### 2.7 while
 
-**while** statement is used to execute a block of code while a condition is true.  
+The **while** statement evaluates a condition, and if it is true, a set of statements is repeated until the condition is false.
 
 > ```TS
 > // Wing program:
@@ -1185,6 +1183,19 @@ The loop invariant in for loops is implicitly re-assignable (`var`).
 [`▲ top`][top]
 
 ---
+
+### 2.8 throw
+
+The **throw** statement throws a user-defined exception.
+Execution of the current function will stop (the statements after throw won't be executed), and control will be passed to the first catch block in the call stack.
+If no catch block exists among caller functions, the program will terminate.
+
+> ```TS
+> // Wing program:
+> throw "Username must be at least 3 characters long.";
+> ```
+
+[`▲ top`][top]
 
 ## 3. Declarations
 

--- a/docs/docs/03-language-reference.md
+++ b/docs/docs/03-language-reference.md
@@ -1186,9 +1186,10 @@ The **while** statement evaluates a condition, and if it is true, a set of state
 
 ### 2.8 throw
 
-The **throw** statement throws a user-defined exception.
+The **throw** statement raises a user-defined exception, which must be a string expression.
 Execution of the current function will stop (the statements after throw won't be executed), and control will be passed to the first catch block in the call stack.
 If no catch block exists among caller functions, the program will terminate.
+(An uncaught exception in preflight causes a compilation error, while an uncaught exception in inflight causes a runtime error.)
 
 > ```TS
 > // Wing program:

--- a/examples/proposed/counting-semaphore.w
+++ b/examples/proposed/counting-semaphore.w
@@ -59,13 +59,13 @@ queue.add_consumer(inflight (message: str) => {
   let is_resource_1_acquired = resource_1.try_acquire();
   if !is_resource_1_acquired {
     // brutally error out to re-enqueue
-    throw("Failed to acquire resource 1");
+    throw "Failed to acquire resource 1";
   }
   let is_resource_2_acquired = resource_2.try_acquire();
   if !is_resource_2_acquired {
     resource_1.release();
     // brutally error out to re-enqueue
-    throw("Failed to acquire resource 2");
+    throw "Failed to acquire resource 2";
   }
 
   // real work

--- a/examples/proposed/task-manager.w
+++ b/examples/proposed/task-manager.w
@@ -54,7 +54,7 @@ resource TaskManager {
     try {
       return this.bucket.get("${id}/status");
     } catch e {
-      throw("no such key: ${id}");
+      throw "no such key: ${id}";
     }
   }
 
@@ -65,7 +65,7 @@ resource TaskManager {
     try {
       return this.bucket.get("${id}/result");
     } catch e {
-      throw("no such id: ${id}");
+      throw "no such id: ${id}";
     }
   }
 

--- a/examples/tests/error/utilities.w
+++ b/examples/tests/error/utilities.w
@@ -1,3 +1,3 @@
 assert(false);
 log("W");
-throw("me");
+throw "me";

--- a/examples/tests/invalid/throw_non_string.w
+++ b/examples/tests/invalid/throw_non_string.w
@@ -1,0 +1,3 @@
+throw 42;
+    //^ error: expected expression of type str, but received num
+    

--- a/examples/tests/sdk_tests/util/wait-until.w
+++ b/examples/tests/sdk_tests/util/wait-until.w
@@ -63,7 +63,7 @@ test "throwing exception from predicate should throw immediately" {
   try {
     util.waitUntil((): bool => { 
       invokeCounter.inc();
-      throw("ERROR"); 
+      throw "ERROR";
     });
     assert(false);
   } catch {

--- a/examples/tests/valid/dynamo.w
+++ b/examples/tests/valid/dynamo.w
@@ -25,7 +25,7 @@ class DynamoTable {
   init() {
     let target = util.env("WING_TARGET");
     if target != "tf-aws" {
-      throw("Unsupported target: ${target} (expected 'tf-aws')");
+      throw "Unsupported target: ${target} (expected 'tf-aws')";
     }
 
     this.table = new tfaws.dynamodbTable.DynamodbTable(

--- a/examples/tests/valid/dynamo_awscdk.w
+++ b/examples/tests/valid/dynamo_awscdk.w
@@ -25,7 +25,7 @@ class DynamoTable {
   init() {
     let target = util.env("WING_TARGET");
     if target != "awscdk" {
-      throw("Unsupported target: ${target} (expected 'awscdk')");
+      throw "Unsupported target: ${target} (expected 'awscdk')";
     }
 
     this.table = new awscdk.aws_dynamodb.Table(

--- a/examples/tests/valid/try_catch.w
+++ b/examples/tests/valid/try_catch.w
@@ -2,7 +2,7 @@ let var x = "";
 
 // Verify throw works and both catch and finally are executed.
 try {
-  throw("hello");
+  throw "hello";
   x = "no way I got here";
 } catch e {
   assert(e == "hello");
@@ -27,7 +27,7 @@ assert(x == "finally");
 // Verify that finally is executed even if there's no catch block.
 try {
   try {
-    throw("hello");
+    throw "hello";
   } finally {
     x = "finally with no catch";
   }
@@ -46,6 +46,6 @@ assert(x == "finally with no catch and no exception");
 // Verify we can return from a closure in a finally block.
 assert((():num => { try {} finally {return 1;}})() == 1);
 // Verify we can return from a closure in a catch block.
-assert((():num => { try {throw("");} catch {return 2;}})() == 2);
+assert((():num => { try {throw "";} catch {return 2;}})() == 2);
 // Verify we can return from a closure in a try block.
 assert((():num => { try {return 3;} finally {}})() == 3);

--- a/libs/tree-sitter-wing/grammar.js
+++ b/libs/tree-sitter-wing/grammar.js
@@ -117,7 +117,8 @@ module.exports = grammar({
         $.enum_definition,
         $.try_catch_statement,
         $.compiler_dbg_env,
-        $.super_constructor_statement
+        $.super_constructor_statement,
+        $.throw_statement,
       ),
 
     import_statement: ($) =>
@@ -147,6 +148,9 @@ module.exports = grammar({
 
     return_statement: ($) =>
       seq("return", optional(field("expression", $.expression)), $._semicolon),
+
+    throw_statement: ($) =>
+      seq("throw", optional(field("expression", $.expression)), $._semicolon),
 
     variable_assignment_statement: ($) =>
       seq(

--- a/libs/wingc/src/ast.rs
+++ b/libs/wingc/src/ast.rs
@@ -466,6 +466,7 @@ pub enum StmtKind {
 	Break,
 	Continue,
 	Return(Option<Expr>),
+	Throw(Expr),
 	Expression(Expr),
 	Assignment {
 		variable: Reference,

--- a/libs/wingc/src/fold.rs
+++ b/libs/wingc/src/fold.rs
@@ -156,6 +156,7 @@ where
 		StmtKind::Break => StmtKind::Break,
 		StmtKind::Continue => StmtKind::Continue,
 		StmtKind::Return(value) => StmtKind::Return(value.map(|value| f.fold_expr(value))),
+		StmtKind::Throw(value) => StmtKind::Throw(f.fold_expr(value)),
 		StmtKind::Expression(expr) => StmtKind::Expression(f.fold_expr(expr)),
 		StmtKind::Assignment { variable, value } => StmtKind::Assignment {
 			variable: f.fold_reference(variable),

--- a/libs/wingc/src/jsify.rs
+++ b/libs/wingc/src/jsify.rs
@@ -1039,6 +1039,7 @@ impl<'a> JSifier<'a> {
 					CodeMaker::one_line("return;")
 				}
 			}
+			StmtKind::Throw(exp) => CodeMaker::one_line(format!("throw new Error({});", self.jsify_expression(exp, ctx))),
 			StmtKind::Class(class) => self.jsify_class(env, class, ctx),
 			StmtKind::Interface { .. } => {
 				// This is a no-op in JS
@@ -1649,6 +1650,7 @@ fn get_public_symbols(scope: &Scope) -> Vec<Symbol> {
 			StmtKind::Break => {}
 			StmtKind::Continue => {}
 			StmtKind::Return(_) => {}
+			StmtKind::Throw(_) => {}
 			StmtKind::Expression(_) => {}
 			StmtKind::Assignment { .. } => {}
 			StmtKind::Scope(_) => {}

--- a/libs/wingc/src/lib.rs
+++ b/libs/wingc/src/lib.rs
@@ -242,24 +242,6 @@ pub fn type_check(
 		scope,
 		types,
 	);
-	add_builtin(
-		UtilityFunctions::Throw.to_string().as_str(),
-		Type::Function(FunctionSignature {
-			this_type: None,
-			parameters: vec![FunctionParameter {
-				typeref: types.string(),
-				name: "message".into(),
-				docs: Docs::with_summary("The message to throw"),
-				variadic: false,
-			}],
-			return_type: types.void(),
-			phase: Phase::Independent,
-			js_override: Some("{((msg) => {throw new Error(msg)})($args$)}".to_string()),
-			docs: Docs::with_summary("throws an error"),
-		}),
-		scope,
-		types,
-	);
 
 	let mut scope_env = types.get_scope_env(&scope);
 	let mut tc = TypeChecker::new(types, file_path, jsii_types, jsii_imports);

--- a/libs/wingc/src/lsp/hover.rs
+++ b/libs/wingc/src/lsp/hover.rs
@@ -673,7 +673,7 @@ assert(true);
 		r#"
 class Foo {
   inflight bar() {
-    throw("hello");
+    assert(true);
     //^
   }
 }

--- a/libs/wingc/src/lsp/snapshots/completions/call_struct_expansion.snap
+++ b/libs/wingc/src/lsp/snapshots/completions/call_struct_expansion.snap
@@ -37,18 +37,6 @@ source: libs/wingc/src/lsp/completions.rs
   command:
     title: triggerParameterHints
     command: editor.action.triggerParameterHints
-- label: throw
-  kind: 3
-  detail: "(message: str): void"
-  documentation:
-    kind: markdown
-    value: "```wing\nthrow: (message: str): void\n```\n---\nthrows an error\n\n### Parameters\n- `message` — The message to throw"
-  sortText: cc|throw
-  insertText: throw($0)
-  insertTextFormat: 2
-  command:
-    title: triggerParameterHints
-    command: editor.action.triggerParameterHints
 - label: x
   kind: 3
   detail: "preflight (arg1: A): void"

--- a/libs/wingc/src/lsp/snapshots/completions/call_struct_expansion_partial.snap
+++ b/libs/wingc/src/lsp/snapshots/completions/call_struct_expansion_partial.snap
@@ -37,18 +37,6 @@ source: libs/wingc/src/lsp/completions.rs
   command:
     title: triggerParameterHints
     command: editor.action.triggerParameterHints
-- label: throw
-  kind: 3
-  detail: "(message: str): void"
-  documentation:
-    kind: markdown
-    value: "```wing\nthrow: (message: str): void\n```\n---\nthrows an error\n\n### Parameters\n- `message` — The message to throw"
-  sortText: cc|throw
-  insertText: throw($0)
-  insertTextFormat: 2
-  command:
-    title: triggerParameterHints
-    command: editor.action.triggerParameterHints
 - label: x
   kind: 3
   detail: "preflight (arg1: A): void"

--- a/libs/wingc/src/lsp/snapshots/completions/empty.snap
+++ b/libs/wingc/src/lsp/snapshots/completions/empty.snap
@@ -25,18 +25,6 @@ source: libs/wingc/src/lsp/completions.rs
   command:
     title: triggerParameterHints
     command: editor.action.triggerParameterHints
-- label: throw
-  kind: 3
-  detail: "(message: str): void"
-  documentation:
-    kind: markdown
-    value: "```wing\nthrow: (message: str): void\n```\n---\nthrows an error\n\n### Parameters\n- `message` — The message to throw"
-  sortText: cc|throw
-  insertText: throw($0)
-  insertTextFormat: 2
-  command:
-    title: triggerParameterHints
-    command: editor.action.triggerParameterHints
 - label: "inflight () => {}"
   kind: 15
   sortText: "ll|inflight () => {}"

--- a/libs/wingc/src/lsp/snapshots/completions/only_show_symbols_in_scope.snap
+++ b/libs/wingc/src/lsp/snapshots/completions/only_show_symbols_in_scope.snap
@@ -39,18 +39,6 @@ source: libs/wingc/src/lsp/completions.rs
   command:
     title: triggerParameterHints
     command: editor.action.triggerParameterHints
-- label: throw
-  kind: 3
-  detail: "(message: str): void"
-  documentation:
-    kind: markdown
-    value: "```wing\nthrow: (message: str): void\n```\n---\nthrows an error\n\n### Parameters\n- `message` — The message to throw"
-  sortText: cc|throw
-  insertText: throw($0)
-  insertTextFormat: 2
-  command:
-    title: triggerParameterHints
-    command: editor.action.triggerParameterHints
 - label: "inflight () => {}"
   kind: 15
   sortText: "ll|inflight () => {}"

--- a/libs/wingc/src/lsp/snapshots/completions/struct_literal_value.snap
+++ b/libs/wingc/src/lsp/snapshots/completions/struct_literal_value.snap
@@ -25,18 +25,6 @@ source: libs/wingc/src/lsp/completions.rs
   command:
     title: triggerParameterHints
     command: editor.action.triggerParameterHints
-- label: throw
-  kind: 3
-  detail: "(message: str): void"
-  documentation:
-    kind: markdown
-    value: "```wing\nthrow: (message: str): void\n```\n---\nthrows an error\n\n### Parameters\n- `message` — The message to throw"
-  sortText: cc|throw
-  insertText: throw($0)
-  insertTextFormat: 2
-  command:
-    title: triggerParameterHints
-    command: editor.action.triggerParameterHints
 - label: Foo
   kind: 22
   documentation:

--- a/libs/wingc/src/lsp/snapshots/hovers/builtin_in_inflight.snap
+++ b/libs/wingc/src/lsp/snapshots/hovers/builtin_in_inflight.snap
@@ -3,12 +3,12 @@ source: libs/wingc/src/lsp/hover.rs
 ---
 contents:
   kind: markdown
-  value: "```wing\nthrow: (message: str): void\n```\n---\nthrows an error\n\n### Parameters\n- `message` — The message to throw"
+  value: "```wing\nassert: (condition: bool): void\n```\n---\nAsserts that a condition is true\n\n### Parameters\n- `condition` — The condition to assert"
 range:
   start:
     line: 3
     character: 4
   end:
     line: 3
-    character: 9
+    character: 10
 

--- a/libs/wingc/src/parser.rs
+++ b/libs/wingc/src/parser.rs
@@ -454,6 +454,7 @@ impl<'s> Parser<'s> {
 			"break_statement" => self.build_break_statement(statement_node)?,
 			"continue_statement" => self.build_continue_statement(statement_node)?,
 			"return_statement" => self.build_return_statement(statement_node, phase)?,
+			"throw_statement" => self.build_throw_statement(statement_node, phase)?,
 			"class_definition" => self.build_class_statement(statement_node, Phase::Inflight)?, // `inflight class` is always "inflight"
 			"resource_definition" => self.build_class_statement(statement_node, phase)?, // `class` without a modifier inherits from scope
 			"interface_definition" => self.build_interface_statement(statement_node, phase)?,
@@ -518,6 +519,11 @@ impl<'s> Parser<'s> {
 				None
 			},
 		))
+	}
+
+	fn build_throw_statement(&self, statement_node: &Node, phase: Phase) -> DiagnosticResult<StmtKind> {
+		let expr = self.build_expression(&statement_node.child_by_field_name("expression").unwrap(), phase)?;
+		Ok(StmtKind::Throw(expr))
 	}
 
 	/// Builds scope statements for a loop (while/for), and maintains the is_in_loop flag

--- a/libs/wingc/src/type_check.rs
+++ b/libs/wingc/src/type_check.rs
@@ -3235,6 +3235,10 @@ impl<'a> TypeChecker<'a> {
 				self.types.set_scope_env(scope, scope_env);
 				self.inner_scopes.push(scope)
 			}
+			StmtKind::Throw(exp) => {
+				let (exp_type, _) = self.type_check_exp(exp, env);
+				self.validate_type(exp_type, self.types.string(), exp);
+			}
 			StmtKind::Return(exp) => {
 				let return_type_inferred = self.update_known_inferences(&mut env.return_type, &stmt.span);
 				if let Some(return_expression) = exp {
@@ -5109,6 +5113,7 @@ fn check_is_bringable(scope: &Scope) -> bool {
 		StmtKind::Break => false,
 		StmtKind::Continue => false,
 		StmtKind::Return(_) => false,
+		StmtKind::Throw(_) => false,
 		StmtKind::Expression(_) => false,
 		StmtKind::Assignment { .. } => false,
 		StmtKind::Scope(_) => false,

--- a/libs/wingc/src/visit.rs
+++ b/libs/wingc/src/visit.rs
@@ -179,6 +179,9 @@ where
 				v.visit_expr(expr);
 			}
 		}
+		StmtKind::Throw(expr) => {
+			v.visit_expr(expr);
+		}
 		StmtKind::Scope(scope) => {
 			v.visit_scope(scope);
 		}

--- a/tools/hangar/__snapshots__/error.ts.snap
+++ b/tools/hangar/__snapshots__/error.ts.snap
@@ -214,7 +214,7 @@ exports[`utilities.w 1`] = `
        super(scope, id);
 >>     {((cond) => {if (!cond) throw new Error(\\"assertion failed: false\\")})(false)};
        {console.log(\\"W\\")};
-       {((msg) => {throw new Error(msg)})(\\"me\\")};
+       throw new Error(\\"me\\");
 
  
  

--- a/tools/hangar/__snapshots__/invalid.ts.snap
+++ b/tools/hangar/__snapshots__/invalid.ts.snap
@@ -2386,6 +2386,21 @@ Test Files 1 failed (1)
 Duration <DURATION>"
 `;
 
+exports[`throw_non_string.w 1`] = `
+"error: Expected type to be \\"str\\", but got \\"num\\" instead
+  --> ../../../examples/tests/invalid/throw_non_string.w:1:7
+  |
+1 | throw 42;
+  |       ^^ Expected type to be \\"str\\", but got \\"num\\" instead
+
+
+ 
+ 
+Tests 1 failed (1)
+Test Files 1 failed (1)
+Duration <DURATION>"
+`;
+
 exports[`try_no_catch_or_finally.w 1`] = `
 "error: Missing \`catch\` or \`finally\` blocks for this try statement
   --> ../../../examples/tests/invalid/try_no_catch_or_finally.w:1:1

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/util/wait-until.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/util/wait-until.w_compile_tf-aws.md
@@ -127,7 +127,7 @@ module.exports = function({ $invokeCounter, $util_Util }) {
       try {
         (await $util_Util.waitUntil(async () => {
           (await $invokeCounter.inc());
-          {((msg) => {throw new Error(msg)})("ERROR")};
+          throw new Error("ERROR");
         }
         ));
         {((cond) => {if (!cond) throw new Error("assertion failed: false")})(false)};

--- a/tools/hangar/__snapshots__/test_corpus/valid/debug_env.w_test_sim.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/debug_env.w_test_sim.md
@@ -4,7 +4,7 @@
 ```log
 [symbol environment at ../../../../examples/tests/valid/debug_env.w:7:5]
 level 0: { this => A }
-level 1: { A => A [type], assert => (condition: bool): void, cloud => cloud [namespace], log => (message: str): void, std => std [namespace], throw => (message: str): void }
+level 1: { A => A [type], assert => (condition: bool): void, cloud => cloud [namespace], log => (message: str): void, std => std [namespace] }
 pass ─ debug_env.wsim (no tests)
  
  

--- a/tools/hangar/__snapshots__/test_corpus/valid/try_catch.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/try_catch.w_compile_tf-aws.md
@@ -44,7 +44,7 @@ class $Root extends $stdlib.std.Resource {
     super(scope, id);
     let x = "";
     try {
-      {((msg) => {throw new Error(msg)})("hello")};
+      throw new Error("hello");
       x = "no way I got here";
     }
     catch ($error_e) {
@@ -71,7 +71,7 @@ class $Root extends $stdlib.std.Resource {
     {((cond) => {if (!cond) throw new Error("assertion failed: x == \"finally\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(x,"finally")))};
     try {
       try {
-        {((msg) => {throw new Error(msg)})("hello")};
+        throw new Error("hello");
       }
       finally {
         x = "finally with no catch";
@@ -93,9 +93,9 @@ class $Root extends $stdlib.std.Resource {
         return 1;
       }
     })()),1)))};
-    {((cond) => {if (!cond) throw new Error("assertion failed: (():num => { try {throw(\"\");} catch {return 2;}})() == 2")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(((() => {
+    {((cond) => {if (!cond) throw new Error("assertion failed: (():num => { try {throw \"\";} catch {return 2;}})() == 2")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(((() => {
       try {
-        {((msg) => {throw new Error(msg)})("")};
+        throw new Error("");
       }
       catch {
         return 2;


### PR DESCRIPTION
Changes the built-in function "throw" into a dedicated keyword. The rationale for this change (described in #2150) is that throwing is a primary operation that changes the control flow of your program - just like `if`, `while`, `return`, or `try`/`catch` - so it's more natural to have it as a dedicated statement. This means it will receive the same syntax highlighting treatment as `return` and `while` etc.

Closes #2150.

BREAKING CHANGE: `throw` is now a built-in keyword, instead of a global function. Use `throw "blah"` instead of `throw("blah")`

## Checklist

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [x] Tests added (always)
- [x] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
