### PR TITLE
chore(build): no need to generate tree-sitter wasm as part of build

### DIFF
--- a/libs/tree-sitter-wing/turbo.json
+++ b/libs/tree-sitter-wing/turbo.json
@@ -3,7 +3,7 @@
   "extends": ["//"],
   "pipeline": {
     "build:generate": {
-      "inputs": ["grammar.js", "src/scanner.c"],
+      "inputs": ["!*.wasm", "*", "grammar.js", "src/scanner.c"],
       "outputs": ["src/**", "!src/scanner.c", "bindings/**", "binding.gyp"]
     },
     "build:wasm": {
@@ -11,7 +11,8 @@
       "outputs": ["tree-sitter-wing.wasm"]
     },
     "compile": {
-      "dependsOn": ["build:wasm"]
+      "dependsOn": ["build:generate"],
+      "inputs": [""]
     },
     "test": {
       "inputs": ["test/**"],


### PR DESCRIPTION
Generating the .wasm for the grammar is only needed when running the tree-sitter playground, otherwise the rust build handles consuming the C files when targeting wasm32-wasi. Skipping this unnecessary work is much faster and removes a pretty big dependency from our core build path (docker, although it's still used in tests)

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
