### PR TITLE
fix(compiler): missing message in panic

### DIFF
--- a/libs/wingc/src/comp_ctx.rs
+++ b/libs/wingc/src/comp_ctx.rs
@@ -102,10 +102,9 @@ pub fn set_custom_panic_hook() {
 
 		report_diagnostic(Diagnostic {
 			message: format!(
-				"Compiler bug ('{}' at {}) during {}, please report at https://www.winglang.io/contributing/start-here/bugs",
-				pi.payload().downcast_ref::<&str>().unwrap_or(&""),
-				pi.location().unwrap_or(&std::panic::Location::caller()),
-				CompilationContext::get_phase()
+				"Compiler bug during {} ('{}'), please report at https://www.winglang.io/contributing/start-here/bugs",
+				CompilationContext::get_phase(),
+				pi,
 			),
 			span: Some(CompilationContext::get_span()),
 			annotations: vec![],

--- a/libs/wingc/src/type_check.rs
+++ b/libs/wingc/src/type_check.rs
@@ -2608,13 +2608,13 @@ impl<'a> TypeChecker<'a> {
 		}
 
 		// Verify variadic args
-		if variadic_index.is_some() {
-			let variadic_args_param = func_sig.parameters.get(variadic_index.unwrap()).unwrap();
+		if let Some(variadic_index) = variadic_index {
+			let variadic_args_param = func_sig.parameters.get(variadic_index).unwrap();
 			let variadic_args_inner_type = variadic_args_param.typeref.collection_item_type().unwrap();
 
 			for (arg_expr, arg_type) in izip!(
-				arg_list.pos_args.iter().skip(variadic_index.unwrap()),
-				arg_list_types.pos_args.iter().skip(variadic_index.unwrap()),
+				arg_list.pos_args.iter().skip(variadic_index),
+				arg_list_types.pos_args.iter().skip(variadic_index),
 			) {
 				self.validate_type(*arg_type, variadic_args_inner_type, arg_expr);
 			}

--- a/tools/hangar/__snapshots__/invalid.ts.snap
+++ b/tools/hangar/__snapshots__/invalid.ts.snap
@@ -2396,11 +2396,13 @@ Duration <DURATION>"
 `;
 
 exports[`panic.test.w 1`] = `
-"error: Compiler bug ('User invoked panic' at libs/wingc/src/type_check.rs:LINE:COL) during type-checking, please report at https://www.winglang.io/contributing/start-here/bugs
+"error: Compiler bug during type-checking ('panicked at libs/wingc/src/type_check.rs:LINE:COL:
+User invoked panic'), please report at https://www.winglang.io/contributing/start-here/bugs
   --> ../../../examples/tests/invalid/panic.test.w:6:1
   |
 6 | 😱;
-  | ^^ Compiler bug ('User invoked panic' at libs/wingc/src/type_check.rs:LINE:COL) during type-checking, please report at https://www.winglang.io/contributing/start-here/bugs
+  | ^^ Compiler bug during type-checking ('panicked at libs/wingc/src/type_check.rs:LINE:COL:
+User invoked panic'), please report at https://www.winglang.io/contributing/start-here/bugs
 
 
  


### PR DESCRIPTION
There was a regression in the panic message where it sometimes did not show anything when a panic occurs. This basically reverts to the previous message

Misc change: wingc had a lint error regarding optional unwrapping

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
