### PR TITLE
feat(docs): add note about variable mutability

### DIFF
--- a/docs/docs/03-language-reference.md
+++ b/docs/docs/03-language-reference.md
@@ -1523,10 +1523,17 @@ let [var] <name>[: <type>] = [<type>] <value>;
 Assignment operator is `=`.  
 Assignment declaration keyword is `let`.  
 Type annotation is optional if a default value is given.  
+`var` keyword after `let` makes a variable mutable.
 
 > ```TS
 > let n = 10;
 > let s: str = "hello";
+> s = "world"; // error: Variable is not reassignable
+> ```
+
+> ```TS
+> let var s = "hello";
+> s = "hello world"; // compiles
 > ```
 
 [`▲ top`][top]


### PR DESCRIPTION
It took me a while to realise how to create a mutable variable - I feel like `let [var] <name>[: <type>] = [<type>] <value>;` is not enough, it is easy to not notice the `[var]`. I added a small note about it.

## Checklist

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [ ] Tests added (always)
- [x] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
