### PR TITLE
chore: prevent publish job from partial publishing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -387,8 +387,6 @@ jobs:
           max_attempts: 7
           timeout_minutes: 5
           command: |
-            set -o pipefail
-
             cd dist
             PACKAGES=("@winglang/sdk" "@winglang/compiler" "@wingconsole/design-system" "@wingconsole/ui" "@wingconsole/server" "@wingconsole/app" "winglang")
             for PACKAGE in "${PACKAGES[@]}"; do
@@ -403,6 +401,11 @@ jobs:
               TARBALL=$(echo "$PACKAGE-$PACKAGE_VERSION.tgz" | sed 's/@//g' | sed 's/\//-/g')
 
               npm publish "$TARBALL" --access public --verbose
+
+              if [ $? -ne 0 ]; then
+                echo "Publishing $PACKAGE failed, exiting"
+                exit 1
+              fi
             done
 
       - name: Publish Extension to Visual Studio Marketplace

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -387,6 +387,8 @@ jobs:
           max_attempts: 7
           timeout_minutes: 5
           command: |
+            set -o pipefail
+
             cd dist
             PACKAGES=("@winglang/sdk" "@winglang/compiler" "@wingconsole/design-system" "@wingconsole/ui" "@wingconsole/server" "@wingconsole/app" "winglang")
             for PACKAGE in "${PACKAGES[@]}"; do

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -385,9 +385,11 @@ jobs:
           PACKAGE_VERSION: ${{ needs.build.outputs.version }}
         with:
           max_attempts: 7
-          retry_on: error
+          retry_on: any
           timeout_minutes: 5
           command: |
+            set -o pipefail
+
             cd dist
             PACKAGES=("@winglang/sdk" "@winglang/compiler" "@wingconsole/design-system" "@wingconsole/ui" "@wingconsole/server" "@wingconsole/app" "winglang")
             for PACKAGE in "${PACKAGES[@]}"; do

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -385,7 +385,6 @@ jobs:
           PACKAGE_VERSION: ${{ needs.build.outputs.version }}
         with:
           max_attempts: 7
-          retry_on: any
           timeout_minutes: 5
           command: |
             set -o pipefail

--- a/.github/workflows/tf-aws-test.yml
+++ b/.github/workflows/tf-aws-test.yml
@@ -64,6 +64,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
+      max-parallel: 10
       matrix: ${{ fromJson(needs.setup.outputs.tests) }}
     name: ${{ matrix.test.name }}
     steps:


### PR DESCRIPTION
Typically when a bad publish happens, it fails on the first one. Because the publish is in a loop, it does not exit the script properly on error (set -e doesn't matter cause bash is crazy).

Also, too many spec tests are happening at once.

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
