### PR TITLE
chore: rerun baseline benchmark as part of workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -184,13 +184,14 @@ jobs:
 
       - name: Run Baseline Benchmarks
         working-directory: tools/hangar
+        if: github.event_name == 'pull_request'
         env:
           HANGAR_WINGLANG_PACKAGE: "winglang@latest"
         run: pnpm bench
 
-      - name: Run E2E Benchmarks
+      - name: Run Benchmarks
         env:
-          BENCH_FAIL_THRESHOLD_PERCENT: "50"
+          BENCH_FAIL_THRESHOLD_PERCENT: "25"
           GITHUB_TOKEN: ${{ env.IS_SAME_REPO_PR == 'true' && secrets.PROJEN_GITHUB_TOKEN || secrets.GITHUB_TOKEN  }}
           BENCH_PR: "${{ env.IS_SAME_REPO_PR == 'true' && github.event.pull_request.number || '' }}"
         working-directory: tools/hangar

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -182,10 +182,15 @@ jobs:
       - name: Install Dependencies
         run: pnpm install --ignore-scripts --frozen-lockfile --filter hangar --filter examples-valid --filter examples-invalid
 
+      - name: Run Baseline Benchmarks
+        working-directory: tools/hangar
+        env:
+          HANGAR_WINGLANG_PACKAGE: "winglang@latest"
+        run: pnpm bench
+
       - name: Run E2E Benchmarks
         env:
           BENCH_FAIL_THRESHOLD_PERCENT: "50"
-          BENCH_COMPARE_PREVIOUS: "${{ github.event_name == 'pull_request' && 'main' || '' }}"
           GITHUB_TOKEN: ${{ env.IS_SAME_REPO_PR == 'true' && secrets.PROJEN_GITHUB_TOKEN || secrets.GITHUB_TOKEN  }}
           BENCH_PR: "${{ env.IS_SAME_REPO_PR == 'true' && github.event.pull_request.number || '' }}"
         working-directory: tools/hangar

--- a/tools/hangar/src/benchmarking/cli.bench.ts
+++ b/tools/hangar/src/benchmarking/cli.bench.ts
@@ -33,7 +33,7 @@ describe("compile", async () => {
         },
         {
           warmupIterations: 1,
-          iterations: 15,
+          iterations: 10,
           time: 0,
           setup: async (f) => {
             f.opts.beforeEach = async () => {

--- a/tools/hangar/src/benchmarking/compare.ts
+++ b/tools/hangar/src/benchmarking/compare.ts
@@ -111,6 +111,11 @@ export async function compareBenchmarks(
     } else if (diff.meanDiff <= 0) {
       appendColor = "🟩";
     }
+
+    if (Math.abs(diff.meanDiff) <= Math.max(diff.moeBefore, diff.moeAfter)) {
+      appendColor = "⬜";
+    }
+
     let changeText = !!diff.meanPercentDiff
       ? `${prependSign}${fmtNum(diff.meanDiff, "ms")} (${prependSign}${fmtNum(diff.meanPercentDiff, "%")})${appendColor}`
       : "...";
@@ -147,16 +152,16 @@ export async function compareBenchmarks(
 ## Benchmarks
 
 <details>
-<summary>Results</summary>
+<summary>Comparison to Baseline</summary>
 
-${createTable(targetResult[0])}
+${markdown}
 
 </details>
 
 <details>
-<summary>Comparison to ${previousSource}</summary>
+<summary>Results</summary>
 
-${markdown}
+${createTable(targetResult[0])}
 
 </details>
 

--- a/tools/hangar/src/benchmarking/compare.ts
+++ b/tools/hangar/src/benchmarking/compare.ts
@@ -6,10 +6,13 @@ import { createTable } from "./table_report";
 interface ProcessedBenchData {
   mean: number;
   moe: number;
+  sd: number;
   name: string;
 }
 
-function avgBenches(benchList: any[]): Record<string, ProcessedBenchData | undefined> {
+function avgBenches(
+  benchList: any[]
+): Record<string, ProcessedBenchData | undefined> {
   const benchValues: Record<string, ProcessedBenchData[]> = {};
   for (const bench of benchList) {
     for (const item of bench) {
@@ -20,6 +23,7 @@ function avgBenches(benchList: any[]): Record<string, ProcessedBenchData | undef
         name: item.name,
         mean: item["mean"],
         moe: item["moe"],
+        sd: item["sd"],
       };
       benchValues[item.name].push(data);
     }
@@ -30,10 +34,12 @@ function avgBenches(benchList: any[]): Record<string, ProcessedBenchData | undef
     const data = benchValues[key];
     const mean = data.reduce((acc, cur) => acc + cur.mean, 0) / data.length;
     const moe = data.reduce((acc, cur) => acc + cur.moe, 0) / data.length;
+    const sd = data.reduce((acc, cur) => acc + cur.sd, 0) / data.length;
     returnData[key] = {
       name: key,
       mean,
       moe,
+      sd,
     };
   }
 
@@ -92,15 +98,29 @@ export async function compareBenchmarks(
     differences[itemName].moeAfter = newData?.moe ?? NaN;
     differences[itemName].meanAfter = newData?.mean ?? NaN;
 
+    differences[itemName].maxSD = Math.max(
+      newData?.sd ?? NaN,
+      oldData?.sd ?? NaN
+    );
+
     differences[itemName].meanDiff =
-      Math.round((differences[itemName].meanAfter - differences[itemName].meanBefore) * 100) / 100;
+      Math.round(
+        (differences[itemName].meanAfter - differences[itemName].meanBefore) *
+          100
+      ) / 100;
     differences[itemName].meanPercentDiff =
-      Math.round(((differences[itemName].meanAfter - differences[itemName].meanBefore) / differences[itemName].meanBefore) * 10000) / 100;
+      Math.round(
+        ((differences[itemName].meanAfter - differences[itemName].meanBefore) /
+          differences[itemName].meanBefore) *
+          10000
+      ) / 100;
   }
 
   // create a markdown table of the differences
   let markdown = `| Benchmark | Before | After | Change |\n`;
   markdown += `| :-- | --: | --: | --: |\n`;
+  let colors = "";
+
   for (const key in differences) {
     const diff = differences[key];
     let prependSign = "";
@@ -112,20 +132,25 @@ export async function compareBenchmarks(
       appendColor = "🟩";
     }
 
-    if (Math.abs(diff.meanDiff) <= Math.max(diff.moeBefore, diff.moeAfter)) {
+    if (Math.abs(diff.meanDiff) <= diff.maxSD) {
       appendColor = "⬜";
     }
 
+    colors += appendColor;
+
     let changeText = !!diff.meanPercentDiff
-      ? `${prependSign}${fmtNum(diff.meanDiff, "ms")} (${prependSign}${fmtNum(diff.meanPercentDiff, "%")})${appendColor}`
+      ? `${prependSign}${fmtNum(diff.meanDiff, "ms")} (${prependSign}${fmtNum(
+          diff.meanPercentDiff,
+          "%"
+        )})${appendColor}`
       : "...";
 
     let beforeText = fmtNum(diff.meanBefore, "ms");
-    if(!isNaN(diff.meanBefore)) {
+    if (!isNaN(diff.meanBefore)) {
       beforeText += `±${fmtNum(diff.moeBefore)}`;
     }
     let afterText = fmtNum(diff.meanAfter, "ms");
-    if(!isNaN(diff.meanAfter)) {
+    if (!isNaN(diff.meanAfter)) {
       afterText += `±${fmtNum(diff.moeAfter)}`;
     }
 
@@ -152,7 +177,7 @@ export async function compareBenchmarks(
 ## Benchmarks
 
 <details>
-<summary>Comparison to Baseline</summary>
+<summary>Comparison to Baseline ${colors}</summary>
 
 ${markdown}
 

--- a/tools/hangar/src/benchmarking/compare.ts
+++ b/tools/hangar/src/benchmarking/compare.ts
@@ -101,7 +101,7 @@ export async function compareBenchmarks(
     differences[itemName].maxSD = Math.max(
       newData?.sd ?? NaN,
       oldData?.sd ?? NaN
-    );
+    ) * 1.5;
 
     differences[itemName].meanDiff =
       Math.round(
@@ -180,6 +180,12 @@ export async function compareBenchmarks(
 <summary>Comparison to Baseline ${colors}</summary>
 
 ${markdown}
+
+⬜ Within 1.5 standard deviations
+🟩 Faster, Above 1.5 standard deviations
+🟥 Slower, Above 1.5 standard deviations
+
+_Benchmarks may vary outside of normal expectations, especially when running in GitHub Actions CI._
 
 </details>
 

--- a/tools/hangar/src/package.setup.ts
+++ b/tools/hangar/src/package.setup.ts
@@ -24,7 +24,7 @@ const getInstallArgs = async () => {
       "install",
       "--no-package-lock",
       "--install-links=false",
-      process.env.HANGAR_WING_VERSION
+      process.env.HANGAR_WINGLANG_PACKAGE!
     ];
   }
 

--- a/tools/hangar/src/package.setup.ts
+++ b/tools/hangar/src/package.setup.ts
@@ -19,6 +19,15 @@ const shellEnv = {
 };
 
 const getInstallArgs = async () => {
+  if(process.env.HANGAR_WINGLANG_PACKAGE) {
+    return [
+      "install",
+      "--no-package-lock",
+      "--install-links=false",
+      process.env.HANGAR_WING_VERSION
+    ];
+  }
+
   if (process.env.CI) {
     const tarballsDir = path.resolve(`${__dirname}/../../../dist`);
     const tarballs = (await fs.readdir(tarballsDir))


### PR DESCRIPTION
Now the benchmark runs twice: Once for the latest version and once for the PR. They run on the same machine in the same job, so there are less variables to worry about.

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
