### PR TITLE
fix(cli): compile with DEBUG=1 shows wrong stack trace

### DIFF
--- a/apps/wing/src/commands/compile.ts
+++ b/apps/wing/src/commands/compile.ts
@@ -125,7 +125,7 @@ export async function compile(entrypoint: string, options: CompileOptions): Prom
         output.push(
           "--------------------------------- STACK TRACE ---------------------------------"
         );
-        output.push(error.stack ?? "");
+        output.push(causedBy.stack ?? "");
       }
 
       throw new Error(output.join("\n"));


### PR DESCRIPTION
Fixes #4343

## Checklist

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [ ] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
