### PR TITLE
feat(sdk): add Assert.throws

### DIFF
--- a/examples/tests/sdk_tests/bucket/delete.test.w
+++ b/examples/tests/sdk_tests/bucket/delete.test.w
@@ -1,20 +1,10 @@
 bring cloud;
+bring "./../../valid/assertions.w" as assertions;
 
 let b = new cloud.Bucket();
 b.addObject("file2.txt", "Bar");
 
 test "delete" {
-  let assertThrows = (expected: str, block: (): void) => {
-    let var error = false;
-    try {
-      block();
-    } catch actual {
-      assert(actual == expected);
-      error = true;
-    }
-    assert(error);
-  };
-
   let OBJECT_DOES_NOT_EXIST_ERROR = "Object does not exist (key=file1.json).";
   let jsonObj1 = Json { key1: "value1" };
 
@@ -26,7 +16,7 @@ test "delete" {
 
   b.delete("file1.json", mustExist: true);
 
-  assertThrows(OBJECT_DOES_NOT_EXIST_ERROR, () => {
+  assertions.Assert.throws(OBJECT_DOES_NOT_EXIST_ERROR, () => {
     b.delete("file1.json", mustExist: true);
   });
   assert(b.exists("file2.txt"));

--- a/examples/tests/sdk_tests/bucket/public_url.test.w
+++ b/examples/tests/sdk_tests/bucket/public_url.test.w
@@ -1,22 +1,12 @@
 bring cloud;
 bring http;
 bring util;
+bring "./../../valid/assertions.w" as assertions;
 
 let publicBucket = new cloud.Bucket(public: true) as "publicBucket";
 let privateBucket = new cloud.Bucket() as "privateBucket";
 
 test "publicUrl" {
-  let assertThrows = (expected: str, block: (): void) => {
-    let var error = false;
-    try {
-      block();
-    } catch actual {
-      assert(actual == expected);
-      error = true;
-    }
-    assert(error);
-  };
-
   let BUCKET_NOT_PUBLIC_ERROR = "Cannot provide public url for a non-public bucket";
 
   publicBucket.put("file1.txt", "Foo");
@@ -30,7 +20,7 @@ test "publicUrl" {
     assert(http.get(publicUrl).body ==  "Foo");
   }
 
-  assertThrows(BUCKET_NOT_PUBLIC_ERROR, () => {
+  assertions.Assert.throws(BUCKET_NOT_PUBLIC_ERROR, () => {
     privateBucket.publicUrl("file2.txt");
   });
 }

--- a/examples/tests/sdk_tests/bucket/signed_url.test.w
+++ b/examples/tests/sdk_tests/bucket/signed_url.test.w
@@ -1,6 +1,7 @@
 bring cloud;
 bring http;
 bring util;
+bring "./../../valid/assertions.w" as assertions;
 
 let testBucket = new cloud.Bucket(public: true) as "testBucket";
 
@@ -17,13 +18,9 @@ test "signedUrl" {
 test "signedUrl for non existent key" {
   let var error = "";
   
-  if (util.env("WING_TARGET") != "sim") { 
-    try{
+  if (util.env("WING_TARGET") != "sim") {
+    assertions.Assert.throws("Cannot provide signed url for a non-existent key (key=file.txt)", () =>{
       let signedUrl = testBucket.signedUrl("file.txt");
-    } catch e {
-      error = e;
-    }
-
-    assert(error == "Cannot provide signed url for a non-existent key (key=file.txt)");
+    });
   }
 }

--- a/examples/tests/sdk_tests/http/url.test.w
+++ b/examples/tests/sdk_tests/http/url.test.w
@@ -1,17 +1,7 @@
 bring http;
+bring "./../../valid/assertions.w" as assertions;
 
 test "parseUrl()" {
-    let assertThrows = (expected: str, block: (): void) => {
-        let var error = false;
-        try {
-            block();
-        } catch actual {
-            assert(actual == expected);
-            error = true;
-        }
-        assert(error);
-    };
-
     let INVALID_URL_STRING = "hello world";
     let INVALID_URL_ERROR = "Invalid URL: ${INVALID_URL_STRING}";
     let URL_STRING = "http://username:password@www.example.com:3000/pathname?search=test#hash";
@@ -33,23 +23,12 @@ test "parseUrl()" {
     let parsedUrlStruct = http.parseUrl(URL_STRING);
     assert(urlStruct == parsedUrlStruct);
 
-    assertThrows(INVALID_URL_ERROR, () => {
+    assertions.Assert.throws(INVALID_URL_ERROR, () => {
         let invalidUrlStruct = http.parseUrl(INVALID_URL_STRING);
     });
 }
 
 test "formatUrl()" {
-    let assertThrows = (expected: str, block: (): void) => {
-        let var error = false;
-        try {
-            block();
-        } catch actual {
-            assert(actual == expected);
-            error = true;
-        }
-        assert(error);
-    };
-
     let UNABLE_TO_FORMAT_URL_STRUCT_ERROR = "Unable to format URL Struct: Invalid URL";
     let urlStruct = http.parseUrl("https://a:b@測試.com/path?query=1#fragment");
 
@@ -80,7 +59,7 @@ test "formatUrl()" {
         password: urlStruct.password,
     };
 
-    assertThrows(UNABLE_TO_FORMAT_URL_STRUCT_ERROR, () => {
+    assertions.Assert.throws(UNABLE_TO_FORMAT_URL_STRUCT_ERROR, () => {
         http.formatUrl(invalidUrlStruct);
     });
 }

--- a/examples/tests/sdk_tests/math/acos.test.w
+++ b/examples/tests/sdk_tests/math/acos.test.w
@@ -1,34 +1,28 @@
 bring math;
-try {
+bring "./../../valid/assertions.w" as assertions;
+
+assertions.PreflightAssert.throws("Input value must be between -1 and 1, inclusive.", () => {
   log("${math.acos(-2)}");
-} catch e {
-  assert(e == "Input value must be between -1 and 1, inclusive.");
-}
+});
 assert(math.acos(-1) == math.PI);
 assert(math.acos(-0) == 1.5707963267948966);
 assert(math.acos(0) == 1.5707963267948966);
 assert(math.acos(0.5) == 1.0471975511965979);
 assert(math.acos(1) == 0);
-try {
+assertions.PreflightAssert.throws("Input value must be between -1 and 1, inclusive.", () => {
   log("${math.acos(2)}");
-} catch e {
-  assert(e == "Input value must be between -1 and 1, inclusive.");
-}
+});
 
 test "inflight arc cosine" {
-  try {
+  assertions.Assert.throws("Input value must be between -1 and 1, inclusive.", () => {
     log("${math.acos(-2)}");
-  } catch e {
-    assert(e == "Input value must be between -1 and 1, inclusive.");
-  }
+  });
   assert(math.acos(-1) == math.PI);
   assert(math.acos(-0) == 1.5707963267948966);
   assert(math.acos(0) == 1.5707963267948966);
   assert(math.acos(0.5) == 1.0471975511965979);
   assert(math.acos(1) == 0);
-  try {
+  assertions.Assert.throws("Input value must be between -1 and 1, inclusive.", () => {
     log("${math.acos(2)}");
-  } catch e {
-    assert(e == "Input value must be between -1 and 1, inclusive.");
-  }
+  });
 }

--- a/examples/tests/sdk_tests/math/acsc.test.w
+++ b/examples/tests/sdk_tests/math/acsc.test.w
@@ -1,10 +1,9 @@
 bring math;
+bring "./../../valid/assertions.w" as assertions;
 
-try {
+assertions.PreflightAssert.throws("Input value must be equal or greater than |1|.", () => {
   log("${math.acsc(0.5)}");
-} catch e {
-  assert(e == "Input value must be equal or greater than |1|.");
-}
+});
 assert(math.acsc(1) == 1.5707963267948966);
 assert(math.acsc(math.PI / 2) == 0.69010709137454);
 assert(math.acsc(math.PI) == 0.3239461069319807);
@@ -12,11 +11,9 @@ assert(math.acsc(math.TAU) == 0.15983462638513704);
 assert(math.acsc(-1) == -1.5707963267948966);
 
 test "inflight arc cosecant" {
-  try {
+  assertions.Assert.throws("Input value must be equal or greater than |1|.", () => {
     log("${math.acsc(0.5)}");
-  } catch e {
-    assert(e == "Input value must be equal or greater than |1|.");
-  }
+  });
   assert(math.acsc(1) == 1.5707963267948966);
   assert(math.acsc(math.PI / 2) == 0.69010709137454);
   assert(math.acsc(math.PI) == 0.3239461069319807);

--- a/examples/tests/sdk_tests/math/asec.test.w
+++ b/examples/tests/sdk_tests/math/asec.test.w
@@ -1,10 +1,9 @@
 bring math;
+bring "./../../valid/assertions.w" as assertions;
 
-try {
+assertions.PreflightAssert.throws("Input value must be equal or greater than |1|.", () => {
   log("${math.asec(0.5)}");
-} catch e {
-  assert(e == "Input value must be equal or greater than |1|.");
-}
+});
 assert(math.asec(2) == 1.0471975511965979);
 assert(math.asec(1) == 0);
 assert(math.asec(math.PI) == 1.2468502198629159);
@@ -13,11 +12,9 @@ assert(math.asec(-1) == math.PI);
 assert(math.asec(-2) == 2.0943951023931957);
 
 test "inflight arc cosecant" {
-  try {
+  assertions.Assert.throws("Input value must be equal or greater than |1|.", () => {
     log("${math.asec(0.5)}");
-  } catch e {
-    assert(e == "Input value must be equal or greater than |1|.");
-  }
+  });
   assert(math.asec(2) == 1.0471975511965979);
   assert(math.asec(1) == 0);
   assert(math.asec(math.PI) == 1.2468502198629159);

--- a/examples/tests/sdk_tests/math/asin.test.w
+++ b/examples/tests/sdk_tests/math/asin.test.w
@@ -1,34 +1,28 @@
 bring math;
-try {
+bring "./../../valid/assertions.w" as assertions;
+
+assertions.PreflightAssert.throws("Input value must be between -1 and 1, inclusive.", () => {
   log("${math.asin(-2)}");
-} catch e {
-  assert(e == "Input value must be between -1 and 1, inclusive.");
-}
+});
 assert(math.asin(-1) == -1.5707963267948966);
 assert(math.asin(-0) == -0);
 assert(math.asin(0) == 0);
 assert(math.asin(0.5) == 0.5235987755982989);
 assert(math.asin(1) == 1.5707963267948966);
-try {
+assertions.PreflightAssert.throws("Input value must be between -1 and 1, inclusive.", () => {
   log("${math.asin(2)}");
-} catch e {
-  assert(e == "Input value must be between -1 and 1, inclusive.");
-}
+});
 
 test "inflight arc sine" {
-  try {
+  assertions.Assert.throws("Input value must be between -1 and 1, inclusive.", () => {
     log("${math.asin(-2)}");
-  } catch e {
-    assert(e == "Input value must be between -1 and 1, inclusive.");
-  }
+  });
   assert(math.asin(-1) == -1.5707963267948966);
   assert(math.asin(-0) == -0);
   assert(math.asin(0) == 0);
   assert(math.asin(0.5) == 0.5235987755982989);
   assert(math.asin(1) == 1.5707963267948966);
-  try {
+  assertions.Assert.throws("Input value must be between -1 and 1, inclusive.", () => {
     log("${math.asin(2)}");
-  } catch e {
-    assert(e == "Input value must be between -1 and 1, inclusive.");
-  }
+  });
 }

--- a/examples/tests/sdk_tests/math/sqrt.test.w
+++ b/examples/tests/sdk_tests/math/sqrt.test.w
@@ -1,9 +1,9 @@
 bring math;
-try {
+bring "./../../valid/assertions.w" as assertions;
+
+assertions.PreflightAssert.throws("Input value must be greater than or equal to 0.", () => {
   log("${math.sqrt(-1)}");
-} catch e {
-  assert(e == "Input value must be greater than or equal to 0.");
-}
+});
 assert(math.sqrt(-0) == -0);
 assert(math.sqrt(0) == 0);
 assert(math.sqrt(1) == 1);
@@ -12,11 +12,9 @@ assert(math.sqrt(9) == 3);
 assert(math.sqrt(math.INF) == math.INF);
 
 test "inflight square root" {
-  try {
+  assertions.Assert.throws("Input value must be greater than or equal to 0.", () => {
     log("${math.sqrt(-1)}");
-  } catch e {
-    assert(e == "Input value must be greater than or equal to 0.");
-  }
+  });
   assert(math.sqrt(-0) == -0);
   assert(math.sqrt(0) == 0);
   assert(math.sqrt(1) == 1);

--- a/examples/tests/sdk_tests/queue/push.test.w
+++ b/examples/tests/sdk_tests/queue/push.test.w
@@ -1,5 +1,6 @@
 bring cloud;
 bring util;
+bring "./../../valid/assertions.w" as assertions;
 
 let q = new cloud.Queue();
 
@@ -13,19 +14,13 @@ new std.Test(inflight () => {
     }
   };
 
-  try {
+  assertions.Assert.throws("Empty messages are not allowed", () => {
     q.push("");
-    assert(false);
-  } catch e {
-    assert(e == "Empty messages are not allowed");
-  }
+  });
 
-  try {
+  assertions.Assert.throws("Empty messages are not allowed", () => {
     q.push("Foo", "");
-    assert(false);
-  } catch e {
-    assert(e == "Empty messages are not allowed");
-  }
+  });
 
   q.push("Foo");
   

--- a/examples/tests/sdk_tests/schedule/init.test.w
+++ b/examples/tests/sdk_tests/schedule/init.test.w
@@ -4,43 +4,25 @@ skip: true
 // doesn't work on sim: #2732
 
 bring cloud;
+bring "./../../valid/assertions.w" as assertions;
 
 // Those are testing the many errors in intalization of a cloud.Schedule
-let var error = "";
-try {
+assertions.PreflightAssert.throws("rate or cron need to be filled.", () => {
     new cloud.Schedule( rate: nil, cron: nil ) as "s1";
-} catch e {
-    error = e;
-}
-assert(error == "rate or cron need to be filled.");
+});
 
-try {
+assertions.PreflightAssert.throws("rate and cron cannot be configured simultaneously.", () => {
     new cloud.Schedule( rate: 2m, cron: "* * * * *" ) as "s2";
-} catch e {
-    error = e;
-}
-assert(error == "rate and cron cannot be configured simultaneously.");
+});
 
-
-try {
+assertions.PreflightAssert.throws("rate can not be set to less than 1 minute.", () => {
     new cloud.Schedule( rate: 1s ) as "s3";
-} catch e {
-    error = e;
-}
-assert(error == "rate can not be set to less than 1 minute.");
+});
 
-try {
+assertions.PreflightAssert.throws("cron string must be UNIX cron format [minute] [hour] [day of month] [month] [day of week]", () => {
     new cloud.Schedule( cron: "* * * * * *" ) as "s4";
-} catch e {
-    error = e;
-}
-assert(error ==  "cron string must be UNIX cron format [minute] [hour] [day of month] [month] [day of week]");
+});
 
-
-try {
+assertions.PreflightAssert.throws("cannot use * in both the Day-of-month and Day-of-week fields. If you use it in one, you must use ? in the other", () => {
     new cloud.Schedule( cron: "* * * * *" ) as "s5";
-} catch e {
-    error = e;
-}
-assert(error == "cannot use * in both the Day-of-month and Day-of-week fields. If you use it in one, you must use ? in the other");
-
+});

--- a/examples/tests/sdk_tests/std/array.test.w
+++ b/examples/tests/sdk_tests/std/array.test.w
@@ -1,4 +1,6 @@
 bring cloud;
+bring "./../../valid/assertions.w" as asserions;
+
 //-----------------------------------------------------------------------------
 // length
 
@@ -63,17 +65,6 @@ test "pushAndPop()" {
 // popAt()
 
 test "popAt()" {
-  let assertThrows = (expected: str, block: (): void) => {
-    let var error = false;
-    try {
-      block();
-    } catch actual {
-      assert(actual == expected);
-      error = true;
-    }
-    assert(error);
-  };
-
   let INDEX_OUT_OF_BOUNDS_ERROR = "Index out of bounds";
   let mutArr = MutArray<str>["hello", "world"];
 
@@ -83,11 +74,11 @@ test "popAt()" {
   assert(mutArr.length == 1);
   assert(mutArr.at(0) == "world");
 
-  assertThrows(INDEX_OUT_OF_BOUNDS_ERROR, () => {
+  asserions.Assert.throws(INDEX_OUT_OF_BOUNDS_ERROR, () => {
     mutArr.popAt(-3);
   });
 
-  assertThrows(INDEX_OUT_OF_BOUNDS_ERROR, () => {
+  asserions.Assert.throws(INDEX_OUT_OF_BOUNDS_ERROR, () => {
     mutArr.popAt(3);
   });
 }
@@ -274,17 +265,6 @@ test "lastIndexOf()" {
 // set()
 
 test "set()" {
-  let assertThrows = (expected: str, block: (): void) => {
-    let var error = false;
-    try {
-      block();
-    } catch actual {
-      assert(actual == expected);
-      error = true;
-    }
-    assert(error);
-  };
-
   let INDEX_OUT_OF_BOUNDS_ERROR = "Index out of bounds";
   let mutArr = MutArray<num>[1, 3, 5, 7, 9];
 
@@ -292,10 +272,10 @@ test "set()" {
   mutArr.set(0, 2);
   assert(mutArr.at(0) == 2);
 
-  assertThrows(INDEX_OUT_OF_BOUNDS_ERROR, () => {
+  asserions.Assert.throws(INDEX_OUT_OF_BOUNDS_ERROR, () => {
     mutArr.set(-1, 1);
   });
-  assertThrows(INDEX_OUT_OF_BOUNDS_ERROR, () => {
+  asserions.Assert.throws(INDEX_OUT_OF_BOUNDS_ERROR, () => {
     mutArr.set(5, 11);
   });
 }
@@ -304,17 +284,6 @@ test "set()" {
 // insert()
 
 test "insert()" {
-  let assertThrows = (expected: str, block: (): void) => {
-    let var error = false;
-    try {
-      block();
-    } catch actual {
-      assert(actual == expected);
-      error = true;
-    }
-    assert(error);
-  };
-
   let INDEX_OUT_OF_BOUNDS_ERROR = "Index out of bounds";
   let mutArr = MutArray<num>[5, 10, 20];
 
@@ -324,13 +293,13 @@ test "insert()" {
   assert(mutArr.at(2) == 15);
   assert(mutArr.at(3) == 20);
 
-  assertThrows(INDEX_OUT_OF_BOUNDS_ERROR, () => {
+  asserions.Assert.throws(INDEX_OUT_OF_BOUNDS_ERROR, () => {
     mutArr.insert(-3, 15);
   });
 
   assert(mutArr.length == 4);
 
-  assertThrows(INDEX_OUT_OF_BOUNDS_ERROR, () => {
+  asserions.Assert.throws(INDEX_OUT_OF_BOUNDS_ERROR, () => {
     mutArr.insert(7, 15);
   });
 

--- a/examples/tests/sdk_tests/std/bool.test.w
+++ b/examples/tests/sdk_tests/std/bool.test.w
@@ -1,16 +1,6 @@
-let assertThrows = (expected: str, block: (): void) => {
-  let var error = false;
-  try {
-    block();
-  } catch actual {
-    assert(actual.contains(expected));
-    error = true;
-  }
+bring "./../../valid/assertions.w" as assertions;
 
-  assert(error);
-};
-
-let PARSE_ERROR = "unable to parse bool";
+let PARSE_ERROR = "unable to parse bool:\n- instance is not of a type(s) boolean";
 
 //-----------------------------------------------------------------------------
 // fromJson
@@ -18,7 +8,7 @@ let PARSE_ERROR = "unable to parse bool";
 let t = bool.fromJson(Json.parse("true"));
 assert(t == true);
 
-assertThrows(PARSE_ERROR, () => {
+assertions.PreflightAssert.throws(PARSE_ERROR, () => {
   bool.fromJson(Json 123); 
 });
 
@@ -32,5 +22,7 @@ test "fromJson()" {
   let f = bool.fromJson(Json.parse("false"));
   assert(f == false);
 
-  try { bool.fromJson(Json 123); } catch s { assert(s.contains(PARSE_ERROR)); }
+  assertions.Assert.throws(PARSE_ERROR, () => {
+    bool.fromJson(Json 123);
+  });
 }

--- a/examples/tests/sdk_tests/std/json.test.w
+++ b/examples/tests/sdk_tests/std/json.test.w
@@ -2,6 +2,7 @@
 // TODO: https://github.com/winglang/wing/issues/2785
 //-----------------------------------------------------------------------------
 bring cloud;
+bring "./../../valid/assertions.w" as assertions;
 
 test "has()" {
   let obj = Json { key1: 1, key2: 2};
@@ -11,17 +12,6 @@ test "has()" {
 }
 
 test "get()" {
-  let assertThrows = (expected: str, block: (): void) => {
-    let var error = false;
-    try {
-      block();
-    } catch actual {
-      assert(actual == expected);
-      error = true;
-    }
-    assert(error);
-  };
-
   let JSON_PROPERTY_DOES_NOT_EXIST_ERROR = "Json property \"c\" does not exist";
   let obj = Json { a: 1, b: 2 };
   let mutObj = MutJson { a: 1, b: 2 };
@@ -29,26 +19,15 @@ test "get()" {
   assert(obj.get("b") == 2);
   assert(mutObj.get("b") == 2);
 
-  assertThrows(JSON_PROPERTY_DOES_NOT_EXIST_ERROR, () => {
+  assertions.Assert.throws(JSON_PROPERTY_DOES_NOT_EXIST_ERROR, () => {
     obj.get("c");
   });
-  assertThrows(JSON_PROPERTY_DOES_NOT_EXIST_ERROR, () => {
+  assertions.Assert.throws(JSON_PROPERTY_DOES_NOT_EXIST_ERROR, () => {
     mutObj.get("c");
   });
 }
 
 test "getAt()" {
-  let assertThrows = (expected: str, block: (): void) => {
-    let var error = false;
-    try {
-      block();
-    } catch actual {
-      assert(actual == expected);
-      error = true;
-    }
-    assert(error);
-  };
-
   let INDEX_OUT_OF_BOUNDS_ERROR = "Index out of bounds";
   let jsonArray = Json ["foo", "bar", "baz"];
   let mutJsonArray = MutJson [1, 2, 3];
@@ -56,7 +35,7 @@ test "getAt()" {
   assert(jsonArray.getAt(2) == "baz");
   assert(mutJsonArray.getAt(2) == 3);
 
-  assertThrows(INDEX_OUT_OF_BOUNDS_ERROR, () => {
+  assertions.Assert.throws(INDEX_OUT_OF_BOUNDS_ERROR, () => {
     jsonArray.getAt(3);
     mutJsonArray.getAt(3);
   });

--- a/examples/tests/sdk_tests/std/string.test.w
+++ b/examples/tests/sdk_tests/std/string.test.w
@@ -1,28 +1,20 @@
-let assertThrows = (expected: str, block: (): void) => {
-  let var error = false;
-  try {
-    block();
-  } catch actual {
-    assert(actual.contains(expected) == true);
-    error = true;
-  }
-
-  assert(error);
-};
+bring "./../../valid/assertions.w" as assertions;
 
 //-----------------------------------------------------------------------------
 // fromJson (static)
 
-let PARSE_ERROR = "unable to parse string";
+let PARSE_ERROR = "unable to parse string:\n- instance is not of a type(s) string";
 
 assert(str.fromJson(Json "Hello") == "Hello");
-assertThrows(PARSE_ERROR, () => {
+assertions.PreflightAssert.throws(PARSE_ERROR, () => {
   str.fromJson(Json 123); 
 });
 
 test "fromJson" {
   assert(str.fromJson(Json "World") == "World");
-  try { str.fromJson(Json 123); } catch s { assert(s.contains(PARSE_ERROR)); }
+  assertions.Assert.throws(PARSE_ERROR, () => {
+    str.fromJson(Json 123);
+  });
 }
 
 //-----------------------------------------------------------------------------
@@ -46,10 +38,10 @@ assert("boom".at(2) == "o");
 assert("boom".at(-4) == "b");
 assert("boom".at(-1) == "m");
 // Should throw an exception
-assertThrows(INDEX_OUT_OF_BOUNDS_ERROR, () => {
+assertions.PreflightAssert.throws(INDEX_OUT_OF_BOUNDS_ERROR, () => {
   "boom".at(4);
 });
-assertThrows(INDEX_OUT_OF_BOUNDS_ERROR, () => {
+assertions.PreflightAssert.throws(INDEX_OUT_OF_BOUNDS_ERROR, () => {
   "boom".at(-5);
 });
 
@@ -59,8 +51,13 @@ test "at()" {
   assert("boom".at(-4) == "b");
   assert("boom".at(-1) == "m");
   // Should throw an exception
-  try { "boom".at(4); } catch s { assert(s == INDEX_OUT_OF_BOUNDS_ERROR ); } // <-- Passes if no exception is thrown, see issue #3341
-  try { "boom".at(-5); } catch s { assert(s == INDEX_OUT_OF_BOUNDS_ERROR ); }
+  assertions.Assert.throws(INDEX_OUT_OF_BOUNDS_ERROR, () => {
+    // Passes if no exception is thrown, see issue #3341
+    "boom".at(4);
+  });
+  assertions.Assert.throws(INDEX_OUT_OF_BOUNDS_ERROR, () => {
+    "boom".at(-5);
+  });
 }
 
 //-----------------------------------------------------------------------------

--- a/examples/tests/sdk_tests/table/get.test.w
+++ b/examples/tests/sdk_tests/table/get.test.w
@@ -1,5 +1,6 @@
 bring cloud;
 bring ex;
+bring "./../../valid/assertions.w" as assertions;
 
 let table = new ex.Table( 
     name: "users",
@@ -15,20 +16,9 @@ test "get" {
   let NON_EXISTENT_KEY = "bar";
   let ROW_DOES_NOT_EXIST_ERROR = "Row does not exist (key=${NON_EXISTENT_KEY})";
 
-  let assertThrows = (expected: str, block: (): void) => {
-    let var error = false;
-    try {
-      block();
-    } catch actual {
-      assert(actual == expected);
-      error = true;
-    }
-    assert(error);
-  };
-
   table.insert(VALID_KEY, Json { gender: COLUMN_VALUE });
   assert(table.get(VALID_KEY).get(COLUMN_NAME) == COLUMN_VALUE);
-  assertThrows(ROW_DOES_NOT_EXIST_ERROR, () => {
+  assertions.Assert.throws(ROW_DOES_NOT_EXIST_ERROR, () => {
     table.get(NON_EXISTENT_KEY);
   });
 

--- a/examples/tests/sdk_tests/table/upsert.test.w
+++ b/examples/tests/sdk_tests/table/upsert.test.w
@@ -1,5 +1,6 @@
 bring ex;
 bring util;
+bring "./../../valid/assertions.w" as assertions;
 
 let table = new ex.Table(
   name: "users",
@@ -14,17 +15,6 @@ table.addRow("mario", { gender: "male", role: "plumber" });
 table.addRow("luigi", { gender: "male", role: "plumber" });
 
 test "upsert" {
-  let assertThrows = (expected: str, block: (): void) => {
-    let var error = false;
-    try {
-        block();
-    } catch actual {
-      assert(actual == expected);
-      error = true;
-    }
-    assert(error);
-  };
-
   let JSON_PROPERTY_ROLE_DOES_NOT_EXIST_ERROR = "Json property \"role\" does not exist";
   let JSON_PROPERTY_GENDER_DOES_NOT_EXIST_ERROR = "Json property \"gender\" does not exist";
 
@@ -32,15 +22,15 @@ test "upsert" {
   table.upsert("luigi", { role: "ghostbuster" });
   table.upsert("peach", { gender: "female", role: "princess" });
 
-  assertThrows(JSON_PROPERTY_ROLE_DOES_NOT_EXIST_ERROR, () => {
+  assertions.Assert.throws(JSON_PROPERTY_ROLE_DOES_NOT_EXIST_ERROR, () => {
     table.get("mario").get("role");
   });
-  assertThrows(JSON_PROPERTY_GENDER_DOES_NOT_EXIST_ERROR, () => {
+  assertions.Assert.throws(JSON_PROPERTY_GENDER_DOES_NOT_EXIST_ERROR, () => {
     table.get("mario").get("gender");
   });
 
   assert(table.get("luigi").get("role") == "ghostbuster");
-  assertThrows(JSON_PROPERTY_GENDER_DOES_NOT_EXIST_ERROR, () => {
+  assertions.Assert.throws(JSON_PROPERTY_GENDER_DOES_NOT_EXIST_ERROR, () => {
     table.get("luigi").get("gender");
   });
 

--- a/examples/tests/valid/api_valid_path.test.w
+++ b/examples/tests/valid/api_valid_path.test.w
@@ -1,4 +1,5 @@
 bring cloud;
+bring "./assertions.w" as assertions;
 
 let api = new cloud.Api();
 
@@ -12,13 +13,9 @@ let handler = inflight (req: cloud.ApiRequest): cloud.ApiResponse => {
 
 let testInvalidPath = (path:str) => {
   let var error = "";
-  let expected = "Invalid path ${path}. Url parts can only contain alpha-numeric chars, \"-\", \"_\" and \".\". Params can only contain alpha-numeric chars and \"_\".";
-  try {
+  assertions.PreflightAssert.throws("Invalid path ${path}. Url parts can only contain alpha-numeric chars, \"-\", \"_\" and \".\". Params can only contain alpha-numeric chars and \"_\".", () => {
     api.get(path, handler);
-  } catch e {
-    error = e;
-  }
-  assert(error == expected);
+  });
 };
 
 let testValidPath = (path:str) => {

--- a/examples/tests/valid/assertions.w
+++ b/examples/tests/valid/assertions.w
@@ -4,6 +4,21 @@
 // - website_with_api.test.w
 
 inflight class Assert {
+  pub static throws(expected: str, block: (): void): void {
+    let var actual = "";
+    try {
+      block();
+    } catch e {
+      actual = e;
+    }
+    if (actual == "") {
+      throw("expected error, but none thrown.");
+    }
+    if (actual != expected) {
+      throw("expected error message: \"${expected}\" got: \"${actual}\"");
+    }
+  }
+
   pub static equalStr(a: str, b: str): bool {
     try {
       assert(a == b);
@@ -27,6 +42,23 @@ inflight class Assert {
     } catch e {
       log(e);
       throw("expected: ${b} got: ${a}");
+    }
+  }
+}
+
+class PreflightAssert {
+  pub static throws(expected: str, block: (): void): void {
+    let var actual = "";
+    try {
+      block();
+    } catch e {
+      actual = e;
+    }
+    if (actual == "") {
+      throw("expected error, but none thrown.");
+    }
+    if (actual != expected) {
+      throw("expected error message: \"${expected}\" got: \"${actual}\"");
     }
   }
 }

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/delete.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/delete.test.w_compile_tf-aws.md
@@ -1,8 +1,8 @@
 # [delete.test.w](../../../../../../examples/tests/sdk_tests/bucket/delete.test.w) | compile | tf-aws
 
-## inflight.$Closure1-1.js
+## inflight.$Closure1-2.js
 ```js
-module.exports = function({ $b }) {
+module.exports = function({ $assertions_Assert, $b }) {
   class $Closure1 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
@@ -10,19 +10,6 @@ module.exports = function({ $b }) {
       return $obj;
     }
     async handle() {
-      const assertThrows = async (expected, block) => {
-        let error = false;
-        try {
-          (await block());
-        }
-        catch ($error_actual) {
-          const actual = $error_actual.message;
-          {((cond) => {if (!cond) throw new Error("assertion failed: actual == expected")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(actual,expected)))};
-          error = true;
-        }
-        {((cond) => {if (!cond) throw new Error("assertion failed: error")})(error)};
-      }
-      ;
       const OBJECT_DOES_NOT_EXIST_ERROR = "Object does not exist (key=file1.json).";
       const jsonObj1 = ({"key1": "value1"});
       (await $b.putJson("file1.json",jsonObj1));
@@ -30,7 +17,7 @@ module.exports = function({ $b }) {
       {((cond) => {if (!cond) throw new Error("assertion failed: b.exists(\"file1.json\")")})((await $b.exists("file1.json")))};
       {((cond) => {if (!cond) throw new Error("assertion failed: b.exists(\"file2.txt\")")})((await $b.exists("file2.txt")))};
       (await $b.delete("file1.json",{ mustExist: true }));
-      (await assertThrows(OBJECT_DOES_NOT_EXIST_ERROR,async () => {
+      (await $assertions_Assert.throws(OBJECT_DOES_NOT_EXIST_ERROR,async () => {
         (await $b.delete("file1.json",{ mustExist: true }));
       }
       ));
@@ -40,6 +27,73 @@ module.exports = function({ $b }) {
     }
   }
   return $Closure1;
+}
+
+```
+
+## inflight.Assert-1.js
+```js
+module.exports = function({  }) {
+  class Assert {
+    static async throws(expected, block) {
+      let actual = "";
+      try {
+        (await block());
+      }
+      catch ($error_e) {
+        const e = $error_e.message;
+        actual = e;
+      }
+      if ((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(actual,""))) {
+        throw new Error("expected error, but none thrown.");
+      }
+      if ((((a,b) => { try { return require('assert').notDeepStrictEqual(a,b) === undefined; } catch { return false; } })(actual,expected))) {
+        throw new Error(String.raw({ raw: ["expected error message: \"", "\" got: \"", "\""] }, expected, actual));
+      }
+    }
+    static async equalStr(a, b) {
+      try {
+        {((cond) => {if (!cond) throw new Error("assertion failed: a == b")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(a,b)))};
+      }
+      catch ($error_e) {
+        const e = $error_e.message;
+        throw new Error(String.raw({ raw: ["expected: ", " got: ", ""] }, b, a));
+      }
+    }
+    static async isNil(a) {
+      try {
+        {((cond) => {if (!cond) throw new Error("assertion failed: a == nil")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(a,undefined)))};
+      }
+      catch ($error_e) {
+        const e = $error_e.message;
+        {console.log(e)};
+        throw new Error(String.raw({ raw: ["expected '", "' to be nil"] }, a));
+      }
+    }
+    static async equalNum(a, b) {
+      try {
+        {((cond) => {if (!cond) throw new Error("assertion failed: a == b")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(a,b)))};
+      }
+      catch ($error_e) {
+        const e = $error_e.message;
+        {console.log(e)};
+        throw new Error(String.raw({ raw: ["expected: ", " got: ", ""] }, b, a));
+      }
+    }
+  }
+  return Assert;
+}
+
+```
+
+## inflight.PreflightAssert-1.js
+```js
+module.exports = function({  }) {
+  class PreflightAssert {
+    constructor({  }) {
+    }
+  }
+  return PreflightAssert;
 }
 
 ```
@@ -103,6 +157,81 @@ module.exports = function({ $b }) {
 }
 ```
 
+## preflight.assertions-1.js
+```js
+module.exports = function({ $stdlib }) {
+  const std = $stdlib.std;
+  class Assert extends $stdlib.std.Resource {
+    constructor(scope, id, ) {
+      super(scope, id);
+    }
+    static _toInflightType(context) {
+      return `
+        require("./inflight.Assert-1.js")({
+        })
+      `;
+    }
+    _toInflight() {
+      return `
+        (await (async () => {
+          const AssertClient = ${Assert._toInflightType(this)};
+          const client = new AssertClient({
+          });
+          if (client.$inflight_init) { await client.$inflight_init(); }
+          return client;
+        })())
+      `;
+    }
+    _getInflightOps() {
+      return ["throws", "equalStr", "isNil", "equalNum", "$inflight_init"];
+    }
+  }
+  class PreflightAssert extends $stdlib.std.Resource {
+    constructor(scope, id, ) {
+      super(scope, id);
+    }
+    static throws(expected, block) {
+      let actual = "";
+      try {
+        (block());
+      }
+      catch ($error_e) {
+        const e = $error_e.message;
+        actual = e;
+      }
+      if ((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(actual,""))) {
+        throw new Error("expected error, but none thrown.");
+      }
+      if ((((a,b) => { try { return require('assert').notDeepStrictEqual(a,b) === undefined; } catch { return false; } })(actual,expected))) {
+        throw new Error(String.raw({ raw: ["expected error message: \"", "\" got: \"", "\""] }, expected, actual));
+      }
+    }
+    static _toInflightType(context) {
+      return `
+        require("./inflight.PreflightAssert-1.js")({
+        })
+      `;
+    }
+    _toInflight() {
+      return `
+        (await (async () => {
+          const PreflightAssertClient = ${PreflightAssert._toInflightType(this)};
+          const client = new PreflightAssertClient({
+          });
+          if (client.$inflight_init) { await client.$inflight_init(); }
+          return client;
+        })())
+      `;
+    }
+    _getInflightOps() {
+      return ["$inflight_init"];
+    }
+  }
+  return { Assert, PreflightAssert };
+};
+
+```
+
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
@@ -111,6 +240,7 @@ const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const cloud = $stdlib.cloud;
+const assertions = require("./preflight.assertions-1.js")({ $stdlib });
 class $Root extends $stdlib.std.Resource {
   constructor(scope, id) {
     super(scope, id);
@@ -121,7 +251,8 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("./inflight.$Closure1-2.js")({
+            $assertions_Assert: ${context._lift($stdlib.core.toLiftableModuleType(assertions.Assert, "", "Assert"))},
             $b: ${context._lift(b)},
           })
         `;

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/public_url.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/public_url.test.w_compile_tf-aws.md
@@ -1,8 +1,8 @@
 # [public_url.test.w](../../../../../../examples/tests/sdk_tests/bucket/public_url.test.w) | compile | tf-aws
 
-## inflight.$Closure1-1.js
+## inflight.$Closure1-2.js
 ```js
-module.exports = function({ $http_Util, $privateBucket, $publicBucket, $util_Util }) {
+module.exports = function({ $assertions_Assert, $http_Util, $privateBucket, $publicBucket, $util_Util }) {
   class $Closure1 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
@@ -10,19 +10,6 @@ module.exports = function({ $http_Util, $privateBucket, $publicBucket, $util_Uti
       return $obj;
     }
     async handle() {
-      const assertThrows = async (expected, block) => {
-        let error = false;
-        try {
-          (await block());
-        }
-        catch ($error_actual) {
-          const actual = $error_actual.message;
-          {((cond) => {if (!cond) throw new Error("assertion failed: actual == expected")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(actual,expected)))};
-          error = true;
-        }
-        {((cond) => {if (!cond) throw new Error("assertion failed: error")})(error)};
-      }
-      ;
       const BUCKET_NOT_PUBLIC_ERROR = "Cannot provide public url for a non-public bucket";
       (await $publicBucket.put("file1.txt","Foo"));
       (await $privateBucket.put("file2.txt","Bar"));
@@ -31,13 +18,80 @@ module.exports = function({ $http_Util, $privateBucket, $publicBucket, $util_Uti
       if ((((a,b) => { try { return require('assert').notDeepStrictEqual(a,b) === undefined; } catch { return false; } })((await $util_Util.env("WING_TARGET")),"sim"))) {
         {((cond) => {if (!cond) throw new Error("assertion failed: http.get(publicUrl).body ==  \"Foo\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $http_Util.get(publicUrl)).body,"Foo")))};
       }
-      (await assertThrows(BUCKET_NOT_PUBLIC_ERROR,async () => {
+      (await $assertions_Assert.throws(BUCKET_NOT_PUBLIC_ERROR,async () => {
         (await $privateBucket.publicUrl("file2.txt"));
       }
       ));
     }
   }
   return $Closure1;
+}
+
+```
+
+## inflight.Assert-1.js
+```js
+module.exports = function({  }) {
+  class Assert {
+    static async throws(expected, block) {
+      let actual = "";
+      try {
+        (await block());
+      }
+      catch ($error_e) {
+        const e = $error_e.message;
+        actual = e;
+      }
+      if ((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(actual,""))) {
+        throw new Error("expected error, but none thrown.");
+      }
+      if ((((a,b) => { try { return require('assert').notDeepStrictEqual(a,b) === undefined; } catch { return false; } })(actual,expected))) {
+        throw new Error(String.raw({ raw: ["expected error message: \"", "\" got: \"", "\""] }, expected, actual));
+      }
+    }
+    static async equalStr(a, b) {
+      try {
+        {((cond) => {if (!cond) throw new Error("assertion failed: a == b")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(a,b)))};
+      }
+      catch ($error_e) {
+        const e = $error_e.message;
+        throw new Error(String.raw({ raw: ["expected: ", " got: ", ""] }, b, a));
+      }
+    }
+    static async isNil(a) {
+      try {
+        {((cond) => {if (!cond) throw new Error("assertion failed: a == nil")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(a,undefined)))};
+      }
+      catch ($error_e) {
+        const e = $error_e.message;
+        {console.log(e)};
+        throw new Error(String.raw({ raw: ["expected '", "' to be nil"] }, a));
+      }
+    }
+    static async equalNum(a, b) {
+      try {
+        {((cond) => {if (!cond) throw new Error("assertion failed: a == b")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(a,b)))};
+      }
+      catch ($error_e) {
+        const e = $error_e.message;
+        {console.log(e)};
+        throw new Error(String.raw({ raw: ["expected: ", " got: ", ""] }, b, a));
+      }
+    }
+  }
+  return Assert;
+}
+
+```
+
+## inflight.PreflightAssert-1.js
+```js
+module.exports = function({  }) {
+  class PreflightAssert {
+    constructor({  }) {
+    }
+  }
+  return PreflightAssert;
 }
 
 ```
@@ -128,6 +182,81 @@ module.exports = function({ $http_Util, $privateBucket, $publicBucket, $util_Uti
 }
 ```
 
+## preflight.assertions-1.js
+```js
+module.exports = function({ $stdlib }) {
+  const std = $stdlib.std;
+  class Assert extends $stdlib.std.Resource {
+    constructor(scope, id, ) {
+      super(scope, id);
+    }
+    static _toInflightType(context) {
+      return `
+        require("./inflight.Assert-1.js")({
+        })
+      `;
+    }
+    _toInflight() {
+      return `
+        (await (async () => {
+          const AssertClient = ${Assert._toInflightType(this)};
+          const client = new AssertClient({
+          });
+          if (client.$inflight_init) { await client.$inflight_init(); }
+          return client;
+        })())
+      `;
+    }
+    _getInflightOps() {
+      return ["throws", "equalStr", "isNil", "equalNum", "$inflight_init"];
+    }
+  }
+  class PreflightAssert extends $stdlib.std.Resource {
+    constructor(scope, id, ) {
+      super(scope, id);
+    }
+    static throws(expected, block) {
+      let actual = "";
+      try {
+        (block());
+      }
+      catch ($error_e) {
+        const e = $error_e.message;
+        actual = e;
+      }
+      if ((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(actual,""))) {
+        throw new Error("expected error, but none thrown.");
+      }
+      if ((((a,b) => { try { return require('assert').notDeepStrictEqual(a,b) === undefined; } catch { return false; } })(actual,expected))) {
+        throw new Error(String.raw({ raw: ["expected error message: \"", "\" got: \"", "\""] }, expected, actual));
+      }
+    }
+    static _toInflightType(context) {
+      return `
+        require("./inflight.PreflightAssert-1.js")({
+        })
+      `;
+    }
+    _toInflight() {
+      return `
+        (await (async () => {
+          const PreflightAssertClient = ${PreflightAssert._toInflightType(this)};
+          const client = new PreflightAssertClient({
+          });
+          if (client.$inflight_init) { await client.$inflight_init(); }
+          return client;
+        })())
+      `;
+    }
+    _getInflightOps() {
+      return ["$inflight_init"];
+    }
+  }
+  return { Assert, PreflightAssert };
+};
+
+```
+
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
@@ -138,6 +267,7 @@ const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 const http = $stdlib.http;
 const util = $stdlib.util;
+const assertions = require("./preflight.assertions-1.js")({ $stdlib });
 class $Root extends $stdlib.std.Resource {
   constructor(scope, id) {
     super(scope, id);
@@ -148,7 +278,8 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("./inflight.$Closure1-2.js")({
+            $assertions_Assert: ${context._lift($stdlib.core.toLiftableModuleType(assertions.Assert, "", "Assert"))},
             $http_Util: ${context._lift($stdlib.core.toLiftableModuleType(http.Util, "@winglang/sdk/http", "Util"))},
             $privateBucket: ${context._lift(privateBucket)},
             $publicBucket: ${context._lift(publicBucket)},

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/signed_url.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/signed_url.test.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [signed_url.test.w](../../../../../../examples/tests/sdk_tests/bucket/signed_url.test.w) | compile | tf-aws
 
-## inflight.$Closure1-1.js
+## inflight.$Closure1-2.js
 ```js
 module.exports = function({ $http_Util, $testBucket, $util_Util }) {
   class $Closure1 {
@@ -23,9 +23,9 @@ module.exports = function({ $http_Util, $testBucket, $util_Util }) {
 
 ```
 
-## inflight.$Closure2-1.js
+## inflight.$Closure2-2.js
 ```js
-module.exports = function({ $testBucket, $util_Util }) {
+module.exports = function({ $assertions_Assert, $testBucket, $util_Util }) {
   class $Closure2 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
@@ -35,18 +35,81 @@ module.exports = function({ $testBucket, $util_Util }) {
     async handle() {
       let error = "";
       if ((((a,b) => { try { return require('assert').notDeepStrictEqual(a,b) === undefined; } catch { return false; } })((await $util_Util.env("WING_TARGET")),"sim"))) {
-        try {
+        (await $assertions_Assert.throws("Cannot provide signed url for a non-existent key (key=file.txt)",async () => {
           const signedUrl = (await $testBucket.signedUrl("file.txt"));
         }
-        catch ($error_e) {
-          const e = $error_e.message;
-          error = e;
-        }
-        {((cond) => {if (!cond) throw new Error("assertion failed: error == \"Cannot provide signed url for a non-existent key (key=file.txt)\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(error,"Cannot provide signed url for a non-existent key (key=file.txt)")))};
+        ));
       }
     }
   }
   return $Closure2;
+}
+
+```
+
+## inflight.Assert-1.js
+```js
+module.exports = function({  }) {
+  class Assert {
+    static async throws(expected, block) {
+      let actual = "";
+      try {
+        (await block());
+      }
+      catch ($error_e) {
+        const e = $error_e.message;
+        actual = e;
+      }
+      if ((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(actual,""))) {
+        throw new Error("expected error, but none thrown.");
+      }
+      if ((((a,b) => { try { return require('assert').notDeepStrictEqual(a,b) === undefined; } catch { return false; } })(actual,expected))) {
+        throw new Error(String.raw({ raw: ["expected error message: \"", "\" got: \"", "\""] }, expected, actual));
+      }
+    }
+    static async equalStr(a, b) {
+      try {
+        {((cond) => {if (!cond) throw new Error("assertion failed: a == b")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(a,b)))};
+      }
+      catch ($error_e) {
+        const e = $error_e.message;
+        throw new Error(String.raw({ raw: ["expected: ", " got: ", ""] }, b, a));
+      }
+    }
+    static async isNil(a) {
+      try {
+        {((cond) => {if (!cond) throw new Error("assertion failed: a == nil")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(a,undefined)))};
+      }
+      catch ($error_e) {
+        const e = $error_e.message;
+        {console.log(e)};
+        throw new Error(String.raw({ raw: ["expected '", "' to be nil"] }, a));
+      }
+    }
+    static async equalNum(a, b) {
+      try {
+        {((cond) => {if (!cond) throw new Error("assertion failed: a == b")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(a,b)))};
+      }
+      catch ($error_e) {
+        const e = $error_e.message;
+        {console.log(e)};
+        throw new Error(String.raw({ raw: ["expected: ", " got: ", ""] }, b, a));
+      }
+    }
+  }
+  return Assert;
+}
+
+```
+
+## inflight.PreflightAssert-1.js
+```js
+module.exports = function({  }) {
+  class PreflightAssert {
+    constructor({  }) {
+    }
+  }
+  return PreflightAssert;
 }
 
 ```
@@ -127,6 +190,81 @@ module.exports = function({ $testBucket, $util_Util }) {
 }
 ```
 
+## preflight.assertions-1.js
+```js
+module.exports = function({ $stdlib }) {
+  const std = $stdlib.std;
+  class Assert extends $stdlib.std.Resource {
+    constructor(scope, id, ) {
+      super(scope, id);
+    }
+    static _toInflightType(context) {
+      return `
+        require("./inflight.Assert-1.js")({
+        })
+      `;
+    }
+    _toInflight() {
+      return `
+        (await (async () => {
+          const AssertClient = ${Assert._toInflightType(this)};
+          const client = new AssertClient({
+          });
+          if (client.$inflight_init) { await client.$inflight_init(); }
+          return client;
+        })())
+      `;
+    }
+    _getInflightOps() {
+      return ["throws", "equalStr", "isNil", "equalNum", "$inflight_init"];
+    }
+  }
+  class PreflightAssert extends $stdlib.std.Resource {
+    constructor(scope, id, ) {
+      super(scope, id);
+    }
+    static throws(expected, block) {
+      let actual = "";
+      try {
+        (block());
+      }
+      catch ($error_e) {
+        const e = $error_e.message;
+        actual = e;
+      }
+      if ((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(actual,""))) {
+        throw new Error("expected error, but none thrown.");
+      }
+      if ((((a,b) => { try { return require('assert').notDeepStrictEqual(a,b) === undefined; } catch { return false; } })(actual,expected))) {
+        throw new Error(String.raw({ raw: ["expected error message: \"", "\" got: \"", "\""] }, expected, actual));
+      }
+    }
+    static _toInflightType(context) {
+      return `
+        require("./inflight.PreflightAssert-1.js")({
+        })
+      `;
+    }
+    _toInflight() {
+      return `
+        (await (async () => {
+          const PreflightAssertClient = ${PreflightAssert._toInflightType(this)};
+          const client = new PreflightAssertClient({
+          });
+          if (client.$inflight_init) { await client.$inflight_init(); }
+          return client;
+        })())
+      `;
+    }
+    _getInflightOps() {
+      return ["$inflight_init"];
+    }
+  }
+  return { Assert, PreflightAssert };
+};
+
+```
+
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
@@ -137,6 +275,7 @@ const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 const http = $stdlib.http;
 const util = $stdlib.util;
+const assertions = require("./preflight.assertions-1.js")({ $stdlib });
 class $Root extends $stdlib.std.Resource {
   constructor(scope, id) {
     super(scope, id);
@@ -147,7 +286,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("./inflight.$Closure1-2.js")({
             $http_Util: ${context._lift($stdlib.core.toLiftableModuleType(http.Util, "@winglang/sdk/http", "Util"))},
             $testBucket: ${context._lift(testBucket)},
             $util_Util: ${context._lift($stdlib.core.toLiftableModuleType(util.Util, "@winglang/sdk/util", "Util"))},
@@ -182,7 +321,8 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return `
-          require("./inflight.$Closure2-1.js")({
+          require("./inflight.$Closure2-2.js")({
+            $assertions_Assert: ${context._lift($stdlib.core.toLiftableModuleType(assertions.Assert, "", "Assert"))},
             $testBucket: ${context._lift(testBucket)},
             $util_Util: ${context._lift($stdlib.core.toLiftableModuleType(util.Util, "@winglang/sdk/util", "Util"))},
           })

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/http/url.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/http/url.test.w_compile_tf-aws.md
@@ -1,8 +1,8 @@
 # [url.test.w](../../../../../../examples/tests/sdk_tests/http/url.test.w) | compile | tf-aws
 
-## inflight.$Closure1-1.js
+## inflight.$Closure1-2.js
 ```js
-module.exports = function({ $http_Util }) {
+module.exports = function({ $assertions_Assert, $http_Util }) {
   class $Closure1 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
@@ -10,26 +10,13 @@ module.exports = function({ $http_Util }) {
       return $obj;
     }
     async handle() {
-      const assertThrows = async (expected, block) => {
-        let error = false;
-        try {
-          (await block());
-        }
-        catch ($error_actual) {
-          const actual = $error_actual.message;
-          {((cond) => {if (!cond) throw new Error("assertion failed: actual == expected")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(actual,expected)))};
-          error = true;
-        }
-        {((cond) => {if (!cond) throw new Error("assertion failed: error")})(error)};
-      }
-      ;
       const INVALID_URL_STRING = "hello world";
       const INVALID_URL_ERROR = String.raw({ raw: ["Invalid URL: ", ""] }, INVALID_URL_STRING);
       const URL_STRING = "http://username:password@www.example.com:3000/pathname?search=test#hash";
       const urlStruct = ({"href": URL_STRING,"protocol": "http:","host": "www.example.com:3000","hostname": "www.example.com","port": "3000","pathname": "/pathname","search": "?search=test","hash": "#hash","origin": "http://www.example.com:3000","username": "username","password": "password"});
       const parsedUrlStruct = (await $http_Util.parseUrl(URL_STRING));
       {((cond) => {if (!cond) throw new Error("assertion failed: urlStruct == parsedUrlStruct")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(urlStruct,parsedUrlStruct)))};
-      (await assertThrows(INVALID_URL_ERROR,async () => {
+      (await $assertions_Assert.throws(INVALID_URL_ERROR,async () => {
         const invalidUrlStruct = (await $http_Util.parseUrl(INVALID_URL_STRING));
       }
       ));
@@ -40,9 +27,9 @@ module.exports = function({ $http_Util }) {
 
 ```
 
-## inflight.$Closure2-1.js
+## inflight.$Closure2-2.js
 ```js
-module.exports = function({ $http_Util }) {
+module.exports = function({ $assertions_Assert, $http_Util }) {
   class $Closure2 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
@@ -50,19 +37,6 @@ module.exports = function({ $http_Util }) {
       return $obj;
     }
     async handle() {
-      const assertThrows = async (expected, block) => {
-        let error = false;
-        try {
-          (await block());
-        }
-        catch ($error_actual) {
-          const actual = $error_actual.message;
-          {((cond) => {if (!cond) throw new Error("assertion failed: actual == expected")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(actual,expected)))};
-          error = true;
-        }
-        {((cond) => {if (!cond) throw new Error("assertion failed: error")})(error)};
-      }
-      ;
       const UNABLE_TO_FORMAT_URL_STRUCT_ERROR = "Unable to format URL Struct: Invalid URL";
       const urlStruct = (await $http_Util.parseUrl("https://a:b@測試.com/path?query=1#fragment"));
       {((cond) => {if (!cond) throw new Error("assertion failed: http.formatUrl(urlStruct, { unicode: false }) == \"https://a:b@xn--g6w251d.com/path?query=1#fragment\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $http_Util.formatUrl(urlStruct,({"unicode": false}))),"https://a:b@xn--g6w251d.com/path?query=1#fragment")))};
@@ -74,13 +48,80 @@ module.exports = function({ $http_Util }) {
       {((cond) => {if (!cond) throw new Error("assertion failed: http.formatUrl(urlStruct, { auth: false }) == \"https://xn--g6w251d.com/path?query=1#fragment\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $http_Util.formatUrl(urlStruct,({"auth": false}))),"https://xn--g6w251d.com/path?query=1#fragment")))};
       {((cond) => {if (!cond) throw new Error("assertion failed: http.formatUrl(urlStruct, { auth: true }) == \"https://a:b@xn--g6w251d.com/path?query=1#fragment\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $http_Util.formatUrl(urlStruct,({"auth": true}))),"https://a:b@xn--g6w251d.com/path?query=1#fragment")))};
       const invalidUrlStruct = ({"href": "hello world","protocol": urlStruct.protocol,"host": urlStruct.host,"hostname": urlStruct.hostname,"port": urlStruct.hostname,"pathname": urlStruct.pathname,"search": urlStruct.search,"hash": urlStruct.hash,"origin": urlStruct.origin,"username": urlStruct.username,"password": urlStruct.password});
-      (await assertThrows(UNABLE_TO_FORMAT_URL_STRUCT_ERROR,async () => {
+      (await $assertions_Assert.throws(UNABLE_TO_FORMAT_URL_STRUCT_ERROR,async () => {
         (await $http_Util.formatUrl(invalidUrlStruct));
       }
       ));
     }
   }
   return $Closure2;
+}
+
+```
+
+## inflight.Assert-1.js
+```js
+module.exports = function({  }) {
+  class Assert {
+    static async throws(expected, block) {
+      let actual = "";
+      try {
+        (await block());
+      }
+      catch ($error_e) {
+        const e = $error_e.message;
+        actual = e;
+      }
+      if ((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(actual,""))) {
+        throw new Error("expected error, but none thrown.");
+      }
+      if ((((a,b) => { try { return require('assert').notDeepStrictEqual(a,b) === undefined; } catch { return false; } })(actual,expected))) {
+        throw new Error(String.raw({ raw: ["expected error message: \"", "\" got: \"", "\""] }, expected, actual));
+      }
+    }
+    static async equalStr(a, b) {
+      try {
+        {((cond) => {if (!cond) throw new Error("assertion failed: a == b")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(a,b)))};
+      }
+      catch ($error_e) {
+        const e = $error_e.message;
+        throw new Error(String.raw({ raw: ["expected: ", " got: ", ""] }, b, a));
+      }
+    }
+    static async isNil(a) {
+      try {
+        {((cond) => {if (!cond) throw new Error("assertion failed: a == nil")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(a,undefined)))};
+      }
+      catch ($error_e) {
+        const e = $error_e.message;
+        {console.log(e)};
+        throw new Error(String.raw({ raw: ["expected '", "' to be nil"] }, a));
+      }
+    }
+    static async equalNum(a, b) {
+      try {
+        {((cond) => {if (!cond) throw new Error("assertion failed: a == b")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(a,b)))};
+      }
+      catch ($error_e) {
+        const e = $error_e.message;
+        {console.log(e)};
+        throw new Error(String.raw({ raw: ["expected: ", " got: ", ""] }, b, a));
+      }
+    }
+  }
+  return Assert;
+}
+
+```
+
+## inflight.PreflightAssert-1.js
+```js
+module.exports = function({  }) {
+  class PreflightAssert {
+    constructor({  }) {
+    }
+  }
+  return PreflightAssert;
 }
 
 ```
@@ -117,6 +158,81 @@ module.exports = function({ $http_Util }) {
 }
 ```
 
+## preflight.assertions-1.js
+```js
+module.exports = function({ $stdlib }) {
+  const std = $stdlib.std;
+  class Assert extends $stdlib.std.Resource {
+    constructor(scope, id, ) {
+      super(scope, id);
+    }
+    static _toInflightType(context) {
+      return `
+        require("./inflight.Assert-1.js")({
+        })
+      `;
+    }
+    _toInflight() {
+      return `
+        (await (async () => {
+          const AssertClient = ${Assert._toInflightType(this)};
+          const client = new AssertClient({
+          });
+          if (client.$inflight_init) { await client.$inflight_init(); }
+          return client;
+        })())
+      `;
+    }
+    _getInflightOps() {
+      return ["throws", "equalStr", "isNil", "equalNum", "$inflight_init"];
+    }
+  }
+  class PreflightAssert extends $stdlib.std.Resource {
+    constructor(scope, id, ) {
+      super(scope, id);
+    }
+    static throws(expected, block) {
+      let actual = "";
+      try {
+        (block());
+      }
+      catch ($error_e) {
+        const e = $error_e.message;
+        actual = e;
+      }
+      if ((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(actual,""))) {
+        throw new Error("expected error, but none thrown.");
+      }
+      if ((((a,b) => { try { return require('assert').notDeepStrictEqual(a,b) === undefined; } catch { return false; } })(actual,expected))) {
+        throw new Error(String.raw({ raw: ["expected error message: \"", "\" got: \"", "\""] }, expected, actual));
+      }
+    }
+    static _toInflightType(context) {
+      return `
+        require("./inflight.PreflightAssert-1.js")({
+        })
+      `;
+    }
+    _toInflight() {
+      return `
+        (await (async () => {
+          const PreflightAssertClient = ${PreflightAssert._toInflightType(this)};
+          const client = new PreflightAssertClient({
+          });
+          if (client.$inflight_init) { await client.$inflight_init(); }
+          return client;
+        })())
+      `;
+    }
+    _getInflightOps() {
+      return ["$inflight_init"];
+    }
+  }
+  return { Assert, PreflightAssert };
+};
+
+```
+
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
@@ -125,6 +241,7 @@ const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const http = $stdlib.http;
+const assertions = require("./preflight.assertions-1.js")({ $stdlib });
 class $Root extends $stdlib.std.Resource {
   constructor(scope, id) {
     super(scope, id);
@@ -135,7 +252,8 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("./inflight.$Closure1-2.js")({
+            $assertions_Assert: ${context._lift($stdlib.core.toLiftableModuleType(assertions.Assert, "", "Assert"))},
             $http_Util: ${context._lift($stdlib.core.toLiftableModuleType(http.Util, "@winglang/sdk/http", "Util"))},
           })
         `;
@@ -162,7 +280,8 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return `
-          require("./inflight.$Closure2-1.js")({
+          require("./inflight.$Closure2-2.js")({
+            $assertions_Assert: ${context._lift($stdlib.core.toLiftableModuleType(assertions.Assert, "", "Assert"))},
             $http_Util: ${context._lift($stdlib.core.toLiftableModuleType(http.Util, "@winglang/sdk/http", "Util"))},
           })
         `;

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/acos.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/acos.test.w_compile_tf-aws.md
@@ -1,8 +1,8 @@
 # [acos.test.w](../../../../../../examples/tests/sdk_tests/math/acos.test.w) | compile | tf-aws
 
-## inflight.$Closure1-1.js
+## inflight.$Closure1-2.js
 ```js
-module.exports = function({ $math_Util }) {
+module.exports = function({ $assertions_Assert, $math_Util }) {
   class $Closure1 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
@@ -10,28 +10,89 @@ module.exports = function({ $math_Util }) {
       return $obj;
     }
     async handle() {
-      try {
+      (await $assertions_Assert.throws("Input value must be between -1 and 1, inclusive.",async () => {
         {console.log(String.raw({ raw: ["", ""] }, (await $math_Util.acos((-2)))))};
       }
-      catch ($error_e) {
-        const e = $error_e.message;
-        {((cond) => {if (!cond) throw new Error("assertion failed: e == \"Input value must be between -1 and 1, inclusive.\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(e,"Input value must be between -1 and 1, inclusive.")))};
-      }
+      ));
       {((cond) => {if (!cond) throw new Error("assertion failed: math.acos(-1) == math.PI")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $math_Util.acos((-1))),$math_Util.PI)))};
       {((cond) => {if (!cond) throw new Error("assertion failed: math.acos(-0) == 1.5707963267948966")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $math_Util.acos((-0))),1.5707963267948966)))};
       {((cond) => {if (!cond) throw new Error("assertion failed: math.acos(0) == 1.5707963267948966")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $math_Util.acos(0)),1.5707963267948966)))};
       {((cond) => {if (!cond) throw new Error("assertion failed: math.acos(0.5) == 1.0471975511965979")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $math_Util.acos(0.5)),1.0471975511965979)))};
       {((cond) => {if (!cond) throw new Error("assertion failed: math.acos(1) == 0")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $math_Util.acos(1)),0)))};
-      try {
+      (await $assertions_Assert.throws("Input value must be between -1 and 1, inclusive.",async () => {
         {console.log(String.raw({ raw: ["", ""] }, (await $math_Util.acos(2))))};
       }
-      catch ($error_e) {
-        const e = $error_e.message;
-        {((cond) => {if (!cond) throw new Error("assertion failed: e == \"Input value must be between -1 and 1, inclusive.\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(e,"Input value must be between -1 and 1, inclusive.")))};
-      }
+      ));
     }
   }
   return $Closure1;
+}
+
+```
+
+## inflight.Assert-1.js
+```js
+module.exports = function({  }) {
+  class Assert {
+    static async throws(expected, block) {
+      let actual = "";
+      try {
+        (await block());
+      }
+      catch ($error_e) {
+        const e = $error_e.message;
+        actual = e;
+      }
+      if ((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(actual,""))) {
+        throw new Error("expected error, but none thrown.");
+      }
+      if ((((a,b) => { try { return require('assert').notDeepStrictEqual(a,b) === undefined; } catch { return false; } })(actual,expected))) {
+        throw new Error(String.raw({ raw: ["expected error message: \"", "\" got: \"", "\""] }, expected, actual));
+      }
+    }
+    static async equalStr(a, b) {
+      try {
+        {((cond) => {if (!cond) throw new Error("assertion failed: a == b")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(a,b)))};
+      }
+      catch ($error_e) {
+        const e = $error_e.message;
+        throw new Error(String.raw({ raw: ["expected: ", " got: ", ""] }, b, a));
+      }
+    }
+    static async isNil(a) {
+      try {
+        {((cond) => {if (!cond) throw new Error("assertion failed: a == nil")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(a,undefined)))};
+      }
+      catch ($error_e) {
+        const e = $error_e.message;
+        {console.log(e)};
+        throw new Error(String.raw({ raw: ["expected '", "' to be nil"] }, a));
+      }
+    }
+    static async equalNum(a, b) {
+      try {
+        {((cond) => {if (!cond) throw new Error("assertion failed: a == b")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(a,b)))};
+      }
+      catch ($error_e) {
+        const e = $error_e.message;
+        {console.log(e)};
+        throw new Error(String.raw({ raw: ["expected: ", " got: ", ""] }, b, a));
+      }
+    }
+  }
+  return Assert;
+}
+
+```
+
+## inflight.PreflightAssert-1.js
+```js
+module.exports = function({  }) {
+  class PreflightAssert {
+    constructor({  }) {
+    }
+  }
+  return PreflightAssert;
 }
 
 ```
@@ -68,6 +129,81 @@ module.exports = function({ $math_Util }) {
 }
 ```
 
+## preflight.assertions-1.js
+```js
+module.exports = function({ $stdlib }) {
+  const std = $stdlib.std;
+  class Assert extends $stdlib.std.Resource {
+    constructor(scope, id, ) {
+      super(scope, id);
+    }
+    static _toInflightType(context) {
+      return `
+        require("./inflight.Assert-1.js")({
+        })
+      `;
+    }
+    _toInflight() {
+      return `
+        (await (async () => {
+          const AssertClient = ${Assert._toInflightType(this)};
+          const client = new AssertClient({
+          });
+          if (client.$inflight_init) { await client.$inflight_init(); }
+          return client;
+        })())
+      `;
+    }
+    _getInflightOps() {
+      return ["throws", "equalStr", "isNil", "equalNum", "$inflight_init"];
+    }
+  }
+  class PreflightAssert extends $stdlib.std.Resource {
+    constructor(scope, id, ) {
+      super(scope, id);
+    }
+    static throws(expected, block) {
+      let actual = "";
+      try {
+        (block());
+      }
+      catch ($error_e) {
+        const e = $error_e.message;
+        actual = e;
+      }
+      if ((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(actual,""))) {
+        throw new Error("expected error, but none thrown.");
+      }
+      if ((((a,b) => { try { return require('assert').notDeepStrictEqual(a,b) === undefined; } catch { return false; } })(actual,expected))) {
+        throw new Error(String.raw({ raw: ["expected error message: \"", "\" got: \"", "\""] }, expected, actual));
+      }
+    }
+    static _toInflightType(context) {
+      return `
+        require("./inflight.PreflightAssert-1.js")({
+        })
+      `;
+    }
+    _toInflight() {
+      return `
+        (await (async () => {
+          const PreflightAssertClient = ${PreflightAssert._toInflightType(this)};
+          const client = new PreflightAssertClient({
+          });
+          if (client.$inflight_init) { await client.$inflight_init(); }
+          return client;
+        })())
+      `;
+    }
+    _getInflightOps() {
+      return ["$inflight_init"];
+    }
+  }
+  return { Assert, PreflightAssert };
+};
+
+```
+
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
@@ -76,6 +212,7 @@ const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const math = $stdlib.math;
+const assertions = require("./preflight.assertions-1.js")({ $stdlib });
 class $Root extends $stdlib.std.Resource {
   constructor(scope, id) {
     super(scope, id);
@@ -86,7 +223,8 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("./inflight.$Closure1-2.js")({
+            $assertions_Assert: ${context._lift($stdlib.core.toLiftableModuleType(assertions.Assert, "", "Assert"))},
             $math_Util: ${context._lift($stdlib.core.toLiftableModuleType(math.Util, "@winglang/sdk/math", "Util"))},
           })
         `;
@@ -106,25 +244,17 @@ class $Root extends $stdlib.std.Resource {
         return ["handle", "$inflight_init"];
       }
     }
-    try {
+    (assertions.PreflightAssert.throws("Input value must be between -1 and 1, inclusive.",(() => {
       {console.log(String.raw({ raw: ["", ""] }, (math.Util.acos((-2)))))};
-    }
-    catch ($error_e) {
-      const e = $error_e.message;
-      {((cond) => {if (!cond) throw new Error("assertion failed: e == \"Input value must be between -1 and 1, inclusive.\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(e,"Input value must be between -1 and 1, inclusive.")))};
-    }
+    })));
     {((cond) => {if (!cond) throw new Error("assertion failed: math.acos(-1) == math.PI")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((math.Util.acos((-1))),math.Util.PI)))};
     {((cond) => {if (!cond) throw new Error("assertion failed: math.acos(-0) == 1.5707963267948966")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((math.Util.acos((-0))),1.5707963267948966)))};
     {((cond) => {if (!cond) throw new Error("assertion failed: math.acos(0) == 1.5707963267948966")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((math.Util.acos(0)),1.5707963267948966)))};
     {((cond) => {if (!cond) throw new Error("assertion failed: math.acos(0.5) == 1.0471975511965979")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((math.Util.acos(0.5)),1.0471975511965979)))};
     {((cond) => {if (!cond) throw new Error("assertion failed: math.acos(1) == 0")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((math.Util.acos(1)),0)))};
-    try {
+    (assertions.PreflightAssert.throws("Input value must be between -1 and 1, inclusive.",(() => {
       {console.log(String.raw({ raw: ["", ""] }, (math.Util.acos(2))))};
-    }
-    catch ($error_e) {
-      const e = $error_e.message;
-      {((cond) => {if (!cond) throw new Error("assertion failed: e == \"Input value must be between -1 and 1, inclusive.\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(e,"Input value must be between -1 and 1, inclusive.")))};
-    }
+    })));
     this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:inflight arc cosine",new $Closure1(this,"$Closure1"));
   }
 }

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/acsc.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/acsc.test.w_compile_tf-aws.md
@@ -1,8 +1,8 @@
 # [acsc.test.w](../../../../../../examples/tests/sdk_tests/math/acsc.test.w) | compile | tf-aws
 
-## inflight.$Closure1-1.js
+## inflight.$Closure1-2.js
 ```js
-module.exports = function({ $math_Util }) {
+module.exports = function({ $assertions_Assert, $math_Util }) {
   class $Closure1 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
@@ -10,13 +10,10 @@ module.exports = function({ $math_Util }) {
       return $obj;
     }
     async handle() {
-      try {
+      (await $assertions_Assert.throws("Input value must be equal or greater than |1|.",async () => {
         {console.log(String.raw({ raw: ["", ""] }, (await $math_Util.acsc(0.5))))};
       }
-      catch ($error_e) {
-        const e = $error_e.message;
-        {((cond) => {if (!cond) throw new Error("assertion failed: e == \"Input value must be equal or greater than |1|.\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(e,"Input value must be equal or greater than |1|.")))};
-      }
+      ));
       {((cond) => {if (!cond) throw new Error("assertion failed: math.acsc(1) == 1.5707963267948966")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $math_Util.acsc(1)),1.5707963267948966)))};
       {((cond) => {if (!cond) throw new Error("assertion failed: math.acsc(math.PI / 2) == 0.69010709137454")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $math_Util.acsc(($math_Util.PI / 2))),0.69010709137454)))};
       {((cond) => {if (!cond) throw new Error("assertion failed: math.acsc(math.PI) == 0.3239461069319807")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $math_Util.acsc($math_Util.PI)),0.3239461069319807)))};
@@ -25,6 +22,73 @@ module.exports = function({ $math_Util }) {
     }
   }
   return $Closure1;
+}
+
+```
+
+## inflight.Assert-1.js
+```js
+module.exports = function({  }) {
+  class Assert {
+    static async throws(expected, block) {
+      let actual = "";
+      try {
+        (await block());
+      }
+      catch ($error_e) {
+        const e = $error_e.message;
+        actual = e;
+      }
+      if ((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(actual,""))) {
+        throw new Error("expected error, but none thrown.");
+      }
+      if ((((a,b) => { try { return require('assert').notDeepStrictEqual(a,b) === undefined; } catch { return false; } })(actual,expected))) {
+        throw new Error(String.raw({ raw: ["expected error message: \"", "\" got: \"", "\""] }, expected, actual));
+      }
+    }
+    static async equalStr(a, b) {
+      try {
+        {((cond) => {if (!cond) throw new Error("assertion failed: a == b")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(a,b)))};
+      }
+      catch ($error_e) {
+        const e = $error_e.message;
+        throw new Error(String.raw({ raw: ["expected: ", " got: ", ""] }, b, a));
+      }
+    }
+    static async isNil(a) {
+      try {
+        {((cond) => {if (!cond) throw new Error("assertion failed: a == nil")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(a,undefined)))};
+      }
+      catch ($error_e) {
+        const e = $error_e.message;
+        {console.log(e)};
+        throw new Error(String.raw({ raw: ["expected '", "' to be nil"] }, a));
+      }
+    }
+    static async equalNum(a, b) {
+      try {
+        {((cond) => {if (!cond) throw new Error("assertion failed: a == b")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(a,b)))};
+      }
+      catch ($error_e) {
+        const e = $error_e.message;
+        {console.log(e)};
+        throw new Error(String.raw({ raw: ["expected: ", " got: ", ""] }, b, a));
+      }
+    }
+  }
+  return Assert;
+}
+
+```
+
+## inflight.PreflightAssert-1.js
+```js
+module.exports = function({  }) {
+  class PreflightAssert {
+    constructor({  }) {
+    }
+  }
+  return PreflightAssert;
 }
 
 ```
@@ -61,6 +125,81 @@ module.exports = function({ $math_Util }) {
 }
 ```
 
+## preflight.assertions-1.js
+```js
+module.exports = function({ $stdlib }) {
+  const std = $stdlib.std;
+  class Assert extends $stdlib.std.Resource {
+    constructor(scope, id, ) {
+      super(scope, id);
+    }
+    static _toInflightType(context) {
+      return `
+        require("./inflight.Assert-1.js")({
+        })
+      `;
+    }
+    _toInflight() {
+      return `
+        (await (async () => {
+          const AssertClient = ${Assert._toInflightType(this)};
+          const client = new AssertClient({
+          });
+          if (client.$inflight_init) { await client.$inflight_init(); }
+          return client;
+        })())
+      `;
+    }
+    _getInflightOps() {
+      return ["throws", "equalStr", "isNil", "equalNum", "$inflight_init"];
+    }
+  }
+  class PreflightAssert extends $stdlib.std.Resource {
+    constructor(scope, id, ) {
+      super(scope, id);
+    }
+    static throws(expected, block) {
+      let actual = "";
+      try {
+        (block());
+      }
+      catch ($error_e) {
+        const e = $error_e.message;
+        actual = e;
+      }
+      if ((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(actual,""))) {
+        throw new Error("expected error, but none thrown.");
+      }
+      if ((((a,b) => { try { return require('assert').notDeepStrictEqual(a,b) === undefined; } catch { return false; } })(actual,expected))) {
+        throw new Error(String.raw({ raw: ["expected error message: \"", "\" got: \"", "\""] }, expected, actual));
+      }
+    }
+    static _toInflightType(context) {
+      return `
+        require("./inflight.PreflightAssert-1.js")({
+        })
+      `;
+    }
+    _toInflight() {
+      return `
+        (await (async () => {
+          const PreflightAssertClient = ${PreflightAssert._toInflightType(this)};
+          const client = new PreflightAssertClient({
+          });
+          if (client.$inflight_init) { await client.$inflight_init(); }
+          return client;
+        })())
+      `;
+    }
+    _getInflightOps() {
+      return ["$inflight_init"];
+    }
+  }
+  return { Assert, PreflightAssert };
+};
+
+```
+
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
@@ -69,6 +208,7 @@ const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const math = $stdlib.math;
+const assertions = require("./preflight.assertions-1.js")({ $stdlib });
 class $Root extends $stdlib.std.Resource {
   constructor(scope, id) {
     super(scope, id);
@@ -79,7 +219,8 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("./inflight.$Closure1-2.js")({
+            $assertions_Assert: ${context._lift($stdlib.core.toLiftableModuleType(assertions.Assert, "", "Assert"))},
             $math_Util: ${context._lift($stdlib.core.toLiftableModuleType(math.Util, "@winglang/sdk/math", "Util"))},
           })
         `;
@@ -99,13 +240,9 @@ class $Root extends $stdlib.std.Resource {
         return ["handle", "$inflight_init"];
       }
     }
-    try {
+    (assertions.PreflightAssert.throws("Input value must be equal or greater than |1|.",(() => {
       {console.log(String.raw({ raw: ["", ""] }, (math.Util.acsc(0.5))))};
-    }
-    catch ($error_e) {
-      const e = $error_e.message;
-      {((cond) => {if (!cond) throw new Error("assertion failed: e == \"Input value must be equal or greater than |1|.\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(e,"Input value must be equal or greater than |1|.")))};
-    }
+    })));
     {((cond) => {if (!cond) throw new Error("assertion failed: math.acsc(1) == 1.5707963267948966")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((math.Util.acsc(1)),1.5707963267948966)))};
     {((cond) => {if (!cond) throw new Error("assertion failed: math.acsc(math.PI / 2) == 0.69010709137454")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((math.Util.acsc((math.Util.PI / 2))),0.69010709137454)))};
     {((cond) => {if (!cond) throw new Error("assertion failed: math.acsc(math.PI) == 0.3239461069319807")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((math.Util.acsc(math.Util.PI)),0.3239461069319807)))};

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/asec.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/asec.test.w_compile_tf-aws.md
@@ -1,8 +1,8 @@
 # [asec.test.w](../../../../../../examples/tests/sdk_tests/math/asec.test.w) | compile | tf-aws
 
-## inflight.$Closure1-1.js
+## inflight.$Closure1-2.js
 ```js
-module.exports = function({ $math_Util }) {
+module.exports = function({ $assertions_Assert, $math_Util }) {
   class $Closure1 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
@@ -10,13 +10,10 @@ module.exports = function({ $math_Util }) {
       return $obj;
     }
     async handle() {
-      try {
+      (await $assertions_Assert.throws("Input value must be equal or greater than |1|.",async () => {
         {console.log(String.raw({ raw: ["", ""] }, (await $math_Util.asec(0.5))))};
       }
-      catch ($error_e) {
-        const e = $error_e.message;
-        {((cond) => {if (!cond) throw new Error("assertion failed: e == \"Input value must be equal or greater than |1|.\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(e,"Input value must be equal or greater than |1|.")))};
-      }
+      ));
       {((cond) => {if (!cond) throw new Error("assertion failed: math.asec(2) == 1.0471975511965979")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $math_Util.asec(2)),1.0471975511965979)))};
       {((cond) => {if (!cond) throw new Error("assertion failed: math.asec(1) == 0")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $math_Util.asec(1)),0)))};
       {((cond) => {if (!cond) throw new Error("assertion failed: math.asec(math.PI) == 1.2468502198629159")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $math_Util.asec($math_Util.PI)),1.2468502198629159)))};
@@ -26,6 +23,73 @@ module.exports = function({ $math_Util }) {
     }
   }
   return $Closure1;
+}
+
+```
+
+## inflight.Assert-1.js
+```js
+module.exports = function({  }) {
+  class Assert {
+    static async throws(expected, block) {
+      let actual = "";
+      try {
+        (await block());
+      }
+      catch ($error_e) {
+        const e = $error_e.message;
+        actual = e;
+      }
+      if ((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(actual,""))) {
+        throw new Error("expected error, but none thrown.");
+      }
+      if ((((a,b) => { try { return require('assert').notDeepStrictEqual(a,b) === undefined; } catch { return false; } })(actual,expected))) {
+        throw new Error(String.raw({ raw: ["expected error message: \"", "\" got: \"", "\""] }, expected, actual));
+      }
+    }
+    static async equalStr(a, b) {
+      try {
+        {((cond) => {if (!cond) throw new Error("assertion failed: a == b")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(a,b)))};
+      }
+      catch ($error_e) {
+        const e = $error_e.message;
+        throw new Error(String.raw({ raw: ["expected: ", " got: ", ""] }, b, a));
+      }
+    }
+    static async isNil(a) {
+      try {
+        {((cond) => {if (!cond) throw new Error("assertion failed: a == nil")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(a,undefined)))};
+      }
+      catch ($error_e) {
+        const e = $error_e.message;
+        {console.log(e)};
+        throw new Error(String.raw({ raw: ["expected '", "' to be nil"] }, a));
+      }
+    }
+    static async equalNum(a, b) {
+      try {
+        {((cond) => {if (!cond) throw new Error("assertion failed: a == b")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(a,b)))};
+      }
+      catch ($error_e) {
+        const e = $error_e.message;
+        {console.log(e)};
+        throw new Error(String.raw({ raw: ["expected: ", " got: ", ""] }, b, a));
+      }
+    }
+  }
+  return Assert;
+}
+
+```
+
+## inflight.PreflightAssert-1.js
+```js
+module.exports = function({  }) {
+  class PreflightAssert {
+    constructor({  }) {
+    }
+  }
+  return PreflightAssert;
 }
 
 ```
@@ -62,6 +126,81 @@ module.exports = function({ $math_Util }) {
 }
 ```
 
+## preflight.assertions-1.js
+```js
+module.exports = function({ $stdlib }) {
+  const std = $stdlib.std;
+  class Assert extends $stdlib.std.Resource {
+    constructor(scope, id, ) {
+      super(scope, id);
+    }
+    static _toInflightType(context) {
+      return `
+        require("./inflight.Assert-1.js")({
+        })
+      `;
+    }
+    _toInflight() {
+      return `
+        (await (async () => {
+          const AssertClient = ${Assert._toInflightType(this)};
+          const client = new AssertClient({
+          });
+          if (client.$inflight_init) { await client.$inflight_init(); }
+          return client;
+        })())
+      `;
+    }
+    _getInflightOps() {
+      return ["throws", "equalStr", "isNil", "equalNum", "$inflight_init"];
+    }
+  }
+  class PreflightAssert extends $stdlib.std.Resource {
+    constructor(scope, id, ) {
+      super(scope, id);
+    }
+    static throws(expected, block) {
+      let actual = "";
+      try {
+        (block());
+      }
+      catch ($error_e) {
+        const e = $error_e.message;
+        actual = e;
+      }
+      if ((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(actual,""))) {
+        throw new Error("expected error, but none thrown.");
+      }
+      if ((((a,b) => { try { return require('assert').notDeepStrictEqual(a,b) === undefined; } catch { return false; } })(actual,expected))) {
+        throw new Error(String.raw({ raw: ["expected error message: \"", "\" got: \"", "\""] }, expected, actual));
+      }
+    }
+    static _toInflightType(context) {
+      return `
+        require("./inflight.PreflightAssert-1.js")({
+        })
+      `;
+    }
+    _toInflight() {
+      return `
+        (await (async () => {
+          const PreflightAssertClient = ${PreflightAssert._toInflightType(this)};
+          const client = new PreflightAssertClient({
+          });
+          if (client.$inflight_init) { await client.$inflight_init(); }
+          return client;
+        })())
+      `;
+    }
+    _getInflightOps() {
+      return ["$inflight_init"];
+    }
+  }
+  return { Assert, PreflightAssert };
+};
+
+```
+
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
@@ -70,6 +209,7 @@ const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const math = $stdlib.math;
+const assertions = require("./preflight.assertions-1.js")({ $stdlib });
 class $Root extends $stdlib.std.Resource {
   constructor(scope, id) {
     super(scope, id);
@@ -80,7 +220,8 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("./inflight.$Closure1-2.js")({
+            $assertions_Assert: ${context._lift($stdlib.core.toLiftableModuleType(assertions.Assert, "", "Assert"))},
             $math_Util: ${context._lift($stdlib.core.toLiftableModuleType(math.Util, "@winglang/sdk/math", "Util"))},
           })
         `;
@@ -100,13 +241,9 @@ class $Root extends $stdlib.std.Resource {
         return ["handle", "$inflight_init"];
       }
     }
-    try {
+    (assertions.PreflightAssert.throws("Input value must be equal or greater than |1|.",(() => {
       {console.log(String.raw({ raw: ["", ""] }, (math.Util.asec(0.5))))};
-    }
-    catch ($error_e) {
-      const e = $error_e.message;
-      {((cond) => {if (!cond) throw new Error("assertion failed: e == \"Input value must be equal or greater than |1|.\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(e,"Input value must be equal or greater than |1|.")))};
-    }
+    })));
     {((cond) => {if (!cond) throw new Error("assertion failed: math.asec(2) == 1.0471975511965979")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((math.Util.asec(2)),1.0471975511965979)))};
     {((cond) => {if (!cond) throw new Error("assertion failed: math.asec(1) == 0")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((math.Util.asec(1)),0)))};
     {((cond) => {if (!cond) throw new Error("assertion failed: math.asec(math.PI) == 1.2468502198629159")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((math.Util.asec(math.Util.PI)),1.2468502198629159)))};

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/asin.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/asin.test.w_compile_tf-aws.md
@@ -1,8 +1,8 @@
 # [asin.test.w](../../../../../../examples/tests/sdk_tests/math/asin.test.w) | compile | tf-aws
 
-## inflight.$Closure1-1.js
+## inflight.$Closure1-2.js
 ```js
-module.exports = function({ $math_Util }) {
+module.exports = function({ $assertions_Assert, $math_Util }) {
   class $Closure1 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
@@ -10,28 +10,89 @@ module.exports = function({ $math_Util }) {
       return $obj;
     }
     async handle() {
-      try {
+      (await $assertions_Assert.throws("Input value must be between -1 and 1, inclusive.",async () => {
         {console.log(String.raw({ raw: ["", ""] }, (await $math_Util.asin((-2)))))};
       }
-      catch ($error_e) {
-        const e = $error_e.message;
-        {((cond) => {if (!cond) throw new Error("assertion failed: e == \"Input value must be between -1 and 1, inclusive.\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(e,"Input value must be between -1 and 1, inclusive.")))};
-      }
+      ));
       {((cond) => {if (!cond) throw new Error("assertion failed: math.asin(-1) == -1.5707963267948966")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $math_Util.asin((-1))),(-1.5707963267948966))))};
       {((cond) => {if (!cond) throw new Error("assertion failed: math.asin(-0) == -0")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $math_Util.asin((-0))),(-0))))};
       {((cond) => {if (!cond) throw new Error("assertion failed: math.asin(0) == 0")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $math_Util.asin(0)),0)))};
       {((cond) => {if (!cond) throw new Error("assertion failed: math.asin(0.5) == 0.5235987755982989")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $math_Util.asin(0.5)),0.5235987755982989)))};
       {((cond) => {if (!cond) throw new Error("assertion failed: math.asin(1) == 1.5707963267948966")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $math_Util.asin(1)),1.5707963267948966)))};
-      try {
+      (await $assertions_Assert.throws("Input value must be between -1 and 1, inclusive.",async () => {
         {console.log(String.raw({ raw: ["", ""] }, (await $math_Util.asin(2))))};
       }
-      catch ($error_e) {
-        const e = $error_e.message;
-        {((cond) => {if (!cond) throw new Error("assertion failed: e == \"Input value must be between -1 and 1, inclusive.\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(e,"Input value must be between -1 and 1, inclusive.")))};
-      }
+      ));
     }
   }
   return $Closure1;
+}
+
+```
+
+## inflight.Assert-1.js
+```js
+module.exports = function({  }) {
+  class Assert {
+    static async throws(expected, block) {
+      let actual = "";
+      try {
+        (await block());
+      }
+      catch ($error_e) {
+        const e = $error_e.message;
+        actual = e;
+      }
+      if ((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(actual,""))) {
+        throw new Error("expected error, but none thrown.");
+      }
+      if ((((a,b) => { try { return require('assert').notDeepStrictEqual(a,b) === undefined; } catch { return false; } })(actual,expected))) {
+        throw new Error(String.raw({ raw: ["expected error message: \"", "\" got: \"", "\""] }, expected, actual));
+      }
+    }
+    static async equalStr(a, b) {
+      try {
+        {((cond) => {if (!cond) throw new Error("assertion failed: a == b")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(a,b)))};
+      }
+      catch ($error_e) {
+        const e = $error_e.message;
+        throw new Error(String.raw({ raw: ["expected: ", " got: ", ""] }, b, a));
+      }
+    }
+    static async isNil(a) {
+      try {
+        {((cond) => {if (!cond) throw new Error("assertion failed: a == nil")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(a,undefined)))};
+      }
+      catch ($error_e) {
+        const e = $error_e.message;
+        {console.log(e)};
+        throw new Error(String.raw({ raw: ["expected '", "' to be nil"] }, a));
+      }
+    }
+    static async equalNum(a, b) {
+      try {
+        {((cond) => {if (!cond) throw new Error("assertion failed: a == b")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(a,b)))};
+      }
+      catch ($error_e) {
+        const e = $error_e.message;
+        {console.log(e)};
+        throw new Error(String.raw({ raw: ["expected: ", " got: ", ""] }, b, a));
+      }
+    }
+  }
+  return Assert;
+}
+
+```
+
+## inflight.PreflightAssert-1.js
+```js
+module.exports = function({  }) {
+  class PreflightAssert {
+    constructor({  }) {
+    }
+  }
+  return PreflightAssert;
 }
 
 ```
@@ -68,6 +129,81 @@ module.exports = function({ $math_Util }) {
 }
 ```
 
+## preflight.assertions-1.js
+```js
+module.exports = function({ $stdlib }) {
+  const std = $stdlib.std;
+  class Assert extends $stdlib.std.Resource {
+    constructor(scope, id, ) {
+      super(scope, id);
+    }
+    static _toInflightType(context) {
+      return `
+        require("./inflight.Assert-1.js")({
+        })
+      `;
+    }
+    _toInflight() {
+      return `
+        (await (async () => {
+          const AssertClient = ${Assert._toInflightType(this)};
+          const client = new AssertClient({
+          });
+          if (client.$inflight_init) { await client.$inflight_init(); }
+          return client;
+        })())
+      `;
+    }
+    _getInflightOps() {
+      return ["throws", "equalStr", "isNil", "equalNum", "$inflight_init"];
+    }
+  }
+  class PreflightAssert extends $stdlib.std.Resource {
+    constructor(scope, id, ) {
+      super(scope, id);
+    }
+    static throws(expected, block) {
+      let actual = "";
+      try {
+        (block());
+      }
+      catch ($error_e) {
+        const e = $error_e.message;
+        actual = e;
+      }
+      if ((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(actual,""))) {
+        throw new Error("expected error, but none thrown.");
+      }
+      if ((((a,b) => { try { return require('assert').notDeepStrictEqual(a,b) === undefined; } catch { return false; } })(actual,expected))) {
+        throw new Error(String.raw({ raw: ["expected error message: \"", "\" got: \"", "\""] }, expected, actual));
+      }
+    }
+    static _toInflightType(context) {
+      return `
+        require("./inflight.PreflightAssert-1.js")({
+        })
+      `;
+    }
+    _toInflight() {
+      return `
+        (await (async () => {
+          const PreflightAssertClient = ${PreflightAssert._toInflightType(this)};
+          const client = new PreflightAssertClient({
+          });
+          if (client.$inflight_init) { await client.$inflight_init(); }
+          return client;
+        })())
+      `;
+    }
+    _getInflightOps() {
+      return ["$inflight_init"];
+    }
+  }
+  return { Assert, PreflightAssert };
+};
+
+```
+
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
@@ -76,6 +212,7 @@ const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const math = $stdlib.math;
+const assertions = require("./preflight.assertions-1.js")({ $stdlib });
 class $Root extends $stdlib.std.Resource {
   constructor(scope, id) {
     super(scope, id);
@@ -86,7 +223,8 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("./inflight.$Closure1-2.js")({
+            $assertions_Assert: ${context._lift($stdlib.core.toLiftableModuleType(assertions.Assert, "", "Assert"))},
             $math_Util: ${context._lift($stdlib.core.toLiftableModuleType(math.Util, "@winglang/sdk/math", "Util"))},
           })
         `;
@@ -106,25 +244,17 @@ class $Root extends $stdlib.std.Resource {
         return ["handle", "$inflight_init"];
       }
     }
-    try {
+    (assertions.PreflightAssert.throws("Input value must be between -1 and 1, inclusive.",(() => {
       {console.log(String.raw({ raw: ["", ""] }, (math.Util.asin((-2)))))};
-    }
-    catch ($error_e) {
-      const e = $error_e.message;
-      {((cond) => {if (!cond) throw new Error("assertion failed: e == \"Input value must be between -1 and 1, inclusive.\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(e,"Input value must be between -1 and 1, inclusive.")))};
-    }
+    })));
     {((cond) => {if (!cond) throw new Error("assertion failed: math.asin(-1) == -1.5707963267948966")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((math.Util.asin((-1))),(-1.5707963267948966))))};
     {((cond) => {if (!cond) throw new Error("assertion failed: math.asin(-0) == -0")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((math.Util.asin((-0))),(-0))))};
     {((cond) => {if (!cond) throw new Error("assertion failed: math.asin(0) == 0")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((math.Util.asin(0)),0)))};
     {((cond) => {if (!cond) throw new Error("assertion failed: math.asin(0.5) == 0.5235987755982989")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((math.Util.asin(0.5)),0.5235987755982989)))};
     {((cond) => {if (!cond) throw new Error("assertion failed: math.asin(1) == 1.5707963267948966")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((math.Util.asin(1)),1.5707963267948966)))};
-    try {
+    (assertions.PreflightAssert.throws("Input value must be between -1 and 1, inclusive.",(() => {
       {console.log(String.raw({ raw: ["", ""] }, (math.Util.asin(2))))};
-    }
-    catch ($error_e) {
-      const e = $error_e.message;
-      {((cond) => {if (!cond) throw new Error("assertion failed: e == \"Input value must be between -1 and 1, inclusive.\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(e,"Input value must be between -1 and 1, inclusive.")))};
-    }
+    })));
     this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:inflight arc sine",new $Closure1(this,"$Closure1"));
   }
 }

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/sqrt.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/sqrt.test.w_compile_tf-aws.md
@@ -1,8 +1,8 @@
 # [sqrt.test.w](../../../../../../examples/tests/sdk_tests/math/sqrt.test.w) | compile | tf-aws
 
-## inflight.$Closure1-1.js
+## inflight.$Closure1-2.js
 ```js
-module.exports = function({ $math_Util }) {
+module.exports = function({ $assertions_Assert, $math_Util }) {
   class $Closure1 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
@@ -10,13 +10,10 @@ module.exports = function({ $math_Util }) {
       return $obj;
     }
     async handle() {
-      try {
+      (await $assertions_Assert.throws("Input value must be greater than or equal to 0.",async () => {
         {console.log(String.raw({ raw: ["", ""] }, (await $math_Util.sqrt((-1)))))};
       }
-      catch ($error_e) {
-        const e = $error_e.message;
-        {((cond) => {if (!cond) throw new Error("assertion failed: e == \"Input value must be greater than or equal to 0.\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(e,"Input value must be greater than or equal to 0.")))};
-      }
+      ));
       {((cond) => {if (!cond) throw new Error("assertion failed: math.sqrt(-0) == -0")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $math_Util.sqrt((-0))),(-0))))};
       {((cond) => {if (!cond) throw new Error("assertion failed: math.sqrt(0) == 0")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $math_Util.sqrt(0)),0)))};
       {((cond) => {if (!cond) throw new Error("assertion failed: math.sqrt(1) == 1")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $math_Util.sqrt(1)),1)))};
@@ -26,6 +23,73 @@ module.exports = function({ $math_Util }) {
     }
   }
   return $Closure1;
+}
+
+```
+
+## inflight.Assert-1.js
+```js
+module.exports = function({  }) {
+  class Assert {
+    static async throws(expected, block) {
+      let actual = "";
+      try {
+        (await block());
+      }
+      catch ($error_e) {
+        const e = $error_e.message;
+        actual = e;
+      }
+      if ((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(actual,""))) {
+        throw new Error("expected error, but none thrown.");
+      }
+      if ((((a,b) => { try { return require('assert').notDeepStrictEqual(a,b) === undefined; } catch { return false; } })(actual,expected))) {
+        throw new Error(String.raw({ raw: ["expected error message: \"", "\" got: \"", "\""] }, expected, actual));
+      }
+    }
+    static async equalStr(a, b) {
+      try {
+        {((cond) => {if (!cond) throw new Error("assertion failed: a == b")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(a,b)))};
+      }
+      catch ($error_e) {
+        const e = $error_e.message;
+        throw new Error(String.raw({ raw: ["expected: ", " got: ", ""] }, b, a));
+      }
+    }
+    static async isNil(a) {
+      try {
+        {((cond) => {if (!cond) throw new Error("assertion failed: a == nil")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(a,undefined)))};
+      }
+      catch ($error_e) {
+        const e = $error_e.message;
+        {console.log(e)};
+        throw new Error(String.raw({ raw: ["expected '", "' to be nil"] }, a));
+      }
+    }
+    static async equalNum(a, b) {
+      try {
+        {((cond) => {if (!cond) throw new Error("assertion failed: a == b")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(a,b)))};
+      }
+      catch ($error_e) {
+        const e = $error_e.message;
+        {console.log(e)};
+        throw new Error(String.raw({ raw: ["expected: ", " got: ", ""] }, b, a));
+      }
+    }
+  }
+  return Assert;
+}
+
+```
+
+## inflight.PreflightAssert-1.js
+```js
+module.exports = function({  }) {
+  class PreflightAssert {
+    constructor({  }) {
+    }
+  }
+  return PreflightAssert;
 }
 
 ```
@@ -62,6 +126,81 @@ module.exports = function({ $math_Util }) {
 }
 ```
 
+## preflight.assertions-1.js
+```js
+module.exports = function({ $stdlib }) {
+  const std = $stdlib.std;
+  class Assert extends $stdlib.std.Resource {
+    constructor(scope, id, ) {
+      super(scope, id);
+    }
+    static _toInflightType(context) {
+      return `
+        require("./inflight.Assert-1.js")({
+        })
+      `;
+    }
+    _toInflight() {
+      return `
+        (await (async () => {
+          const AssertClient = ${Assert._toInflightType(this)};
+          const client = new AssertClient({
+          });
+          if (client.$inflight_init) { await client.$inflight_init(); }
+          return client;
+        })())
+      `;
+    }
+    _getInflightOps() {
+      return ["throws", "equalStr", "isNil", "equalNum", "$inflight_init"];
+    }
+  }
+  class PreflightAssert extends $stdlib.std.Resource {
+    constructor(scope, id, ) {
+      super(scope, id);
+    }
+    static throws(expected, block) {
+      let actual = "";
+      try {
+        (block());
+      }
+      catch ($error_e) {
+        const e = $error_e.message;
+        actual = e;
+      }
+      if ((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(actual,""))) {
+        throw new Error("expected error, but none thrown.");
+      }
+      if ((((a,b) => { try { return require('assert').notDeepStrictEqual(a,b) === undefined; } catch { return false; } })(actual,expected))) {
+        throw new Error(String.raw({ raw: ["expected error message: \"", "\" got: \"", "\""] }, expected, actual));
+      }
+    }
+    static _toInflightType(context) {
+      return `
+        require("./inflight.PreflightAssert-1.js")({
+        })
+      `;
+    }
+    _toInflight() {
+      return `
+        (await (async () => {
+          const PreflightAssertClient = ${PreflightAssert._toInflightType(this)};
+          const client = new PreflightAssertClient({
+          });
+          if (client.$inflight_init) { await client.$inflight_init(); }
+          return client;
+        })())
+      `;
+    }
+    _getInflightOps() {
+      return ["$inflight_init"];
+    }
+  }
+  return { Assert, PreflightAssert };
+};
+
+```
+
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
@@ -70,6 +209,7 @@ const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const math = $stdlib.math;
+const assertions = require("./preflight.assertions-1.js")({ $stdlib });
 class $Root extends $stdlib.std.Resource {
   constructor(scope, id) {
     super(scope, id);
@@ -80,7 +220,8 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("./inflight.$Closure1-2.js")({
+            $assertions_Assert: ${context._lift($stdlib.core.toLiftableModuleType(assertions.Assert, "", "Assert"))},
             $math_Util: ${context._lift($stdlib.core.toLiftableModuleType(math.Util, "@winglang/sdk/math", "Util"))},
           })
         `;
@@ -100,13 +241,9 @@ class $Root extends $stdlib.std.Resource {
         return ["handle", "$inflight_init"];
       }
     }
-    try {
+    (assertions.PreflightAssert.throws("Input value must be greater than or equal to 0.",(() => {
       {console.log(String.raw({ raw: ["", ""] }, (math.Util.sqrt((-1)))))};
-    }
-    catch ($error_e) {
-      const e = $error_e.message;
-      {((cond) => {if (!cond) throw new Error("assertion failed: e == \"Input value must be greater than or equal to 0.\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(e,"Input value must be greater than or equal to 0.")))};
-    }
+    })));
     {((cond) => {if (!cond) throw new Error("assertion failed: math.sqrt(-0) == -0")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((math.Util.sqrt((-0))),(-0))))};
     {((cond) => {if (!cond) throw new Error("assertion failed: math.sqrt(0) == 0")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((math.Util.sqrt(0)),0)))};
     {((cond) => {if (!cond) throw new Error("assertion failed: math.sqrt(1) == 1")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((math.Util.sqrt(1)),1)))};

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/queue/push.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/queue/push.test.w_compile_tf-aws.md
@@ -1,8 +1,8 @@
 # [push.test.w](../../../../../../examples/tests/sdk_tests/queue/push.test.w) | compile | tf-aws
 
-## inflight.$Closure1-1.js
+## inflight.$Closure1-2.js
 ```js
-module.exports = function({ $q, $std_Duration, $util_Util }) {
+module.exports = function({ $assertions_Assert, $q, $std_Duration, $util_Util }) {
   class $Closure1 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
@@ -11,22 +11,14 @@ module.exports = function({ $q, $std_Duration, $util_Util }) {
     }
     async handle() {
       const obj = ({"k1": 1,"k2": "hello","k3": true,"k4": ({"k1": [1, "a", true, ({})]})});
-      try {
+      (await $assertions_Assert.throws("Empty messages are not allowed",async () => {
         (await $q.push(""));
-        {((cond) => {if (!cond) throw new Error("assertion failed: false")})(false)};
       }
-      catch ($error_e) {
-        const e = $error_e.message;
-        {((cond) => {if (!cond) throw new Error("assertion failed: e == \"Empty messages are not allowed\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(e,"Empty messages are not allowed")))};
-      }
-      try {
+      ));
+      (await $assertions_Assert.throws("Empty messages are not allowed",async () => {
         (await $q.push("Foo",""));
-        {((cond) => {if (!cond) throw new Error("assertion failed: false")})(false)};
       }
-      catch ($error_e) {
-        const e = $error_e.message;
-        {((cond) => {if (!cond) throw new Error("assertion failed: e == \"Empty messages are not allowed\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(e,"Empty messages are not allowed")))};
-      }
+      ));
       (await $q.push("Foo"));
       {((cond) => {if (!cond) throw new Error("assertion failed: util.waitUntil((): bool => {\n    return q.approxSize() == 1;\n  })")})((await $util_Util.waitUntil(async () => {
         return (((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $q.approxSize()),1));
@@ -48,6 +40,73 @@ module.exports = function({ $q, $std_Duration, $util_Util }) {
     }
   }
   return $Closure1;
+}
+
+```
+
+## inflight.Assert-1.js
+```js
+module.exports = function({  }) {
+  class Assert {
+    static async throws(expected, block) {
+      let actual = "";
+      try {
+        (await block());
+      }
+      catch ($error_e) {
+        const e = $error_e.message;
+        actual = e;
+      }
+      if ((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(actual,""))) {
+        throw new Error("expected error, but none thrown.");
+      }
+      if ((((a,b) => { try { return require('assert').notDeepStrictEqual(a,b) === undefined; } catch { return false; } })(actual,expected))) {
+        throw new Error(String.raw({ raw: ["expected error message: \"", "\" got: \"", "\""] }, expected, actual));
+      }
+    }
+    static async equalStr(a, b) {
+      try {
+        {((cond) => {if (!cond) throw new Error("assertion failed: a == b")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(a,b)))};
+      }
+      catch ($error_e) {
+        const e = $error_e.message;
+        throw new Error(String.raw({ raw: ["expected: ", " got: ", ""] }, b, a));
+      }
+    }
+    static async isNil(a) {
+      try {
+        {((cond) => {if (!cond) throw new Error("assertion failed: a == nil")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(a,undefined)))};
+      }
+      catch ($error_e) {
+        const e = $error_e.message;
+        {console.log(e)};
+        throw new Error(String.raw({ raw: ["expected '", "' to be nil"] }, a));
+      }
+    }
+    static async equalNum(a, b) {
+      try {
+        {((cond) => {if (!cond) throw new Error("assertion failed: a == b")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(a,b)))};
+      }
+      catch ($error_e) {
+        const e = $error_e.message;
+        {console.log(e)};
+        throw new Error(String.raw({ raw: ["expected: ", " got: ", ""] }, b, a));
+      }
+    }
+  }
+  return Assert;
+}
+
+```
+
+## inflight.PreflightAssert-1.js
+```js
+module.exports = function({  }) {
+  class PreflightAssert {
+    constructor({  }) {
+    }
+  }
+  return PreflightAssert;
 }
 
 ```
@@ -97,6 +156,81 @@ module.exports = function({ $q, $std_Duration, $util_Util }) {
 }
 ```
 
+## preflight.assertions-1.js
+```js
+module.exports = function({ $stdlib }) {
+  const std = $stdlib.std;
+  class Assert extends $stdlib.std.Resource {
+    constructor(scope, id, ) {
+      super(scope, id);
+    }
+    static _toInflightType(context) {
+      return `
+        require("./inflight.Assert-1.js")({
+        })
+      `;
+    }
+    _toInflight() {
+      return `
+        (await (async () => {
+          const AssertClient = ${Assert._toInflightType(this)};
+          const client = new AssertClient({
+          });
+          if (client.$inflight_init) { await client.$inflight_init(); }
+          return client;
+        })())
+      `;
+    }
+    _getInflightOps() {
+      return ["throws", "equalStr", "isNil", "equalNum", "$inflight_init"];
+    }
+  }
+  class PreflightAssert extends $stdlib.std.Resource {
+    constructor(scope, id, ) {
+      super(scope, id);
+    }
+    static throws(expected, block) {
+      let actual = "";
+      try {
+        (block());
+      }
+      catch ($error_e) {
+        const e = $error_e.message;
+        actual = e;
+      }
+      if ((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(actual,""))) {
+        throw new Error("expected error, but none thrown.");
+      }
+      if ((((a,b) => { try { return require('assert').notDeepStrictEqual(a,b) === undefined; } catch { return false; } })(actual,expected))) {
+        throw new Error(String.raw({ raw: ["expected error message: \"", "\" got: \"", "\""] }, expected, actual));
+      }
+    }
+    static _toInflightType(context) {
+      return `
+        require("./inflight.PreflightAssert-1.js")({
+        })
+      `;
+    }
+    _toInflight() {
+      return `
+        (await (async () => {
+          const PreflightAssertClient = ${PreflightAssert._toInflightType(this)};
+          const client = new PreflightAssertClient({
+          });
+          if (client.$inflight_init) { await client.$inflight_init(); }
+          return client;
+        })())
+      `;
+    }
+    _getInflightOps() {
+      return ["$inflight_init"];
+    }
+  }
+  return { Assert, PreflightAssert };
+};
+
+```
+
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
@@ -106,6 +240,7 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 const util = $stdlib.util;
+const assertions = require("./preflight.assertions-1.js")({ $stdlib });
 class $Root extends $stdlib.std.Resource {
   constructor(scope, id) {
     super(scope, id);
@@ -116,7 +251,8 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("./inflight.$Closure1-2.js")({
+            $assertions_Assert: ${context._lift($stdlib.core.toLiftableModuleType(assertions.Assert, "", "Assert"))},
             $q: ${context._lift(q)},
             $std_Duration: ${context._lift($stdlib.core.toLiftableModuleType(std.Duration, "@winglang/sdk/std", "Duration"))},
             $util_Util: ${context._lift($stdlib.core.toLiftableModuleType(util.Util, "@winglang/sdk/util", "Util"))},

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/std/array.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/std/array.test.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [array.test.w](../../../../../../examples/tests/sdk_tests/std/array.test.w) | compile | tf-aws
 
-## inflight.$Closure1-1.js
+## inflight.$Closure1-2.js
 ```js
 module.exports = function({  }) {
   class $Closure1 {
@@ -19,7 +19,7 @@ module.exports = function({  }) {
 
 ```
 
-## inflight.$Closure10-1.js
+## inflight.$Closure10-2.js
 ```js
 module.exports = function({  }) {
   class $Closure10 {
@@ -41,7 +41,7 @@ module.exports = function({  }) {
 
 ```
 
-## inflight.$Closure11-1.js
+## inflight.$Closure11-2.js
 ```js
 module.exports = function({  }) {
   class $Closure11 {
@@ -63,7 +63,7 @@ module.exports = function({  }) {
 
 ```
 
-## inflight.$Closure12-1.js
+## inflight.$Closure12-2.js
 ```js
 module.exports = function({  }) {
   class $Closure12 {
@@ -84,7 +84,7 @@ module.exports = function({  }) {
 
 ```
 
-## inflight.$Closure13-1.js
+## inflight.$Closure13-2.js
 ```js
 module.exports = function({  }) {
   class $Closure13 {
@@ -105,7 +105,7 @@ module.exports = function({  }) {
 
 ```
 
-## inflight.$Closure14-1.js
+## inflight.$Closure14-2.js
 ```js
 module.exports = function({  }) {
   class $Closure14 {
@@ -126,9 +126,9 @@ module.exports = function({  }) {
 
 ```
 
-## inflight.$Closure15-1.js
+## inflight.$Closure15-2.js
 ```js
-module.exports = function({  }) {
+module.exports = function({ $asserions_Assert }) {
   class $Closure15 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
@@ -136,29 +136,16 @@ module.exports = function({  }) {
       return $obj;
     }
     async handle() {
-      const assertThrows = async (expected, block) => {
-        let error = false;
-        try {
-          (await block());
-        }
-        catch ($error_actual) {
-          const actual = $error_actual.message;
-          {((cond) => {if (!cond) throw new Error("assertion failed: actual == expected")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(actual,expected)))};
-          error = true;
-        }
-        {((cond) => {if (!cond) throw new Error("assertion failed: error")})(error)};
-      }
-      ;
       const INDEX_OUT_OF_BOUNDS_ERROR = "Index out of bounds";
       const mutArr = [1, 3, 5, 7, 9];
       {((cond) => {if (!cond) throw new Error("assertion failed: mutArr.at(0) == 1")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await mutArr.at(0)),1)))};
       ((obj, args) => { if (args[0] < 0 || args[0] >= mutArr.length) throw new Error("Index out of bounds"); obj[args[0]] = args[1]; })(mutArr, [0,2]);
       {((cond) => {if (!cond) throw new Error("assertion failed: mutArr.at(0) == 2")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await mutArr.at(0)),2)))};
-      (await assertThrows(INDEX_OUT_OF_BOUNDS_ERROR,async () => {
+      (await $asserions_Assert.throws(INDEX_OUT_OF_BOUNDS_ERROR,async () => {
         ((obj, args) => { if (args[0] < 0 || args[0] >= mutArr.length) throw new Error("Index out of bounds"); obj[args[0]] = args[1]; })(mutArr, [(-1),1]);
       }
       ));
-      (await assertThrows(INDEX_OUT_OF_BOUNDS_ERROR,async () => {
+      (await $asserions_Assert.throws(INDEX_OUT_OF_BOUNDS_ERROR,async () => {
         ((obj, args) => { if (args[0] < 0 || args[0] >= mutArr.length) throw new Error("Index out of bounds"); obj[args[0]] = args[1]; })(mutArr, [5,11]);
       }
       ));
@@ -169,9 +156,9 @@ module.exports = function({  }) {
 
 ```
 
-## inflight.$Closure16-1.js
+## inflight.$Closure16-2.js
 ```js
-module.exports = function({  }) {
+module.exports = function({ $asserions_Assert }) {
   class $Closure16 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
@@ -179,31 +166,18 @@ module.exports = function({  }) {
       return $obj;
     }
     async handle() {
-      const assertThrows = async (expected, block) => {
-        let error = false;
-        try {
-          (await block());
-        }
-        catch ($error_actual) {
-          const actual = $error_actual.message;
-          {((cond) => {if (!cond) throw new Error("assertion failed: actual == expected")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(actual,expected)))};
-          error = true;
-        }
-        {((cond) => {if (!cond) throw new Error("assertion failed: error")})(error)};
-      }
-      ;
       const INDEX_OUT_OF_BOUNDS_ERROR = "Index out of bounds";
       const mutArr = [5, 10, 20];
       ((obj, args) => { if (args[0] < 0 || args[0] > mutArr.length) throw new Error("Index out of bounds"); obj.splice(args[0], 0, args[1]); })(mutArr, [2,15]);
       {((cond) => {if (!cond) throw new Error("assertion failed: mutArr.length == 4")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(mutArr.length,4)))};
       {((cond) => {if (!cond) throw new Error("assertion failed: mutArr.at(2) == 15")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await mutArr.at(2)),15)))};
       {((cond) => {if (!cond) throw new Error("assertion failed: mutArr.at(3) == 20")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await mutArr.at(3)),20)))};
-      (await assertThrows(INDEX_OUT_OF_BOUNDS_ERROR,async () => {
+      (await $asserions_Assert.throws(INDEX_OUT_OF_BOUNDS_ERROR,async () => {
         ((obj, args) => { if (args[0] < 0 || args[0] > mutArr.length) throw new Error("Index out of bounds"); obj.splice(args[0], 0, args[1]); })(mutArr, [(-3),15]);
       }
       ));
       {((cond) => {if (!cond) throw new Error("assertion failed: mutArr.length == 4")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(mutArr.length,4)))};
-      (await assertThrows(INDEX_OUT_OF_BOUNDS_ERROR,async () => {
+      (await $asserions_Assert.throws(INDEX_OUT_OF_BOUNDS_ERROR,async () => {
         ((obj, args) => { if (args[0] < 0 || args[0] > mutArr.length) throw new Error("Index out of bounds"); obj.splice(args[0], 0, args[1]); })(mutArr, [7,15]);
       }
       ));
@@ -218,7 +192,7 @@ module.exports = function({  }) {
 
 ```
 
-## inflight.$Closure17-1.js
+## inflight.$Closure17-2.js
 ```js
 module.exports = function({  }) {
   class $Closure17 {
@@ -243,7 +217,7 @@ module.exports = function({  }) {
 
 ```
 
-## inflight.$Closure2-1.js
+## inflight.$Closure2-2.js
 ```js
 module.exports = function({  }) {
   class $Closure2 {
@@ -262,7 +236,7 @@ module.exports = function({  }) {
 
 ```
 
-## inflight.$Closure3-1.js
+## inflight.$Closure3-2.js
 ```js
 module.exports = function({  }) {
   class $Closure3 {
@@ -289,9 +263,9 @@ module.exports = function({  }) {
 
 ```
 
-## inflight.$Closure4-1.js
+## inflight.$Closure4-2.js
 ```js
-module.exports = function({  }) {
+module.exports = function({ $asserions_Assert }) {
   class $Closure4 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
@@ -299,30 +273,17 @@ module.exports = function({  }) {
       return $obj;
     }
     async handle() {
-      const assertThrows = async (expected, block) => {
-        let error = false;
-        try {
-          (await block());
-        }
-        catch ($error_actual) {
-          const actual = $error_actual.message;
-          {((cond) => {if (!cond) throw new Error("assertion failed: actual == expected")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(actual,expected)))};
-          error = true;
-        }
-        {((cond) => {if (!cond) throw new Error("assertion failed: error")})(error)};
-      }
-      ;
       const INDEX_OUT_OF_BOUNDS_ERROR = "Index out of bounds";
       const mutArr = ["hello", "world"];
       const item = ((obj, args) => { if (args[0] < 0 || args[0] >= mutArr.length) throw new Error("Index out of bounds"); return obj.splice(args[0], 1)[0]; })(mutArr, [0]);
       {((cond) => {if (!cond) throw new Error("assertion failed: item == \"hello\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(item,"hello")))};
       {((cond) => {if (!cond) throw new Error("assertion failed: mutArr.length == 1")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(mutArr.length,1)))};
       {((cond) => {if (!cond) throw new Error("assertion failed: mutArr.at(0) == \"world\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await mutArr.at(0)),"world")))};
-      (await assertThrows(INDEX_OUT_OF_BOUNDS_ERROR,async () => {
+      (await $asserions_Assert.throws(INDEX_OUT_OF_BOUNDS_ERROR,async () => {
         ((obj, args) => { if (args[0] < 0 || args[0] >= mutArr.length) throw new Error("Index out of bounds"); return obj.splice(args[0], 1)[0]; })(mutArr, [(-3)]);
       }
       ));
-      (await assertThrows(INDEX_OUT_OF_BOUNDS_ERROR,async () => {
+      (await $asserions_Assert.throws(INDEX_OUT_OF_BOUNDS_ERROR,async () => {
         ((obj, args) => { if (args[0] < 0 || args[0] >= mutArr.length) throw new Error("Index out of bounds"); return obj.splice(args[0], 1)[0]; })(mutArr, [3]);
       }
       ));
@@ -333,7 +294,7 @@ module.exports = function({  }) {
 
 ```
 
-## inflight.$Closure5-1.js
+## inflight.$Closure5-2.js
 ```js
 module.exports = function({  }) {
   class $Closure5 {
@@ -356,7 +317,7 @@ module.exports = function({  }) {
 
 ```
 
-## inflight.$Closure6-1.js
+## inflight.$Closure6-2.js
 ```js
 module.exports = function({  }) {
   class $Closure6 {
@@ -381,7 +342,7 @@ module.exports = function({  }) {
 
 ```
 
-## inflight.$Closure7-1.js
+## inflight.$Closure7-2.js
 ```js
 module.exports = function({  }) {
   class $Closure7 {
@@ -404,7 +365,7 @@ module.exports = function({  }) {
 
 ```
 
-## inflight.$Closure8-1.js
+## inflight.$Closure8-2.js
 ```js
 module.exports = function({  }) {
   class $Closure8 {
@@ -424,7 +385,7 @@ module.exports = function({  }) {
 
 ```
 
-## inflight.$Closure9-1.js
+## inflight.$Closure9-2.js
 ```js
 module.exports = function({  }) {
   class $Closure9 {
@@ -440,6 +401,73 @@ module.exports = function({  }) {
     }
   }
   return $Closure9;
+}
+
+```
+
+## inflight.Assert-1.js
+```js
+module.exports = function({  }) {
+  class Assert {
+    static async throws(expected, block) {
+      let actual = "";
+      try {
+        (await block());
+      }
+      catch ($error_e) {
+        const e = $error_e.message;
+        actual = e;
+      }
+      if ((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(actual,""))) {
+        throw new Error("expected error, but none thrown.");
+      }
+      if ((((a,b) => { try { return require('assert').notDeepStrictEqual(a,b) === undefined; } catch { return false; } })(actual,expected))) {
+        throw new Error(String.raw({ raw: ["expected error message: \"", "\" got: \"", "\""] }, expected, actual));
+      }
+    }
+    static async equalStr(a, b) {
+      try {
+        {((cond) => {if (!cond) throw new Error("assertion failed: a == b")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(a,b)))};
+      }
+      catch ($error_e) {
+        const e = $error_e.message;
+        throw new Error(String.raw({ raw: ["expected: ", " got: ", ""] }, b, a));
+      }
+    }
+    static async isNil(a) {
+      try {
+        {((cond) => {if (!cond) throw new Error("assertion failed: a == nil")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(a,undefined)))};
+      }
+      catch ($error_e) {
+        const e = $error_e.message;
+        {console.log(e)};
+        throw new Error(String.raw({ raw: ["expected '", "' to be nil"] }, a));
+      }
+    }
+    static async equalNum(a, b) {
+      try {
+        {((cond) => {if (!cond) throw new Error("assertion failed: a == b")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(a,b)))};
+      }
+      catch ($error_e) {
+        const e = $error_e.message;
+        {console.log(e)};
+        throw new Error(String.raw({ raw: ["expected: ", " got: ", ""] }, b, a));
+      }
+    }
+  }
+  return Assert;
+}
+
+```
+
+## inflight.PreflightAssert-1.js
+```js
+module.exports = function({  }) {
+  class PreflightAssert {
+    constructor({  }) {
+    }
+  }
+  return PreflightAssert;
 }
 
 ```
@@ -510,6 +538,81 @@ module.exports = function({  }) {
 }
 ```
 
+## preflight.assertions-1.js
+```js
+module.exports = function({ $stdlib }) {
+  const std = $stdlib.std;
+  class Assert extends $stdlib.std.Resource {
+    constructor(scope, id, ) {
+      super(scope, id);
+    }
+    static _toInflightType(context) {
+      return `
+        require("./inflight.Assert-1.js")({
+        })
+      `;
+    }
+    _toInflight() {
+      return `
+        (await (async () => {
+          const AssertClient = ${Assert._toInflightType(this)};
+          const client = new AssertClient({
+          });
+          if (client.$inflight_init) { await client.$inflight_init(); }
+          return client;
+        })())
+      `;
+    }
+    _getInflightOps() {
+      return ["throws", "equalStr", "isNil", "equalNum", "$inflight_init"];
+    }
+  }
+  class PreflightAssert extends $stdlib.std.Resource {
+    constructor(scope, id, ) {
+      super(scope, id);
+    }
+    static throws(expected, block) {
+      let actual = "";
+      try {
+        (block());
+      }
+      catch ($error_e) {
+        const e = $error_e.message;
+        actual = e;
+      }
+      if ((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(actual,""))) {
+        throw new Error("expected error, but none thrown.");
+      }
+      if ((((a,b) => { try { return require('assert').notDeepStrictEqual(a,b) === undefined; } catch { return false; } })(actual,expected))) {
+        throw new Error(String.raw({ raw: ["expected error message: \"", "\" got: \"", "\""] }, expected, actual));
+      }
+    }
+    static _toInflightType(context) {
+      return `
+        require("./inflight.PreflightAssert-1.js")({
+        })
+      `;
+    }
+    _toInflight() {
+      return `
+        (await (async () => {
+          const PreflightAssertClient = ${PreflightAssert._toInflightType(this)};
+          const client = new PreflightAssertClient({
+          });
+          if (client.$inflight_init) { await client.$inflight_init(); }
+          return client;
+        })())
+      `;
+    }
+    _getInflightOps() {
+      return ["$inflight_init"];
+    }
+  }
+  return { Assert, PreflightAssert };
+};
+
+```
+
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
@@ -518,6 +621,7 @@ const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const cloud = $stdlib.cloud;
+const asserions = require("./preflight.assertions-1.js")({ $stdlib });
 class $Root extends $stdlib.std.Resource {
   constructor(scope, id) {
     super(scope, id);
@@ -528,7 +632,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("./inflight.$Closure1-2.js")({
           })
         `;
       }
@@ -554,7 +658,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return `
-          require("./inflight.$Closure2-1.js")({
+          require("./inflight.$Closure2-2.js")({
           })
         `;
       }
@@ -580,7 +684,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return `
-          require("./inflight.$Closure3-1.js")({
+          require("./inflight.$Closure3-2.js")({
           })
         `;
       }
@@ -606,7 +710,8 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return `
-          require("./inflight.$Closure4-1.js")({
+          require("./inflight.$Closure4-2.js")({
+            $asserions_Assert: ${context._lift($stdlib.core.toLiftableModuleType(asserions.Assert, "", "Assert"))},
           })
         `;
       }
@@ -632,7 +737,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return `
-          require("./inflight.$Closure5-1.js")({
+          require("./inflight.$Closure5-2.js")({
           })
         `;
       }
@@ -658,7 +763,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return `
-          require("./inflight.$Closure6-1.js")({
+          require("./inflight.$Closure6-2.js")({
           })
         `;
       }
@@ -684,7 +789,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return `
-          require("./inflight.$Closure7-1.js")({
+          require("./inflight.$Closure7-2.js")({
           })
         `;
       }
@@ -710,7 +815,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return `
-          require("./inflight.$Closure8-1.js")({
+          require("./inflight.$Closure8-2.js")({
           })
         `;
       }
@@ -736,7 +841,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return `
-          require("./inflight.$Closure9-1.js")({
+          require("./inflight.$Closure9-2.js")({
           })
         `;
       }
@@ -762,7 +867,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return `
-          require("./inflight.$Closure10-1.js")({
+          require("./inflight.$Closure10-2.js")({
           })
         `;
       }
@@ -788,7 +893,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return `
-          require("./inflight.$Closure11-1.js")({
+          require("./inflight.$Closure11-2.js")({
           })
         `;
       }
@@ -814,7 +919,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return `
-          require("./inflight.$Closure12-1.js")({
+          require("./inflight.$Closure12-2.js")({
           })
         `;
       }
@@ -840,7 +945,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return `
-          require("./inflight.$Closure13-1.js")({
+          require("./inflight.$Closure13-2.js")({
           })
         `;
       }
@@ -866,7 +971,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return `
-          require("./inflight.$Closure14-1.js")({
+          require("./inflight.$Closure14-2.js")({
           })
         `;
       }
@@ -892,7 +997,8 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return `
-          require("./inflight.$Closure15-1.js")({
+          require("./inflight.$Closure15-2.js")({
+            $asserions_Assert: ${context._lift($stdlib.core.toLiftableModuleType(asserions.Assert, "", "Assert"))},
           })
         `;
       }
@@ -918,7 +1024,8 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return `
-          require("./inflight.$Closure16-1.js")({
+          require("./inflight.$Closure16-2.js")({
+            $asserions_Assert: ${context._lift($stdlib.core.toLiftableModuleType(asserions.Assert, "", "Assert"))},
           })
         `;
       }
@@ -944,7 +1051,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return `
-          require("./inflight.$Closure17-1.js")({
+          require("./inflight.$Closure17-2.js")({
           })
         `;
       }

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/std/bool.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/std/bool.test.w_compile_tf-aws.md
@@ -1,8 +1,8 @@
 # [bool.test.w](../../../../../../examples/tests/sdk_tests/std/bool.test.w) | compile | tf-aws
 
-## inflight.$Closure1-1.js
+## inflight.$Closure1-2.js
 ```js
-module.exports = function({ $PARSE_ERROR, $std_Boolean, $std_Json }) {
+module.exports = function({ $PARSE_ERROR, $assertions_Assert, $std_Boolean, $std_Json }) {
   class $Closure1 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
@@ -14,16 +14,80 @@ module.exports = function({ $PARSE_ERROR, $std_Boolean, $std_Json }) {
       {((cond) => {if (!cond) throw new Error("assertion failed: t == true")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(t,true)))};
       const f = (await $std_Boolean.fromJson((JSON.parse("false"))));
       {((cond) => {if (!cond) throw new Error("assertion failed: f == false")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(f,false)))};
-      try {
+      (await $assertions_Assert.throws($PARSE_ERROR,async () => {
         (await $std_Boolean.fromJson(123));
       }
-      catch ($error_s) {
-        const s = $error_s.message;
-        {((cond) => {if (!cond) throw new Error("assertion failed: s.contains(PARSE_ERROR)")})(s.includes($PARSE_ERROR))};
-      }
+      ));
     }
   }
   return $Closure1;
+}
+
+```
+
+## inflight.Assert-1.js
+```js
+module.exports = function({  }) {
+  class Assert {
+    static async throws(expected, block) {
+      let actual = "";
+      try {
+        (await block());
+      }
+      catch ($error_e) {
+        const e = $error_e.message;
+        actual = e;
+      }
+      if ((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(actual,""))) {
+        throw new Error("expected error, but none thrown.");
+      }
+      if ((((a,b) => { try { return require('assert').notDeepStrictEqual(a,b) === undefined; } catch { return false; } })(actual,expected))) {
+        throw new Error(String.raw({ raw: ["expected error message: \"", "\" got: \"", "\""] }, expected, actual));
+      }
+    }
+    static async equalStr(a, b) {
+      try {
+        {((cond) => {if (!cond) throw new Error("assertion failed: a == b")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(a,b)))};
+      }
+      catch ($error_e) {
+        const e = $error_e.message;
+        throw new Error(String.raw({ raw: ["expected: ", " got: ", ""] }, b, a));
+      }
+    }
+    static async isNil(a) {
+      try {
+        {((cond) => {if (!cond) throw new Error("assertion failed: a == nil")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(a,undefined)))};
+      }
+      catch ($error_e) {
+        const e = $error_e.message;
+        {console.log(e)};
+        throw new Error(String.raw({ raw: ["expected '", "' to be nil"] }, a));
+      }
+    }
+    static async equalNum(a, b) {
+      try {
+        {((cond) => {if (!cond) throw new Error("assertion failed: a == b")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(a,b)))};
+      }
+      catch ($error_e) {
+        const e = $error_e.message;
+        {console.log(e)};
+        throw new Error(String.raw({ raw: ["expected: ", " got: ", ""] }, b, a));
+      }
+    }
+  }
+  return Assert;
+}
+
+```
+
+## inflight.PreflightAssert-1.js
+```js
+module.exports = function({  }) {
+  class PreflightAssert {
+    constructor({  }) {
+    }
+  }
+  return PreflightAssert;
 }
 
 ```
@@ -60,6 +124,81 @@ module.exports = function({ $PARSE_ERROR, $std_Boolean, $std_Json }) {
 }
 ```
 
+## preflight.assertions-1.js
+```js
+module.exports = function({ $stdlib }) {
+  const std = $stdlib.std;
+  class Assert extends $stdlib.std.Resource {
+    constructor(scope, id, ) {
+      super(scope, id);
+    }
+    static _toInflightType(context) {
+      return `
+        require("./inflight.Assert-1.js")({
+        })
+      `;
+    }
+    _toInflight() {
+      return `
+        (await (async () => {
+          const AssertClient = ${Assert._toInflightType(this)};
+          const client = new AssertClient({
+          });
+          if (client.$inflight_init) { await client.$inflight_init(); }
+          return client;
+        })())
+      `;
+    }
+    _getInflightOps() {
+      return ["throws", "equalStr", "isNil", "equalNum", "$inflight_init"];
+    }
+  }
+  class PreflightAssert extends $stdlib.std.Resource {
+    constructor(scope, id, ) {
+      super(scope, id);
+    }
+    static throws(expected, block) {
+      let actual = "";
+      try {
+        (block());
+      }
+      catch ($error_e) {
+        const e = $error_e.message;
+        actual = e;
+      }
+      if ((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(actual,""))) {
+        throw new Error("expected error, but none thrown.");
+      }
+      if ((((a,b) => { try { return require('assert').notDeepStrictEqual(a,b) === undefined; } catch { return false; } })(actual,expected))) {
+        throw new Error(String.raw({ raw: ["expected error message: \"", "\" got: \"", "\""] }, expected, actual));
+      }
+    }
+    static _toInflightType(context) {
+      return `
+        require("./inflight.PreflightAssert-1.js")({
+        })
+      `;
+    }
+    _toInflight() {
+      return `
+        (await (async () => {
+          const PreflightAssertClient = ${PreflightAssert._toInflightType(this)};
+          const client = new PreflightAssertClient({
+          });
+          if (client.$inflight_init) { await client.$inflight_init(); }
+          return client;
+        })())
+      `;
+    }
+    _getInflightOps() {
+      return ["$inflight_init"];
+    }
+  }
+  return { Assert, PreflightAssert };
+};
+
+```
+
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
@@ -67,6 +206,7 @@ const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
+const assertions = require("./preflight.assertions-1.js")({ $stdlib });
 class $Root extends $stdlib.std.Resource {
   constructor(scope, id) {
     super(scope, id);
@@ -77,8 +217,9 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("./inflight.$Closure1-2.js")({
             $PARSE_ERROR: ${context._lift(PARSE_ERROR)},
+            $assertions_Assert: ${context._lift($stdlib.core.toLiftableModuleType(assertions.Assert, "", "Assert"))},
             $std_Boolean: ${context._lift($stdlib.core.toLiftableModuleType(std.Boolean, "@winglang/sdk/std", "Boolean"))},
             $std_Json: ${context._lift($stdlib.core.toLiftableModuleType(std.Json, "@winglang/sdk/std", "Json"))},
           })
@@ -105,22 +246,10 @@ class $Root extends $stdlib.std.Resource {
         super._registerBind(host, ops);
       }
     }
-    const assertThrows = ((expected, block) => {
-      let error = false;
-      try {
-        (block());
-      }
-      catch ($error_actual) {
-        const actual = $error_actual.message;
-        {((cond) => {if (!cond) throw new Error("assertion failed: actual.contains(expected)")})(actual.includes(expected))};
-        error = true;
-      }
-      {((cond) => {if (!cond) throw new Error("assertion failed: error")})(error)};
-    });
-    const PARSE_ERROR = "unable to parse bool";
+    const PARSE_ERROR = "unable to parse bool:\n- instance is not of a type(s) boolean";
     const t = (std.Boolean.fromJson((JSON.parse("true"))));
     {((cond) => {if (!cond) throw new Error("assertion failed: t == true")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(t,true)))};
-    (assertThrows(PARSE_ERROR,(() => {
+    (assertions.PreflightAssert.throws(PARSE_ERROR,(() => {
       (std.Boolean.fromJson(123));
     })));
     const f = (std.Boolean.fromJson((JSON.parse("false"))));

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/std/json.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/std/json.test.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [json.test.w](../../../../../../examples/tests/sdk_tests/std/json.test.w) | compile | tf-aws
 
-## inflight.$Closure1-1.js
+## inflight.$Closure1-2.js
 ```js
 module.exports = function({ $std_Json }) {
   class $Closure1 {
@@ -20,7 +20,7 @@ module.exports = function({ $std_Json }) {
 
 ```
 
-## inflight.$Closure10-1.js
+## inflight.$Closure10-2.js
 ```js
 module.exports = function({ $std_Json }) {
   class $Closure10 {
@@ -45,9 +45,9 @@ module.exports = function({ $std_Json }) {
 
 ```
 
-## inflight.$Closure2-1.js
+## inflight.$Closure2-2.js
 ```js
-module.exports = function({  }) {
+module.exports = function({ $assertions_Assert }) {
   class $Closure2 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
@@ -55,29 +55,16 @@ module.exports = function({  }) {
       return $obj;
     }
     async handle() {
-      const assertThrows = async (expected, block) => {
-        let error = false;
-        try {
-          (await block());
-        }
-        catch ($error_actual) {
-          const actual = $error_actual.message;
-          {((cond) => {if (!cond) throw new Error("assertion failed: actual == expected")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(actual,expected)))};
-          error = true;
-        }
-        {((cond) => {if (!cond) throw new Error("assertion failed: error")})(error)};
-      }
-      ;
       const JSON_PROPERTY_DOES_NOT_EXIST_ERROR = "Json property \"c\" does not exist";
       const obj = ({"a": 1,"b": 2});
       const mutObj = ({"a": 1,"b": 2});
       {((cond) => {if (!cond) throw new Error("assertion failed: obj.get(\"b\") == 2")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(((obj, args) => { if (obj[args] === undefined) throw new Error(`Json property "${args}" does not exist`); return obj[args] })(obj, "b"),2)))};
       {((cond) => {if (!cond) throw new Error("assertion failed: mutObj.get(\"b\") == 2")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(((obj, args) => { if (obj[args] === undefined) throw new Error(`Json property "${args}" does not exist`); return obj[args] })(mutObj, "b"),2)))};
-      (await assertThrows(JSON_PROPERTY_DOES_NOT_EXIST_ERROR,async () => {
+      (await $assertions_Assert.throws(JSON_PROPERTY_DOES_NOT_EXIST_ERROR,async () => {
         ((obj, args) => { if (obj[args] === undefined) throw new Error(`Json property "${args}" does not exist`); return obj[args] })(obj, "c");
       }
       ));
-      (await assertThrows(JSON_PROPERTY_DOES_NOT_EXIST_ERROR,async () => {
+      (await $assertions_Assert.throws(JSON_PROPERTY_DOES_NOT_EXIST_ERROR,async () => {
         ((obj, args) => { if (obj[args] === undefined) throw new Error(`Json property "${args}" does not exist`); return obj[args] })(mutObj, "c");
       }
       ));
@@ -88,9 +75,9 @@ module.exports = function({  }) {
 
 ```
 
-## inflight.$Closure3-1.js
+## inflight.$Closure3-2.js
 ```js
-module.exports = function({  }) {
+module.exports = function({ $assertions_Assert }) {
   class $Closure3 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
@@ -98,25 +85,12 @@ module.exports = function({  }) {
       return $obj;
     }
     async handle() {
-      const assertThrows = async (expected, block) => {
-        let error = false;
-        try {
-          (await block());
-        }
-        catch ($error_actual) {
-          const actual = $error_actual.message;
-          {((cond) => {if (!cond) throw new Error("assertion failed: actual == expected")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(actual,expected)))};
-          error = true;
-        }
-        {((cond) => {if (!cond) throw new Error("assertion failed: error")})(error)};
-      }
-      ;
       const INDEX_OUT_OF_BOUNDS_ERROR = "Index out of bounds";
       const jsonArray = ["foo", "bar", "baz"];
       const mutJsonArray = [1, 2, 3];
       {((cond) => {if (!cond) throw new Error("assertion failed: jsonArray.getAt(2) == \"baz\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(((obj, args) => { if (obj[args] === undefined) throw new Error("Index out of bounds"); return obj[args] })(jsonArray, 2),"baz")))};
       {((cond) => {if (!cond) throw new Error("assertion failed: mutJsonArray.getAt(2) == 3")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(((obj, args) => { if (obj[args] === undefined) throw new Error("Index out of bounds"); return obj[args] })(mutJsonArray, 2),3)))};
-      (await assertThrows(INDEX_OUT_OF_BOUNDS_ERROR,async () => {
+      (await $assertions_Assert.throws(INDEX_OUT_OF_BOUNDS_ERROR,async () => {
         ((obj, args) => { if (obj[args] === undefined) throw new Error("Index out of bounds"); return obj[args] })(jsonArray, 3);
         ((obj, args) => { if (obj[args] === undefined) throw new Error("Index out of bounds"); return obj[args] })(mutJsonArray, 3);
       }
@@ -128,7 +102,7 @@ module.exports = function({  }) {
 
 ```
 
-## inflight.$Closure4-1.js
+## inflight.$Closure4-2.js
 ```js
 module.exports = function({  }) {
   class $Closure4 {
@@ -150,7 +124,7 @@ module.exports = function({  }) {
 
 ```
 
-## inflight.$Closure5-1.js
+## inflight.$Closure5-2.js
 ```js
 module.exports = function({  }) {
   class $Closure5 {
@@ -172,7 +146,7 @@ module.exports = function({  }) {
 
 ```
 
-## inflight.$Closure6-1.js
+## inflight.$Closure6-2.js
 ```js
 module.exports = function({ $std_Json }) {
   class $Closure6 {
@@ -194,7 +168,7 @@ module.exports = function({ $std_Json }) {
 
 ```
 
-## inflight.$Closure7-1.js
+## inflight.$Closure7-2.js
 ```js
 module.exports = function({ $std_Json }) {
   class $Closure7 {
@@ -221,7 +195,7 @@ module.exports = function({ $std_Json }) {
 
 ```
 
-## inflight.$Closure8-1.js
+## inflight.$Closure8-2.js
 ```js
 module.exports = function({ $std_Json }) {
   class $Closure8 {
@@ -243,7 +217,7 @@ module.exports = function({ $std_Json }) {
 
 ```
 
-## inflight.$Closure9-1.js
+## inflight.$Closure9-2.js
 ```js
 module.exports = function({ $std_Json }) {
   class $Closure9 {
@@ -264,6 +238,73 @@ module.exports = function({ $std_Json }) {
     }
   }
   return $Closure9;
+}
+
+```
+
+## inflight.Assert-1.js
+```js
+module.exports = function({  }) {
+  class Assert {
+    static async throws(expected, block) {
+      let actual = "";
+      try {
+        (await block());
+      }
+      catch ($error_e) {
+        const e = $error_e.message;
+        actual = e;
+      }
+      if ((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(actual,""))) {
+        throw new Error("expected error, but none thrown.");
+      }
+      if ((((a,b) => { try { return require('assert').notDeepStrictEqual(a,b) === undefined; } catch { return false; } })(actual,expected))) {
+        throw new Error(String.raw({ raw: ["expected error message: \"", "\" got: \"", "\""] }, expected, actual));
+      }
+    }
+    static async equalStr(a, b) {
+      try {
+        {((cond) => {if (!cond) throw new Error("assertion failed: a == b")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(a,b)))};
+      }
+      catch ($error_e) {
+        const e = $error_e.message;
+        throw new Error(String.raw({ raw: ["expected: ", " got: ", ""] }, b, a));
+      }
+    }
+    static async isNil(a) {
+      try {
+        {((cond) => {if (!cond) throw new Error("assertion failed: a == nil")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(a,undefined)))};
+      }
+      catch ($error_e) {
+        const e = $error_e.message;
+        {console.log(e)};
+        throw new Error(String.raw({ raw: ["expected '", "' to be nil"] }, a));
+      }
+    }
+    static async equalNum(a, b) {
+      try {
+        {((cond) => {if (!cond) throw new Error("assertion failed: a == b")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(a,b)))};
+      }
+      catch ($error_e) {
+        const e = $error_e.message;
+        {console.log(e)};
+        throw new Error(String.raw({ raw: ["expected: ", " got: ", ""] }, b, a));
+      }
+    }
+  }
+  return Assert;
+}
+
+```
+
+## inflight.PreflightAssert-1.js
+```js
+module.exports = function({  }) {
+  class PreflightAssert {
+    constructor({  }) {
+    }
+  }
+  return PreflightAssert;
 }
 
 ```
@@ -300,6 +341,81 @@ module.exports = function({ $std_Json }) {
 }
 ```
 
+## preflight.assertions-1.js
+```js
+module.exports = function({ $stdlib }) {
+  const std = $stdlib.std;
+  class Assert extends $stdlib.std.Resource {
+    constructor(scope, id, ) {
+      super(scope, id);
+    }
+    static _toInflightType(context) {
+      return `
+        require("./inflight.Assert-1.js")({
+        })
+      `;
+    }
+    _toInflight() {
+      return `
+        (await (async () => {
+          const AssertClient = ${Assert._toInflightType(this)};
+          const client = new AssertClient({
+          });
+          if (client.$inflight_init) { await client.$inflight_init(); }
+          return client;
+        })())
+      `;
+    }
+    _getInflightOps() {
+      return ["throws", "equalStr", "isNil", "equalNum", "$inflight_init"];
+    }
+  }
+  class PreflightAssert extends $stdlib.std.Resource {
+    constructor(scope, id, ) {
+      super(scope, id);
+    }
+    static throws(expected, block) {
+      let actual = "";
+      try {
+        (block());
+      }
+      catch ($error_e) {
+        const e = $error_e.message;
+        actual = e;
+      }
+      if ((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(actual,""))) {
+        throw new Error("expected error, but none thrown.");
+      }
+      if ((((a,b) => { try { return require('assert').notDeepStrictEqual(a,b) === undefined; } catch { return false; } })(actual,expected))) {
+        throw new Error(String.raw({ raw: ["expected error message: \"", "\" got: \"", "\""] }, expected, actual));
+      }
+    }
+    static _toInflightType(context) {
+      return `
+        require("./inflight.PreflightAssert-1.js")({
+        })
+      `;
+    }
+    _toInflight() {
+      return `
+        (await (async () => {
+          const PreflightAssertClient = ${PreflightAssert._toInflightType(this)};
+          const client = new PreflightAssertClient({
+          });
+          if (client.$inflight_init) { await client.$inflight_init(); }
+          return client;
+        })())
+      `;
+    }
+    _getInflightOps() {
+      return ["$inflight_init"];
+    }
+  }
+  return { Assert, PreflightAssert };
+};
+
+```
+
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
@@ -308,6 +424,7 @@ const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const cloud = $stdlib.cloud;
+const assertions = require("./preflight.assertions-1.js")({ $stdlib });
 class $Root extends $stdlib.std.Resource {
   constructor(scope, id) {
     super(scope, id);
@@ -318,7 +435,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("./inflight.$Closure1-2.js")({
             $std_Json: ${context._lift($stdlib.core.toLiftableModuleType(std.Json, "@winglang/sdk/std", "Json"))},
           })
         `;
@@ -345,7 +462,8 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return `
-          require("./inflight.$Closure2-1.js")({
+          require("./inflight.$Closure2-2.js")({
+            $assertions_Assert: ${context._lift($stdlib.core.toLiftableModuleType(assertions.Assert, "", "Assert"))},
           })
         `;
       }
@@ -371,7 +489,8 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return `
-          require("./inflight.$Closure3-1.js")({
+          require("./inflight.$Closure3-2.js")({
+            $assertions_Assert: ${context._lift($stdlib.core.toLiftableModuleType(assertions.Assert, "", "Assert"))},
           })
         `;
       }
@@ -397,7 +516,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return `
-          require("./inflight.$Closure4-1.js")({
+          require("./inflight.$Closure4-2.js")({
           })
         `;
       }
@@ -423,7 +542,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return `
-          require("./inflight.$Closure5-1.js")({
+          require("./inflight.$Closure5-2.js")({
           })
         `;
       }
@@ -449,7 +568,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return `
-          require("./inflight.$Closure6-1.js")({
+          require("./inflight.$Closure6-2.js")({
             $std_Json: ${context._lift($stdlib.core.toLiftableModuleType(std.Json, "@winglang/sdk/std", "Json"))},
           })
         `;
@@ -476,7 +595,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return `
-          require("./inflight.$Closure7-1.js")({
+          require("./inflight.$Closure7-2.js")({
             $std_Json: ${context._lift($stdlib.core.toLiftableModuleType(std.Json, "@winglang/sdk/std", "Json"))},
           })
         `;
@@ -503,7 +622,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return `
-          require("./inflight.$Closure8-1.js")({
+          require("./inflight.$Closure8-2.js")({
             $std_Json: ${context._lift($stdlib.core.toLiftableModuleType(std.Json, "@winglang/sdk/std", "Json"))},
           })
         `;
@@ -530,7 +649,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return `
-          require("./inflight.$Closure9-1.js")({
+          require("./inflight.$Closure9-2.js")({
             $std_Json: ${context._lift($stdlib.core.toLiftableModuleType(std.Json, "@winglang/sdk/std", "Json"))},
           })
         `;
@@ -557,7 +676,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return `
-          require("./inflight.$Closure10-1.js")({
+          require("./inflight.$Closure10-2.js")({
             $std_Json: ${context._lift($stdlib.core.toLiftableModuleType(std.Json, "@winglang/sdk/std", "Json"))},
           })
         `;

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/std/string.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/std/string.test.w_compile_tf-aws.md
@@ -1,8 +1,8 @@
 # [string.test.w](../../../../../../examples/tests/sdk_tests/std/string.test.w) | compile | tf-aws
 
-## inflight.$Closure1-1.js
+## inflight.$Closure1-2.js
 ```js
-module.exports = function({ $PARSE_ERROR, $std_String }) {
+module.exports = function({ $PARSE_ERROR, $assertions_Assert, $std_String }) {
   class $Closure1 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
@@ -11,13 +11,10 @@ module.exports = function({ $PARSE_ERROR, $std_String }) {
     }
     async handle() {
       {((cond) => {if (!cond) throw new Error("assertion failed: str.fromJson(Json \"World\") == \"World\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $std_String.fromJson("World")),"World")))};
-      try {
+      (await $assertions_Assert.throws($PARSE_ERROR,async () => {
         (await $std_String.fromJson(123));
       }
-      catch ($error_s) {
-        const s = $error_s.message;
-        {((cond) => {if (!cond) throw new Error("assertion failed: s.contains(PARSE_ERROR)")})(s.includes($PARSE_ERROR))};
-      }
+      ));
     }
   }
   return $Closure1;
@@ -25,7 +22,7 @@ module.exports = function({ $PARSE_ERROR, $std_String }) {
 
 ```
 
-## inflight.$Closure10-1.js
+## inflight.$Closure10-2.js
 ```js
 module.exports = function({  }) {
   class $Closure10 {
@@ -45,7 +42,7 @@ module.exports = function({  }) {
 
 ```
 
-## inflight.$Closure11-1.js
+## inflight.$Closure11-2.js
 ```js
 module.exports = function({  }) {
   class $Closure11 {
@@ -64,7 +61,7 @@ module.exports = function({  }) {
 
 ```
 
-## inflight.$Closure12-1.js
+## inflight.$Closure12-2.js
 ```js
 module.exports = function({  }) {
   class $Closure12 {
@@ -85,7 +82,7 @@ module.exports = function({  }) {
 
 ```
 
-## inflight.$Closure13-1.js
+## inflight.$Closure13-2.js
 ```js
 module.exports = function({  }) {
   class $Closure13 {
@@ -105,7 +102,7 @@ module.exports = function({  }) {
 
 ```
 
-## inflight.$Closure14-1.js
+## inflight.$Closure14-2.js
 ```js
 module.exports = function({  }) {
   class $Closure14 {
@@ -127,7 +124,7 @@ module.exports = function({  }) {
 
 ```
 
-## inflight.$Closure2-1.js
+## inflight.$Closure2-2.js
 ```js
 module.exports = function({  }) {
   class $Closure2 {
@@ -146,9 +143,9 @@ module.exports = function({  }) {
 
 ```
 
-## inflight.$Closure3-1.js
+## inflight.$Closure3-2.js
 ```js
-module.exports = function({ $INDEX_OUT_OF_BOUNDS_ERROR }) {
+module.exports = function({ $INDEX_OUT_OF_BOUNDS_ERROR, $assertions_Assert }) {
   class $Closure3 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
@@ -159,20 +156,14 @@ module.exports = function({ $INDEX_OUT_OF_BOUNDS_ERROR }) {
       {((cond) => {if (!cond) throw new Error("assertion failed: \"boom\".at(0) == \"b\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(((args) => { if (0 >= "boom".length || 0 + "boom".length < 0) {throw new Error("index out of bounds")}; return "boom".at(0) })(0),"b")))};
       {((cond) => {if (!cond) throw new Error("assertion failed: \"boom\".at(-4) == \"b\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(((args) => { if ((-4) >= "boom".length || (-4) + "boom".length < 0) {throw new Error("index out of bounds")}; return "boom".at((-4)) })((-4)),"b")))};
       {((cond) => {if (!cond) throw new Error("assertion failed: \"boom\".at(-1) == \"m\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(((args) => { if ((-1) >= "boom".length || (-1) + "boom".length < 0) {throw new Error("index out of bounds")}; return "boom".at((-1)) })((-1)),"m")))};
-      try {
+      (await $assertions_Assert.throws($INDEX_OUT_OF_BOUNDS_ERROR,async () => {
         ((args) => { if (4 >= "boom".length || 4 + "boom".length < 0) {throw new Error("index out of bounds")}; return "boom".at(4) })(4);
       }
-      catch ($error_s) {
-        const s = $error_s.message;
-        {((cond) => {if (!cond) throw new Error("assertion failed: s == INDEX_OUT_OF_BOUNDS_ERROR ")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(s,$INDEX_OUT_OF_BOUNDS_ERROR)))};
-      }
-      try {
+      ));
+      (await $assertions_Assert.throws($INDEX_OUT_OF_BOUNDS_ERROR,async () => {
         ((args) => { if ((-5) >= "boom".length || (-5) + "boom".length < 0) {throw new Error("index out of bounds")}; return "boom".at((-5)) })((-5));
       }
-      catch ($error_s) {
-        const s = $error_s.message;
-        {((cond) => {if (!cond) throw new Error("assertion failed: s == INDEX_OUT_OF_BOUNDS_ERROR ")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(s,$INDEX_OUT_OF_BOUNDS_ERROR)))};
-      }
+      ));
     }
   }
   return $Closure3;
@@ -180,7 +171,7 @@ module.exports = function({ $INDEX_OUT_OF_BOUNDS_ERROR }) {
 
 ```
 
-## inflight.$Closure4-1.js
+## inflight.$Closure4-2.js
 ```js
 module.exports = function({  }) {
   class $Closure4 {
@@ -198,7 +189,7 @@ module.exports = function({  }) {
 
 ```
 
-## inflight.$Closure5-1.js
+## inflight.$Closure5-2.js
 ```js
 module.exports = function({  }) {
   class $Closure5 {
@@ -217,7 +208,7 @@ module.exports = function({  }) {
 
 ```
 
-## inflight.$Closure6-1.js
+## inflight.$Closure6-2.js
 ```js
 module.exports = function({  }) {
   class $Closure6 {
@@ -236,7 +227,7 @@ module.exports = function({  }) {
 
 ```
 
-## inflight.$Closure7-1.js
+## inflight.$Closure7-2.js
 ```js
 module.exports = function({  }) {
   class $Closure7 {
@@ -257,7 +248,7 @@ module.exports = function({  }) {
 
 ```
 
-## inflight.$Closure8-1.js
+## inflight.$Closure8-2.js
 ```js
 module.exports = function({  }) {
   class $Closure8 {
@@ -278,7 +269,7 @@ module.exports = function({  }) {
 
 ```
 
-## inflight.$Closure9-1.js
+## inflight.$Closure9-2.js
 ```js
 module.exports = function({  }) {
   class $Closure9 {
@@ -298,6 +289,73 @@ module.exports = function({  }) {
     }
   }
   return $Closure9;
+}
+
+```
+
+## inflight.Assert-1.js
+```js
+module.exports = function({  }) {
+  class Assert {
+    static async throws(expected, block) {
+      let actual = "";
+      try {
+        (await block());
+      }
+      catch ($error_e) {
+        const e = $error_e.message;
+        actual = e;
+      }
+      if ((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(actual,""))) {
+        throw new Error("expected error, but none thrown.");
+      }
+      if ((((a,b) => { try { return require('assert').notDeepStrictEqual(a,b) === undefined; } catch { return false; } })(actual,expected))) {
+        throw new Error(String.raw({ raw: ["expected error message: \"", "\" got: \"", "\""] }, expected, actual));
+      }
+    }
+    static async equalStr(a, b) {
+      try {
+        {((cond) => {if (!cond) throw new Error("assertion failed: a == b")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(a,b)))};
+      }
+      catch ($error_e) {
+        const e = $error_e.message;
+        throw new Error(String.raw({ raw: ["expected: ", " got: ", ""] }, b, a));
+      }
+    }
+    static async isNil(a) {
+      try {
+        {((cond) => {if (!cond) throw new Error("assertion failed: a == nil")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(a,undefined)))};
+      }
+      catch ($error_e) {
+        const e = $error_e.message;
+        {console.log(e)};
+        throw new Error(String.raw({ raw: ["expected '", "' to be nil"] }, a));
+      }
+    }
+    static async equalNum(a, b) {
+      try {
+        {((cond) => {if (!cond) throw new Error("assertion failed: a == b")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(a,b)))};
+      }
+      catch ($error_e) {
+        const e = $error_e.message;
+        {console.log(e)};
+        throw new Error(String.raw({ raw: ["expected: ", " got: ", ""] }, b, a));
+      }
+    }
+  }
+  return Assert;
+}
+
+```
+
+## inflight.PreflightAssert-1.js
+```js
+module.exports = function({  }) {
+  class PreflightAssert {
+    constructor({  }) {
+    }
+  }
+  return PreflightAssert;
 }
 
 ```
@@ -334,6 +392,81 @@ module.exports = function({  }) {
 }
 ```
 
+## preflight.assertions-1.js
+```js
+module.exports = function({ $stdlib }) {
+  const std = $stdlib.std;
+  class Assert extends $stdlib.std.Resource {
+    constructor(scope, id, ) {
+      super(scope, id);
+    }
+    static _toInflightType(context) {
+      return `
+        require("./inflight.Assert-1.js")({
+        })
+      `;
+    }
+    _toInflight() {
+      return `
+        (await (async () => {
+          const AssertClient = ${Assert._toInflightType(this)};
+          const client = new AssertClient({
+          });
+          if (client.$inflight_init) { await client.$inflight_init(); }
+          return client;
+        })())
+      `;
+    }
+    _getInflightOps() {
+      return ["throws", "equalStr", "isNil", "equalNum", "$inflight_init"];
+    }
+  }
+  class PreflightAssert extends $stdlib.std.Resource {
+    constructor(scope, id, ) {
+      super(scope, id);
+    }
+    static throws(expected, block) {
+      let actual = "";
+      try {
+        (block());
+      }
+      catch ($error_e) {
+        const e = $error_e.message;
+        actual = e;
+      }
+      if ((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(actual,""))) {
+        throw new Error("expected error, but none thrown.");
+      }
+      if ((((a,b) => { try { return require('assert').notDeepStrictEqual(a,b) === undefined; } catch { return false; } })(actual,expected))) {
+        throw new Error(String.raw({ raw: ["expected error message: \"", "\" got: \"", "\""] }, expected, actual));
+      }
+    }
+    static _toInflightType(context) {
+      return `
+        require("./inflight.PreflightAssert-1.js")({
+        })
+      `;
+    }
+    _toInflight() {
+      return `
+        (await (async () => {
+          const PreflightAssertClient = ${PreflightAssert._toInflightType(this)};
+          const client = new PreflightAssertClient({
+          });
+          if (client.$inflight_init) { await client.$inflight_init(); }
+          return client;
+        })())
+      `;
+    }
+    _getInflightOps() {
+      return ["$inflight_init"];
+    }
+  }
+  return { Assert, PreflightAssert };
+};
+
+```
+
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
@@ -341,6 +474,7 @@ const $plugins = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLUGIN_PATHS);
 const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
+const assertions = require("./preflight.assertions-1.js")({ $stdlib });
 class $Root extends $stdlib.std.Resource {
   constructor(scope, id) {
     super(scope, id);
@@ -351,8 +485,9 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("./inflight.$Closure1-2.js")({
             $PARSE_ERROR: ${context._lift(PARSE_ERROR)},
+            $assertions_Assert: ${context._lift($stdlib.core.toLiftableModuleType(assertions.Assert, "", "Assert"))},
             $std_String: ${context._lift($stdlib.core.toLiftableModuleType(std.String, "@winglang/sdk/std", "String"))},
           })
         `;
@@ -385,7 +520,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return `
-          require("./inflight.$Closure2-1.js")({
+          require("./inflight.$Closure2-2.js")({
           })
         `;
       }
@@ -411,8 +546,9 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return `
-          require("./inflight.$Closure3-1.js")({
+          require("./inflight.$Closure3-2.js")({
             $INDEX_OUT_OF_BOUNDS_ERROR: ${context._lift(INDEX_OUT_OF_BOUNDS_ERROR)},
+            $assertions_Assert: ${context._lift($stdlib.core.toLiftableModuleType(assertions.Assert, "", "Assert"))},
           })
         `;
       }
@@ -444,7 +580,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return `
-          require("./inflight.$Closure4-1.js")({
+          require("./inflight.$Closure4-2.js")({
           })
         `;
       }
@@ -470,7 +606,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return `
-          require("./inflight.$Closure5-1.js")({
+          require("./inflight.$Closure5-2.js")({
           })
         `;
       }
@@ -496,7 +632,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return `
-          require("./inflight.$Closure6-1.js")({
+          require("./inflight.$Closure6-2.js")({
           })
         `;
       }
@@ -522,7 +658,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return `
-          require("./inflight.$Closure7-1.js")({
+          require("./inflight.$Closure7-2.js")({
           })
         `;
       }
@@ -548,7 +684,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return `
-          require("./inflight.$Closure8-1.js")({
+          require("./inflight.$Closure8-2.js")({
           })
         `;
       }
@@ -574,7 +710,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return `
-          require("./inflight.$Closure9-1.js")({
+          require("./inflight.$Closure9-2.js")({
           })
         `;
       }
@@ -600,7 +736,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return `
-          require("./inflight.$Closure10-1.js")({
+          require("./inflight.$Closure10-2.js")({
           })
         `;
       }
@@ -626,7 +762,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return `
-          require("./inflight.$Closure11-1.js")({
+          require("./inflight.$Closure11-2.js")({
           })
         `;
       }
@@ -652,7 +788,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return `
-          require("./inflight.$Closure12-1.js")({
+          require("./inflight.$Closure12-2.js")({
           })
         `;
       }
@@ -678,7 +814,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return `
-          require("./inflight.$Closure13-1.js")({
+          require("./inflight.$Closure13-2.js")({
           })
         `;
       }
@@ -704,7 +840,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return `
-          require("./inflight.$Closure14-1.js")({
+          require("./inflight.$Closure14-2.js")({
           })
         `;
       }
@@ -723,21 +859,9 @@ class $Root extends $stdlib.std.Resource {
         return ["handle", "$inflight_init"];
       }
     }
-    const assertThrows = ((expected, block) => {
-      let error = false;
-      try {
-        (block());
-      }
-      catch ($error_actual) {
-        const actual = $error_actual.message;
-        {((cond) => {if (!cond) throw new Error("assertion failed: actual.contains(expected) == true")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(actual.includes(expected),true)))};
-        error = true;
-      }
-      {((cond) => {if (!cond) throw new Error("assertion failed: error")})(error)};
-    });
-    const PARSE_ERROR = "unable to parse string";
+    const PARSE_ERROR = "unable to parse string:\n- instance is not of a type(s) string";
     {((cond) => {if (!cond) throw new Error("assertion failed: str.fromJson(Json \"Hello\") == \"Hello\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((std.String.fromJson("Hello")),"Hello")))};
-    (assertThrows(PARSE_ERROR,(() => {
+    (assertions.PreflightAssert.throws(PARSE_ERROR,(() => {
       (std.String.fromJson(123));
     })));
     this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:fromJson",new $Closure1(this,"$Closure1"));
@@ -748,10 +872,10 @@ class $Root extends $stdlib.std.Resource {
     {((cond) => {if (!cond) throw new Error("assertion failed: \"boom\".at(2) == \"o\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(((args) => { if (2 >= "boom".length || 2 + "boom".length < 0) {throw new Error("index out of bounds")}; return "boom".at(2) })(2),"o")))};
     {((cond) => {if (!cond) throw new Error("assertion failed: \"boom\".at(-4) == \"b\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(((args) => { if ((-4) >= "boom".length || (-4) + "boom".length < 0) {throw new Error("index out of bounds")}; return "boom".at((-4)) })((-4)),"b")))};
     {((cond) => {if (!cond) throw new Error("assertion failed: \"boom\".at(-1) == \"m\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(((args) => { if ((-1) >= "boom".length || (-1) + "boom".length < 0) {throw new Error("index out of bounds")}; return "boom".at((-1)) })((-1)),"m")))};
-    (assertThrows(INDEX_OUT_OF_BOUNDS_ERROR,(() => {
+    (assertions.PreflightAssert.throws(INDEX_OUT_OF_BOUNDS_ERROR,(() => {
       ((args) => { if (4 >= "boom".length || 4 + "boom".length < 0) {throw new Error("index out of bounds")}; return "boom".at(4) })(4);
     })));
-    (assertThrows(INDEX_OUT_OF_BOUNDS_ERROR,(() => {
+    (assertions.PreflightAssert.throws(INDEX_OUT_OF_BOUNDS_ERROR,(() => {
       ((args) => { if ((-5) >= "boom".length || (-5) + "boom".length < 0) {throw new Error("index out of bounds")}; return "boom".at((-5)) })((-5));
     })));
     this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:at()",new $Closure3(this,"$Closure3"));

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/table/get.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/table/get.test.w_compile_tf-aws.md
@@ -1,8 +1,8 @@
 # [get.test.w](../../../../../../examples/tests/sdk_tests/table/get.test.w) | compile | tf-aws
 
-## inflight.$Closure1-1.js
+## inflight.$Closure1-2.js
 ```js
-module.exports = function({ $table }) {
+module.exports = function({ $assertions_Assert, $table }) {
   class $Closure1 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
@@ -15,22 +15,9 @@ module.exports = function({ $table }) {
       const VALID_KEY = "foo";
       const NON_EXISTENT_KEY = "bar";
       const ROW_DOES_NOT_EXIST_ERROR = String.raw({ raw: ["Row does not exist (key=", ")"] }, NON_EXISTENT_KEY);
-      const assertThrows = async (expected, block) => {
-        let error = false;
-        try {
-          (await block());
-        }
-        catch ($error_actual) {
-          const actual = $error_actual.message;
-          {((cond) => {if (!cond) throw new Error("assertion failed: actual == expected")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(actual,expected)))};
-          error = true;
-        }
-        {((cond) => {if (!cond) throw new Error("assertion failed: error")})(error)};
-      }
-      ;
       (await $table.insert(VALID_KEY,({"gender": COLUMN_VALUE})));
       {((cond) => {if (!cond) throw new Error("assertion failed: table.get(VALID_KEY).get(COLUMN_NAME) == COLUMN_VALUE")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(((obj, args) => { if (obj[args] === undefined) throw new Error(`Json property "${args}" does not exist`); return obj[args] })((await $table.get(VALID_KEY)), COLUMN_NAME),COLUMN_VALUE)))};
-      (await assertThrows(ROW_DOES_NOT_EXIST_ERROR,async () => {
+      (await $assertions_Assert.throws(ROW_DOES_NOT_EXIST_ERROR,async () => {
         (await $table.get(NON_EXISTENT_KEY));
       }
       ));
@@ -40,6 +27,73 @@ module.exports = function({ $table }) {
     }
   }
   return $Closure1;
+}
+
+```
+
+## inflight.Assert-1.js
+```js
+module.exports = function({  }) {
+  class Assert {
+    static async throws(expected, block) {
+      let actual = "";
+      try {
+        (await block());
+      }
+      catch ($error_e) {
+        const e = $error_e.message;
+        actual = e;
+      }
+      if ((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(actual,""))) {
+        throw new Error("expected error, but none thrown.");
+      }
+      if ((((a,b) => { try { return require('assert').notDeepStrictEqual(a,b) === undefined; } catch { return false; } })(actual,expected))) {
+        throw new Error(String.raw({ raw: ["expected error message: \"", "\" got: \"", "\""] }, expected, actual));
+      }
+    }
+    static async equalStr(a, b) {
+      try {
+        {((cond) => {if (!cond) throw new Error("assertion failed: a == b")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(a,b)))};
+      }
+      catch ($error_e) {
+        const e = $error_e.message;
+        throw new Error(String.raw({ raw: ["expected: ", " got: ", ""] }, b, a));
+      }
+    }
+    static async isNil(a) {
+      try {
+        {((cond) => {if (!cond) throw new Error("assertion failed: a == nil")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(a,undefined)))};
+      }
+      catch ($error_e) {
+        const e = $error_e.message;
+        {console.log(e)};
+        throw new Error(String.raw({ raw: ["expected '", "' to be nil"] }, a));
+      }
+    }
+    static async equalNum(a, b) {
+      try {
+        {((cond) => {if (!cond) throw new Error("assertion failed: a == b")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(a,b)))};
+      }
+      catch ($error_e) {
+        const e = $error_e.message;
+        {console.log(e)};
+        throw new Error(String.raw({ raw: ["expected: ", " got: ", ""] }, b, a));
+      }
+    }
+  }
+  return Assert;
+}
+
+```
+
+## inflight.PreflightAssert-1.js
+```js
+module.exports = function({  }) {
+  class PreflightAssert {
+    constructor({  }) {
+    }
+  }
+  return PreflightAssert;
 }
 
 ```
@@ -97,6 +151,81 @@ module.exports = function({ $table }) {
 }
 ```
 
+## preflight.assertions-1.js
+```js
+module.exports = function({ $stdlib }) {
+  const std = $stdlib.std;
+  class Assert extends $stdlib.std.Resource {
+    constructor(scope, id, ) {
+      super(scope, id);
+    }
+    static _toInflightType(context) {
+      return `
+        require("./inflight.Assert-1.js")({
+        })
+      `;
+    }
+    _toInflight() {
+      return `
+        (await (async () => {
+          const AssertClient = ${Assert._toInflightType(this)};
+          const client = new AssertClient({
+          });
+          if (client.$inflight_init) { await client.$inflight_init(); }
+          return client;
+        })())
+      `;
+    }
+    _getInflightOps() {
+      return ["throws", "equalStr", "isNil", "equalNum", "$inflight_init"];
+    }
+  }
+  class PreflightAssert extends $stdlib.std.Resource {
+    constructor(scope, id, ) {
+      super(scope, id);
+    }
+    static throws(expected, block) {
+      let actual = "";
+      try {
+        (block());
+      }
+      catch ($error_e) {
+        const e = $error_e.message;
+        actual = e;
+      }
+      if ((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(actual,""))) {
+        throw new Error("expected error, but none thrown.");
+      }
+      if ((((a,b) => { try { return require('assert').notDeepStrictEqual(a,b) === undefined; } catch { return false; } })(actual,expected))) {
+        throw new Error(String.raw({ raw: ["expected error message: \"", "\" got: \"", "\""] }, expected, actual));
+      }
+    }
+    static _toInflightType(context) {
+      return `
+        require("./inflight.PreflightAssert-1.js")({
+        })
+      `;
+    }
+    _toInflight() {
+      return `
+        (await (async () => {
+          const PreflightAssertClient = ${PreflightAssert._toInflightType(this)};
+          const client = new PreflightAssertClient({
+          });
+          if (client.$inflight_init) { await client.$inflight_init(); }
+          return client;
+        })())
+      `;
+    }
+    _getInflightOps() {
+      return ["$inflight_init"];
+    }
+  }
+  return { Assert, PreflightAssert };
+};
+
+```
+
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
@@ -106,6 +235,7 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 const ex = $stdlib.ex;
+const assertions = require("./preflight.assertions-1.js")({ $stdlib });
 class $Root extends $stdlib.std.Resource {
   constructor(scope, id) {
     super(scope, id);
@@ -116,7 +246,8 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("./inflight.$Closure1-2.js")({
+            $assertions_Assert: ${context._lift($stdlib.core.toLiftableModuleType(assertions.Assert, "", "Assert"))},
             $table: ${context._lift(table)},
           })
         `;

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/table/upsert.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/table/upsert.test.w_compile_tf-aws.md
@@ -1,8 +1,8 @@
 # [upsert.test.w](../../../../../../examples/tests/sdk_tests/table/upsert.test.w) | compile | tf-aws
 
-## inflight.$Closure1-1.js
+## inflight.$Closure1-2.js
 ```js
-module.exports = function({ $table }) {
+module.exports = function({ $assertions_Assert, $table }) {
   class $Closure1 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
@@ -10,34 +10,21 @@ module.exports = function({ $table }) {
       return $obj;
     }
     async handle() {
-      const assertThrows = async (expected, block) => {
-        let error = false;
-        try {
-          (await block());
-        }
-        catch ($error_actual) {
-          const actual = $error_actual.message;
-          {((cond) => {if (!cond) throw new Error("assertion failed: actual == expected")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(actual,expected)))};
-          error = true;
-        }
-        {((cond) => {if (!cond) throw new Error("assertion failed: error")})(error)};
-      }
-      ;
       const JSON_PROPERTY_ROLE_DOES_NOT_EXIST_ERROR = "Json property \"role\" does not exist";
       const JSON_PROPERTY_GENDER_DOES_NOT_EXIST_ERROR = "Json property \"gender\" does not exist";
       (await $table.upsert("mario",({})));
       (await $table.upsert("luigi",({"role": "ghostbuster"})));
       (await $table.upsert("peach",({"gender": "female","role": "princess"})));
-      (await assertThrows(JSON_PROPERTY_ROLE_DOES_NOT_EXIST_ERROR,async () => {
+      (await $assertions_Assert.throws(JSON_PROPERTY_ROLE_DOES_NOT_EXIST_ERROR,async () => {
         ((obj, args) => { if (obj[args] === undefined) throw new Error(`Json property "${args}" does not exist`); return obj[args] })((await $table.get("mario")), "role");
       }
       ));
-      (await assertThrows(JSON_PROPERTY_GENDER_DOES_NOT_EXIST_ERROR,async () => {
+      (await $assertions_Assert.throws(JSON_PROPERTY_GENDER_DOES_NOT_EXIST_ERROR,async () => {
         ((obj, args) => { if (obj[args] === undefined) throw new Error(`Json property "${args}" does not exist`); return obj[args] })((await $table.get("mario")), "gender");
       }
       ));
       {((cond) => {if (!cond) throw new Error("assertion failed: table.get(\"luigi\").get(\"role\") == \"ghostbuster\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(((obj, args) => { if (obj[args] === undefined) throw new Error(`Json property "${args}" does not exist`); return obj[args] })((await $table.get("luigi")), "role"),"ghostbuster")))};
-      (await assertThrows(JSON_PROPERTY_GENDER_DOES_NOT_EXIST_ERROR,async () => {
+      (await $assertions_Assert.throws(JSON_PROPERTY_GENDER_DOES_NOT_EXIST_ERROR,async () => {
         ((obj, args) => { if (obj[args] === undefined) throw new Error(`Json property "${args}" does not exist`); return obj[args] })((await $table.get("luigi")), "gender");
       }
       ));
@@ -47,6 +34,73 @@ module.exports = function({ $table }) {
     }
   }
   return $Closure1;
+}
+
+```
+
+## inflight.Assert-1.js
+```js
+module.exports = function({  }) {
+  class Assert {
+    static async throws(expected, block) {
+      let actual = "";
+      try {
+        (await block());
+      }
+      catch ($error_e) {
+        const e = $error_e.message;
+        actual = e;
+      }
+      if ((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(actual,""))) {
+        throw new Error("expected error, but none thrown.");
+      }
+      if ((((a,b) => { try { return require('assert').notDeepStrictEqual(a,b) === undefined; } catch { return false; } })(actual,expected))) {
+        throw new Error(String.raw({ raw: ["expected error message: \"", "\" got: \"", "\""] }, expected, actual));
+      }
+    }
+    static async equalStr(a, b) {
+      try {
+        {((cond) => {if (!cond) throw new Error("assertion failed: a == b")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(a,b)))};
+      }
+      catch ($error_e) {
+        const e = $error_e.message;
+        throw new Error(String.raw({ raw: ["expected: ", " got: ", ""] }, b, a));
+      }
+    }
+    static async isNil(a) {
+      try {
+        {((cond) => {if (!cond) throw new Error("assertion failed: a == nil")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(a,undefined)))};
+      }
+      catch ($error_e) {
+        const e = $error_e.message;
+        {console.log(e)};
+        throw new Error(String.raw({ raw: ["expected '", "' to be nil"] }, a));
+      }
+    }
+    static async equalNum(a, b) {
+      try {
+        {((cond) => {if (!cond) throw new Error("assertion failed: a == b")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(a,b)))};
+      }
+      catch ($error_e) {
+        const e = $error_e.message;
+        {console.log(e)};
+        throw new Error(String.raw({ raw: ["expected: ", " got: ", ""] }, b, a));
+      }
+    }
+  }
+  return Assert;
+}
+
+```
+
+## inflight.PreflightAssert-1.js
+```js
+module.exports = function({  }) {
+  class PreflightAssert {
+    constructor({  }) {
+    }
+  }
+  return PreflightAssert;
 }
 
 ```
@@ -128,6 +182,81 @@ module.exports = function({ $table }) {
 }
 ```
 
+## preflight.assertions-1.js
+```js
+module.exports = function({ $stdlib }) {
+  const std = $stdlib.std;
+  class Assert extends $stdlib.std.Resource {
+    constructor(scope, id, ) {
+      super(scope, id);
+    }
+    static _toInflightType(context) {
+      return `
+        require("./inflight.Assert-1.js")({
+        })
+      `;
+    }
+    _toInflight() {
+      return `
+        (await (async () => {
+          const AssertClient = ${Assert._toInflightType(this)};
+          const client = new AssertClient({
+          });
+          if (client.$inflight_init) { await client.$inflight_init(); }
+          return client;
+        })())
+      `;
+    }
+    _getInflightOps() {
+      return ["throws", "equalStr", "isNil", "equalNum", "$inflight_init"];
+    }
+  }
+  class PreflightAssert extends $stdlib.std.Resource {
+    constructor(scope, id, ) {
+      super(scope, id);
+    }
+    static throws(expected, block) {
+      let actual = "";
+      try {
+        (block());
+      }
+      catch ($error_e) {
+        const e = $error_e.message;
+        actual = e;
+      }
+      if ((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(actual,""))) {
+        throw new Error("expected error, but none thrown.");
+      }
+      if ((((a,b) => { try { return require('assert').notDeepStrictEqual(a,b) === undefined; } catch { return false; } })(actual,expected))) {
+        throw new Error(String.raw({ raw: ["expected error message: \"", "\" got: \"", "\""] }, expected, actual));
+      }
+    }
+    static _toInflightType(context) {
+      return `
+        require("./inflight.PreflightAssert-1.js")({
+        })
+      `;
+    }
+    _toInflight() {
+      return `
+        (await (async () => {
+          const PreflightAssertClient = ${PreflightAssert._toInflightType(this)};
+          const client = new PreflightAssertClient({
+          });
+          if (client.$inflight_init) { await client.$inflight_init(); }
+          return client;
+        })())
+      `;
+    }
+    _getInflightOps() {
+      return ["$inflight_init"];
+    }
+  }
+  return { Assert, PreflightAssert };
+};
+
+```
+
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
@@ -137,6 +266,7 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const ex = $stdlib.ex;
 const util = $stdlib.util;
+const assertions = require("./preflight.assertions-1.js")({ $stdlib });
 class $Root extends $stdlib.std.Resource {
   constructor(scope, id) {
     super(scope, id);
@@ -147,7 +277,8 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("./inflight.$Closure1-2.js")({
+            $assertions_Assert: ${context._lift($stdlib.core.toLiftableModuleType(assertions.Assert, "", "Assert"))},
             $table: ${context._lift(table)},
           })
         `;

--- a/tools/hangar/__snapshots__/test_corpus/valid/api_cors_custom.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/api_cors_custom.test.w_compile_tf-aws.md
@@ -95,6 +95,22 @@ module.exports = function({ $api_url, $http_HttpMethod, $http_Util, $t_Assert })
 ```js
 module.exports = function({  }) {
   class Assert {
+    static async throws(expected, block) {
+      let actual = "";
+      try {
+        (await block());
+      }
+      catch ($error_e) {
+        const e = $error_e.message;
+        actual = e;
+      }
+      if ((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(actual,""))) {
+        throw new Error("expected error, but none thrown.");
+      }
+      if ((((a,b) => { try { return require('assert').notDeepStrictEqual(a,b) === undefined; } catch { return false; } })(actual,expected))) {
+        throw new Error(String.raw({ raw: ["expected error message: \"", "\" got: \"", "\""] }, expected, actual));
+      }
+    }
     static async equalStr(a, b) {
       try {
         {((cond) => {if (!cond) throw new Error("assertion failed: a == b")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(a,b)))};
@@ -126,6 +142,18 @@ module.exports = function({  }) {
     }
   }
   return Assert;
+}
+
+```
+
+## inflight.PreflightAssert-1.js
+```js
+module.exports = function({  }) {
+  class PreflightAssert {
+    constructor({  }) {
+    }
+  }
+  return PreflightAssert;
 }
 
 ```
@@ -361,10 +389,51 @@ module.exports = function({ $stdlib }) {
       `;
     }
     _getInflightOps() {
-      return ["equalStr", "isNil", "equalNum", "$inflight_init"];
+      return ["throws", "equalStr", "isNil", "equalNum", "$inflight_init"];
     }
   }
-  return { Assert };
+  class PreflightAssert extends $stdlib.std.Resource {
+    constructor(scope, id, ) {
+      super(scope, id);
+    }
+    static throws(expected, block) {
+      let actual = "";
+      try {
+        (block());
+      }
+      catch ($error_e) {
+        const e = $error_e.message;
+        actual = e;
+      }
+      if ((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(actual,""))) {
+        throw new Error("expected error, but none thrown.");
+      }
+      if ((((a,b) => { try { return require('assert').notDeepStrictEqual(a,b) === undefined; } catch { return false; } })(actual,expected))) {
+        throw new Error(String.raw({ raw: ["expected error message: \"", "\" got: \"", "\""] }, expected, actual));
+      }
+    }
+    static _toInflightType(context) {
+      return `
+        require("./inflight.PreflightAssert-1.js")({
+        })
+      `;
+    }
+    _toInflight() {
+      return `
+        (await (async () => {
+          const PreflightAssertClient = ${PreflightAssert._toInflightType(this)};
+          const client = new PreflightAssertClient({
+          });
+          if (client.$inflight_init) { await client.$inflight_init(); }
+          return client;
+        })())
+      `;
+    }
+    _getInflightOps() {
+      return ["$inflight_init"];
+    }
+  }
+  return { Assert, PreflightAssert };
 };
 
 ```

--- a/tools/hangar/__snapshots__/test_corpus/valid/api_cors_default.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/api_cors_default.test.w_compile_tf-aws.md
@@ -72,6 +72,22 @@ module.exports = function({ $apiDefaultCors_url, $http_HttpMethod, $http_Util, $
 ```js
 module.exports = function({  }) {
   class Assert {
+    static async throws(expected, block) {
+      let actual = "";
+      try {
+        (await block());
+      }
+      catch ($error_e) {
+        const e = $error_e.message;
+        actual = e;
+      }
+      if ((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(actual,""))) {
+        throw new Error("expected error, but none thrown.");
+      }
+      if ((((a,b) => { try { return require('assert').notDeepStrictEqual(a,b) === undefined; } catch { return false; } })(actual,expected))) {
+        throw new Error(String.raw({ raw: ["expected error message: \"", "\" got: \"", "\""] }, expected, actual));
+      }
+    }
     static async equalStr(a, b) {
       try {
         {((cond) => {if (!cond) throw new Error("assertion failed: a == b")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(a,b)))};
@@ -103,6 +119,18 @@ module.exports = function({  }) {
     }
   }
   return Assert;
+}
+
+```
+
+## inflight.PreflightAssert-1.js
+```js
+module.exports = function({  }) {
+  class PreflightAssert {
+    constructor({  }) {
+    }
+  }
+  return PreflightAssert;
 }
 
 ```
@@ -338,10 +366,51 @@ module.exports = function({ $stdlib }) {
       `;
     }
     _getInflightOps() {
-      return ["equalStr", "isNil", "equalNum", "$inflight_init"];
+      return ["throws", "equalStr", "isNil", "equalNum", "$inflight_init"];
     }
   }
-  return { Assert };
+  class PreflightAssert extends $stdlib.std.Resource {
+    constructor(scope, id, ) {
+      super(scope, id);
+    }
+    static throws(expected, block) {
+      let actual = "";
+      try {
+        (block());
+      }
+      catch ($error_e) {
+        const e = $error_e.message;
+        actual = e;
+      }
+      if ((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(actual,""))) {
+        throw new Error("expected error, but none thrown.");
+      }
+      if ((((a,b) => { try { return require('assert').notDeepStrictEqual(a,b) === undefined; } catch { return false; } })(actual,expected))) {
+        throw new Error(String.raw({ raw: ["expected error message: \"", "\" got: \"", "\""] }, expected, actual));
+      }
+    }
+    static _toInflightType(context) {
+      return `
+        require("./inflight.PreflightAssert-1.js")({
+        })
+      `;
+    }
+    _toInflight() {
+      return `
+        (await (async () => {
+          const PreflightAssertClient = ${PreflightAssert._toInflightType(this)};
+          const client = new PreflightAssertClient({
+          });
+          if (client.$inflight_init) { await client.$inflight_init(); }
+          return client;
+        })())
+      `;
+    }
+    _getInflightOps() {
+      return ["$inflight_init"];
+    }
+  }
+  return { Assert, PreflightAssert };
 };
 
 ```

--- a/tools/hangar/__snapshots__/test_corpus/valid/api_valid_path.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/api_valid_path.test.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [api_valid_path.test.w](../../../../../examples/tests/valid/api_valid_path.test.w) | compile | tf-aws
 
-## inflight.$Closure1-1.js
+## inflight.$Closure1-2.js
 ```js
 module.exports = function({  }) {
   class $Closure1 {
@@ -14,6 +14,73 @@ module.exports = function({  }) {
     }
   }
   return $Closure1;
+}
+
+```
+
+## inflight.Assert-1.js
+```js
+module.exports = function({  }) {
+  class Assert {
+    static async throws(expected, block) {
+      let actual = "";
+      try {
+        (await block());
+      }
+      catch ($error_e) {
+        const e = $error_e.message;
+        actual = e;
+      }
+      if ((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(actual,""))) {
+        throw new Error("expected error, but none thrown.");
+      }
+      if ((((a,b) => { try { return require('assert').notDeepStrictEqual(a,b) === undefined; } catch { return false; } })(actual,expected))) {
+        throw new Error(String.raw({ raw: ["expected error message: \"", "\" got: \"", "\""] }, expected, actual));
+      }
+    }
+    static async equalStr(a, b) {
+      try {
+        {((cond) => {if (!cond) throw new Error("assertion failed: a == b")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(a,b)))};
+      }
+      catch ($error_e) {
+        const e = $error_e.message;
+        throw new Error(String.raw({ raw: ["expected: ", " got: ", ""] }, b, a));
+      }
+    }
+    static async isNil(a) {
+      try {
+        {((cond) => {if (!cond) throw new Error("assertion failed: a == nil")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(a,undefined)))};
+      }
+      catch ($error_e) {
+        const e = $error_e.message;
+        {console.log(e)};
+        throw new Error(String.raw({ raw: ["expected '", "' to be nil"] }, a));
+      }
+    }
+    static async equalNum(a, b) {
+      try {
+        {((cond) => {if (!cond) throw new Error("assertion failed: a == b")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(a,b)))};
+      }
+      catch ($error_e) {
+        const e = $error_e.message;
+        {console.log(e)};
+        throw new Error(String.raw({ raw: ["expected: ", " got: ", ""] }, b, a));
+      }
+    }
+  }
+  return Assert;
+}
+
+```
+
+## inflight.PreflightAssert-1.js
+```js
+module.exports = function({  }) {
+  class PreflightAssert {
+    constructor({  }) {
+    }
+  }
+  return PreflightAssert;
 }
 
 ```
@@ -366,6 +433,81 @@ module.exports = function({  }) {
 }
 ```
 
+## preflight.assertions-1.js
+```js
+module.exports = function({ $stdlib }) {
+  const std = $stdlib.std;
+  class Assert extends $stdlib.std.Resource {
+    constructor(scope, id, ) {
+      super(scope, id);
+    }
+    static _toInflightType(context) {
+      return `
+        require("./inflight.Assert-1.js")({
+        })
+      `;
+    }
+    _toInflight() {
+      return `
+        (await (async () => {
+          const AssertClient = ${Assert._toInflightType(this)};
+          const client = new AssertClient({
+          });
+          if (client.$inflight_init) { await client.$inflight_init(); }
+          return client;
+        })())
+      `;
+    }
+    _getInflightOps() {
+      return ["throws", "equalStr", "isNil", "equalNum", "$inflight_init"];
+    }
+  }
+  class PreflightAssert extends $stdlib.std.Resource {
+    constructor(scope, id, ) {
+      super(scope, id);
+    }
+    static throws(expected, block) {
+      let actual = "";
+      try {
+        (block());
+      }
+      catch ($error_e) {
+        const e = $error_e.message;
+        actual = e;
+      }
+      if ((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(actual,""))) {
+        throw new Error("expected error, but none thrown.");
+      }
+      if ((((a,b) => { try { return require('assert').notDeepStrictEqual(a,b) === undefined; } catch { return false; } })(actual,expected))) {
+        throw new Error(String.raw({ raw: ["expected error message: \"", "\" got: \"", "\""] }, expected, actual));
+      }
+    }
+    static _toInflightType(context) {
+      return `
+        require("./inflight.PreflightAssert-1.js")({
+        })
+      `;
+    }
+    _toInflight() {
+      return `
+        (await (async () => {
+          const PreflightAssertClient = ${PreflightAssert._toInflightType(this)};
+          const client = new PreflightAssertClient({
+          });
+          if (client.$inflight_init) { await client.$inflight_init(); }
+          return client;
+        })())
+      `;
+    }
+    _getInflightOps() {
+      return ["$inflight_init"];
+    }
+  }
+  return { Assert, PreflightAssert };
+};
+
+```
+
 ## preflight.js
 ```js
 const $stdlib = require('@winglang/sdk');
@@ -374,6 +516,7 @@ const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const cloud = $stdlib.cloud;
+const assertions = require("./preflight.assertions-1.js")({ $stdlib });
 class $Root extends $stdlib.std.Resource {
   constructor(scope, id) {
     super(scope, id);
@@ -384,7 +527,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType(context) {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("./inflight.$Closure1-2.js")({
           })
         `;
       }
@@ -407,15 +550,9 @@ class $Root extends $stdlib.std.Resource {
     const handler = new $Closure1(this,"$Closure1");
     const testInvalidPath = ((path) => {
       let error = "";
-      const expected = String.raw({ raw: ["Invalid path ", ". Url parts can only contain alpha-numeric chars, \"-\", \"_\" and \".\". Params can only contain alpha-numeric chars and \"_\"."] }, path);
-      try {
+      (assertions.PreflightAssert.throws(String.raw({ raw: ["Invalid path ", ". Url parts can only contain alpha-numeric chars, \"-\", \"_\" and \".\". Params can only contain alpha-numeric chars and \"_\"."] }, path),(() => {
         (api.get(path,handler));
-      }
-      catch ($error_e) {
-        const e = $error_e.message;
-        error = e;
-      }
-      {((cond) => {if (!cond) throw new Error("assertion failed: error == expected")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(error,expected)))};
+      })));
     });
     const testValidPath = ((path) => {
       let error = "";

--- a/tools/hangar/__snapshots__/test_corpus/valid/assertions.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/assertions.w_compile_tf-aws.md
@@ -4,6 +4,22 @@
 ```js
 module.exports = function({  }) {
   class Assert {
+    static async throws(expected, block) {
+      let actual = "";
+      try {
+        (await block());
+      }
+      catch ($error_e) {
+        const e = $error_e.message;
+        actual = e;
+      }
+      if ((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(actual,""))) {
+        throw new Error("expected error, but none thrown.");
+      }
+      if ((((a,b) => { try { return require('assert').notDeepStrictEqual(a,b) === undefined; } catch { return false; } })(actual,expected))) {
+        throw new Error(String.raw({ raw: ["expected error message: \"", "\" got: \"", "\""] }, expected, actual));
+      }
+    }
     static async equalStr(a, b) {
       try {
         {((cond) => {if (!cond) throw new Error("assertion failed: a == b")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(a,b)))};
@@ -39,6 +55,18 @@ module.exports = function({  }) {
 
 ```
 
+## inflight.PreflightAssert-1.js
+```js
+module.exports = function({  }) {
+  class PreflightAssert {
+    constructor({  }) {
+    }
+  }
+  return PreflightAssert;
+}
+
+```
+
 ## preflight.js
 ```js
 module.exports = function({ $stdlib }) {
@@ -65,10 +93,51 @@ module.exports = function({ $stdlib }) {
       `;
     }
     _getInflightOps() {
-      return ["equalStr", "isNil", "equalNum", "$inflight_init"];
+      return ["throws", "equalStr", "isNil", "equalNum", "$inflight_init"];
     }
   }
-  return { Assert };
+  class PreflightAssert extends $stdlib.std.Resource {
+    constructor(scope, id, ) {
+      super(scope, id);
+    }
+    static throws(expected, block) {
+      let actual = "";
+      try {
+        (block());
+      }
+      catch ($error_e) {
+        const e = $error_e.message;
+        actual = e;
+      }
+      if ((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(actual,""))) {
+        throw new Error("expected error, but none thrown.");
+      }
+      if ((((a,b) => { try { return require('assert').notDeepStrictEqual(a,b) === undefined; } catch { return false; } })(actual,expected))) {
+        throw new Error(String.raw({ raw: ["expected error message: \"", "\" got: \"", "\""] }, expected, actual));
+      }
+    }
+    static _toInflightType(context) {
+      return `
+        require("./inflight.PreflightAssert-1.js")({
+        })
+      `;
+    }
+    _toInflight() {
+      return `
+        (await (async () => {
+          const PreflightAssertClient = ${PreflightAssert._toInflightType(this)};
+          const client = new PreflightAssertClient({
+          });
+          if (client.$inflight_init) { await client.$inflight_init(); }
+          return client;
+        })())
+      `;
+    }
+    _getInflightOps() {
+      return ["$inflight_init"];
+    }
+  }
+  return { Assert, PreflightAssert };
 };
 
 ```

--- a/tools/hangar/__snapshots__/test_corpus/valid/website_with_api.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/website_with_api.test.w_compile_tf-aws.md
@@ -92,6 +92,22 @@ module.exports = function({ $api_url, $http_HttpMethod, $http_Util, $t_Assert })
 ```js
 module.exports = function({  }) {
   class Assert {
+    static async throws(expected, block) {
+      let actual = "";
+      try {
+        (await block());
+      }
+      catch ($error_e) {
+        const e = $error_e.message;
+        actual = e;
+      }
+      if ((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(actual,""))) {
+        throw new Error("expected error, but none thrown.");
+      }
+      if ((((a,b) => { try { return require('assert').notDeepStrictEqual(a,b) === undefined; } catch { return false; } })(actual,expected))) {
+        throw new Error(String.raw({ raw: ["expected error message: \"", "\" got: \"", "\""] }, expected, actual));
+      }
+    }
     static async equalStr(a, b) {
       try {
         {((cond) => {if (!cond) throw new Error("assertion failed: a == b")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(a,b)))};
@@ -123,6 +139,18 @@ module.exports = function({  }) {
     }
   }
   return Assert;
+}
+
+```
+
+## inflight.PreflightAssert-1.js
+```js
+module.exports = function({  }) {
+  class PreflightAssert {
+    constructor({  }) {
+    }
+  }
+  return PreflightAssert;
 }
 
 ```
@@ -644,10 +672,51 @@ module.exports = function({ $stdlib }) {
       `;
     }
     _getInflightOps() {
-      return ["equalStr", "isNil", "equalNum", "$inflight_init"];
+      return ["throws", "equalStr", "isNil", "equalNum", "$inflight_init"];
     }
   }
-  return { Assert };
+  class PreflightAssert extends $stdlib.std.Resource {
+    constructor(scope, id, ) {
+      super(scope, id);
+    }
+    static throws(expected, block) {
+      let actual = "";
+      try {
+        (block());
+      }
+      catch ($error_e) {
+        const e = $error_e.message;
+        actual = e;
+      }
+      if ((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(actual,""))) {
+        throw new Error("expected error, but none thrown.");
+      }
+      if ((((a,b) => { try { return require('assert').notDeepStrictEqual(a,b) === undefined; } catch { return false; } })(actual,expected))) {
+        throw new Error(String.raw({ raw: ["expected error message: \"", "\" got: \"", "\""] }, expected, actual));
+      }
+    }
+    static _toInflightType(context) {
+      return `
+        require("./inflight.PreflightAssert-1.js")({
+        })
+      `;
+    }
+    _toInflight() {
+      return `
+        (await (async () => {
+          const PreflightAssertClient = ${PreflightAssert._toInflightType(this)};
+          const client = new PreflightAssertClient({
+          });
+          if (client.$inflight_init) { await client.$inflight_init(); }
+          return client;
+        })())
+      `;
+    }
+    _getInflightOps() {
+      return ["$inflight_init"];
+    }
+  }
+  return { Assert, PreflightAssert };
 };
 
 ```


### PR DESCRIPTION
Part of https://github.com/winglang/wing/issues/1977

This PR adds `Assert.throws` in `/examples/tests/valid/assertions.w`.
Since phase-independent class/function is not supported yet (see https://github.com/winglang/wing/issues/435 https://github.com/winglang/wing/pull/1711), `PreflightAssert.throws` is added too.
It should be merged into `Assert.throws` once phase-independency is supported.

`/example/tests/**/*.test.w` are now refactored to use `(Preflight)Assert.throws` as much as possible.



## Checklist

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [x] Tests added (always)
- [x] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
