### PR TITLE
fix(compiler): tiny cleanup `VisitContext`'s `push_class` can use class's phase

### DIFF
--- a/libs/wingc/src/lifting.rs
+++ b/libs/wingc/src/lifting.rs
@@ -351,13 +351,7 @@ impl<'a> Visit<'a> for LiftVisitor<'a> {
 			return;
 		}
 
-		let udt = UserDefinedType {
-			root: node.name.clone(),
-			fields: vec![],
-			span: node.name.span.clone(),
-		};
-
-		self.ctx.push_class(udt.clone(), &node.phase);
+		self.ctx.push_class(node);
 
 		self.lifts_stack.push(Lifts::new());
 
@@ -374,7 +368,7 @@ impl<'a> Visit<'a> for LiftVisitor<'a> {
 		let lifts = self.lifts_stack.pop().expect("Unable to pop class tokens");
 
 		if let Some(env) = self.ctx.current_env() {
-			if let Some(mut t) = resolve_user_defined_type(&udt, env, 0).ok() {
+			if let Some(mut t) = resolve_user_defined_type(&UserDefinedType::for_class(node), env, 0).ok() {
 				let mut_class = t.as_class_mut().unwrap();
 				mut_class.set_lifts(lifts);
 			}

--- a/libs/wingc/src/type_check.rs
+++ b/libs/wingc/src/type_check.rs
@@ -3526,7 +3526,7 @@ impl<'a> TypeChecker<'a> {
 	}
 
 	fn type_check_class(&mut self, env: &mut SymbolEnv, stmt: &Stmt, ast_class: &AstClass) {
-		self.ctx.push_class(UserDefinedType::for_class(ast_class), &env.phase);
+		self.ctx.push_class(ast_class);
 
 		// preflight classes cannot be declared inside an inflight scope
 		// (the other way is okay)

--- a/libs/wingc/src/visit_context.rs
+++ b/libs/wingc/src/visit_context.rs
@@ -1,7 +1,7 @@
 use itertools::Itertools;
 
 use crate::{
-	ast::{ExprId, FunctionSignature, Phase, Symbol, UserDefinedType},
+	ast::{Class, ExprId, FunctionSignature, Phase, Symbol, UserDefinedType},
 	type_check::symbol_env::SymbolEnvRef,
 };
 
@@ -79,9 +79,9 @@ impl VisitContext {
 
 	// --
 
-	pub fn push_class(&mut self, class: UserDefinedType, phase: &Phase) {
-		self.class.push(class);
-		self.push_phase(*phase);
+	pub fn push_class(&mut self, class: &Class) {
+		self.class.push(UserDefinedType::for_class(class));
+		self.push_phase(class.phase);
 	}
 
 	pub fn pop_class(&mut self) {


### PR DESCRIPTION
Cleanup in visit context to remove extra complexity.

## Checklist

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [ ] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
