### PR TITLE
fix(sdk)!: change addPolicyStatements to take variadic parameter

### DIFF
--- a/docs/docs/04-standard-library/01-cloud/function.md
+++ b/docs/docs/04-standard-library/01-cloud/function.md
@@ -45,15 +45,35 @@ new cloud.Function(inflight () => {
 
 ### Simulator (`sim`)
 
-The sim implementation of `cloud.Function` uses JavaScript's function
+The sim implementation of `cloud.Function` runs the inflight code as a JavaScript function.
 
 ### AWS (`tf-aws` and `awscdk`)
 
-The AWS implementation of `cloud.Function` uses [Amazon Lambda](https://aws.amazon.com/lambda/).
+The AWS implementation of `cloud.Function` uses [AWS Lambda](https://aws.amazon.com/lambda/).
+
+To add extra IAM permissions to the function, you can use the `aws.Function` class as shown below.
+
+```ts playground
+bring aws;
+bring cloud;
+
+let f = new cloud.Function(inflight () => {
+  log("Hello world!");
+});
+if let lambdaFn = aws.Function.from(f) {
+  lambdaFn.addPolicyStatements(
+    aws.PolicyStatement {
+      actions: ["ses:sendEmail"],
+      effect: aws.Effect.ALLOW,
+      resources: ["*"],
+    },
+  );
+}
+```
 
 ### Azure (`tf-azure`)
 
-The Azure implementation of `cloud.Function` uses [Azure Function](https://azure.microsoft.com/en-us/products/function).
+The Azure implementation of `cloud.Function` uses [Azure Functions](https://azure.microsoft.com/en-us/products/functions).
 
 🚧 `invoke` API is not supported yet (tracking issue: [#1371](https://github.com/winglang/wing/issues/1371))
 

--- a/docs/docs/04-standard-library/05-aws/api-reference.md
+++ b/docs/docs/04-standard-library/05-aws/api-reference.md
@@ -132,7 +132,28 @@ A shared interface for AWS functions.
 
 | **Name** | **Description** |
 | --- | --- |
+| <code><a href="#@winglang/sdk.aws.IAwsFunction.addEnvironment">addEnvironment</a></code> | Add an environment variable to the function. |
 | <code><a href="#@winglang/sdk.aws.IAwsFunction.addPolicyStatements">addPolicyStatements</a></code> | Add policy statements to the function's IAM role. |
+
+---
+
+##### `addEnvironment` <a name="addEnvironment" id="@winglang/sdk.aws.IAwsFunction.addEnvironment"></a>
+
+```wing
+addEnvironment(key: str, value: str): void
+```
+
+Add an environment variable to the function.
+
+###### `key`<sup>Required</sup> <a name="key" id="@winglang/sdk.aws.IAwsFunction.addEnvironment.parameter.key"></a>
+
+- *Type:* str
+
+---
+
+###### `value`<sup>Required</sup> <a name="value" id="@winglang/sdk.aws.IAwsFunction.addEnvironment.parameter.value"></a>
+
+- *Type:* str
 
 ---
 

--- a/docs/docs/04-standard-library/05-aws/api-reference.md
+++ b/docs/docs/04-standard-library/05-aws/api-reference.md
@@ -132,45 +132,21 @@ A shared interface for AWS functions.
 
 | **Name** | **Description** |
 | --- | --- |
-| <code><a href="#@winglang/sdk.aws.IAwsFunction.addEnvironment">addEnvironment</a></code> | Add an environment variable to the function. |
 | <code><a href="#@winglang/sdk.aws.IAwsFunction.addPolicyStatements">addPolicyStatements</a></code> | Add policy statements to the function's IAM role. |
-
----
-
-##### `addEnvironment` <a name="addEnvironment" id="@winglang/sdk.aws.IAwsFunction.addEnvironment"></a>
-
-```wing
-addEnvironment(key: str, value: str): void
-```
-
-Add an environment variable to the function.
-
-###### `key`<sup>Required</sup> <a name="key" id="@winglang/sdk.aws.IAwsFunction.addEnvironment.parameter.key"></a>
-
-- *Type:* str
-
----
-
-###### `value`<sup>Required</sup> <a name="value" id="@winglang/sdk.aws.IAwsFunction.addEnvironment.parameter.value"></a>
-
-- *Type:* str
 
 ---
 
 ##### `addPolicyStatements` <a name="addPolicyStatements" id="@winglang/sdk.aws.IAwsFunction.addPolicyStatements"></a>
 
 ```wing
-addPolicyStatements(policies: MutArray<PolicyStatement>): void
+addPolicyStatements(...policies: Array<PolicyStatement>): void
 ```
 
 Add policy statements to the function's IAM role.
 
-TODO: update this to accept a variadic parameter (...policies)
-https://github.com/winglang/wing/issues/397
-
 ###### `policies`<sup>Required</sup> <a name="policies" id="@winglang/sdk.aws.IAwsFunction.addPolicyStatements.parameter.policies"></a>
 
-- *Type:* MutArray&lt;<a href="#@winglang/sdk.aws.PolicyStatement">PolicyStatement</a>&gt;
+- *Type:* <a href="#@winglang/sdk.aws.PolicyStatement">PolicyStatement</a>
 
 ---
 

--- a/examples/tests/valid/dynamo.main.w
+++ b/examples/tests/valid/dynamo.main.w
@@ -45,11 +45,11 @@ class DynamoTable {
   bind(host: std.IInflightHost, ops: Array<str>) {
     if let host = aws.Function.from(host) {
       if ops.contains("putItem") {
-        host.addPolicyStatements([aws.PolicyStatement {
+        host.addPolicyStatements(aws.PolicyStatement {
           actions: ["dynamodb:PutItem"],
           resources: [this.table.arn],
           effect: aws.Effect.ALLOW,
-        }]);
+        });
       }
     }
   }

--- a/examples/tests/valid/dynamo_awscdk.main.w
+++ b/examples/tests/valid/dynamo_awscdk.main.w
@@ -43,19 +43,19 @@ class DynamoTable {
   bind(host: std.IInflightHost, ops: Array<str>) {
     if let host = aws.Function.from(host) {
       if ops.contains("putItem") {
-        host.addPolicyStatements([aws.PolicyStatement {
+        host.addPolicyStatements(aws.PolicyStatement {
           actions: ["dynamodb:PutItem"],
           resources: [this.table.tableArn],
           effect: aws.Effect.ALLOW,
-        }]);
+        });
       }
 
       if ops.contains("getItem") {
-        host.addPolicyStatements([aws.PolicyStatement {
+        host.addPolicyStatements(aws.PolicyStatement {
           actions: ["dynamodb:GetItem"],
           resources: [this.table.tableArn],
           effect: aws.Effect.ALLOW,
-        }]);
+        });
       }
     }
   }

--- a/libs/wingsdk/src/cloud/function.md
+++ b/libs/wingsdk/src/cloud/function.md
@@ -45,15 +45,35 @@ new cloud.Function(inflight () => {
 
 ### Simulator (`sim`)
 
-The sim implementation of `cloud.Function` uses JavaScript's function
+The sim implementation of `cloud.Function` runs the inflight code as a JavaScript function.
 
 ### AWS (`tf-aws` and `awscdk`)
 
-The AWS implementation of `cloud.Function` uses [Amazon Lambda](https://aws.amazon.com/lambda/).
+The AWS implementation of `cloud.Function` uses [AWS Lambda](https://aws.amazon.com/lambda/).
+
+To add extra IAM permissions to the function, you can use the `aws.Function` class as shown below.
+
+```ts playground
+bring aws;
+bring cloud;
+
+let f = new cloud.Function(inflight () => {
+  log("Hello world!");
+});
+if let lambdaFn = aws.Function.from(f) {
+  lambdaFn.addPolicyStatements(
+    aws.PolicyStatement {
+      actions: ["ses:sendEmail"],
+      effect: aws.Effect.ALLOW,
+      resources: ["*"],
+    },
+  );
+}
+```
 
 ### Azure (`tf-azure`)
 
-The Azure implementation of `cloud.Function` uses [Azure Function](https://azure.microsoft.com/en-us/products/function).
+The Azure implementation of `cloud.Function` uses [Azure Functions](https://azure.microsoft.com/en-us/products/functions).
 
 🚧 `invoke` API is not supported yet (tracking issue: [#1371](https://github.com/winglang/wing/issues/1371))
 

--- a/libs/wingsdk/src/shared-aws/function.ts
+++ b/libs/wingsdk/src/shared-aws/function.ts
@@ -6,17 +6,9 @@ import { IInflightHost } from "../std";
  */
 export interface IAwsFunction {
   /**
-   * Add an environment variable to the function.
-   */
-  addEnvironment(key: string, value: string): void;
-
-  /**
    * Add policy statements to the function's IAM role.
-   *
-   * TODO: update this to accept a variadic parameter (...policies)
-   * https://github.com/winglang/wing/issues/397
    */
-  addPolicyStatements(policies: PolicyStatement[]): void;
+  addPolicyStatements(...policies: PolicyStatement[]): void;
 }
 
 /**
@@ -36,9 +28,6 @@ export class Function {
   }
 
   private static isAwsFunction(obj: any): obj is IAwsFunction {
-    return (
-      typeof obj.addPolicyStatements === "function" &&
-      typeof obj.addEnvironment === "function"
-    );
+    return typeof obj.addPolicyStatements === "function";
   }
 }

--- a/libs/wingsdk/src/shared-aws/function.ts
+++ b/libs/wingsdk/src/shared-aws/function.ts
@@ -6,6 +6,11 @@ import { IInflightHost } from "../std";
  */
 export interface IAwsFunction {
   /**
+   * Add an environment variable to the function.
+   */
+  addEnvironment(key: string, value: string): void;
+
+  /**
    * Add policy statements to the function's IAM role.
    */
   addPolicyStatements(...policies: PolicyStatement[]): void;
@@ -28,6 +33,9 @@ export class Function {
   }
 
   private static isAwsFunction(obj: any): obj is IAwsFunction {
-    return typeof obj.addPolicyStatements === "function";
+    return (
+      typeof obj.addPolicyStatements === "function" &&
+      typeof obj.addEnvironment === "function"
+    );
   }
 }

--- a/libs/wingsdk/src/target-awscdk/bucket.ts
+++ b/libs/wingsdk/src/target-awscdk/bucket.ts
@@ -186,7 +186,7 @@ export class Bucket extends cloud.Bucket {
     }
 
     host.addPolicyStatements(
-      calculateBucketPermissions(this.bucket.bucketArn, ops)
+      ...calculateBucketPermissions(this.bucket.bucketArn, ops)
     );
 
     // The bucket name needs to be passed through an environment variable since

--- a/libs/wingsdk/src/target-awscdk/counter.ts
+++ b/libs/wingsdk/src/target-awscdk/counter.ts
@@ -32,7 +32,7 @@ export class Counter extends cloud.Counter {
     }
 
     host.addPolicyStatements(
-      calculateCounterPermissions(this.table.tableArn, ops)
+      ...calculateCounterPermissions(this.table.tableArn, ops)
     );
 
     host.addEnvironment(this.envName(), this.table.tableName);

--- a/libs/wingsdk/src/target-awscdk/function.ts
+++ b/libs/wingsdk/src/target-awscdk/function.ts
@@ -57,12 +57,10 @@ export class Function extends cloud.Function implements IAwsFunction {
     }
 
     if (ops.includes(cloud.FunctionInflightMethods.INVOKE)) {
-      host.addPolicyStatements([
-        {
-          actions: ["lambda:InvokeFunction"],
-          resources: [`${this.function.functionArn}`],
-        },
-      ]);
+      host.addPolicyStatements({
+        actions: ["lambda:InvokeFunction"],
+        resources: [`${this.function.functionArn}`],
+      });
     }
 
     // The function name needs to be passed through an environment variable since
@@ -97,7 +95,7 @@ export class Function extends cloud.Function implements IAwsFunction {
   /**
    * Add a policy statement to the Lambda role.
    */
-  public addPolicyStatements(statements: PolicyStatement[]) {
+  public addPolicyStatements(...statements: PolicyStatement[]) {
     for (const statement of statements) {
       this.function.addToRolePolicy(new CdkPolicyStatement(statement));
     }

--- a/libs/wingsdk/src/target-awscdk/queue.ts
+++ b/libs/wingsdk/src/target-awscdk/queue.ts
@@ -81,7 +81,7 @@ export class Queue extends cloud.Queue {
     const env = this.envName();
 
     host.addPolicyStatements(
-      calculateQueuePermissions(this.queue.queueArn, ops)
+      ...calculateQueuePermissions(this.queue.queueArn, ops)
     );
 
     // The queue url needs to be passed through an environment variable since

--- a/libs/wingsdk/src/target-awscdk/secret.ts
+++ b/libs/wingsdk/src/target-awscdk/secret.ts
@@ -47,7 +47,7 @@ export class Secret extends cloud.Secret {
     }
 
     host.addPolicyStatements(
-      calculateSecretPermissions(this.arnForPolicies, ops)
+      ...calculateSecretPermissions(this.arnForPolicies, ops)
     );
 
     host.addEnvironment(this.envName(), this.secret.secretArn);

--- a/libs/wingsdk/src/target-awscdk/topic.ts
+++ b/libs/wingsdk/src/target-awscdk/topic.ts
@@ -75,7 +75,7 @@ export class Topic extends cloud.Topic {
     }
 
     host.addPolicyStatements(
-      calculateTopicPermissions(this.topic.topicArn, ops)
+      ...calculateTopicPermissions(this.topic.topicArn, ops)
     );
 
     host.addEnvironment(this.envName(), this.topic.topicArn);

--- a/libs/wingsdk/src/target-tf-aws/bucket.ts
+++ b/libs/wingsdk/src/target-tf-aws/bucket.ts
@@ -113,7 +113,9 @@ export class Bucket extends cloud.Bucket {
       throw new Error("buckets can only be bound by tfaws.Function for now");
     }
 
-    host.addPolicyStatements(calculateBucketPermissions(this.bucket.arn, ops));
+    host.addPolicyStatements(
+      ...calculateBucketPermissions(this.bucket.arn, ops)
+    );
 
     // The bucket name needs to be passed through an environment variable since
     // it may not be resolved until deployment time.

--- a/libs/wingsdk/src/target-tf-aws/counter.ts
+++ b/libs/wingsdk/src/target-tf-aws/counter.ts
@@ -42,7 +42,9 @@ export class Counter extends cloud.Counter {
       throw new Error("counters can only be bound by tfaws.Function for now");
     }
 
-    host.addPolicyStatements(calculateCounterPermissions(this.table.arn, ops));
+    host.addPolicyStatements(
+      ...calculateCounterPermissions(this.table.arn, ops)
+    );
 
     host.addEnvironment(this.envName(), this.table.name);
 

--- a/libs/wingsdk/src/target-tf-aws/function.ts
+++ b/libs/wingsdk/src/target-tf-aws/function.ts
@@ -229,12 +229,10 @@ export class Function extends cloud.Function implements IAwsFunction {
     }
 
     if (ops.includes(cloud.FunctionInflightMethods.INVOKE)) {
-      host.addPolicyStatements([
-        {
-          actions: ["lambda:InvokeFunction"],
-          resources: [`${this.function.arn}`],
-        },
-      ]);
+      host.addPolicyStatements({
+        actions: ["lambda:InvokeFunction"],
+        resources: [`${this.function.arn}`],
+      });
     }
 
     // The function name needs to be passed through an environment variable since
@@ -269,7 +267,7 @@ export class Function extends cloud.Function implements IAwsFunction {
   /**
    * Add a policy statement to the Lambda role.
    */
-  public addPolicyStatements(statements: PolicyStatement[]) {
+  public addPolicyStatements(...statements: PolicyStatement[]) {
     // we do lazy initialization here because addPolicyStatements() might be called through the
     // constructor chain of the Function base class which means that our constructor might not have
     // been called yet... yes, ugly.

--- a/libs/wingsdk/src/target-tf-aws/queue.ts
+++ b/libs/wingsdk/src/target-tf-aws/queue.ts
@@ -65,18 +65,16 @@ export class Queue extends cloud.Queue {
       throw new Error("Queue only supports creating tfaws.Function right now");
     }
 
-    fn.addPolicyStatements([
-      {
-        actions: [
-          "sqs:ReceiveMessage",
-          "sqs:ChangeMessageVisibility",
-          "sqs:GetQueueUrl",
-          "sqs:DeleteMessage",
-          "sqs:GetQueueAttributes",
-        ],
-        resources: [this.queue.arn],
-      },
-    ]);
+    fn.addPolicyStatements({
+      actions: [
+        "sqs:ReceiveMessage",
+        "sqs:ChangeMessageVisibility",
+        "sqs:GetQueueUrl",
+        "sqs:DeleteMessage",
+        "sqs:GetQueueAttributes",
+      ],
+      resources: [this.queue.arn],
+    });
 
     new LambdaEventSourceMapping(this, "EventSourceMapping", {
       functionName: fn._functionName,
@@ -100,7 +98,7 @@ export class Queue extends cloud.Queue {
 
     const env = this.envName();
 
-    host.addPolicyStatements(calculateQueuePermissions(this.queue.arn, ops));
+    host.addPolicyStatements(...calculateQueuePermissions(this.queue.arn, ops));
 
     // The queue url needs to be passed through an environment variable since
     // it may not be resolved until deployment time.

--- a/libs/wingsdk/src/target-tf-aws/redis.ts
+++ b/libs/wingsdk/src/target-tf-aws/redis.ts
@@ -102,12 +102,10 @@ export class Redis extends ex.Redis {
     // Ops do not matter here since the client connects directly to the cluster.
     // The only thing that we need to use AWS API for is to get the cluster endpoint
     // from the cluster ID.
-    host.addPolicyStatements([
-      {
-        actions: ["elasticache:Describe*"],
-        resources: [this.clusterArn],
-      },
-    ]);
+    host.addPolicyStatements({
+      actions: ["elasticache:Describe*"],
+      resources: [this.clusterArn],
+    });
 
     host.addEnvironment(env, this.clusterId);
     host.addNetworkConfig({

--- a/libs/wingsdk/src/target-tf-aws/secret.ts
+++ b/libs/wingsdk/src/target-tf-aws/secret.ts
@@ -54,7 +54,9 @@ export class Secret extends cloud.Secret {
       throw new Error("secrets can only be bound by tfaws.Function for now");
     }
 
-    host.addPolicyStatements(calculateSecretPermissions(this.secret.arn, ops));
+    host.addPolicyStatements(
+      ...calculateSecretPermissions(this.secret.arn, ops)
+    );
 
     host.addEnvironment(this.envName(), this.secret.arn);
 

--- a/libs/wingsdk/src/target-tf-aws/table.ts
+++ b/libs/wingsdk/src/target-tf-aws/table.ts
@@ -60,47 +60,37 @@ export class Table extends ex.Table {
       ops.includes(ex.TableInflightMethods.INSERT) ||
       ops.includes(ex.TableInflightMethods.UPSERT)
     ) {
-      host.addPolicyStatements([
-        {
-          actions: ["dynamodb:PutItem"],
-          resources: [this.table.arn],
-        },
-      ]);
+      host.addPolicyStatements({
+        actions: ["dynamodb:PutItem"],
+        resources: [this.table.arn],
+      });
     }
     if (ops.includes(ex.TableInflightMethods.UPDATE)) {
-      host.addPolicyStatements([
-        {
-          actions: ["dynamodb:UpdateItem"],
-          resources: [this.table.arn],
-        },
-      ]);
+      host.addPolicyStatements({
+        actions: ["dynamodb:UpdateItem"],
+        resources: [this.table.arn],
+      });
     }
 
     if (ops.includes(ex.TableInflightMethods.DELETE)) {
-      host.addPolicyStatements([
-        {
-          actions: ["dynamodb:DeleteItem"],
-          resources: [this.table.arn],
-        },
-      ]);
+      host.addPolicyStatements({
+        actions: ["dynamodb:DeleteItem"],
+        resources: [this.table.arn],
+      });
     }
 
     if (ops.includes(ex.TableInflightMethods.GET)) {
-      host.addPolicyStatements([
-        {
-          actions: ["dynamodb:GetItem"],
-          resources: [this.table.arn],
-        },
-      ]);
+      host.addPolicyStatements({
+        actions: ["dynamodb:GetItem"],
+        resources: [this.table.arn],
+      });
     }
 
     if (ops.includes(ex.TableInflightMethods.LIST)) {
-      host.addPolicyStatements([
-        {
-          actions: ["dynamodb:Scan"],
-          resources: [this.table.arn],
-        },
-      ]);
+      host.addPolicyStatements({
+        actions: ["dynamodb:Scan"],
+        resources: [this.table.arn],
+      });
     }
 
     host.addEnvironment(this.envName(), this.table.name);

--- a/libs/wingsdk/src/target-tf-aws/topic.ts
+++ b/libs/wingsdk/src/target-tf-aws/topic.ts
@@ -139,7 +139,7 @@ export class Topic extends cloud.Topic {
       throw new Error("topics can only be bound by tfaws.Function for now");
     }
 
-    host.addPolicyStatements(calculateTopicPermissions(this.topic.arn, ops));
+    host.addPolicyStatements(...calculateTopicPermissions(this.topic.arn, ops));
 
     host.addEnvironment(this.envName(), this.topic.arn);
 


### PR DESCRIPTION
Resolves a small TODO we had in our SDK that we had from prior to the language having variadics. I also added some docs about how to use `aws.Function`.

BREAKING CHANGE: The parameter to `addPolicyStatements` on `aws.Function` is now variadic, so instead of calling `addPolicyStatements([policy1, policy2])` you must omit the array brackets, calling `addPolicyStatements(policy1, policy2)`.

## Checklist

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [x] Tests added (always)
- [x] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
