### PR TITLE
chore(compiler): store paths with Utf8PathBuf

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -134,6 +134,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
 
 [[package]]
+name = "camino"
+version = "1.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c59e92b5a388f549b863a7bea62612c09f24c8393560709a54558a9abdfb3b9c"
+
+[[package]]
 name = "cc"
 version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1667,6 +1673,7 @@ name = "wingc"
 version = "0.1.0"
 dependencies = [
  "aho-corasick 0.7.20",
+ "camino",
  "colored",
  "const_format",
  "derivative",
@@ -1696,6 +1703,7 @@ name = "wingii"
 version = "0.1.0"
 dependencies = [
  "blake3",
+ "camino",
  "filetime",
  "flate2",
  "rand",

--- a/libs/wingc/Cargo.toml
+++ b/libs/wingc/Cargo.toml
@@ -24,6 +24,7 @@ const_format = "0.2.30"
 duplicate = "1.0.0"
 strum = { version = "0.24", features = ["derive"] }
 petgraph = "0.6.3"
+camino = "1.1.6"
 
 [lib]
 crate-type = ["rlib", "cdylib"]

--- a/libs/wingc/examples/compile.rs
+++ b/libs/wingc/examples/compile.rs
@@ -1,7 +1,8 @@
 // Compiles a source file and prints any errors to stderr.
 // This should only be used for testing wingc directly.
 
-use std::{env, fs, path::Path, process};
+use camino::{Utf8Path, Utf8PathBuf};
+use std::{env, fs, process};
 use wingc::{compile, diagnostic::get_diagnostics};
 
 pub fn main() {
@@ -11,15 +12,15 @@ pub fn main() {
 		panic!("Usage: cargo run --example compile <source_file>");
 	}
 
-	let source_path = &args[1];
-	let source_path = Path::new(source_path);
-	let source_text = fs::read_to_string(source_path).unwrap();
+	let source_path = Utf8Path::new(&args[1]).canonicalize_utf8().unwrap();
+	let source_text = fs::read_to_string(&source_path).unwrap();
+	let target_dir: Utf8PathBuf = env::current_dir().unwrap().join("target").try_into().unwrap();
 
 	let results = compile(
-		source_path,
+		&source_path,
 		source_text,
-		Some(env::current_dir().unwrap().join("target").as_path()),
-		Some(source_path.canonicalize().unwrap().parent().unwrap()),
+		Some(&target_dir),
+		Some(source_path.parent().unwrap()),
 	);
 	if results.is_err() {
 		let mut diags = get_diagnostics();

--- a/libs/wingc/src/lib.rs
+++ b/libs/wingc/src/lib.rs
@@ -8,6 +8,7 @@
 extern crate lazy_static;
 
 use ast::{Scope, Symbol, UtilityFunctions};
+use camino::{Utf8Path, Utf8PathBuf};
 use closure_transform::ClosureTransformer;
 use comp_ctx::set_custom_panic_hook;
 use diagnostic::{found_errors, report_diagnostic, Diagnostic};
@@ -30,7 +31,6 @@ use wingii::type_system::TypeSystem;
 use crate::docs::Docs;
 use std::alloc::{alloc, dealloc, Layout};
 
-use std::path::{Path, PathBuf};
 use std::{fs, mem};
 
 use crate::ast::Phase;
@@ -150,13 +150,13 @@ pub unsafe extern "C" fn wingc_compile(ptr: u32, len: u32) -> u64 {
 	let args = ptr_to_string(ptr, len);
 
 	let split = args.split(";").collect::<Vec<&str>>();
-	let source_file = Path::new(split[0]);
-	let output_dir = split.get(1).map(|s| Path::new(s));
-	let absolute_project_dir = split.get(2).map(|s| Path::new(s));
+	let source_file = Utf8Path::new(split[0]);
+	let output_dir = split.get(1).map(|s| Utf8Path::new(s));
+	let absolute_project_dir = split.get(2).map(|s| Utf8Path::new(s));
 
 	if !source_file.exists() {
 		report_diagnostic(Diagnostic {
-			message: format!("Source file cannot be found: {}", source_file.display()),
+			message: format!("Source file cannot be found: {}", source_file),
 			span: None,
 		});
 		return WASM_RETURN_ERROR;
@@ -164,10 +164,7 @@ pub unsafe extern "C" fn wingc_compile(ptr: u32, len: u32) -> u64 {
 
 	if source_file.is_dir() {
 		report_diagnostic(Diagnostic {
-			message: format!(
-				"Source path must be a file (not a directory): {}",
-				source_file.display()
-			),
+			message: format!("Source path must be a file (not a directory): {}", source_file),
 			span: None,
 		});
 		return WASM_RETURN_ERROR;
@@ -177,7 +174,7 @@ pub unsafe extern "C" fn wingc_compile(ptr: u32, len: u32) -> u64 {
 		Ok(text) => text,
 		Err(e) => {
 			report_diagnostic(Diagnostic {
-				message: format!("Could not read file \"{}\": {}", source_file.display(), e),
+				message: format!("Could not read file \"{}\": {}", source_file, e),
 				span: None,
 			});
 			return WASM_RETURN_ERROR;
@@ -195,7 +192,7 @@ pub unsafe extern "C" fn wingc_compile(ptr: u32, len: u32) -> u64 {
 pub fn type_check(
 	scope: &mut Scope,
 	types: &mut Types,
-	file_path: &Path,
+	file_path: &Utf8Path,
 	jsii_types: &mut TypeSystem,
 	jsii_imports: &mut Vec<JsiiImportSpec>,
 ) {
@@ -288,13 +285,13 @@ fn add_builtin(name: &str, typ: Type, scope: &mut Scope, types: &mut Types) {
 }
 
 pub fn compile(
-	source_path: &Path,
+	source_path: &Utf8Path,
 	source_text: String,
-	out_dir: Option<&Path>,
-	absolute_project_root: Option<&Path>,
+	out_dir: Option<&Utf8Path>,
+	absolute_project_root: Option<&Utf8Path>,
 ) -> Result<CompilerOutput, ()> {
-	let file_name = source_path.file_name().unwrap().to_str().unwrap();
-	let default_out_dir = PathBuf::from(format!("{}.out", file_name));
+	let file_name = source_path.file_name().unwrap();
+	let default_out_dir = Utf8PathBuf::from(format!("{}.out", file_name));
 	let out_dir = out_dir.unwrap_or(default_out_dir.as_ref());
 
 	// -- PARSING PHASE --
@@ -321,7 +318,7 @@ pub fn compile(
 			let scope = inflight_transformer.fold_scope(scope);
 			(path, scope)
 		})
-		.collect::<IndexMap<PathBuf, Scope>>();
+		.collect::<IndexMap<Utf8PathBuf, Scope>>();
 
 	// -- TYPECHECKING PHASE --
 
@@ -354,7 +351,7 @@ pub fn compile(
 	// Verify that the project dir is absolute
 	if !is_project_dir_absolute(&project_dir) {
 		report_diagnostic(Diagnostic {
-			message: format!("Project directory must be absolute: {}", project_dir.display()),
+			message: format!("Project directory must be absolute: {}", project_dir),
 			span: None,
 		});
 		return Err(());
@@ -371,7 +368,7 @@ pub fn compile(
 			lift.visit_scope(&scope);
 			(path, scope)
 		})
-		.collect::<IndexMap<PathBuf, Scope>>();
+		.collect::<IndexMap<Utf8PathBuf, Scope>>();
 
 	// bail out now (before jsification) if there are errors (no point in jsifying)
 	if found_errors() {
@@ -398,15 +395,15 @@ pub fn compile(
 	return Ok(CompilerOutput {});
 }
 
-fn is_project_dir_absolute(project_dir: &PathBuf) -> bool {
+fn is_project_dir_absolute(project_dir: &Utf8PathBuf) -> bool {
 	if project_dir.starts_with("/") {
 		return true;
 	}
 
-	let dir_str = project_dir.to_str().expect("Project dir is valid UTF-8");
+	let project_dir = project_dir.as_str();
 	// Check if this is a Windows path instead by checking if the second char is a colon
-	// Note: Cannot use Path::is_absolute() because it doesn't work with Windows paths on WASI
-	if dir_str.len() < 2 || dir_str.chars().nth(1).expect("Project dir has second character") != ':' {
+	// Note: Cannot use Utf8Path::is_absolute() because it doesn't work with Windows paths on WASI
+	if project_dir.len() < 2 || project_dir.chars().nth(1).expect("Project dir has second character") != ':' {
 		return false;
 	}
 
@@ -415,31 +412,27 @@ fn is_project_dir_absolute(project_dir: &PathBuf) -> bool {
 
 #[cfg(test)]
 mod sanity {
-	use crate::{compile, diagnostic::assert_no_panics};
-	use std::{
-		fs,
-		path::{Path, PathBuf},
-	};
+	use camino::Utf8PathBuf;
 
-	fn get_wing_files<P>(dir: P) -> impl Iterator<Item = PathBuf>
+	use crate::{compile, diagnostic::assert_no_panics};
+	use std::{fs, path::Path};
+
+	fn get_wing_files<P>(dir: P) -> impl Iterator<Item = Utf8PathBuf>
 	where
 		P: AsRef<Path>,
 	{
 		fs::read_dir(dir)
 			.unwrap()
-			.map(|entry| entry.unwrap().path())
+			.map(|entry| Utf8PathBuf::from_path_buf(entry.unwrap().path()).expect("invalid unicode path"))
 			.filter(|path| path.is_file() && path.extension().map(|ext| ext == "w").unwrap_or(false))
 	}
 
 	fn compile_test(test_dir: &str, expect_failure: bool) {
 		for test_file in get_wing_files(test_dir) {
-			println!("\n=== {} ===\n", test_file.display());
+			println!("\n=== {} ===\n", test_file);
 
 			let mut out_dir = test_file.parent().unwrap().to_path_buf();
-			out_dir.push(format!(
-				"target/wingc/{}.out",
-				test_file.file_name().unwrap().to_str().unwrap()
-			));
+			out_dir.push(format!("target/wingc/{}.out", test_file.file_name().unwrap()));
 
 			// reset out_dir
 			if out_dir.exists() {
@@ -452,14 +445,14 @@ mod sanity {
 				&test_file,
 				test_text,
 				Some(&out_dir),
-				Some(test_file.canonicalize().unwrap().parent().unwrap()),
+				Some(test_file.canonicalize_utf8().unwrap().parent().unwrap()),
 			);
 
 			if result.is_err() {
 				assert!(
 					expect_failure,
 					"{}: Expected compilation success, but failed: {:#?}",
-					test_file.display(),
+					test_file,
 					result.err().unwrap()
 				);
 
@@ -469,7 +462,7 @@ mod sanity {
 				assert!(
 					!expect_failure,
 					"{}: Expected compilation failure, but succeeded",
-					test_file.display()
+					test_file,
 				);
 			}
 		}

--- a/libs/wingc/src/lsp/completions.rs
+++ b/libs/wingc/src/lsp/completions.rs
@@ -22,6 +22,8 @@ use crate::visit::{visit_expr, visit_type_annotation, Visit};
 use crate::wasm_util::{ptr_to_string, string_to_combined_ptr, WASM_RETURN_ERROR};
 use crate::{WINGSDK_ASSEMBLY_NAME, WINGSDK_STD_MODULE};
 
+use super::sync::check_utf8;
+
 #[no_mangle]
 pub unsafe extern "C" fn wingc_on_completion(ptr: u32, len: u32) -> u64 {
 	let parse_string = ptr_to_string(ptr, len);
@@ -42,8 +44,7 @@ pub fn on_completion(params: lsp_types::CompletionParams) -> CompletionResponse 
 		let mut final_completions = PROJECT_DATA.with(|project_data| {
 			let project_data = project_data.borrow();
 			let uri = params.text_document_position.text_document.uri;
-			let file = uri.to_file_path().ok().expect("LSP only works on real filesystems");
-			let file_id = file.to_str().expect("File path must be valid utf8");
+			let file = check_utf8(uri.to_file_path().expect("LSP only works on real filesystems"));
 			let root_ts_node = project_data.trees.get(&file).expect("tree not found").root_node();
 			let root_scope = project_data.asts.get(&file).expect("ast not found");
 			let root_env = types.get_scope_env(root_scope);
@@ -89,12 +90,12 @@ pub fn on_completion(params: lsp_types::CompletionParams) -> CompletionResponse 
 				node_to_complete.parent().map(|parent| WingSpan {
 					start: parent.start_position().into(),
 					end: parent.end_position().into(),
-					file_id: file_id.to_string(),
+					file_id: file.to_string(),
 				}),
 				WingSpan {
 					start: node_to_complete.start_position().into(),
 					end: node_to_complete.end_position().into(),
-					file_id: file_id.to_string(),
+					file_id: file.to_string(),
 				},
 				params.text_document_position.position.into(),
 				&root_scope,

--- a/libs/wingc/src/lsp/document_symbols.rs
+++ b/libs/wingc/src/lsp/document_symbols.rs
@@ -5,6 +5,8 @@ use crate::visit::Visit;
 use crate::wasm_util::{ptr_to_string, string_to_combined_ptr, WASM_RETURN_ERROR};
 use lsp_types::{DocumentSymbol, SymbolKind};
 
+use super::sync::check_utf8;
+
 pub struct DocumentSymbolVisitor {
 	pub document_symbols: Vec<DocumentSymbol>,
 }
@@ -93,7 +95,7 @@ pub fn on_document_symbols(params: lsp_types::DocumentSymbolParams) -> Vec<Docum
 	PROJECT_DATA.with(|project_data| {
 		let project_data = project_data.borrow();
 		let uri = params.text_document.uri;
-		let file = uri.to_file_path().ok().expect("LSP only works on real filesystems");
+		let file = check_utf8(uri.to_file_path().expect("LSP only works on real filesystems"));
 		let scope = project_data.asts.get(&file).unwrap();
 
 		let mut visitor = DocumentSymbolVisitor::new();

--- a/libs/wingc/src/lsp/goto_definition.rs
+++ b/libs/wingc/src/lsp/goto_definition.rs
@@ -2,6 +2,8 @@ use crate::lsp::sync::PROJECT_DATA;
 use crate::wasm_util::{ptr_to_string, string_to_combined_ptr, WASM_RETURN_ERROR};
 use tree_sitter::Point;
 
+use super::sync::check_utf8;
+
 #[no_mangle]
 pub unsafe extern "C" fn wingc_on_goto_definition(ptr: u32, len: u32) -> u64 {
 	let parse_string = ptr_to_string(ptr, len);
@@ -19,7 +21,7 @@ pub fn on_goto_definition(params: lsp_types::GotoDefinitionParams) -> Vec<lsp_ty
 	PROJECT_DATA.with(|project_data| {
 		let project_data = project_data.borrow();
 		let uri = params.text_document_position_params.text_document.uri;
-		let file = uri.to_file_path().ok().expect("LSP only works on real filesystems");
+		let file = check_utf8(uri.to_file_path().expect("LSP only works on real filesystems"));
 		let wing_source = project_data.files.get_file(&file).unwrap().as_bytes();
 
 		let point = Point::new(

--- a/libs/wingc/src/lsp/hover.rs
+++ b/libs/wingc/src/lsp/hover.rs
@@ -15,7 +15,7 @@ use crate::wasm_util::WASM_RETURN_ERROR;
 use crate::wasm_util::{ptr_to_string, string_to_combined_ptr};
 use lsp_types::{Hover, HoverContents, MarkupContent, MarkupKind, Position};
 
-use super::sync::WING_TYPES;
+use super::sync::{check_utf8, WING_TYPES};
 
 pub struct HoverVisitor<'a> {
 	position: Position,
@@ -435,8 +435,7 @@ pub fn on_hover(params: lsp_types::HoverParams) -> Option<Hover> {
 		PROJECT_DATA.with(|project_data| {
 			let project_data = project_data.borrow();
 			let uri = params.text_document_position_params.text_document.uri.clone();
-			let file = uri.to_file_path().ok().expect("LSP only works on real filesystems");
-
+			let file = check_utf8(uri.to_file_path().expect("LSP only works on real filesystems"));
 			let root_scope = &project_data.asts.get(&file).unwrap();
 
 			let mut hover_visitor = HoverVisitor::new(params.text_document_position_params.position, &root_scope, &types);

--- a/libs/wingc/src/lsp/signature.rs
+++ b/libs/wingc/src/lsp/signature.rs
@@ -14,6 +14,8 @@ use crate::type_check::{resolve_super_method, resolve_user_defined_type, Types, 
 use crate::visit::{visit_expr, visit_scope, Visit};
 use crate::wasm_util::{ptr_to_string, string_to_combined_ptr, WASM_RETURN_ERROR};
 
+use super::sync::check_utf8;
+
 #[no_mangle]
 pub unsafe extern "C" fn wingc_on_signature_help(ptr: u32, len: u32) -> u64 {
 	let parse_string = ptr_to_string(ptr, len);
@@ -34,7 +36,7 @@ pub fn on_signature_help(params: lsp_types::SignatureHelpParams) -> Option<Signa
 		PROJECT_DATA.with(|project_data| {
 			let project_data = project_data.borrow();
 			let uri = params.text_document_position_params.text_document.uri;
-			let file = uri.to_file_path().ok().expect("LSP only works on real filesystems");
+			let file = check_utf8(uri.to_file_path().ok().expect("LSP only works on real filesystems"));
 			let root_scope = &project_data.asts.get(&file).unwrap();
 
 			let mut scope_visitor = ScopeVisitor::new(&types, params.text_document_position_params.position);

--- a/libs/wingc/src/lsp/sync.rs
+++ b/libs/wingc/src/lsp/sync.rs
@@ -1,3 +1,4 @@
+use camino::{Utf8Path, Utf8PathBuf};
 use indexmap::IndexMap;
 use lsp_types::{DidChangeTextDocumentParams, DidOpenTextDocumentParams};
 use wingii::type_system::TypeSystem;
@@ -28,9 +29,9 @@ pub struct ProjectData {
 	/// A graph that tracks the dependencies between files
 	pub file_graph: FileGraph,
 	/// tree-sitter trees
-	pub trees: IndexMap<PathBuf, Tree>,
+	pub trees: IndexMap<Utf8PathBuf, Tree>,
 	/// AST for each file
-	pub asts: IndexMap<PathBuf, Scope>,
+	pub asts: IndexMap<Utf8PathBuf, Scope>,
 	/// The JSII imports for the file. This is saved so we can load JSII types (for autocompletion for example)
 	/// which don't exist explicitly in the source.
 	pub jsii_imports: Vec<JsiiImportSpec>,
@@ -134,6 +135,8 @@ fn partial_compile(
 	// Reset diagnostics before new compilation (`partial_compile` can be called multiple times)
 	reset_diagnostics();
 
+	let source_path = Utf8Path::from_path(source_path).expect("invalid unicide path");
+
 	let topo_sorted_files = parse_wing_project(
 		&source_path,
 		source_text,
@@ -189,6 +192,10 @@ fn partial_compile(
 	}
 
 	// no need to JSify in the LSP
+}
+
+pub fn check_utf8(path: PathBuf) -> Utf8PathBuf {
+	path.try_into().expect("invalid unicode path")
 }
 
 #[cfg(test)]

--- a/libs/wingc/src/parser.rs
+++ b/libs/wingc/src/parser.rs
@@ -1,8 +1,8 @@
+use camino::{Utf8Component, Utf8Path, Utf8PathBuf};
 use indexmap::{IndexMap, IndexSet};
 use phf::{phf_map, phf_set};
 use std::cell::RefCell;
 use std::collections::HashSet;
-use std::path::{Component as PathComponent, Path, PathBuf};
 use std::{fs, str, vec};
 use tree_sitter::Node;
 use tree_sitter_traversal::{traverse, Order};
@@ -144,13 +144,13 @@ static RESERVED_WORDS: phf::Set<&'static str> = phf_set! {
 /// Returns a topological ordering of all known Wing files, where each file only depends on
 /// files that come before it in the ordering.
 pub fn parse_wing_project(
-	init_path: &Path,
+	init_path: &Utf8Path,
 	init_text: String,
 	files: &mut Files,
 	file_graph: &mut FileGraph,
-	tree_sitter_trees: &mut IndexMap<PathBuf, tree_sitter::Tree>,
-	asts: &mut IndexMap<PathBuf, Scope>,
-) -> Vec<PathBuf> {
+	tree_sitter_trees: &mut IndexMap<Utf8PathBuf, tree_sitter::Tree>,
+	asts: &mut IndexMap<Utf8PathBuf, Scope>,
+) -> Vec<Utf8PathBuf> {
 	// Parse the initial file (even if we have already seen it before)
 	let (tree_sitter_tree, ast, dependent_wing_files) = parse_wing_file(init_path, &init_text);
 
@@ -203,15 +203,12 @@ pub fn parse_wing_project(
 	match file_graph.toposort() {
 		Ok(files) => files,
 		Err(cycle) => {
-			let formatted_cycle = cycle
-				.iter()
-				.map(|path| format!("- {}\n", path.to_str().unwrap()))
-				.collect::<String>();
+			let formatted_cycle = cycle.iter().map(|path| format!("- {}\n", path)).collect::<String>();
 
 			report_diagnostic(Diagnostic {
 				message: format!(
 					"Could not compile \"{}\" due to cyclic bring statements:\n{}",
-					init_path.display(),
+					init_path,
 					formatted_cycle.trim_end()
 				),
 				span: None,
@@ -223,7 +220,7 @@ pub fn parse_wing_project(
 	}
 }
 
-fn parse_wing_file(source_path: &Path, source_text: &str) -> (tree_sitter::Tree, Scope, Vec<PathBuf>) {
+fn parse_wing_file(source_path: &Utf8Path, source_text: &str) -> (tree_sitter::Tree, Scope, Vec<Utf8PathBuf>) {
 	let language = tree_sitter_wing::language();
 	let mut tree_sitter_parser = tree_sitter::Parser::new();
 	tree_sitter_parser.set_language(language).unwrap();
@@ -231,13 +228,13 @@ fn parse_wing_file(source_path: &Path, source_text: &str) -> (tree_sitter::Tree,
 	let tree_sitter_tree = match tree_sitter_parser.parse(&source_text.as_bytes(), None) {
 		Some(tree) => tree,
 		None => {
-			panic!("Error parsing source file with tree-sitter: {}", source_path.display());
+			panic!("Error parsing source file with tree-sitter: {}", source_path);
 		}
 	};
 
 	let tree_sitter_root = tree_sitter_tree.root_node();
 
-	let parser = Parser::new(&source_text.as_bytes(), source_path.to_string_lossy().to_string());
+	let parser = Parser::new(&source_text.as_bytes(), source_path.to_string());
 	let (scope, dependent_wing_files) = parser.parse(&tree_sitter_root);
 	(tree_sitter_tree, scope, dependent_wing_files)
 }
@@ -254,7 +251,7 @@ pub struct Parser<'a> {
 	is_in_loop: RefCell<bool>,
 	/// Track all file paths that have been found while parsing the current file
 	/// These will need to be eventually parsed (or diagnostics will be reported if they don't exist)
-	referenced_wing_files: RefCell<Vec<PathBuf>>,
+	referenced_wing_files: RefCell<Vec<Utf8PathBuf>>,
 }
 
 impl<'s> Parser<'s> {
@@ -274,7 +271,7 @@ impl<'s> Parser<'s> {
 		}
 	}
 
-	pub fn parse(self, root: &Node) -> (Scope, Vec<PathBuf>) {
+	pub fn parse(self, root: &Node) -> (Scope, Vec<Utf8PathBuf>) {
 		let scope = match root.kind() {
 			"source" => self.build_scope(&root, Phase::Preflight),
 			_ => Scope::empty(),
@@ -416,7 +413,7 @@ impl<'s> Parser<'s> {
 		WingSpan {
 			start: node_range.start_point.into(),
 			end: node_range.end_point.into(),
-			file_id: self.source_name.to_string(),
+			file_id: self.source_name.clone(),
 		}
 	}
 
@@ -707,20 +704,17 @@ impl<'s> Parser<'s> {
 		// if the module name is a path ending in .w, create a new Parser to parse it as a new Scope,
 		// and create a StmtKind::Module instead
 		if module_name.name.starts_with("\"") && module_name.name.ends_with(".w\"") {
-			let module_path = Path::new(&module_name.name[1..module_name.name.len() - 1]);
-			let source_path = normalize_path(module_path, Some(&Path::new(&self.source_name)));
-			if source_path == Path::new(&self.source_name) {
+			let module_path = Utf8Path::new(&module_name.name[1..module_name.name.len() - 1]);
+			let source_path = normalize_path(module_path, Some(&Utf8Path::new(&self.source_name)));
+			if source_path == Utf8Path::new(&self.source_name) {
 				return self.with_error("Cannot bring a module into itself", statement_node);
 			}
 			if !source_path.exists() {
-				return self.with_error(
-					format!("Cannot find module \"{}\"", source_path.display()),
-					statement_node,
-				);
+				return self.with_error(format!("Cannot find module \"{}\"", source_path), statement_node);
 			}
 			if !source_path.is_file() {
 				return self.with_error(
-					format!("Cannot bring module \"{}\": not a file", source_path.display()),
+					format!("Cannot bring module \"{}\": not a file", source_path),
 					statement_node,
 				);
 			}
@@ -730,7 +724,7 @@ impl<'s> Parser<'s> {
 			let module = if let Some(alias) = alias {
 				Ok(StmtKind::Bring {
 					source: BringSource::WingFile(Symbol {
-						name: source_path.to_string_lossy().to_string(),
+						name: source_path.to_string(),
 						span: module_name.span,
 					}),
 					identifier: Some(alias),
@@ -2108,13 +2102,13 @@ impl<'s> Parser<'s> {
 
 // TODO: this function seems fragile
 // use inodes as source of truth instead https://github.com/winglang/wing/issues/3627
-pub fn normalize_path(path: &Path, relative_to: Option<&Path>) -> PathBuf {
+pub fn normalize_path(path: &Utf8Path, relative_to: Option<&Utf8Path>) -> Utf8PathBuf {
 	let path = if path.is_absolute() {
 		// if the path is absolute, we ignore "relative_to"
 		path.to_path_buf()
 	} else {
 		relative_to
-			.map(|p| p.parent().unwrap_or_else(|| Path::new(".")).join(path))
+			.map(|p| p.parent().unwrap_or_else(|| Utf8Path::new(".")).join(path))
 			.unwrap_or_else(|| path.to_path_buf())
 	};
 
@@ -2122,29 +2116,29 @@ pub fn normalize_path(path: &Path, relative_to: Option<&Path>) -> PathBuf {
 	// This is tricky because ".." usually means we pop the last component
 	// but if a path starts with ".." or looks like "a/../../b" we need to track
 	// how many components we've popped and add them later.
-	let mut normalized = PathBuf::new();
-	let mut extra_pops = PathBuf::new();
+	let mut normalized = Utf8PathBuf::new();
+	let mut extra_pops = Utf8PathBuf::new();
 	for part in path.components() {
 		match part {
-			PathComponent::Prefix(ref prefix) => {
-				normalized.push(prefix.as_os_str());
+			Utf8Component::Prefix(ref prefix) => {
+				normalized.push(prefix.as_str());
 			}
-			PathComponent::RootDir => {
+			Utf8Component::RootDir => {
 				normalized.push("/");
 			}
-			PathComponent::ParentDir => {
+			Utf8Component::ParentDir => {
 				let popped = normalized.pop();
 				if !popped {
 					extra_pops.push("..");
 				}
 			}
-			PathComponent::CurDir => {
+			Utf8Component::CurDir => {
 				// Nothing
 			}
-			PathComponent::Normal(name) => {
+			Utf8Component::Normal(name) => {
 				if extra_pops.components().next().is_some() {
 					normalized = extra_pops;
-					extra_pops = PathBuf::new();
+					extra_pops = Utf8PathBuf::new();
 					normalized.push(name);
 				} else {
 					normalized.push(name);
@@ -2162,57 +2156,57 @@ mod tests {
 
 	#[test]
 	fn normalize_path_relative_to_nothing() {
-		let file_path = Path::new("/a/b/c/d/e.f");
+		let file_path = Utf8Path::new("/a/b/c/d/e.f");
 		assert_eq!(normalize_path(file_path, None), file_path);
 
-		let file_path = Path::new("/a/b/./c/../d/e.f");
-		assert_eq!(normalize_path(file_path, None), Path::new("/a/b/d/e.f"));
+		let file_path = Utf8Path::new("/a/b/./c/../d/e.f");
+		assert_eq!(normalize_path(file_path, None), Utf8Path::new("/a/b/d/e.f"));
 
-		let file_path = Path::new("a/b/c/d/e.f");
-		assert_eq!(normalize_path(file_path, None), Path::new("a/b/c/d/e.f"));
+		let file_path = Utf8Path::new("a/b/c/d/e.f");
+		assert_eq!(normalize_path(file_path, None), Utf8Path::new("a/b/c/d/e.f"));
 
-		let file_path = Path::new("a/b/./c/../d/e.f");
-		assert_eq!(normalize_path(file_path, None), Path::new("a/b/d/e.f"));
+		let file_path = Utf8Path::new("a/b/./c/../d/e.f");
+		assert_eq!(normalize_path(file_path, None), Utf8Path::new("a/b/d/e.f"));
 
-		let file_path = Path::new("a/../e.f");
-		assert_eq!(normalize_path(file_path, None), Path::new("e.f"));
+		let file_path = Utf8Path::new("a/../e.f");
+		assert_eq!(normalize_path(file_path, None), Utf8Path::new("e.f"));
 
-		let file_path = Path::new("a/../../../e.f");
-		assert_eq!(normalize_path(file_path, None), Path::new("../../e.f"));
+		let file_path = Utf8Path::new("a/../../../e.f");
+		assert_eq!(normalize_path(file_path, None), Utf8Path::new("../../e.f"));
 
-		let file_path = Path::new("./e.f");
-		assert_eq!(normalize_path(file_path, None), Path::new("e.f"));
+		let file_path = Utf8Path::new("./e.f");
+		assert_eq!(normalize_path(file_path, None), Utf8Path::new("e.f"));
 
-		let file_path = Path::new("../e.f");
-		assert_eq!(normalize_path(file_path, None), Path::new("../e.f"));
+		let file_path = Utf8Path::new("../e.f");
+		assert_eq!(normalize_path(file_path, None), Utf8Path::new("../e.f"));
 
-		let file_path = Path::new("../foo/.././e.f");
-		assert_eq!(normalize_path(file_path, None), Path::new("../e.f"));
+		let file_path = Utf8Path::new("../foo/.././e.f");
+		assert_eq!(normalize_path(file_path, None), Utf8Path::new("../e.f"));
 	}
 
 	#[test]
 	fn normalize_path_relative_to_something() {
 		// If the path is absolute, we ignore "relative_to"
-		let file_path = Path::new("/a/b/c/d/e.f");
-		let relative_to = Path::new("/g/h/i");
+		let file_path = Utf8Path::new("/a/b/c/d/e.f");
+		let relative_to = Utf8Path::new("/g/h/i");
 		assert_eq!(normalize_path(file_path, Some(relative_to)), file_path);
 
-		let file_path = Path::new("a/b/c/d/e.f");
-		let relative_to = Path::new("/g/h/i");
+		let file_path = Utf8Path::new("a/b/c/d/e.f");
+		let relative_to = Utf8Path::new("/g/h/i");
 		assert_eq!(
 			normalize_path(file_path, Some(relative_to)),
-			Path::new("/g/h/a/b/c/d/e.f")
+			Utf8Path::new("/g/h/a/b/c/d/e.f")
 		);
 
-		let file_path = Path::new("a/b/c/d/e.f");
-		let relative_to = Path::new("g/h/i");
+		let file_path = Utf8Path::new("a/b/c/d/e.f");
+		let relative_to = Utf8Path::new("g/h/i");
 		assert_eq!(
 			normalize_path(file_path, Some(relative_to)),
-			Path::new("g/h/a/b/c/d/e.f")
+			Utf8Path::new("g/h/a/b/c/d/e.f")
 		);
 
-		let file_path = Path::new("../foo.w");
-		let relative_to = Path::new("subdir/bar.w");
-		assert_eq!(normalize_path(file_path, Some(relative_to)), Path::new("foo.w"));
+		let file_path = Utf8Path::new("../foo.w");
+		let relative_to = Utf8Path::new("subdir/bar.w");
+		assert_eq!(normalize_path(file_path, Some(relative_to)), Utf8Path::new("foo.w"));
 	}
 }

--- a/libs/wingc/src/test_utils.rs
+++ b/libs/wingc/src/test_utils.rs
@@ -1,7 +1,8 @@
-use itertools::Itertools;
 use std::env;
 use std::fs::read_dir;
-use std::path::Path;
+
+use camino::Utf8Path;
+use itertools::Itertools;
 use tempfile;
 
 use crate::{
@@ -51,8 +52,9 @@ pub fn compile_fail(code: &str) -> String {
 /// Compiles `code` and returns the capture scanner results as a string that can be snapshotted
 fn compile_code(code: &str) -> String {
 	let outdir = tempfile::tempdir().unwrap();
+	let outdir_path = Utf8Path::from_path(outdir.path()).unwrap();
 
-	let source_path = Path::new("main.w");
+	let source_path = Utf8Path::new("main.w");
 
 	// NOTE: this is needed for debugging to work regardless of where you run the test
 	env::set_current_dir(env!("CARGO_MANIFEST_DIR")).unwrap();
@@ -60,7 +62,7 @@ fn compile_code(code: &str) -> String {
 	// convert tabs to 2 spaces
 	let code = code.replace("\t", "  ");
 
-	let result = compile(source_path, code.clone(), Some(outdir.path()), Some(outdir.path()));
+	let result = compile(source_path, code.clone(), Some(outdir_path), Some(outdir_path));
 
 	let mut snap = vec![];
 

--- a/libs/wingc/src/type_check.rs
+++ b/libs/wingc/src/type_check.rs
@@ -19,6 +19,7 @@ use crate::{
 	WINGSDK_MAP, WINGSDK_MUT_ARRAY, WINGSDK_MUT_JSON, WINGSDK_MUT_MAP, WINGSDK_MUT_SET, WINGSDK_RESOURCE, WINGSDK_SET,
 	WINGSDK_STD_MODULE, WINGSDK_STRING, WINGSDK_STRUCT,
 };
+use camino::{Utf8Path, Utf8PathBuf};
 use derivative::Derivative;
 use duplicate::duplicate_item;
 use indexmap::{IndexMap, IndexSet};
@@ -28,7 +29,6 @@ use jsii_importer::JsiiImporter;
 use std::collections::HashMap;
 use std::fmt::{Debug, Display};
 use std::iter::FilterMap;
-use std::path::{Path, PathBuf};
 use symbol_env::{StatementIdx, SymbolEnv};
 use wingii::fqn::FQN;
 use wingii::type_system::TypeSystem;
@@ -1234,7 +1234,7 @@ pub struct Types {
 	namespaces: Vec<Box<Namespace>>,
 	symbol_envs: Vec<Box<SymbolEnv>>,
 	/// A map from source file name to the symbol environment for that file (and whether that file is safe to bring)
-	source_file_envs: IndexMap<PathBuf, (SymbolEnvRef, bool)>,
+	source_file_envs: IndexMap<Utf8PathBuf, (SymbolEnvRef, bool)>,
 	pub libraries: SymbolEnv,
 	numeric_idx: usize,
 	string_idx: usize,
@@ -1595,7 +1595,7 @@ pub struct TypeChecker<'a> {
 	inner_scopes: Vec<*const Scope>,
 
 	/// The path to the source file being type checked.
-	source_path: &'a Path,
+	source_path: &'a Utf8Path,
 
 	/// JSII Manifest descriptions to be imported.
 	/// May be reused between compilations
@@ -1616,7 +1616,7 @@ pub struct TypeChecker<'a> {
 impl<'a> TypeChecker<'a> {
 	pub fn new(
 		types: &'a mut Types,
-		source_path: &'a Path,
+		source_path: &'a Utf8Path,
 		jsii_types: &'a mut TypeSystem,
 		jsii_imports: &'a mut Vec<JsiiImportSpec>,
 	) -> Self {
@@ -2770,7 +2770,7 @@ impl<'a> TypeChecker<'a> {
 		first_expected_type
 	}
 
-	pub fn type_check_file(&mut self, source_path: &Path, scope: &Scope) {
+	pub fn type_check_file(&mut self, source_path: &Utf8Path, scope: &Scope) {
 		CompilationContext::set(CompilationPhase::TypeChecking, &scope.span);
 		self.type_check_scope(scope);
 
@@ -3178,7 +3178,7 @@ impl<'a> TypeChecker<'a> {
 						alias = identifier.as_ref().unwrap();
 					}
 					BringSource::WingFile(name) => {
-						let (brought_env, is_bringable) = match self.types.source_file_envs.get(Path::new(&name.name)) {
+						let (brought_env, is_bringable) = match self.types.source_file_envs.get(Utf8Path::new(&name.name)) {
 							Some((env, is_bringable)) => (*env, *is_bringable),
 							None => {
 								self.spanned_error(
@@ -3995,7 +3995,7 @@ impl<'a> TypeChecker<'a> {
 			let assembly_name = if library_name == WINGSDK_ASSEMBLY_NAME {
 				// in runtime, if "WINGSDK_MANIFEST_ROOT" env var is set, read it. otherwise set to "../wingsdk" for dev
 				let manifest_root = std::env::var("WINGSDK_MANIFEST_ROOT").unwrap_or_else(|_| "../wingsdk".to_string());
-				let assembly_name = match self.jsii_types.load_module(manifest_root.as_str()) {
+				let assembly_name = match self.jsii_types.load_module(&Utf8Path::new(&manifest_root)) {
 					Ok(name) => name,
 					Err(type_error) => {
 						self.spanned_error(
@@ -4011,7 +4011,7 @@ impl<'a> TypeChecker<'a> {
 
 				assembly_name
 			} else {
-				let source_dir = self.source_path.parent().unwrap().to_str().unwrap();
+				let source_dir = self.source_path.parent().unwrap();
 				let assembly_name = match self.jsii_types.load_dep(library_name.as_str(), source_dir) {
 					Ok(name) => name,
 					Err(type_error) => {

--- a/libs/wingii/Cargo.toml
+++ b/libs/wingii/Cargo.toml
@@ -11,6 +11,7 @@ serde_json = "1.0"
 flate2 = "1.0.25"
 blake3 = "1.4.1"
 speedy = "0.8.6"
+camino = "1.1.6"
 
 [dev-dependencies]
 rand = "0.8.5"

--- a/libs/wingii/src/util.rs
+++ b/libs/wingii/src/util.rs
@@ -2,11 +2,9 @@ extern crate serde;
 extern crate serde_json;
 
 pub mod package_json {
-	use std::{
-		collections::HashSet,
-		fs,
-		path::{Path, PathBuf},
-	};
+	use std::{collections::HashSet, fs};
+
+	use camino::{Utf8Path, Utf8PathBuf};
 
 	use crate::node_resolve::{is_path_dependency, resolve_from};
 
@@ -46,7 +44,7 @@ pub mod package_json {
 		deps
 	}
 
-	pub fn find_up(mut directory: PathBuf, predicate: impl Fn(&PathBuf) -> bool) -> Option<PathBuf> {
+	pub fn find_up(mut directory: Utf8PathBuf, predicate: impl Fn(&Utf8PathBuf) -> bool) -> Option<Utf8PathBuf> {
 		loop {
 			if predicate(&directory) {
 				return Some(directory);
@@ -60,7 +58,7 @@ pub mod package_json {
 		}
 	}
 
-	pub fn find_package_json_up(package_name: &str, directory: PathBuf) -> Option<PathBuf> {
+	pub fn find_package_json_up(package_name: &str, directory: Utf8PathBuf) -> Option<Utf8PathBuf> {
 		find_up(directory, |dir| {
 			let package_json = dir.join("package.json");
 			if package_json.exists() {
@@ -76,13 +74,13 @@ pub mod package_json {
 		})
 	}
 
-	pub fn find_dependency_directory(dependency_name: &str, search_start: &str) -> Option<String> {
-		let entrypoint = resolve_from(dependency_name, Path::new(search_start));
+	pub fn find_dependency_directory(dependency_name: &str, search_start: &Utf8Path) -> Option<Utf8PathBuf> {
+		let entrypoint = resolve_from(dependency_name, search_start);
 		let entrypoint = entrypoint.ok()?;
 		let dep_pkg_json_path = find_package_json_up(dependency_name, entrypoint);
 		let dep_pkg_json_path = dep_pkg_json_path?;
 		if dep_pkg_json_path.exists() {
-			Some(dep_pkg_json_path.to_str().unwrap().to_string())
+			Some(dep_pkg_json_path)
 		} else {
 			None
 		}


### PR DESCRIPTION
A `str` or `String` in Rust represents a sequence of Unicode characters, while a `Path` or `PathBuf` in Rust represents a sequence of any bytes that represents a path. In practice though, non-Unicode paths are vanishingly uncommon, and there isn't a strong need to support them in Wing. (https://crates.io/crates/camino has some more details)

In this PR I've updated our Rust crates to use the `Utf8PathBuf` and `Utf8Path` types throughout. By doing so we're able to check that our paths are UTF-8 once, and then manipulate them as valid UTF-8 from there on, avoiding repeated lossy and confusing conversions like `path.to_str().unwrap()` and `path.display()`.

## Checklist

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [ ] Tests added (always)
- [ ] Docs updated (only required for features)
- [x] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
