### PR TITLE
chore: skip std spec tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,6 @@ on:
     branches:
       - main
       - dev
-      - tsuf/skip-std-tests
   workflow_dispatch: {}
 
 concurrency:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,7 @@ on:
     branches:
       - main
       - dev
+      - tsuf/skip-std-tests
   workflow_dispatch: {}
 
 concurrency:
@@ -316,7 +317,7 @@ jobs:
         with:
           message: |
             Console preview environment is available at https://${{env.APP_NAME}}.fly.dev :rocket:
-            
+
             ###### Last Updated (UTC) ${{steps.deploy-fly.outputs.deploytime }}
           comment_tag: Console preview environment
           GITHUB_TOKEN: ${{secrets.PROJEN_GITHUB_TOKEN}}

--- a/.github/workflows/tf-aws-test.yml
+++ b/.github/workflows/tf-aws-test.yml
@@ -137,10 +137,10 @@ jobs:
             if  ${{ env.MANUAL == 'true' }}
             then
               pnpm install
-              pnpm wing test -t tf-aws ${{ matrix.test.directory }}/*.w
+              pnpm wing test -t sim ${{ matrix.test.directory }}/*.w
             elif ${{ env.LOCAL_BUILD == 'false'}}
             then 
-              wing test -t tf-aws ${{ matrix.test.directory }}/*.w
+              wing test -t sim ${{ matrix.test.directory }}/*.w
             else
             ./localwing/node_modules/.bin/wing test -t sim ${{ matrix.test.directory }}/*.w
             fi

--- a/.github/workflows/tf-aws-test.yml
+++ b/.github/workflows/tf-aws-test.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Get list of directories and save them to the output
         id: setdirs
         shell: bash
-        run: |
+        run: | # TODO: skipping std and external folders, when https://github.com/winglang/wing/issues/3168 is resolve- we'll skip only the external folder.
           dirs=$(ls -d examples/tests/sdk_tests/*/ | sed 's/\/$//' | grep -v "external\|std" | jq -R -s -c 'split("\n")[:-1]')
           processed_dirs=$(echo "{ \"directory\": $dirs }" | jq -c '[ .directory[] | {directory: ., name: (split("/") | last)}]')
           wrapped_dirs=$(echo "{ \"test\": $processed_dirs }" | jq -c .)
@@ -136,12 +136,12 @@ jobs:
             if  ${{ env.MANUAL == 'true' }}
             then
               pnpm install
-              pnpm wing test -t sim ${{ matrix.test.directory }}/*.w
+              pnpm wing test -t tf-aws ${{ matrix.test.directory }}/*.w
             elif ${{ env.LOCAL_BUILD == 'false'}}
             then 
-              wing test -t sim ${{ matrix.test.directory }}/*.w
+              wing test -t tf-aws ${{ matrix.test.directory }}/*.w
             else
-            ./localwing/node_modules/.bin/wing test -t sim ${{ matrix.test.directory }}/*.w
+            ./localwing/node_modules/.bin/wing test -t tf-aws ${{ matrix.test.directory }}/*.w
             fi
 
       - name: Output Terraform log

--- a/.github/workflows/tf-aws-test.yml
+++ b/.github/workflows/tf-aws-test.yml
@@ -67,6 +67,7 @@ jobs:
       max-parallel: 10
       matrix: ${{ fromJson(needs.setup.outputs.tests) }}
     name: ${{ matrix.test.name }}
+    if: ${{ matrix.test.directory != 'std'}}
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v3
@@ -141,7 +142,7 @@ jobs:
             then 
               wing test -t tf-aws ${{ matrix.test.directory }}/*.w
             else
-            ./localwing/node_modules/.bin/wing test -t tf-aws ${{ matrix.test.directory }}/*.w
+            ./localwing/node_modules/.bin/wing test -t sim ${{ matrix.test.directory }}/*.w
             fi
 
       - name: Output Terraform log

--- a/.github/workflows/tf-aws-test.yml
+++ b/.github/workflows/tf-aws-test.yml
@@ -52,7 +52,7 @@ jobs:
         id: setdirs
         shell: bash
         run: |
-          dirs=$(ls -d examples/tests/sdk_tests/*/ | sed 's/\/$//' | grep -v "external" | jq -R -s -c 'split("\n")[:-1]')
+          dirs=$(ls -d examples/tests/sdk_tests/*/ | sed 's/\/$//' | grep -v "external\|std" | jq -R -s -c 'split("\n")[:-1]')
           processed_dirs=$(echo "{ \"directory\": $dirs }" | jq -c '[ .directory[] | {directory: ., name: (split("/") | last)}]')
           wrapped_dirs=$(echo "{ \"test\": $processed_dirs }" | jq -c .)
           echo "dirs=$wrapped_dirs" >> $GITHUB_OUTPUT
@@ -67,7 +67,6 @@ jobs:
       max-parallel: 10
       matrix: ${{ fromJson(needs.setup.outputs.tests) }}
     name: ${{ matrix.test.name }}
-    if: ${{ matrix.test.directory != 'std'}}
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v3


### PR DESCRIPTION
## Description 
Currently, there are plenty of tests in a single file of any std test, and our current test scope (which duplicates resources by the number of tests) isn't handling it well, so we often get timeouts and exceptions.
Since the std tests' code is identical both on aws and the sim (and tested in the sim via hangar) I think we can skip it until the [testing issue](https://github.com/winglang/wing/issues/3168) resolves.
link to test run: https://github.com/winglang/wing/actions/runs/6480615481

## Checklist

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [ ] Description explains motivation and solution
- [ ] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
