### PR TITLE
chore: queue retention time in spec test is too short

### DIFF
--- a/examples/tests/sdk_tests/queue/retention_period.main.w
+++ b/examples/tests/sdk_tests/queue/retention_period.main.w
@@ -1,13 +1,15 @@
 bring cloud;
 bring util;
 
-let var timeout = 100ms;
-let var retentionPeriod = 1s;
+let var timeout = 30s;
+let var retentionPeriod = 60s;
 
 let q = new cloud.Queue(timeout: timeout, retentionPeriod: retentionPeriod);
 
 test "retentionPeriod" {
   q.push("hello", "world");
+
+  util.sleep(retentionPeriod);
 
   assert(util.waitUntil(() => {
     return q.approxSize() == 0;


### PR DESCRIPTION
Looks like the minimum is 60 seconds

See https://github.com/winglang/wing/actions/runs/6314317373/job/17144314958

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
