### PR TITLE
chore(build): make `binaryen` installation more robust

### DIFF
--- a/scripts/setup_wasi.sh
+++ b/scripts/setup_wasi.sh
@@ -28,22 +28,7 @@ fi
 
 # Download binaryen tools
 BINARYEN_INSTALL_DIR="$TOOL_INSTALL_DIR/binaryen-$BINARYEN_VERSION"
-BINARIES=(
-    "binaryen-unittests"
-    "wasm-as"
-    "wasm-ctor-eval"
-    "wasm-dis"
-    "wasm-emscripten-finalize"
-    "wasm-fuzz-lattices"
-    "wasm-fuzz-types"
-    "wasm-merge"
-    "wasm-metadce"
-    "wasm-opt"
-    "wasm-reduce"
-    "wasm-shell"
-    "wasm-split"
-    "wasm2js"
-)
+BINARYEN_BINARIES=("wasm-opt")
 all_binaries_present() {
     for binary in "${BINARIES[@]}"; do
         if [ ! -f "$BINARYEN_INSTALL_DIR/bin/$binary" ]; then

--- a/scripts/setup_wasi.sh
+++ b/scripts/setup_wasi.sh
@@ -28,7 +28,31 @@ fi
 
 # Download binaryen tools
 BINARYEN_INSTALL_DIR="$TOOL_INSTALL_DIR/binaryen-$BINARYEN_VERSION"
-if [ ! -d $BINARYEN_INSTALL_DIR ]; then
+BINARIES=(
+    "binaryen-unittests"
+    "wasm-as"
+    "wasm-ctor-eval"
+    "wasm-dis"
+    "wasm-emscripten-finalize"
+    "wasm-fuzz-lattices"
+    "wasm-fuzz-types"
+    "wasm-merge"
+    "wasm-metadce"
+    "wasm-opt"
+    "wasm-reduce"
+    "wasm-shell"
+    "wasm-split"
+    "wasm2js"
+)
+all_binaries_present() {
+    for binary in "${BINARIES[@]}"; do
+        if [ ! -f "$BINARYEN_INSTALL_DIR/bin/$binary" ]; then
+            return 1
+        fi
+    done
+    return 0
+}
+if ! all_binaries_present; then
     TARBALL="binaryen-$BINARYEN_VERSION-$SYS_ARCH-$SYS_OS.tar.gz"
     INSTALL_URL="https://github.com/WebAssembly/binaryen/releases/download/$BINARYEN_VERSION/$TARBALL"
     OUTFILE="/tmp/$TARBALL"
@@ -37,11 +61,19 @@ if [ ! -d $BINARYEN_INSTALL_DIR ]; then
 
     if [ ! -f $OUTFILE ]; then
         echo "Downloading Binaryen $BINARYEN_VERSION to $OUTFILE..."
-        curl --retry 2 -L $INSTALL_URL -o $OUTFILE
+        if ! curl --retry 2 -L $INSTALL_URL -o $OUTFILE; then
+            echo "Error downloading Binaryen. Exiting."
+            exit 1
+        fi
     fi
 
     echo "Extracting to $BINARYEN_INSTALL_DIR..."
-    tar zxf $OUTFILE -C $TOOL_INSTALL_DIR
+    if ! tar zxf $OUTFILE -C $TOOL_INSTALL_DIR; then
+        echo "Error extracting Binaryen. Exiting."
+        exit 1
+    fi
+else
+    echo "Binaryen $BINARYEN_VERSION already installed."
 fi
 
 # Download wasi-sdk

--- a/scripts/setup_wasi.sh
+++ b/scripts/setup_wasi.sh
@@ -28,16 +28,8 @@ fi
 
 # Download binaryen tools
 BINARYEN_INSTALL_DIR="$TOOL_INSTALL_DIR/binaryen-$BINARYEN_VERSION"
-BINARYEN_BINARIES=("wasm-opt")
-all_binaries_present() {
-    for binary in "${BINARIES[@]}"; do
-        if [ ! -f "$BINARYEN_INSTALL_DIR/bin/$binary" ]; then
-            return 1
-        fi
-    done
-    return 0
-}
-if ! all_binaries_present; then
+BINARYEN_BINARIES="$BINARYEN_INSTALL_DIR/bin/wasm-opt"
+if [ ! -f $BINARYEN_BINARIES ]; then
     TARBALL="binaryen-$BINARYEN_VERSION-$SYS_ARCH-$SYS_OS.tar.gz"
     INSTALL_URL="https://github.com/WebAssembly/binaryen/releases/download/$BINARYEN_VERSION/$TARBALL"
     OUTFILE="/tmp/$TARBALL"


### PR DESCRIPTION
This change improves the robustness of `binaryen` installation by making sure that all binaries are correctly installed.

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
