### PR TITLE
chore(repo): quality gate must fail if preceding jobs fail

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -322,7 +322,7 @@ jobs:
       - test
     steps:
       - name: Check failure
-        if: failure()
+        if: needs.build.result == 'failure' || needs.e2e-test.result == 'failure' || needs.benchmark.result == 'failure' || needs.test.result == 'failure'
         run: exit 1
       - name: Download patches
         uses: actions/download-artifact@v3


### PR DESCRIPTION
`failure()` checks for failed steps within a job, not jobs within a workflow.

Sorry for testing in prod, workflows are hard 😢 

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
