### PR TITLE
chore(docs): minor reorg tweeks of contributor guide

### DIFF
--- a/docs/contributing/01-start-here/01-contributing-to-wing.md
+++ b/docs/contributing/01-start-here/01-contributing-to-wing.md
@@ -10,13 +10,13 @@ to know to help out with the Wing project.
 
 There are many ways to contribute to Wing:
 
+* Contributing to the [Wing SDK (standard library)](/contributing/start-here/wingsdk)
 * Reporting bugs through a [GitHub issue](https://github.com/winglang/wing/issues)
 * Writing [documentation and guides](https://github.com/winglang/wing/issues?q=is%3Aissue+is%3Aopen+label%3A%22%F0%9F%93%9A+documentation%22) or adding [examples](/contributing/start-here/docs#%EF%B8%8F-how-do-i-add-an-example)
 * Setting up your [development environment](/contributing/start-here/development) and working on the code
 * Submitting [pull requests](/contributing/start-here/pull_requests) for new features or helping with [reviews](https://github.com/winglang/wing/pulls)
 * Picking up a [good first issue](https://github.com/winglang/wing/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22+no%3Aassignee+sort%3Aupdated-desc+) to work on
 * Reporting and fixing [bugs](/contributing/start-here/bugs)
-* Contributing to the [Wing SDK (standard library)](/contributing/start-here/wingsdk)
 * Find solutions to common issues in our [troubleshooting guide](/contributing/start-here/troubleshooting)
 * Commenting on [RFCs](/contributing/category/rfcs) or submitting one for major features
 * Asking and answering questions in the [Wing Slack](https://t.winglang.io/slack)

--- a/docs/contributing/01-start-here/05-development.md
+++ b/docs/contributing/01-start-here/05-development.md
@@ -73,6 +73,12 @@ pnpm build
 It will compile, lint, test and package all modules.
 
 ## 🏠 What's the recommended development workflow?
+:::info
+When testing your changes to Wing, locally it may be helpful to be able to easily invoke your local version of the Wing CLI.
+In which case adding a shell alias may be helpful for instance on Linux and Mac you could add: 
+
+`alias mywing=/<PATH_TO_WING_REPO>/apps/wing/bin/wing` to your shell's rc file.
+:::
 
 The `pnpm wing` command can be executed from the root of the repository in order to build and run the
 compiler, SDK (standard library) and the Wing CLI. Turbo is configured to make sure only the changed components are built
@@ -84,6 +90,13 @@ To get full diagnostics, use these exports:
 export NODE_OPTIONS=--stack-trace-limit=100
 export RUST_BACKTRACE=full
 ```
+
+Or if you just want to compile your changes and run a local version of the Wing CLI:
+
+```sh
+pnpm compile --filter=winglang
+```
+
 
 Now, you can edit a source file anywhere across the stack and run the compiler with arguments.
 For example:

--- a/docs/contributing/01-start-here/07-wingsdk.md
+++ b/docs/contributing/01-start-here/07-wingsdk.md
@@ -10,13 +10,13 @@ This topic includes contribution guidelines related to the Wing SDK, the package
 
 The SDK resides in `libs/wingsdk`. It's written in TypeScript, and is published to npm.
 
+From within the SDK directory you can build it using `pnpm build`. You can also just run the tests with `pnpm test`.
+
 The SDK is built using a couple of extra libraries and tools:
 
 * [CDK for Terraform] ("cdktf") is a framework for defining Terraform infrastructure. The SDK uses it to generate the Terraform files that users deploy.
 * [JSII] is a tool we used to compile the SDK. JSII is a wrapper over TypeScript that makes it possible to use the SDK in other languages like Python, Java, C#, and Go. This is made possible through extra type checks. In practice, the main difference from ordinary TypeScript is that you cannot use advanced TypeScript types like `Partial` or generics in public APIs.
 * [Projen] is a tool used to manage project configuration files. It uses the `.projenrc.ts` file to generate `package.json` and other files. You can modify it and run `pnpm projen` to regenerate the resources. If you are not touching configuration files, you can totally ignore this.
-
-Everything in the SDK can be built by running `pnpm build` from `libs/wingsdk`. You can also run `pnpm test` to just run tests.
 
 In order to work on the source code, you will need to the build at least once so that TypeScript bindings for Terraform resources will be automatically generated.
 These files are not checked in because they are quite large.


### PR DESCRIPTION
Trying to re-organize and add a few things to contributor guide for clarity sake. 

(stems from slack conversations)

## Checklist

- [ ] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [ ] Description explains motivation and solution
- [ ] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
