### PR TITLE
chore: pin node to 20.5.1 in ci

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -204,7 +204,8 @@ jobs:
       fail-fast: true
       matrix:
         runner: [windows, macos, ubuntu]
-        node: ["18", "20"]
+        # Pinned 20 to 20.5.1 until https://github.com/nodejs/node/issues/49497 is released
+        node: ["18", "20.5.1"]
         shard: ["1/2", "2/2"]
         full_run:
           # Do a full run on push or when the PR is labeled "pr/e2e-full"


### PR DESCRIPTION
Fixes #4099

Waiting for https://github.com/nodejs/node/issues/49497 to be released

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
