### PR TITLE
fix(docs): fix typo in compatibility matrix

### DIFF
--- a/docs/docs/04-standard-library/compatibility/compatibility.json
+++ b/docs/docs/04-standard-library/compatibility/compatibility.json
@@ -1,690 +1,690 @@
 {
   "Bucket": {
     "BucketProps.public": {
-      "sim": {"implemented": true},
-      "tf-aws": {"implemented": true},
-      "tf-azure": {"implemented": true},
-      "tf-gcp": {"implemented": true},
-      "aws-cdk": {"implemented": true}
+      "sim": { "implemented": true },
+      "tf-aws": { "implemented": true },
+      "tf-azure": { "implemented": true },
+      "tf-gcp": { "implemented": true },
+      "awscdk": { "implemented": true }
     },
     "public": {
-      "sim": {"implemented": true},
-      "tf-aws": {"implemented": true},
-      "tf-azure": {"implemented": true},
-      "tf-gcp": {"implemented": false},
-      "aws-cdk": {"implemented": true}
+      "sim": { "implemented": true },
+      "tf-aws": { "implemented": true },
+      "tf-azure": { "implemented": true },
+      "tf-gcp": { "implemented": false },
+      "awscdk": { "implemented": true }
     },
     "onUpload": {
-      "sim": {"implemented": true},
-      "tf-aws": {"implemented": false, "issue": 2724},
-      "tf-azure": {"implemented": false, "issue": 1954},
-      "tf-gcp": {"implemented": false},
-      "aws-cdk": {"implemented": true}
+      "sim": { "implemented": true },
+      "tf-aws": { "implemented": false, "issue": 2724 },
+      "tf-azure": { "implemented": false, "issue": 1954 },
+      "tf-gcp": { "implemented": false },
+      "awscdk": { "implemented": true }
     },
     "onDelete": {
-      "sim": {"implemented": true},
-      "tf-aws": {"implemented": true},
-      "tf-azure": {"implemented": false, "issue": 1954},
-      "tf-gcp": {"implemented": false},
-      "aws-cdk": {"implemented": true}
+      "sim": { "implemented": true },
+      "tf-aws": { "implemented": true },
+      "tf-azure": { "implemented": false, "issue": 1954 },
+      "tf-gcp": { "implemented": false },
+      "awscdk": { "implemented": true }
     },
     "onUpdate": {
-      "sim": {"implemented": true},
-      "tf-aws": {"implemented": false, "issue": 2724},
-      "tf-azure": {"implemented": false, "issue": 1954},
-      "tf-gcp": {"implemented": false},
-      "aws-cdk": {"implemented": true}
+      "sim": { "implemented": true },
+      "tf-aws": { "implemented": false, "issue": 2724 },
+      "tf-azure": { "implemented": false, "issue": 1954 },
+      "tf-gcp": { "implemented": false },
+      "awscdk": { "implemented": true }
     },
     "onEvent": {
-      "sim": {"implemented": true},
-      "tf-aws": {"implemented": false, "issue": 2724},
-      "tf-azure": {"implemented": false, "issue": 1954},
-      "tf-gcp": {"implemented": false},
-      "aws-cdk": {"implemented": true}
+      "sim": { "implemented": true },
+      "tf-aws": { "implemented": false, "issue": 2724 },
+      "tf-azure": { "implemented": false, "issue": 1954 },
+      "tf-gcp": { "implemented": false },
+      "awscdk": { "implemented": true }
     },
     "addObject": {
-      "sim": {"implemented": true},
-      "tf-aws": {"implemented": true},
-      "tf-azure": {"implemented": true},
-      "tf-gcp": {"implemented": true},
-      "aws-cdk": {"implemented": true}
+      "sim": { "implemented": true },
+      "tf-aws": { "implemented": true },
+      "tf-azure": { "implemented": true },
+      "tf-gcp": { "implemented": true },
+      "awscdk": { "implemented": true }
     },
     "put": {
-      "sim": {"implemented": true},
-      "tf-aws": {"implemented": true},
-      "tf-azure": {"implemented": true},
-      "tf-gcp": {"implemented": false, "issue": 1282},
-      "aws-cdk": {"implemented": true}
+      "sim": { "implemented": true },
+      "tf-aws": { "implemented": true },
+      "tf-azure": { "implemented": true },
+      "tf-gcp": { "implemented": false, "issue": 1282 },
+      "awscdk": { "implemented": true }
     },
     "putJson": {
-      "sim": {"implemented": true},
-      "tf-aws": {"implemented": true},
-      "tf-azure": {"implemented": true},
-      "tf-gcp": {"implemented": false, "issue": 1282},
-      "aws-cdk": {"implemented": true}
+      "sim": { "implemented": true },
+      "tf-aws": { "implemented": true },
+      "tf-azure": { "implemented": true },
+      "tf-gcp": { "implemented": false, "issue": 1282 },
+      "awscdk": { "implemented": true }
     },
     "get": {
-      "sim": {"implemented": true},
-      "tf-aws": {"implemented": true},
-      "tf-azure": {"implemented": true},
-      "tf-gcp": {"implemented": false, "issue": 1282},
-      "aws-cdk": {"implemented": true}
+      "sim": { "implemented": true },
+      "tf-aws": { "implemented": true },
+      "tf-azure": { "implemented": true },
+      "tf-gcp": { "implemented": false, "issue": 1282 },
+      "awscdk": { "implemented": true }
     },
     "tryGet": {
-      "sim": {"implemented": true},
-      "tf-aws": {"implemented": true},
-      "tf-azure": {"implemented": true},
-      "tf-gcp": {"implemented": false},
-      "aws-cdk": {"implemented": false}
+      "sim": { "implemented": true },
+      "tf-aws": { "implemented": true },
+      "tf-azure": { "implemented": true },
+      "tf-gcp": { "implemented": false },
+      "awscdk": { "implemented": false }
     },
     "getJson": {
-      "sim": {"implemented": true},
-      "tf-aws": {"implemented": true},
-      "tf-azure": {"implemented": true},
-      "tf-gcp": {"implemented": false},
-      "aws-cdk": {"implemented": false}
+      "sim": { "implemented": true },
+      "tf-aws": { "implemented": true },
+      "tf-azure": { "implemented": true },
+      "tf-gcp": { "implemented": false },
+      "awscdk": { "implemented": false }
     },
     "tryGetJson": {
-      "sim": {"implemented": true},
-      "tf-aws": {"implemented": true},
-      "tf-azure": {"implemented": true},
-      "tf-gcp": {"implemented": false},
-      "aws-cdk": {"implemented": false}
+      "sim": { "implemented": true },
+      "tf-aws": { "implemented": true },
+      "tf-azure": { "implemented": true },
+      "tf-gcp": { "implemented": false },
+      "awscdk": { "implemented": false }
     },
     "delete": {
-      "sim": {"implemented": true},
-      "tf-aws": {"implemented": true},
-      "tf-azure": {"implemented": true},
-      "tf-gcp": {"implemented": false, "issue": 1282},
-      "aws-cdk": {"implemented": true}
+      "sim": { "implemented": true },
+      "tf-aws": { "implemented": true },
+      "tf-azure": { "implemented": true },
+      "tf-gcp": { "implemented": false, "issue": 1282 },
+      "awscdk": { "implemented": true }
     },
     "tryDelete": {
-      "sim": {"implemented": true},
-      "tf-aws": {"implemented": true},
-      "tf-azure": {"implemented": true},
-      "tf-gcp": {"implemented": false},
-      "aws-cdk": {"implemented": false}
+      "sim": { "implemented": true },
+      "tf-aws": { "implemented": true },
+      "tf-azure": { "implemented": true },
+      "tf-gcp": { "implemented": false },
+      "awscdk": { "implemented": false }
     },
     "exists": {
-      "sim": {"implemented": true},
-      "tf-aws": {"implemented": true},
-      "tf-azure": {"implemented": true},
-      "tf-gcp": {"implemented": false},
-      "aws-cdk": {"implemented": false}
+      "sim": { "implemented": true },
+      "tf-aws": { "implemented": true },
+      "tf-azure": { "implemented": true },
+      "tf-gcp": { "implemented": false },
+      "awscdk": { "implemented": false }
     },
     "metadata": {
-      "sim": {"implemented": false},
-      "tf-aws": {"implemented": false},
-      "tf-azure": {"implemented": false},
-      "tf-gcp": {"implemented": false},
-      "aws-cdk": {"implemented": false}
+      "sim": { "implemented": false },
+      "tf-aws": { "implemented": false },
+      "tf-azure": { "implemented": false },
+      "tf-gcp": { "implemented": false },
+      "awscdk": { "implemented": false }
     },
     "rename": {
-      "sim": {"implemented": false},
-      "tf-aws": {"implemented": false},
-      "tf-azure": {"implemented": false},
-      "tf-gcp": {"implemented": false},
-      "aws-cdk": {"implemented": false}
+      "sim": { "implemented": false },
+      "tf-aws": { "implemented": false },
+      "tf-azure": { "implemented": false },
+      "tf-gcp": { "implemented": false },
+      "awscdk": { "implemented": false }
     },
     "copy": {
-      "sim": {"implemented": false},
-      "tf-aws": {"implemented": false},
-      "tf-azure": {"implemented": false},
-      "tf-gcp": {"implemented": false},
-      "aws-cdk": {"implemented": false}
+      "sim": { "implemented": false },
+      "tf-aws": { "implemented": false },
+      "tf-azure": { "implemented": false },
+      "tf-gcp": { "implemented": false },
+      "awscdk": { "implemented": false }
     },
     "list": {
-      "sim": {"implemented": true},
-      "tf-aws": {"implemented": true},
-      "tf-azure": {"implemented": true},
-      "tf-gcp": {"implemented": false},
-      "aws-cdk": {"implemented": true}
+      "sim": { "implemented": true },
+      "tf-aws": { "implemented": true },
+      "tf-azure": { "implemented": true },
+      "tf-gcp": { "implemented": false },
+      "awscdk": { "implemented": true }
     },
     "publicUrl": {
-      "sim": {"implemented": true},
-      "tf-aws": {"implemented": true},
-      "tf-azure": {"implemented": false, "issue": 1805},
-      "tf-gcp": {"implemented": false, "issue": 1282},
-      "aws-cdk": {"implemented": true}
+      "sim": { "implemented": true },
+      "tf-aws": { "implemented": true },
+      "tf-azure": { "implemented": false, "issue": 1805 },
+      "tf-gcp": { "implemented": false, "issue": 1282 },
+      "awscdk": { "implemented": true }
     },
     "signedUrl": {
-      "sim": {"implemented": false, "issue": 1383},
-      "tf-aws": {"implemented": false, "issue": 1383},
-      "tf-azure": {"implemented": false},
-      "tf-gcp": {"implemented": false},
-      "aws-cdk": {"implemented": false}
+      "sim": { "implemented": false, "issue": 1383 },
+      "tf-aws": { "implemented": false, "issue": 1383 },
+      "tf-azure": { "implemented": false },
+      "tf-gcp": { "implemented": false },
+      "awscdk": { "implemented": false }
     }
   },
   "Queue": {
     "QueueProps.duration": {
-      "sim": {"implemented": true},
-      "tf-aws": {"implemented": false},
-      "tf-azure": {"implemented": false},
-      "tf-gcp": {"implemented": false},
-      "aws-cdk": {"implemented": true}
+      "sim": { "implemented": true },
+      "tf-aws": { "implemented": false },
+      "tf-azure": { "implemented": false },
+      "tf-gcp": { "implemented": false },
+      "awscdk": { "implemented": true }
     },
     "QueueProps.retentionPeriod": {
-      "sim": {"implemented": true},
-      "tf-aws": {"implemented": false},
-      "tf-azure": {"implemented": false},
-      "tf-gcp": {"implemented": false},
-      "aws-cdk": {"implemented": true}
+      "sim": { "implemented": true },
+      "tf-aws": { "implemented": false },
+      "tf-azure": { "implemented": false },
+      "tf-gcp": { "implemented": false },
+      "awscdk": { "implemented": true }
     },
     "QueueProps.initialMessages": {
-      "sim": {"implemented": true},
-      "tf-aws": {"implemented": true},
-      "tf-azure": {"implemented": false},
-      "tf-gcp": {"implemented": false},
-      "aws-cdk": {"implemented": true}
+      "sim": { "implemented": true },
+      "tf-aws": { "implemented": true },
+      "tf-azure": { "implemented": false },
+      "tf-gcp": { "implemented": false },
+      "awscdk": { "implemented": true }
     },
     "timeout": {
-      "sim": {"implemented": false, "issue": 1980},
-      "tf-aws": {"implemented": false, "issue": 3354},
-      "tf-azure": {"implemented": false},
-      "tf-gcp": {"implemented": false},
-      "aws-cdk": {"implemented": true}
+      "sim": { "implemented": false, "issue": 1980 },
+      "tf-aws": { "implemented": false, "issue": 3354 },
+      "tf-azure": { "implemented": false },
+      "tf-gcp": { "implemented": false },
+      "awscdk": { "implemented": true }
     },
     "setConsumer": {
-      "sim": {"implemented": true},
-      "tf-aws": {"implemented": true},
-      "tf-azure": {"implemented": false},
-      "tf-gcp": {"implemented": false},
-      "aws-cdk": {"implemented": true}
+      "sim": { "implemented": true },
+      "tf-aws": { "implemented": true },
+      "tf-azure": { "implemented": false },
+      "tf-gcp": { "implemented": false },
+      "awscdk": { "implemented": true }
     },
     "approxSize": {
-      "sim": {"implemented": true},
-      "tf-aws": {"implemented": true},
-      "tf-azure": {"implemented": false},
-      "tf-gcp": {"implemented": false},
-      "aws-cdk": {"implemented": true}
+      "sim": { "implemented": true },
+      "tf-aws": { "implemented": true },
+      "tf-azure": { "implemented": false },
+      "tf-gcp": { "implemented": false },
+      "awscdk": { "implemented": true }
     },
     "push": {
-      "sim": {"implemented": true},
-      "tf-aws": {"implemented": true},
-      "tf-azure": {"implemented": false},
-      "tf-gcp": {"implemented": false},
-      "aws-cdk": {"implemented": true}
+      "sim": { "implemented": true },
+      "tf-aws": { "implemented": true },
+      "tf-azure": { "implemented": false },
+      "tf-gcp": { "implemented": false },
+      "awscdk": { "implemented": true }
     },
     "pop": {
-      "sim": {"implemented": true},
-      "tf-aws": {"implemented": true},
-      "tf-azure": {"implemented": false},
-      "tf-gcp": {"implemented": false},
-      "aws-cdk": {"implemented": true}
+      "sim": { "implemented": true },
+      "tf-aws": { "implemented": true },
+      "tf-azure": { "implemented": false },
+      "tf-gcp": { "implemented": false },
+      "awscdk": { "implemented": true }
     },
     "purge": {
-      "sim": {"implemented": true},
-      "tf-aws": {"implemented": true},
-      "tf-azure": {"implemented": false},
-      "tf-gcp": {"implemented": false},
-      "aws-cdk": {"implemented": true}
+      "sim": { "implemented": true },
+      "tf-aws": { "implemented": true },
+      "tf-azure": { "implemented": false },
+      "tf-gcp": { "implemented": false },
+      "awscdk": { "implemented": true }
     }
   },
   "Function": {
     "FunctionProps.timeout": {
-      "sim": {"implemented": false, "issue": 1980},
-      "tf-aws": {"implemented": true},
-      "tf-azure": {"implemented": true},
-      "tf-gcp": {"implemented": false},
-      "aws-cdk": {"implemented": true}
+      "sim": { "implemented": false, "issue": 1980 },
+      "tf-aws": { "implemented": true },
+      "tf-azure": { "implemented": true },
+      "tf-gcp": { "implemented": false },
+      "awscdk": { "implemented": true }
     },
     "FunctionProps.memory": {
-      "sim": {"implemented": false},
-      "tf-aws": {"implemented": true},
-      "tf-azure": {"implemented": false},
-      "tf-gcp": {"implemented": false},
-      "aws-cdk": {"implemented": true}
+      "sim": { "implemented": false },
+      "tf-aws": { "implemented": true },
+      "tf-azure": { "implemented": false },
+      "tf-gcp": { "implemented": false },
+      "awscdk": { "implemented": true }
     },
     "FunctionProps.concurrency": {
-      "sim": {"implemented": false},
-      "tf-aws": {"implemented": false},
-      "tf-azure": {"implemented": false},
-      "tf-gcp": {"implemented": false},
-      "aws-cdk": {"implemented": false}
+      "sim": { "implemented": false },
+      "tf-aws": { "implemented": false },
+      "tf-azure": { "implemented": false },
+      "tf-gcp": { "implemented": false },
+      "awscdk": { "implemented": false }
     },
     "FunctionProps.env": {
-      "sim": {"implemented": false},
-      "tf-aws": {"implemented": true},
-      "tf-azure": {"implemented": false},
-      "tf-gcp": {"implemented": false},
-      "aws-cdk": {"implemented": true}
+      "sim": { "implemented": false },
+      "tf-aws": { "implemented": true },
+      "tf-azure": { "implemented": false },
+      "tf-gcp": { "implemented": false },
+      "awscdk": { "implemented": true }
     },
     "timeout": {
-      "sim": {"implemented": true},
-      "tf-aws": {"implemented": true},
-      "tf-azure": {"implemented": false},
-      "tf-gcp": {"implemented": false},
-      "aws-cdk": {"implemented": true}
+      "sim": { "implemented": true },
+      "tf-aws": { "implemented": true },
+      "tf-azure": { "implemented": false },
+      "tf-gcp": { "implemented": false },
+      "awscdk": { "implemented": true }
     },
     "memory": {
-      "sim": {"implemented": false},
-      "tf-aws": {"implemented": true},
-      "tf-azure": {"implemented": false},
-      "tf-gcp": {"implemented": false},
-      "aws-cdk": {"implemented": false}
+      "sim": { "implemented": false },
+      "tf-aws": { "implemented": true },
+      "tf-azure": { "implemented": false },
+      "tf-gcp": { "implemented": false },
+      "awscdk": { "implemented": false }
     },
     "concurrency": {
-      "sim": {"implemented": false},
-      "tf-aws": {"implemented": false},
-      "tf-azure": {"implemented": false},
-      "tf-gcp": {"implemented": false},
-      "aws-cdk": {"implemented": false}
+      "sim": { "implemented": false },
+      "tf-aws": { "implemented": false },
+      "tf-azure": { "implemented": false },
+      "tf-gcp": { "implemented": false },
+      "awscdk": { "implemented": false }
     },
     "addEnvironment": {
-      "sim": {"implemented": true},
-      "tf-aws": {"implemented": true},
-      "tf-azure": {"implemented": false},
-      "tf-gcp": {"implemented": false},
-      "aws-cdk": {"implemented": true}
+      "sim": { "implemented": true },
+      "tf-aws": { "implemented": true },
+      "tf-azure": { "implemented": false },
+      "tf-gcp": { "implemented": false },
+      "awscdk": { "implemented": true }
     },
     "invoke": {
-      "sim": {"implemented": true},
-      "tf-aws": {"implemented": true},
-      "tf-azure": {"implemented": false},
-      "tf-gcp": {"implemented": false, "issue": 614},
-      "aws-cdk": {"implemented": true}
+      "sim": { "implemented": true },
+      "tf-aws": { "implemented": true },
+      "tf-azure": { "implemented": false },
+      "tf-gcp": { "implemented": false, "issue": 614 },
+      "awscdk": { "implemented": true }
     },
     "invokeAsync": {
-      "sim": {"implemented": false},
-      "tf-aws": {"implemented": false},
-      "tf-azure": {"implemented": false},
-      "tf-gcp": {"implemented": false},
-      "aws-cdk": {"implemented": false}
+      "sim": { "implemented": false },
+      "tf-aws": { "implemented": false },
+      "tf-azure": { "implemented": false },
+      "tf-gcp": { "implemented": false },
+      "awscdk": { "implemented": false }
     }
   },
   "Counter": {
     "CounterProps.initial": {
-      "sim": {"implemented": true},
-      "tf-aws": {"implemented": true},
-      "tf-azure": {"implemented": false, "issue": 629},
-      "tf-gcp": {"implemented": false, "issue": 628},
-      "aws-cdk": {"implemented": true}
+      "sim": { "implemented": true },
+      "tf-aws": { "implemented": true },
+      "tf-azure": { "implemented": false, "issue": 629 },
+      "tf-gcp": { "implemented": false, "issue": 628 },
+      "awscdk": { "implemented": true }
     },
     "inc": {
-      "sim": {"implemented": true},
-      "tf-aws": {"implemented": true},
-      "tf-azure": {"implemented": false, "issue": 629},
-      "tf-gcp": {"implemented": false, "issue": 628},
-      "aws-cdk": {"implemented": true}
+      "sim": { "implemented": true },
+      "tf-aws": { "implemented": true },
+      "tf-azure": { "implemented": false, "issue": 629 },
+      "tf-gcp": { "implemented": false, "issue": 628 },
+      "awscdk": { "implemented": true }
     },
     "dec": {
-      "sim": {"implemented": true},
-      "tf-aws": {"implemented": true},
-      "tf-azure": {"implemented": false, "issue": 629},
-      "tf-gcp": {"implemented": false, "issue": 628},
-      "aws-cdk": {"implemented": true}
+      "sim": { "implemented": true },
+      "tf-aws": { "implemented": true },
+      "tf-azure": { "implemented": false, "issue": 629 },
+      "tf-gcp": { "implemented": false, "issue": 628 },
+      "awscdk": { "implemented": true }
     },
     "peek": {
-      "sim": {"implemented": true},
-      "tf-aws": {"implemented": true},
-      "tf-azure": {"implemented": false, "issue": 629},
-      "tf-gcp": {"implemented": false, "issue": 628},
-      "aws-cdk": {"implemented": true}
+      "sim": { "implemented": true },
+      "tf-aws": { "implemented": true },
+      "tf-azure": { "implemented": false, "issue": 629 },
+      "tf-gcp": { "implemented": false, "issue": 628 },
+      "awscdk": { "implemented": true }
     },
     "reset": {
-      "sim": {"implemented": true},
-      "tf-aws": {"implemented": true},
-      "tf-azure": {"implemented": false, "issue": 629},
-      "tf-gcp": {"implemented": false, "issue": 628},
-      "aws-cdk": {"implemented": true}
+      "sim": { "implemented": true },
+      "tf-aws": { "implemented": true },
+      "tf-azure": { "implemented": false, "issue": 629 },
+      "tf-gcp": { "implemented": false, "issue": 628 },
+      "awscdk": { "implemented": true }
     }
   },
   "Topic": {
     "publish": {
-      "sim": {"implemented": true},
-      "tf-aws": {"implemented": true},
-      "tf-azure": {"implemented": false, "issue": 621},
-      "tf-gcp": {"implemented": false, "issue": 620},
-      "aws-cdk": {"implemented": true}
+      "sim": { "implemented": true },
+      "tf-aws": { "implemented": true },
+      "tf-azure": { "implemented": false, "issue": 621 },
+      "tf-gcp": { "implemented": false, "issue": 620 },
+      "awscdk": { "implemented": true }
     },
     "onMessage": {
-      "sim": {"implemented": true},
-      "tf-aws": {"implemented": true},
-      "tf-azure": {"implemented": false, "issue": 621},
-      "tf-gcp": {"implemented": false, "issue": 620},
-      "aws-cdk": {"implemented": true}
+      "sim": { "implemented": true },
+      "tf-aws": { "implemented": true },
+      "tf-azure": { "implemented": false, "issue": 621 },
+      "tf-gcp": { "implemented": false, "issue": 620 },
+      "awscdk": { "implemented": true }
     }
   },
   "Schedule": {
     "ScheduleProps.cron": {
-      "sim": {"implemented": true},
-      "tf-aws": {"implemented": true},
-      "tf-azure": {"implemented": false, "issue": 1291},
-      "tf-gcp": {"implemented": false, "issue": 1292},
-      "aws-cdk": {"implemented": false}
+      "sim": { "implemented": true },
+      "tf-aws": { "implemented": true },
+      "tf-azure": { "implemented": false, "issue": 1291 },
+      "tf-gcp": { "implemented": false, "issue": 1292 },
+      "awscdk": { "implemented": false }
     },
     "ScheduleProps.rate": {
-      "sim": {"implemented": true},
-      "tf-aws": {"implemented": true},
-      "tf-azure": {"implemented": false, "issue": 1291},
-      "tf-gcp": {"implemented": false, "issue": 1292},
-      "aws-cdk": {"implemented": false}
+      "sim": { "implemented": true },
+      "tf-aws": { "implemented": true },
+      "tf-azure": { "implemented": false, "issue": 1291 },
+      "tf-gcp": { "implemented": false, "issue": 1292 },
+      "awscdk": { "implemented": false }
     },
     "onTick": {
-      "sim": {"implemented": true},
-      "tf-aws": {"implemented": true},
-      "tf-azure": {"implemented": false, "issue": 1291},
-      "tf-gcp": {"implemented": false, "issue": 1292},
-      "aws-cdk": {"implemented": false}
+      "sim": { "implemented": true },
+      "tf-aws": { "implemented": true },
+      "tf-azure": { "implemented": false, "issue": 1291 },
+      "tf-gcp": { "implemented": false, "issue": 1292 },
+      "awscdk": { "implemented": false }
     }
   },
   "Website": {
     "WebsiteProps.path": {
-      "sim": {"implemented": true},
-      "tf-aws": {"implemented": true},
-      "tf-azure": {"implemented": false, "issue": 1295},
-      "tf-gcp": {"implemented": false, "issue": 1296},
-      "aws-cdk": {"implemented": false}
+      "sim": { "implemented": true },
+      "tf-aws": { "implemented": true },
+      "tf-azure": { "implemented": false, "issue": 1295 },
+      "tf-gcp": { "implemented": false, "issue": 1296 },
+      "awscdk": { "implemented": false }
     },
     "WebsiteProps.domain": {
-      "sim": {"implemented": false},
-      "tf-aws": {"implemented": false, "issue": 2440},
-      "tf-azure": {"implemented": false, "issue": 1295},
-      "tf-gcp": {"implemented": false, "issue": 1296},
-      "aws-cdk": {"implemented": false}
+      "sim": { "implemented": false },
+      "tf-aws": { "implemented": false, "issue": 2440 },
+      "tf-azure": { "implemented": false, "issue": 1295 },
+      "tf-gcp": { "implemented": false, "issue": 1296 },
+      "awscdk": { "implemented": false }
     },
     "path": {
-      "sim": {"implemented": true},
-      "tf-aws": {"implemented": true},
-      "tf-azure": {"implemented": false, "issue": 1295},
-      "tf-gcp": {"implemented": false, "issue": 1296},
-      "aws-cdk": {"implemented": false}
+      "sim": { "implemented": true },
+      "tf-aws": { "implemented": true },
+      "tf-azure": { "implemented": false, "issue": 1295 },
+      "tf-gcp": { "implemented": false, "issue": 1296 },
+      "awscdk": { "implemented": false }
     },
     "url": {
-      "sim": {"implemented": true},
-      "tf-aws": {"implemented": true},
-      "tf-azure": {"implemented": false, "issue": 1295},
-      "tf-gcp": {"implemented": false, "issue": 1296},
-      "aws-cdk": {"implemented": false}
+      "sim": { "implemented": true },
+      "tf-aws": { "implemented": true },
+      "tf-azure": { "implemented": false, "issue": 1295 },
+      "tf-gcp": { "implemented": false, "issue": 1296 },
+      "awscdk": { "implemented": false }
     }
   },
   "Api": {
     "ApiProps.ApiCorsProps": {
-      "sim": {"implemented": false},
-      "tf-aws": {"implemented": false},
-      "tf-azure": {"implemented": false, "issue": 625},
-      "tf-gcp": {"implemented": false, "issue": 624},
-      "aws-cdk": {"implemented": false}
+      "sim": { "implemented": false },
+      "tf-aws": { "implemented": false },
+      "tf-azure": { "implemented": false, "issue": 625 },
+      "tf-gcp": { "implemented": false, "issue": 624 },
+      "awscdk": { "implemented": false }
     },
     "url": {
-      "sim": {"implemented": true},
-      "tf-aws": {"implemented": false, "issue": 3342},
-      "tf-azure": {"implemented": false, "issue": 625},
-      "tf-gcp": {"implemented": false, "issue": 624},
-      "aws-cdk": {"implemented": false}
+      "sim": { "implemented": true },
+      "tf-aws": { "implemented": false, "issue": 3342 },
+      "tf-azure": { "implemented": false, "issue": 625 },
+      "tf-gcp": { "implemented": false, "issue": 624 },
+      "awscdk": { "implemented": false }
     },
     "cors": {
-      "sim": {"implemented": false, "issue": 2289},
-      "tf-aws": {"implemented": false, "issue": 2289},
-      "tf-azure": {"implemented": false, "issue": 625},
-      "tf-gcp": {"implemented": false, "issue": 624},
-      "aws-cdk": {"implemented": false, "issue": 2289}
+      "sim": { "implemented": false, "issue": 2289 },
+      "tf-aws": { "implemented": false, "issue": 2289 },
+      "tf-azure": { "implemented": false, "issue": 625 },
+      "tf-gcp": { "implemented": false, "issue": 624 },
+      "awscdk": { "implemented": false, "issue": 2289 }
     },
     "get": {
-      "sim": {"implemented": true},
-      "tf-aws": {"implemented": true},
-      "tf-azure": {"implemented": false, "issue": 625},
-      "tf-gcp": {"implemented": false, "issue": 624},
-      "aws-cdk": {"implemented": false}
+      "sim": { "implemented": true },
+      "tf-aws": { "implemented": true },
+      "tf-azure": { "implemented": false, "issue": 625 },
+      "tf-gcp": { "implemented": false, "issue": 624 },
+      "awscdk": { "implemented": false }
     },
     "post": {
-      "sim": {"implemented": true},
-      "tf-aws": {"implemented": true},
-      "tf-azure": {"implemented": false, "issue": 625},
-      "tf-gcp": {"implemented": false, "issue": 624},
-      "aws-cdk": {"implemented": false}
+      "sim": { "implemented": true },
+      "tf-aws": { "implemented": true },
+      "tf-azure": { "implemented": false, "issue": 625 },
+      "tf-gcp": { "implemented": false, "issue": 624 },
+      "awscdk": { "implemented": false }
     },
     "put": {
-      "sim": {"implemented": true},
-      "tf-aws": {"implemented": true},
-      "tf-azure": {"implemented": false, "issue": 625},
-      "tf-gcp": {"implemented": false, "issue": 624},
-      "aws-cdk": {"implemented": false}
+      "sim": { "implemented": true },
+      "tf-aws": { "implemented": true },
+      "tf-azure": { "implemented": false, "issue": 625 },
+      "tf-gcp": { "implemented": false, "issue": 624 },
+      "awscdk": { "implemented": false }
     },
     "delete": {
-      "sim": {"implemented": true},
-      "tf-aws": {"implemented": true},
-      "tf-azure": {"implemented": false, "issue": 625},
-      "tf-gcp": {"implemented": false, "issue": 624},
-      "aws-cdk": {"implemented": false}
+      "sim": { "implemented": true },
+      "tf-aws": { "implemented": true },
+      "tf-azure": { "implemented": false, "issue": 625 },
+      "tf-gcp": { "implemented": false, "issue": 624 },
+      "awscdk": { "implemented": false }
     },
     "patch": {
-      "sim": {"implemented": true},
-      "tf-aws": {"implemented": true},
-      "tf-azure": {"implemented": false, "issue": 625},
-      "tf-gcp": {"implemented": false, "issue": 624},
-      "aws-cdk": {"implemented": false}
+      "sim": { "implemented": true },
+      "tf-aws": { "implemented": true },
+      "tf-azure": { "implemented": false, "issue": 625 },
+      "tf-gcp": { "implemented": false, "issue": 624 },
+      "awscdk": { "implemented": false }
     },
     "any": {
-      "sim": {"implemented": false, "issue": 1848},
-      "tf-aws": {"implemented": false, "issue": 1848},
-      "tf-azure": {"implemented": false, "issue": 625},
-      "tf-gcp": {"implemented": false, "issue": 624},
-      "aws-cdk": {"implemented": false, "issue": 1848}
+      "sim": { "implemented": false, "issue": 1848 },
+      "tf-aws": { "implemented": false, "issue": 1848 },
+      "tf-azure": { "implemented": false, "issue": 625 },
+      "tf-gcp": { "implemented": false, "issue": 624 },
+      "awscdk": { "implemented": false, "issue": 1848 }
     },
     "request": {
-      "sim": {"implemented": false, "issue": 1850},
-      "tf-aws": {"implemented": false, "issue": 1850},
-      "tf-azure": {"implemented": false, "issue": 625},
-      "tf-gcp": {"implemented": false, "issue": 624},
-      "aws-cdk": {"implemented": false, "issue": 1850}
+      "sim": { "implemented": false, "issue": 1850 },
+      "tf-aws": { "implemented": false, "issue": 1850 },
+      "tf-azure": { "implemented": false, "issue": 625 },
+      "tf-gcp": { "implemented": false, "issue": 624 },
+      "awscdk": { "implemented": false, "issue": 1850 }
     }
   },
 
   "Secret": {
     "SecretProps.name": {
-      "sim": {"implemented": true},
-      "tf-aws": {"implemented": true},
-      "tf-azure": {"implemented": false, "issue": 2178},
-      "tf-gcp": {"implemented": false, "issue": 2179},
-      "aws-cdk": {"implemented": true}
+      "sim": { "implemented": true },
+      "tf-aws": { "implemented": true },
+      "tf-azure": { "implemented": false, "issue": 2178 },
+      "tf-gcp": { "implemented": false, "issue": 2179 },
+      "awscdk": { "implemented": true }
     },
     "SecretProps.value": {
-      "sim": {"implemented": true},
-      "tf-aws": {"implemented": true},
-      "tf-azure": {"implemented": false, "issue": 2178},
-      "tf-gcp": {"implemented": false, "issue": 2179},
-      "aws-cdk": {"implemented": true}
+      "sim": { "implemented": true },
+      "tf-aws": { "implemented": true },
+      "tf-azure": { "implemented": false, "issue": 2178 },
+      "tf-gcp": { "implemented": false, "issue": 2179 },
+      "awscdk": { "implemented": true }
     },
     "SecretProps.valueJson": {
-      "sim": {"implemented": true},
-      "tf-aws": {"implemented": true},
-      "tf-azure": {"implemented": false, "issue": 2178},
-      "tf-gcp": {"implemented": false, "issue": 2179},
-      "aws-cdk": {"implemented": true}
+      "sim": { "implemented": true },
+      "tf-aws": { "implemented": true },
+      "tf-azure": { "implemented": false, "issue": 2178 },
+      "tf-gcp": { "implemented": false, "issue": 2179 },
+      "awscdk": { "implemented": true }
     }
   },
   "Service": {
     "ServiceProps.buildpackPath": {
-      "sim": {"implemented": false, "issue": 1305},
-      "tf-aws": {"implemented": false, "issue": 1306},
-      "tf-azure": {"implemented": false, "issue": 1307},
-      "tf-gcp": {"implemented": false, "issue": 1308},
-      "aws-cdk": {"implemented": false}
+      "sim": { "implemented": false, "issue": 1305 },
+      "tf-aws": { "implemented": false, "issue": 1306 },
+      "tf-azure": { "implemented": false, "issue": 1307 },
+      "tf-gcp": { "implemented": false, "issue": 1308 },
+      "awscdk": { "implemented": false }
     },
     "ServiceProps.env": {
-      "sim": {"implemented": false, "issue": 1305},
-      "tf-aws": {"implemented": false, "issue": 1306},
-      "tf-azure": {"implemented": false, "issue": 1307},
-      "tf-gcp": {"implemented": false, "issue": 1308},
-      "aws-cdk": {"implemented": false}
+      "sim": { "implemented": false, "issue": 1305 },
+      "tf-aws": { "implemented": false, "issue": 1306 },
+      "tf-azure": { "implemented": false, "issue": 1307 },
+      "tf-gcp": { "implemented": false, "issue": 1308 },
+      "awscdk": { "implemented": false }
     },
     "ServiceProps.command": {
-      "sim": {"implemented": false, "issue": 1305},
-      "tf-aws": {"implemented": false, "issue": 1306},
-      "tf-azure": {"implemented": false, "issue": 1307},
-      "tf-gcp": {"implemented": false, "issue": 1308},
-      "aws-cdk": {"implemented": false}
+      "sim": { "implemented": false, "issue": 1305 },
+      "tf-aws": { "implemented": false, "issue": 1306 },
+      "tf-azure": { "implemented": false, "issue": 1307 },
+      "tf-gcp": { "implemented": false, "issue": 1308 },
+      "awscdk": { "implemented": false }
     },
     "ServiceProps.port": {
-      "sim": {"implemented": false, "issue": 1305},
-      "tf-aws": {"implemented": false, "issue": 1306},
-      "tf-azure": {"implemented": false, "issue": 1307},
-      "tf-gcp": {"implemented": false, "issue": 1308},
-      "aws-cdk": {"implemented": false}
+      "sim": { "implemented": false, "issue": 1305 },
+      "tf-aws": { "implemented": false, "issue": 1306 },
+      "tf-azure": { "implemented": false, "issue": 1307 },
+      "tf-gcp": { "implemented": false, "issue": 1308 },
+      "awscdk": { "implemented": false }
     },
     "ServiceProps.memory": {
-      "sim": {"implemented": false, "issue": 1305},
-      "tf-aws": {"implemented": false, "issue": 1306},
-      "tf-azure": {"implemented": false, "issue": 1307},
-      "tf-gcp": {"implemented": false, "issue": 1308},
-      "aws-cdk": {"implemented": false}
+      "sim": { "implemented": false, "issue": 1305 },
+      "tf-aws": { "implemented": false, "issue": 1306 },
+      "tf-azure": { "implemented": false, "issue": 1307 },
+      "tf-gcp": { "implemented": false, "issue": 1308 },
+      "awscdk": { "implemented": false }
     },
     "ServiceProps.cpu": {
-      "sim": {"implemented": false, "issue": 1305},
-      "tf-aws": {"implemented": false, "issue": 1306},
-      "tf-azure": {"implemented": false, "issue": 1307},
-      "tf-gcp": {"implemented": false, "issue": 1308},
-      "aws-cdk": {"implemented": false}
+      "sim": { "implemented": false, "issue": 1305 },
+      "tf-aws": { "implemented": false, "issue": 1306 },
+      "tf-azure": { "implemented": false, "issue": 1307 },
+      "tf-gcp": { "implemented": false, "issue": 1308 },
+      "awscdk": { "implemented": false }
     },
     "url": {
-      "sim": {"implemented": false, "issue": 1305},
-      "tf-aws": {"implemented": false, "issue": 1306},
-      "tf-azure": {"implemented": false, "issue": 1307},
-      "tf-gcp": {"implemented": false, "issue": 1308},
-      "aws-cdk": {"implemented": false}
+      "sim": { "implemented": false, "issue": 1305 },
+      "tf-aws": { "implemented": false, "issue": 1306 },
+      "tf-azure": { "implemented": false, "issue": 1307 },
+      "tf-gcp": { "implemented": false, "issue": 1308 },
+      "awscdk": { "implemented": false }
     },
     "buildpackPath": {
-      "sim": {"implemented": false, "issue": 1305},
-      "tf-aws": {"implemented": false, "issue": 1306},
-      "tf-azure": {"implemented": false, "issue": 1307},
-      "tf-gcp": {"implemented": false, "issue": 1308},
-      "aws-cdk": {"implemented": false}
+      "sim": { "implemented": false, "issue": 1305 },
+      "tf-aws": { "implemented": false, "issue": 1306 },
+      "tf-azure": { "implemented": false, "issue": 1307 },
+      "tf-gcp": { "implemented": false, "issue": 1308 },
+      "awscdk": { "implemented": false }
     },
     "command": {
-      "sim": {"implemented": false, "issue": 1305},
-      "tf-aws": {"implemented": false, "issue": 1306},
-      "tf-azure": {"implemented": false, "issue": 1307},
-      "tf-gcp": {"implemented": false, "issue": 1308},
-      "aws-cdk": {"implemented": false}
+      "sim": { "implemented": false, "issue": 1305 },
+      "tf-aws": { "implemented": false, "issue": 1306 },
+      "tf-azure": { "implemented": false, "issue": 1307 },
+      "tf-gcp": { "implemented": false, "issue": 1308 },
+      "awscdk": { "implemented": false }
     },
     "port": {
-      "sim": {"implemented": false, "issue": 1305},
-      "tf-aws": {"implemented": false, "issue": 1306},
-      "tf-azure": {"implemented": false, "issue": 1307},
-      "tf-gcp": {"implemented": false, "issue": 1308},
-      "aws-cdk": {"implemented": false}
+      "sim": { "implemented": false, "issue": 1305 },
+      "tf-aws": { "implemented": false, "issue": 1306 },
+      "tf-azure": { "implemented": false, "issue": 1307 },
+      "tf-gcp": { "implemented": false, "issue": 1308 },
+      "awscdk": { "implemented": false }
     },
     "memory": {
-      "sim": {"implemented": false, "issue": 1305},
-      "tf-aws": {"implemented": false, "issue": 1306},
-      "tf-azure": {"implemented": false, "issue": 1307},
-      "tf-gcp": {"implemented": false, "issue": 1308},
-      "aws-cdk": {"implemented": false}
+      "sim": { "implemented": false, "issue": 1305 },
+      "tf-aws": { "implemented": false, "issue": 1306 },
+      "tf-azure": { "implemented": false, "issue": 1307 },
+      "tf-gcp": { "implemented": false, "issue": 1308 },
+      "awscdk": { "implemented": false }
     },
     "cpu": {
-      "sim": {"implemented": false, "issue": 1305},
-      "tf-aws": {"implemented": false, "issue": 1306},
-      "tf-azure": {"implemented": false, "issue": 1307},
-      "tf-gcp": {"implemented": false, "issue": 1308},
-      "aws-cdk": {"implemented": false}
+      "sim": { "implemented": false, "issue": 1305 },
+      "tf-aws": { "implemented": false, "issue": 1306 },
+      "tf-azure": { "implemented": false, "issue": 1307 },
+      "tf-gcp": { "implemented": false, "issue": 1308 },
+      "awscdk": { "implemented": false }
     },
     "replicas": {
-      "sim": {"implemented": false, "issue": 1305},
-      "tf-aws": {"implemented": false, "issue": 1306},
-      "tf-azure": {"implemented": false, "issue": 1307},
-      "tf-gcp": {"implemented": false, "issue": 1308},
-      "aws-cdk": {"implemented": false}
+      "sim": { "implemented": false, "issue": 1305 },
+      "tf-aws": { "implemented": false, "issue": 1306 },
+      "tf-azure": { "implemented": false, "issue": 1307 },
+      "tf-gcp": { "implemented": false, "issue": 1308 },
+      "awscdk": { "implemented": false }
     },
     "addEnv": {
-      "sim": {"implemented": false, "issue": 1305},
-      "tf-aws": {"implemented": false, "issue": 1306},
-      "tf-azure": {"implemented": false, "issue": 1307},
-      "tf-gcp": {"implemented": false, "issue": 1308},
-      "aws-cdk": {"implemented": false}
+      "sim": { "implemented": false, "issue": 1305 },
+      "tf-aws": { "implemented": false, "issue": 1306 },
+      "tf-azure": { "implemented": false, "issue": 1307 },
+      "tf-gcp": { "implemented": false, "issue": 1308 },
+      "awscdk": { "implemented": false }
     },
     "request": {
-      "sim": {"implemented": false, "issue": 1305},
-      "tf-aws": {"implemented": false, "issue": 1306},
-      "tf-azure": {"implemented": false, "issue": 1307},
-      "tf-gcp": {"implemented": false, "issue": 1308},
-      "aws-cdk": {"implemented": false}
+      "sim": { "implemented": false, "issue": 1305 },
+      "tf-aws": { "implemented": false, "issue": 1306 },
+      "tf-azure": { "implemented": false, "issue": 1307 },
+      "tf-gcp": { "implemented": false, "issue": 1308 },
+      "awscdk": { "implemented": false }
     }
   },
   "Table": {
     "TableProps.name": {
-      "sim": {"implemented": true},
-      "tf-aws": {"implemented": true},
-      "tf-azure": {"implemented": false, "issue": 1315},
-      "tf-gcp": {"implemented": false, "issue": 1316},
-      "aws-cdk": {"implemented": false}
+      "sim": { "implemented": true },
+      "tf-aws": { "implemented": true },
+      "tf-azure": { "implemented": false, "issue": 1315 },
+      "tf-gcp": { "implemented": false, "issue": 1316 },
+      "awscdk": { "implemented": false }
     },
     "TableProps.columns": {
-      "sim": {"implemented": true},
-      "tf-aws": {"implemented": true},
-      "tf-azure": {"implemented": false, "issue": 1315},
-      "tf-gcp": {"implemented": false, "issue": 1316},
-      "aws-cdk": {"implemented": false}
+      "sim": { "implemented": true },
+      "tf-aws": { "implemented": true },
+      "tf-azure": { "implemented": false, "issue": 1315 },
+      "tf-gcp": { "implemented": false, "issue": 1316 },
+      "awscdk": { "implemented": false }
     },
     "TableProps.primaryKey": {
-      "sim": {"implemented": true},
-      "tf-aws": {"implemented": true},
-      "tf-azure": {"implemented": false, "issue": 1315},
-      "tf-gcp": {"implemented": false, "issue": 1316},
-      "aws-cdk": {"implemented": false}
+      "sim": { "implemented": true },
+      "tf-aws": { "implemented": true },
+      "tf-azure": { "implemented": false, "issue": 1315 },
+      "tf-gcp": { "implemented": false, "issue": 1316 },
+      "awscdk": { "implemented": false }
     },
     "name": {
-      "sim": {"implemented": true},
-      "tf-aws": {"implemented": true},
-      "tf-azure": {"implemented": false, "issue": 1315},
-      "tf-gcp": {"implemented": false, "issue": 1316},
-      "aws-cdk": {"implemented": false}
+      "sim": { "implemented": true },
+      "tf-aws": { "implemented": true },
+      "tf-azure": { "implemented": false, "issue": 1315 },
+      "tf-gcp": { "implemented": false, "issue": 1316 },
+      "awscdk": { "implemented": false }
     },
     "columns": {
-      "sim": {"implemented": true},
-      "tf-aws": {"implemented": true},
-      "tf-azure": {"implemented": false, "issue": 1315},
-      "tf-gcp": {"implemented": false, "issue": 1316},
-      "aws-cdk": {"implemented": false}
+      "sim": { "implemented": true },
+      "tf-aws": { "implemented": true },
+      "tf-azure": { "implemented": false, "issue": 1315 },
+      "tf-gcp": { "implemented": false, "issue": 1316 },
+      "awscdk": { "implemented": false }
     },
     "primaryKey": {
-      "sim": {"implemented": true},
-      "tf-aws": {"implemented": true},
-      "tf-azure": {"implemented": false, "issue": 1315},
-      "tf-gcp": {"implemented": false, "issue": 1316},
-      "aws-cdk": {"implemented": false}
+      "sim": { "implemented": true },
+      "tf-aws": { "implemented": true },
+      "tf-azure": { "implemented": false, "issue": 1315 },
+      "tf-gcp": { "implemented": false, "issue": 1316 },
+      "awscdk": { "implemented": false }
     },
     "addRow": {
-      "sim": {"implemented": true},
-      "tf-aws": {"implemented": true},
-      "tf-azure": {"implemented": false},
-      "tf-gcp": {"implemented": false},
-      "aws-cdk": {"implemented": false}
+      "sim": { "implemented": true },
+      "tf-aws": { "implemented": true },
+      "tf-azure": { "implemented": false },
+      "tf-gcp": { "implemented": false },
+      "awscdk": { "implemented": false }
     },
     "insert": {
-      "sim": {"implemented": true},
-      "tf-aws": {"implemented": true},
-      "tf-azure": {"implemented": false, "issue": 1315},
-      "tf-gcp": {"implemented": false, "issue": 1316},
-      "aws-cdk": {"implemented": false}
+      "sim": { "implemented": true },
+      "tf-aws": { "implemented": true },
+      "tf-azure": { "implemented": false, "issue": 1315 },
+      "tf-gcp": { "implemented": false, "issue": 1316 },
+      "awscdk": { "implemented": false }
     },
     "update": {
-      "sim": {"implemented": true},
-      "tf-aws": {"implemented": true},
-      "tf-azure": {"implemented": false, "issue": 1315},
-      "tf-gcp": {"implemented": false, "issue": 1316},
-      "aws-cdk": {"implemented": false}
+      "sim": { "implemented": true },
+      "tf-aws": { "implemented": true },
+      "tf-azure": { "implemented": false, "issue": 1315 },
+      "tf-gcp": { "implemented": false, "issue": 1316 },
+      "awscdk": { "implemented": false }
     },
     "delete": {
-      "sim": {"implemented": true},
-      "tf-aws": {"implemented": true},
-      "tf-azure": {"implemented": false, "issue": 1315},
-      "tf-gcp": {"implemented": false, "issue": 1316},
-      "aws-cdk": {"implemented": false}
+      "sim": { "implemented": true },
+      "tf-aws": { "implemented": true },
+      "tf-azure": { "implemented": false, "issue": 1315 },
+      "tf-gcp": { "implemented": false, "issue": 1316 },
+      "awscdk": { "implemented": false }
     },
     "get": {
-      "sim": {"implemented": true},
-      "tf-aws": {"implemented": true},
-      "tf-azure": {"implemented": false, "issue": 1315},
-      "tf-gcp": {"implemented": false, "issue": 1316},
-      "aws-cdk": {"implemented": false}
+      "sim": { "implemented": true },
+      "tf-aws": { "implemented": true },
+      "tf-azure": { "implemented": false, "issue": 1315 },
+      "tf-gcp": { "implemented": false, "issue": 1316 },
+      "awscdk": { "implemented": false }
     },
     "list": {
-      "sim": {"implemented": true},
-      "tf-aws": {"implemented": true},
-      "tf-azure": {"implemented": false, "issue": 1315},
-      "tf-gcp": {"implemented": false, "issue": 1316},
-      "aws-cdk": {"implemented": false}
+      "sim": { "implemented": true },
+      "tf-aws": { "implemented": true },
+      "tf-azure": { "implemented": false, "issue": 1315 },
+      "tf-gcp": { "implemented": false, "issue": 1316 },
+      "awscdk": { "implemented": false }
     }
   }
 }


### PR DESCRIPTION
The target is called `awscdk`, not `aws-cdk`.

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
