### PR TITLE
fix(vscode): default `wing.bin` fails if there is a wing file/dir in home directory

### DIFF
--- a/apps/vscode-wing/src/bin-helper.ts
+++ b/apps/vscode-wing/src/bin-helper.ts
@@ -64,9 +64,8 @@ export async function getWingBin(): Promise<string | null> {
     env.WING_BIN ??
     workspace.getConfiguration(CFG_WING).get<string>(CFG_WING_BIN);
 
-  configuredWingBin = configuredWingBin?.trim();
-
   if (configuredWingBin) {
+    configuredWingBin = configuredWingBin.trim();
     const configuredPath = await resolvePath(configuredWingBin);
     if (configuredPath) {
       // this is already a path, so we can just return it

--- a/apps/vscode-wing/src/bin-helper.ts
+++ b/apps/vscode-wing/src/bin-helper.ts
@@ -62,18 +62,18 @@ export async function updateStatusBar(wingBin: string) {
 export async function getWingBin(): Promise<string | null> {
   let configuredWingBin =
     env.WING_BIN ??
-    workspace.getConfiguration(CFG_WING).get<string>(CFG_WING_BIN, "wing");
+    workspace.getConfiguration(CFG_WING).get<string>(CFG_WING_BIN);
 
-  configuredWingBin = configuredWingBin.trim();
+  configuredWingBin = configuredWingBin?.trim();
 
-  if (!configuredWingBin) {
+  if (configuredWingBin) {
+    const configuredPath = await resolvePath(configuredWingBin);
+    if (configuredPath) {
+      // this is already a path, so we can just return it
+      return configuredPath;
+    }
+  } else {
     configuredWingBin = "wing";
-  }
-
-  const configuredPath = await resolvePath(configuredWingBin);
-  if (configuredPath) {
-    // this is already a path, so we can just return it
-    return configuredPath;
   }
 
   try {


### PR DESCRIPTION
Fixes #3980

https://github.com/winglang/wing/issues/3980#issuecomment-1724946053

> Why do we even attempt to call `resolvePath` if there's no `configuredWingBin`?

Good point :)

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
