### PR TITLE
fix(vscode): panic when hovering over std types

### DIFF
--- a/libs/wingc/src/diagnostic.rs
+++ b/libs/wingc/src/diagnostic.rs
@@ -191,15 +191,13 @@ impl WingSpan {
 	}
 
 	pub fn merge(&self, other: &Self) -> Self {
-		let merged_file_id = if self.file_id == other.file_id {
-			&self.file_id
-		} else if self.file_id.is_empty() {
-			&other.file_id
-		} else if other.file_id.is_empty() {
-			&self.file_id
-		} else {
-			panic!("Cannot merge spans from different files")
-		};
+		if self.is_default() {
+			return other.clone();
+		} else if other.is_default() {
+			return self.clone();
+		}
+
+		assert!(self.file_id == other.file_id);
 
 		let start = if self.start < other.start {
 			self.start
@@ -210,8 +208,13 @@ impl WingSpan {
 		Self {
 			start,
 			end,
-			file_id: merged_file_id.clone(),
+			file_id: self.file_id.clone(),
 		}
+	}
+
+	/// Checks if this span is the default span. This means the span is covers nothing by ending at (0,0).
+	pub fn is_default(&self) -> bool {
+		self.end == WingLocation::default()
 	}
 }
 

--- a/libs/wingc/src/diagnostic.rs
+++ b/libs/wingc/src/diagnostic.rs
@@ -191,7 +191,16 @@ impl WingSpan {
 	}
 
 	pub fn merge(&self, other: &Self) -> Self {
-		assert!(self.file_id == other.file_id);
+		let merged_file_id = if self.file_id == other.file_id {
+			&self.file_id
+		} else if self.file_id.is_empty() {
+			&other.file_id
+		} else if other.file_id.is_empty() {
+			&self.file_id
+		} else {
+			panic!("Cannot merge spans from different files")
+		};
+
 		let start = if self.start < other.start {
 			self.start
 		} else {
@@ -201,7 +210,7 @@ impl WingSpan {
 		Self {
 			start,
 			end,
-			file_id: self.file_id.clone(),
+			file_id: merged_file_id.clone(),
 		}
 	}
 }

--- a/libs/wingc/src/lsp/hover.rs
+++ b/libs/wingc/src/lsp/hover.rs
@@ -40,7 +40,7 @@ pub fn on_hover(params: lsp_types::HoverParams) -> Option<Hover> {
 			if let Some(lookup) = symbol_finder.lookup_located_symbol() {
 				if let LookupResult::Found(symbol_info, ..) = &lookup {
 					let docs = symbol_info.render_docs();
-					let span = symbol_finder.located_span().unwrap();
+					let span = symbol_finder.located_span()?;
 					return Some(Hover {
 						contents: HoverContents::Markup(MarkupContent {
 							kind: MarkupKind::Markdown,
@@ -414,6 +414,14 @@ struct S {
   field: str;
   //^
 }
+"#
+	);
+
+	test_hover_list!(
+		static_method_root,
+		r#"
+Json.stringify({});
+//^
 "#
 	);
 }

--- a/libs/wingc/src/lsp/snapshots/hovers/static_method_root.snap
+++ b/libs/wingc/src/lsp/snapshots/hovers/static_method_root.snap
@@ -3,7 +3,7 @@ source: libs/wingc/src/lsp/hover.rs
 ---
 contents:
   kind: markdown
-  value: "```wing\nclass Json\n```\n---\nImmutable Json.\n\n### Methods\n- `asBool` — Convert Json element to boolean if possible.\n- `asNum` — Convert Json element to number if possible.\n- `asStr` — Convert Json element to string if possible.\n- `deepCopy` — Creates an immutable deep copy of the Json.\n- `deepCopyMut` — Creates a mutable deep copy of the Json.\n- `delete` — Deletes a key in a given Json.\n- `entries` — Returns the entries from the Json.\n- `get` — Returns the value associated with the specified Json key.\n- `getAt` — Returns a specified element at a given index from Json Array.\n- `has` — Checks if a Json object has a given key.\n- `keys` — Returns the keys from the Json.\n- `parse` — Parse a string into a Json.\n- `stringify` — Formats Json as string.\n- `tryAsBool` — Convert Json element to boolean if possible.\n- `tryAsNum` — Convert Json element to number if possible.\n- `tryAsStr` — Convert Json element to string if possible.\n- `tryGet` — Optionally returns an specified element from the Json.\n- `tryGetAt` — Optionally returns a specified element at a given index from Json Array.\n- `tryParse` — Try to parse a string into a Json.\n- `values` — Returns the values from the Json."
+  value: "```wing\nclass Json\n```\n---\nImmutable Json."
 range:
   start:
     line: 1

--- a/libs/wingc/src/lsp/snapshots/hovers/static_method_root.snap
+++ b/libs/wingc/src/lsp/snapshots/hovers/static_method_root.snap
@@ -6,7 +6,7 @@ contents:
   value: "```wing\nclass Json\n```\n---\nImmutable Json.\n\n### Methods\n- `asBool` — Convert Json element to boolean if possible.\n- `asNum` — Convert Json element to number if possible.\n- `asStr` — Convert Json element to string if possible.\n- `deepCopy` — Creates an immutable deep copy of the Json.\n- `deepCopyMut` — Creates a mutable deep copy of the Json.\n- `delete` — Deletes a key in a given Json.\n- `entries` — Returns the entries from the Json.\n- `get` — Returns the value associated with the specified Json key.\n- `getAt` — Returns a specified element at a given index from Json Array.\n- `has` — Checks if a Json object has a given key.\n- `keys` — Returns the keys from the Json.\n- `parse` — Parse a string into a Json.\n- `stringify` — Formats Json as string.\n- `tryAsBool` — Convert Json element to boolean if possible.\n- `tryAsNum` — Convert Json element to number if possible.\n- `tryAsStr` — Convert Json element to string if possible.\n- `tryGet` — Optionally returns an specified element from the Json.\n- `tryGetAt` — Optionally returns a specified element at a given index from Json Array.\n- `tryParse` — Try to parse a string into a Json.\n- `values` — Returns the values from the Json."
 range:
   start:
-    line: 0
+    line: 1
     character: 0
   end:
     line: 1

--- a/libs/wingc/src/lsp/snapshots/hovers/static_method_root.snap
+++ b/libs/wingc/src/lsp/snapshots/hovers/static_method_root.snap
@@ -1,0 +1,14 @@
+---
+source: libs/wingc/src/lsp/hover.rs
+---
+contents:
+  kind: markdown
+  value: "```wing\nclass Json\n```\n---\nImmutable Json.\n\n### Methods\n- `asBool` — Convert Json element to boolean if possible.\n- `asNum` — Convert Json element to number if possible.\n- `asStr` — Convert Json element to string if possible.\n- `deepCopy` — Creates an immutable deep copy of the Json.\n- `deepCopyMut` — Creates a mutable deep copy of the Json.\n- `delete` — Deletes a key in a given Json.\n- `entries` — Returns the entries from the Json.\n- `get` — Returns the value associated with the specified Json key.\n- `getAt` — Returns a specified element at a given index from Json Array.\n- `has` — Checks if a Json object has a given key.\n- `keys` — Returns the keys from the Json.\n- `parse` — Parse a string into a Json.\n- `stringify` — Formats Json as string.\n- `tryAsBool` — Convert Json element to boolean if possible.\n- `tryAsNum` — Convert Json element to number if possible.\n- `tryAsStr` — Convert Json element to string if possible.\n- `tryGet` — Optionally returns an specified element from the Json.\n- `tryGetAt` — Optionally returns a specified element at a given index from Json Array.\n- `tryParse` — Try to parse a string into a Json.\n- `values` — Returns the values from the Json."
+range:
+  start:
+    line: 0
+    character: 0
+  end:
+    line: 1
+    character: 4
+


### PR DESCRIPTION
A std type like `Json` is actually `std.Json` in the AST. That `std` part is not technically part of the file so it does not have an actual span. This panicked when comparing file_id in the merge function.

This change allows the span merge function to basically ignore default spans.

Sidenote: I'd really like to make WingSpan into an enum, but that change sounds like a lot of work to fix this panic.

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
