### PR TITLE
fix: flakey installation step in canary workflow

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -23,21 +23,16 @@ jobs:
           - 18
           - 20
         install_command:
-          - npm install -g winglang
+          - npm install -g winglang@latest
     runs-on: ${{ matrix.runner }}
     steps:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node }}
-      - name: Get Latest Wing Version
-        id: get-version
-        shell: bash
-        run: |
-          echo version=$(npm view winglang version) >> $GITHUB_OUTPUT
       - name: Install Wing
         run: |
-          ${{ matrix.install_command }}@${{ steps.get-version.outputs.version }}
+          ${{ matrix.install_command }}
       - name: Download examples/tests/valid/test_bucket.main.w
         run: |
           curl -L https://raw.githubusercontent.com/winglang/wing/main/examples/tests/valid/test_bucket.main.w > test_bucket.main.w


### PR DESCRIPTION
Fixes an operational issue with our canary workflow where installing the latest version of Winglang fails because npm reports a new version as the "latest" before it's actually available for download. (see https://github.com/winglang/wing/actions/runs/6224395212/job/16892506244)

## Checklist

- [ ] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [ ] Description explains motivation and solution
- [ ] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
