### PR TITLE
feat(console): optional express app for server 

### DIFF
--- a/apps/wing-console/console/app/src/index.ts
+++ b/apps/wing-console/console/app/src/index.ts
@@ -33,6 +33,7 @@ export interface CreateConsoleAppOptions {
   requestedPort?: number;
   hostUtils?: HostUtils;
   onTrace?: (trace: Trace) => void;
+  expressApp?: express.Express;
   onExpressCreated?: CreateConsoleServerOptions["onExpressCreated"];
   requireAcceptTerms?: boolean;
   layoutConfig?: LayoutConfig;

--- a/apps/wing-console/console/server/src/expressServer.ts
+++ b/apps/wing-console/console/server/src/expressServer.ts
@@ -35,6 +35,7 @@ export interface CreateExpressServerOptions {
   requestedPort?: number;
   appState(): State;
   hostUtils?: HostUtils;
+  expressApp?: express.Express;
   onExpressCreated?: (app: express.Express) => void;
   wingfile: string;
   requireAcceptTerms?: boolean;
@@ -55,6 +56,7 @@ export const createExpressServer = async ({
   requestedPort,
   appState,
   hostUtils,
+  expressApp,
   onExpressCreated,
   wingfile,
   requireAcceptTerms = false,
@@ -63,7 +65,7 @@ export const createExpressServer = async ({
   setSelectedNode,
   testsStateManager,
 }: CreateExpressServerOptions) => {
-  const app = express();
+  const app = expressApp ?? express();
   app.use(cors());
 
   const { router } = mergeAllRouters();

--- a/apps/wing-console/console/server/src/index.ts
+++ b/apps/wing-console/console/server/src/index.ts
@@ -1,6 +1,6 @@
 import type { inferRouterInputs } from "@trpc/server";
 import Emittery from "emittery";
-import type { Application as ExpressApplication } from "express";
+import type { Express } from "express";
 
 import type { Config } from "./config.js";
 import { type ConsoleLogger, createConsoleLogger } from "./consoleLogger.js";
@@ -57,7 +57,8 @@ export interface CreateConsoleServerOptions {
   requestedPort?: number;
   hostUtils?: HostUtils;
   onTrace?: (trace: Trace) => void;
-  onExpressCreated?: (app: ExpressApplication) => void;
+  expressApp?: Express;
+  onExpressCreated?: (app: Express) => void;
   requireAcceptTerms?: boolean;
   layoutConfig?: LayoutConfig;
 }
@@ -70,6 +71,7 @@ export const createConsoleServer = async ({
   requestedPort,
   hostUtils,
   onTrace,
+  expressApp,
   onExpressCreated,
   requireAcceptTerms,
   layoutConfig,
@@ -224,6 +226,7 @@ export const createConsoleServer = async ({
       return appState;
     },
     hostUtils,
+    expressApp,
     onExpressCreated,
     wingfile,
     requireAcceptTerms,


### PR DESCRIPTION
the console server now accepts an optional express app. useful for setting up authentication and other routes prior to the console routes

## Checklist

- [X] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [X] Description explains motivation and solution
- [ ] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
