### PR TITLE
chore(sdk): remove unnecessary `cloud.Bucket` encryption config for aws targets

### DIFF
--- a/libs/wingsdk/src/target-tf-aws/bucket.ts
+++ b/libs/wingsdk/src/target-tf-aws/bucket.ts
@@ -12,7 +12,6 @@ import {
 
 import { S3BucketPolicy } from "../.gen/providers/aws/s3-bucket-policy";
 import { S3BucketPublicAccessBlock } from "../.gen/providers/aws/s3-bucket-public-access-block";
-import { S3BucketServerSideEncryptionConfigurationA } from "../.gen/providers/aws/s3-bucket-server-side-encryption-configuration";
 import { S3Object } from "../.gen/providers/aws/s3-object";
 import * as cloud from "../cloud";
 import * as core from "../core";
@@ -164,18 +163,6 @@ export function createEncryptedBucket(
   const bucket = new S3Bucket(scope, name, {
     bucketPrefix,
     forceDestroy: isTestEnvironment ? true : false,
-  });
-
-  // best practice: (at-rest) data encryption with Amazon S3-managed keys
-  new S3BucketServerSideEncryptionConfigurationA(scope, "Encryption", {
-    bucket: bucket.bucket,
-    rule: [
-      {
-        applyServerSideEncryptionByDefault: {
-          sseAlgorithm: "AES256",
-        },
-      },
-    ],
   });
 
   if (isPublic) {

--- a/libs/wingsdk/test/target-tf-aws/__snapshots__/bucket.test.ts.snap
+++ b/libs/wingsdk/test/target-tf-aws/__snapshots__/bucket.test.ts.snap
@@ -32,18 +32,6 @@ exports[`bucket is public 1`] = `
         "restrict_public_buckets": false,
       },
     },
-    "aws_s3_bucket_server_side_encryption_configuration": {
-      "my_bucket_Encryption_3B1569A4": {
-        "bucket": "\${aws_s3_bucket.my_bucket.bucket}",
-        "rule": [
-          {
-            "apply_server_side_encryption_by_default": {
-              "sse_algorithm": "AES256",
-            },
-          },
-        ],
-      },
-    },
   },
 }
 `;
@@ -96,14 +84,6 @@ exports[`bucket is public 2`] = `
                     },
                     "id": "Default",
                     "path": "root/Default/my_bucket/Default",
-                  },
-                  "Encryption": {
-                    "constructInfo": {
-                      "fqn": "cdktf.TerraformResource",
-                      "version": "0.17.0",
-                    },
-                    "id": "Encryption",
-                    "path": "root/Default/my_bucket/Encryption",
                   },
                   "PublicAccessBlock": {
                     "constructInfo": {
@@ -183,18 +163,6 @@ exports[`bucket prefix must be lowercase 1`] = `
         "force_destroy": false,
       },
     },
-    "aws_s3_bucket_server_side_encryption_configuration": {
-      "The-UncannyBucket_Encryption_4CFC1E98": {
-        "bucket": "\${aws_s3_bucket.The-UncannyBucket.bucket}",
-        "rule": [
-          {
-            "apply_server_side_encryption_by_default": {
-              "sse_algorithm": "AES256",
-            },
-          },
-        ],
-      },
-    },
   },
 }
 `;
@@ -216,14 +184,6 @@ exports[`bucket prefix must be lowercase 2`] = `
                     },
                     "id": "Default",
                     "path": "root/Default/The-Uncanny.Bucket/Default",
-                  },
-                  "Encryption": {
-                    "constructInfo": {
-                      "fqn": "cdktf.TerraformResource",
-                      "version": "0.17.0",
-                    },
-                    "id": "Encryption",
-                    "path": "root/Default/The-Uncanny.Bucket/Encryption",
                   },
                 },
                 "constructInfo": {
@@ -318,18 +278,6 @@ exports[`bucket prefix valid 1`] = `
         "force_destroy": false,
       },
     },
-    "aws_s3_bucket_server_side_encryption_configuration": {
-      "the-uncannybucket_Encryption_78D02B71": {
-        "bucket": "\${aws_s3_bucket.the-uncannybucket.bucket}",
-        "rule": [
-          {
-            "apply_server_side_encryption_by_default": {
-              "sse_algorithm": "AES256",
-            },
-          },
-        ],
-      },
-    },
   },
 }
 `;
@@ -382,14 +330,6 @@ exports[`bucket prefix valid 2`] = `
                     },
                     "id": "Default",
                     "path": "root/Default/the-uncanny.bucket/Default",
-                  },
-                  "Encryption": {
-                    "constructInfo": {
-                      "fqn": "cdktf.TerraformResource",
-                      "version": "0.17.0",
-                    },
-                    "id": "Encryption",
-                    "path": "root/Default/the-uncanny.bucket/Encryption",
                   },
                 },
                 "constructInfo": {
@@ -540,18 +480,6 @@ exports[`bucket with onCreate method 1`] = `
         "restrict_public_buckets": false,
       },
     },
-    "aws_s3_bucket_server_side_encryption_configuration": {
-      "my_bucket_Encryption_3B1569A4": {
-        "bucket": "\${aws_s3_bucket.my_bucket.bucket}",
-        "rule": [
-          {
-            "apply_server_side_encryption_by_default": {
-              "sse_algorithm": "AES256",
-            },
-          },
-        ],
-      },
-    },
     "aws_s3_object": {
       "my_bucket_my_bucket-oncreate-OnMessage-7b961f4d_S3Object_AA8B2734": {
         "bucket": "\${aws_s3_bucket.Code.bucket}",
@@ -650,14 +578,6 @@ exports[`bucket with onCreate method 2`] = `
                     },
                     "id": "Default",
                     "path": "root/Default/my_bucket/Default",
-                  },
-                  "Encryption": {
-                    "constructInfo": {
-                      "fqn": "cdktf.TerraformResource",
-                      "version": "0.17.0",
-                    },
-                    "id": "Encryption",
-                    "path": "root/Default/my_bucket/Encryption",
                   },
                   "PublicAccessBlock": {
                     "constructInfo": {
@@ -962,18 +882,6 @@ exports[`bucket with onDelete method 1`] = `
         "restrict_public_buckets": false,
       },
     },
-    "aws_s3_bucket_server_side_encryption_configuration": {
-      "my_bucket_Encryption_3B1569A4": {
-        "bucket": "\${aws_s3_bucket.my_bucket.bucket}",
-        "rule": [
-          {
-            "apply_server_side_encryption_by_default": {
-              "sse_algorithm": "AES256",
-            },
-          },
-        ],
-      },
-    },
     "aws_s3_object": {
       "my_bucket_my_bucket-ondelete-OnMessage-1de1a361_S3Object_2203B527": {
         "bucket": "\${aws_s3_bucket.Code.bucket}",
@@ -1072,14 +980,6 @@ exports[`bucket with onDelete method 2`] = `
                     },
                     "id": "Default",
                     "path": "root/Default/my_bucket/Default",
-                  },
-                  "Encryption": {
-                    "constructInfo": {
-                      "fqn": "cdktf.TerraformResource",
-                      "version": "0.17.0",
-                    },
-                    "id": "Encryption",
-                    "path": "root/Default/my_bucket/Encryption",
                   },
                   "PublicAccessBlock": {
                     "constructInfo": {
@@ -1478,18 +1378,6 @@ exports[`bucket with onEvent method 1`] = `
         "restrict_public_buckets": false,
       },
     },
-    "aws_s3_bucket_server_side_encryption_configuration": {
-      "my_bucket_Encryption_3B1569A4": {
-        "bucket": "\${aws_s3_bucket.my_bucket.bucket}",
-        "rule": [
-          {
-            "apply_server_side_encryption_by_default": {
-              "sse_algorithm": "AES256",
-            },
-          },
-        ],
-      },
-    },
     "aws_s3_object": {
       "my_bucket_my_bucket-oncreate-OnMessage-7b961f4d_S3Object_AA8B2734": {
         "bucket": "\${aws_s3_bucket.Code.bucket}",
@@ -1622,14 +1510,6 @@ exports[`bucket with onEvent method 2`] = `
                     },
                     "id": "Default",
                     "path": "root/Default/my_bucket/Default",
-                  },
-                  "Encryption": {
-                    "constructInfo": {
-                      "fqn": "cdktf.TerraformResource",
-                      "version": "0.17.0",
-                    },
-                    "id": "Encryption",
-                    "path": "root/Default/my_bucket/Encryption",
                   },
                   "PublicAccessBlock": {
                     "constructInfo": {
@@ -2194,18 +2074,6 @@ exports[`bucket with onUpdate method 1`] = `
         "restrict_public_buckets": false,
       },
     },
-    "aws_s3_bucket_server_side_encryption_configuration": {
-      "my_bucket_Encryption_3B1569A4": {
-        "bucket": "\${aws_s3_bucket.my_bucket.bucket}",
-        "rule": [
-          {
-            "apply_server_side_encryption_by_default": {
-              "sse_algorithm": "AES256",
-            },
-          },
-        ],
-      },
-    },
     "aws_s3_object": {
       "my_bucket_my_bucket-onupdate-OnMessage-46c07356_S3Object_0B6EDB66": {
         "bucket": "\${aws_s3_bucket.Code.bucket}",
@@ -2304,14 +2172,6 @@ exports[`bucket with onUpdate method 2`] = `
                     },
                     "id": "Default",
                     "path": "root/Default/my_bucket/Default",
-                  },
-                  "Encryption": {
-                    "constructInfo": {
-                      "fqn": "cdktf.TerraformResource",
-                      "version": "0.17.0",
-                    },
-                    "id": "Encryption",
-                    "path": "root/Default/my_bucket/Encryption",
                   },
                   "PublicAccessBlock": {
                     "constructInfo": {
@@ -2547,18 +2407,6 @@ exports[`bucket with two preflight files 1`] = `
         "restrict_public_buckets": false,
       },
     },
-    "aws_s3_bucket_server_side_encryption_configuration": {
-      "my_bucket_Encryption_3B1569A4": {
-        "bucket": "\${aws_s3_bucket.my_bucket.bucket}",
-        "rule": [
-          {
-            "apply_server_side_encryption_by_default": {
-              "sse_algorithm": "AES256",
-            },
-          },
-        ],
-      },
-    },
     "aws_s3_object": {
       "my_bucket_S3Object-file1txt_7AFE54AE": {
         "bucket": "\${aws_s3_bucket.my_bucket.bucket}",
@@ -2623,14 +2471,6 @@ exports[`bucket with two preflight files 2`] = `
                     },
                     "id": "Default",
                     "path": "root/Default/my_bucket/Default",
-                  },
-                  "Encryption": {
-                    "constructInfo": {
-                      "fqn": "cdktf.TerraformResource",
-                      "version": "0.17.0",
-                    },
-                    "id": "Encryption",
-                    "path": "root/Default/my_bucket/Encryption",
                   },
                   "PublicAccessBlock": {
                     "constructInfo": {
@@ -2744,18 +2584,6 @@ exports[`bucket with two preflight objects 1`] = `
         "restrict_public_buckets": false,
       },
     },
-    "aws_s3_bucket_server_side_encryption_configuration": {
-      "my_bucket_Encryption_3B1569A4": {
-        "bucket": "\${aws_s3_bucket.my_bucket.bucket}",
-        "rule": [
-          {
-            "apply_server_side_encryption_by_default": {
-              "sse_algorithm": "AES256",
-            },
-          },
-        ],
-      },
-    },
     "aws_s3_object": {
       "my_bucket_S3Object-file1txt_7AFE54AE": {
         "bucket": "\${aws_s3_bucket.my_bucket.bucket}",
@@ -2820,14 +2648,6 @@ exports[`bucket with two preflight objects 2`] = `
                     },
                     "id": "Default",
                     "path": "root/Default/my_bucket/Default",
-                  },
-                  "Encryption": {
-                    "constructInfo": {
-                      "fqn": "cdktf.TerraformResource",
-                      "version": "0.17.0",
-                    },
-                    "id": "Encryption",
-                    "path": "root/Default/my_bucket/Encryption",
                   },
                   "PublicAccessBlock": {
                     "constructInfo": {
@@ -2923,18 +2743,6 @@ exports[`create a bucket 1`] = `
         "force_destroy": false,
       },
     },
-    "aws_s3_bucket_server_side_encryption_configuration": {
-      "my_bucket_Encryption_3B1569A4": {
-        "bucket": "\${aws_s3_bucket.my_bucket.bucket}",
-        "rule": [
-          {
-            "apply_server_side_encryption_by_default": {
-              "sse_algorithm": "AES256",
-            },
-          },
-        ],
-      },
-    },
   },
 }
 `;
@@ -2987,14 +2795,6 @@ exports[`create a bucket 2`] = `
                     },
                     "id": "Default",
                     "path": "root/Default/my_bucket/Default",
-                  },
-                  "Encryption": {
-                    "constructInfo": {
-                      "fqn": "cdktf.TerraformResource",
-                      "version": "0.17.0",
-                    },
-                    "id": "Encryption",
-                    "path": "root/Default/my_bucket/Encryption",
                   },
                 },
                 "constructInfo": {

--- a/libs/wingsdk/test/target-tf-aws/__snapshots__/captures.test.ts.snap
+++ b/libs/wingsdk/test/target-tf-aws/__snapshots__/captures.test.ts.snap
@@ -357,18 +357,6 @@ exports[`function with bucket binding > put operation 2`] = `
         "bucket_prefix": "code-c84a50b1-",
       },
     },
-    "aws_s3_bucket_server_side_encryption_configuration": {
-      "Bucket_Encryption_016FDA0C": {
-        "bucket": "\${aws_s3_bucket.Bucket.bucket}",
-        "rule": [
-          {
-            "apply_server_side_encryption_by_default": {
-              "sse_algorithm": "AES256",
-            },
-          },
-        ],
-      },
-    },
     "aws_s3_object": {
       "Function_S3Object_C62A0C2D": {
         "bucket": "\${aws_s3_bucket.Code.bucket}",

--- a/libs/wingsdk/test/target-tf-aws/__snapshots__/on-deploy.test.ts.snap
+++ b/libs/wingsdk/test/target-tf-aws/__snapshots__/on-deploy.test.ts.snap
@@ -261,7 +261,6 @@ exports[`execute OnDeploy after other resources 1`] = `
       "my_on_deploy_Invocation_1A26E3B9": {
         "depends_on": [
           "aws_s3_bucket.my_bucket",
-          "aws_s3_bucket_server_side_encryption_configuration.my_bucket_Encryption_3B1569A4",
         ],
         "function_name": "\${aws_lambda_function.my_on_deploy_Function_59669FC0.function_name}",
         "input": "{}",
@@ -322,18 +321,6 @@ exports[`execute OnDeploy after other resources 1`] = `
       "my_bucket": {
         "bucket_prefix": "my-bucket-c8045fcc-",
         "force_destroy": false,
-      },
-    },
-    "aws_s3_bucket_server_side_encryption_configuration": {
-      "my_bucket_Encryption_3B1569A4": {
-        "bucket": "\${aws_s3_bucket.my_bucket.bucket}",
-        "rule": [
-          {
-            "apply_server_side_encryption_by_default": {
-              "sse_algorithm": "AES256",
-            },
-          },
-        ],
       },
     },
     "aws_s3_object": {
@@ -416,14 +403,6 @@ exports[`execute OnDeploy after other resources 2`] = `
                     },
                     "id": "Default",
                     "path": "root/Default/my_bucket/Default",
-                  },
-                  "Encryption": {
-                    "constructInfo": {
-                      "fqn": "cdktf.TerraformResource",
-                      "version": "0.17.0",
-                    },
-                    "id": "Encryption",
-                    "path": "root/Default/my_bucket/Encryption",
                   },
                 },
                 "constructInfo": {
@@ -627,21 +606,6 @@ exports[`execute OnDeploy before other resources 1`] = `
         "force_destroy": false,
       },
     },
-    "aws_s3_bucket_server_side_encryption_configuration": {
-      "my_bucket_Encryption_3B1569A4": {
-        "bucket": "\${aws_s3_bucket.my_bucket.bucket}",
-        "depends_on": [
-          "\${data.aws_lambda_invocation.my_on_deploy_Invocation_1A26E3B9}",
-        ],
-        "rule": [
-          {
-            "apply_server_side_encryption_by_default": {
-              "sse_algorithm": "AES256",
-            },
-          },
-        ],
-      },
-    },
     "aws_s3_object": {
       "my_on_deploy_Function_S3Object_69D52AC4": {
         "bucket": "\${aws_s3_bucket.Code.bucket}",
@@ -722,14 +686,6 @@ exports[`execute OnDeploy before other resources 2`] = `
                     },
                     "id": "Default",
                     "path": "root/Default/my_bucket/Default",
-                  },
-                  "Encryption": {
-                    "constructInfo": {
-                      "fqn": "cdktf.TerraformResource",
-                      "version": "0.17.0",
-                    },
-                    "id": "Encryption",
-                    "path": "root/Default/my_bucket/Encryption",
                   },
                 },
                 "constructInfo": {

--- a/libs/wingsdk/test/target-tf-aws/__snapshots__/website.test.ts.snap
+++ b/libs/wingsdk/test/target-tf-aws/__snapshots__/website.test.ts.snap
@@ -106,18 +106,6 @@ exports[`default website behavior 1`] = `
         "policy": "\${data.aws_iam_policy_document.Website_AllowDistributionReadOnly_24CFF6C0.json}",
       },
     },
-    "aws_s3_bucket_server_side_encryption_configuration": {
-      "Website_Encryption_5BBFE612": {
-        "bucket": "\${aws_s3_bucket.Website_WebsiteBucket_3C0321F0.bucket}",
-        "rule": [
-          {
-            "apply_server_side_encryption_by_default": {
-              "sse_algorithm": "AES256",
-            },
-          },
-        ],
-      },
-    },
     "aws_s3_bucket_website_configuration": {
       "Website_BucketWebsiteConfiguration_58F891B4": {
         "bucket": "\${aws_s3_bucket.Website_WebsiteBucket_3C0321F0.bucket}",
@@ -201,14 +189,6 @@ exports[`default website behavior 2`] = `
                     },
                     "id": "DistributionS3BucketPolicy",
                     "path": "root/Default/Website/DistributionS3BucketPolicy",
-                  },
-                  "Encryption": {
-                    "constructInfo": {
-                      "fqn": "cdktf.TerraformResource",
-                      "version": "0.17.0",
-                    },
-                    "id": "Encryption",
-                    "path": "root/Default/Website/Encryption",
                   },
                   "File--b.html": {
                     "constructInfo": {
@@ -419,18 +399,6 @@ exports[`website with add_json 1`] = `
         "policy": "\${data.aws_iam_policy_document.Website_AllowDistributionReadOnly_24CFF6C0.json}",
       },
     },
-    "aws_s3_bucket_server_side_encryption_configuration": {
-      "Website_Encryption_5BBFE612": {
-        "bucket": "\${aws_s3_bucket.Website_WebsiteBucket_3C0321F0.bucket}",
-        "rule": [
-          {
-            "apply_server_side_encryption_by_default": {
-              "sse_algorithm": "AES256",
-            },
-          },
-        ],
-      },
-    },
     "aws_s3_bucket_website_configuration": {
       "Website_BucketWebsiteConfiguration_58F891B4": {
         "bucket": "\${aws_s3_bucket.Website_WebsiteBucket_3C0321F0.bucket}",
@@ -523,14 +491,6 @@ exports[`website with add_json 2`] = `
                     },
                     "id": "DistributionS3BucketPolicy",
                     "path": "root/Default/Website/DistributionS3BucketPolicy",
-                  },
-                  "Encryption": {
-                    "constructInfo": {
-                      "fqn": "cdktf.TerraformResource",
-                      "version": "0.17.0",
-                    },
-                    "id": "Encryption",
-                    "path": "root/Default/Website/Encryption",
                   },
                   "File--b.html": {
                     "constructInfo": {

--- a/libs/wingsdk/test/target-tf-aws/bucket.test.ts
+++ b/libs/wingsdk/test/target-tf-aws/bucket.test.ts
@@ -21,7 +21,6 @@ test("create a bucket", () => {
   // THEN
   expect(tfResourcesOf(output)).toEqual([
     "aws_s3_bucket", // main bucket
-    "aws_s3_bucket_server_side_encryption_configuration", // server side encryption
   ]);
   expect(tfSanitize(output)).toMatchSnapshot();
   expect(treeJsonOf(app.outdir)).toMatchSnapshot();
@@ -54,7 +53,6 @@ test("bucket is public", () => {
     "aws_s3_bucket", // main bucket
     "aws_s3_bucket_policy", // resource policy to grant read access to anyone
     "aws_s3_bucket_public_access_block", // allow public access to an s3 bucket
-    "aws_s3_bucket_server_side_encryption_configuration", // server side encryption
   ]);
   expect(tfSanitize(output)).toMatchSnapshot();
   expect(treeJsonOf(app.outdir)).toMatchSnapshot();
@@ -73,7 +71,6 @@ test("bucket with two preflight objects", () => {
     "aws_s3_bucket", // main bucket
     "aws_s3_bucket_policy", // resource policy to grant read access to anyone
     "aws_s3_bucket_public_access_block", // allow public access to an s3 bucket
-    "aws_s3_bucket_server_side_encryption_configuration", // server side encryption
     "aws_s3_object", // file1.txt
   ]);
   expect(tfResourcesOfCount(output, "aws_s3_object")).toEqual(2);
@@ -94,7 +91,6 @@ test("bucket with two preflight files", () => {
     "aws_s3_bucket", // main bucket
     "aws_s3_bucket_policy", // resource policy to grant read access to anyone
     "aws_s3_bucket_public_access_block", // allow public access to an s3 bucket
-    "aws_s3_bucket_server_side_encryption_configuration", // server side encryption
     "aws_s3_object", // file1.txt
   ]);
   expect(tfResourcesOfCount(output, "aws_s3_object")).toEqual(2);
@@ -173,7 +169,6 @@ test("bucket with onCreate method", () => {
     "aws_s3_bucket_notification",
     "aws_s3_bucket_policy", // resource policy to grant read access to anyone
     "aws_s3_bucket_public_access_block", // allow public access to an s3 bucket
-    "aws_s3_bucket_server_side_encryption_configuration", // server side encryption
     "aws_s3_object",
     "aws_sns_topic", // topic to subscribe to bucket events
     "aws_sns_topic_policy", //permission of the bucket to publish events
@@ -212,7 +207,6 @@ test("bucket with onDelete method", () => {
     "aws_s3_bucket_notification",
     "aws_s3_bucket_policy", // resource policy to grant read access to anyone
     "aws_s3_bucket_public_access_block", // allow public access to an s3 bucket
-    "aws_s3_bucket_server_side_encryption_configuration", // server side encryption
     "aws_s3_object",
     "aws_sns_topic", // topic to subscribe to bucket events
     "aws_sns_topic_policy", //permission of the bucket to publish events
@@ -251,7 +245,6 @@ test("bucket with onUpdate method", () => {
     "aws_s3_bucket_notification",
     "aws_s3_bucket_policy", // resource policy to grant read access to anyone
     "aws_s3_bucket_public_access_block", // allow public access to an s3 bucket
-    "aws_s3_bucket_server_side_encryption_configuration", // server side encryption
     "aws_s3_object",
     "aws_sns_topic", // topic to subscribe to bucket events
     "aws_sns_topic_policy", //permission of the bucket to publish events
@@ -290,7 +283,6 @@ test("bucket with onEvent method", () => {
     "aws_s3_bucket_notification",
     "aws_s3_bucket_policy", // resource policy to grant read access to anyone
     "aws_s3_bucket_public_access_block", // allow public access to an s3 bucket
-    "aws_s3_bucket_server_side_encryption_configuration", // server side encryption
     "aws_s3_object",
     "aws_sns_topic", // topic to subscribe to bucket events
     "aws_sns_topic_policy", //permission of the bucket to publish events

--- a/libs/wingsdk/test/target-tf-aws/captures.test.ts
+++ b/libs/wingsdk/test/target-tf-aws/captures.test.ts
@@ -55,7 +55,6 @@ describe("function with bucket binding", () => {
       "aws_iam_role_policy_attachment",
       "aws_lambda_function",
       "aws_s3_bucket",
-      "aws_s3_bucket_server_side_encryption_configuration",
       "aws_s3_object",
     ]);
     expect(tfSanitize(output)).toMatchSnapshot();

--- a/libs/wingsdk/test/target-tf-aws/website.test.ts
+++ b/libs/wingsdk/test/target-tf-aws/website.test.ts
@@ -25,7 +25,6 @@ test("default website behavior", () => {
     "aws_cloudfront_origin_access_control",
     "aws_s3_bucket",
     "aws_s3_bucket_policy",
-    "aws_s3_bucket_server_side_encryption_configuration",
     "aws_s3_bucket_website_configuration",
     "aws_s3_object",
   ]);
@@ -72,7 +71,6 @@ test("website with add_json", () => {
     "aws_cloudfront_origin_access_control",
     "aws_s3_bucket",
     "aws_s3_bucket_policy",
-    "aws_s3_bucket_server_side_encryption_configuration",
     "aws_s3_bucket_website_configuration",
     "aws_s3_object",
   ]);

--- a/tools/hangar/__snapshots__/plugins.ts.snap
+++ b/tools/hangar/__snapshots__/plugins.ts.snap
@@ -131,24 +131,6 @@ exports[`Plugin examples > AWS target plugins > permission-boundary.js 1`] = `
         "force_destroy": false,
       },
     },
-    "aws_s3_bucket_server_side_encryption_configuration": {
-      "cloudBucket_Encryption_77B6AEEF": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/cloud.Bucket/Encryption",
-            "uniqueId": "cloudBucket_Encryption_77B6AEEF",
-          },
-        },
-        "bucket": "\${aws_s3_bucket.cloudBucket.bucket}",
-        "rule": [
-          {
-            "apply_server_side_encryption_by_default": {
-              "sse_algorithm": "AES256",
-            },
-          },
-        ],
-      },
-    },
     "aws_s3_object": {
       "cloudQueue-SetConsumer-cdafee6e_S3Object_8868B9FB": {
         "//": {
@@ -445,24 +427,6 @@ exports[`Plugin examples > AWS target plugins > replicate-s3.js 1`] = `
         ],
       },
     },
-    "aws_s3_bucket_server_side_encryption_configuration": {
-      "cloudBucket_Encryption_77B6AEEF": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/cloud.Bucket/Encryption",
-            "uniqueId": "cloudBucket_Encryption_77B6AEEF",
-          },
-        },
-        "bucket": "\${aws_s3_bucket.cloudBucket.bucket}",
-        "rule": [
-          {
-            "apply_server_side_encryption_by_default": {
-              "sse_algorithm": "AES256",
-            },
-          },
-        ],
-      },
-    },
     "aws_s3_bucket_versioning": {
       "ReplicaCodeVersioning": {
         "//": {
@@ -671,24 +635,6 @@ exports[`Plugin examples > AWS target plugins > tf-backend.js > azurerm backend 
         "force_destroy": false,
       },
     },
-    "aws_s3_bucket_server_side_encryption_configuration": {
-      "cloudBucket_Encryption_77B6AEEF": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/cloud.Bucket/Encryption",
-            "uniqueId": "cloudBucket_Encryption_77B6AEEF",
-          },
-        },
-        "bucket": "\${aws_s3_bucket.cloudBucket.bucket}",
-        "rule": [
-          {
-            "apply_server_side_encryption_by_default": {
-              "sse_algorithm": "AES256",
-            },
-          },
-        ],
-      },
-    },
     "aws_s3_object": {
       "cloudQueue-SetConsumer-cdafee6e_S3Object_8868B9FB": {
         "//": {
@@ -847,24 +793,6 @@ exports[`Plugin examples > AWS target plugins > tf-backend.js > gcp backend 1`] 
         "force_destroy": false,
       },
     },
-    "aws_s3_bucket_server_side_encryption_configuration": {
-      "cloudBucket_Encryption_77B6AEEF": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/cloud.Bucket/Encryption",
-            "uniqueId": "cloudBucket_Encryption_77B6AEEF",
-          },
-        },
-        "bucket": "\${aws_s3_bucket.cloudBucket.bucket}",
-        "rule": [
-          {
-            "apply_server_side_encryption_by_default": {
-              "sse_algorithm": "AES256",
-            },
-          },
-        ],
-      },
-    },
     "aws_s3_object": {
       "cloudQueue-SetConsumer-cdafee6e_S3Object_8868B9FB": {
         "//": {
@@ -1021,24 +949,6 @@ exports[`Plugin examples > AWS target plugins > tf-backend.js > s3 backend 1`] =
         },
         "bucket_prefix": "cloud-bucket-c87175e7-",
         "force_destroy": false,
-      },
-    },
-    "aws_s3_bucket_server_side_encryption_configuration": {
-      "cloudBucket_Encryption_77B6AEEF": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/cloud.Bucket/Encryption",
-            "uniqueId": "cloudBucket_Encryption_77B6AEEF",
-          },
-        },
-        "bucket": "\${aws_s3_bucket.cloudBucket.bucket}",
-        "rule": [
-          {
-            "apply_server_side_encryption_by_default": {
-              "sse_algorithm": "AES256",
-            },
-          },
-        ],
       },
     },
     "aws_s3_object": {

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/add_file.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/add_file.w_compile_tf-aws.md
@@ -62,24 +62,6 @@ module.exports = function({ $b }) {
         "force_destroy": false
       }
     },
-    "aws_s3_bucket_server_side_encryption_configuration": {
-      "cloudBucket_Encryption_77B6AEEF": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/cloud.Bucket/Encryption",
-            "uniqueId": "cloudBucket_Encryption_77B6AEEF"
-          }
-        },
-        "bucket": "${aws_s3_bucket.cloudBucket.bucket}",
-        "rule": [
-          {
-            "apply_server_side_encryption_by_default": {
-              "sse_algorithm": "AES256"
-            }
-          }
-        ]
-      }
-    },
     "aws_s3_object": {
       "cloudBucket_S3Object-file1txt_2E641337": {
         "//": {

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/add_object.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/add_object.w_compile_tf-aws.md
@@ -62,24 +62,6 @@ module.exports = function({ $b, $jsonObj1, $std_Json }) {
         "force_destroy": false
       }
     },
-    "aws_s3_bucket_server_side_encryption_configuration": {
-      "cloudBucket_Encryption_77B6AEEF": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/cloud.Bucket/Encryption",
-            "uniqueId": "cloudBucket_Encryption_77B6AEEF"
-          }
-        },
-        "bucket": "${aws_s3_bucket.cloudBucket.bucket}",
-        "rule": [
-          {
-            "apply_server_side_encryption_by_default": {
-              "sse_algorithm": "AES256"
-            }
-          }
-        ]
-      }
-    },
     "aws_s3_object": {
       "cloudBucket_S3Object-file1json_574A6AAF": {
         "//": {

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/bucket_list.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/bucket_list.w_compile_tf-aws.md
@@ -76,24 +76,6 @@ module.exports = function({ $b }) {
         "force_destroy": false
       }
     },
-    "aws_s3_bucket_server_side_encryption_configuration": {
-      "cloudBucket_Encryption_77B6AEEF": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/cloud.Bucket/Encryption",
-            "uniqueId": "cloudBucket_Encryption_77B6AEEF"
-          }
-        },
-        "bucket": "${aws_s3_bucket.cloudBucket.bucket}",
-        "rule": [
-          {
-            "apply_server_side_encryption_by_default": {
-              "sse_algorithm": "AES256"
-            }
-          }
-        ]
-      }
-    },
     "aws_s3_object": {
       "cloudBucket_S3Object-file3txt_DFC4715B": {
         "//": {

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/delete.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/delete.w_compile_tf-aws.md
@@ -86,24 +86,6 @@ module.exports = function({ $b }) {
         "force_destroy": false
       }
     },
-    "aws_s3_bucket_server_side_encryption_configuration": {
-      "cloudBucket_Encryption_77B6AEEF": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/cloud.Bucket/Encryption",
-            "uniqueId": "cloudBucket_Encryption_77B6AEEF"
-          }
-        },
-        "bucket": "${aws_s3_bucket.cloudBucket.bucket}",
-        "rule": [
-          {
-            "apply_server_side_encryption_by_default": {
-              "sse_algorithm": "AES256"
-            }
-          }
-        ]
-      }
-    },
     "aws_s3_object": {
       "cloudBucket_S3Object-file2txt_C6672D6C": {
         "//": {

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/events.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/events.w_compile_tf-aws.md
@@ -757,24 +757,6 @@ module.exports = function({ $Source, $b, $checkHitCount, $util_Util, $wait }) {
         ]
       }
     },
-    "aws_s3_bucket_server_side_encryption_configuration": {
-      "cloudBucket_Encryption_77B6AEEF": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/cloud.Bucket/Encryption",
-            "uniqueId": "cloudBucket_Encryption_77B6AEEF"
-          }
-        },
-        "bucket": "${aws_s3_bucket.cloudBucket.bucket}",
-        "rule": [
-          {
-            "apply_server_side_encryption_by_default": {
-              "sse_algorithm": "AES256"
-            }
-          }
-        ]
-      }
-    },
     "aws_s3_object": {
       "cloudBucket_cloudBucket-oncreate-OnMessage-42558af0_S3Object_141E43E0": {
         "//": {

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/exists.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/exists.w_compile_tf-aws.md
@@ -65,24 +65,6 @@ module.exports = function({ $b }) {
         "bucket_prefix": "cloud-bucket-c87175e7-",
         "force_destroy": false
       }
-    },
-    "aws_s3_bucket_server_side_encryption_configuration": {
-      "cloudBucket_Encryption_77B6AEEF": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/cloud.Bucket/Encryption",
-            "uniqueId": "cloudBucket_Encryption_77B6AEEF"
-          }
-        },
-        "bucket": "${aws_s3_bucket.cloudBucket.bucket}",
-        "rule": [
-          {
-            "apply_server_side_encryption_by_default": {
-              "sse_algorithm": "AES256"
-            }
-          }
-        ]
-      }
     }
   }
 }

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/public_url.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/public_url.w_compile_tf-aws.md
@@ -123,40 +123,6 @@ module.exports = function({ $http_Util, $privateBucket, $publicBucket, $util_Uti
         "ignore_public_acls": false,
         "restrict_public_buckets": false
       }
-    },
-    "aws_s3_bucket_server_side_encryption_configuration": {
-      "privateBucket_Encryption_0E029000": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/privateBucket/Encryption",
-            "uniqueId": "privateBucket_Encryption_0E029000"
-          }
-        },
-        "bucket": "${aws_s3_bucket.privateBucket.bucket}",
-        "rule": [
-          {
-            "apply_server_side_encryption_by_default": {
-              "sse_algorithm": "AES256"
-            }
-          }
-        ]
-      },
-      "publicBucket_Encryption_60BD8E69": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/publicBucket/Encryption",
-            "uniqueId": "publicBucket_Encryption_60BD8E69"
-          }
-        },
-        "bucket": "${aws_s3_bucket.publicBucket.bucket}",
-        "rule": [
-          {
-            "apply_server_side_encryption_by_default": {
-              "sse_algorithm": "AES256"
-            }
-          }
-        ]
-      }
     }
   }
 }

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/put.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/put.w_compile_tf-aws.md
@@ -71,24 +71,6 @@ module.exports = function({ $b }) {
         "bucket_prefix": "cloud-bucket-c87175e7-",
         "force_destroy": false
       }
-    },
-    "aws_s3_bucket_server_side_encryption_configuration": {
-      "cloudBucket_Encryption_77B6AEEF": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/cloud.Bucket/Encryption",
-            "uniqueId": "cloudBucket_Encryption_77B6AEEF"
-          }
-        },
-        "bucket": "${aws_s3_bucket.cloudBucket.bucket}",
-        "rule": [
-          {
-            "apply_server_side_encryption_by_default": {
-              "sse_algorithm": "AES256"
-            }
-          }
-        ]
-      }
     }
   }
 }

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/put_json.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/put_json.w_compile_tf-aws.md
@@ -74,24 +74,6 @@ module.exports = function({ $b }) {
         "bucket_prefix": "cloud-bucket-c87175e7-",
         "force_destroy": false
       }
-    },
-    "aws_s3_bucket_server_side_encryption_configuration": {
-      "cloudBucket_Encryption_77B6AEEF": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/cloud.Bucket/Encryption",
-            "uniqueId": "cloudBucket_Encryption_77B6AEEF"
-          }
-        },
-        "bucket": "${aws_s3_bucket.cloudBucket.bucket}",
-        "rule": [
-          {
-            "apply_server_side_encryption_by_default": {
-              "sse_algorithm": "AES256"
-            }
-          }
-        ]
-      }
     }
   }
 }

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/try_delete.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/try_delete.w_compile_tf-aws.md
@@ -69,24 +69,6 @@ module.exports = function({ $b }) {
         "bucket_prefix": "cloud-bucket-c87175e7-",
         "force_destroy": false
       }
-    },
-    "aws_s3_bucket_server_side_encryption_configuration": {
-      "cloudBucket_Encryption_77B6AEEF": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/cloud.Bucket/Encryption",
-            "uniqueId": "cloudBucket_Encryption_77B6AEEF"
-          }
-        },
-        "bucket": "${aws_s3_bucket.cloudBucket.bucket}",
-        "rule": [
-          {
-            "apply_server_side_encryption_by_default": {
-              "sse_algorithm": "AES256"
-            }
-          }
-        ]
-      }
     }
   }
 }

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/try_get.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/try_get.w_compile_tf-aws.md
@@ -65,24 +65,6 @@ module.exports = function({ $b }) {
         "bucket_prefix": "cloud-bucket-c87175e7-",
         "force_destroy": false
       }
-    },
-    "aws_s3_bucket_server_side_encryption_configuration": {
-      "cloudBucket_Encryption_77B6AEEF": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/cloud.Bucket/Encryption",
-            "uniqueId": "cloudBucket_Encryption_77B6AEEF"
-          }
-        },
-        "bucket": "${aws_s3_bucket.cloudBucket.bucket}",
-        "rule": [
-          {
-            "apply_server_side_encryption_by_default": {
-              "sse_algorithm": "AES256"
-            }
-          }
-        ]
-      }
     }
   }
 }

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/try_get_json.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/try_get_json.w_compile_tf-aws.md
@@ -69,24 +69,6 @@ module.exports = function({ $b, $std_Json }) {
         "bucket_prefix": "cloud-bucket-c87175e7-",
         "force_destroy": false
       }
-    },
-    "aws_s3_bucket_server_side_encryption_configuration": {
-      "cloudBucket_Encryption_77B6AEEF": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/cloud.Bucket/Encryption",
-            "uniqueId": "cloudBucket_Encryption_77B6AEEF"
-          }
-        },
-        "bucket": "${aws_s3_bucket.cloudBucket.bucket}",
-        "rule": [
-          {
-            "apply_server_side_encryption_by_default": {
-              "sse_algorithm": "AES256"
-            }
-          }
-        ]
-      }
     }
   }
 }

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/function/memory_and_env.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/function/memory_and_env.w_compile_tf-aws.md
@@ -258,24 +258,6 @@ module.exports = function({ $c, $f1, $f2 }) {
         "force_destroy": false
       }
     },
-    "aws_s3_bucket_server_side_encryption_configuration": {
-      "cloudBucket_Encryption_77B6AEEF": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/cloud.Bucket/Encryption",
-            "uniqueId": "cloudBucket_Encryption_77B6AEEF"
-          }
-        },
-        "bucket": "${aws_s3_bucket.cloudBucket.bucket}",
-        "rule": [
-          {
-            "apply_server_side_encryption_by_default": {
-              "sse_algorithm": "AES256"
-            }
-          }
-        ]
-      }
-    },
     "aws_s3_object": {
       "envfn_S3Object_0080F00E": {
         "//": {

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/std/array.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/std/array.w_compile_tf-aws.md
@@ -505,56 +505,6 @@ module.exports = function({  }) {
         "bucket_prefix": "mysecondbucket-c8d5dc33-",
         "force_destroy": false
       }
-    },
-    "aws_s3_bucket_server_side_encryption_configuration": {
-      "cloudBucket_Encryption_77B6AEEF": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/cloud.Bucket/Encryption",
-            "uniqueId": "cloudBucket_Encryption_77B6AEEF"
-          }
-        },
-        "bucket": "${aws_s3_bucket.cloudBucket.bucket}",
-        "rule": [
-          {
-            "apply_server_side_encryption_by_default": {
-              "sse_algorithm": "AES256"
-            }
-          }
-        ]
-      },
-      "myBucket_Encryption_689540CB": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/myBucket/Encryption",
-            "uniqueId": "myBucket_Encryption_689540CB"
-          }
-        },
-        "bucket": "${aws_s3_bucket.myBucket.bucket}",
-        "rule": [
-          {
-            "apply_server_side_encryption_by_default": {
-              "sse_algorithm": "AES256"
-            }
-          }
-        ]
-      },
-      "mySecondBucket_Encryption_4630E612": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/mySecondBucket/Encryption",
-            "uniqueId": "mySecondBucket_Encryption_4630E612"
-          }
-        },
-        "bucket": "${aws_s3_bucket.mySecondBucket.bucket}",
-        "rule": [
-          {
-            "apply_server_side_encryption_by_default": {
-              "sse_algorithm": "AES256"
-            }
-          }
-        ]
-      }
     }
   }
 }

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/website/two_websites.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/website/two_websites.w_compile_tf-aws.md
@@ -293,40 +293,6 @@ module.exports = function({ $http_Util, $w1_url, $w2_url }) {
         "policy": "${data.aws_iam_policy_document.website-2_AllowDistributionReadOnly_994269D9.json}"
       }
     },
-    "aws_s3_bucket_server_side_encryption_configuration": {
-      "cloudWebsite_Encryption_6A8A4E29": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/cloud.Website/Encryption",
-            "uniqueId": "cloudWebsite_Encryption_6A8A4E29"
-          }
-        },
-        "bucket": "${aws_s3_bucket.cloudWebsite_WebsiteBucket_EB03D355.bucket}",
-        "rule": [
-          {
-            "apply_server_side_encryption_by_default": {
-              "sse_algorithm": "AES256"
-            }
-          }
-        ]
-      },
-      "website-2_Encryption_A1B72094": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/website-2/Encryption",
-            "uniqueId": "website-2_Encryption_A1B72094"
-          }
-        },
-        "bucket": "${aws_s3_bucket.website-2_WebsiteBucket_59576A0C.bucket}",
-        "rule": [
-          {
-            "apply_server_side_encryption_by_default": {
-              "sse_algorithm": "AES256"
-            }
-          }
-        ]
-      }
-    },
     "aws_s3_bucket_website_configuration": {
       "cloudWebsite_BucketWebsiteConfiguration_920E8E41": {
         "//": {

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/website/website.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/website/website.w_compile_tf-aws.md
@@ -190,24 +190,6 @@ module.exports = function({  }) {
         "policy": "${data.aws_iam_policy_document.cloudWebsite_AllowDistributionReadOnly_89DC4FD0.json}"
       }
     },
-    "aws_s3_bucket_server_side_encryption_configuration": {
-      "cloudWebsite_Encryption_6A8A4E29": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/cloud.Website/Encryption",
-            "uniqueId": "cloudWebsite_Encryption_6A8A4E29"
-          }
-        },
-        "bucket": "${aws_s3_bucket.cloudWebsite_WebsiteBucket_EB03D355.bucket}",
-        "rule": [
-          {
-            "apply_server_side_encryption_by_default": {
-              "sse_algorithm": "AES256"
-            }
-          }
-        ]
-      }
-    },
     "aws_s3_bucket_website_configuration": {
       "cloudWebsite_BucketWebsiteConfiguration_920E8E41": {
         "//": {

--- a/tools/hangar/__snapshots__/test_corpus/valid/bring_local.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/bring_local.w_compile_tf-aws.md
@@ -233,24 +233,6 @@ module.exports = function({  }) {
         "force_destroy": false
       }
     },
-    "aws_s3_bucket_server_side_encryption_configuration": {
-      "file1Store_cloudBucket_Encryption_387D9114": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/file1.Store/cloud.Bucket/Encryption",
-            "uniqueId": "file1Store_cloudBucket_Encryption_387D9114"
-          }
-        },
-        "bucket": "${aws_s3_bucket.file1Store_cloudBucket_86CE87B1.bucket}",
-        "rule": [
-          {
-            "apply_server_side_encryption_by_default": {
-              "sse_algorithm": "AES256"
-            }
-          }
-        ]
-      }
-    },
     "aws_s3_object": {
       "file1Store_cloudOnDeploy_Function_S3Object_CBBF816B": {
         "//": {

--- a/tools/hangar/__snapshots__/test_corpus/valid/bucket_events.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/bucket_events.w_compile_tf-aws.md
@@ -892,40 +892,6 @@ module.exports = function({ $b }) {
         ]
       }
     },
-    "aws_s3_bucket_server_side_encryption_configuration": {
-      "b_Encryption_AF1DCBD9": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/b/Encryption",
-            "uniqueId": "b_Encryption_AF1DCBD9"
-          }
-        },
-        "bucket": "${aws_s3_bucket.b.bucket}",
-        "rule": [
-          {
-            "apply_server_side_encryption_by_default": {
-              "sse_algorithm": "AES256"
-            }
-          }
-        ]
-      },
-      "other_Encryption_D901EDA1": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/other/Encryption",
-            "uniqueId": "other_Encryption_D901EDA1"
-          }
-        },
-        "bucket": "${aws_s3_bucket.other.bucket}",
-        "rule": [
-          {
-            "apply_server_side_encryption_by_default": {
-              "sse_algorithm": "AES256"
-            }
-          }
-        ]
-      }
-    },
     "aws_s3_object": {
       "b_b-oncreate-OnMessage-1d3b2039_S3Object_5BB7AE5C": {
         "//": {

--- a/tools/hangar/__snapshots__/test_corpus/valid/bucket_keys.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/bucket_keys.w_compile_tf-aws.md
@@ -69,24 +69,6 @@ module.exports = function({ $b }) {
         "bucket_prefix": "cloud-bucket-c87175e7-",
         "force_destroy": false
       }
-    },
-    "aws_s3_bucket_server_side_encryption_configuration": {
-      "cloudBucket_Encryption_77B6AEEF": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/cloud.Bucket/Encryption",
-            "uniqueId": "cloudBucket_Encryption_77B6AEEF"
-          }
-        },
-        "bucket": "${aws_s3_bucket.cloudBucket.bucket}",
-        "rule": [
-          {
-            "apply_server_side_encryption_by_default": {
-              "sse_algorithm": "AES256"
-            }
-          }
-        ]
-      }
     }
   }
 }

--- a/tools/hangar/__snapshots__/test_corpus/valid/capture_in_binary.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/capture_in_binary.w_compile_tf-aws.md
@@ -61,24 +61,6 @@ module.exports = function({ $b, $x }) {
         "bucket_prefix": "cloud-bucket-c87175e7-",
         "force_destroy": false
       }
-    },
-    "aws_s3_bucket_server_side_encryption_configuration": {
-      "cloudBucket_Encryption_77B6AEEF": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/cloud.Bucket/Encryption",
-            "uniqueId": "cloudBucket_Encryption_77B6AEEF"
-          }
-        },
-        "bucket": "${aws_s3_bucket.cloudBucket.bucket}",
-        "rule": [
-          {
-            "apply_server_side_encryption_by_default": {
-              "sse_algorithm": "AES256"
-            }
-          }
-        ]
-      }
     }
   }
 }

--- a/tools/hangar/__snapshots__/test_corpus/valid/capture_reassigable_class_field.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/capture_reassigable_class_field.w_compile_tf-aws.md
@@ -146,24 +146,6 @@ module.exports = function({  }) {
         "bucket_prefix": "cloud-bucket-c8a9ef69-",
         "force_destroy": false
       }
-    },
-    "aws_s3_bucket_server_side_encryption_configuration": {
-      "KeyValueStore_cloudBucket_Encryption_D3F8A987": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/KeyValueStore/cloud.Bucket/Encryption",
-            "uniqueId": "KeyValueStore_cloudBucket_Encryption_D3F8A987"
-          }
-        },
-        "bucket": "${aws_s3_bucket.KeyValueStore_cloudBucket_D9D365FD.bucket}",
-        "rule": [
-          {
-            "apply_server_side_encryption_by_default": {
-              "sse_algorithm": "AES256"
-            }
-          }
-        ]
-      }
     }
   }
 }

--- a/tools/hangar/__snapshots__/test_corpus/valid/capture_resource_and_data.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/capture_resource_and_data.w_compile_tf-aws.md
@@ -63,24 +63,6 @@ module.exports = function({ $data_size, $queue, $res }) {
         "force_destroy": false
       }
     },
-    "aws_s3_bucket_server_side_encryption_configuration": {
-      "cloudBucket_Encryption_77B6AEEF": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/cloud.Bucket/Encryption",
-            "uniqueId": "cloudBucket_Encryption_77B6AEEF"
-          }
-        },
-        "bucket": "${aws_s3_bucket.cloudBucket.bucket}",
-        "rule": [
-          {
-            "apply_server_side_encryption_by_default": {
-              "sse_algorithm": "AES256"
-            }
-          }
-        ]
-      }
-    },
     "aws_sqs_queue": {
       "cloudQueue": {
         "//": {

--- a/tools/hangar/__snapshots__/test_corpus/valid/captures.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/captures.w_compile_tf-aws.md
@@ -482,56 +482,6 @@ module.exports = function({ $headers }) {
         "restrict_public_buckets": false
       }
     },
-    "aws_s3_bucket_server_side_encryption_configuration": {
-      "PrivateBucket_Encryption_38F5F83C": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/PrivateBucket/Encryption",
-            "uniqueId": "PrivateBucket_Encryption_38F5F83C"
-          }
-        },
-        "bucket": "${aws_s3_bucket.PrivateBucket.bucket}",
-        "rule": [
-          {
-            "apply_server_side_encryption_by_default": {
-              "sse_algorithm": "AES256"
-            }
-          }
-        ]
-      },
-      "PublicBucket_Encryption_4F6F735E": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/PublicBucket/Encryption",
-            "uniqueId": "PublicBucket_Encryption_4F6F735E"
-          }
-        },
-        "bucket": "${aws_s3_bucket.PublicBucket.bucket}",
-        "rule": [
-          {
-            "apply_server_side_encryption_by_default": {
-              "sse_algorithm": "AES256"
-            }
-          }
-        ]
-      },
-      "cloudBucket_Encryption_77B6AEEF": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/cloud.Bucket/Encryption",
-            "uniqueId": "cloudBucket_Encryption_77B6AEEF"
-          }
-        },
-        "bucket": "${aws_s3_bucket.cloudBucket.bucket}",
-        "rule": [
-          {
-            "apply_server_side_encryption_by_default": {
-              "sse_algorithm": "AES256"
-            }
-          }
-        ]
-      }
-    },
     "aws_s3_object": {
       "AnotherFunction_S3Object_6987727B": {
         "//": {

--- a/tools/hangar/__snapshots__/test_corpus/valid/container_types.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/container_types.w_compile_tf-aws.md
@@ -61,56 +61,6 @@
         "bucket_prefix": "bucket3-c8b6c706-",
         "force_destroy": false
       }
-    },
-    "aws_s3_bucket_server_side_encryption_configuration": {
-      "bucket1_Encryption_4417F366": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/bucket1/Encryption",
-            "uniqueId": "bucket1_Encryption_4417F366"
-          }
-        },
-        "bucket": "${aws_s3_bucket.bucket1.bucket}",
-        "rule": [
-          {
-            "apply_server_side_encryption_by_default": {
-              "sse_algorithm": "AES256"
-            }
-          }
-        ]
-      },
-      "bucket2_Encryption_6F02F3D7": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/bucket2/Encryption",
-            "uniqueId": "bucket2_Encryption_6F02F3D7"
-          }
-        },
-        "bucket": "${aws_s3_bucket.bucket2.bucket}",
-        "rule": [
-          {
-            "apply_server_side_encryption_by_default": {
-              "sse_algorithm": "AES256"
-            }
-          }
-        ]
-      },
-      "bucket3_Encryption_43A64F29": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/bucket3/Encryption",
-            "uniqueId": "bucket3_Encryption_43A64F29"
-          }
-        },
-        "bucket": "${aws_s3_bucket.bucket3.bucket}",
-        "rule": [
-          {
-            "apply_server_side_encryption_by_default": {
-              "sse_algorithm": "AES256"
-            }
-          }
-        ]
-      }
     }
   }
 }

--- a/tools/hangar/__snapshots__/test_corpus/valid/file_counter.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/file_counter.w_compile_tf-aws.md
@@ -171,24 +171,6 @@ module.exports = function({ $bucket, $counter }) {
         "force_destroy": false
       }
     },
-    "aws_s3_bucket_server_side_encryption_configuration": {
-      "cloudBucket_Encryption_77B6AEEF": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/cloud.Bucket/Encryption",
-            "uniqueId": "cloudBucket_Encryption_77B6AEEF"
-          }
-        },
-        "bucket": "${aws_s3_bucket.cloudBucket.bucket}",
-        "rule": [
-          {
-            "apply_server_side_encryption_by_default": {
-              "sse_algorithm": "AES256"
-            }
-          }
-        ]
-      }
-    },
     "aws_s3_object": {
       "cloudQueue-SetConsumer-cdafee6e_S3Object_8868B9FB": {
         "//": {

--- a/tools/hangar/__snapshots__/test_corpus/valid/function_variadic_arguments.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/function_variadic_arguments.w_compile_tf-aws.md
@@ -61,56 +61,6 @@
         "bucket_prefix": "bucket3-c8b6c706-",
         "force_destroy": false
       }
-    },
-    "aws_s3_bucket_server_side_encryption_configuration": {
-      "bucket1_Encryption_4417F366": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/bucket1/Encryption",
-            "uniqueId": "bucket1_Encryption_4417F366"
-          }
-        },
-        "bucket": "${aws_s3_bucket.bucket1.bucket}",
-        "rule": [
-          {
-            "apply_server_side_encryption_by_default": {
-              "sse_algorithm": "AES256"
-            }
-          }
-        ]
-      },
-      "bucket2_Encryption_6F02F3D7": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/bucket2/Encryption",
-            "uniqueId": "bucket2_Encryption_6F02F3D7"
-          }
-        },
-        "bucket": "${aws_s3_bucket.bucket2.bucket}",
-        "rule": [
-          {
-            "apply_server_side_encryption_by_default": {
-              "sse_algorithm": "AES256"
-            }
-          }
-        ]
-      },
-      "bucket3_Encryption_43A64F29": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/bucket3/Encryption",
-            "uniqueId": "bucket3_Encryption_43A64F29"
-          }
-        },
-        "bucket": "${aws_s3_bucket.bucket3.bucket}",
-        "rule": [
-          {
-            "apply_server_side_encryption_by_default": {
-              "sse_algorithm": "AES256"
-            }
-          }
-        ]
-      }
     }
   }
 }

--- a/tools/hangar/__snapshots__/test_corpus/valid/hello.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/hello.w_compile_tf-aws.md
@@ -149,24 +149,6 @@ module.exports = function({ $bucket }) {
         "force_destroy": false
       }
     },
-    "aws_s3_bucket_server_side_encryption_configuration": {
-      "cloudBucket_Encryption_77B6AEEF": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/cloud.Bucket/Encryption",
-            "uniqueId": "cloudBucket_Encryption_77B6AEEF"
-          }
-        },
-        "bucket": "${aws_s3_bucket.cloudBucket.bucket}",
-        "rule": [
-          {
-            "apply_server_side_encryption_by_default": {
-              "sse_algorithm": "AES256"
-            }
-          }
-        ]
-      }
-    },
     "aws_s3_object": {
       "cloudQueue-SetConsumer-cdafee6e_S3Object_8868B9FB": {
         "//": {

--- a/tools/hangar/__snapshots__/test_corpus/valid/inflight_class_inside_inflight_closure.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/inflight_class_inside_inflight_closure.w_compile_tf-aws.md
@@ -202,24 +202,6 @@ module.exports = function({  }) {
         "force_destroy": false
       }
     },
-    "aws_s3_bucket_server_side_encryption_configuration": {
-      "PreflightClass_cloudBucket_Encryption_30FD2B0E": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/PreflightClass/cloud.Bucket/Encryption",
-            "uniqueId": "PreflightClass_cloudBucket_Encryption_30FD2B0E"
-          }
-        },
-        "bucket": "${aws_s3_bucket.PreflightClass_cloudBucket_05421049.bucket}",
-        "rule": [
-          {
-            "apply_server_side_encryption_by_default": {
-              "sse_algorithm": "AES256"
-            }
-          }
-        ]
-      }
-    },
     "aws_s3_object": {
       "PreflightClass_cloudFunction_S3Object_D4E803CB": {
         "//": {

--- a/tools/hangar/__snapshots__/test_corpus/valid/inflights_calling_inflights.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/inflights_calling_inflights.w_compile_tf-aws.md
@@ -227,24 +227,6 @@ module.exports = function({  }) {
         "force_destroy": false
       }
     },
-    "aws_s3_bucket_server_side_encryption_configuration": {
-      "cloudBucket_Encryption_77B6AEEF": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/cloud.Bucket/Encryption",
-            "uniqueId": "cloudBucket_Encryption_77B6AEEF"
-          }
-        },
-        "bucket": "${aws_s3_bucket.cloudBucket.bucket}",
-        "rule": [
-          {
-            "apply_server_side_encryption_by_default": {
-              "sse_algorithm": "AES256"
-            }
-          }
-        ]
-      }
-    },
     "aws_s3_object": {
       "func1_S3Object_33D0CBF3": {
         "//": {

--- a/tools/hangar/__snapshots__/test_corpus/valid/json.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/json.w_compile_tf-aws.md
@@ -53,24 +53,6 @@ module.exports = function({  }) {
         "bucket_prefix": "cloud-bucket-c87175e7-",
         "force_destroy": false
       }
-    },
-    "aws_s3_bucket_server_side_encryption_configuration": {
-      "cloudBucket_Encryption_77B6AEEF": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/cloud.Bucket/Encryption",
-            "uniqueId": "cloudBucket_Encryption_77B6AEEF"
-          }
-        },
-        "bucket": "${aws_s3_bucket.cloudBucket.bucket}",
-        "rule": [
-          {
-            "apply_server_side_encryption_by_default": {
-              "sse_algorithm": "AES256"
-            }
-          }
-        ]
-      }
     }
   }
 }

--- a/tools/hangar/__snapshots__/test_corpus/valid/json_bucket.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/json_bucket.w_compile_tf-aws.md
@@ -156,24 +156,6 @@ module.exports = function({ $b, $fileName, $getJson, $j }) {
         "force_destroy": false
       }
     },
-    "aws_s3_bucket_server_side_encryption_configuration": {
-      "cloudBucket_Encryption_77B6AEEF": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/cloud.Bucket/Encryption",
-            "uniqueId": "cloudBucket_Encryption_77B6AEEF"
-          }
-        },
-        "bucket": "${aws_s3_bucket.cloudBucket.bucket}",
-        "rule": [
-          {
-            "apply_server_side_encryption_by_default": {
-              "sse_algorithm": "AES256"
-            }
-          }
-        ]
-      }
-    },
     "aws_s3_object": {
       "cloudFunction_S3Object_71908BAD": {
         "//": {

--- a/tools/hangar/__snapshots__/test_corpus/valid/lift_via_closure.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/lift_via_closure.w_compile_tf-aws.md
@@ -136,40 +136,6 @@ module.exports = function({ $bucket2 }) {
         "bucket_prefix": "cloud-bucket-c87175e7-",
         "force_destroy": false
       }
-    },
-    "aws_s3_bucket_server_side_encryption_configuration": {
-      "MyClosure_cloudBucket_Encryption_31C1B5A0": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/MyClosure/cloud.Bucket/Encryption",
-            "uniqueId": "MyClosure_cloudBucket_Encryption_31C1B5A0"
-          }
-        },
-        "bucket": "${aws_s3_bucket.MyClosure_cloudBucket_4DAD12C0.bucket}",
-        "rule": [
-          {
-            "apply_server_side_encryption_by_default": {
-              "sse_algorithm": "AES256"
-            }
-          }
-        ]
-      },
-      "cloudBucket_Encryption_77B6AEEF": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/cloud.Bucket/Encryption",
-            "uniqueId": "cloudBucket_Encryption_77B6AEEF"
-          }
-        },
-        "bucket": "${aws_s3_bucket.cloudBucket.bucket}",
-        "rule": [
-          {
-            "apply_server_side_encryption_by_default": {
-              "sse_algorithm": "AES256"
-            }
-          }
-        ]
-      }
     }
   }
 }

--- a/tools/hangar/__snapshots__/test_corpus/valid/mut_container_types.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/mut_container_types.w_compile_tf-aws.md
@@ -61,56 +61,6 @@
         "bucket_prefix": "bucket3-c8b6c706-",
         "force_destroy": false
       }
-    },
-    "aws_s3_bucket_server_side_encryption_configuration": {
-      "bucket1_Encryption_4417F366": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/bucket1/Encryption",
-            "uniqueId": "bucket1_Encryption_4417F366"
-          }
-        },
-        "bucket": "${aws_s3_bucket.bucket1.bucket}",
-        "rule": [
-          {
-            "apply_server_side_encryption_by_default": {
-              "sse_algorithm": "AES256"
-            }
-          }
-        ]
-      },
-      "bucket2_Encryption_6F02F3D7": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/bucket2/Encryption",
-            "uniqueId": "bucket2_Encryption_6F02F3D7"
-          }
-        },
-        "bucket": "${aws_s3_bucket.bucket2.bucket}",
-        "rule": [
-          {
-            "apply_server_side_encryption_by_default": {
-              "sse_algorithm": "AES256"
-            }
-          }
-        ]
-      },
-      "bucket3_Encryption_43A64F29": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/bucket3/Encryption",
-            "uniqueId": "bucket3_Encryption_43A64F29"
-          }
-        },
-        "bucket": "${aws_s3_bucket.bucket3.bucket}",
-        "rule": [
-          {
-            "apply_server_side_encryption_by_default": {
-              "sse_algorithm": "AES256"
-            }
-          }
-        ]
-      }
     }
   }
 }

--- a/tools/hangar/__snapshots__/test_corpus/valid/optionals.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/optionals.w_compile_tf-aws.md
@@ -112,24 +112,6 @@ module.exports = function({  }) {
         "bucket_prefix": "orange-bucket-c8ecc927-",
         "force_destroy": false
       }
-    },
-    "aws_s3_bucket_server_side_encryption_configuration": {
-      "orangebucket_Encryption_F338E6D4": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/orange bucket/Encryption",
-            "uniqueId": "orangebucket_Encryption_F338E6D4"
-          }
-        },
-        "bucket": "${aws_s3_bucket.orangebucket.bucket}",
-        "rule": [
-          {
-            "apply_server_side_encryption_by_default": {
-              "sse_algorithm": "AES256"
-            }
-          }
-        ]
-      }
     }
   }
 }

--- a/tools/hangar/__snapshots__/test_corpus/valid/resource.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/resource.w_compile_tf-aws.md
@@ -539,56 +539,6 @@ module.exports = function({  }) {
         ]
       }
     },
-    "aws_s3_bucket_server_side_encryption_configuration": {
-      "BigPublisher_b2_Encryption_24266321": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/BigPublisher/b2/Encryption",
-            "uniqueId": "BigPublisher_b2_Encryption_24266321"
-          }
-        },
-        "bucket": "${aws_s3_bucket.BigPublisher_b2_702AC841.bucket}",
-        "rule": [
-          {
-            "apply_server_side_encryption_by_default": {
-              "sse_algorithm": "AES256"
-            }
-          }
-        ]
-      },
-      "BigPublisher_cloudBucket_Encryption_F03B9FDE": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/BigPublisher/cloud.Bucket/Encryption",
-            "uniqueId": "BigPublisher_cloudBucket_Encryption_F03B9FDE"
-          }
-        },
-        "bucket": "${aws_s3_bucket.BigPublisher_cloudBucket_ABF95118.bucket}",
-        "rule": [
-          {
-            "apply_server_side_encryption_by_default": {
-              "sse_algorithm": "AES256"
-            }
-          }
-        ]
-      },
-      "cloudBucket_Encryption_77B6AEEF": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/cloud.Bucket/Encryption",
-            "uniqueId": "cloudBucket_Encryption_77B6AEEF"
-          }
-        },
-        "bucket": "${aws_s3_bucket.cloudBucket.bucket}",
-        "rule": [
-          {
-            "apply_server_side_encryption_by_default": {
-              "sse_algorithm": "AES256"
-            }
-          }
-        ]
-      }
-    },
     "aws_s3_object": {
       "BigPublisher_b2_b2-oncreate-OnMessage-59543b60_S3Object_759B056E": {
         "//": {

--- a/tools/hangar/__snapshots__/test_corpus/valid/resource_captures.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/resource_captures.w_compile_tf-aws.md
@@ -224,56 +224,6 @@ module.exports = function({  }) {
         "force_destroy": false
       }
     },
-    "aws_s3_bucket_server_side_encryption_configuration": {
-      "MyResource_Another_First_cloudBucket_Encryption_0413154A": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/MyResource/Another/First/cloud.Bucket/Encryption",
-            "uniqueId": "MyResource_Another_First_cloudBucket_Encryption_0413154A"
-          }
-        },
-        "bucket": "${aws_s3_bucket.MyResource_Another_First_cloudBucket_5C44A510.bucket}",
-        "rule": [
-          {
-            "apply_server_side_encryption_by_default": {
-              "sse_algorithm": "AES256"
-            }
-          }
-        ]
-      },
-      "MyResource_cloudBucket_Encryption_F4ED77DB": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/MyResource/cloud.Bucket/Encryption",
-            "uniqueId": "MyResource_cloudBucket_Encryption_F4ED77DB"
-          }
-        },
-        "bucket": "${aws_s3_bucket.MyResource_cloudBucket_B5E6C951.bucket}",
-        "rule": [
-          {
-            "apply_server_side_encryption_by_default": {
-              "sse_algorithm": "AES256"
-            }
-          }
-        ]
-      },
-      "cloudBucket_Encryption_77B6AEEF": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/cloud.Bucket/Encryption",
-            "uniqueId": "cloudBucket_Encryption_77B6AEEF"
-          }
-        },
-        "bucket": "${aws_s3_bucket.cloudBucket.bucket}",
-        "rule": [
-          {
-            "apply_server_side_encryption_by_default": {
-              "sse_algorithm": "AES256"
-            }
-          }
-        ]
-      }
-    },
     "aws_sqs_queue": {
       "MyResource_cloudQueue_E7A2C0F4": {
         "//": {

--- a/tools/hangar/__snapshots__/test_corpus/valid/resource_captures_globals.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/resource_captures_globals.w_compile_tf-aws.md
@@ -295,40 +295,6 @@ module.exports = function({ $_parentThis_localCounter, $globalCounter }) {
         "force_destroy": false
       }
     },
-    "aws_s3_bucket_server_side_encryption_configuration": {
-      "Another_First_cloudBucket_Encryption_C22274BF": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/Another/First/cloud.Bucket/Encryption",
-            "uniqueId": "Another_First_cloudBucket_Encryption_C22274BF"
-          }
-        },
-        "bucket": "${aws_s3_bucket.Another_First_cloudBucket_DB822B7C.bucket}",
-        "rule": [
-          {
-            "apply_server_side_encryption_by_default": {
-              "sse_algorithm": "AES256"
-            }
-          }
-        ]
-      },
-      "cloudBucket_Encryption_77B6AEEF": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/cloud.Bucket/Encryption",
-            "uniqueId": "cloudBucket_Encryption_77B6AEEF"
-          }
-        },
-        "bucket": "${aws_s3_bucket.cloudBucket.bucket}",
-        "rule": [
-          {
-            "apply_server_side_encryption_by_default": {
-              "sse_algorithm": "AES256"
-            }
-          }
-        ]
-      }
-    },
     "aws_s3_object": {
       "MyResource_cloudTopic-OnMessage-f10eb240_S3Object_B244E1DD": {
         "//": {

--- a/tools/hangar/__snapshots__/test_corpus/valid/super_call.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/super_call.w_compile_tf-aws.md
@@ -200,24 +200,6 @@ module.exports = function({ $InflightA }) {
         "bucket_prefix": "cloud-bucket-c87175e7-",
         "force_destroy": false
       }
-    },
-    "aws_s3_bucket_server_side_encryption_configuration": {
-      "cloudBucket_Encryption_77B6AEEF": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/cloud.Bucket/Encryption",
-            "uniqueId": "cloudBucket_Encryption_77B6AEEF"
-          }
-        },
-        "bucket": "${aws_s3_bucket.cloudBucket.bucket}",
-        "rule": [
-          {
-            "apply_server_side_encryption_by_default": {
-              "sse_algorithm": "AES256"
-            }
-          }
-        ]
-      }
     }
   }
 }

--- a/tools/hangar/__snapshots__/test_corpus/valid/test_bucket.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/test_bucket.w_compile_tf-aws.md
@@ -80,24 +80,6 @@ module.exports = function({ $b }) {
         "bucket_prefix": "cloud-bucket-c87175e7-",
         "force_destroy": false
       }
-    },
-    "aws_s3_bucket_server_side_encryption_configuration": {
-      "cloudBucket_Encryption_77B6AEEF": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/cloud.Bucket/Encryption",
-            "uniqueId": "cloudBucket_Encryption_77B6AEEF"
-          }
-        },
-        "bucket": "${aws_s3_bucket.cloudBucket.bucket}",
-        "rule": [
-          {
-            "apply_server_side_encryption_by_default": {
-              "sse_algorithm": "AES256"
-            }
-          }
-        ]
-      }
     }
   }
 }

--- a/tools/hangar/__snapshots__/test_corpus/valid/website_with_api.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/website_with_api.w_compile_tf-aws.md
@@ -523,24 +523,6 @@ module.exports = function({  }) {
         "policy": "${data.aws_iam_policy_document.cloudWebsite_AllowDistributionReadOnly_89DC4FD0.json}"
       }
     },
-    "aws_s3_bucket_server_side_encryption_configuration": {
-      "cloudWebsite_Encryption_6A8A4E29": {
-        "//": {
-          "metadata": {
-            "path": "root/Default/Default/cloud.Website/Encryption",
-            "uniqueId": "cloudWebsite_Encryption_6A8A4E29"
-          }
-        },
-        "bucket": "${aws_s3_bucket.cloudWebsite_WebsiteBucket_EB03D355.bucket}",
-        "rule": [
-          {
-            "apply_server_side_encryption_by_default": {
-              "sse_algorithm": "AES256"
-            }
-          }
-        ]
-      }
-    },
     "aws_s3_bucket_website_configuration": {
       "cloudWebsite_BucketWebsiteConfiguration_920E8E41": {
         "//": {

--- a/tools/hangar/__snapshots__/tree_json.ts.snap
+++ b/tools/hangar/__snapshots__/tree_json.ts.snap
@@ -127,14 +127,6 @@ exports[`tree.json for an app with many resources 1`] = `
                             "id": "Default",
                             "path": "root/Default/Default/BigPublisher/b2/Default",
                           },
-                          "Encryption": {
-                            "constructInfo": {
-                              "fqn": "cdktf.TerraformResource",
-                              "version": "0.17.0",
-                            },
-                            "id": "Encryption",
-                            "path": "root/Default/Default/BigPublisher/b2/Encryption",
-                          },
                           "S3BucketNotification": {
                             "constructInfo": {
                               "fqn": "cdktf.TerraformResource",
@@ -294,14 +286,6 @@ exports[`tree.json for an app with many resources 1`] = `
                             },
                             "id": "Default",
                             "path": "root/Default/Default/BigPublisher/cloud.Bucket/Default",
-                          },
-                          "Encryption": {
-                            "constructInfo": {
-                              "fqn": "cdktf.TerraformResource",
-                              "version": "0.17.0",
-                            },
-                            "id": "Encryption",
-                            "path": "root/Default/Default/BigPublisher/cloud.Bucket/Encryption",
                           },
                         },
                         "constructInfo": {
@@ -598,14 +582,6 @@ exports[`tree.json for an app with many resources 1`] = `
                         },
                         "id": "Default",
                         "path": "root/Default/Default/cloud.Bucket/Default",
-                      },
-                      "Encryption": {
-                        "constructInfo": {
-                          "fqn": "cdktf.TerraformResource",
-                          "version": "0.17.0",
-                        },
-                        "id": "Encryption",
-                        "path": "root/Default/Default/cloud.Bucket/Encryption",
                       },
                     },
                     "constructInfo": {


### PR DESCRIPTION
Starting January 5, 2023, Amazon S3 automatically applies server-side encryption with Amazon S3 managed keys (SSE-S3) as the base level of encryption for every bucket. All new object uploads to Amazon S3 are automatically encrypted at no additional cost and with no impact on performance.  SSE-S3 uses 256-bit Advanced Encryption Standard.

See [HERE](https://aws.amazon.com/about-aws/whats-new/2023/01/amazon-s3-automatically-encrypts-new-objects/).

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
