### PR TITLE
feat(vscode): add underlined hints for error annotations

### DIFF
--- a/apps/wing/src/commands/lsp.ts
+++ b/apps/wing/src/commands/lsp.ts
@@ -144,11 +144,28 @@ export async function lsp() {
           }))
         );
 
+        // Add annotations as notes hinting back to the original diagnostic
+        const extraNotes = rd.annotations.map((a) =>
+          Diagnostic.create(
+            Range.create(a.span.start.line, a.span.start.col, a.span.end.line, a.span.end.col),
+            `Original: ${a.message}`,
+            DiagnosticSeverity.Hint,
+            undefined,
+            undefined,
+            [
+              {
+                location: Location.create(diagnosticUri, diag.range),
+                message: diag.message,
+              },
+            ]
+          )
+        );
+
         if (!allDiagnostics.has(diagnosticUri)) {
           allDiagnostics.set(diagnosticUri, []);
           seenFiles.add(diagnosticUri);
         }
-        allDiagnostics.get(diagnosticUri)!.push(diag);
+        allDiagnostics.get(diagnosticUri)!.push(diag, ...extraNotes);
       } else {
         // skip if diagnostic is not associated with any file
       }

--- a/apps/wing/src/commands/lsp.ts
+++ b/apps/wing/src/commands/lsp.ts
@@ -155,7 +155,7 @@ export async function lsp() {
             [
               {
                 location: Location.create(diagnosticUri, diag.range),
-                message: `(Source) ${diag.message}`,
+                message: `(source) ${diag.message}`,
               },
             ]
           )

--- a/apps/wing/src/commands/lsp.ts
+++ b/apps/wing/src/commands/lsp.ts
@@ -148,14 +148,14 @@ export async function lsp() {
         const extraNotes = rd.annotations.map((a) =>
           Diagnostic.create(
             Range.create(a.span.start.line, a.span.start.col, a.span.end.line, a.span.end.col),
-            `Original: ${a.message}`,
+            a.message,
             DiagnosticSeverity.Hint,
             undefined,
             undefined,
             [
               {
                 location: Location.create(diagnosticUri, diag.range),
-                message: diag.message,
+                message: `(Source) ${diag.message}`,
               },
             ]
           )


### PR DESCRIPTION
Stealing rust's idea:

<img width="891" alt="image" src="https://github.com/winglang/wing/assets/1237390/52a385c0-2e6f-40e8-a6f4-a8424062f706">

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
