### PR TITLE
chore(sdk): fix error message

### DIFF
--- a/libs/wingsdk/src/target-tf-aws/api.ts
+++ b/libs/wingsdk/src/target-tf-aws/api.ts
@@ -342,7 +342,7 @@ export class Api extends cloud.Api {
   /** @internal */
   public onLift(host: IInflightHost, ops: string[]): void {
     if (!(host instanceof Function)) {
-      throw new Error("topics can only be bound by tfaws.Function for now");
+      throw new Error("apis can only be bound by tfaws.Function for now");
     }
 
     host.addEnvironment(this.urlEnvName(), this.url);


### PR DESCRIPTION
The `onLift` method of the `cloud.Api` had an error message stating, `topics can only be bound by tfaws.Function for now.`

I changed `topics` to `apis`.

## Checklist

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [ ] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
