### PR TITLE
chore(sdk): remove fs `extern` module

### DIFF
--- a/examples/tests/sdk_tests/external/fs.js
+++ b/examples/tests/sdk_tests/external/fs.js
@@ -1,7 +1,0 @@
-const fs = require("fs");
-const path = require("path");
-
-exports.readFile = function (filePath) {
-  // reading file from sdk_tests root
-  return fs.readFileSync(path.join(path.resolve(__dirname), "../", filePath), "utf-8");
-};

--- a/examples/tests/sdk_tests/website/website.test.w
+++ b/examples/tests/sdk_tests/website/website.test.w
@@ -1,16 +1,13 @@
 bring cloud;
 bring http;
+bring fs;
 
 let w = new cloud.Website(path: "./website");
 let config = Json { json: 1 };
 let htmlContent = "<html>Hello World!</html>";
-
-class Util {
-  extern "../external/fs.js" pub static readFile(path: str): str;    
-}
  
-let indexFile = Util.readFile("./website/website/index.html");
-let otherFile = Util.readFile("./website/website/inner-folder/other.html");
+let indexFile = fs.readFile("${w.path}/index.html");
+let otherFile = fs.readFile("${w.path}/inner-folder/other.html");
 
 w.addJson("config.json", config);
 w.addFile("another-file.html", htmlContent, contentType: "text/html");

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/website/website.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/website/website.test.w_compile_tf-aws.md
@@ -22,19 +22,6 @@ module.exports = function({ $config, $htmlContent, $http_Util, $indexFile, $othe
 
 ```
 
-## inflight.Util-1.js
-```js
-"use strict";
-module.exports = function({  }) {
-  class Util {
-    constructor({  }) {
-    }
-  }
-  return Util;
-}
-
-```
-
 ## main.tf.json
 ```json
 {
@@ -285,37 +272,10 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 const http = $stdlib.http;
+const fs = $stdlib.fs;
 class $Root extends $stdlib.std.Resource {
   constructor(scope, id) {
     super(scope, id);
-    class Util extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
-      }
-      static readFile(path) {
-        return (require("<ABSOLUTE_PATH>/fs.js")["readFile"])(path)
-      }
-      static _toInflightType(context) {
-        return `
-          require("./inflight.Util-1.js")({
-          })
-        `;
-      }
-      _toInflight() {
-        return `
-          (await (async () => {
-            const UtilClient = ${Util._toInflightType(this)};
-            const client = new UtilClient({
-            });
-            if (client.$inflight_init) { await client.$inflight_init(); }
-            return client;
-          })())
-        `;
-      }
-      _getInflightOps() {
-        return ["$inflight_init"];
-      }
-    }
     class $Closure1 extends $stdlib.std.Resource {
       constructor(scope, id, ) {
         super(scope, id);
@@ -362,8 +322,8 @@ class $Root extends $stdlib.std.Resource {
     const w = this.node.root.newAbstract("@winglang/sdk.cloud.Website",this,"cloud.Website",{ path: "./website" });
     const config = ({"json": 1});
     const htmlContent = "<html>Hello World!</html>";
-    const indexFile = (Util.readFile("./website/website/index.html"));
-    const otherFile = (Util.readFile("./website/website/inner-folder/other.html"));
+    const indexFile = (fs.Util.readFile(String.raw({ raw: ["", "/index.html"] }, w.path)));
+    const otherFile = (fs.Util.readFile(String.raw({ raw: ["", "/inner-folder/other.html"] }, w.path)));
     (w.addJson("config.json",config));
     (w.addFile("another-file.html",htmlContent,{ contentType: "text/html" }));
     {((cond) => {if (!cond) throw new Error("assertion failed: w.path.endsWith(\"sdk_tests/website/website\") || w.path.endsWith(\"sdk_tests\\\\website\\\\website\")")})((w.path.endsWith("sdk_tests/website/website") || w.path.endsWith("sdk_tests\\website\\website")))};


### PR DESCRIPTION
Following #4135, there's no more need for a fs `extern` module.

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
