### PR TITLE
fix(compiler): extern methods not resolved in multi-file projects

### DIFF
--- a/apps/wing/src/commands/compile.ts
+++ b/apps/wing/src/commands/compile.ts
@@ -64,6 +64,7 @@ export async function compile(entrypoint: string, options: CompileOptions): Prom
           const source = await fsPromise.readFile(span.file_id, "utf8");
           const start = byteOffsetFromLineAndColumn(source, span.start.line, span.start.col);
           const end = byteOffsetFromLineAndColumn(source, span.end.line, span.end.col);
+          // display the file path relative to the current working directory
           const filePath = relative(process.cwd(), span.file_id);
           files.push({ name: filePath, source });
           labels.push({

--- a/apps/wing/src/commands/compile.ts
+++ b/apps/wing/src/commands/compile.ts
@@ -64,9 +64,10 @@ export async function compile(entrypoint: string, options: CompileOptions): Prom
           const source = await fsPromise.readFile(span.file_id, "utf8");
           const start = byteOffsetFromLineAndColumn(source, span.start.line, span.start.col);
           const end = byteOffsetFromLineAndColumn(source, span.end.line, span.end.col);
-          files.push({ name: span.file_id, source });
+          const filePath = relative(process.cwd(), span.file_id);
+          files.push({ name: filePath, source });
           labels.push({
-            fileId: span.file_id,
+            fileId: filePath,
             rangeStart: start,
             rangeEnd: end,
             message,

--- a/examples/tests/invalid/extern.w
+++ b/examples/tests/invalid/extern.w
@@ -1,6 +1,4 @@
 class Foo {
   extern "./sad.js" static getNum(): num;
 //^ "./sad.js" not found
-  extern "not-installed" static tooBad(): bool;
-//^ "not-installed" not found
 }

--- a/examples/tests/valid/extern_implementation.w
+++ b/examples/tests/valid/extern_implementation.w
@@ -6,7 +6,6 @@ class Foo {
   extern "./external_js.js" static inflight getUuid(): str;
   extern "./external_js.js" static inflight getData(): str;
   extern "./external_js.js" inflight print(msg: str);
-  extern "uuid" static v4(): str;
 
   inflight call() {
     assert(Foo.regexInflight("[a-z]+-\\d+", "abc-123"));
@@ -18,7 +17,6 @@ class Foo {
 }
 
 assert(Foo.getGreeting("Wingding") == "Hello, Wingding!");
-assert(Foo.v4().length == 36);
 
 let f = new Foo();
 

--- a/examples/tests/valid/subdir/subfile.w
+++ b/examples/tests/valid/subdir/subfile.w
@@ -1,3 +1,5 @@
 bring math;
 
-class Q {}
+class Q {
+  extern "./util.js" static inflight greet(name: str): str;
+}

--- a/examples/tests/valid/subdir/util.js
+++ b/examples/tests/valid/subdir/util.js
@@ -1,0 +1,3 @@
+exports.greet = function(name) {
+    return 'Hello ' + name;
+}

--- a/libs/wingc/examples/compile.rs
+++ b/libs/wingc/examples/compile.rs
@@ -16,12 +16,7 @@ pub fn main() {
 	let source_text = fs::read_to_string(&source_path).unwrap();
 	let target_dir: Utf8PathBuf = env::current_dir().unwrap().join("target").try_into().unwrap();
 
-	let results = compile(
-		&source_path,
-		source_text,
-		Some(&target_dir),
-		Some(source_path.parent().unwrap()),
-	);
+	let results = compile(source_path.parent().unwrap(), &source_path, source_text, &target_dir);
 	if results.is_err() {
 		let mut diags = get_diagnostics();
 		// Sort error messages by line number (ascending)

--- a/libs/wingc/src/lib.rs
+++ b/libs/wingc/src/lib.rs
@@ -277,9 +277,9 @@ pub fn compile(
 	source_text: String,
 	out_dir: &Utf8Path,
 ) -> Result<CompilerOutput, ()> {
-	assert!(project_dir.is_absolute());
-	assert!(source_path.is_absolute());
-	assert!(out_dir.is_absolute());
+	assert!(is_absolute(&project_dir));
+	assert!(is_absolute(&source_path));
+	assert!(is_absolute(&out_dir));
 
 	// -- PARSING PHASE --
 	let mut files = Files::new();
@@ -367,6 +367,21 @@ pub fn compile(
 	}
 
 	return Ok(CompilerOutput {});
+}
+
+fn is_absolute(path: &Utf8Path) -> bool {
+	if path.starts_with("/") {
+		return true;
+	}
+
+	let path = path.as_str();
+	// Check if this is a Windows path instead by checking if the second char is a colon
+	// Note: Cannot use Utf8Path::is_absolute() because it doesn't work with Windows paths on WASI
+	if path.len() < 2 || path.chars().nth(1).expect("path has second character") != ':' {
+		return false;
+	}
+
+	return true;
 }
 
 #[cfg(test)]

--- a/libs/wingc/src/lsp/sync.rs
+++ b/libs/wingc/src/lsp/sync.rs
@@ -179,11 +179,7 @@ fn partial_compile(
 	}
 
 	// -- LIFTING PHASE --
-
-	// source_file will never be "" because it is the path to the file being compiled and lsp does not allow empty paths
-	let project_dir = source_path.parent().expect("Empty filename");
-
-	let jsifier = JSifier::new(&mut types, &project_data.files, &source_path, &project_dir);
+	let jsifier = JSifier::new(&mut types, &project_data.files, &source_path);
 	for file in &topo_sorted_files {
 		let mut lift = LiftVisitor::new(&jsifier);
 		let scope = project_data.asts.remove(file).expect("matching AST not found");

--- a/libs/wingc/src/test_utils.rs
+++ b/libs/wingc/src/test_utils.rs
@@ -51,10 +51,10 @@ pub fn compile_fail(code: &str) -> String {
 
 /// Compiles `code` and returns the capture scanner results as a string that can be snapshotted
 fn compile_code(code: &str) -> String {
-	let outdir = tempfile::tempdir().unwrap();
-	let outdir_path = Utf8Path::from_path(outdir.path()).unwrap();
-
-	let source_path = Utf8Path::new("main.w");
+	let project_dir = tempfile::tempdir().unwrap();
+	let project_dir = Utf8Path::from_path(project_dir.path()).unwrap();
+	let source_path = project_dir.join("main.w");
+	let out_dir = project_dir.join("target/main.out/.wing");
 
 	// NOTE: this is needed for debugging to work regardless of where you run the test
 	env::set_current_dir(env!("CARGO_MANIFEST_DIR")).unwrap();
@@ -62,15 +62,15 @@ fn compile_code(code: &str) -> String {
 	// convert tabs to 2 spaces
 	let code = code.replace("\t", "  ");
 
-	let result = compile(source_path, code.clone(), Some(outdir_path), Some(outdir_path));
+	let result = compile(&project_dir, &source_path, code.clone(), &out_dir);
 
 	let mut snap = vec![];
 
 	match result {
 		Ok(_) => {
-			let Ok(files) = read_dir(outdir.path()) else {
-        panic!("failed to read dir");
-      };
+			let Ok(files) = read_dir(&out_dir) else {
+			panic!("failed to read dir");
+		};
 
 			snap.push("## Code".to_string());
 			snap.push("".into());

--- a/libs/wingc/src/type_check.rs
+++ b/libs/wingc/src/type_check.rs
@@ -2077,7 +2077,10 @@ impl<'a> TypeChecker<'a> {
 				if let CalleeKind::Expr(call_expr) = callee {
 					if let ExprKind::Reference(Reference::Identifier(ident)) = &call_expr.kind {
 						if ident.name == "wingc_env" {
-							println!("[symbol environment at {}]", exp.span().to_string());
+							println!(
+								"[symbol environment at {}]",
+								Utf8Path::new(&exp.span().file_id).file_name().unwrap(),
+							);
 							println!("{}", env.to_string());
 						}
 					}
@@ -2402,7 +2405,7 @@ impl<'a> TypeChecker<'a> {
 				None => {
 					self.spanned_error(
 						exp,
-						format!("Expected 0 named arguments for func at {}", exp.span().to_string()),
+						format!("Expected 0 named arguments but got {}", arg_list.named_args.len()),
 					);
 					return Some(self.types.error());
 				}

--- a/libs/wingcompiler/src/compile.ts
+++ b/libs/wingcompiler/src/compile.ts
@@ -84,9 +84,9 @@ export async function compile(entrypoint: string, options: CompileOptions): Prom
   const { log } = options;
   // create a unique temporary directory for the compilation
   const targetdir = options.targetDir ?? join(dirname(entrypoint), "target");
-  const wingFile = entrypoint;
+  const wingFile = resolve(entrypoint);
   log?.("wing file: %s", wingFile);
-  const wingDir = dirname(wingFile);
+  const wingDir = resolve(dirname(wingFile));
   log?.("wing dir: %s", wingDir);
   const testing = options.testing ?? false;
   log?.("testing: %s", testing);
@@ -105,12 +105,12 @@ export async function compile(entrypoint: string, options: CompileOptions): Prom
 
   const tempProcess: { env: Record<string, string | undefined> } = { env: { ...process.env } };
 
-  tempProcess.env["WING_SOURCE_DIR"] = resolve(wingDir);
+  tempProcess.env["WING_SOURCE_DIR"] = wingDir;
   if (options.rootId) {
     tempProcess.env["WING_ROOT_ID"] = options.rootId;
   }
   // from wingDir, find the nearest node_modules directory
-  let wingNodeModules = resolve(wingDir, "node_modules");
+  let wingNodeModules = join(wingDir, "node_modules");
   while (!existsSync(wingNodeModules)) {
     wingNodeModules = dirname(dirname(wingNodeModules));
 
@@ -158,7 +158,7 @@ export async function compile(entrypoint: string, options: CompileOptions): Prom
     errors.push(JSON.parse(data_str));
   }
 
-  const arg = `${normalPath(wingFile)};${normalPath(workDir)};${normalPath(resolve(wingDir))}`;
+  const arg = `${normalPath(wingFile)};${normalPath(workDir)};${normalPath(wingDir)}`;
   log?.(`invoking %s with: "%s"`, WINGC_COMPILE, arg);
   let compileSuccess: boolean;
   try {
@@ -173,7 +173,7 @@ export async function compile(entrypoint: string, options: CompileOptions): Prom
     throw new CompileError(errors);
   }
 
-  const artifactPath = resolve(workDir, WINGC_PREFLIGHT);
+  const artifactPath = join(workDir, WINGC_PREFLIGHT);
   log?.("reading artifact from %s", artifactPath);
   const artifact = await fs.readFile(artifactPath, "utf-8");
   log?.("artifact: %s", artifact);

--- a/tools/hangar/__snapshots__/invalid.ts.snap
+++ b/tools/hangar/__snapshots__/invalid.ts.snap
@@ -4,7 +4,7 @@ exports[`access_hidden_namespace.w 1`] = `
 "error: Unknown symbol \\"core\\"
   --> ../../../examples/tests/invalid/access_hidden_namespace.w:7:5
   |
-7 | new core.NodeJsCode(\\"/tmp/test.txt\\"); // This should fail even though \`fs.TextFile\` extends \`core.FileBase\` because we didn't bring in \`core\` explicitly.
+7 | new core.NodeJsCode(\\"<ABSOLUTE_PATH>/test.txt\\"); // This should fail even though \`fs.TextFile\` extends \`core.FileBase\` because we didn't bring in \`core\` explicitly.
   |     ^^^^ Unknown symbol \\"core\\"
 
 
@@ -95,11 +95,11 @@ exports[`bring_jsii.w 1`] = `
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^ bring \\"jsii-code-samples\\" must be assigned to an identifier (e.g. bring \\"foo\\" as foo)
 
 
-error: Cannot find module \\"foobar\\" in source directory: Unable to load \\"foobar\\": Module not found in \\"../../../examples/tests/invalid\\"
+error: Cannot find module \\"foobar\\" in source directory: Unable to load \\"foobar\\": Module not found in \\"<ABSOLUTE_PATH>/invalid\\"
   --> ../../../examples/tests/invalid/bring_jsii.w:4:1
   |
 4 | bring \\"foobar\\" as baz;
-  | ^^^^^^^^^^^^^^^^^^^^^^ Cannot find module \\"foobar\\" in source directory: Unable to load \\"foobar\\": Module not found in \\"../../../examples/tests/invalid\\"
+  | ^^^^^^^^^^^^^^^^^^^^^^ Cannot find module \\"foobar\\" in source directory: Unable to load \\"foobar\\": Module not found in \\"<ABSOLUTE_PATH>/invalid\\"
 
 
  
@@ -117,11 +117,11 @@ exports[`bring_local_self.w 1`] = `
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Cannot bring a module into itself
 
 
-error: Cannot find module \\"../../../examples/tests/invalid/non-existent.w\\"
+error: Cannot find module \\"./non-existent.w\\"
   --> ../../../examples/tests/invalid/bring_local_self.w:4:1
   |
 4 | bring \\"./non-existent.w\\" as bar;
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Cannot find module \\"../../../examples/tests/invalid/non-existent.w\\"
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Cannot find module \\"./non-existent.w\\"
 
 
  
@@ -139,11 +139,11 @@ exports[`bring_local_variables.w 1`] = `
    |   ^ Preflight field \\"x\\" is not initialized
 
 
-error: Cannot bring \\"../../../examples/tests/invalid/file_with_variables.w\\" - modules with statements besides classes, interfaces, enums, and structs cannot be brought
+error: Cannot bring \\"<ABSOLUTE_PATH>/file_with_variables.w\\" - modules with statements besides classes, interfaces, enums, and structs cannot be brought
   --> ../../../examples/tests/invalid/bring_local_variables.w:1:1
   |
 1 | bring \\"./file_with_variables.w\\" as stuff;
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Cannot bring \\"../../../examples/tests/invalid/file_with_variables.w\\" - modules with statements besides classes, interfaces, enums, and structs cannot be brought
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Cannot bring \\"<ABSOLUTE_PATH>/file_with_variables.w\\" - modules with statements besides classes, interfaces, enums, and structs cannot be brought
 
 
 error: Unknown symbol \\"stuff\\"
@@ -297,11 +297,11 @@ error: Expected 0 arguments but got 1
   | ^^^^^^^^^ Expected 0 arguments but got 1
 
 
-error: Expected 0 named arguments for func at ../../../examples/tests/invalid/class.w:13:1
+error: Expected 0 named arguments but got 1
    --> ../../../examples/tests/invalid/class.w:13:1
    |
 13 | new C9(token: \\"1\\");
-   | ^^^^^^^^^^^^^^^^^^ Expected 0 named arguments for func at ../../../examples/tests/invalid/class.w:13:1
+   | ^^^^^^^^^^^^^^^^^^ Expected 0 named arguments but got 1
 
 
 error: Expected 1 positional argument(s) but got 0
@@ -615,24 +615,24 @@ Duration <DURATION>"
 `;
 
 exports[`cyclic_bring1.w 1`] = `
-"error: Could not compile \\"../../../examples/tests/invalid/cyclic_bring1.w\\" due to cyclic bring statements:
-- ../../../examples/tests/invalid/cyclic_bring3.w
-- ../../../examples/tests/invalid/cyclic_bring2.w
-- ../../../examples/tests/invalid/cyclic_bring1.w
+"error: Could not compile \\"<ABSOLUTE_PATH>/cyclic_bring1.w\\" due to cyclic bring statements:
+- <ABSOLUTE_PATH>/cyclic_bring3.w
+- <ABSOLUTE_PATH>/cyclic_bring2.w
+- <ABSOLUTE_PATH>/cyclic_bring1.w
 
 
-error: Could not type check \\"../../../examples/tests/invalid/cyclic_bring2.w\\" due to cyclic bring statements
+error: Could not type check \\"<ABSOLUTE_PATH>/cyclic_bring2.w\\" due to cyclic bring statements
   --> ../../../examples/tests/invalid/cyclic_bring1.w:1:1
   |
 1 | bring \\"./cyclic_bring2.w\\" as foo;
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Could not type check \\"../../../examples/tests/invalid/cyclic_bring2.w\\" due to cyclic bring statements
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Could not type check \\"<ABSOLUTE_PATH>/cyclic_bring2.w\\" due to cyclic bring statements
 
 
-error: Could not type check \\"../../../examples/tests/invalid/cyclic_bring3.w\\" due to cyclic bring statements
+error: Could not type check \\"<ABSOLUTE_PATH>/cyclic_bring3.w\\" due to cyclic bring statements
   --> ../../../examples/tests/invalid/cyclic_bring2.w:1:1
   |
 1 | bring \\"./cyclic_bring3.w\\" as foo;
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Could not type check \\"../../../examples/tests/invalid/cyclic_bring3.w\\" due to cyclic bring statements
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Could not type check \\"<ABSOLUTE_PATH>/cyclic_bring3.w\\" due to cyclic bring statements
 
 
  
@@ -643,24 +643,24 @@ Duration <DURATION>"
 `;
 
 exports[`cyclic_bring2.w 1`] = `
-"error: Could not compile \\"../../../examples/tests/invalid/cyclic_bring2.w\\" due to cyclic bring statements:
-- ../../../examples/tests/invalid/cyclic_bring1.w
-- ../../../examples/tests/invalid/cyclic_bring3.w
-- ../../../examples/tests/invalid/cyclic_bring2.w
+"error: Could not compile \\"<ABSOLUTE_PATH>/cyclic_bring2.w\\" due to cyclic bring statements:
+- <ABSOLUTE_PATH>/cyclic_bring1.w
+- <ABSOLUTE_PATH>/cyclic_bring3.w
+- <ABSOLUTE_PATH>/cyclic_bring2.w
 
 
-error: Could not type check \\"../../../examples/tests/invalid/cyclic_bring3.w\\" due to cyclic bring statements
+error: Could not type check \\"<ABSOLUTE_PATH>/cyclic_bring3.w\\" due to cyclic bring statements
   --> ../../../examples/tests/invalid/cyclic_bring2.w:1:1
   |
 1 | bring \\"./cyclic_bring3.w\\" as foo;
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Could not type check \\"../../../examples/tests/invalid/cyclic_bring3.w\\" due to cyclic bring statements
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Could not type check \\"<ABSOLUTE_PATH>/cyclic_bring3.w\\" due to cyclic bring statements
 
 
-error: Could not type check \\"../../../examples/tests/invalid/cyclic_bring1.w\\" due to cyclic bring statements
+error: Could not type check \\"<ABSOLUTE_PATH>/cyclic_bring1.w\\" due to cyclic bring statements
   --> ../../../examples/tests/invalid/cyclic_bring3.w:1:1
   |
 1 | bring \\"./cyclic_bring1.w\\" as foo;
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Could not type check \\"../../../examples/tests/invalid/cyclic_bring1.w\\" due to cyclic bring statements
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Could not type check \\"<ABSOLUTE_PATH>/cyclic_bring1.w\\" due to cyclic bring statements
 
 
  
@@ -671,24 +671,24 @@ Duration <DURATION>"
 `;
 
 exports[`cyclic_bring3.w 1`] = `
-"error: Could not compile \\"../../../examples/tests/invalid/cyclic_bring3.w\\" due to cyclic bring statements:
-- ../../../examples/tests/invalid/cyclic_bring2.w
-- ../../../examples/tests/invalid/cyclic_bring1.w
-- ../../../examples/tests/invalid/cyclic_bring3.w
+"error: Could not compile \\"<ABSOLUTE_PATH>/cyclic_bring3.w\\" due to cyclic bring statements:
+- <ABSOLUTE_PATH>/cyclic_bring2.w
+- <ABSOLUTE_PATH>/cyclic_bring1.w
+- <ABSOLUTE_PATH>/cyclic_bring3.w
 
 
-error: Could not type check \\"../../../examples/tests/invalid/cyclic_bring1.w\\" due to cyclic bring statements
+error: Could not type check \\"<ABSOLUTE_PATH>/cyclic_bring1.w\\" due to cyclic bring statements
   --> ../../../examples/tests/invalid/cyclic_bring3.w:1:1
   |
 1 | bring \\"./cyclic_bring1.w\\" as foo;
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Could not type check \\"../../../examples/tests/invalid/cyclic_bring1.w\\" due to cyclic bring statements
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Could not type check \\"<ABSOLUTE_PATH>/cyclic_bring1.w\\" due to cyclic bring statements
 
 
-error: Could not type check \\"../../../examples/tests/invalid/cyclic_bring2.w\\" due to cyclic bring statements
+error: Could not type check \\"<ABSOLUTE_PATH>/cyclic_bring2.w\\" due to cyclic bring statements
   --> ../../../examples/tests/invalid/cyclic_bring1.w:1:1
   |
 1 | bring \\"./cyclic_bring2.w\\" as foo;
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Could not type check \\"../../../examples/tests/invalid/cyclic_bring2.w\\" due to cyclic bring statements
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Could not type check \\"<ABSOLUTE_PATH>/cyclic_bring2.w\\" due to cyclic bring statements
 
 
  
@@ -736,18 +736,11 @@ Duration <DURATION>"
 `;
 
 exports[`extern.w 1`] = `
-"error: Failed to resolve extern \\"./sad.js\\": Not Found
+"error: File not found: \\"./sad.js\\"
   --> ../../../examples/tests/invalid/extern.w:2:3
   |
 2 |   extern \\"./sad.js\\" static getNum(): num;
-  |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Failed to resolve extern \\"./sad.js\\": Not Found
-
-
-error: Failed to resolve extern \\"not-installed\\": Not Found
-  --> ../../../examples/tests/invalid/extern.w:4:3
-  |
-4 |   extern \\"not-installed\\" static tooBad(): bool;
-  |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Failed to resolve extern \\"not-installed\\": Not Found
+  |   ^^^^^^^^^^^^^^^^^ File not found: \\"./sad.js\\"
 
 
  

--- a/tools/hangar/__snapshots__/invalid.ts.snap
+++ b/tools/hangar/__snapshots__/invalid.ts.snap
@@ -751,7 +751,14 @@ Duration <DURATION>"
 `;
 
 exports[`extern_static.w 1`] = `
-"error: Extern methods must be declared \\"static\\" (they cannot access instance members)
+"error: File not found: \\"../external_js.js\\"
+  --> ../../../examples/tests/invalid/extern_static.w:2:3
+  |
+2 |   extern \\"../external_js.js\\" inflight getGreeting(name: str): str;
+  |   ^^^^^^^^^^^^^^^^^^^^^^^^^^ File not found: \\"../external_js.js\\"
+
+
+error: Extern methods must be declared \\"static\\" (they cannot access instance members)
   --> ../../../examples/tests/invalid/extern_static.w:2:39
   |
 2 |   extern \\"../external_js.js\\" inflight getGreeting(name: str): str;

--- a/tools/hangar/__snapshots__/test_corpus/valid/bring_local.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/bring_local.w_compile_tf-aws.md
@@ -74,6 +74,9 @@ module.exports = function({  }) {
   class Q {
     constructor({  }) {
     }
+    static async greet(name) {
+      return (require("<ABSOLUTE_PATH>/util.js")["greet"])(name)
+    }
   }
   return Q;
 }
@@ -637,7 +640,7 @@ module.exports = function({ $stdlib }) {
       `;
     }
     _getInflightOps() {
-      return ["$inflight_init"];
+      return ["greet", "$inflight_init"];
     }
   }
   return { Q };

--- a/tools/hangar/__snapshots__/test_corpus/valid/debug_env.w_test_sim.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/debug_env.w_test_sim.md
@@ -2,7 +2,7 @@
 
 ## stdout.log
 ```log
-[symbol environment at ../../../../examples/tests/valid/debug_env.w:7:5]
+[symbol environment at /Users/chrisr/dev/wing3/examples/tests/valid/debug_env.w:7:5]
 level 0: { this => A }
 level 1: { A => A [type], assert => (condition: bool): void, cloud => cloud [namespace], log => (message: str): void, std => std [namespace] }
 pass ─ debug_env.wsim (no tests)

--- a/tools/hangar/__snapshots__/test_corpus/valid/debug_env.w_test_sim.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/debug_env.w_test_sim.md
@@ -2,7 +2,7 @@
 
 ## stdout.log
 ```log
-[symbol environment at /Users/chrisr/dev/wing3/examples/tests/valid/debug_env.w:7:5]
+[symbol environment at /home/runner/work/wing/wing/examples/tests/valid/debug_env.w:7:5]
 level 0: { this => A }
 level 1: { A => A [type], assert => (condition: bool): void, cloud => cloud [namespace], log => (message: str): void, std => std [namespace] }
 pass ─ debug_env.wsim (no tests)

--- a/tools/hangar/__snapshots__/test_corpus/valid/extern_implementation.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/extern_implementation.w_compile_tf-aws.md
@@ -277,9 +277,6 @@ class $Root extends $stdlib.std.Resource {
       static getGreeting(name) {
         return (require("<ABSOLUTE_PATH>/external_js.js")["getGreeting"])(name)
       }
-      static v4() {
-        return (require("<ABSOLUTE_PATH>/index.js")["v4"])()
-      }
       static _toInflightType(context) {
         return `
           require("./inflight.Foo-1.js")({
@@ -374,7 +371,6 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     {((cond) => {if (!cond) throw new Error("assertion failed: Foo.getGreeting(\"Wingding\") == \"Hello, Wingding!\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((Foo.getGreeting("Wingding")),"Hello, Wingding!")))};
-    {((cond) => {if (!cond) throw new Error("assertion failed: Foo.v4().length == 36")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((Foo.v4()).length,36)))};
     const f = new Foo(this,"Foo");
     this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:call",new $Closure1(this,"$Closure1"));
     this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:console",new $Closure2(this,"$Closure2"));

--- a/tools/hangar/src/invalid.test.ts
+++ b/tools/hangar/src/invalid.test.ts
@@ -8,10 +8,8 @@ invalidWingFiles.forEach((wingFile) => {
   test(wingFile, async ({ expect }) => {
     const args = ["test", "-t", "sim"];
 
-    const relativeWingFile = path.relative(
-      tmpDir,
-      path.join(invalidTestDir, wingFile)
-    );
+    const absoluteWingFile = path.join(invalidTestDir, wingFile);
+    const relativeWingFile = path.relative(tmpDir, absoluteWingFile);
 
     const metaComment = parseMetaCommentFromPath(
       path.join(invalidTestDir, wingFile)
@@ -28,7 +26,8 @@ invalidWingFiles.forEach((wingFile) => {
     const sanitize = (output: string) =>
       output
         // Remove absolute paths to wing files
-        .replaceAll(relativeWingFile, relativeWingFile.replaceAll("\\", "/"))
+        // .replaceAll(absoluteWingFile, "<")
+        .replaceAll(/(?<=[\s"])(\/|\w:)\S+\/(.+)/g, "<ABSOLUTE_PATH>/$2")
         // Remove absolute paths to source code
         .replaceAll(/(src\/.+\.rs):\d+:\d+/g, "$1:LINE:COL")
         // Normalize line endings


### PR DESCRIPTION
Previously, the compiler resolved strings in `extern` methods by performing a lookup, starting at the project's root directory. However, in multi-file projects this gives incorrect results since the source file might be inside a subdirectory of the user's project, resulting in bugs like #3916.

To fix this I opted to try resolving all paths while we're parsing all of the files, while we have information available about the path of the file containing the `extern` statement. This still had some issues, because most of the compiler was storing paths as relative paths, but the compiler's output directory could be in a different place from the project's entrypoint directory. So then I tried storing absolute paths everywhere. Maybe this is better? I'm not totally sure.

Fixes #3916

## Checklist

- [ ] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [ ] Description explains motivation and solution
- [ ] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
