### PR TITLE
fix(cli): analytics error

### DIFF
--- a/apps/wing/src/analytics/scripts/detached-export.ts
+++ b/apps/wing/src/analytics/scripts/detached-export.ts
@@ -60,7 +60,7 @@ async function reportAnalytic() {
   fs.unlinkSync(filePath);
 }
 
-await (async () => {
+void (async () => {
   try {
     await reportAnalytic();
   } catch (err: any) {


### PR DESCRIPTION
Calling `await` at the top level isn't supported in Node.js, so the code in `detached-export.ts` (which is run in a child process) was silently failing. Reverting to the previous behavior (not using `await`) resolves the issue.

Fixes #4546

## Checklist

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [ ] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
