### PR TITLE
feat(cli): compile directories

### DIFF
--- a/apps/wing/src/commands/compile.test.ts
+++ b/apps/wing/src/commands/compile.test.ts
@@ -6,6 +6,7 @@ import { Target } from "@winglang/compiler";
 import { generateTmpDir } from "src/util";
 
 const exampleDir = resolve("../../examples/tests/valid");
+const exampleSmallDir = resolve("../../examples/tests/valid/subdir2");
 const exampleFilePath = join(exampleDir, "captures.test.w");
 
 describe(
@@ -43,6 +44,26 @@ describe(
       return expect(compile("non-existent-file.w", { target: Target.SIM })).rejects.toThrowError(
         /Source file cannot be found/
       );
+    });
+
+    test("should be able to compile a directory", async () => {
+      const artifactDir = await compile(exampleSmallDir, {
+        target: Target.SIM,
+        targetDir: `${await generateTmpDir()}/target`,
+      });
+
+      const stats = await stat(artifactDir);
+      expect(stats.isDirectory()).toBeTruthy();
+    });
+
+    test("should be able to compile a directory to tf-aws", async () => {
+      const artifactDir = await compile(exampleSmallDir, {
+        target: Target.TF_AWS,
+        targetDir: `${await generateTmpDir()}/target`,
+      });
+
+      const stats = await stat(artifactDir);
+      expect(stats.isDirectory()).toBeTruthy();
     });
 
     // https://github.com/winglang/wing/issues/2081

--- a/libs/wingc/examples/compile.rs
+++ b/libs/wingc/examples/compile.rs
@@ -15,12 +15,7 @@ pub fn main() {
 	let source_path = Utf8Path::new(&args[1]).canonicalize_utf8().unwrap();
 	let target_dir: Utf8PathBuf = env::current_dir().unwrap().join("target").try_into().unwrap();
 
-	let results = compile(
-		&source_path,
-		None,
-		Some(&target_dir),
-		Some(source_path.parent().unwrap()),
-	);
+	let results = compile(&source_path, None, &target_dir, source_path.parent().unwrap());
 	if results.is_err() {
 		let mut diags = get_diagnostics();
 		// Sort error messages by line number (ascending)

--- a/libs/wingc/examples/compile.rs
+++ b/libs/wingc/examples/compile.rs
@@ -2,7 +2,7 @@
 // This should only be used for testing wingc directly.
 
 use camino::{Utf8Path, Utf8PathBuf};
-use std::{env, fs, process};
+use std::{env, process};
 use wingc::{compile, diagnostic::get_diagnostics};
 
 pub fn main() {
@@ -13,12 +13,11 @@ pub fn main() {
 	}
 
 	let source_path = Utf8Path::new(&args[1]).canonicalize_utf8().unwrap();
-	let source_text = fs::read_to_string(&source_path).unwrap();
 	let target_dir: Utf8PathBuf = env::current_dir().unwrap().join("target").try_into().unwrap();
 
 	let results = compile(
 		&source_path,
-		source_text,
+		None,
 		Some(&target_dir),
 		Some(source_path.parent().unwrap()),
 	);

--- a/libs/wingc/src/lib.rs
+++ b/libs/wingc/src/lib.rs
@@ -30,9 +30,10 @@ use wasm_util::{ptr_to_string, string_to_combined_ptr, WASM_RETURN_ERROR};
 use wingii::type_system::TypeSystem;
 
 use crate::docs::Docs;
+use crate::parser::normalize_path;
 use std::alloc::{alloc, dealloc, Layout};
 
-use std::{fs, mem};
+use std::mem;
 
 use crate::ast::Phase;
 use crate::type_check::symbol_env::SymbolEnv;
@@ -158,38 +159,19 @@ pub unsafe extern "C" fn wingc_compile(ptr: u32, len: u32) -> u64 {
 	let args = ptr_to_string(ptr, len);
 
 	let split = args.split(";").collect::<Vec<&str>>();
-	let source_file = Utf8Path::new(split[0]);
+	let source_path = Utf8Path::new(split[0]);
 	let output_dir = split.get(1).map(|s| Utf8Path::new(s));
 	let absolute_project_dir = split.get(2).map(|s| Utf8Path::new(s));
 
-	if !source_file.exists() {
+	if !source_path.exists() {
 		report_diagnostic(Diagnostic {
-			message: format!("Source file cannot be found: {}", source_file),
+			message: format!("Source path cannot be found: {}", source_path),
 			span: None,
 		});
 		return WASM_RETURN_ERROR;
 	}
 
-	if source_file.is_dir() {
-		report_diagnostic(Diagnostic {
-			message: format!("Source path must be a file (not a directory): {}", source_file),
-			span: None,
-		});
-		return WASM_RETURN_ERROR;
-	}
-
-	let source_text = match fs::read_to_string(&source_file) {
-		Ok(text) => text,
-		Err(e) => {
-			report_diagnostic(Diagnostic {
-				message: format!("Could not read file \"{}\": {}", source_file, e),
-				span: None,
-			});
-			return WASM_RETURN_ERROR;
-		}
-	};
-
-	let results = compile(source_file, source_text, output_dir, absolute_project_dir);
+	let results = compile(source_path, None, output_dir, absolute_project_dir);
 	if results.is_err() {
 		WASM_RETURN_ERROR
 	} else {
@@ -277,11 +259,12 @@ fn add_builtin(name: &str, typ: Type, scope: &mut Scope, types: &mut Types) {
 
 pub fn compile(
 	source_path: &Utf8Path,
-	source_text: String,
+	source_text: Option<String>,
 	out_dir: Option<&Utf8Path>,
 	absolute_project_root: Option<&Utf8Path>,
 ) -> Result<CompilerOutput, ()> {
-	let file_name = source_path.file_name().unwrap();
+	let source_path = normalize_path(source_path, None);
+	let file_name = source_path.file_name().unwrap_or("default"); // TODO: make out_dir required instead
 	let default_out_dir = Utf8PathBuf::from(format!("{}.out", file_name));
 	let out_dir = out_dir.unwrap_or(default_out_dir.as_ref());
 
@@ -448,11 +431,9 @@ mod sanity {
 				fs::remove_dir_all(&out_dir).expect("remove out dir");
 			}
 
-			let test_text = fs::read_to_string(&test_file).expect("read test file");
-
 			let result = compile(
 				&test_file,
-				test_text,
+				None,
 				Some(&out_dir),
 				Some(test_file.canonicalize_utf8().unwrap().parent().unwrap()),
 			);

--- a/libs/wingc/src/lsp/sync.rs
+++ b/libs/wingc/src/lsp/sync.rs
@@ -14,7 +14,7 @@ use crate::files::Files;
 use crate::fold::Fold;
 use crate::jsify::JSifier;
 use crate::lifting::LiftVisitor;
-use crate::parser::parse_wing_project;
+use crate::parser::{normalize_path, parse_wing_project};
 use crate::type_check;
 use crate::type_check::jsii_importer::JsiiImportSpec;
 use crate::type_check_assert::TypeCheckAssert;
@@ -136,10 +136,11 @@ fn partial_compile(
 	reset_diagnostics();
 
 	let source_path = Utf8Path::from_path(source_path).expect("invalid unicide path");
+	let source_path = normalize_path(source_path, None);
 
 	let topo_sorted_files = parse_wing_project(
 		&source_path,
-		source_text,
+		Some(source_text),
 		&mut project_data.files,
 		&mut project_data.file_graph,
 		&mut project_data.trees,

--- a/libs/wingc/src/parser.rs
+++ b/libs/wingc/src/parser.rs
@@ -134,8 +134,11 @@ static RESERVED_WORDS: phf::Set<&'static str> = phf_set! {
 ///
 /// Expects an initial Wing file to be parsed. For Wing's CLI, this is usually
 /// the file the user asked to compile, and in the case of the LSP, the file that was
-/// just opened or changed. The file's path and text can be passed through `init_path` and
-/// `init_text`, respectively.
+/// just opened or changed.
+///
+/// If `init_text` is `None`, then the file will be read from disk. Otherwise, the
+/// provided text will be used as the source text for the file. This is useful for
+/// the LSP, where the text may not be saved to the disk yet, and for unit tests.
 ///
 /// Internally it parses the initial file, and then recursively parse all of the files that
 /// it depends on, storing all results in the `files`, `file_graph`, `tree_sitter_trees`,
@@ -146,32 +149,19 @@ static RESERVED_WORDS: phf::Set<&'static str> = phf_set! {
 /// files that come before it in the ordering.
 pub fn parse_wing_project(
 	init_path: &Utf8Path,
-	init_text: String,
+	init_text: Option<String>,
 	files: &mut Files,
 	file_graph: &mut FileGraph,
 	tree_sitter_trees: &mut IndexMap<Utf8PathBuf, tree_sitter::Tree>,
 	asts: &mut IndexMap<Utf8PathBuf, Scope>,
 ) -> Vec<Utf8PathBuf> {
-	// Parse the initial file (even if we have already seen it before)
-	let (tree_sitter_tree, ast, dependent_wing_paths) = parse_wing_file(init_path, &init_text);
+	// Parse the initial path (even if we have already seen it before)
+	let dependent_wing_paths = match init_path.is_dir() {
+		true => parse_wing_directory(&init_path, files, file_graph, tree_sitter_trees, asts),
+		false => parse_wing_file(&init_path, init_text, files, file_graph, tree_sitter_trees, asts),
+	};
 
-	// Update our files collection with the new source text. For a fresh compilation,
-	// this will be the first time we've seen this file. In the LSP we might already have
-	// text from a previous compilation, so we'll replace the contents.
-	files.update_file(&init_path, init_text);
-
-	// Update our collections of trees and ASTs and our file graph
-	update_trees_and_graph(
-		init_path,
-		tree_sitter_tree,
-		ast,
-		&dependent_wing_paths,
-		tree_sitter_trees,
-		asts,
-		file_graph,
-	);
-
-	// Store a stack (Vec) of which files still need parsing
+	// Store a stack of files that still need parsing
 	let mut unparsed_files = dependent_wing_paths;
 
 	// Parse all remaining files in the project
@@ -190,64 +180,10 @@ pub fn parse_wing_project(
 			continue;
 		}
 
-		// Handle directories specially
-		if file_or_dir_path.is_dir() {
-			// Collect a list of all files and subdirectories in the directory
-			let mut files_and_dirs = Vec::new();
-			for entry in fs::read_dir(&file_or_dir_path).expect("read_dir call failed") {
-				let entry = entry.unwrap();
-				let path = Utf8PathBuf::from_path_buf(entry.path()).expect("invalid utf8 path");
-				if path.is_dir() || path.extension() == Some("w") {
-					files_and_dirs.push(path);
-				}
-			}
-
-			// Sort the files and directories so that we always visit them in the same order
-			files_and_dirs.sort();
-
-			// Parse the file here (since it doesn't exist)
-			let mut tree_sitter_parser = tree_sitter::Parser::new();
-			tree_sitter_parser.set_language(tree_sitter_wing::language()).unwrap();
-			let tree_sitter_tree = tree_sitter_parser.parse("", None).unwrap();
-			let ast = Scope::empty();
-			let dependent_wing_paths = files_and_dirs;
-
-			// Update our collections of trees and ASTs and our file graph
-			update_trees_and_graph(
-				&file_or_dir_path,
-				tree_sitter_tree,
-				ast,
-				&dependent_wing_paths,
-				tree_sitter_trees,
-				asts,
-				file_graph,
-			);
-
-			// Add all children files and directories to the list of files to parse
-			unparsed_files.extend(dependent_wing_paths);
-
-			continue;
-		}
-
-		let file_text = fs::read_to_string(&file_or_dir_path).unwrap_or(String::new());
-		files.add_file(&file_or_dir_path, file_text.clone()).unwrap();
-		files.get_file(&file_or_dir_path).unwrap();
-
-		// Parse the file
-		let (tree_sitter_tree, ast, dependent_wing_paths) = parse_wing_file(&file_or_dir_path, &file_text);
-
-		// Update our collections of trees and ASTs and our file graph
-		update_trees_and_graph(
-			&file_or_dir_path,
-			tree_sitter_tree,
-			ast,
-			&dependent_wing_paths,
-			tree_sitter_trees,
-			asts,
-			file_graph,
-		);
-
-		// Add the file's dependencies to the list of files to parse
+		let dependent_wing_paths = match file_or_dir_path.is_dir() {
+			true => parse_wing_directory(&file_or_dir_path, files, file_graph, tree_sitter_trees, asts),
+			false => parse_wing_file(&file_or_dir_path, None, files, file_graph, tree_sitter_trees, asts),
+		};
 		unparsed_files.extend(dependent_wing_paths);
 	}
 
@@ -272,22 +208,24 @@ pub fn parse_wing_project(
 	}
 }
 
-fn update_trees_and_graph(
-	file_or_dir_path: &Utf8Path,
-	tree_sitter_tree: tree_sitter::Tree,
-	ast: Scope,
-	dependent_wing_paths: &[Utf8PathBuf],
+fn parse_wing_file(
+	source_path: &Utf8Path,
+	source_text: Option<String>,
+	files: &mut Files,
+	file_graph: &mut FileGraph,
 	tree_sitter_trees: &mut IndexMap<Utf8PathBuf, tree_sitter::Tree>,
 	asts: &mut IndexMap<Utf8PathBuf, Scope>,
-	file_graph: &mut FileGraph,
-) {
-	// Update our collections of trees and ASTs and our file graph
-	tree_sitter_trees.insert(file_or_dir_path.to_owned(), tree_sitter_tree);
-	asts.insert(file_or_dir_path.to_owned(), ast);
-	file_graph.update_file(file_or_dir_path, &dependent_wing_paths);
-}
+) -> Vec<Utf8PathBuf> {
+	let source_text = match source_text {
+		Some(text) => text,
+		None => fs::read_to_string(source_path).expect("read_to_string call failed"),
+	};
 
-fn parse_wing_file(source_path: &Utf8Path, source_text: &str) -> (tree_sitter::Tree, Scope, Vec<Utf8PathBuf>) {
+	// Update our files collection with the new source text. On a fresh compilation,
+	// this will be the first time we've seen this file. In the LSP we might already have
+	// text from a previous compilation, so we'll replace the contents.
+	files.update_file(&source_path, source_text.clone());
+
 	let language = tree_sitter_wing::language();
 	let mut tree_sitter_parser = tree_sitter::Parser::new();
 	tree_sitter_parser.set_language(language).unwrap();
@@ -303,7 +241,49 @@ fn parse_wing_file(source_path: &Utf8Path, source_text: &str) -> (tree_sitter::T
 
 	let parser = Parser::new(&source_text.as_bytes(), source_path.to_owned());
 	let (scope, dependent_wing_paths) = parser.parse(&tree_sitter_root);
-	(tree_sitter_tree, scope, dependent_wing_paths)
+
+	// Update our collections of trees and ASTs and our file graph
+	tree_sitter_trees.insert(source_path.to_owned(), tree_sitter_tree);
+	asts.insert(source_path.to_owned(), scope);
+	file_graph.update_file(source_path, &dependent_wing_paths);
+
+	dependent_wing_paths
+}
+
+fn parse_wing_directory(
+	source_path: &Utf8Path,
+	files: &mut Files,
+	file_graph: &mut FileGraph,
+	tree_sitter_trees: &mut IndexMap<Utf8PathBuf, tree_sitter::Tree>,
+	asts: &mut IndexMap<Utf8PathBuf, Scope>,
+) -> Vec<Utf8PathBuf> {
+	// Collect a list of all files and subdirectories in the directory
+	let mut files_and_dirs = Vec::new();
+	for entry in fs::read_dir(&source_path).expect("read_dir call failed") {
+		let entry = entry.unwrap();
+		let path = Utf8PathBuf::from_path_buf(entry.path()).expect("invalid utf8 path");
+		if path.is_dir() || path.extension() == Some("w") {
+			files_and_dirs.push(path);
+		}
+	}
+
+	// Sort the files and directories so that we always visit them in the same order
+	files_and_dirs.sort();
+
+	// Parse the file here (since it doesn't exist)
+	let mut tree_sitter_parser = tree_sitter::Parser::new();
+	tree_sitter_parser.set_language(tree_sitter_wing::language()).unwrap();
+	let tree_sitter_tree = tree_sitter_parser.parse("", None).unwrap();
+	let scope = Scope::empty();
+	let dependent_wing_paths = files_and_dirs;
+
+	// Update our collections of trees and ASTs and our file graph
+	files.update_file(&source_path, "".to_string());
+	tree_sitter_trees.insert(source_path.to_owned(), tree_sitter_tree);
+	asts.insert(source_path.to_owned(), scope);
+	file_graph.update_file(source_path, &dependent_wing_paths);
+
+	dependent_wing_paths
 }
 
 /// Parses a single Wing source file.

--- a/libs/wingc/src/test_utils.rs
+++ b/libs/wingc/src/test_utils.rs
@@ -62,7 +62,7 @@ fn compile_code(code: &str) -> String {
 	// convert tabs to 2 spaces
 	let code = code.replace("\t", "  ");
 
-	let result = compile(source_path, Some(code.clone()), Some(outdir_path), Some(outdir_path));
+	let result = compile(source_path, Some(code.clone()), outdir_path, outdir_path);
 
 	let mut snap = vec![];
 

--- a/libs/wingc/src/test_utils.rs
+++ b/libs/wingc/src/test_utils.rs
@@ -62,7 +62,7 @@ fn compile_code(code: &str) -> String {
 	// convert tabs to 2 spaces
 	let code = code.replace("\t", "  ");
 
-	let result = compile(source_path, code.clone(), Some(outdir_path), Some(outdir_path));
+	let result = compile(source_path, Some(code.clone()), Some(outdir_path), Some(outdir_path));
 
 	let mut snap = vec![];
 

--- a/libs/wingcompiler/src/compile.ts
+++ b/libs/wingcompiler/src/compile.ts
@@ -186,7 +186,8 @@ export async function compile(entrypoint: string, options: CompileOptions): Prom
     throw new CompileError(errors);
   }
 
-  if (isEntrypointFile(entrypoint)) {
+  // don't run preflight code if compiling a directory
+  if (entrypoint.endsWith(".w")) {
     await runPreflightCodeInVm(workDir, wingDir, tempProcess, log);
   }
 
@@ -205,15 +206,6 @@ export async function compile(entrypoint: string, options: CompileOptions): Prom
   }
 
   return synthDir;
-}
-
-function isEntrypointFile(path: string) {
-  return (
-    path.endsWith(".main.w") ||
-    path.endsWith(".test.w") ||
-    path.endsWith("/main.w") ||
-    path === "main.w"
-  );
 }
 
 async function runPreflightCodeInVm(

--- a/libs/wingcompiler/src/compile.ts
+++ b/libs/wingcompiler/src/compile.ts
@@ -186,8 +186,7 @@ export async function compile(entrypoint: string, options: CompileOptions): Prom
     throw new CompileError(errors);
   }
 
-  // don't run preflight code if compiling a directory
-  if (entrypoint.endsWith(".w")) {
+  if (isEntrypointFile(entrypoint)) {
     await runPreflightCodeInVm(workDir, wingDir, tempProcess, log);
   }
 
@@ -206,6 +205,15 @@ export async function compile(entrypoint: string, options: CompileOptions): Prom
   }
 
   return synthDir;
+}
+
+function isEntrypointFile(path: string) {
+  return (
+    path.endsWith(".main.w") ||
+    path.endsWith(".test.w") ||
+    path.endsWith("/main.w") ||
+    path === "main.w"
+  );
 }
 
 async function runPreflightCodeInVm(

--- a/libs/wingcompiler/src/compile.ts
+++ b/libs/wingcompiler/src/compile.ts
@@ -1,6 +1,6 @@
 import * as vm from "vm";
 
-import { promises as fs } from "fs";
+import { promises as fs, lstatSync } from "fs";
 import { basename, dirname, join, resolve } from "path";
 import * as os from "os";
 
@@ -58,13 +58,26 @@ function resolveSynthDir(
   entrypoint: string,
   target: Target,
   testing: boolean = false,
-  tmp: boolean = false
+  tmp: boolean = false,
+  log?: (...args: any[]) => void
 ) {
   const targetDirSuffix = DEFAULT_SYNTH_DIR_SUFFIX[target];
   if (!targetDirSuffix) {
     throw new Error(`unsupported target ${target}`);
   }
-  const entrypointName = basename(entrypoint, ".w");
+
+  let entrypointName;
+  try {
+    const isDirectory = lstatSync(entrypoint).isDirectory();
+    if (isDirectory) {
+      entrypointName = basename(resolve(entrypoint));
+    } else {
+      entrypointName = basename(entrypoint, ".w");
+    }
+  } catch (err) {
+    log?.(err);
+    throw new Error("Source file cannot be found");
+  }
   const tmpSuffix = tmp ? `.${Date.now().toString().slice(-6)}.tmp` : "";
   const lastPart = `${entrypointName}.${targetDirSuffix}${tmpSuffix}`;
   if (testing) {
@@ -173,6 +186,42 @@ export async function compile(entrypoint: string, options: CompileOptions): Prom
     throw new CompileError(errors);
   }
 
+  if (isEntrypointFile(entrypoint)) {
+    await runPreflightCodeInVm(workDir, wingDir, tempProcess, log);
+  }
+
+  if (os.platform() === "win32") {
+    // Windows doesn't really support fully atomic moves.
+    // So we just copy the directory instead.
+    // Also only using sync methods to avoid possible async fs issues.
+    await fs.rm(synthDir, { recursive: true, force: true });
+    await fs.mkdir(synthDir, { recursive: true });
+    await copyDir(tmpSynthDir, synthDir);
+    await fs.rm(tmpSynthDir, { recursive: true, force: true });
+  } else {
+    // Move the temporary directory to the final target location in an atomic operation
+    await copyDir(tmpSynthDir, synthDir);
+    await fs.rm(tmpSynthDir, { recursive: true, force: true });
+  }
+
+  return synthDir;
+}
+
+function isEntrypointFile(path: string) {
+  return (
+    path.endsWith(".main.w") ||
+    path.endsWith(".test.w") ||
+    path.endsWith("/main.w") ||
+    path === "main.w"
+  );
+}
+
+async function runPreflightCodeInVm(
+  workDir: string,
+  wingDir: string,
+  tempProcess: { env: Record<string, string | undefined> },
+  log?: (...args: any[]) => void
+): Promise<void> {
   const artifactPath = resolve(workDir, WINGC_PREFLIGHT);
   log?.("reading artifact from %s", artifactPath);
   const artifact = await fs.readFile(artifactPath, "utf-8");
@@ -217,22 +266,6 @@ export async function compile(entrypoint: string, options: CompileOptions): Prom
   } catch (error) {
     throw new PreflightError(error as any, artifactPath, artifact);
   }
-
-  if (os.platform() === "win32") {
-    // Windows doesn't really support fully atomic moves.
-    // So we just copy the directory instead.
-    // Also only using sync methods to avoid possible async fs issues.
-    await fs.rm(synthDir, { recursive: true, force: true });
-    await fs.mkdir(synthDir, { recursive: true });
-    await copyDir(tmpSynthDir, synthDir);
-    await fs.rm(tmpSynthDir, { recursive: true, force: true });
-  } else {
-    // Move the temporary directory to the final target location in an atomic operation
-    await copyDir(tmpSynthDir, synthDir);
-    await fs.rm(tmpSynthDir, { recursive: true, force: true });
-  }
-
-  return synthDir;
 }
 
 /**

--- a/tools/hangar/__snapshots__/test_corpus/valid/assertions.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/assertions.w_compile_tf-aws.md
@@ -39,77 +39,37 @@ module.exports = function({  }) {
 
 ```
 
-## main.tf.json
-```json
-{
-  "//": {
-    "metadata": {
-      "backend": "local",
-      "stackName": "root",
-      "version": "0.17.0"
-    },
-    "outputs": {
-      "root": {
-        "Default": {
-          "cloud.TestRunner": {
-            "TestFunctionArns": "WING_TEST_RUNNER_FUNCTION_ARNS"
-          }
-        }
-      }
-    }
-  },
-  "output": {
-    "WING_TEST_RUNNER_FUNCTION_ARNS": {
-      "value": "[]"
-    }
-  },
-  "provider": {
-    "aws": [
-      {}
-    ]
-  }
-}
-```
-
 ## preflight.js
 ```js
-const $stdlib = require('@winglang/sdk');
-const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
-const $outdir = process.env.WING_SYNTH_DIR ?? ".";
-const $wing_is_test = process.env.WING_IS_TEST === "true";
-const std = $stdlib.std;
-class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
-    class Assert extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
-      }
-      static _toInflightType(context) {
-        return `
-          require("./inflight.Assert-1.js")({
-          })
-        `;
-      }
-      _toInflight() {
-        return `
-          (await (async () => {
-            const AssertClient = ${Assert._toInflightType(this)};
-            const client = new AssertClient({
-            });
-            if (client.$inflight_init) { await client.$inflight_init(); }
-            return client;
-          })())
-        `;
-      }
-      _getInflightOps() {
-        return ["equalStr", "isNil", "equalNum", "$inflight_init"];
-      }
+module.exports = function({ $stdlib }) {
+  const std = $stdlib.std;
+  class Assert extends $stdlib.std.Resource {
+    constructor(scope, id, ) {
+      super(scope, id);
+    }
+    static _toInflightType(context) {
+      return `
+        require("./inflight.Assert-1.js")({
+        })
+      `;
+    }
+    _toInflight() {
+      return `
+        (await (async () => {
+          const AssertClient = ${Assert._toInflightType(this)};
+          const client = new AssertClient({
+          });
+          if (client.$inflight_init) { await client.$inflight_init(); }
+          return client;
+        })())
+      `;
+    }
+    _getInflightOps() {
+      return ["equalStr", "isNil", "equalNum", "$inflight_init"];
     }
   }
-}
-const $App = $stdlib.core.App.for(process.env.WING_TARGET);
-new $App({ outdir: $outdir, name: "assertions", rootConstruct: $Root, plugins: $plugins, isTestEnvironment: $wing_is_test, entrypointDir: process.env['WING_SOURCE_DIR'], rootId: process.env['WING_ROOT_ID'] }).synth();
+  return { Assert };
+};
 
 ```
 

--- a/tools/hangar/__snapshots__/test_corpus/valid/baz.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/baz.w_compile_tf-aws.md
@@ -12,80 +12,40 @@ module.exports = function({  }) {
 
 ```
 
-## main.tf.json
-```json
-{
-  "//": {
-    "metadata": {
-      "backend": "local",
-      "stackName": "root",
-      "version": "0.17.0"
-    },
-    "outputs": {
-      "root": {
-        "Default": {
-          "cloud.TestRunner": {
-            "TestFunctionArns": "WING_TEST_RUNNER_FUNCTION_ARNS"
-          }
-        }
-      }
-    }
-  },
-  "output": {
-    "WING_TEST_RUNNER_FUNCTION_ARNS": {
-      "value": "[]"
-    }
-  },
-  "provider": {
-    "aws": [
-      {}
-    ]
-  }
-}
-```
-
 ## preflight.js
 ```js
-const $stdlib = require('@winglang/sdk');
-const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
-const $outdir = process.env.WING_SYNTH_DIR ?? ".";
-const $wing_is_test = process.env.WING_IS_TEST === "true";
-const std = $stdlib.std;
-class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
-    class Baz extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
-      }
-      static baz() {
-        return "baz";
-      }
-      static _toInflightType(context) {
-        return `
-          require("./inflight.Baz-1.js")({
-          })
-        `;
-      }
-      _toInflight() {
-        return `
-          (await (async () => {
-            const BazClient = ${Baz._toInflightType(this)};
-            const client = new BazClient({
-            });
-            if (client.$inflight_init) { await client.$inflight_init(); }
-            return client;
-          })())
-        `;
-      }
-      _getInflightOps() {
-        return ["$inflight_init"];
-      }
+module.exports = function({ $stdlib }) {
+  const std = $stdlib.std;
+  class Baz extends $stdlib.std.Resource {
+    constructor(scope, id, ) {
+      super(scope, id);
+    }
+    static baz() {
+      return "baz";
+    }
+    static _toInflightType(context) {
+      return `
+        require("./inflight.Baz-1.js")({
+        })
+      `;
+    }
+    _toInflight() {
+      return `
+        (await (async () => {
+          const BazClient = ${Baz._toInflightType(this)};
+          const client = new BazClient({
+          });
+          if (client.$inflight_init) { await client.$inflight_init(); }
+          return client;
+        })())
+      `;
+    }
+    _getInflightOps() {
+      return ["$inflight_init"];
     }
   }
-}
-const $App = $stdlib.core.App.for(process.env.WING_TARGET);
-new $App({ outdir: $outdir, name: "baz", rootConstruct: $Root, plugins: $plugins, isTestEnvironment: $wing_is_test, entrypointDir: process.env['WING_SOURCE_DIR'], rootId: process.env['WING_ROOT_ID'] }).synth();
+  return { Baz };
+};
 
 ```
 

--- a/tools/hangar/__snapshots__/test_corpus/valid/store.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/store.w_compile_tf-aws.md
@@ -46,38 +46,6 @@ module.exports = function({  }) {
 
 ```
 
-## main.tf.json
-```json
-{
-  "//": {
-    "metadata": {
-      "backend": "local",
-      "stackName": "root",
-      "version": "0.17.0"
-    },
-    "outputs": {
-      "root": {
-        "Default": {
-          "cloud.TestRunner": {
-            "TestFunctionArns": "WING_TEST_RUNNER_FUNCTION_ARNS"
-          }
-        }
-      }
-    }
-  },
-  "output": {
-    "WING_TEST_RUNNER_FUNCTION_ARNS": {
-      "value": "[]"
-    }
-  },
-  "provider": {
-    "aws": [
-      {}
-    ]
-  }
-}
-```
-
 ## preflight.empty-1.js
 ```js
 module.exports = function({ $stdlib }) {
@@ -89,125 +57,117 @@ module.exports = function({ $stdlib }) {
 
 ## preflight.js
 ```js
-const $stdlib = require('@winglang/sdk');
-const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
-const $outdir = process.env.WING_SYNTH_DIR ?? ".";
-const $wing_is_test = process.env.WING_IS_TEST === "true";
-const std = $stdlib.std;
-const file3 = require("./preflight.empty-1.js")({ $stdlib });
-const math = $stdlib.math;
-const cloud = $stdlib.cloud;
-class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
-    class Util extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
-      }
-      static _toInflightType(context) {
-        return `
-          require("./inflight.Util-1.js")({
-          })
-        `;
-      }
-      _toInflight() {
-        return `
-          (await (async () => {
-            const UtilClient = ${Util._toInflightType(this)};
-            const client = new UtilClient({
-            });
-            if (client.$inflight_init) { await client.$inflight_init(); }
-            return client;
-          })())
-        `;
-      }
-      _getInflightOps() {
-        return ["$inflight_init"];
-      }
+module.exports = function({ $stdlib }) {
+  const std = $stdlib.std;
+  const file3 = require("./preflight.empty-1.js")({ $stdlib });
+  const math = $stdlib.math;
+  const cloud = $stdlib.cloud;
+  class Util extends $stdlib.std.Resource {
+    constructor(scope, id, ) {
+      super(scope, id);
     }
-    class Store extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
-        this.b = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this,"cloud.Bucket");
-        const __parent_this_1 = this;
-        class $Closure1 extends $stdlib.std.Resource {
-          constructor(scope, id, ) {
-            super(scope, id);
-            (std.Node.of(this)).hidden = true;
-          }
-          static _toInflightType(context) {
-            return `
-              require("./inflight.$Closure1-1.js")({
-                $__parent_this_1_b: ${context._lift(__parent_this_1.b)},
-              })
-            `;
-          }
-          _toInflight() {
-            return `
-              (await (async () => {
-                const $Closure1Client = ${$Closure1._toInflightType(this)};
-                const client = new $Closure1Client({
-                });
-                if (client.$inflight_init) { await client.$inflight_init(); }
-                return client;
-              })())
-            `;
-          }
-          _getInflightOps() {
-            return ["handle", "$inflight_init"];
-          }
-          _registerBind(host, ops) {
-            if (ops.includes("handle")) {
-              $Closure1._registerBindObject(__parent_this_1.b, host, ["put"]);
-            }
-            super._registerBind(host, ops);
-          }
-        }
-        const prefill = this.node.root.newAbstract("@winglang/sdk.cloud.OnDeploy",this,"cloud.OnDeploy",new $Closure1(this,"$Closure1"));
-      }
-      static _toInflightType(context) {
-        return `
-          require("./inflight.Store-1.js")({
-          })
-        `;
-      }
-      _toInflight() {
-        return `
-          (await (async () => {
-            const StoreClient = ${Store._toInflightType(this)};
-            const client = new StoreClient({
-              $this_b: ${this._lift(this.b)},
-            });
-            if (client.$inflight_init) { await client.$inflight_init(); }
-            return client;
-          })())
-        `;
-      }
-      _getInflightOps() {
-        return ["store", "$inflight_init"];
-      }
-      _registerBind(host, ops) {
-        if (ops.includes("$inflight_init")) {
-          Store._registerBindObject(this.b, host, []);
-        }
-        if (ops.includes("store")) {
-          Store._registerBindObject(this.b, host, ["put"]);
-        }
-        super._registerBind(host, ops);
-      }
+    static _toInflightType(context) {
+      return `
+        require("./inflight.Util-1.js")({
+        })
+      `;
     }
-    const Color =
-      (function (tmp) {
-        tmp[tmp["RED"] = 0] = "RED";
-        tmp[tmp["GREEN"] = 1] = "GREEN";
-        tmp[tmp["BLUE"] = 2] = "BLUE";
-        return tmp;
-      })({})
-    ;
+    _toInflight() {
+      return `
+        (await (async () => {
+          const UtilClient = ${Util._toInflightType(this)};
+          const client = new UtilClient({
+          });
+          if (client.$inflight_init) { await client.$inflight_init(); }
+          return client;
+        })())
+      `;
+    }
+    _getInflightOps() {
+      return ["$inflight_init"];
+    }
   }
-}
-const $App = $stdlib.core.App.for(process.env.WING_TARGET);
-new $App({ outdir: $outdir, name: "store", rootConstruct: $Root, plugins: $plugins, isTestEnvironment: $wing_is_test, entrypointDir: process.env['WING_SOURCE_DIR'], rootId: process.env['WING_ROOT_ID'] }).synth();
+  class Store extends $stdlib.std.Resource {
+    constructor(scope, id, ) {
+      super(scope, id);
+      this.b = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this,"cloud.Bucket");
+      const __parent_this_1 = this;
+      class $Closure1 extends $stdlib.std.Resource {
+        constructor(scope, id, ) {
+          super(scope, id);
+          (std.Node.of(this)).hidden = true;
+        }
+        static _toInflightType(context) {
+          return `
+            require("./inflight.$Closure1-1.js")({
+              $__parent_this_1_b: ${context._lift(__parent_this_1.b)},
+            })
+          `;
+        }
+        _toInflight() {
+          return `
+            (await (async () => {
+              const $Closure1Client = ${$Closure1._toInflightType(this)};
+              const client = new $Closure1Client({
+              });
+              if (client.$inflight_init) { await client.$inflight_init(); }
+              return client;
+            })())
+          `;
+        }
+        _getInflightOps() {
+          return ["handle", "$inflight_init"];
+        }
+        _registerBind(host, ops) {
+          if (ops.includes("handle")) {
+            $Closure1._registerBindObject(__parent_this_1.b, host, ["put"]);
+          }
+          super._registerBind(host, ops);
+        }
+      }
+      const prefill = this.node.root.newAbstract("@winglang/sdk.cloud.OnDeploy",this,"cloud.OnDeploy",new $Closure1(this,"$Closure1"));
+    }
+    static _toInflightType(context) {
+      return `
+        require("./inflight.Store-1.js")({
+        })
+      `;
+    }
+    _toInflight() {
+      return `
+        (await (async () => {
+          const StoreClient = ${Store._toInflightType(this)};
+          const client = new StoreClient({
+            $this_b: ${this._lift(this.b)},
+          });
+          if (client.$inflight_init) { await client.$inflight_init(); }
+          return client;
+        })())
+      `;
+    }
+    _getInflightOps() {
+      return ["store", "$inflight_init"];
+    }
+    _registerBind(host, ops) {
+      if (ops.includes("$inflight_init")) {
+        Store._registerBindObject(this.b, host, []);
+      }
+      if (ops.includes("store")) {
+        Store._registerBindObject(this.b, host, ["put"]);
+      }
+      super._registerBind(host, ops);
+    }
+  }
+  const Color =
+    (function (tmp) {
+      tmp[tmp["RED"] = 0] = "RED";
+      tmp[tmp["GREEN"] = 1] = "GREEN";
+      tmp[tmp["BLUE"] = 2] = "BLUE";
+      return tmp;
+    })({})
+  ;
+  return { Util, Store, Color };
+};
 
 ```
 

--- a/tools/hangar/src/generated_test_targets.ts
+++ b/tools/hangar/src/generated_test_targets.ts
@@ -7,6 +7,8 @@ import {
   sanitize_json_paths,
 } from "./utils";
 
+const TERRAFORM_JSON_FILENAME = "main.tf.json";
+
 export async function compileTest(
   sourceDir: string,
   wingFile: string,
@@ -21,7 +23,6 @@ export async function compileTest(
     `${wingBasename.replace(".w", "")}.tfaws`
   );
   await fs.rm(targetDir, { recursive: true, force: true });
-  const tf_json = join(targetDir, "main.tf.json");
 
   const filePath = join(sourceDir, wingBasename);
   await runWingCommand({
@@ -32,9 +33,11 @@ export async function compileTest(
     env,
   });
 
-  const npx_tfJson = sanitize_json_paths(tf_json);
-
-  fileMap["main.tf.json"] = JSON.stringify(npx_tfJson, null, 2);
+  if (isEntrypointFile(filePath)) {
+    const tf_json = join(targetDir, TERRAFORM_JSON_FILENAME);
+    const npx_tfJson = sanitize_json_paths(tf_json);
+    fileMap[TERRAFORM_JSON_FILENAME] = JSON.stringify(npx_tfJson, null, 2);
+  }
 
   // which files to include from the .wing directory
   const dotWing = join(targetDir, ".wing");
@@ -67,6 +70,12 @@ export async function testTest(
   const fileMap: Record<string, string> = {};
   const args = ["test", "-t", "sim"];
   const testDir = join(tmpDir, `${wingFile}_sim`);
+
+  // only entrypoint files have tests (for now)
+  if (!isEntrypointFile(wingFile)) {
+    return;
+  }
+
   await fs.mkdir(testDir, { recursive: true });
 
   const relativeWingFile = relative(testDir, join(sourceDir, wingFile));
@@ -83,4 +92,13 @@ export async function testTest(
   fileMap["stdout.log"] = out.stdout;
 
   await createMarkdownSnapshot(fileMap, filePath, "test", "sim");
+}
+
+function isEntrypointFile(path: string) {
+  return (
+    path.endsWith(".main.w") ||
+    path.endsWith(".test.w") ||
+    path.endsWith("/main.w") ||
+    path === "main.w"
+  );
 }


### PR DESCRIPTION
The wing toolchain now supports compiling directories. For example:

```
$ wing compile .
```

When a directory is compiled, no preflight code is executed (this only happens when an entrypoint file like `main.w` is passed to `wing compile`).

Required for https://github.com/winglang/wing/pull/3938

## Checklist

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [x] Tests added (always)
- [x] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
