### PR TITLE
chore: publish script fix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -370,7 +370,7 @@ jobs:
           PACKAGES=("@winglang/sdk" "@winglang/compiler" "@wingconsole/design-system" "@wingconsole/ui" "@wingconsole/server" "@wingconsole/app" "winglang")
           for PACKAGE in "${PACKAGES[@]}"; do
             # Check if already published
-            VERSION_FOUND=$(npm view "$PACKAGE@$PACKAGE_VERSION" version 2> /dev/null)
+            VERSION_FOUND=$(npm view "$PACKAGE@$PACKAGE_VERSION" version || true)
             if [ "$VERSION_FOUND" = "$PACKAGE_VERSION" ]; then
               echo "$PACKAGE@$PACKAGE_VERSION already published, skipping"
               continue


### PR DESCRIPTION
`npm view` causes the task to fail if the version isn't found. We don't want that here

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
