### PR TITLE
feat(cli): introduce default entrypoints

### DIFF
--- a/apps/wing/package.json
+++ b/apps/wing/package.json
@@ -31,6 +31,7 @@
   },
   "dependencies": {
     "@segment/analytics-node": "^1.1.0",
+    "@types/glob": "^8.1.0",
     "@wingconsole/app": "workspace:^",
     "@wingconsole/server": "workspace:^",
     "@winglang/compiler": "workspace:^",
@@ -40,6 +41,7 @@
     "commander": "^10.0.1",
     "compare-versions": "^5.0.3",
     "debug": "^4.3.4",
+    "glob": "^8.1.0",
     "nanoid": "^3.3.6",
     "open": "^8.4.2",
     "ora": "^5.4.1",

--- a/apps/wing/src/commands/run.test.ts
+++ b/apps/wing/src/commands/run.test.ts
@@ -26,11 +26,11 @@ test("wing it runs the only .w file", async () => {
   try {
     process.chdir(workdir);
 
-    writeFileSync("foo.w", "bring cloud;");
+    writeFileSync("foo.main.w", "bring cloud;");
 
-    await run();
+    await run("foo.main.w");
     expect(createConsoleApp).toBeCalledWith({
-      wingfile: resolve("foo.w"),
+      wingfile: resolve("foo.main.w"),
       requestedPort: 3000,
       hostUtils: expect.anything(),
       requireAcceptTerms: false,
@@ -47,8 +47,8 @@ test("wing it with no file throws error for a directory with more than 1 .w file
   try {
     process.chdir(workdir);
 
-    writeFileSync("foo.w", "bring cloud;");
-    writeFileSync("bar.w", "bring cloud;");
+    writeFileSync("foo.main.w", "bring cloud;");
+    writeFileSync("bar.main.w", "bring cloud;");
 
     await expect(run).rejects.toThrow("Please specify which file you want to run");
   } finally {
@@ -62,11 +62,11 @@ test("wing it with a file runs", async () => {
   try {
     process.chdir(workdir);
 
-    writeFileSync("foo.w", "bring cloud;");
+    writeFileSync("foo.main.w", "bring cloud;");
 
-    await run("foo.w");
+    await run("foo.main.w");
     expect(createConsoleApp).toBeCalledWith({
-      wingfile: resolve("foo.w"),
+      wingfile: resolve("foo.main.w"),
       requestedPort: 3000,
       hostUtils: expect.anything(),
       requireAcceptTerms: false,
@@ -80,7 +80,7 @@ test("wing it with a file runs", async () => {
 test("wing it with a nested file runs", async () => {
   const workdir = await mkdtemp(join(tmpdir(), "-wing-it-test"));
   const subdir = join(workdir, "subdir");
-  const filePath = join(subdir, "foo.w");
+  const filePath = join(subdir, "foo.main.w");
   const prevdir = process.cwd();
   try {
     process.chdir(workdir);
@@ -107,9 +107,9 @@ test("wing it with an invalid file throws exception", async () => {
   try {
     process.chdir(workdir);
 
-    writeFileSync("foo.w", "bring cloud;");
+    writeFileSync("foo.main.w", "bring cloud;");
 
-    await expect(run("bar.w")).rejects.toThrow("bar.w doesn't exist");
+    await expect(run("bar.main.w")).rejects.toThrow("bar.main.w doesn't exist");
   } finally {
     process.chdir(prevdir);
   }
@@ -121,11 +121,11 @@ test("wing it with a custom port runs", async () => {
   try {
     process.chdir(workdir);
 
-    writeFileSync("foo.w", "bring cloud;");
+    writeFileSync("foo.main.w", "bring cloud;");
 
-    await run("foo.w", { port: "5000" });
+    await run("foo.main.w", { port: "5000" });
     expect(createConsoleApp).toBeCalledWith({
-      wingfile: resolve("foo.w"),
+      wingfile: resolve("foo.main.w"),
       requestedPort: 5000,
       hostUtils: expect.anything(),
       requireAcceptTerms: false,
@@ -142,10 +142,10 @@ test("wing it throws when invalid port number is used", async () => {
   try {
     process.chdir(workdir);
 
-    writeFileSync("foo.w", "bring cloud;");
+    writeFileSync("foo.main.w", "bring cloud;");
 
     await expect(async () => {
-      await run("foo.w", { port: "not a number" });
+      await run("foo.main.w", { port: "not a number" });
     }).rejects.toThrowError('"not a number" is not a number');
   } finally {
     process.chdir(prevdir);

--- a/apps/wing/src/commands/run.ts
+++ b/apps/wing/src/commands/run.ts
@@ -1,4 +1,4 @@
-import { readdirSync, existsSync } from "fs";
+import { existsSync } from "fs";
 import { debug } from "debug";
 import { resolve } from "path";
 import open from "open";
@@ -30,17 +30,9 @@ export interface RunOptions {
  * @param entrypoint The program .w entrypoint. Looks for a .w file in the current directory if not specified.
  * @param options Run options.
  */
-export async function run(entrypoint?: string, options?: RunOptions) {
+export async function run(entrypoint: string, options?: RunOptions) {
   const requestedPort = parseNumericString(options?.port) ?? 3000;
   const openBrowser = options?.open ?? true;
-
-  if (!entrypoint) {
-    const wingFiles = readdirSync(".").filter((item) => item.endsWith(".w"));
-    if (wingFiles.length !== 1) {
-      throw new Error("Please specify which file you want to run");
-    }
-    entrypoint = wingFiles[0];
-  }
 
   if (!existsSync(entrypoint)) {
     throw new Error(entrypoint + " doesn't exist");

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -273,6 +273,9 @@ importers:
       '@segment/analytics-node':
         specifier: ^1.1.0
         version: 1.1.0
+      '@types/glob':
+        specifier: ^8.1.0
+        version: 8.1.0
       '@wingconsole/app':
         specifier: workspace:^
         version: link:../wing-console/console/app
@@ -300,6 +303,9 @@ importers:
       debug:
         specifier: ^4.3.4
         version: 4.3.4
+      glob:
+        specifier: ^8.1.0
+        version: 8.1.0
       nanoid:
         specifier: ^3.3.6
         version: 3.3.6
@@ -12438,7 +12444,7 @@ packages:
     dependencies:
       semver: 7.5.4
       shelljs: 0.8.5
-      typescript: 5.3.0-dev.20230911
+      typescript: 5.3.0-dev.20230921
     dev: true
 
   /dset@3.1.2:
@@ -21476,8 +21482,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  /typescript@5.3.0-dev.20230911:
-    resolution: {integrity: sha512-2iI2l7OuGvU668gBje+JQKE8bsf7SH8w8ScwUkENHCcrbaDpXa/Oqfuwq5gdFM7SfVfp5p6c8kHZRMvL+kabJg==}
+  /typescript@5.3.0-dev.20230921:
+    resolution: {integrity: sha512-TZnDMkY/mgooSXJv72Zxr71MvXYUKiH05lekDOB9FaScoHLGNDvqw6IrT6qXx/kD6eJFpW2gadIz1eJQeA/URw==}
     engines: {node: '>=14.17'}
     hasBin: true
     dev: true


### PR DESCRIPTION
Wing CLI can now run the following commands without passing any entrypoint:
- `wing test` - looks for`*.test.w` files in current directory and tests them
- `wing compile` - looks for `main.w` file in current directory and compiles it
- `wing it` - looks for `main.w` file in current directory and runs it

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
