### PR TITLE
fix(compiler): implicit structs don't work in collections

### DIFF
--- a/examples/tests/invalid/json.main.w
+++ b/examples/tests/invalid/json.main.w
@@ -58,6 +58,16 @@ let notJsonMissingField: StructyJson = {
 };
 //^ Missing required field "maybe" from "StructyJson"
 
+let notJsonMissingFieldArray: Map<Set<Array<StructyJson>>> = {
+  "1" => {[ 
+    {
+      foo: "bar",
+      stuff: [],
+    }
+  //^ Missing required field "maybe" from "StructyJson"
+  ]}
+};
+
 let notJsonBadNesting: StructyJson = {
   foo: "bar",
   stuff: [1, 2, 3],

--- a/examples/tests/valid/json.main.w
+++ b/examples/tests/valid/json.main.w
@@ -227,6 +227,10 @@ struct StructyJson {
   maybe: InnerStructyJson?;
 }
 
+let arrayStruct: Array<StructyJson> = [ { foo: "", stuff: [] } ];
+let setStruct: Set<StructyJson> = { { foo: "", stuff: [] } };
+let mapStruct: Map<StructyJson> = { "1" => ({ foo: "", stuff: [] }) };
+
 let notJsonMissingField: StructyJson = {
   foo: "bar",
   stuff: [],

--- a/examples/tests/valid/json.main.w
+++ b/examples/tests/valid/json.main.w
@@ -230,6 +230,7 @@ struct StructyJson {
 let arrayStruct: Array<StructyJson> = [ { foo: "", stuff: [] } ];
 let setStruct: Set<StructyJson> = { { foo: "", stuff: [] } };
 let mapStruct: Map<StructyJson> = { "1" => ({ foo: "", stuff: [] }) };
+let deepCollectionStruct: Map<Array<Set<StructyJson>>> = { "1" => [ { { foo: "", stuff: [] } } ] };
 
 let notJsonMissingField: StructyJson = {
   foo: "bar",

--- a/libs/wingc/src/type_check.rs
+++ b/libs/wingc/src/type_check.rs
@@ -2801,7 +2801,7 @@ impl<'a> TypeChecker<'a> {
 		if return_type.is_nil() && expected_types.len() == 1 {
 			message = format!("{message} (hint: to allow \"nil\" assignment use optional type: \"{first_expected_type}?\")");
 		}
-		if !return_type.is_known_json() {
+		if return_type.is_json() {
 			// known json data is statically known
 			message = format!("{message} (hint: use {first_expected_type}.fromJson() to convert dynamic Json)");
 		}

--- a/tools/hangar/__snapshots__/invalid.ts.snap
+++ b/tools/hangar/__snapshots__/invalid.ts.snap
@@ -1684,32 +1684,42 @@ error: Missing required field \\"maybe\\" from \\"StructyJson\\"
    | \\\\-^ Missing required field \\"maybe\\" from \\"StructyJson\\"
 
 
+error: Missing required field \\"maybe\\" from \\"StructyJson\\"
+   --> ../../../examples/tests/invalid/json.main.w:63:5
+   |  
+63 | /     {
+64 | |       foo: \\"bar\\",
+65 | |       stuff: [],
+66 | |     }
+   | \\\\-----^ Missing required field \\"maybe\\" from \\"StructyJson\\"
+
+
 error: Expected type to be \\"bool\\", but got \\"num\\" instead
-   --> ../../../examples/tests/invalid/json.main.w:65:11
+   --> ../../../examples/tests/invalid/json.main.w:75:11
    |
-65 |     good: 2,
+75 |     good: 2,
    |           ^ Expected type to be \\"bool\\", but got \\"num\\" instead
 
 
 error: Expected type to be \\"num\\", but got \\"str\\" instead
-   --> ../../../examples/tests/invalid/json.main.w:72:14
+   --> ../../../examples/tests/invalid/json.main.w:82:14
    |
-72 |   stuff: [1, \\"hi\\", 3],
+82 |   stuff: [1, \\"hi\\", 3],
    |              ^^^^ Expected type to be \\"num\\", but got \\"str\\" instead
 
 
 error: Expected type to be \\"num\\", but got \\"str\\" instead
-   --> ../../../examples/tests/invalid/json.main.w:83:8
+   --> ../../../examples/tests/invalid/json.main.w:93:8
    |
-83 |     b: \\"\\",
+93 |     b: \\"\\",
    |        ^^ Expected type to be \\"num\\", but got \\"str\\" instead
 
 
 error: Expected type to be \\"StructyJson\\", but got \\"Json\\" instead (hint: use StructyJson.fromJson() to convert dynamic Json)
-   --> ../../../examples/tests/invalid/json.main.w:96:38
-   |
-96 | let mutableJsonStruct: StructyJson = mutableJson;
-   |                                      ^^^^^^^^^^^ Expected type to be \\"StructyJson\\", but got \\"Json\\" instead (hint: use StructyJson.fromJson() to convert dynamic Json)
+    --> ../../../examples/tests/invalid/json.main.w:106:38
+    |
+106 | let mutableJsonStruct: StructyJson = mutableJson;
+    |                                      ^^^^^^^^^^^ Expected type to be \\"StructyJson\\", but got \\"Json\\" instead (hint: use StructyJson.fromJson() to convert dynamic Json)
 
 
 error: \\"Array<Json>\\" is not a legal JSON value
@@ -1727,16 +1737,16 @@ error: \\"Bucket\\" is not a legal JSON value
 
 
 error: \\"Bucket\\" is not a legal JSON value
-    --> ../../../examples/tests/invalid/json.main.w:100:6
+    --> ../../../examples/tests/invalid/json.main.w:110:6
     |
-100 |   b: new cloud.Bucket()
+110 |   b: new cloud.Bucket()
     |      ^^^^^^^^^^^^^^^^^^ \\"Bucket\\" is not a legal JSON value
 
 
 error: \\"Bucket\\" is not a legal JSON value
-    --> ../../../examples/tests/invalid/json.main.w:104:21
+    --> ../../../examples/tests/invalid/json.main.w:114:21
     |
-104 | let isBucket = Json new cloud.Bucket();
+114 | let isBucket = Json new cloud.Bucket();
     |                     ^^^^^^^^^^^^^^^^^^ \\"Bucket\\" is not a legal JSON value
 
 

--- a/tools/hangar/__snapshots__/test_corpus/valid/json.main.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/json.main.w_compile_tf-aws.md
@@ -219,6 +219,7 @@ class $Root extends $stdlib.std.Resource {
     const arrayStruct = [({"foo": "","stuff": []})];
     const setStruct = new Set([({"foo": "","stuff": []})]);
     const mapStruct = ({"1": ({"foo": "","stuff": []})});
+    const deepCollectionStruct = ({"1": [new Set([({"foo": "","stuff": []})])]});
     const notJsonMissingField = ({"foo": "bar","stuff": []});
     const notJson = ({"foo": "bar","stuff": [1, 2, 3],"maybe": ({"good": true,"inner_stuff": [({"hi": 1,"base": "base"})]})});
     let mutableJson = ({"foo": "bar","stuff": [1, 2, 3],"maybe": ({"good": true,"inner_stuff": [({"hi": 1,"base": "base"})]})});

--- a/tools/hangar/__snapshots__/test_corpus/valid/json.main.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/json.main.w_compile_tf-aws.md
@@ -216,6 +216,9 @@ class $Root extends $stdlib.std.Resource {
     {((cond) => {if (!cond) throw new Error("assertion failed: notSpecified.get(\"foo\") == \"bar\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(((obj, args) => { if (obj[args] === undefined) throw new Error(`Json property "${args}" does not exist`); return obj[args] })(notSpecified, "foo"),"bar")))};
     const empty = ({});
     {((cond) => {if (!cond) throw new Error("assertion failed: Json.has(empty, \"something\") == false")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(((args) => { return args[0].hasOwnProperty(args[1]); })([empty,"something"]),false)))};
+    const arrayStruct = [({"foo": "","stuff": []})];
+    const setStruct = new Set([({"foo": "","stuff": []})]);
+    const mapStruct = ({"1": ({"foo": "","stuff": []})});
     const notJsonMissingField = ({"foo": "bar","stuff": []});
     const notJson = ({"foo": "bar","stuff": [1, 2, 3],"maybe": ({"good": true,"inner_stuff": [({"hi": 1,"base": "base"})]})});
     let mutableJson = ({"foo": "bar","stuff": [1, 2, 3],"maybe": ({"good": true,"inner_stuff": [({"hi": 1,"base": "base"})]})});


### PR DESCRIPTION
Fixes #4185
Fixes #3231 (should be allowed to assign Map to Json, no need to change the error. Fixed specific bug which prevented this for `Json?`)

Most of the change here was in two areas:
- Made sure that collections of Json will always have the Json type data stored in them
- Extracted the json logic from validate_type_in to a new function because it needed some recursion. Heavily commented it now too. The overall logic is only slightly changed, though, to support nested collections.

You'll notice some duplication between the collection literals. If there is concern about it I'm cool with doing some consolidation in this PR, but I figured it could wait until https://github.com/winglang/wing/issues/3873

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
