### PR TITLE
fix(console): missing brackets in console BSOD

### DIFF
--- a/apps/wing-console/console/ui/src/shared/use-file-link.tsx
+++ b/apps/wing-console/console/ui/src/shared/use-file-link.tsx
@@ -8,6 +8,8 @@ export const createHtmlLink = (
   expanded: boolean = false,
 ) => {
   return error
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
     .replaceAll(
       /\B((?:[a-z]:)?[/\\]\S+):(\d+):(\d+)/gi,
       (match, path, line, column) => {


### PR DESCRIPTION
Before
<img width="879" alt="image" src="https://github.com/winglang/wing/assets/1237390/113975f0-b934-4034-869c-91ad7f347f15">

After
<img width="1073" alt="image" src="https://github.com/winglang/wing/assets/1237390/97a375ed-ffaa-41ff-ae05-9c9cef4c47b2">

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
