### PR TITLE
fix(sdk): removing aws-sdk v3 from bundling

### DIFF
--- a/libs/wingsdk/src/shared/bundling.ts
+++ b/libs/wingsdk/src/shared/bundling.ts
@@ -32,7 +32,7 @@ export function createBundle(entrypoint: string, outputDir?: string): Bundle {
     minify: false,
     platform: "node",
     target: "node18",
-    external: ["aws-sdk", "@aws-sdk"],
+    external: ["@aws-sdk"],
   });
 
   if (esbuild.errors.length > 0) {

--- a/libs/wingsdk/src/shared/bundling.ts
+++ b/libs/wingsdk/src/shared/bundling.ts
@@ -31,8 +31,8 @@ export function createBundle(entrypoint: string, outputDir?: string): Bundle {
       : undefined,
     minify: false,
     platform: "node",
-    target: "node16",
-    external: ["aws-sdk"],
+    target: "node18",
+    external: ["aws-sdk", "@aws-sdk"],
   });
 
   if (esbuild.errors.length > 0) {


### PR DESCRIPTION
The bundling is configured for Node.js 16 (pointing to `aws-sdk` v2 as an external library), but we are configuring our functions on AWS with Node.js 18, which already includes `aws-sdk` v3.

Our entire implementation is using version 3 of `aws-sdk`, so I am updating the bundling to use Node.js 18 and marking `@aws-sdk` as an external library.

from this
![image](https://github.com/winglang/wing/assets/67694075/0b5ca67b-81ba-4db9-a95f-538c0f668385)
to this
![image](https://github.com/winglang/wing/assets/67694075/9bfddbc7-140d-4c58-b0ab-fcd4921633cf)


Close #4103 

## Checklist

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [ ] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
