### PR TITLE
fix(sdk): bundling aws-sdk v3 again

### DIFF
--- a/libs/wingsdk/src/shared/bundling.ts
+++ b/libs/wingsdk/src/shared/bundling.ts
@@ -32,7 +32,6 @@ export function createBundle(entrypoint: string, outputDir?: string): Bundle {
     minify: false,
     platform: "node",
     target: "node18",
-    external: ["@aws-sdk"],
   });
 
   if (esbuild.errors.length > 0) {


### PR DESCRIPTION
Bundling aws-sdk v3 again, removing the library made the execution slower

Closes #4125 

## Checklist

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [ ] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
