### PR TITLE
fix: crash when root file isn't able to be `stat`ed

### DIFF
--- a/libs/wingcompiler/src/wingc.ts
+++ b/libs/wingcompiler/src/wingc.ts
@@ -118,8 +118,13 @@ export async function load(options: WingCompilerLoadOptions) {
       }
 
       const fullPath = `/${file}`;
-      const fileStat = await fs.promises.stat(fullPath);
+      const fileStat = await fs.promises.stat(fullPath)?.catch((err) => {
+        log?.(`Failed to stat "${fullPath}": ${err}`);
+        return undefined;
+      });
       if (
+        // ignore anything we can't stat (e.g. broken symlinks)
+        fileStat &&
         // include directories and symlinks to directories
         fileStat.isDirectory() &&
         // on mac only preopen directories within the root device


### PR DESCRIPTION
Fixes #4196

Would be nice to find a better way to give the wasm side more file access (or avoid doing any fs ops in wasm at all https://github.com/winglang/wing/issues/1560)

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
