### PR TITLE
chore(cli): fix argument description for `wing run`

### DIFF
--- a/apps/wing/src/cli.ts
+++ b/apps/wing/src/cli.ts
@@ -123,7 +123,7 @@ async function main() {
     .command("run")
     .alias("it")
     .description("Runs a Wing program in the Wing Console")
-    .argument("[entrypoint]", "program .w entrypoint")
+    .argument("[entrypoint]", "program .w or .wsim entrypoint")
     .option("-p, --port <port>", "specify port")
     .option("--no-open", "Do not open the Wing Console in the browser")
     .hook("preAction", collectAnalyticsHook)


### PR DESCRIPTION
Aligning argument description for `wing run` to the docs.

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
