### PR TITLE
feat (docs): YAML file for sim section,

### DIFF
--- a/docs/docs/04-standard-library/09-sim/_category_.yml
+++ b/docs/docs/04-standard-library/09-sim/_category_.yml
@@ -1,0 +1,3 @@
+label: Simulator
+collapsible: true
+collapsed: true


### PR DESCRIPTION
Fixes #4632
I have added a YAML file which was absent in the docs/docs/04-standard-library/09-sim folder to update the title of `sim` to `Simulator`.

## Checklist

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [ ] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.

