### PR TITLE
chore(docs): remove double word from tests heading

### DIFF
--- a/docs/docs/02-concepts/04-tests.md
+++ b/docs/docs/02-concepts/04-tests.md
@@ -69,7 +69,7 @@ test "bucket starts empty" {
 
 In the first test (`bucket list should include created file`), a file is created in the bucket. The second test (`bucket starts empty`) verifies that the bucket is initialized without any file.
 
-### Running tests in a the cloud
+### Running tests in the cloud
 
 Consider the following example:
 


### PR DESCRIPTION
Stumbled on it while reading the docs and think it reads a bit better without the additional "a".

## Checklist

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [x] Tests added (always)
- [x] Docs updated (only required for features)
- [x] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
