### PR TITLE
chore: idempotent npm release and fix for git tag determination

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -367,9 +367,19 @@ jobs:
         env:
           PACKAGE_VERSION: ${{ needs.build.outputs.version }}
         run: |
-          PACKAGES=("winglang-sdk" "winglang-compiler" "wingconsole-design-system" "wingconsole-ui" "wingconsole-server" "wingconsole-app" "winglang")
+          PACKAGES=("@winglang/sdk" "@winglang/compiler" "@wingconsole/design-system" "@wingconsole/ui" "@wingconsole/server" "@wingconsole/app" "winglang")
           for PACKAGE in "${PACKAGES[@]}"; do
-            npm publish "$PACKAGE-$PACKAGE_VERSION.tgz" --access public
+            # Check if already published
+            VERSION_FOUND=$(npm view "$PACKAGE@$PACKAGE_VERSION" version 2> /dev/null)
+            if [ "$VERSION_FOUND" = "$PACKAGE_VERSION" ]; then
+              echo "$PACKAGE@$PACKAGE_VERSION already published, skipping"
+              continue
+            fi
+
+            # remove "@" and replace "/" with "-"
+            TARBALL=$(echo "$PACKAGE-$PACKAGE_VERSION.tgz" | sed 's/@//g' | sed 's/\//-/g')
+
+            npm publish "$TARBALL" --access public
           done
 
       - name: Publish Extension to Visual Studio Marketplace

--- a/tools/bump-pack/src/release-files.ts
+++ b/tools/bump-pack/src/release-files.ts
@@ -38,7 +38,7 @@ export async function getReleaseData() {
     },
   });
 
-  const lastTag = execSync("git tag --sort=committerdate | tail -1", {
+  const lastTag = execSync("git tag -l --sort=version:refname | tail -1", {
     encoding: "utf8",
   }).trim();
   const lastVersion = lastTag.replace("v", "");


### PR DESCRIPTION
- If a version is already published, will skip it instead of failing
- Use the latest version of git tag based on semver sort rather than date. This previously failed if a commit had more than one tag

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
