### PR TITLE
fix: automatically semicolon incorrectly inserted into `as` and `in` expressions

### DIFF
--- a/libs/tree-sitter-wing/src/scanner.c
+++ b/libs/tree-sitter-wing/src/scanner.c
@@ -85,6 +85,16 @@ static bool scan_whitespace_and_comments(TSLexer *lexer)
 }
 
 /**
+ * Check if a character is a valid identifier character
+ *
+ * @return true if the character is a valid identifier character, false otherwise
+ */
+static bool iswidentifier(int c)
+{
+  return iswalnum(c) || c == '_';
+}
+
+/**
  * Check if an automatic semicolon could be inserted
  *
  * @return true if an automatic semicolon was found (aka "inserted"), false otherwise
@@ -146,6 +156,26 @@ static bool scan_automatic_semicolon(TSLexer *lexer)
   case '!':
     skip(lexer);
     return lexer->lookahead != '=';
+
+  // Don't insert a semicolon before `in` (unless it's part of an identifier)
+  case 'i':
+    skip(lexer);
+    if (lexer->lookahead == 'n')
+    {
+      skip(lexer);
+      if (!iswidentifier(lexer->lookahead))
+        return false;
+    }
+  
+  // Don't insert a semicolon before `as` (unless it's part of an identifier)
+  case 'a':
+    skip(lexer);
+    if (lexer->lookahead == 's')
+    {
+      skip(lexer);
+      if (!iswidentifier(lexer->lookahead))
+        return false;
+    }
   }
 
   return true;

--- a/libs/tree-sitter-wing/test/corpus/expressions.txt
+++ b/libs/tree-sitter-wing/test/corpus/expressions.txt
@@ -169,6 +169,28 @@ new A() as "b" in c;
         (reference_identifier)))))
 
 ================================================================================
+New expression with id and scope on different lines
+================================================================================
+
+new A()
+  as 
+  "b" 
+  in 
+  c;
+
+--------------------------------------------------------------------------------
+
+(source
+  (expression_statement
+    (new_expression
+      class: (custom_type
+        object: (type_identifier))
+      args: (argument_list)
+      id: (string)
+      scope: (reference
+        (reference_identifier)))))
+
+================================================================================
 preflight anonymous closure
 ================================================================================
 


### PR DESCRIPTION
Fixes #4247

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
