### PR TITLE
fix(sdk)!: change Json.entries() to return Array<JsonEntry>

### DIFF
--- a/docs/docs/04-standard-library/02-std/api-reference.md
+++ b/docs/docs/04-standard-library/02-std/api-reference.md
@@ -2942,6 +2942,49 @@ Year.
 
 ---
 
+### JsonEntry <a name="JsonEntry" id="@winglang/sdk.std.JsonEntry"></a>
+
+Json entry representation.
+
+#### Initializer <a name="Initializer" id="@winglang/sdk.std.JsonEntry.Initializer"></a>
+
+```wing
+let JsonEntry = JsonEntry{ ... };
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#@winglang/sdk.std.JsonEntry.property.key">key</a></code> | <code>str</code> | The entry key. |
+| <code><a href="#@winglang/sdk.std.JsonEntry.property.value">value</a></code> | <code><a href="#@winglang/sdk.std.Json">Json</a></code> | The entry value. |
+
+---
+
+##### `key`<sup>Required</sup> <a name="key" id="@winglang/sdk.std.JsonEntry.property.key"></a>
+
+```wing
+key: str;
+```
+
+- *Type:* str
+
+The entry key.
+
+---
+
+##### `value`<sup>Required</sup> <a name="value" id="@winglang/sdk.std.JsonEntry.property.value"></a>
+
+```wing
+value: Json;
+```
+
+- *Type:* <a href="#@winglang/sdk.std.Json">Json</a>
+
+The entry value.
+
+---
+
 ### JsonStringifyOptions <a name="JsonStringifyOptions" id="@winglang/sdk.std.JsonStringifyOptions"></a>
 
 Options for stringify() method.

--- a/examples/tests/sdk_tests/std/json.main.w
+++ b/examples/tests/sdk_tests/std/json.main.w
@@ -96,9 +96,11 @@ test "keys(), values(), entries()" {
   let keys = Json.keys(obj);
   let values = Json.values(obj);
 
-  for i in 0..entries.length {
-    assert(entries.at(i).getAt(0) == keys.at(i));
-    assert(entries.at(i).getAt(1) == values.at(i));
+  let var i = 0;
+  for e in entries {
+    assert(e.key == keys.at(i));
+    assert(e.value == values.at(i));
+    i += 1;
   }
 }
 

--- a/libs/wingc/src/lsp/snapshots/completions/json_statics.snap
+++ b/libs/wingc/src/lsp/snapshots/completions/json_statics.snap
@@ -39,10 +39,10 @@ source: libs/wingc/src/lsp/completions.rs
     command: editor.action.triggerParameterHints
 - label: entries
   kind: 2
-  detail: "(json: Json): Array<Json>"
+  detail: "(json: Json): Array<JsonEntry>"
   documentation:
     kind: markdown
-    value: "```wing\nstatic entries: (json: Json): Array<Json>\n```\n---\nReturns the entries from the Json.\n\n\n### Returns\nthe entries as Array<Json> consisting of enumerable [key, value] pairs"
+    value: "```wing\nstatic entries: (json: Json): Array<JsonEntry>\n```\n---\nReturns the entries from the Json.\n\n\n### Returns\nthe entries as Array<JsonEntry>"
   sortText: ff|entries
   insertText: entries($0)
   insertTextFormat: 2

--- a/libs/wingc/src/lsp/snapshots/completions/static_completions_after_expression.snap
+++ b/libs/wingc/src/lsp/snapshots/completions/static_completions_after_expression.snap
@@ -39,10 +39,10 @@ source: libs/wingc/src/lsp/completions.rs
     command: editor.action.triggerParameterHints
 - label: entries
   kind: 2
-  detail: "(json: Json): Array<Json>"
+  detail: "(json: Json): Array<JsonEntry>"
   documentation:
     kind: markdown
-    value: "```wing\nstatic entries: (json: Json): Array<Json>\n```\n---\nReturns the entries from the Json.\n\n\n### Returns\nthe entries as Array<Json> consisting of enumerable [key, value] pairs"
+    value: "```wing\nstatic entries: (json: Json): Array<JsonEntry>\n```\n---\nReturns the entries from the Json.\n\n\n### Returns\nthe entries as Array<JsonEntry>"
   sortText: ff|entries
   insertText: entries($0)
   insertTextFormat: 2

--- a/libs/wingc/src/lsp/snapshots/completions/static_json_after_expression.snap
+++ b/libs/wingc/src/lsp/snapshots/completions/static_json_after_expression.snap
@@ -39,10 +39,10 @@ source: libs/wingc/src/lsp/completions.rs
     command: editor.action.triggerParameterHints
 - label: entries
   kind: 2
-  detail: "(json: Json): Array<Json>"
+  detail: "(json: Json): Array<JsonEntry>"
   documentation:
     kind: markdown
-    value: "```wing\nstatic entries: (json: Json): Array<Json>\n```\n---\nReturns the entries from the Json.\n\n\n### Returns\nthe entries as Array<Json> consisting of enumerable [key, value] pairs"
+    value: "```wing\nstatic entries: (json: Json): Array<JsonEntry>\n```\n---\nReturns the entries from the Json.\n\n\n### Returns\nthe entries as Array<JsonEntry>"
   sortText: ff|entries
   insertText: entries($0)
   insertTextFormat: 2

--- a/libs/wingc/src/lsp/snapshots/completions/static_json_after_expression_statement.snap
+++ b/libs/wingc/src/lsp/snapshots/completions/static_json_after_expression_statement.snap
@@ -39,10 +39,10 @@ source: libs/wingc/src/lsp/completions.rs
     command: editor.action.triggerParameterHints
 - label: entries
   kind: 2
-  detail: "(json: Json): Array<Json>"
+  detail: "(json: Json): Array<JsonEntry>"
   documentation:
     kind: markdown
-    value: "```wing\nstatic entries: (json: Json): Array<Json>\n```\n---\nReturns the entries from the Json.\n\n\n### Returns\nthe entries as Array<Json> consisting of enumerable [key, value] pairs"
+    value: "```wing\nstatic entries: (json: Json): Array<JsonEntry>\n```\n---\nReturns the entries from the Json.\n\n\n### Returns\nthe entries as Array<JsonEntry>"
   sortText: ff|entries
   insertText: entries($0)
   insertTextFormat: 2

--- a/libs/wingsdk/src/std/json.ts
+++ b/libs/wingsdk/src/std/json.ts
@@ -9,6 +9,16 @@ export interface JsonStringifyOptions {
 }
 
 /**
+ * Json entry representation
+ */
+export interface JsonEntry {
+  /** The entry key */
+  readonly key: string;
+  /** The entry value */
+  readonly value: Json;
+}
+
+/**
  * Immutable Json
  */
 export class Json {
@@ -48,14 +58,11 @@ export class Json {
   /**
    * Returns the entries from the Json.
    *
-   * @macro (Object.entries($args$))
-   *
    * @param json map to get the entries from
-   * @returns the entries as Array<Json> consisting of enumerable [key, value] pairs
+   * @returns the entries as Array<JsonEntry>
    */
-  public static entries(json: Json): Json[] {
-    json;
-    throw new Error("Macro");
+  public static entries(json: Json): JsonEntry[] {
+    return Object.entries(json).map(([key, value]) => ({ key, value }));
   }
 
   /**

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/std/json.main.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/std/json.main.w_compile_tf-aws.md
@@ -160,12 +160,14 @@ module.exports = function({ $std_Json }) {
     }
     async handle() {
       const obj = ({"a": 1,"b": [3, 7, 9],"c": ({"foo": "bar"})});
-      const entries = (Object.entries(obj));
+      const entries = (await $std_Json.entries(obj));
       const keys = (Object.keys(obj));
       const values = (Object.values(obj));
-      for (const i of ((s,e,i) => { function* iterator(start,end,inclusive) { let i = start; let limit = inclusive ? ((end < start) ? end - 1 : end + 1) : end; while (i < limit) yield i++; while (i > limit) yield i--; }; return iterator(s,e,i); })(0,entries.length,false)) {
-        {((cond) => {if (!cond) throw new Error("assertion failed: entries.at(i).getAt(0) == keys.at(i)")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(((obj, args) => { if (obj[args] === undefined) throw new Error("Index out of bounds"); return obj[args] })((await entries.at(i)), 0),(await keys.at(i)))))};
-        {((cond) => {if (!cond) throw new Error("assertion failed: entries.at(i).getAt(1) == values.at(i)")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(((obj, args) => { if (obj[args] === undefined) throw new Error("Index out of bounds"); return obj[args] })((await entries.at(i)), 1),(await values.at(i)))))};
+      let i = 0;
+      for (const e of entries) {
+        {((cond) => {if (!cond) throw new Error("assertion failed: e.key == keys.at(i)")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(e.key,(await keys.at(i)))))};
+        {((cond) => {if (!cond) throw new Error("assertion failed: e.value == values.at(i)")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(e.value,(await values.at(i)))))};
+        i += 1;
       }
     }
   }


### PR DESCRIPTION
Brought up during Wingly, we can just return a struct that holds the key and value when calling Json.entries(). Also this does not need to be a macro function

## Checklist

- [ ] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [ ] Description explains motivation and solution
- [ ] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
