### PR TITLE
chore(sdk): add `contentType` to `Bucket.putJson()`

### DIFF
--- a/examples/tests/sdk_tests/bucket/metadata.test.w
+++ b/examples/tests/sdk_tests/bucket/metadata.test.w
@@ -4,8 +4,9 @@ let b = new cloud.Bucket();
 
 test "metadata()" {
   b.put("file1.main.w", "Foo");
-  b.put("file2.txt", "Bar",);
+  b.put("file2.txt", "Bar");
   b.put("file3.txt", "Baz", { contentType: "application/json" });
+  b.putJson("file4.txt", "Qux");
 
   let file1Metadata = b.metadata("file1.main.w");
   assert(file1Metadata.size == 3);
@@ -21,6 +22,11 @@ test "metadata()" {
   assert(file3Metadata.size == 3);
   assert(file3Metadata.contentType == "application/json");
   assert(file3Metadata.lastModified.year >= 2023);
+
+  let file4Metadata = b.metadata("file4.txt");
+  assert(file4Metadata.size == 5);
+  assert(file4Metadata.contentType == "application/json");
+  assert(file4Metadata.lastModified.year >= 2023);
 
   try {
     b.metadata("no-such-file.txt");

--- a/libs/wingsdk/src/target-sim/bucket.inflight.ts
+++ b/libs/wingsdk/src/target-sim/bucket.inflight.ts
@@ -99,7 +99,11 @@ export class Bucket implements IBucketClient, ISimulatorResourceInstance {
     return this.context.withTrace({
       message: `Put Json (key=${key}).`,
       activity: async () => {
-        await this.addFile(key, JSON.stringify(body, null, 2));
+        await this.addFile(
+          key,
+          JSON.stringify(body, null, 2),
+          "application/json"
+        );
       },
     });
   }

--- a/libs/wingsdk/test/target-sim/bucket.test.ts
+++ b/libs/wingsdk/test/target-sim/bucket.test.ts
@@ -155,7 +155,7 @@ test("put and get object from bucket", async () => {
   expect(listMessages(s)).toMatchSnapshot();
 });
 
-test("put and getMetadata of objects from bucket", async () => {
+test("put and get metadata of objects from bucket", async () => {
   // GIVEN
   const app = new SimApp();
   cloud.Bucket._newBucket(app, "my_bucket");
@@ -193,6 +193,30 @@ test("put and getMetadata of objects from bucket", async () => {
   expect(response3.contentType).toEqual("application/json");
   expect(response3.lastModified.year).toEqual(currentYear);
   expect(listMessages(s)).toMatchSnapshot();
+});
+
+test("putJson and get metadata of object from bucket", async () => {
+  // GIVEN
+  const app = new SimApp();
+  cloud.Bucket._newBucket(app, "my_bucket");
+
+  const s = await app.startSimulator();
+
+  const client = s.getResource("/my_bucket") as cloud.IBucketClient;
+  const KEY = "json-file.txt";
+  const VALUE = "bring cloud;";
+
+  // WHEN
+  await client.putJson(KEY, VALUE as any);
+  const response = await client.metadata("json-file.txt");
+
+  // THEN
+  await s.stop();
+  const currentYear = new Date().getFullYear();
+
+  expect(response.size).toEqual(14);
+  expect(response.contentType).toEqual("application/json");
+  expect(response.lastModified.year).toEqual(currentYear);
 });
 
 test("put multiple objects and list all from bucket", async () => {


### PR DESCRIPTION
Following #4515, this sets the Content-Type of an object to `application/json` automatically when using the `Bucket.putJson()` method.

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
