### PR TITLE
fix(docs): readme gif link

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Winglang addresses these pains by letting you work at a higher level of abstract
 We also provide you with a set of tools that let you test your code locally, significantly faster than before.
 
 <p align="center">
-  <img src="./logo/demo.gif" alt="Wing Demo" height="360px">
+  <img src="./apps/wing/logo/demo.gif" alt="Wing Demo" height="360px">
 </p>
 
 Wing is built by [Elad Ben-Israel](https://github.com/eladb), the guy behind the [AWS CDK](https://github.com/aws/aws-cdk), the gang at the [Wing Cloud team](https://www.wing.cloud/) and an amazing [community](https://t.winglang.io/slack) of contributors (also known as Wingnuts).


### PR DESCRIPTION
Fixed broken link to Gif in readme

## Checklist

- [X] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [X] Description explains motivation and solution
- [ ] Tests added (always)
- [X] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
