### PR TITLE
fix: windows fails if any drives are inaccessible

### DIFF
--- a/libs/wingcompiler/src/wingc.ts
+++ b/libs/wingcompiler/src/wingc.ts
@@ -103,8 +103,14 @@ export async function load(options: WingCompilerLoadOptions) {
       .map((value) => value.trim());
 
     for (const drive of drives) {
-      // drive will be something like "C:"
-      preopens[`${drive}/`] = `${drive}\\`;
+      try {
+        let actualPath = `${drive}\\`;
+        await fs.promises.access(actualPath, fs.constants.R_OK | fs.constants.F_OK);
+        // drive will be something like "C:"
+        preopens[`${drive}/`] = actualPath;
+      } catch {
+        // can't access the drive, don't bother preopening it
+      }
     }
   } else {
     // mapping the root is not sufficient on linux/mac


### PR DESCRIPTION
This makes the behavior match between windows and non-windows (checking the drive first before adding preopen)

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
