### PR TITLE
fix: ensure wing process is killed from vscode

### DIFF
--- a/apps/wing-console/console/server/src/index.ts
+++ b/apps/wing-console/console/server/src/index.ts
@@ -246,6 +246,7 @@ export const createConsoleServer = async ({
       updater?.removeEventListener("status-change", invalidateUpdaterStatus);
       config?.removeEventListener("config-change", invalidateConfig);
       await Promise.allSettled([
+        server.closeAllConnections(),
         server.close(),
         compiler.stop(),
         simulator.stop(),
@@ -256,8 +257,6 @@ export const createConsoleServer = async ({
       if (typeof callback === "function") callback();
     }
   };
-
-  process.on("SIGINT", () => close(() => process.exit(0)));
 
   return {
     port,

--- a/apps/wing/src/commands/run.test.ts
+++ b/apps/wing/src/commands/run.test.ts
@@ -33,7 +33,7 @@ test("wing it runs the only .w file", async () => {
       wingfile: resolve("foo.w"),
       requestedPort: 3000,
       hostUtils: expect.anything(),
-      requireAcceptTerms: true,
+      requireAcceptTerms: false,
     });
     expect(open).toBeCalledWith("http://localhost:3000/");
   } finally {
@@ -69,7 +69,7 @@ test("wing it with a file runs", async () => {
       wingfile: resolve("foo.w"),
       requestedPort: 3000,
       hostUtils: expect.anything(),
-      requireAcceptTerms: true,
+      requireAcceptTerms: false,
     });
     expect(open).toBeCalledWith("http://localhost:3000/");
   } finally {
@@ -93,7 +93,7 @@ test("wing it with a nested file runs", async () => {
       wingfile: resolve(filePath),
       requestedPort: 3000,
       hostUtils: expect.anything(),
-      requireAcceptTerms: true,
+      requireAcceptTerms: false,
     });
     expect(open).toBeCalledWith("http://localhost:3000/");
   } finally {
@@ -128,7 +128,7 @@ test("wing it with a custom port runs", async () => {
       wingfile: resolve("foo.w"),
       requestedPort: 5000,
       hostUtils: expect.anything(),
-      requireAcceptTerms: true,
+      requireAcceptTerms: false,
     });
     expect(open).toBeCalledWith("http://localhost:5000/");
   } finally {

--- a/apps/wing/src/commands/run.ts
+++ b/apps/wing/src/commands/run.ts
@@ -57,7 +57,7 @@ export async function run(entrypoint?: string, options?: RunOptions) {
         await open(url);
       },
     },
-    requireAcceptTerms: process.stdin.isTTY,
+    requireAcceptTerms: !!process.stdin.isTTY,
   });
   const url = `http://localhost:${port}/`;
   if (openBrowser) {

--- a/apps/wing/src/commands/run.ts
+++ b/apps/wing/src/commands/run.ts
@@ -49,19 +49,27 @@ export async function run(entrypoint?: string, options?: RunOptions) {
   entrypoint = resolve(entrypoint);
   debug("opening the wing console with:" + entrypoint);
 
-  const { port } = await createConsoleApp({
+  const { port, close } = await createConsoleApp({
     wingfile: entrypoint,
     requestedPort,
     hostUtils: {
-      async openExternal(url) {
+      async openExternal(url: string) {
         await open(url);
       },
     },
-    requireAcceptTerms: true,
+    requireAcceptTerms: process.stdin.isTTY,
   });
   const url = `http://localhost:${port}/`;
   if (openBrowser) {
     await open(url);
   }
   console.log(`The Wing Console is running at ${url}`);
+
+  const onExit = async (exitCode: number) => {
+    await close(() => process.exit(exitCode));
+  };
+
+  process.once("exit", async (c) => await onExit(c));
+  process.once("SIGTERM", async () => await onExit(0));
+  process.once("SIGINT", async () => await onExit(0));
 }

--- a/libs/wingsdk/src/.gen/versions.json
+++ b/libs/wingsdk/src/.gen/versions.json
@@ -1,6 +1,6 @@
 {
+  "registry.terraform.io/hashicorp/aws": "4.65.0",
   "registry.terraform.io/hashicorp/random": "3.5.1",
-  "registry.terraform.io/hashicorp/google": "4.63.1",
   "registry.terraform.io/hashicorp/azurerm": "3.54.0",
-  "registry.terraform.io/hashicorp/aws": "4.65.0"
+  "registry.terraform.io/hashicorp/google": "4.63.1"
 }


### PR DESCRIPTION
Fixes #4119

Since wing itself is being run in a child process of vscode, it wasn't handling the kill signal. Detaching it allows it to have its own process tree and be killed more reliably. Special handling is needed for windows, of course.

This also ensures that any process spawned by `wing it` itself is terminated too.

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
