### PR TITLE
chore(repo): quality gate must run even if e2e tests are skipped

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -314,12 +314,16 @@ jobs:
   quality-gate:
     name: Quality Gate
     runs-on: ubuntu-latest
+    if: ${{ !cancelled() }}
     needs:
       - build
       - e2e-test
       - benchmark
       - test
     steps:
+      - name: Check failure
+        if: failure()
+        run: exit 1
       - name: Download patches
         uses: actions/download-artifact@v3
       - name: Check patches


### PR DESCRIPTION
A regression from https://github.com/winglang/wing/pull/3791

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
