### PR TITLE
chore(repo): prevent instable mutations from running multiple times in a row

### DIFF
--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -55,10 +55,10 @@ jobs:
         if: steps.download-artifacts.outputs.found_artifact == 'true'
         run: |
           git config --global core.hooksPath /dev/null
-
+      
       - name: Update PR Branch
         uses: actions/github-script@v6
-        if: github.event.workflow_run.event == 'pull_request' && steps.download-artifacts.outputs.found_artifact == 'true'
+        if: steps.download-artifacts.outputs.found_artifact == 'true'
         with:
           github-token: ${{ secrets.MUTATION_TOKEN }}
           script: |
@@ -111,6 +111,39 @@ jobs:
           ref: ${{ github.event.workflow_run.head_branch }}
           repository: ${{ github.event.workflow_run.head_repository.full_name }}
           path: repo
+          fetch-depth: 0
+
+      - name: Check if last commit is a mutation
+        id: last_commit_mutation
+        if: steps.download-artifacts.outputs.found_artifact == 'true'
+        run: |
+          git log -1 --pretty=%B ${{ github.event.workflow_run.head_sha }} | grep -q "^chore: self mutation"
+          if [ $? -eq 0 ]; then
+            echo "is_mutation=true" >> $GITHUB_OUTPUT
+          else
+            echo "is_mutation=false" >> $GITHUB_OUTPUT
+          fi
+      
+      - name: Unstable mutation comment
+        if: steps.download-artifacts.outputs.found_artifact == 'true' && steps.last_commit_mutation.outputs.is_mutation == 'true'
+        uses: thollander/actions-comment-pull-request@v2
+        with:
+          mode: recreate
+          message: |
+            ### :x: Unstable Self-Mutation :x:
+            Self-mutation has run twice in a row. There may be a something non-deterministic in the build or test process.
+            Check the last mutation commit (${{ github.event.workflow_run.head_sha }}) for suspicious changes.
+            This is typically caused by:
+            - Absolute paths
+            - Timestamps
+            - Random values
+            - Flakey tests (relying on one of the above)
+          comment_tag: UnstableMutation
+          GITHUB_TOKEN: ${{ secrets.PROJEN_GITHUB_TOKEN }}
+      
+      - name: Unstable mutation fail
+        if: steps.download-artifacts.outputs.found_artifact == 'true' && steps.last_commit_mutation.outputs.is_mutation == 'true'
+        run: exit 1
 
       - id: self_mutation
         if: steps.download-artifacts.outputs.found_artifact == 'true'
@@ -141,7 +174,7 @@ jobs:
 
       - name: Add label to block auto merge
         uses: actions/github-script@v6
-        if: github.event.workflow_run.event == 'pull_request' && steps.download-artifacts.outputs.found_artifact == 'true'
+        if: steps.download-artifacts.outputs.found_artifact == 'true'
         with:
           github-token: ${{ secrets.MUTATION_TOKEN }}
           script: |

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -76,7 +76,7 @@ jobs:
         if: steps.download-artifacts.outputs.found_artifact == 'true'
         run: |
           git config --global core.hooksPath /dev/null
-      
+
       - name: Update PR Branch
         uses: actions/github-script@v6
         if: steps.download-artifacts.outputs.found_artifact == 'true'
@@ -132,7 +132,6 @@ jobs:
           ref: ${{ github.event.workflow_run.head_branch }}
           repository: ${{ github.event.workflow_run.head_repository.full_name }}
           path: repo
-          fetch-depth: 0
 
       - id: self_mutation
         if: steps.download-artifacts.outputs.found_artifact == 'true'

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -57,7 +57,7 @@ jobs:
         with:
           mode: recreate
           message: |
-            ### ❌ Unstable Self-Mutation ❌
+            ### :x: Unstable Self-Mutation :x:
             Self-mutation has run twice in a row. There may be a something non-deterministic in the build or test process.
             Check the last mutation commit (${{ github.event.workflow_run.head_sha }}) for suspicious changes.
             This is typically caused by:

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -51,6 +51,27 @@ jobs:
             exit 1
           fi
 
+      - name: Unstable mutation comment
+        if: steps.download-artifacts.outputs.found_artifact == 'true' && startsWith(github.event.workflow_run.head_commit.message, format('chore{0} self mutation', ':'))
+        uses: thollander/actions-comment-pull-request@v2
+        with:
+          mode: recreate
+          message: |
+            ### ❌ Unstable Self-Mutation ❌
+            Self-mutation has run twice in a row. There may be a something non-deterministic in the build or test process.
+            Check the last mutation commit (${{ github.event.workflow_run.head_sha }}) for suspicious changes.
+            This is typically caused by:
+            - Absolute paths
+            - Timestamps
+            - Random values
+            - Flakey tests (relying on one of the above)
+          comment_tag: UnstableMutation
+          GITHUB_TOKEN: ${{ secrets.PROJEN_GITHUB_TOKEN }}
+      
+      - name: Unstable mutation fail
+        if: steps.download-artifacts.outputs.found_artifact == 'true' && startsWith(github.event.workflow_run.head_commit.message, format('chore{0} self mutation', ':'))
+        run: exit 1
+
       - name: Disable Git Hooks
         if: steps.download-artifacts.outputs.found_artifact == 'true'
         run: |
@@ -112,38 +133,6 @@ jobs:
           repository: ${{ github.event.workflow_run.head_repository.full_name }}
           path: repo
           fetch-depth: 0
-
-      - name: Check if last commit is a mutation
-        id: last_commit_mutation
-        if: steps.download-artifacts.outputs.found_artifact == 'true'
-        run: |
-          git log -1 --pretty=%B ${{ github.event.workflow_run.head_sha }} | grep -q "^chore: self mutation"
-          if [ $? -eq 0 ]; then
-            echo "is_mutation=true" >> $GITHUB_OUTPUT
-          else
-            echo "is_mutation=false" >> $GITHUB_OUTPUT
-          fi
-      
-      - name: Unstable mutation comment
-        if: steps.download-artifacts.outputs.found_artifact == 'true' && steps.last_commit_mutation.outputs.is_mutation == 'true'
-        uses: thollander/actions-comment-pull-request@v2
-        with:
-          mode: recreate
-          message: |
-            ### :x: Unstable Self-Mutation :x:
-            Self-mutation has run twice in a row. There may be a something non-deterministic in the build or test process.
-            Check the last mutation commit (${{ github.event.workflow_run.head_sha }}) for suspicious changes.
-            This is typically caused by:
-            - Absolute paths
-            - Timestamps
-            - Random values
-            - Flakey tests (relying on one of the above)
-          comment_tag: UnstableMutation
-          GITHUB_TOKEN: ${{ secrets.PROJEN_GITHUB_TOKEN }}
-      
-      - name: Unstable mutation fail
-        if: steps.download-artifacts.outputs.found_artifact == 'true' && steps.last_commit_mutation.outputs.is_mutation == 'true'
-        run: exit 1
 
       - id: self_mutation
         if: steps.download-artifacts.outputs.found_artifact == 'true'


### PR DESCRIPTION
Double mutations are a waste of CI time. This should prevent that and alert the user that something is wrong with their PR.

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
