### PR TITLE
chore(repo): ready for implementation field in issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -37,16 +37,6 @@ body:
     label: "Is there a workaround?"
     placeholder: "What's the workaround to avoid this issue?"
 - type: dropdown
-  id: impl-ready
-  attributes:
-    label: "Ready for implementation?"
-    description: "Does this issue contain enough info to start implementation or does it need further discussion?"
-    options:
-    - "Yes"
-    - "No"
-  validations:
-    required: true
-- type: dropdown
   id: Component
   attributes:
     label: "Component"

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -37,6 +37,16 @@ body:
     label: "Is there a workaround?"
     placeholder: "What's the workaround to avoid this issue?"
 - type: dropdown
+  id: impl-ready
+  attributes:
+    label: "Ready for implementation?"
+    description: "Does this issue contain enough info to start implementation or does it need further discussion?"
+    options:
+    - "Yes"
+    - "No"
+  validations:
+    required: true
+- type: dropdown
   id: Component
   attributes:
     label: "Component"

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -35,6 +35,16 @@ body:
     placeholder: |
       Any thoughts regarding how this should be implemented?
 - type: dropdown
+  id: impl-ready
+  attributes:
+    label: "Ready for implementation?"
+    description: "Does this issue contain enough info to start implementation or does it need further discussion?"
+    options:
+    - "Yes"
+    - "No"
+  validations:
+    required: true
+- type: dropdown
   id: Component
   attributes:
     label: Component

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -65,8 +65,6 @@ body:
       <!-- Please keep this note for the community -->
       * Please vote by adding a 👍 reaction to the issue to help us prioritize.
       * If you are interested to work on this issue, please leave a comment.
-      * For issues labeled needs-discussion, please begin by understanding the
-      requirements. 
-      * Pose questions in a comment, inquire on Slack #dev
-      channel, or bring it up in a community meeting (preferably informing us
-      before the meeting).
+      * If this issue is labeled **needs-discussion**, it means the spec
+        has not been finalized yet. Please reach out on the #dev channel
+        in the [Wing Slack](https://t.winglang.io/slack).

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,6 +1,6 @@
 name: Enhancement 🚀
 description: Suggest a new feature or other improvement
-labels: ["✨ enhancement"]
+labels: ["✨ enhancement","needs-discussion"]
 body:
 - type: markdown
   attributes:
@@ -35,16 +35,6 @@ body:
     placeholder: |
       Any thoughts regarding how this should be implemented?
 - type: dropdown
-  id: impl-ready
-  attributes:
-    label: "Ready for implementation?"
-    description: "Does this issue contain enough info to start implementation or does it need further discussion?"
-    options:
-    - "Yes"
-    - "No"
-  validations:
-    required: true
-- type: dropdown
   id: Component
   attributes:
     label: Component
@@ -75,3 +65,8 @@ body:
       <!-- Please keep this note for the community -->
       * Please vote by adding a 👍 reaction to the issue to help us prioritize.
       * If you are interested to work on this issue, please leave a comment.
+      * For issues labeled needs-discussion, please begin by understanding the
+      requirements. 
+      * Pose questions in a comment, inquire on Slack #dev
+      channel, or bring it up in a community meeting (preferably informing us
+      before the meeting).


### PR DESCRIPTION
Adding another field to issue templates, to indicate whether this issue is ready to start implementation or whether some further discussion is needed first.

## Checklist

- [ ] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [ ] Description explains motivation and solution
- [ ] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
