### PR TITLE
chore: remove newlines from community note

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -65,6 +65,4 @@ body:
       <!-- Please keep this note for the community -->
       * Please vote by adding a 👍 reaction to the issue to help us prioritize.
       * If you are interested to work on this issue, please leave a comment.
-      * If this issue is labeled **needs-discussion**, it means the spec
-        has not been finalized yet. Please reach out on the #dev channel
-        in the [Wing Slack](https://t.winglang.io/slack).
+      * If this issue is labeled **needs-discussion**, it means the spec has not been finalized yet. Please reach out on the #dev channel in the [Wing Slack](https://t.winglang.io/slack).


### PR DESCRIPTION
GitHub renders newlines in markdown...

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
