### PR TITLE
chore(compiler): remove lots of wasm boilerplate and remove redundant clone for WASM/Rust communication

### DIFF
--- a/libs/wingc/src/lib.rs
+++ b/libs/wingc/src/lib.rs
@@ -28,7 +28,7 @@ use type_check::{FunctionSignature, SymbolKind, Type};
 use type_check_assert::TypeCheckAssert;
 use valid_json_visitor::ValidJsonVisitor;
 use visit::Visit;
-use wasm_util::{ptr_to_string, string_to_combined_ptr, WASM_RETURN_ERROR};
+use wasm_util::{ptr_to_str, string_to_combined_ptr, WASM_RETURN_ERROR};
 use wingii::type_system::TypeSystem;
 
 use crate::docs::Docs;
@@ -163,7 +163,7 @@ pub unsafe extern "C" fn wingc_init() {
 
 #[no_mangle]
 pub unsafe extern "C" fn wingc_compile(ptr: u32, len: u32) -> u64 {
-	let args = ptr_to_string(ptr, len);
+	let args = ptr_to_str(ptr, len);
 
 	let split = args.split(";").collect::<Vec<&str>>();
 	if split.len() != 3 {

--- a/libs/wingc/src/lsp/code_actions.rs
+++ b/libs/wingc/src/lsp/code_actions.rs
@@ -5,20 +5,11 @@ use lsp_types::{
 use std::collections::HashMap;
 
 use crate::diagnostic::{get_diagnostics, ERR_EXPECTED_SEMICOLON};
-use crate::wasm_util::{ptr_to_string, string_to_combined_ptr, WASM_RETURN_ERROR};
+use crate::wasm_util::extern_json_fn;
 
 #[no_mangle]
 pub unsafe extern "C" fn wingc_on_code_action(ptr: u32, len: u32) -> u64 {
-	let parse_string = ptr_to_string(ptr, len);
-	if let Ok(parsed) = serde_json::from_str(&parse_string) {
-		let result = on_code_action(parsed);
-		let result = serde_json::to_string(&result).unwrap();
-
-		// return result as u64 with ptr and len
-		string_to_combined_ptr(result)
-	} else {
-		WASM_RETURN_ERROR
-	}
+	extern_json_fn(ptr, len, on_code_action)
 }
 
 pub fn on_code_action(params: CodeActionParams) -> Vec<CodeActionOrCommand> {

--- a/libs/wingc/src/lsp/goto_definition.rs
+++ b/libs/wingc/src/lsp/goto_definition.rs
@@ -2,7 +2,7 @@ use crate::lsp::symbol_locator::SymbolLocator;
 use crate::lsp::sync::PROJECT_DATA;
 use crate::type_check::symbol_env::LookupResult;
 use crate::visit::Visit;
-use crate::wasm_util::{ptr_to_string, string_to_combined_ptr, WASM_RETURN_ERROR};
+use crate::wasm_util::extern_json_fn;
 use lsp_types::{GotoDefinitionParams, LocationLink, Position, Range, Url};
 use tree_sitter::Point;
 
@@ -10,15 +10,7 @@ use super::sync::{check_utf8, WING_TYPES};
 
 #[no_mangle]
 pub unsafe extern "C" fn wingc_on_goto_definition(ptr: u32, len: u32) -> u64 {
-	let parse_string = ptr_to_string(ptr, len);
-	if let Ok(parsed) = serde_json::from_str(&parse_string) {
-		let doc_symbols = on_goto_definition(parsed);
-		let result = serde_json::to_string(&doc_symbols).expect("Failed to serialize GotoDefinition response");
-
-		string_to_combined_ptr(result)
-	} else {
-		WASM_RETURN_ERROR
-	}
+	extern_json_fn(ptr, len, on_goto_definition)
 }
 
 pub fn on_goto_definition(params: GotoDefinitionParams) -> Vec<LocationLink> {

--- a/libs/wingc/src/lsp/signature.rs
+++ b/libs/wingc/src/lsp/signature.rs
@@ -12,22 +12,13 @@ use crate::lsp::sync::WING_TYPES;
 use crate::type_check::symbol_env::SymbolEnvRef;
 use crate::type_check::{resolve_super_method, resolve_user_defined_type, Types, CLASS_INIT_NAME};
 use crate::visit::{visit_expr, visit_scope, Visit};
-use crate::wasm_util::{ptr_to_string, string_to_combined_ptr, WASM_RETURN_ERROR};
+use crate::wasm_util::extern_json_fn;
 
 use super::sync::check_utf8;
 
 #[no_mangle]
 pub unsafe extern "C" fn wingc_on_signature_help(ptr: u32, len: u32) -> u64 {
-	let parse_string = ptr_to_string(ptr, len);
-	if let Ok(parsed) = serde_json::from_str(&parse_string) {
-		let result = on_signature_help(parsed);
-		let result = serde_json::to_string(&result).unwrap();
-
-		// return result as u64 with ptr and len
-		string_to_combined_ptr(result)
-	} else {
-		WASM_RETURN_ERROR
-	}
+	extern_json_fn(ptr, len, on_signature_help)
 }
 
 pub fn on_signature_help(params: lsp_types::SignatureHelpParams) -> Option<SignatureHelp> {

--- a/libs/wingc/src/lsp/sync.rs
+++ b/libs/wingc/src/lsp/sync.rs
@@ -21,7 +21,8 @@ use crate::type_check::type_reference_transform::TypeReferenceTransformer;
 use crate::type_check_assert::TypeCheckAssert;
 use crate::valid_json_visitor::ValidJsonVisitor;
 use crate::visit::Visit;
-use crate::{ast::Scope, type_check::Types, wasm_util::ptr_to_string};
+use crate::wasm_util::extern_json_fn;
+use crate::{ast::Scope, type_check::Types};
 
 /// The output of compiling a Wing project with one or more files
 pub struct ProjectData {
@@ -61,12 +62,7 @@ thread_local! {
 
 #[no_mangle]
 pub unsafe extern "C" fn wingc_on_did_open_text_document(ptr: u32, len: u32) {
-	let parse_string = ptr_to_string(ptr, len);
-	if let Ok(parsed) = serde_json::from_str(&parse_string) {
-		on_document_did_open(parsed);
-	} else {
-		eprintln!("Failed to parse 'did open' text document: {}", parse_string);
-	}
+	extern_json_fn(ptr, len, on_document_did_open);
 }
 
 pub fn on_document_did_open(params: DidOpenTextDocumentParams) {
@@ -91,12 +87,7 @@ pub fn on_document_did_open(params: DidOpenTextDocumentParams) {
 
 #[no_mangle]
 pub unsafe extern "C" fn wingc_on_did_change_text_document(ptr: u32, len: u32) {
-	let parse_string = ptr_to_string(ptr, len);
-	if let Ok(parsed) = serde_json::from_str(&parse_string) {
-		on_document_did_change(parsed);
-	} else {
-		eprintln!("Failed to parse 'did change' text document: {}", parse_string);
-	}
+	extern_json_fn(ptr, len, on_document_did_change);
 }
 
 pub fn on_document_did_change(params: DidChangeTextDocumentParams) {

--- a/libs/wingc/src/wasm_util.rs
+++ b/libs/wingc/src/wasm_util.rs
@@ -1,9 +1,9 @@
 pub static WASM_RETURN_ERROR: u64 = 0;
 
-/// Convert pointer and length into utf8 string represented by the bytes
-pub unsafe fn ptr_to_string(ptr: u32, len: u32) -> String {
+/// Convert pointer and length into utf8 str represented by the bytes
+pub unsafe fn ptr_to_str(ptr: u32, len: u32) -> &'static str {
 	let slice = std::slice::from_raw_parts(ptr as *const u8, len as usize);
-	String::from_utf8_unchecked(slice.to_vec())
+	std::str::from_utf8_unchecked(slice)
 }
 
 /// Convert String into a pointer (32 bit) and length (32 bit) combined into a single 64-bit value
@@ -15,4 +15,37 @@ pub unsafe fn string_to_combined_ptr(str: String) -> u64 {
 /// Uses bitshift to combine pointer and length into a single value
 pub fn combine_ptr_and_length(ptr: u32, len: u32) -> u64 {
 	return ((ptr as u64) << 32_u64) | (len as u64);
+}
+
+/// Convert pointer and length representing JSON string into deserialized object
+pub fn parse_json_string<'a, TRequest>(ptr: u32, len: u32) -> Result<TRequest, u64>
+where
+	TRequest: serde::Deserialize<'a>,
+{
+	let parse_string = unsafe { ptr_to_str(ptr, len) };
+	if let Ok(parsed) = serde_json::from_str(parse_string) {
+		Ok(parsed)
+	} else {
+		Err(WASM_RETURN_ERROR)
+	}
+}
+
+/// Wrapper for common pattern of exporting a function that uses JSON as the communication format between a WASM host and Rust
+pub fn extern_json_fn<'a, TRequest, TResponse>(ptr: u32, len: u32, func: fn(TRequest) -> TResponse) -> u64
+where
+	TRequest: serde::Deserialize<'a>,
+	TResponse: serde::Serialize,
+{
+	let parsed = parse_json_string::<TRequest>(ptr, len);
+	if let Ok(parsed) = parsed {
+		let result = func(parsed);
+
+		if let Ok(json_string) = serde_json::to_string(&result) {
+			unsafe { string_to_combined_ptr(json_string) }
+		} else {
+			WASM_RETURN_ERROR
+		}
+	} else {
+		WASM_RETURN_ERROR
+	}
 }


### PR DESCRIPTION
Was tired of repeating the same function over and over again.

I considered a macro but IMO it didn't look much better and would actually add more duplicated code than necessary (thus making a bigger WASM file)

Also changed `ptr_to_string` into `ptr_to_str` to avoid unnecessarily copying the data we get into an owned String.

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
