### PR TITLE
fix(compiler)!: unexpected heuristic for inference across scopes

### DIFF
--- a/examples/tests/invalid/inference.test.w
+++ b/examples/tests/invalid/inference.test.w
@@ -103,12 +103,12 @@ if true {
 //             ^^^^^^^^^^^^^^^ Expected str, got num
 }
 
+// See https://github.com/winglang/wing/issues/4464 for details
 let unknownArg = (arg) => {
 //                ^^^ Unable to infer type
   return arg.get("a");
 //           ^^^ Property not found
 };
-
 if true {
   unknownArg({ a: true });
 }

--- a/examples/tests/invalid/inference.test.w
+++ b/examples/tests/invalid/inference.test.w
@@ -96,3 +96,19 @@ let badFunc: inflight (str): void = inflight (arg1: num) => {};
 // ^ Inferred type Array<str> conflicts with already inferred type Array<num>
 };
 
+
+let returnsNumber = () => { return 2; };
+if true {
+  let x: str = returnsNumber();
+//             ^^^^^^^^^^^^^^^ Expected str, got num
+}
+
+let unknownArg = (arg) => {
+//                ^^^ Unable to infer type
+  return arg.get("a");
+//           ^^^ Property not found
+};
+
+if true {
+  unknownArg({ a: true });
+}

--- a/examples/tests/valid/inference.test.w
+++ b/examples/tests/valid/inference.test.w
@@ -25,19 +25,21 @@ clonedSet.add(4);
 
 let api = new cloud.Api();
 let func = inflight (request) => {
-  return cloud.ApiResponse {
+  return {
     body: request.body,
     status: 200,
   };
 };
+api.get("/hello/world", func);
 
+let argReturn = (n: num) => { return n; };
+let implicitReturn = () => { return 1; };
 if true {
-  api.get("/hello/world", func);
+  let a = argReturn(1);
+  let b = implicitReturn();
 }
 
-let returnsString = () => {
-  return "hi";
-};
+let returnsString = () => { return "hi"; };
 let shouldBeString = returnsString();
 
 let stringArray = [shouldBeString];

--- a/libs/wingc/src/type_check.rs
+++ b/libs/wingc/src/type_check.rs
@@ -40,7 +40,7 @@ use wingii::fqn::FQN;
 use wingii::type_system::TypeSystem;
 
 use self::class_fields_init::VisitClassInit;
-use self::inference_visitor::InferenceVisitor;
+use self::inference_visitor::{InferenceCounterVisitor, InferenceVisitor};
 use self::jsii_importer::JsiiImportSpec;
 use self::lifts::Lifts;
 use self::symbol_env::{LookupResult, LookupResultMut, SymbolEnvIter, SymbolEnvRef};
@@ -1691,13 +1691,8 @@ impl<'a> TypeChecker<'a> {
 	/// Recursively check if a type is or contains a type inference.
 	///
 	/// Returns true if any inferences were found.
-	fn check_for_inferences(&mut self, node: &TypeRef, span: &WingSpan) -> bool {
-		let mut visitor = InferenceVisitor {
-			types: self.types,
-			found_inference: false,
-			expected_type: None,
-			span,
-		};
+	fn check_for_inferences(&self, node: &TypeRef) -> bool {
+		let mut visitor = InferenceCounterVisitor::default();
 
 		visitor.visit_typeref(node);
 
@@ -3024,9 +3019,7 @@ impl<'a> TypeChecker<'a> {
 			self.type_check_statement(statement, &mut env);
 		}
 
-		// reverse list to type check later scopes first
-		// Why? To improve the inference algorithm. Earlier inner_scopes for closures may need to infer types from later inner_scopes
-		let inner_scopes = self.inner_scopes.drain(..).rev().collect::<Vec<_>>();
+		let inner_scopes = self.inner_scopes.drain(..).collect::<Vec<_>>();
 		for (inner_scope, ctx) in inner_scopes {
 			let scope = unsafe { &*inner_scope };
 			self.ctx = ctx;
@@ -3052,7 +3045,7 @@ impl<'a> TypeChecker<'a> {
 
 				// If we found a variable with an inferred type, this is an error because it means we failed to infer its type
 				// Ignores any transient (no file_id) variables e.g. `this`. Those failed inferences are cascading errors and not useful to the user
-				if self.check_for_inferences(&var_info.type_, &var_info.name.span) && !var_info.name.span.file_id.is_empty() {
+				if !var_info.name.span.file_id.is_empty() && self.check_for_inferences(&var_info.type_) {
 					self.spanned_error(&var_info.name, "Unable to infer type".to_string());
 				}
 			}

--- a/tools/hangar/__snapshots__/invalid.ts.snap
+++ b/tools/hangar/__snapshots__/invalid.ts.snap
@@ -114,18 +114,53 @@ error: Cannot override private method \\"private_method\\" of \\"Foo\\"
     |       ^^^^^^^^^^^^^^ Cannot override private method \\"private_method\\" of \\"Foo\\"
 
 
-error: Cannot access protected member \\"protected_static_method\\" of \\"Foo\\"
-    --> ../../../examples/tests/invalid/access_modifiers.test.w:128:9
-    |
-128 |     Foo.protected_static_method();
-    |         ^^^^^^^^^^^^^^^^^^^^^^^ Cannot access protected member \\"protected_static_method\\" of \\"Foo\\"
+error: Cannot access private member \\"private_field\\" of \\"Bar\\"
+   --> ../../../examples/tests/invalid/access_modifiers.test.w:52:14
+   |
+52 |     log(this.private_field);
+   |              ^^^^^^^^^^^^^ Cannot access private member \\"private_field\\" of \\"Bar\\"
+
+
+error: Cannot access private member \\"private_method\\" of \\"Bar\\"
+   --> ../../../examples/tests/invalid/access_modifiers.test.w:57:10
+   |
+57 |     this.private_method();
+   |          ^^^^^^^^^^^^^^ Cannot access private member \\"private_method\\" of \\"Bar\\"
 
 
 error: Cannot access private member \\"private_static_method\\" of \\"Foo\\"
-    --> ../../../examples/tests/invalid/access_modifiers.test.w:130:9
-    |
-130 |     Foo.private_static_method();
-    |         ^^^^^^^^^^^^^^^^^^^^^ Cannot access private member \\"private_static_method\\" of \\"Foo\\"
+   --> ../../../examples/tests/invalid/access_modifiers.test.w:65:9
+   |
+65 |     Foo.private_static_method();
+   |         ^^^^^^^^^^^^^^^^^^^^^ Cannot access private member \\"private_static_method\\" of \\"Foo\\"
+
+
+error: Cannot access private member \\"private_field\\" of \\"Baz\\"
+   --> ../../../examples/tests/invalid/access_modifiers.test.w:75:14
+   |
+75 |     log(this.private_field);
+   |              ^^^^^^^^^^^^^ Cannot access private member \\"private_field\\" of \\"Baz\\"
+
+
+error: Cannot access private member \\"private_method\\" of \\"Baz\\"
+   --> ../../../examples/tests/invalid/access_modifiers.test.w:80:10
+   |
+80 |     this.private_method();
+   |          ^^^^^^^^^^^^^^ Cannot access private member \\"private_method\\" of \\"Baz\\"
+
+
+error: Cannot access private member \\"private_static_method\\" of \\"Foo\\"
+   --> ../../../examples/tests/invalid/access_modifiers.test.w:88:9
+   |
+88 |     Foo.private_static_method();
+   |         ^^^^^^^^^^^^^^^^^^^^^ Cannot access private member \\"private_static_method\\" of \\"Foo\\"
+
+
+error: Cannot access private member \\"private_static_method\\" of \\"Bar\\"
+   --> ../../../examples/tests/invalid/access_modifiers.test.w:93:9
+   |
+93 |     Bar.private_static_method();
+   |         ^^^^^^^^^^^^^^^^^^^^^ Cannot access private member \\"private_static_method\\" of \\"Bar\\"
 
 
 error: Cannot access protected member \\"protected_field\\" of \\"Foo\\"
@@ -156,53 +191,18 @@ error: Cannot access private member \\"private_method\\" of \\"Foo\\"
     |         ^^^^^^^^^^^^^^ Cannot access private member \\"private_method\\" of \\"Foo\\"
 
 
-error: Cannot access private member \\"private_static_method\\" of \\"Foo\\"
-   --> ../../../examples/tests/invalid/access_modifiers.test.w:88:9
-   |
-88 |     Foo.private_static_method();
-   |         ^^^^^^^^^^^^^^^^^^^^^ Cannot access private member \\"private_static_method\\" of \\"Foo\\"
-
-
-error: Cannot access private member \\"private_static_method\\" of \\"Bar\\"
-   --> ../../../examples/tests/invalid/access_modifiers.test.w:93:9
-   |
-93 |     Bar.private_static_method();
-   |         ^^^^^^^^^^^^^^^^^^^^^ Cannot access private member \\"private_static_method\\" of \\"Bar\\"
-
-
-error: Cannot access private member \\"private_field\\" of \\"Baz\\"
-   --> ../../../examples/tests/invalid/access_modifiers.test.w:75:14
-   |
-75 |     log(this.private_field);
-   |              ^^^^^^^^^^^^^ Cannot access private member \\"private_field\\" of \\"Baz\\"
-
-
-error: Cannot access private member \\"private_method\\" of \\"Baz\\"
-   --> ../../../examples/tests/invalid/access_modifiers.test.w:80:10
-   |
-80 |     this.private_method();
-   |          ^^^^^^^^^^^^^^ Cannot access private member \\"private_method\\" of \\"Baz\\"
+error: Cannot access protected member \\"protected_static_method\\" of \\"Foo\\"
+    --> ../../../examples/tests/invalid/access_modifiers.test.w:128:9
+    |
+128 |     Foo.protected_static_method();
+    |         ^^^^^^^^^^^^^^^^^^^^^^^ Cannot access protected member \\"protected_static_method\\" of \\"Foo\\"
 
 
 error: Cannot access private member \\"private_static_method\\" of \\"Foo\\"
-   --> ../../../examples/tests/invalid/access_modifiers.test.w:65:9
-   |
-65 |     Foo.private_static_method();
-   |         ^^^^^^^^^^^^^^^^^^^^^ Cannot access private member \\"private_static_method\\" of \\"Foo\\"
-
-
-error: Cannot access private member \\"private_field\\" of \\"Bar\\"
-   --> ../../../examples/tests/invalid/access_modifiers.test.w:52:14
-   |
-52 |     log(this.private_field);
-   |              ^^^^^^^^^^^^^ Cannot access private member \\"private_field\\" of \\"Bar\\"
-
-
-error: Cannot access private member \\"private_method\\" of \\"Bar\\"
-   --> ../../../examples/tests/invalid/access_modifiers.test.w:57:10
-   |
-57 |     this.private_method();
-   |          ^^^^^^^^^^^^^^ Cannot access private member \\"private_method\\" of \\"Bar\\"
+    --> ../../../examples/tests/invalid/access_modifiers.test.w:130:9
+    |
+130 |     Foo.private_static_method();
+    |         ^^^^^^^^^^^^^^^^^^^^^ Cannot access private member \\"private_static_method\\" of \\"Foo\\"
 
 
  
@@ -673,10 +673,31 @@ error: Unknown symbol \\"C11\\"
    |                   ^^^ Unknown symbol \\"C11\\"
 
 
-error: Expected 1 positional argument(s) but got 0
-    --> ../../../examples/tests/invalid/class.test.w:157:5
+error: Expected type to be \\"num\\", but got \\"str\\" instead
+   --> ../../../examples/tests/invalid/class.test.w:31:14
+   |
+31 |     this.x = \\"Hi\\";
+   |              ^^^^ Expected type to be \\"num\\", but got \\"str\\" instead
+
+
+error: Variable cannot be reassigned from inflight
+   --> ../../../examples/tests/invalid/class.test.w:61:5
+   |
+61 |     this.y = 1;
+   |     ^^^^^^ Variable cannot be reassigned from inflight
+
+
+error: Expected type to be \\"num\\", but got \\"str\\" instead
+    --> ../../../examples/tests/invalid/class.test.w:123:11
     |
-157 |     super();
+123 |     super(someStr);
+    |           ^^^^^^^ Expected type to be \\"num\\", but got \\"str\\" instead
+
+
+error: Expected 1 positional argument(s) but got 0
+    --> ../../../examples/tests/invalid/class.test.w:132:5
+    |
+132 |     super();
     |     ^^^^^^^^ Expected 1 positional argument(s) but got 0
 
 
@@ -688,31 +709,10 @@ error: Expected 1 arguments but got 2
 
 
 error: Expected 1 positional argument(s) but got 0
-    --> ../../../examples/tests/invalid/class.test.w:132:5
+    --> ../../../examples/tests/invalid/class.test.w:157:5
     |
-132 |     super();
+157 |     super();
     |     ^^^^^^^^ Expected 1 positional argument(s) but got 0
-
-
-error: Expected type to be \\"num\\", but got \\"str\\" instead
-    --> ../../../examples/tests/invalid/class.test.w:123:11
-    |
-123 |     super(someStr);
-    |           ^^^^^^^ Expected type to be \\"num\\", but got \\"str\\" instead
-
-
-error: Variable cannot be reassigned from inflight
-   --> ../../../examples/tests/invalid/class.test.w:61:5
-   |
-61 |     this.y = 1;
-   |     ^^^^^^ Variable cannot be reassigned from inflight
-
-
-error: Expected type to be \\"num\\", but got \\"str\\" instead
-   --> ../../../examples/tests/invalid/class.test.w:31:14
-   |
-31 |     this.x = \\"Hi\\";
-   |              ^^^^ Expected type to be \\"num\\", but got \\"str\\" instead
 
 
  
@@ -1435,22 +1435,18 @@ error: Expected type to be \\"inflight (str): void\\", but got \\"inflight (arg1
    |                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^ Expected type to be \\"inflight (str): void\\", but got \\"inflight (arg1: num): unknown\\" instead
 
 
-error: Inferred type Array<str> conflicts with already inferred type Array<num>
-   --> ../../../examples/tests/invalid/inference.test.w:92:33
-   |  
-92 |     let jsonDoubleInference: SS = {
-   | /---------------------------------^
-93 | |     a: a,
-94 | |     b: a,
-95 | |   };
-   | \\\\---^ Inferred type Array<str> conflicts with already inferred type Array<num>
+error: Unable to infer type
+  --> ../../../examples/tests/invalid/inference.test.w:4:29
+  |
+4 | let preflightClosureArgs = (nice) => { return true; };
+  |                             ^^^^ Unable to infer type
 
 
-error: Unexpected return value from void function. Return type annotations are required for methods.
-   --> ../../../examples/tests/invalid/inference.test.w:75:5
+error: Unable to infer type
+   --> ../../../examples/tests/invalid/inference.test.w:25:44
    |
-75 |     return true;
-   |     ^^^^^^^^^^^^ Unexpected return value from void function. Return type annotations are required for methods.
+25 | let stringInterpolationCannotBeInferred = (nice) => {
+   |                                            ^^^^ Unable to infer type
 
 
 error: Property not found
@@ -1467,18 +1463,43 @@ error: Unable to infer type
    |                       ^^^^^^^ Unable to infer type
 
 
-error: Unable to infer type
-   --> ../../../examples/tests/invalid/inference.test.w:25:44
+error: Unexpected return value from void function. Return type annotations are required for methods.
+   --> ../../../examples/tests/invalid/inference.test.w:75:5
    |
-25 | let stringInterpolationCannotBeInferred = (nice) => {
-   |                                            ^^^^ Unable to infer type
+75 |     return true;
+   |     ^^^^^^^^^^^^ Unexpected return value from void function. Return type annotations are required for methods.
+
+
+error: Inferred type Array<str> conflicts with already inferred type Array<num>
+   --> ../../../examples/tests/invalid/inference.test.w:92:33
+   |  
+92 |     let jsonDoubleInference: SS = {
+   | /---------------------------------^
+93 | |     a: a,
+94 | |     b: a,
+95 | |   };
+   | \\\\---^ Inferred type Array<str> conflicts with already inferred type Array<num>
+
+
+error: Expected type to be \\"str\\", but got \\"num\\" instead
+    --> ../../../examples/tests/invalid/inference.test.w:102:16
+    |
+102 |   let x: str = returnsNumber();
+    |                ^^^^^^^^^^^^^^^ Expected type to be \\"str\\", but got \\"num\\" instead
+
+
+error: Property not found
+    --> ../../../examples/tests/invalid/inference.test.w:108:14
+    |
+108 |   return arg.get(\\"a\\");
+    |              ^^^ Property not found
 
 
 error: Unable to infer type
-  --> ../../../examples/tests/invalid/inference.test.w:4:29
-  |
-4 | let preflightClosureArgs = (nice) => { return true; };
-  |                             ^^^^ Unable to infer type
+    --> ../../../examples/tests/invalid/inference.test.w:106:19
+    |
+106 | let unknownArg = (arg) => {
+    |                   ^^^ Unable to infer type
 
 
 error: Unable to infer type
@@ -1545,11 +1566,11 @@ exports[`inflight_class_created_in_preflight.test.w 1`] = `
   | ^^^^^^^^^ Cannot create inflight class \\"Foo\\" in preflight phase
 
 
-error: Cannot create preflight class \\"PreflightClass\\" in inflight phase
-   --> ../../../examples/tests/invalid/inflight_class_created_in_preflight.test.w:19:3
-   |
-19 |   new PreflightClass();
-   |   ^^^^^^^^^^^^^^^^^^^^ Cannot create preflight class \\"PreflightClass\\" in inflight phase
+error: Cannot create inflight class \\"Foo\\" in preflight phase
+  --> ../../../examples/tests/invalid/inflight_class_created_in_preflight.test.w:8:5
+  |
+8 |     new Foo();
+  |     ^^^^^^^^^ Cannot create inflight class \\"Foo\\" in preflight phase
 
 
 error: Cannot create inflight class \\"Foo\\" in preflight phase
@@ -1559,11 +1580,11 @@ error: Cannot create inflight class \\"Foo\\" in preflight phase
    |     ^^^^^^^^^ Cannot create inflight class \\"Foo\\" in preflight phase
 
 
-error: Cannot create inflight class \\"Foo\\" in preflight phase
-  --> ../../../examples/tests/invalid/inflight_class_created_in_preflight.test.w:8:5
-  |
-8 |     new Foo();
-  |     ^^^^^^^^^ Cannot create inflight class \\"Foo\\" in preflight phase
+error: Cannot create preflight class \\"PreflightClass\\" in inflight phase
+   --> ../../../examples/tests/invalid/inflight_class_created_in_preflight.test.w:19:3
+   |
+19 |   new PreflightClass();
+   |   ^^^^^^^^^^^^^^^^^^^^ Cannot create preflight class \\"PreflightClass\\" in inflight phase
 
 
 error: Cannot qualify access to a lifted type \\"PreflightClass\\" (see https://github.com/winglang/wing/issues/76 for more details)
@@ -2339,25 +2360,6 @@ exports[`reassign_to_nonreassignable.test.w 1`] = `
 
 
 error: Variable is not reassignable
-   --> ../../../examples/tests/invalid/reassign_to_nonreassignable.test.w:42:3
-   |
-41 | let f = (arg: num):num => {
-   |          --- defined here (try adding \\"var\\" in front)
-42 |   arg = 0;
-   |   ^^^ Variable is not reassignable
-
-
-error: Variable is not reassignable
-   --> ../../../examples/tests/invalid/reassign_to_nonreassignable.test.w:35:5
-   |
-16 |   inflight inflightF: num;
-   |            --------- defined here (try adding \\"var\\" in front)
-   .
-35 |     this.inflightF = this.inflightF + 1;
-   |     ^^^^^^^^^^^^^^ Variable is not reassignable
-
-
-error: Variable is not reassignable
    --> ../../../examples/tests/invalid/reassign_to_nonreassignable.test.w:28:5
    |
 14 |   f: num;
@@ -2375,6 +2377,25 @@ error: Variable is not reassignable
    .
 30 |     this.innerR.inner = 2;
    |     ^^^^^^^^^^^^^^^^^ Variable is not reassignable
+
+
+error: Variable is not reassignable
+   --> ../../../examples/tests/invalid/reassign_to_nonreassignable.test.w:35:5
+   |
+16 |   inflight inflightF: num;
+   |            --------- defined here (try adding \\"var\\" in front)
+   .
+35 |     this.inflightF = this.inflightF + 1;
+   |     ^^^^^^^^^^^^^^ Variable is not reassignable
+
+
+error: Variable is not reassignable
+   --> ../../../examples/tests/invalid/reassign_to_nonreassignable.test.w:42:3
+   |
+41 | let f = (arg: num):num => {
+   |          --- defined here (try adding \\"var\\" in front)
+42 |   arg = 0;
+   |   ^^^ Variable is not reassignable
 
 
  
@@ -2480,11 +2501,11 @@ exports[`return_types.test.w 1`] = `
   |     ^^^^^^^^^ Return statement outside of function cannot return a value
 
 
-error: Unexpected return value from void function. Return type annotations are required for methods.
-   --> ../../../examples/tests/invalid/return_types.test.w:19:5
-   |
-19 |     return 9;
-   |     ^^^^^^^^^ Unexpected return value from void function. Return type annotations are required for methods.
+error: Return statement outside of function cannot return a value
+  --> ../../../examples/tests/invalid/return_types.test.w:4:5
+  |
+4 |     return 9;
+  |     ^^^^^^^^^ Return statement outside of function cannot return a value
 
 
 error: Unexpected return value from void function. Return type annotations are required for methods.
@@ -2501,11 +2522,11 @@ error: Unexpected return value from void function. Return type annotations are r
    |     ^^^^^^^^^ Unexpected return value from void function. Return type annotations are required for methods.
 
 
-error: Return statement outside of function cannot return a value
-  --> ../../../examples/tests/invalid/return_types.test.w:4:5
-  |
-4 |     return 9;
-  |     ^^^^^^^^^ Return statement outside of function cannot return a value
+error: Unexpected return value from void function. Return type annotations are required for methods.
+   --> ../../../examples/tests/invalid/return_types.test.w:19:5
+   |
+19 |     return 9;
+   |     ^^^^^^^^^ Unexpected return value from void function. Return type annotations are required for methods.
 
 
  
@@ -2840,25 +2861,11 @@ error: Cannot override private method \\"m1\\" of \\"BaseClass\\"
    |            ^^ Cannot override private method \\"m1\\" of \\"BaseClass\\"
 
 
-error: \`super\` calls inside inflight closures not supported yet, see: https://github.com/winglang/wing/issues/3474
-   --> ../../../examples/tests/invalid/super_call.test.w:52:50
-   |
-52 |       return \\"this: \${this.m1()}, super: \${super.m1()}\\";
-   |                                                  ^^ \`super\` calls inside inflight closures not supported yet, see: https://github.com/winglang/wing/issues/3474
-
-
-error: Cannot call super method inside of a static method
-   --> ../../../examples/tests/invalid/super_call.test.w:26:11
-   |
-26 |     super.method();
-   |           ^^^^^^ Cannot call super method inside of a static method
-
-
-error: super class \\"A\\" does not have a method named \\"child_method\\"
-   --> ../../../examples/tests/invalid/super_call.test.w:20:11
-   |
-20 |     super.child_method();
-   |           ^^^^^^^^^^^^ super class \\"A\\" does not have a method named \\"child_method\\"
+error: Cannot call super method because class A has no parent
+  --> ../../../examples/tests/invalid/super_call.test.w:4:11
+  |
+4 |     super.method();
+  |           ^^^^^^ Cannot call super method because class A has no parent
 
 
 error: Cannot call super method because class InflightA has no parent
@@ -2868,11 +2875,25 @@ error: Cannot call super method because class InflightA has no parent
    |           ^^^^^^ Cannot call super method because class InflightA has no parent
 
 
-error: Cannot call super method because class A has no parent
-  --> ../../../examples/tests/invalid/super_call.test.w:4:11
-  |
-4 |     super.method();
-  |           ^^^^^^ Cannot call super method because class A has no parent
+error: super class \\"A\\" does not have a method named \\"child_method\\"
+   --> ../../../examples/tests/invalid/super_call.test.w:20:11
+   |
+20 |     super.child_method();
+   |           ^^^^^^^^^^^^ super class \\"A\\" does not have a method named \\"child_method\\"
+
+
+error: Cannot call super method inside of a static method
+   --> ../../../examples/tests/invalid/super_call.test.w:26:11
+   |
+26 |     super.method();
+   |           ^^^^^^ Cannot call super method inside of a static method
+
+
+error: \`super\` calls inside inflight closures not supported yet, see: https://github.com/winglang/wing/issues/3474
+   --> ../../../examples/tests/invalid/super_call.test.w:52:50
+   |
+52 |       return \\"this: \${this.m1()}, super: \${super.m1()}\\";
+   |                                                  ^^ \`super\` calls inside inflight closures not supported yet, see: https://github.com/winglang/wing/issues/3474
 
 
  

--- a/tools/hangar/__snapshots__/invalid.ts.snap
+++ b/tools/hangar/__snapshots__/invalid.ts.snap
@@ -114,68 +114,53 @@ error: Cannot override private method \\"private_method\\" of \\"Foo\\"
     |       ^^^^^^^^^^^^^^ Cannot override private method \\"private_method\\" of \\"Foo\\"
 
 
-<<<<<<< HEAD
 error: Cannot access private member \\"private_field\\" of \\"Bar\\"
-   --> ../../../examples/tests/invalid/access_modifiers.test.w:52:14
+   --> ../../../examples/tests/invalid/access_modifiers.test.w:61:14
    |
-52 |     log(this.private_field);
+61 |     log(this.private_field);
    |              ^^^^^^^^^^^^^ Cannot access private member \\"private_field\\" of \\"Bar\\"
 
 
 error: Cannot access private member \\"private_method\\" of \\"Bar\\"
-   --> ../../../examples/tests/invalid/access_modifiers.test.w:57:10
+   --> ../../../examples/tests/invalid/access_modifiers.test.w:66:10
    |
-57 |     this.private_method();
+66 |     this.private_method();
    |          ^^^^^^^^^^^^^^ Cannot access private member \\"private_method\\" of \\"Bar\\"
 
 
 error: Cannot access private member \\"private_static_method\\" of \\"Foo\\"
-   --> ../../../examples/tests/invalid/access_modifiers.test.w:65:9
+   --> ../../../examples/tests/invalid/access_modifiers.test.w:74:9
    |
-65 |     Foo.private_static_method();
+74 |     Foo.private_static_method();
    |         ^^^^^^^^^^^^^^^^^^^^^ Cannot access private member \\"private_static_method\\" of \\"Foo\\"
 
 
 error: Cannot access private member \\"private_field\\" of \\"Baz\\"
-   --> ../../../examples/tests/invalid/access_modifiers.test.w:75:14
+   --> ../../../examples/tests/invalid/access_modifiers.test.w:84:14
    |
-75 |     log(this.private_field);
+84 |     log(this.private_field);
    |              ^^^^^^^^^^^^^ Cannot access private member \\"private_field\\" of \\"Baz\\"
 
 
 error: Cannot access private member \\"private_method\\" of \\"Baz\\"
-   --> ../../../examples/tests/invalid/access_modifiers.test.w:80:10
+   --> ../../../examples/tests/invalid/access_modifiers.test.w:89:10
    |
-80 |     this.private_method();
+89 |     this.private_method();
    |          ^^^^^^^^^^^^^^ Cannot access private member \\"private_method\\" of \\"Baz\\"
 
 
 error: Cannot access private member \\"private_static_method\\" of \\"Foo\\"
-   --> ../../../examples/tests/invalid/access_modifiers.test.w:88:9
+   --> ../../../examples/tests/invalid/access_modifiers.test.w:97:9
    |
-88 |     Foo.private_static_method();
+97 |     Foo.private_static_method();
    |         ^^^^^^^^^^^^^^^^^^^^^ Cannot access private member \\"private_static_method\\" of \\"Foo\\"
 
 
 error: Cannot access private member \\"private_static_method\\" of \\"Bar\\"
-   --> ../../../examples/tests/invalid/access_modifiers.test.w:93:9
-   |
-93 |     Bar.private_static_method();
-   |         ^^^^^^^^^^^^^^^^^^^^^ Cannot access private member \\"private_static_method\\" of \\"Bar\\"
-=======
-error: Cannot access protected member \\"protected_static_method\\" of \\"Foo\\"
-    --> ../../../examples/tests/invalid/access_modifiers.test.w:137:9
+    --> ../../../examples/tests/invalid/access_modifiers.test.w:102:9
     |
-137 |     Foo.protected_static_method();
-    |         ^^^^^^^^^^^^^^^^^^^^^^^ Cannot access protected member \\"protected_static_method\\" of \\"Foo\\"
-
-
-error: Cannot access private member \\"private_static_method\\" of \\"Foo\\"
-    --> ../../../examples/tests/invalid/access_modifiers.test.w:139:9
-    |
-139 |     Foo.private_static_method();
-    |         ^^^^^^^^^^^^^^^^^^^^^ Cannot access private member \\"private_static_method\\" of \\"Foo\\"
->>>>>>> 31c8698f56f4479e5199c2de76097ac40f04fd6c
+102 |     Bar.private_static_method();
+    |         ^^^^^^^^^^^^^^^^^^^^^ Cannot access private member \\"private_static_method\\" of \\"Bar\\"
 
 
 error: Cannot access protected member \\"protected_field\\" of \\"Foo\\"
@@ -206,68 +191,18 @@ error: Cannot access private member \\"private_method\\" of \\"Foo\\"
     |         ^^^^^^^^^^^^^^ Cannot access private member \\"private_method\\" of \\"Foo\\"
 
 
-<<<<<<< HEAD
 error: Cannot access protected member \\"protected_static_method\\" of \\"Foo\\"
-    --> ../../../examples/tests/invalid/access_modifiers.test.w:128:9
+    --> ../../../examples/tests/invalid/access_modifiers.test.w:137:9
     |
-128 |     Foo.protected_static_method();
+137 |     Foo.protected_static_method();
     |         ^^^^^^^^^^^^^^^^^^^^^^^ Cannot access protected member \\"protected_static_method\\" of \\"Foo\\"
 
 
 error: Cannot access private member \\"private_static_method\\" of \\"Foo\\"
-    --> ../../../examples/tests/invalid/access_modifiers.test.w:130:9
+    --> ../../../examples/tests/invalid/access_modifiers.test.w:139:9
     |
-130 |     Foo.private_static_method();
+139 |     Foo.private_static_method();
     |         ^^^^^^^^^^^^^^^^^^^^^ Cannot access private member \\"private_static_method\\" of \\"Foo\\"
-=======
-error: Cannot access private member \\"private_static_method\\" of \\"Foo\\"
-   --> ../../../examples/tests/invalid/access_modifiers.test.w:97:9
-   |
-97 |     Foo.private_static_method();
-   |         ^^^^^^^^^^^^^^^^^^^^^ Cannot access private member \\"private_static_method\\" of \\"Foo\\"
-
-
-error: Cannot access private member \\"private_static_method\\" of \\"Bar\\"
-    --> ../../../examples/tests/invalid/access_modifiers.test.w:102:9
-    |
-102 |     Bar.private_static_method();
-    |         ^^^^^^^^^^^^^^^^^^^^^ Cannot access private member \\"private_static_method\\" of \\"Bar\\"
-
-
-error: Cannot access private member \\"private_field\\" of \\"Baz\\"
-   --> ../../../examples/tests/invalid/access_modifiers.test.w:84:14
-   |
-84 |     log(this.private_field);
-   |              ^^^^^^^^^^^^^ Cannot access private member \\"private_field\\" of \\"Baz\\"
-
-
-error: Cannot access private member \\"private_method\\" of \\"Baz\\"
-   --> ../../../examples/tests/invalid/access_modifiers.test.w:89:10
-   |
-89 |     this.private_method();
-   |          ^^^^^^^^^^^^^^ Cannot access private member \\"private_method\\" of \\"Baz\\"
-
-
-error: Cannot access private member \\"private_static_method\\" of \\"Foo\\"
-   --> ../../../examples/tests/invalid/access_modifiers.test.w:74:9
-   |
-74 |     Foo.private_static_method();
-   |         ^^^^^^^^^^^^^^^^^^^^^ Cannot access private member \\"private_static_method\\" of \\"Foo\\"
-
-
-error: Cannot access private member \\"private_field\\" of \\"Bar\\"
-   --> ../../../examples/tests/invalid/access_modifiers.test.w:61:14
-   |
-61 |     log(this.private_field);
-   |              ^^^^^^^^^^^^^ Cannot access private member \\"private_field\\" of \\"Bar\\"
-
-
-error: Cannot access private member \\"private_method\\" of \\"Bar\\"
-   --> ../../../examples/tests/invalid/access_modifiers.test.w:66:10
-   |
-66 |     this.private_method();
-   |          ^^^^^^^^^^^^^^ Cannot access private member \\"private_method\\" of \\"Bar\\"
->>>>>>> 31c8698f56f4479e5199c2de76097ac40f04fd6c
 
 
  
@@ -1554,16 +1489,16 @@ error: Expected type to be \\"str\\", but got \\"num\\" instead
 
 
 error: Property not found
-    --> ../../../examples/tests/invalid/inference.test.w:108:14
+    --> ../../../examples/tests/invalid/inference.test.w:109:14
     |
-108 |   return arg.get(\\"a\\");
+109 |   return arg.get(\\"a\\");
     |              ^^^ Property not found
 
 
 error: Unable to infer type
-    --> ../../../examples/tests/invalid/inference.test.w:106:19
+    --> ../../../examples/tests/invalid/inference.test.w:107:19
     |
-106 | let unknownArg = (arg) => {
+107 | let unknownArg = (arg) => {
     |                   ^^^ Unable to infer type
 
 

--- a/tools/hangar/__snapshots__/test_corpus/valid/inference.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/inference.test.w_compile_tf-aws.md
@@ -283,8 +283,16 @@ class $Root extends $stdlib.std.Resource {
     (clonedSet.add(4));
     const api = this.node.root.newAbstract("@winglang/sdk.cloud.Api",this,"cloud.Api");
     const func = new $Closure1(this,"$Closure1");
+    (api.get("/hello/world",func));
+    const argReturn = ((n) => {
+      return n;
+    });
+    const implicitReturn = (() => {
+      return 1;
+    });
     if (true) {
-      (api.get("/hello/world",func));
+      const a = (argReturn(1));
+      const b = (implicitReturn());
     }
     const returnsString = (() => {
       return "hi";


### PR DESCRIPTION
Fixes #4438

Due to:
- breadth-first type checking
- simplistic inference
- no re-checking (good)

Currently, this works:

```
let f = (arg) => {
  return arg.get("a");
};

if true {
  let x = f({ a: true });
}
```

but this does not work:

```
let f = () => {
  return { a: true };
};

if true {
  let x = f().get("a");
//        ^^^ don't know what the return type is yet because the closure above hasn't be checked
}
```

Because when first implementing inference, the sub-scopes of a scope were checked in reverse order. I thought this heuristic was kinda neat and figured it had legs. Now I'm thinking that was wrong. 

With this PR, the scope will be checked in normal order. Now the second case will work and the first case above will **not** work. It will require explicit annotation on the argument:

```
let f = (arg: Json) => {
  return arg.get("a");
};

if true {
  let x = f({ a: true });
}
```

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.

BREAKING CHANGE: Inference now prioritizes earlier scopes rather than later ones. This previously allowed closures called from other scopes to leave off argument type annotations. [This](https://github.com/winglang/wing/blob/fcfc3462d37a063d96d49b4105e27466ff7793c8/examples/tests/invalid/inference.test.w#L106) is an example of a case that previously worked.
