### PR TITLE
fix(compiler): can't name a variable "scope" or "id"

### DIFF
--- a/examples/tests/valid/statements_variable_declarations.test.w
+++ b/examples/tests/valid/statements_variable_declarations.test.w
@@ -1,2 +1,6 @@
 let x = 2;
 let y = x;
+
+// Specically test variables named `scope` and `id` (see https://github.com/winglang/wing/issues/3026)
+let id = 1;
+let scope = id;

--- a/libs/wingc/src/jsify.rs
+++ b/libs/wingc/src/jsify.rs
@@ -174,8 +174,8 @@ impl<'a> JSifier<'a> {
 		if is_entrypoint {
 			let mut root_class = CodeMaker::default();
 			root_class.open(format!("class {} extends {} {{", ROOT_CLASS, STDLIB_CORE_RESOURCE));
-			root_class.open(format!("{JS_CONSTRUCTOR}(scope, id) {{"));
-			root_class.line("super(scope, id);");
+			root_class.open(format!("{JS_CONSTRUCTOR}($scope, $id) {{"));
+			root_class.line("super($scope, $id);");
 			root_class.add_code(self.jsify_struct_schemas());
 			root_class.add_code(js);
 			root_class.close("}");
@@ -343,7 +343,7 @@ impl<'a> JSifier<'a> {
 		if args.is_empty() {
 			"".to_string()
 		} else {
-			args.join(",")
+			args.join(", ")
 		}
 	}
 
@@ -822,7 +822,7 @@ impl<'a> JSifier<'a> {
 				let args = self.jsify_arg_list(&arg_list, None, None, ctx);
 				match parent_class_phase(ctx) {
 					Phase::Inflight => CodeMaker::one_line(format!("await this.super_{CLASS_INFLIGHT_INIT_NAME}?.({args});")),
-					Phase::Preflight => CodeMaker::one_line(format!("super(scope,id,{args});")),
+					Phase::Preflight => CodeMaker::one_line(format!("super($scope, $id, {args});")),
 					Phase::Independent => {
 						// If our parent is phase independent then we don't call its super, instead a call to its super will be
 						// generated in `jsify_inflight_init` when we generate the inflight init for this class.
@@ -1246,7 +1246,7 @@ impl<'a> JSifier<'a> {
 	fn jsify_preflight_constructor(&self, class: &AstClass, ctx: &mut JSifyContext) -> CodeMaker {
 		let mut code = CodeMaker::default();
 		code.open(format!(
-			"constructor(scope, id, {}) {{",
+			"{JS_CONSTRUCTOR}($scope, $id, {}) {{",
 			class
 				.initializer
 				.signature
@@ -1274,7 +1274,7 @@ impl<'a> JSifier<'a> {
 		// we always need a super() call because even if the class doesn't have an explicit parent, it
 		// will inherit from core.Resource.
 		if !super_called {
-			body_code.line("super(scope, id);");
+			body_code.line("super($scope, $id);");
 		}
 		body_code.add_code(self.jsify_scope_body(&init_statements, ctx));
 

--- a/libs/wingc/src/jsify/snapshots/access_methods_and_properties_on_collections.snap
+++ b/libs/wingc/src/jsify/snapshots/access_methods_and_properties_on_collections.snap
@@ -45,11 +45,11 @@ const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -84,7 +84,7 @@ class $Root extends $stdlib.std.Resource {
     }
     const x = [1, 2, 3];
     const y = ["hello"];
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:test",new $Closure1(this,"$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:test", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/libs/wingc/src/jsify/snapshots/access_property_on_primitive.snap
+++ b/libs/wingc/src/jsify/snapshots/access_property_on_primitive.snap
@@ -42,11 +42,11 @@ const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -78,7 +78,7 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     const s = "hello";
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:test",new $Closure1(this,"$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:test", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/libs/wingc/src/jsify/snapshots/access_property_on_value_returned_from_collection.snap
+++ b/libs/wingc/src/jsify/snapshots/access_property_on_value_returned_from_collection.snap
@@ -42,11 +42,11 @@ const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -78,7 +78,7 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     const s = ({"hello": "123"});
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:test",new $Closure1(this,"$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:test", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/libs/wingc/src/jsify/snapshots/base_class_captures_inflight.snap
+++ b/libs/wingc/src/jsify/snapshots/base_class_captures_inflight.snap
@@ -64,11 +64,11 @@ const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class Base extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
       }
       static _toInflightType(context) {
         return `
@@ -99,8 +99,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class Derived extends Base {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
       }
       static _toInflightType(context) {
         return `

--- a/libs/wingc/src/jsify/snapshots/base_class_captures_preflight.snap
+++ b/libs/wingc/src/jsify/snapshots/base_class_captures_preflight.snap
@@ -58,11 +58,11 @@ const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class Base extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
       }
       bar() {
         {console.log(x)};
@@ -89,8 +89,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class Derived extends Base {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
       }
       foo() {
         (this.bar());

--- a/libs/wingc/src/jsify/snapshots/base_class_lift_indirect.snap
+++ b/libs/wingc/src/jsify/snapshots/base_class_lift_indirect.snap
@@ -37,7 +37,7 @@ module.exports = function({  }) {
       this.$this_b = $this_b;
     }
     async put() {
-      (await this.$this_b.put("hello","world"));
+      (await this.$this_b.put("hello", "world"));
       (await this.$this_b.list());
     }
   }
@@ -73,12 +73,12 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class Base extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
-        this.b = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this,"cloud.Bucket");
+      constructor($scope, $id, ) {
+        super($scope, $id);
+        this.b = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this, "cloud.Bucket");
       }
       static _toInflightType(context) {
         return `
@@ -112,8 +112,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class Derived extends Base {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
       }
       static _toInflightType(context) {
         return `

--- a/libs/wingc/src/jsify/snapshots/base_class_with_fields_inflight.snap
+++ b/libs/wingc/src/jsify/snapshots/base_class_with_fields_inflight.snap
@@ -73,11 +73,11 @@ const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class Base extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
       }
       static _toInflightType(context) {
         return `
@@ -101,8 +101,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class Derived extends Base {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
       }
       static _toInflightType(context) {
         return `

--- a/libs/wingc/src/jsify/snapshots/base_class_with_fields_preflight.snap
+++ b/libs/wingc/src/jsify/snapshots/base_class_with_fields_preflight.snap
@@ -63,11 +63,11 @@ const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class Base extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         this.f = "hello";
       }
       static _toInflightType(context) {
@@ -92,8 +92,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class Derived extends Base {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         this.g = "world";
       }
       foo() {

--- a/libs/wingc/src/jsify/snapshots/base_class_with_lifted_field_object.snap
+++ b/libs/wingc/src/jsify/snapshots/base_class_with_lifted_field_object.snap
@@ -46,7 +46,7 @@ module.exports = function({ $Base }) {
       this.$this_b = $this_b;
     }
     async foo() {
-      (await this.$this_b.put("hello","world"));
+      (await this.$this_b.put("hello", "world"));
     }
   }
   return Derived;
@@ -64,12 +64,12 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class Base extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
-        this.b = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this,"cloud.Bucket");
+      constructor($scope, $id, ) {
+        super($scope, $id);
+        this.b = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this, "cloud.Bucket");
       }
       static _toInflightType(context) {
         return `
@@ -93,8 +93,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class Derived extends Base {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
       }
       static _toInflightType(context) {
         return `

--- a/libs/wingc/src/jsify/snapshots/base_class_with_lifted_fields.snap
+++ b/libs/wingc/src/jsify/snapshots/base_class_with_lifted_fields.snap
@@ -63,11 +63,11 @@ const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class Base extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         this.f = x;
       }
       static _toInflightType(context) {
@@ -92,8 +92,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class Derived extends Base {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
       }
       static _toInflightType(context) {
         return `

--- a/libs/wingc/src/jsify/snapshots/builtins.snap
+++ b/libs/wingc/src/jsify/snapshots/builtins.snap
@@ -40,11 +40,11 @@ const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -68,7 +68,7 @@ class $Root extends $stdlib.std.Resource {
         return ["handle", "$inflight_init"];
       }
     }
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:test",new $Closure1(this,"$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:test", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/libs/wingc/src/jsify/snapshots/call_static_inflight_from_static_inflight.snap
+++ b/libs/wingc/src/jsify/snapshots/call_static_inflight_from_static_inflight.snap
@@ -57,11 +57,11 @@ const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class A extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
       }
       static _toInflightType(context) {
         return `
@@ -85,8 +85,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class B extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
       }
       static _toInflightType(context) {
         return `

--- a/libs/wingc/src/jsify/snapshots/calls_methods_on_preflight_object.snap
+++ b/libs/wingc/src/jsify/snapshots/calls_methods_on_preflight_object.snap
@@ -27,7 +27,7 @@ module.exports = function({ $b }) {
       return $obj;
     }
     async handle() {
-      (await $b.put("hello","world"));
+      (await $b.put("hello", "world"));
       (await $b.list());
     }
   }
@@ -46,11 +46,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -81,8 +81,8 @@ class $Root extends $stdlib.std.Resource {
         super._registerOnLift(host, ops);
       }
     }
-    const b = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this,"cloud.Bucket");
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:test",new $Closure1(this,"$Closure1"));
+    const b = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this, "cloud.Bucket");
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:test", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/libs/wingc/src/jsify/snapshots/capture_from_inside_an_inflight_closure.snap
+++ b/libs/wingc/src/jsify/snapshots/capture_from_inside_an_inflight_closure.snap
@@ -47,11 +47,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const util = $stdlib.util;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -83,7 +83,7 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     const foo = "test";
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:my test",new $Closure1(this,"$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:my test", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/libs/wingc/src/jsify/snapshots/capture_identifier_closure_from_preflight_scope.snap
+++ b/libs/wingc/src/jsify/snapshots/capture_identifier_closure_from_preflight_scope.snap
@@ -59,11 +59,11 @@ const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -88,8 +88,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure2 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -120,8 +120,8 @@ class $Root extends $stdlib.std.Resource {
         super._registerOnLift(host, ops);
       }
     }
-    const foo = new $Closure1(this,"$Closure1");
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:test",new $Closure2(this,"$Closure2"));
+    const foo = new $Closure1(this, "$Closure1");
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:test", new $Closure2(this, "$Closure2"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/libs/wingc/src/jsify/snapshots/capture_identifier_from_preflight_scope.snap
+++ b/libs/wingc/src/jsify/snapshots/capture_identifier_from_preflight_scope.snap
@@ -41,11 +41,11 @@ const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -77,7 +77,7 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     const x = "hello";
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:test",new $Closure1(this,"$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:test", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/libs/wingc/src/jsify/snapshots/capture_identifier_from_preflight_scope_with_method_call.snap
+++ b/libs/wingc/src/jsify/snapshots/capture_identifier_from_preflight_scope_with_method_call.snap
@@ -60,11 +60,11 @@ const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class Foo extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
       }
       static _toInflightType(context) {
         return `
@@ -88,8 +88,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -120,8 +120,8 @@ class $Root extends $stdlib.std.Resource {
         super._registerOnLift(host, ops);
       }
     }
-    const f = new Foo(this,"Foo");
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:test",new $Closure1(this,"$Closure1"));
+    const f = new Foo(this, "Foo");
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:test", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/libs/wingc/src/jsify/snapshots/capture_identifier_from_preflight_scope_with_nested_object.snap
+++ b/libs/wingc/src/jsify/snapshots/capture_identifier_from_preflight_scope_with_nested_object.snap
@@ -33,7 +33,7 @@ module.exports = function({ $f_b }) {
       return $obj;
     }
     async handle() {
-      (await $f_b.put("hello","world"));
+      (await $f_b.put("hello", "world"));
     }
   }
   return $Closure1;
@@ -64,12 +64,12 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class Foo extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
-        this.b = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this,"cloud.Bucket");
+      constructor($scope, $id, ) {
+        super($scope, $id);
+        this.b = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this, "cloud.Bucket");
       }
       static _toInflightType(context) {
         return `
@@ -93,8 +93,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -125,8 +125,8 @@ class $Root extends $stdlib.std.Resource {
         super._registerOnLift(host, ops);
       }
     }
-    const f = new Foo(this,"Foo");
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:test",new $Closure1(this,"$Closure1"));
+    const f = new Foo(this, "Foo");
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:test", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/libs/wingc/src/jsify/snapshots/capture_identifier_from_preflight_scope_with_property.snap
+++ b/libs/wingc/src/jsify/snapshots/capture_identifier_from_preflight_scope_with_property.snap
@@ -41,11 +41,11 @@ const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -77,7 +77,7 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     const x = "hello";
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:test",new $Closure1(this,"$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:test", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/libs/wingc/src/jsify/snapshots/capture_in_keyword_args.snap
+++ b/libs/wingc/src/jsify/snapshots/capture_in_keyword_args.snap
@@ -29,7 +29,7 @@ module.exports = function({ $util_Util, $x }) {
     async handle() {
       (await $util_Util.waitUntil(async () => {
       }
-      ,{ interval: $x }));
+      , { interval: $x }));
     }
   }
   return $Closure1;
@@ -47,11 +47,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const util = $stdlib.util;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -84,7 +84,7 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     const x = (std.Duration.fromSeconds(1));
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:test",new $Closure1(this,"$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:test", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/libs/wingc/src/jsify/snapshots/capture_object_with_this_in_name.snap
+++ b/libs/wingc/src/jsify/snapshots/capture_object_with_this_in_name.snap
@@ -25,7 +25,7 @@ module.exports = function({ $bucket_this }) {
       return $obj;
     }
     async handle() {
-      (await $bucket_this.put("this","is not a field"));
+      (await $bucket_this.put("this", "is not a field"));
     }
   }
   return $Closure1;
@@ -43,11 +43,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -78,8 +78,8 @@ class $Root extends $stdlib.std.Resource {
         super._registerOnLift(host, ops);
       }
     }
-    const bucket_this = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this,"cloud.Bucket");
-    const fn = new $Closure1(this,"$Closure1");
+    const bucket_this = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this, "cloud.Bucket");
+    const fn = new $Closure1(this, "$Closure1");
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/libs/wingc/src/jsify/snapshots/capture_token.snap
+++ b/libs/wingc/src/jsify/snapshots/capture_token.snap
@@ -42,11 +42,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -77,8 +77,8 @@ class $Root extends $stdlib.std.Resource {
         super._registerOnLift(host, ops);
       }
     }
-    const api = this.node.root.newAbstract("@winglang/sdk.cloud.Api",this,"cloud.Api");
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:test",new $Closure1(this,"$Closure1"));
+    const api = this.node.root.newAbstract("@winglang/sdk.cloud.Api",this, "cloud.Api");
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:test", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/libs/wingc/src/jsify/snapshots/capture_type_inflight_class_sibling_from_init.snap
+++ b/libs/wingc/src/jsify/snapshots/capture_type_inflight_class_sibling_from_init.snap
@@ -65,11 +65,11 @@ const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -93,7 +93,7 @@ class $Root extends $stdlib.std.Resource {
         return ["handle", "$inflight_init"];
       }
     }
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:test",new $Closure1(this,"$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:test", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/libs/wingc/src/jsify/snapshots/capture_type_inflight_class_sibling_from_method.snap
+++ b/libs/wingc/src/jsify/snapshots/capture_type_inflight_class_sibling_from_method.snap
@@ -51,11 +51,11 @@ const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -79,7 +79,7 @@ class $Root extends $stdlib.std.Resource {
         return ["handle", "$inflight_init"];
       }
     }
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:test",new $Closure1(this,"$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:test", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/libs/wingc/src/jsify/snapshots/capture_type_new_inflight_class_inner_no_capture.snap
+++ b/libs/wingc/src/jsify/snapshots/capture_type_new_inflight_class_inner_no_capture.snap
@@ -43,11 +43,11 @@ const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -71,7 +71,7 @@ class $Root extends $stdlib.std.Resource {
         return ["handle", "$inflight_init"];
       }
     }
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:test",new $Closure1(this,"$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:test", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/libs/wingc/src/jsify/snapshots/capture_type_new_inflight_class_outer.snap
+++ b/libs/wingc/src/jsify/snapshots/capture_type_new_inflight_class_outer.snap
@@ -53,11 +53,11 @@ const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class Foo extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
       }
       static _toInflightType(context) {
         return `
@@ -81,8 +81,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -107,7 +107,7 @@ class $Root extends $stdlib.std.Resource {
         return ["handle", "$inflight_init"];
       }
     }
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:test",new $Closure1(this,"$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:test", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/libs/wingc/src/jsify/snapshots/capture_type_static_method.snap
+++ b/libs/wingc/src/jsify/snapshots/capture_type_static_method.snap
@@ -60,11 +60,11 @@ const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class Foo extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
       }
       static _toInflightType(context) {
         return `
@@ -88,8 +88,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -120,7 +120,7 @@ class $Root extends $stdlib.std.Resource {
         super._registerOnLift(host, ops);
       }
     }
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:test",new $Closure1(this,"$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:test", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/libs/wingc/src/jsify/snapshots/capture_type_static_method_inflight_class.snap
+++ b/libs/wingc/src/jsify/snapshots/capture_type_static_method_inflight_class.snap
@@ -58,11 +58,11 @@ const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class Foo extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
       }
       static _toInflightType(context) {
         return `
@@ -86,8 +86,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -112,7 +112,7 @@ class $Root extends $stdlib.std.Resource {
         return ["handle", "$inflight_init"];
       }
     }
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:test",new $Closure1(this,"$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:test", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/libs/wingc/src/jsify/snapshots/capture_var_from_method_inflight.snap
+++ b/libs/wingc/src/jsify/snapshots/capture_var_from_method_inflight.snap
@@ -48,11 +48,11 @@ const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -76,7 +76,7 @@ class $Root extends $stdlib.std.Resource {
         return ["handle", "$inflight_init"];
       }
     }
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:test",new $Closure1(this,"$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:test", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/libs/wingc/src/jsify/snapshots/closed_inflight_class_extends_outer_inflight_class.snap
+++ b/libs/wingc/src/jsify/snapshots/closed_inflight_class_extends_outer_inflight_class.snap
@@ -56,11 +56,11 @@ const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class Base extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
       }
       static _toInflightType(context) {
         return `
@@ -84,8 +84,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -110,7 +110,7 @@ class $Root extends $stdlib.std.Resource {
         return ["handle", "$inflight_init"];
       }
     }
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:test",new $Closure1(this,"$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:test", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/libs/wingc/src/jsify/snapshots/closure_field.snap
+++ b/libs/wingc/src/jsify/snapshots/closure_field.snap
@@ -100,15 +100,15 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class MyResource extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         const __parent_this_1 = this;
         class $Closure1 extends $stdlib.std.Resource {
-          constructor(scope, id, ) {
-            super(scope, id);
+          constructor($scope, $id, ) {
+            super($scope, $id);
             (std.Node.of(this)).hidden = true;
           }
           static _toInflightType(context) {
@@ -139,7 +139,7 @@ class $Root extends $stdlib.std.Resource {
             super._registerOnLift(host, ops);
           }
         }
-        this.closure = new $Closure1(this,"$Closure1");
+        this.closure = new $Closure1(this, "$Closure1");
       }
       static _toInflightType(context) {
         return `
@@ -173,8 +173,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure2 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -205,9 +205,9 @@ class $Root extends $stdlib.std.Resource {
         super._registerOnLift(host, ops);
       }
     }
-    const globalBucket = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this,"cloud.Bucket");
-    const x = new MyResource(this,"MyResource");
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:variable can be an inflight closure",new $Closure2(this,"$Closure2"));
+    const globalBucket = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this, "cloud.Bucket");
+    const x = new MyResource(this, "MyResource");
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:variable can be an inflight closure", new $Closure2(this, "$Closure2"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/libs/wingc/src/jsify/snapshots/enum_value.snap
+++ b/libs/wingc/src/jsify/snapshots/enum_value.snap
@@ -45,11 +45,11 @@ const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -89,7 +89,7 @@ class $Root extends $stdlib.std.Resource {
       })({})
     ;
     const x = MyEnum.C;
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:test",new $Closure1(this,"$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:test", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/libs/wingc/src/jsify/snapshots/free_inflight_obj_from_inflight.snap
+++ b/libs/wingc/src/jsify/snapshots/free_inflight_obj_from_inflight.snap
@@ -53,11 +53,11 @@ const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -81,7 +81,7 @@ class $Root extends $stdlib.std.Resource {
         return ["handle", "$inflight_init"];
       }
     }
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:test",new $Closure1(this,"$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:test", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/libs/wingc/src/jsify/snapshots/free_preflight_object_from_preflight.snap
+++ b/libs/wingc/src/jsify/snapshots/free_preflight_object_from_preflight.snap
@@ -36,11 +36,11 @@ const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class A extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
       }
       foo() {
         {console.log(x)};

--- a/libs/wingc/src/jsify/snapshots/func_returns_func.snap
+++ b/libs/wingc/src/jsify/snapshots/func_returns_func.snap
@@ -50,11 +50,11 @@ const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -78,7 +78,7 @@ class $Root extends $stdlib.std.Resource {
         return ["handle", "$inflight_init"];
       }
     }
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:test",new $Closure1(this,"$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:test", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/libs/wingc/src/jsify/snapshots/identify_field.snap
+++ b/libs/wingc/src/jsify/snapshots/identify_field.snap
@@ -28,7 +28,7 @@ module.exports = function({  }) {
       this.$this_bucket_this = $this_bucket_this;
     }
     async foo() {
-      (await this.$this_bucket_this.put("hello","world"));
+      (await this.$this_bucket_this.put("hello", "world"));
     }
   }
   return A;
@@ -46,12 +46,12 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class A extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
-        this.bucket_this = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this,"cloud.Bucket");
+      constructor($scope, $id, ) {
+        super($scope, $id);
+        this.bucket_this = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this, "cloud.Bucket");
       }
       static _toInflightType(context) {
         return `

--- a/libs/wingc/src/jsify/snapshots/implicit_lift_inflight_init.snap
+++ b/libs/wingc/src/jsify/snapshots/implicit_lift_inflight_init.snap
@@ -64,12 +64,12 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class Foo extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
-        this.c = this.node.root.newAbstract("@winglang/sdk.cloud.Counter",this,"cloud.Counter");
+      constructor($scope, $id, ) {
+        super($scope, $id);
+        this.c = this.node.root.newAbstract("@winglang/sdk.cloud.Counter",this, "cloud.Counter");
       }
       static _toInflightType(context) {
         return `

--- a/libs/wingc/src/jsify/snapshots/indirect_capture.snap
+++ b/libs/wingc/src/jsify/snapshots/indirect_capture.snap
@@ -77,12 +77,12 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class Capture extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
-        this.q = this.node.root.newAbstract("@winglang/sdk.cloud.Queue",this,"cloud.Queue");
+      constructor($scope, $id, ) {
+        super($scope, $id);
+        this.q = this.node.root.newAbstract("@winglang/sdk.cloud.Queue",this, "cloud.Queue");
       }
       static _toInflightType(context) {
         return `
@@ -116,8 +116,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -148,9 +148,9 @@ class $Root extends $stdlib.std.Resource {
         super._registerOnLift(host, ops);
       }
     }
-    const b = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this,"cloud.Bucket");
-    const f = new Capture(this,"Capture");
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:test",new $Closure1(this,"$Closure1"));
+    const b = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this, "cloud.Bucket");
+    const f = new Capture(this, "Capture");
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:test", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/libs/wingc/src/jsify/snapshots/inflight_class_extends_both_inside_inflight_closure.snap
+++ b/libs/wingc/src/jsify/snapshots/inflight_class_extends_both_inside_inflight_closure.snap
@@ -44,11 +44,11 @@ const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -72,7 +72,7 @@ class $Root extends $stdlib.std.Resource {
         return ["handle", "$inflight_init"];
       }
     }
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:test",new $Closure1(this,"$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:test", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/libs/wingc/src/jsify/snapshots/inflight_class_extends_inflight_class.snap
+++ b/libs/wingc/src/jsify/snapshots/inflight_class_extends_inflight_class.snap
@@ -42,11 +42,11 @@ const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class A extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
       }
       static _toInflightType(context) {
         return `
@@ -70,8 +70,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class B extends A {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
       }
       static _toInflightType(context) {
         return `

--- a/libs/wingc/src/jsify/snapshots/inflight_constructor.snap
+++ b/libs/wingc/src/jsify/snapshots/inflight_constructor.snap
@@ -48,11 +48,11 @@ const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class Foo extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
       }
       static _toInflightType(context) {
         return `

--- a/libs/wingc/src/jsify/snapshots/inflight_field.snap
+++ b/libs/wingc/src/jsify/snapshots/inflight_field.snap
@@ -47,11 +47,11 @@ const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class A extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
       }
       static _toInflightType(context) {
         return `

--- a/libs/wingc/src/jsify/snapshots/inflight_field_from_inflight.snap
+++ b/libs/wingc/src/jsify/snapshots/inflight_field_from_inflight.snap
@@ -46,11 +46,11 @@ const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class MyType extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
       }
       static _toInflightType(context) {
         return `

--- a/libs/wingc/src/jsify/snapshots/inflight_field_from_inflight_class.snap
+++ b/libs/wingc/src/jsify/snapshots/inflight_field_from_inflight_class.snap
@@ -45,11 +45,11 @@ const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class MyType extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
       }
       static _toInflightType(context) {
         return `

--- a/libs/wingc/src/jsify/snapshots/inline_inflight_class.snap
+++ b/libs/wingc/src/jsify/snapshots/inline_inflight_class.snap
@@ -34,7 +34,7 @@ module.exports = function({ $__parent_this_1_b }) {
       return $obj;
     }
     async handle() {
-      (await $__parent_this_1_b.put("in","bucket"));
+      (await $__parent_this_1_b.put("in", "bucket"));
     }
   }
   return $Closure1;
@@ -65,17 +65,17 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class Foo extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
-        this.b = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this,"cloud.Bucket");
-        this.q = this.node.root.newAbstract("@winglang/sdk.cloud.Queue",this,"cloud.Queue");
+      constructor($scope, $id, ) {
+        super($scope, $id);
+        this.b = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this, "cloud.Bucket");
+        this.q = this.node.root.newAbstract("@winglang/sdk.cloud.Queue",this, "cloud.Queue");
         const __parent_this_1 = this;
         class $Closure1 extends $stdlib.std.Resource {
-          constructor(scope, id, ) {
-            super(scope, id);
+          constructor($scope, $id, ) {
+            super($scope, $id);
             (std.Node.of(this)).hidden = true;
           }
           static _toInflightType(context) {
@@ -106,7 +106,7 @@ class $Root extends $stdlib.std.Resource {
             super._registerOnLift(host, ops);
           }
         }
-        (this.q.setConsumer(new $Closure1(this,"$Closure1")));
+        (this.q.setConsumer(new $Closure1(this, "$Closure1")));
       }
       static _toInflightType(context) {
         return `

--- a/libs/wingc/src/jsify/snapshots/json_object.snap
+++ b/libs/wingc/src/jsify/snapshots/json_object.snap
@@ -42,11 +42,11 @@ const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -79,7 +79,7 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     const jsonObj1 = ({"key1": "value1"});
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:test",new $Closure1(this,"$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:test", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/libs/wingc/src/jsify/snapshots/lift_binary_preflight_and_inflight_expression.snap
+++ b/libs/wingc/src/jsify/snapshots/lift_binary_preflight_and_inflight_expression.snap
@@ -43,11 +43,11 @@ const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -79,7 +79,7 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     const x = 1;
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:test",new $Closure1(this,"$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:test", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/libs/wingc/src/jsify/snapshots/lift_binary_preflight_expression.snap
+++ b/libs/wingc/src/jsify/snapshots/lift_binary_preflight_expression.snap
@@ -42,11 +42,11 @@ const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -81,7 +81,7 @@ class $Root extends $stdlib.std.Resource {
     }
     const x = 1;
     const y = 2;
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:test",new $Closure1(this,"$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:test", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/libs/wingc/src/jsify/snapshots/lift_element_from_collection_as_field.snap
+++ b/libs/wingc/src/jsify/snapshots/lift_element_from_collection_as_field.snap
@@ -29,7 +29,7 @@ module.exports = function({  }) {
       this.$_this_arr_at_0__ = $_this_arr_at_0__;
     }
     async foo() {
-      (await this.$_this_arr_at_0__.put("hello","world"));
+      (await this.$_this_arr_at_0__.put("hello", "world"));
     }
   }
   return Foo;
@@ -47,12 +47,12 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class Foo extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
-        this.arr = [this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this,"cloud.Bucket")];
+      constructor($scope, $id, ) {
+        super($scope, $id);
+        this.arr = [this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this, "cloud.Bucket")];
       }
       static _toInflightType(context) {
         return `

--- a/libs/wingc/src/jsify/snapshots/lift_element_from_collection_of_objects.snap
+++ b/libs/wingc/src/jsify/snapshots/lift_element_from_collection_of_objects.snap
@@ -26,7 +26,7 @@ module.exports = function({ $_a_at_0__ }) {
       return $obj;
     }
     async handle() {
-      (await $_a_at_0__.put("hello","world"));
+      (await $_a_at_0__.put("hello", "world"));
     }
   }
   return $Closure1;
@@ -44,11 +44,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -79,8 +79,8 @@ class $Root extends $stdlib.std.Resource {
         super._registerOnLift(host, ops);
       }
     }
-    const a = [this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this,"cloud.Bucket")];
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:test",new $Closure1(this,"$Closure1"));
+    const a = [this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this, "cloud.Bucket")];
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:test", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/libs/wingc/src/jsify/snapshots/lift_inflight_closure.snap
+++ b/libs/wingc/src/jsify/snapshots/lift_inflight_closure.snap
@@ -60,11 +60,11 @@ const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -89,8 +89,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure2 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -121,8 +121,8 @@ class $Root extends $stdlib.std.Resource {
         super._registerOnLift(host, ops);
       }
     }
-    const f = new $Closure1(this,"$Closure1");
-    new $Closure2(this,"$Closure2");
+    const f = new $Closure1(this, "$Closure1");
+    new $Closure2(this, "$Closure2");
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/libs/wingc/src/jsify/snapshots/lift_inside_preflight_method.snap
+++ b/libs/wingc/src/jsify/snapshots/lift_inside_preflight_method.snap
@@ -35,7 +35,7 @@ module.exports = function({ $b }) {
       return $obj;
     }
     async handle() {
-      (await $b.put("dirty","x"));
+      (await $b.put("dirty", "x"));
     }
   }
   return $Closure1;
@@ -66,20 +66,20 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class Foo extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (this.defineBucket("b1"));
         (this.defineBucket("b2"));
       }
       defineBucket(name) {
-        const b = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this,name);
+        const b = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this, name);
         const __parent_this_1 = this;
         class $Closure1 extends $stdlib.std.Resource {
-          constructor(scope, id, ) {
-            super(scope, id);
+          constructor($scope, $id, ) {
+            super($scope, $id);
             (std.Node.of(this)).hidden = true;
           }
           static _toInflightType(context) {
@@ -110,7 +110,7 @@ class $Root extends $stdlib.std.Resource {
             super._registerOnLift(host, ops);
           }
         }
-        new $Closure1(this,"$Closure1");
+        new $Closure1(this, "$Closure1");
       }
       static _toInflightType(context) {
         return `

--- a/libs/wingc/src/jsify/snapshots/lift_self_reference.snap
+++ b/libs/wingc/src/jsify/snapshots/lift_self_reference.snap
@@ -43,11 +43,11 @@ const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class Foo extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
       }
       static _toInflightType(context) {
         return `

--- a/libs/wingc/src/jsify/snapshots/lift_string.snap
+++ b/libs/wingc/src/jsify/snapshots/lift_string.snap
@@ -41,11 +41,11 @@ const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -77,7 +77,7 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     const b = "hello";
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:test",new $Closure1(this,"$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:test", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/libs/wingc/src/jsify/snapshots/lift_this.snap
+++ b/libs/wingc/src/jsify/snapshots/lift_this.snap
@@ -77,11 +77,11 @@ const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class Foo extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
       }
       static _toInflightType(context) {
         return `
@@ -111,8 +111,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -143,8 +143,8 @@ class $Root extends $stdlib.std.Resource {
         super._registerOnLift(host, ops);
       }
     }
-    const f = new Foo(this,"Foo");
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:test",new $Closure1(this,"$Closure1"));
+    const f = new Foo(this, "Foo");
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:test", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/libs/wingc/src/jsify/snapshots/lift_var_with_this.snap
+++ b/libs/wingc/src/jsify/snapshots/lift_var_with_this.snap
@@ -60,11 +60,11 @@ const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class Foo extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         this.value = "hello";
       }
       static _toInflightType(context) {
@@ -89,8 +89,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -124,8 +124,8 @@ class $Root extends $stdlib.std.Resource {
         super._registerOnLift(host, ops);
       }
     }
-    const foo_this = new Foo(this,"Foo");
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:test",new $Closure1(this,"$Closure1"));
+    const foo_this = new Foo(this, "Foo");
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:test", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/libs/wingc/src/jsify/snapshots/lift_via_closure.snap
+++ b/libs/wingc/src/jsify/snapshots/lift_via_closure.snap
@@ -31,7 +31,7 @@ module.exports = function({ $bucket }) {
       return $obj;
     }
     async handle() {
-      (await $bucket.put("hello","world"));
+      (await $bucket.put("hello", "world"));
     }
   }
   return $Closure1;
@@ -68,11 +68,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -104,8 +104,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure2 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -136,9 +136,9 @@ class $Root extends $stdlib.std.Resource {
         super._registerOnLift(host, ops);
       }
     }
-    const bucket = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this,"cloud.Bucket");
-    const fn = new $Closure1(this,"$Closure1");
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:test",new $Closure2(this,"$Closure2"));
+    const bucket = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this, "cloud.Bucket");
+    const fn = new $Closure1(this, "$Closure1");
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:test", new $Closure2(this, "$Closure2"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/libs/wingc/src/jsify/snapshots/lift_via_closure_class_explicit.snap
+++ b/libs/wingc/src/jsify/snapshots/lift_via_closure_class_explicit.snap
@@ -83,12 +83,12 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class MyClosure extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
-        this.q = this.node.root.newAbstract("@winglang/sdk.cloud.Queue",this,"cloud.Queue");
+      constructor($scope, $id, ) {
+        super($scope, $id);
+        this.q = this.node.root.newAbstract("@winglang/sdk.cloud.Queue",this, "cloud.Queue");
       }
       static _toInflightType(context) {
         return `
@@ -125,8 +125,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -157,8 +157,8 @@ class $Root extends $stdlib.std.Resource {
         super._registerOnLift(host, ops);
       }
     }
-    const fn = new MyClosure(this,"MyClosure");
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:test",new $Closure1(this,"$Closure1"));
+    const fn = new MyClosure(this, "MyClosure");
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:test", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/libs/wingc/src/jsify/snapshots/namespaced_static_from_inflight.snap
+++ b/libs/wingc/src/jsify/snapshots/namespaced_static_from_inflight.snap
@@ -42,11 +42,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const util = $stdlib.util;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -71,7 +71,7 @@ class $Root extends $stdlib.std.Resource {
         return ["handle", "$inflight_init"];
       }
     }
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:test",new $Closure1(this,"$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:test", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/libs/wingc/src/jsify/snapshots/nested_inflight_after_preflight_operation.snap
+++ b/libs/wingc/src/jsify/snapshots/nested_inflight_after_preflight_operation.snap
@@ -67,11 +67,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class YourType extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
       }
       static _toInflightType(context) {
         return `
@@ -95,8 +95,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -127,8 +127,8 @@ class $Root extends $stdlib.std.Resource {
         super._registerOnLift(host, ops);
       }
     }
-    const y = new YourType(this,"YourType");
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:test",new $Closure1(this,"$Closure1"));
+    const y = new YourType(this, "YourType");
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:test", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/libs/wingc/src/jsify/snapshots/nested_preflight_operation.snap
+++ b/libs/wingc/src/jsify/snapshots/nested_preflight_operation.snap
@@ -39,7 +39,7 @@ module.exports = function({ $t_y_b }) {
       return $obj;
     }
     async handle() {
-      (await $t_y_b.put("hello","world"));
+      (await $t_y_b.put("hello", "world"));
     }
   }
   return $Closure1;
@@ -83,12 +83,12 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class YourType extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
-        this.b = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this,"cloud.Bucket");
+      constructor($scope, $id, ) {
+        super($scope, $id);
+        this.b = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this, "cloud.Bucket");
       }
       static _toInflightType(context) {
         return `
@@ -112,9 +112,9 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class MyType extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
-        this.y = new YourType(this,"YourType");
+      constructor($scope, $id, ) {
+        super($scope, $id);
+        this.y = new YourType(this, "YourType");
       }
       static _toInflightType(context) {
         return `
@@ -138,8 +138,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -170,8 +170,8 @@ class $Root extends $stdlib.std.Resource {
         super._registerOnLift(host, ops);
       }
     }
-    const t = new MyType(this,"MyType");
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:test",new $Closure1(this,"$Closure1"));
+    const t = new MyType(this, "MyType");
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:test", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/libs/wingc/src/jsify/snapshots/new_inflight_object.snap
+++ b/libs/wingc/src/jsify/snapshots/new_inflight_object.snap
@@ -53,11 +53,11 @@ const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class Foo extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
       }
       static _toInflightType(context) {
         return `
@@ -81,8 +81,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -107,7 +107,7 @@ class $Root extends $stdlib.std.Resource {
         return ["handle", "$inflight_init"];
       }
     }
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:test",new $Closure1(this,"$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:test", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/libs/wingc/src/jsify/snapshots/no_capture_inside_methods.snap
+++ b/libs/wingc/src/jsify/snapshots/no_capture_inside_methods.snap
@@ -46,11 +46,11 @@ const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -74,7 +74,7 @@ class $Root extends $stdlib.std.Resource {
         return ["handle", "$inflight_init"];
       }
     }
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:test",new $Closure1(this,"$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:test", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/libs/wingc/src/jsify/snapshots/no_capture_of_identifier_from_inner_scope.snap
+++ b/libs/wingc/src/jsify/snapshots/no_capture_of_identifier_from_inner_scope.snap
@@ -46,11 +46,11 @@ const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -74,7 +74,7 @@ class $Root extends $stdlib.std.Resource {
         return ["handle", "$inflight_init"];
       }
     }
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:test",new $Closure1(this,"$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:test", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/libs/wingc/src/jsify/snapshots/no_capture_of_identifier_from_same_scope.snap
+++ b/libs/wingc/src/jsify/snapshots/no_capture_of_identifier_from_same_scope.snap
@@ -42,11 +42,11 @@ const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -70,7 +70,7 @@ class $Root extends $stdlib.std.Resource {
         return ["handle", "$inflight_init"];
       }
     }
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:test",new $Closure1(this,"$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:test", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/libs/wingc/src/jsify/snapshots/no_capture_shadow_inside_inner_scopes.snap
+++ b/libs/wingc/src/jsify/snapshots/no_capture_shadow_inside_inner_scopes.snap
@@ -54,11 +54,11 @@ const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -82,7 +82,7 @@ class $Root extends $stdlib.std.Resource {
         return ["handle", "$inflight_init"];
       }
     }
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:testing",new $Closure1(this,"$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:testing", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/libs/wingc/src/jsify/snapshots/no_lift_shadow_inside_inner_scopes.snap
+++ b/libs/wingc/src/jsify/snapshots/no_lift_shadow_inside_inner_scopes.snap
@@ -52,11 +52,11 @@ const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -88,7 +88,7 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     const i = 1;
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:testing",new $Closure1(this,"$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:testing", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/libs/wingc/src/jsify/snapshots/preflight_class_extends_preflight_class.snap
+++ b/libs/wingc/src/jsify/snapshots/preflight_class_extends_preflight_class.snap
@@ -47,11 +47,11 @@ const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class Base extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
       }
       static _toInflightType(context) {
         return `
@@ -75,8 +75,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class Derived extends Base {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
       }
       static _toInflightType(context) {
         return `

--- a/libs/wingc/src/jsify/snapshots/preflight_collection.snap
+++ b/libs/wingc/src/jsify/snapshots/preflight_collection.snap
@@ -43,11 +43,11 @@ const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -81,7 +81,7 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     const a = ["hello", "world"];
-    new $Closure1(this,"$Closure1");
+    new $Closure1(this, "$Closure1");
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/libs/wingc/src/jsify/snapshots/preflight_collection_of_preflight_objects.snap
+++ b/libs/wingc/src/jsify/snapshots/preflight_collection_of_preflight_objects.snap
@@ -30,7 +30,7 @@ module.exports = function({ $_arr_at_0__, $arr_length }) {
     }
     async handle() {
       {((cond) => {if (!cond) throw new Error("assertion failed: arr.length == 2")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })($arr_length,2)))};
-      (await $_arr_at_0__.put("hello","world"));
+      (await $_arr_at_0__.put("hello", "world"));
     }
   }
   return $Closure1;
@@ -48,11 +48,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -85,8 +85,8 @@ class $Root extends $stdlib.std.Resource {
         super._registerOnLift(host, ops);
       }
     }
-    const arr = [this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this,"b1"), this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this,"b2")];
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:test",new $Closure1(this,"$Closure1"));
+    const arr = [this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this, "b1"), this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this, "b2")];
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:test", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/libs/wingc/src/jsify/snapshots/preflight_nested_object_with_operations.snap
+++ b/libs/wingc/src/jsify/snapshots/preflight_nested_object_with_operations.snap
@@ -64,11 +64,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class A extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         this.bucky = b;
       }
       static _toInflightType(context) {
@@ -93,8 +93,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -125,9 +125,9 @@ class $Root extends $stdlib.std.Resource {
         super._registerOnLift(host, ops);
       }
     }
-    const b = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this,"cloud.Bucket");
-    const a = new A(this,"A");
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:test",new $Closure1(this,"$Closure1"));
+    const b = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this, "cloud.Bucket");
+    const a = new A(this, "A");
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:test", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/libs/wingc/src/jsify/snapshots/preflight_object.snap
+++ b/libs/wingc/src/jsify/snapshots/preflight_object.snap
@@ -64,11 +64,11 @@ const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class A extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
       }
       static _toInflightType(context) {
         return `
@@ -92,8 +92,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -124,8 +124,8 @@ class $Root extends $stdlib.std.Resource {
         super._registerOnLift(host, ops);
       }
     }
-    const pf_obj = new A(this,"A");
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:test",new $Closure1(this,"$Closure1"));
+    const pf_obj = new A(this, "A");
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:test", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/libs/wingc/src/jsify/snapshots/preflight_object_through_property.snap
+++ b/libs/wingc/src/jsify/snapshots/preflight_object_through_property.snap
@@ -34,7 +34,7 @@ module.exports = function({ $t_b }) {
       return $obj;
     }
     async handle() {
-      (await $t_b.put("hello","world"));
+      (await $t_b.put("hello", "world"));
     }
   }
   return $Closure1;
@@ -65,12 +65,12 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class MyType extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
-        this.b = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this,"cloud.Bucket");
+      constructor($scope, $id, ) {
+        super($scope, $id);
+        this.b = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this, "cloud.Bucket");
       }
       static _toInflightType(context) {
         return `
@@ -94,8 +94,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -126,8 +126,8 @@ class $Root extends $stdlib.std.Resource {
         super._registerOnLift(host, ops);
       }
     }
-    const t = new MyType(this,"MyType");
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:test",new $Closure1(this,"$Closure1"));
+    const t = new MyType(this, "MyType");
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:test", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/libs/wingc/src/jsify/snapshots/preflight_object_with_operations.snap
+++ b/libs/wingc/src/jsify/snapshots/preflight_object_with_operations.snap
@@ -27,7 +27,7 @@ module.exports = function({ $b }) {
     }
     async handle() {
       (await $b.list());
-      (await $b.put("hello","world"));
+      (await $b.put("hello", "world"));
     }
   }
   return $Closure1;
@@ -45,11 +45,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -80,8 +80,8 @@ class $Root extends $stdlib.std.Resource {
         super._registerOnLift(host, ops);
       }
     }
-    const b = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this,"cloud.Bucket");
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:test",new $Closure1(this,"$Closure1"));
+    const b = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this, "cloud.Bucket");
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:test", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/libs/wingc/src/jsify/snapshots/preflight_object_with_operations_multiple_methods.snap
+++ b/libs/wingc/src/jsify/snapshots/preflight_object_with_operations_multiple_methods.snap
@@ -29,7 +29,7 @@ module.exports = function({ $b }) {
     constructor({  }) {
     }
     async put() {
-      (await $b.put("hello1","world"));
+      (await $b.put("hello1", "world"));
     }
     async list() {
       (await $b.list());
@@ -50,11 +50,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class Foo extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
       }
       static _toInflightType(context) {
         return `
@@ -87,7 +87,7 @@ class $Root extends $stdlib.std.Resource {
         super._registerOnLift(host, ops);
       }
     }
-    const b = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this,"cloud.Bucket");
+    const b = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this, "cloud.Bucket");
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/libs/wingc/src/jsify/snapshots/preflight_value_field.snap
+++ b/libs/wingc/src/jsify/snapshots/preflight_value_field.snap
@@ -69,11 +69,11 @@ const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class MyType extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         this.name = "hello";
         this.last = "world";
       }
@@ -99,8 +99,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -135,8 +135,8 @@ class $Root extends $stdlib.std.Resource {
         super._registerOnLift(host, ops);
       }
     }
-    const t = new MyType(this,"MyType");
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:test",new $Closure1(this,"$Closure1"));
+    const t = new MyType(this, "MyType");
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:test", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/libs/wingc/src/jsify/snapshots/read_primitive_value.snap
+++ b/libs/wingc/src/jsify/snapshots/read_primitive_value.snap
@@ -42,11 +42,11 @@ const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -78,7 +78,7 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     const x = "my_string";
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:test",new $Closure1(this,"$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:test", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/libs/wingc/src/jsify/snapshots/reassign_captured_variable.snap
+++ b/libs/wingc/src/jsify/snapshots/reassign_captured_variable.snap
@@ -51,11 +51,11 @@ const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -79,7 +79,7 @@ class $Root extends $stdlib.std.Resource {
         return ["handle", "$inflight_init"];
       }
     }
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:test",new $Closure1(this,"$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:test", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/libs/wingc/src/jsify/snapshots/reassigned_captured_variable_preflight.snap
+++ b/libs/wingc/src/jsify/snapshots/reassigned_captured_variable_preflight.snap
@@ -22,8 +22,8 @@ const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     let i = 10;
     (() => {
       i = 12;

--- a/libs/wingc/src/jsify/snapshots/ref_std_macro.snap
+++ b/libs/wingc/src/jsify/snapshots/ref_std_macro.snap
@@ -42,11 +42,11 @@ const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -78,7 +78,7 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     const arr = [1, 2, 3];
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:test",new $Closure1(this,"$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:test", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/libs/wingc/src/jsify/snapshots/reference_from_static_inflight.snap
+++ b/libs/wingc/src/jsify/snapshots/reference_from_static_inflight.snap
@@ -41,11 +41,11 @@ const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class MyType extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
       }
       static _toInflightType(context) {
         return `

--- a/libs/wingc/src/jsify/snapshots/reference_inflight_class.snap
+++ b/libs/wingc/src/jsify/snapshots/reference_inflight_class.snap
@@ -58,11 +58,11 @@ const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class Foo extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
       }
       static _toInflightType(context) {
         return `
@@ -86,8 +86,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -112,7 +112,7 @@ class $Root extends $stdlib.std.Resource {
         return ["handle", "$inflight_init"];
       }
     }
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:test",new $Closure1(this,"$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:test", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/libs/wingc/src/jsify/snapshots/reference_inflight_field.snap
+++ b/libs/wingc/src/jsify/snapshots/reference_inflight_field.snap
@@ -48,11 +48,11 @@ const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class Foo extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
       }
       static _toInflightType(context) {
         return `

--- a/libs/wingc/src/jsify/snapshots/reference_inflight_from_inflight.snap
+++ b/libs/wingc/src/jsify/snapshots/reference_inflight_from_inflight.snap
@@ -70,11 +70,11 @@ const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class Foo extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
       }
       static _toInflightType(context) {
         return `
@@ -105,8 +105,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -132,7 +132,7 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     const s = "hello";
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:test",new $Closure1(this,"$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:test", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/libs/wingc/src/jsify/snapshots/reference_preflight_field.snap
+++ b/libs/wingc/src/jsify/snapshots/reference_preflight_field.snap
@@ -46,11 +46,11 @@ const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class Foo extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         this.x = "world";
       }
       static _toInflightType(context) {

--- a/libs/wingc/src/jsify/snapshots/reference_preflight_field_call_independent_method.snap
+++ b/libs/wingc/src/jsify/snapshots/reference_preflight_field_call_independent_method.snap
@@ -46,11 +46,11 @@ const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class Foo extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         this.arr = ["hello", "world"];
       }
       static _toInflightType(context) {

--- a/libs/wingc/src/jsify/snapshots/reference_preflight_fields.snap
+++ b/libs/wingc/src/jsify/snapshots/reference_preflight_fields.snap
@@ -44,7 +44,7 @@ module.exports = function({  }) {
       {((cond) => {if (!cond) throw new Error("assertion failed: this.b.list().length > 0")})(((await this.$this_b.list()).length > 0))};
     }
     async bam() {
-      (await this.$this_b.put("hello","world"));
+      (await this.$this_b.put("hello", "world"));
       (await this.$this_b.get("aaa"));
     }
   }
@@ -63,13 +63,13 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class MyType extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         this.s = "hello";
-        this.b = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this,"cloud.Bucket");
+        this.b = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this, "cloud.Bucket");
       }
       static _toInflightType(context) {
         return `

--- a/libs/wingc/src/jsify/snapshots/reference_preflight_free_variable_with_this_in_the_expression.snap
+++ b/libs/wingc/src/jsify/snapshots/reference_preflight_free_variable_with_this_in_the_expression.snap
@@ -32,7 +32,7 @@ module.exports = function({ $b }) {
       this.$this_name = $this_name;
     }
     async method() {
-      (await $b.put(this.$this_name,"value"));
+      (await $b.put(this.$this_name, "value"));
     }
   }
   return Foo;
@@ -50,11 +50,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class Foo extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         this.name = "my_object";
       }
       static _toInflightType(context) {
@@ -90,7 +90,7 @@ class $Root extends $stdlib.std.Resource {
         super._registerOnLift(host, ops);
       }
     }
-    const b = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this,"cloud.Bucket");
+    const b = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this, "cloud.Bucket");
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/libs/wingc/src/jsify/snapshots/reference_preflight_object_from_static_inflight.snap
+++ b/libs/wingc/src/jsify/snapshots/reference_preflight_object_from_static_inflight.snap
@@ -44,11 +44,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class MyType extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
       }
       static _toInflightType(context) {
         return `
@@ -78,7 +78,7 @@ class $Root extends $stdlib.std.Resource {
         super._registerTypeOnLift(host, ops);
       }
     }
-    const q = this.node.root.newAbstract("@winglang/sdk.cloud.Queue",this,"cloud.Queue");
+    const q = this.node.root.newAbstract("@winglang/sdk.cloud.Queue",this, "cloud.Queue");
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/libs/wingc/src/jsify/snapshots/reference_static_inflight.snap
+++ b/libs/wingc/src/jsify/snapshots/reference_static_inflight.snap
@@ -59,11 +59,11 @@ const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class MyType extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
       }
       static _toInflightType(context) {
         return `
@@ -87,8 +87,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -119,7 +119,7 @@ class $Root extends $stdlib.std.Resource {
         super._registerOnLift(host, ops);
       }
     }
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:test",new $Closure1(this,"$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:test", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/libs/wingc/src/jsify/snapshots/reference_static_inflight_which_references_preflight_object.snap
+++ b/libs/wingc/src/jsify/snapshots/reference_static_inflight_which_references_preflight_object.snap
@@ -69,11 +69,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class MyType extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
       }
       static _toInflightType(context) {
         return `
@@ -104,8 +104,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -136,8 +136,8 @@ class $Root extends $stdlib.std.Resource {
         super._registerOnLift(host, ops);
       }
     }
-    const b = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this,"cloud.Bucket");
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:test",new $Closure1(this,"$Closure1"));
+    const b = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this, "cloud.Bucket");
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:test", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/libs/wingc/src/jsify/snapshots/static_external_inflight_class.snap
+++ b/libs/wingc/src/jsify/snapshots/static_external_inflight_class.snap
@@ -69,11 +69,11 @@ const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class A extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
       }
       static _toInflightType(context) {
         return `
@@ -97,8 +97,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -123,7 +123,7 @@ class $Root extends $stdlib.std.Resource {
         return ["handle", "$inflight_init"];
       }
     }
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:test",new $Closure1(this,"$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:test", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/libs/wingc/src/jsify/snapshots/static_external_preflight_class.snap
+++ b/libs/wingc/src/jsify/snapshots/static_external_preflight_class.snap
@@ -68,11 +68,11 @@ const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class A extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
       }
       static _toInflightType(context) {
         return `
@@ -96,8 +96,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -128,7 +128,7 @@ class $Root extends $stdlib.std.Resource {
         super._registerOnLift(host, ops);
       }
     }
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:test",new $Closure1(this,"$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:test", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/libs/wingc/src/jsify/snapshots/static_inflight_operation.snap
+++ b/libs/wingc/src/jsify/snapshots/static_inflight_operation.snap
@@ -66,11 +66,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class A extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
       }
       static _toInflightType(context) {
         return `
@@ -101,8 +101,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -133,8 +133,8 @@ class $Root extends $stdlib.std.Resource {
         super._registerOnLift(host, ops);
       }
     }
-    const b = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this,"cloud.Bucket");
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:test",new $Closure1(this,"$Closure1"));
+    const b = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this, "cloud.Bucket");
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:test", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/libs/wingc/src/jsify/snapshots/static_local_inflight_class.snap
+++ b/libs/wingc/src/jsify/snapshots/static_local_inflight_class.snap
@@ -62,11 +62,11 @@ const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -90,7 +90,7 @@ class $Root extends $stdlib.std.Resource {
         return ["handle", "$inflight_init"];
       }
     }
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:test",new $Closure1(this,"$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:test", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/libs/wingc/src/jsify/snapshots/static_on_std_type.snap
+++ b/libs/wingc/src/jsify/snapshots/static_on_std_type.snap
@@ -42,11 +42,11 @@ const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -72,7 +72,7 @@ class $Root extends $stdlib.std.Resource {
         return ["handle", "$inflight_init"];
       }
     }
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:test",new $Closure1(this,"$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:test", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/libs/wingc/src/jsify/snapshots/transitive_reference.snap
+++ b/libs/wingc/src/jsify/snapshots/transitive_reference.snap
@@ -84,12 +84,12 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class MyType extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
-        this.b = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this,"cloud.Bucket");
+      constructor($scope, $id, ) {
+        super($scope, $id);
+        this.b = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this, "cloud.Bucket");
       }
       static _toInflightType(context) {
         return `
@@ -126,8 +126,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -158,8 +158,8 @@ class $Root extends $stdlib.std.Resource {
         super._registerOnLift(host, ops);
       }
     }
-    const t = new MyType(this,"MyType");
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:test",new $Closure1(this,"$Closure1"));
+    const t = new MyType(this, "MyType");
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:test", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/libs/wingc/src/jsify/snapshots/transitive_reference_via_inflight_class.snap
+++ b/libs/wingc/src/jsify/snapshots/transitive_reference_via_inflight_class.snap
@@ -49,7 +49,7 @@ module.exports = function({ $MyInflightClass }) {
 module.exports = function({ $b }) {
   class MyInflightClass {
     async putInBucket() {
-      (await $b.put("in","bucket"));
+      (await $b.put("in", "bucket"));
     }
   }
   return MyInflightClass;
@@ -67,11 +67,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class MyInflightClass extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
       }
       static _toInflightType(context) {
         return `
@@ -102,8 +102,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -128,8 +128,8 @@ class $Root extends $stdlib.std.Resource {
         return ["handle", "$inflight_init"];
       }
     }
-    const b = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this,"cloud.Bucket");
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:test",new $Closure1(this,"$Closure1"));
+    const b = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this, "cloud.Bucket");
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:test", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/libs/wingc/src/jsify/snapshots/transitive_reference_via_static.snap
+++ b/libs/wingc/src/jsify/snapshots/transitive_reference_via_static.snap
@@ -56,7 +56,7 @@ module.exports = function({ $b }) {
     constructor({  }) {
     }
     static async putInBucket() {
-      (await $b.put("in","bucket"));
+      (await $b.put("in", "bucket"));
     }
   }
   return MyType;
@@ -90,11 +90,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class MyType extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
       }
       static _toInflightType(context) {
         return `
@@ -125,8 +125,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class YourType extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
       }
       static _toInflightType(context) {
         return `
@@ -157,8 +157,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -189,9 +189,9 @@ class $Root extends $stdlib.std.Resource {
         super._registerOnLift(host, ops);
       }
     }
-    const b = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this,"cloud.Bucket");
-    const t = new YourType(this,"YourType");
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:test",new $Closure1(this,"$Closure1"));
+    const b = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this, "cloud.Bucket");
+    const t = new YourType(this, "YourType");
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:test", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/libs/wingc/src/jsify/snapshots/two_identical_lifts.snap
+++ b/libs/wingc/src/jsify/snapshots/two_identical_lifts.snap
@@ -30,9 +30,9 @@ module.exports = function({ $b }) {
       return $obj;
     }
     async handle() {
-      (await $b.put("hello","world"));
+      (await $b.put("hello", "world"));
       async () => {
-        (await $b.put("hello","world"));
+        (await $b.put("hello", "world"));
       }
       ;
     }
@@ -52,11 +52,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -87,8 +87,8 @@ class $Root extends $stdlib.std.Resource {
         super._registerOnLift(host, ops);
       }
     }
-    const b = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this,"cloud.Bucket");
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:test",new $Closure1(this,"$Closure1"));
+    const b = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this, "cloud.Bucket");
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:test", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/libs/wingc/src/jsify/snapshots/unqualified_lift_of_collection.snap
+++ b/libs/wingc/src/jsify/snapshots/unqualified_lift_of_collection.snap
@@ -42,11 +42,11 @@ const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -78,7 +78,7 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     const a = [1, 2, 3];
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:test",new $Closure1(this,"$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:test", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/libs/wingc/src/jsify/snapshots/use_util_functions.snap
+++ b/libs/wingc/src/jsify/snapshots/use_util_functions.snap
@@ -41,11 +41,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const util = $stdlib.util;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -70,7 +70,7 @@ class $Root extends $stdlib.std.Resource {
         return ["handle", "$inflight_init"];
       }
     }
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:test",new $Closure1(this,"$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:test", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/libs/wingc/src/jsify/snapshots/var_inflight_field_from_inflight.snap
+++ b/libs/wingc/src/jsify/snapshots/var_inflight_field_from_inflight.snap
@@ -48,11 +48,11 @@ const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class MyType extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
       }
       static _toInflightType(context) {
         return `

--- a/libs/wingc/src/jsify/snapshots/wait_util.snap
+++ b/libs/wingc/src/jsify/snapshots/wait_util.snap
@@ -49,11 +49,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const util = $stdlib.util;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -79,7 +79,7 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     const foo = "test";
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:returns after some time waiting",new $Closure1(this,"$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:returns after some time waiting", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/error.ts.snap
+++ b/tools/hangar/__snapshots__/error.ts.snap
@@ -5,7 +5,7 @@ exports[`bool_from_json.test.w 1`] = `
 - instance is not of a type(s) boolean
 
 ../../../examples/tests/error/target/test/bool_from_json.test.wsim.[REDACTED].tmp/.wing/preflight.js:10
-       super(scope, id);
+       super($scope, $id);
        const j = ({\\"a\\": 123});
 >>     const a = (std.Boolean.fromJson(((obj, args) => { if (obj[args] === undefined) throw new Error(\`Json property \\"\${args}\\" does not exist\`); return obj[args] })(j, \\"a\\")));
      }
@@ -22,8 +22,8 @@ exports[`num_from_str.test.w 1`] = `
 "ERROR: unable to parse \\"123a\\" as a number
 
 ../../../examples/tests/error/target/test/num_from_str.test.wsim.[REDACTED].tmp/.wing/preflight.js:9
-     constructor(scope, id) {
-       super(scope, id);
+     constructor($scope, $id) {
+       super($scope, $id);
 >>     const a = ((args) => { if (isNaN(args)) {throw new Error(\\"unable to parse /\\"\\" + args + \\"/\\" as a number\\")}; return parseInt(args) })(\\"123a\\");
      }
    }
@@ -40,7 +40,7 @@ exports[`number_from_json.test.w 1`] = `
 - instance is not of a type(s) number
 
 ../../../examples/tests/error/target/test/number_from_json.test.wsim.[REDACTED].tmp/.wing/preflight.js:10
-       super(scope, id);
+       super($scope, $id);
        const j = ({\\"a\\": \\"apples\\"});
 >>     const a = (std.Number.fromJson(((obj, args) => { if (obj[args] === undefined) throw new Error(\`Json property \\"\${args}\\" does not exist\`); return obj[args] })(j, \\"a\\")));
      }
@@ -63,9 +63,9 @@ hint: Every preflight object needs a unique identifier within its scope. You can
 For more information, see https://www.winglang.io/docs/concepts/application-tree
 
 ../../../examples/tests/error/target/test/repeat_construct_id.test.wsim.[REDACTED].tmp/.wing/preflight.js:11
-       super(scope, id);
-       const bucket1 = this.node.root.newAbstract(\\"@winglang/sdk.cloud.Bucket\\",this,\\"cloud.Bucket\\");
->>     const bucket2 = this.node.root.newAbstract(\\"@winglang/sdk.cloud.Bucket\\",this,\\"cloud.Bucket\\");
+       super($scope, $id);
+       const bucket1 = this.node.root.newAbstract(\\"@winglang/sdk.cloud.Bucket\\",this, \\"cloud.Bucket\\");
+>>     const bucket2 = this.node.root.newAbstract(\\"@winglang/sdk.cloud.Bucket\\",this, \\"cloud.Bucket\\");
      }
    }
 
@@ -87,8 +87,8 @@ For more information, see https://www.winglang.io/docs/concepts/application-tree
 
 ../../../examples/tests/error/target/test/repeat_construct_id2.test.wsim.[REDACTED].tmp/.wing/preflight.js:14
        });
-       const bucket1 = this.node.root.newAbstract(\\"@winglang/sdk.cloud.Bucket\\",this,String.raw({ raw: [\\"\\", \\"\\"] }, (make_name())));
->>     const bucket2 = this.node.root.newAbstract(\\"@winglang/sdk.cloud.Bucket\\",this,String.raw({ raw: [\\"\\", \\"\\"] }, (make_name())));
+       const bucket1 = this.node.root.newAbstract(\\"@winglang/sdk.cloud.Bucket\\",this, String.raw({ raw: [\\"\\", \\"\\"] }, (make_name())));
+>>     const bucket2 = this.node.root.newAbstract(\\"@winglang/sdk.cloud.Bucket\\",this, String.raw({ raw: [\\"\\", \\"\\"] }, (make_name())));
      }
    }
 
@@ -104,7 +104,7 @@ exports[`string_from_json.test.w 1`] = `
 - instance is not of a type(s) string
 
 ../../../examples/tests/error/target/test/string_from_json.test.wsim.[REDACTED].tmp/.wing/preflight.js:10
-       super(scope, id);
+       super($scope, $id);
        const j = ({\\"a\\": 123});
 >>     const a = (std.String.fromJson(((obj, args) => { if (obj[args] === undefined) throw new Error(\`Json property \\"\${args}\\" does not exist\`); return obj[args] })(j, \\"a\\")));
      }
@@ -213,8 +213,8 @@ exports[`utilities.test.w 1`] = `
 "ERROR: assertion failed: false
 
 ../../../examples/tests/error/target/test/utilities.test.wsim.[REDACTED].tmp/.wing/preflight.js:9
-     constructor(scope, id) {
-       super(scope, id);
+     constructor($scope, $id) {
+       super($scope, $id);
 >>     {((cond) => {if (!cond) throw new Error(\\"assertion failed: false\\")})(false)};
        {console.log(\\"W\\")};
        throw new Error(\\"me\\");

--- a/tools/hangar/__snapshots__/invalid.ts.snap
+++ b/tools/hangar/__snapshots__/invalid.ts.snap
@@ -329,9 +329,9 @@ exports[`ambiguous_api_paths.test.w 1`] = `
 "ERROR: Endpoint for path '/test/{variable}' and method 'GET' is ambiguous - it conflicts with existing endpoint for path '/test/path'
 
 ../../../examples/tests/invalid/target/test/ambiguous_api_paths.test.wsim.[REDACTED].tmp/.wing/preflight.js:39
-       const handler = new $Closure1(this,\\"$Closure1\\");
-       (api.get(\\"<ABSOLUTE_PATH>/path\\",handler));
->>     (api.get(\\"<ABSOLUTE_PATH>/{variable}\\",handler));
+       const handler = new $Closure1(this, \\"$Closure1\\");
+       (api.get(\\"<ABSOLUTE_PATH>/path\\", handler));
+>>     (api.get(\\"<ABSOLUTE_PATH>/{variable}\\", handler));
      }
    }
 

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/api/404.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/api/404.test.w_compile_tf-aws.md
@@ -257,11 +257,11 @@ const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 const http = $stdlib.http;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -286,8 +286,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure2 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -319,9 +319,9 @@ class $Root extends $stdlib.std.Resource {
         super._registerOnLift(host, ops);
       }
     }
-    const api = this.node.root.newAbstract("@winglang/sdk.cloud.Api",this,"cloud.Api");
-    (api.get("/hello",new $Closure1(this,"$Closure1")));
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:it responds with 404",new $Closure2(this,"$Closure2"));
+    const api = this.node.root.newAbstract("@winglang/sdk.cloud.Api",this, "cloud.Api");
+    (api.get("/hello", new $Closure1(this, "$Closure1")));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:it responds with 404", new $Closure2(this, "$Closure2"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/api/cors.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/api/cors.test.w_compile_tf-aws.md
@@ -257,11 +257,11 @@ const cloud = $stdlib.cloud;
 const http = $stdlib.http;
 const util = $stdlib.util;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -293,8 +293,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure2 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -326,10 +326,10 @@ class $Root extends $stdlib.std.Resource {
         super._registerOnLift(host, ops);
       }
     }
-    const api = this.node.root.newAbstract("@winglang/sdk.cloud.Api",this,"cloud.Api",({"cors": true}));
+    const api = this.node.root.newAbstract("@winglang/sdk.cloud.Api",this, "cloud.Api", ({"cors": true}));
     const body = "ok!";
-    (api.get("/path",new $Closure1(this,"$Closure1")));
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:http.get and http.fetch can preform a call to an api",new $Closure2(this,"$Closure2"));
+    (api.get("/path", new $Closure1(this, "$Closure1")));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:http.get and http.fetch can preform a call to an api", new $Closure2(this, "$Closure2"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/api/delete.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/api/delete.test.w_compile_tf-aws.md
@@ -36,7 +36,7 @@ module.exports = function({ $api_url, $http_HttpMethod, $http_Util }) {
     async handle() {
       const url = String.raw({ raw: ["", "/path?all=true&page=6"] }, $api_url);
       const response = (await $http_Util.delete(url));
-      const fetchResponse = (await $http_Util.fetch(url,{ method: $http_HttpMethod.DELETE }));
+      const fetchResponse = (await $http_Util.fetch(url, { method: $http_HttpMethod.DELETE }));
       {((cond) => {if (!cond) throw new Error("assertion failed: response.body == \"6\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(response.body,"6")))};
       {((cond) => {if (!cond) throw new Error("assertion failed: response.status == 200")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(response.status,200)))};
       {((cond) => {if (!cond) throw new Error("assertion failed: response.url == url")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(response.url,url)))};
@@ -267,11 +267,11 @@ const cloud = $stdlib.cloud;
 const http = $stdlib.http;
 const util = $stdlib.util;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -297,8 +297,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure2 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -331,9 +331,9 @@ class $Root extends $stdlib.std.Resource {
         super._registerOnLift(host, ops);
       }
     }
-    const api = this.node.root.newAbstract("@winglang/sdk.cloud.Api",this,"cloud.Api");
-    (api.delete("/path",new $Closure1(this,"$Closure1")));
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:http.delete and http.fetch can preform a call to an api",new $Closure2(this,"$Closure2"));
+    const api = this.node.root.newAbstract("@winglang/sdk.cloud.Api",this, "cloud.Api");
+    (api.delete("/path", new $Closure1(this, "$Closure1")));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:http.delete and http.fetch can preform a call to an api", new $Closure2(this, "$Closure2"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/api/get.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/api/get.test.w_compile_tf-aws.md
@@ -35,9 +35,9 @@ module.exports = function({ $api_url, $body, $http_HttpMethod, $http_Util }) {
     }
     async handle() {
       const url = ($api_url + "/path");
-      const getResponse = (await $http_Util.get(url,{ headers: ({"content-type": "application/json"}) }));
-      const fetchResponse = (await $http_Util.fetch(url,{ method: $http_HttpMethod.GET, headers: ({"content-type": "application/json"}) }));
-      const fetchResponseNoMethod = (await $http_Util.fetch(url,{ headers: ({"content-type": "application/json"}) }));
+      const getResponse = (await $http_Util.get(url, { headers: ({"content-type": "application/json"}) }));
+      const fetchResponse = (await $http_Util.fetch(url, { method: $http_HttpMethod.GET, headers: ({"content-type": "application/json"}) }));
+      const fetchResponseNoMethod = (await $http_Util.fetch(url, { headers: ({"content-type": "application/json"}) }));
       {((cond) => {if (!cond) throw new Error("assertion failed: getResponse.body == body")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(getResponse.body,$body)))};
       {((cond) => {if (!cond) throw new Error("assertion failed: getResponse.status == 200")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(getResponse.status,200)))};
       {((cond) => {if (!cond) throw new Error("assertion failed: getResponse.url == url")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(getResponse.url,url)))};
@@ -271,11 +271,11 @@ const cloud = $stdlib.cloud;
 const http = $stdlib.http;
 const util = $stdlib.util;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -308,8 +308,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure2 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -344,10 +344,10 @@ class $Root extends $stdlib.std.Resource {
         super._registerOnLift(host, ops);
       }
     }
-    const api = this.node.root.newAbstract("@winglang/sdk.cloud.Api",this,"cloud.Api");
+    const api = this.node.root.newAbstract("@winglang/sdk.cloud.Api",this, "cloud.Api");
     const body = "ok!";
-    (api.get("/path",new $Closure1(this,"$Closure1")));
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:http.get and http.fetch can preform a call to an api",new $Closure2(this,"$Closure2"));
+    (api.get("/path", new $Closure1(this, "$Closure1")));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:http.get and http.fetch can preform a call to an api", new $Closure2(this, "$Closure2"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/api/options.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/api/options.test.w_compile_tf-aws.md
@@ -75,8 +75,8 @@ module.exports = function({ $api_url, $http_HttpMethod, $http_Util, $path }) {
     }
     async handle() {
       const url = ($api_url + $path);
-      const options = (await $http_Util.fetch(url,{ method: $http_HttpMethod.OPTIONS }));
-      const head = (await $http_Util.fetch(url,{ method: $http_HttpMethod.HEAD }));
+      const options = (await $http_Util.fetch(url, { method: $http_HttpMethod.OPTIONS }));
+      const head = (await $http_Util.fetch(url, { method: $http_HttpMethod.HEAD }));
       {((cond) => {if (!cond) throw new Error("assertion failed: options.status == 204")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(options.status,204)))};
       {((cond) => {if (!cond) throw new Error("assertion failed: options.url == url")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(options.url,url)))};
     }
@@ -487,11 +487,11 @@ const cloud = $stdlib.cloud;
 const http = $stdlib.http;
 const util = $stdlib.util;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -524,8 +524,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure2 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -558,8 +558,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure3 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -584,8 +584,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure4 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -620,12 +620,12 @@ class $Root extends $stdlib.std.Resource {
         super._registerOnLift(host, ops);
       }
     }
-    const api = this.node.root.newAbstract("@winglang/sdk.cloud.Api",this,"cloud.Api");
+    const api = this.node.root.newAbstract("@winglang/sdk.cloud.Api",this, "cloud.Api");
     const path = "/path";
-    (api.options(path,new $Closure1(this,"$Closure1")));
-    (api.head(path,new $Closure2(this,"$Closure2")));
-    (api.connect(path,new $Closure3(this,"$Closure3")));
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:http.fetch can preform a call to an api to CONNECT, HEAD and OPTIONS",new $Closure4(this,"$Closure4"));
+    (api.options(path, new $Closure1(this, "$Closure1")));
+    (api.head(path, new $Closure2(this, "$Closure2")));
+    (api.connect(path, new $Closure3(this, "$Closure3")));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:http.fetch can preform a call to an api to CONNECT, HEAD and OPTIONS", new $Closure4(this, "$Closure4"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/api/patch.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/api/patch.test.w_compile_tf-aws.md
@@ -36,8 +36,8 @@ module.exports = function({ $_id, $api_url, $body, $http_HttpMethod, $http_Util,
     }
     async handle() {
       const url = String.raw({ raw: ["", "/path/", ""] }, $api_url, $_id);
-      const response = (await $http_Util.patch(url,{ headers: ({"content-type": "application/json"}), body: ((args) => { return JSON.stringify(args[0], null, args[1]?.indent) })([$body]) }));
-      const fetchResponse = (await $http_Util.patch(url,{ method: $http_HttpMethod.PATCH, headers: ({"content-type": "application/json"}), body: ((args) => { return JSON.stringify(args[0], null, args[1]?.indent) })([$body]) }));
+      const response = (await $http_Util.patch(url, { headers: ({"content-type": "application/json"}), body: ((args) => { return JSON.stringify(args[0], null, args[1]?.indent) })([$body]) }));
+      const fetchResponse = (await $http_Util.patch(url, { method: $http_HttpMethod.PATCH, headers: ({"content-type": "application/json"}), body: ((args) => { return JSON.stringify(args[0], null, args[1]?.indent) })([$body]) }));
       {((cond) => {if (!cond) throw new Error("assertion failed: response.body == _id")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(response.body,$_id)))};
       {((cond) => {if (!cond) throw new Error("assertion failed: response.status == 200")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(response.status,200)))};
       {((cond) => {if (!cond) throw new Error("assertion failed: response.url == url")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(response.url,url)))};
@@ -268,11 +268,11 @@ const cloud = $stdlib.cloud;
 const http = $stdlib.http;
 const util = $stdlib.util;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -308,8 +308,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure2 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -347,11 +347,11 @@ class $Root extends $stdlib.std.Resource {
         super._registerOnLift(host, ops);
       }
     }
-    const api = this.node.root.newAbstract("@winglang/sdk.cloud.Api",this,"cloud.Api");
+    const api = this.node.root.newAbstract("@winglang/sdk.cloud.Api",this, "cloud.Api");
     const body = ({"cat": "Tion"});
     const _id = "12345";
-    (api.patch("/path/{id}",new $Closure1(this,"$Closure1")));
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:http.patch and http.fetch can preform a call to an api",new $Closure2(this,"$Closure2"));
+    (api.patch("/path/{id}", new $Closure1(this, "$Closure1")));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:http.patch and http.fetch can preform a call to an api", new $Closure2(this, "$Closure2"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/api/path_vars.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/api/path_vars.test.w_compile_tf-aws.md
@@ -462,11 +462,11 @@ const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 const http = $stdlib.http;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -492,8 +492,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure2 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -519,8 +519,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure3 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -554,8 +554,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure4 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -589,8 +589,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure5 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -624,8 +624,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure6 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -658,17 +658,17 @@ class $Root extends $stdlib.std.Resource {
         super._registerOnLift(host, ops);
       }
     }
-    const api = this.node.root.newAbstract("@winglang/sdk.cloud.Api",this,"cloud.Api");
-    const handler = new $Closure1(this,"$Closure1");
-    const handler_two = new $Closure2(this,"$Closure2");
-    (api.get("/users/{name}",handler));
-    (api.get("/path/{name}",handler));
-    (api.get("/users/permission/{name}",handler));
-    (api.get("/path/{name}/{age}",handler_two));
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:test",new $Closure3(this,"$Closure3"));
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:test2",new $Closure4(this,"$Closure4"));
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:test3",new $Closure5(this,"$Closure5"));
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:test4",new $Closure6(this,"$Closure6"));
+    const api = this.node.root.newAbstract("@winglang/sdk.cloud.Api",this, "cloud.Api");
+    const handler = new $Closure1(this, "$Closure1");
+    const handler_two = new $Closure2(this, "$Closure2");
+    (api.get("/users/{name}", handler));
+    (api.get("/path/{name}", handler));
+    (api.get("/users/permission/{name}", handler));
+    (api.get("/path/{name}/{age}", handler_two));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:test", new $Closure3(this, "$Closure3"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:test2", new $Closure4(this, "$Closure4"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:test3", new $Closure5(this, "$Closure5"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:test4", new $Closure6(this, "$Closure6"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/api/post.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/api/post.test.w_compile_tf-aws.md
@@ -35,8 +35,8 @@ module.exports = function({ $api_url, $body, $http_HttpMethod, $http_Util, $std_
     }
     async handle() {
       const url = ($api_url + "/path");
-      const response = (await $http_Util.post(url,{ headers: ({"content-type": "application/json"}), body: ((args) => { return JSON.stringify(args[0], null, args[1]?.indent) })([$body]) }));
-      const fetchResponse = (await $http_Util.post(url,{ method: $http_HttpMethod.POST, headers: ({"content-type": "application/json"}), body: ((args) => { return JSON.stringify(args[0], null, args[1]?.indent) })([$body]) }));
+      const response = (await $http_Util.post(url, { headers: ({"content-type": "application/json"}), body: ((args) => { return JSON.stringify(args[0], null, args[1]?.indent) })([$body]) }));
+      const fetchResponse = (await $http_Util.post(url, { method: $http_HttpMethod.POST, headers: ({"content-type": "application/json"}), body: ((args) => { return JSON.stringify(args[0], null, args[1]?.indent) })([$body]) }));
       {((cond) => {if (!cond) throw new Error("assertion failed: response.body == Json.stringify(body)")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(response.body,((args) => { return JSON.stringify(args[0], null, args[1]?.indent) })([$body]))))};
       {((cond) => {if (!cond) throw new Error("assertion failed: response.status == 200")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(response.status,200)))};
       {((cond) => {if (!cond) throw new Error("assertion failed: response.url == url")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(response.url,url)))};
@@ -267,11 +267,11 @@ const cloud = $stdlib.cloud;
 const http = $stdlib.http;
 const util = $stdlib.util;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -305,8 +305,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure2 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -342,10 +342,10 @@ class $Root extends $stdlib.std.Resource {
         super._registerOnLift(host, ops);
       }
     }
-    const api = this.node.root.newAbstract("@winglang/sdk.cloud.Api",this,"cloud.Api");
+    const api = this.node.root.newAbstract("@winglang/sdk.cloud.Api",this, "cloud.Api");
     const body = ({"cat": "Tion"});
-    (api.post("/path",new $Closure1(this,"$Closure1")));
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:http.post and http.fetch can preform a call to an api",new $Closure2(this,"$Closure2"));
+    (api.post("/path", new $Closure1(this, "$Closure1")));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:http.post and http.fetch can preform a call to an api", new $Closure2(this, "$Closure2"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/api/put.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/api/put.test.w_compile_tf-aws.md
@@ -38,8 +38,8 @@ module.exports = function({ $_id, $api_url, $body, $http_HttpMethod, $http_Util,
     }
     async handle() {
       const url = String.raw({ raw: ["", "/path/", "/nn/", ""] }, $api_url, $_id, $user);
-      const response = (await $http_Util.put(url,{ headers: ({"content-type": "application/json"}), body: ((args) => { return JSON.stringify(args[0], null, args[1]?.indent) })([$body]) }));
-      const fetchResponse = (await $http_Util.put(url,{ method: $http_HttpMethod.PUT, headers: ({"content-type": "application/json"}), body: ((args) => { return JSON.stringify(args[0], null, args[1]?.indent) })([$body]) }));
+      const response = (await $http_Util.put(url, { headers: ({"content-type": "application/json"}), body: ((args) => { return JSON.stringify(args[0], null, args[1]?.indent) })([$body]) }));
+      const fetchResponse = (await $http_Util.put(url, { method: $http_HttpMethod.PUT, headers: ({"content-type": "application/json"}), body: ((args) => { return JSON.stringify(args[0], null, args[1]?.indent) })([$body]) }));
       {((cond) => {if (!cond) throw new Error("assertion failed: response.headers.get(\"content-type\") == \"application/json; charset=utf-8\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(((obj, key) => { if (!(key in obj)) throw new Error(`Map does not contain key: "${key}"`); return obj[key]; })(response.headers, "content-type"),"application/json; charset=utf-8")))};
       {((cond) => {if (!cond) throw new Error("assertion failed: response.body == _id")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(response.body,$_id)))};
       {((cond) => {if (!cond) throw new Error("assertion failed: response.status == 200")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(response.status,200)))};
@@ -272,11 +272,11 @@ const cloud = $stdlib.cloud;
 const http = $stdlib.http;
 const util = $stdlib.util;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -314,8 +314,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure2 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -355,12 +355,12 @@ class $Root extends $stdlib.std.Resource {
         super._registerOnLift(host, ops);
       }
     }
-    const api = this.node.root.newAbstract("@winglang/sdk.cloud.Api",this,"cloud.Api");
+    const api = this.node.root.newAbstract("@winglang/sdk.cloud.Api",this, "cloud.Api");
     const body = ({"cat": "Tion"});
     const user = "guy";
     const _id = "12345";
-    (api.put("/path/{id}/nn/{user}",new $Closure1(this,"$Closure1")));
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:http.put and http.fetch can preform a call to an api",new $Closure2(this,"$Closure2"));
+    (api.put("/path/{id}/nn/{user}", new $Closure1(this, "$Closure1")));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:http.put and http.fetch can preform a call to an api", new $Closure2(this, "$Closure2"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/add_file.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/add_file.test.w_compile_tf-aws.md
@@ -101,11 +101,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -136,10 +136,10 @@ class $Root extends $stdlib.std.Resource {
         super._registerOnLift(host, ops);
       }
     }
-    const b = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this,"cloud.Bucket");
-    (b.addFile("file1.txt","test-files/test1.txt"));
-    (b.addFile("file2.txt","test-files/test2.txt"));
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:addObject",new $Closure1(this,"$Closure1"));
+    const b = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this, "cloud.Bucket");
+    (b.addFile("file1.txt", "test-files/test1.txt"));
+    (b.addFile("file2.txt", "test-files/test2.txt"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:addObject", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/add_object.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/add_object.test.w_compile_tf-aws.md
@@ -101,11 +101,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -139,11 +139,11 @@ class $Root extends $stdlib.std.Resource {
         super._registerOnLift(host, ops);
       }
     }
-    const b = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this,"cloud.Bucket");
+    const b = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this, "cloud.Bucket");
     const jsonObj1 = ({"key1": "value1"});
-    (b.addObject("file1.json",((args) => { return JSON.stringify(args[0], null, args[1]?.indent) })([jsonObj1])));
-    (b.addObject("file2.txt","Bar"));
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:addObject",new $Closure1(this,"$Closure1"));
+    (b.addObject("file1.json", ((args) => { return JSON.stringify(args[0], null, args[1]?.indent) })([jsonObj1])));
+    (b.addObject("file2.txt", "Bar"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:addObject", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/bucket_list.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/bucket_list.test.w_compile_tf-aws.md
@@ -13,9 +13,9 @@ module.exports = function({ $b }) {
     async handle() {
       const jsonObj1 = ({"key1": "value1"});
       {((cond) => {if (!cond) throw new Error("assertion failed: b.list().length == 1")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $b.list()).length,1)))};
-      (await $b.putJson("file1.json",jsonObj1));
-      (await $b.put("file2.txt","Bar"));
-      (await $b.put("random","Buz"));
+      (await $b.putJson("file1.json", jsonObj1));
+      (await $b.put("file2.txt", "Bar"));
+      (await $b.put("random", "Buz"));
       const objs = (await $b.list());
       const objs2 = (await $b.list("file"));
       {((cond) => {if (!cond) throw new Error("assertion failed: objs.contains(\"file1.json\")")})(objs.includes("file1.json"))};
@@ -104,11 +104,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -139,9 +139,9 @@ class $Root extends $stdlib.std.Resource {
         super._registerOnLift(host, ops);
       }
     }
-    const b = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this,"cloud.Bucket");
-    (b.addObject("file3.txt","Baz"));
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:list",new $Closure1(this,"$Closure1"));
+    const b = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this, "cloud.Bucket");
+    (b.addObject("file3.txt", "Baz"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:list", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/delete.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/delete.test.w_compile_tf-aws.md
@@ -26,13 +26,13 @@ module.exports = function({ $b }) {
       ;
       const OBJECT_DOES_NOT_EXIST_ERROR = "Object does not exist (key=file1.json).";
       const jsonObj1 = ({"key1": "value1"});
-      (await $b.putJson("file1.json",jsonObj1));
+      (await $b.putJson("file1.json", jsonObj1));
       (await $b.delete("file1.txt"));
       {((cond) => {if (!cond) throw new Error("assertion failed: b.exists(\"file1.json\")")})((await $b.exists("file1.json")))};
       {((cond) => {if (!cond) throw new Error("assertion failed: b.exists(\"file2.txt\")")})((await $b.exists("file2.txt")))};
-      (await $b.delete("file1.json",{ mustExist: true }));
-      (await assertThrows(OBJECT_DOES_NOT_EXIST_ERROR,async () => {
-        (await $b.delete("file1.json",{ mustExist: true }));
+      (await $b.delete("file1.json", { mustExist: true }));
+      (await assertThrows(OBJECT_DOES_NOT_EXIST_ERROR, async () => {
+        (await $b.delete("file1.json", { mustExist: true }));
       }
       ));
       {((cond) => {if (!cond) throw new Error("assertion failed: b.exists(\"file2.txt\")")})((await $b.exists("file2.txt")))};
@@ -114,11 +114,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -149,9 +149,9 @@ class $Root extends $stdlib.std.Resource {
         super._registerOnLift(host, ops);
       }
     }
-    const b = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this,"cloud.Bucket");
-    (b.addObject("file2.txt","Bar"));
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:delete",new $Closure1(this,"$Closure1"));
+    const b = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this, "cloud.Bucket");
+    (b.addObject("file2.txt", "Bar"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:delete", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/events.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/events.test.w_compile_tf-aws.md
@@ -11,7 +11,7 @@ module.exports = function({ $idsCounter, $table }) {
       return $obj;
     }
     async handle(key, operation, source) {
-      (await $table.insert(String.raw({ raw: ["", ""] }, (await $idsCounter.inc())),({"key": key,"operation": operation,"source": String.raw({ raw: ["", ""] }, source)})));
+      (await $table.insert(String.raw({ raw: ["", ""] }, (await $idsCounter.inc())), ({"key": key,"operation": operation,"source": String.raw({ raw: ["", ""] }, source)})));
     }
   }
   return $Closure1;
@@ -30,7 +30,7 @@ module.exports = function({ $Source, $logHistory }) {
       return $obj;
     }
     async handle(key) {
-      (await $logHistory(key,"onDelete()",$Source.anyEvent));
+      (await $logHistory(key, "onDelete()", $Source.anyEvent));
     }
   }
   return $Closure2;
@@ -49,7 +49,7 @@ module.exports = function({ $Source, $logHistory }) {
       return $obj;
     }
     async handle(key) {
-      (await $logHistory(key,"onUpdate()",$Source.anyEvent));
+      (await $logHistory(key, "onUpdate()", $Source.anyEvent));
     }
   }
   return $Closure3;
@@ -68,7 +68,7 @@ module.exports = function({ $Source, $logHistory }) {
       return $obj;
     }
     async handle(key) {
-      (await $logHistory(key,"onCreate()",$Source.anyEvent));
+      (await $logHistory(key, "onCreate()", $Source.anyEvent));
     }
   }
   return $Closure4;
@@ -87,7 +87,7 @@ module.exports = function({ $Source, $logHistory }) {
       return $obj;
     }
     async handle(key, event) {
-      (await $logHistory(key,String.raw({ raw: ["", "()"] }, event),$Source.onEvent));
+      (await $logHistory(key, String.raw({ raw: ["", "()"] }, event), $Source.onEvent));
     }
   }
   return $Closure5;
@@ -161,10 +161,10 @@ module.exports = function({ $Source, $b, $checkHitCount, $util_Util, $wait }) {
       return $obj;
     }
     async handle() {
-      (await $b.put("a","1"));
-      (await $b.put("b","1"));
-      (await $b.put("c","1"));
-      (await $b.put("b","100"));
+      (await $b.put("a", "1"));
+      (await $b.put("b", "1"));
+      (await $b.put("c", "1"));
+      (await $b.put("b", "100"));
       (await $b.delete("c"));
       if ((((a,b) => { try { return require('assert').notDeepStrictEqual(a,b) === undefined; } catch { return false; } })((await $util_Util.env("WING_TARGET")),"tf-aws"))) {
         {((cond) => {if (!cond) throw new Error("assertion failed: wait(checkHitCount(key: \"a\", type: \"onCreate()\", source: Source.anyEvent, count: 1))")})((await $wait((await $checkHitCount({ key: "a", type: "onCreate()", source: $Source.anyEvent, count: 1 })))))};
@@ -1040,11 +1040,11 @@ const cloud = $stdlib.cloud;
 const ex = $stdlib.ex;
 const util = $stdlib.util;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -1078,8 +1078,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure2 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -1112,8 +1112,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure3 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -1146,8 +1146,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure4 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -1180,8 +1180,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure5 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -1214,8 +1214,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure6 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -1242,8 +1242,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure7 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -1275,8 +1275,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure8 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -1320,17 +1320,17 @@ class $Root extends $stdlib.std.Resource {
         return tmp;
       })({})
     ;
-    const b = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this,"cloud.Bucket");
-    const idsCounter = this.node.root.newAbstract("@winglang/sdk.cloud.Counter",this,"cloud.Counter");
-    const table = this.node.root.newAbstract("@winglang/sdk.ex.Table",this,"ex.Table",{ name: "key-history", primaryKey: "_id", columns: ({"_id": ex.ColumnType.STRING,"key": ex.ColumnType.STRING,"operation": ex.ColumnType.STRING,"source": ex.ColumnType.STRING}) });
-    const logHistory = new $Closure1(this,"$Closure1");
-    (b.onDelete(new $Closure2(this,"$Closure2")));
-    (b.onUpdate(new $Closure3(this,"$Closure3")));
-    (b.onCreate(new $Closure4(this,"$Closure4")));
-    (b.onEvent(new $Closure5(this,"$Closure5")));
-    const wait = new $Closure6(this,"$Closure6");
-    const checkHitCount = new $Closure7(this,"$Closure7");
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"hitCount is incremented according to the bucket event",new $Closure8(this,"$Closure8"),{ timeout: (std.Duration.fromSeconds(480)) });
+    const b = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this, "cloud.Bucket");
+    const idsCounter = this.node.root.newAbstract("@winglang/sdk.cloud.Counter",this, "cloud.Counter");
+    const table = this.node.root.newAbstract("@winglang/sdk.ex.Table",this, "ex.Table", { name: "key-history", primaryKey: "_id", columns: ({"_id": ex.ColumnType.STRING,"key": ex.ColumnType.STRING,"operation": ex.ColumnType.STRING,"source": ex.ColumnType.STRING}) });
+    const logHistory = new $Closure1(this, "$Closure1");
+    (b.onDelete(new $Closure2(this, "$Closure2")));
+    (b.onUpdate(new $Closure3(this, "$Closure3")));
+    (b.onCreate(new $Closure4(this, "$Closure4")));
+    (b.onEvent(new $Closure5(this, "$Closure5")));
+    const wait = new $Closure6(this, "$Closure6");
+    const checkHitCount = new $Closure7(this, "$Closure7");
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "hitCount is incremented according to the bucket event", new $Closure8(this, "$Closure8"), { timeout: (std.Duration.fromSeconds(480)) });
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/exists.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/exists.test.w_compile_tf-aws.md
@@ -11,10 +11,10 @@ module.exports = function({ $b }) {
       return $obj;
     }
     async handle() {
-      (await $b.put("test1.txt","Foo"));
+      (await $b.put("test1.txt", "Foo"));
       {((cond) => {if (!cond) throw new Error("assertion failed: b.exists(\"test1.txt\")")})((await $b.exists("test1.txt")))};
       {((cond) => {if (!cond) throw new Error("assertion failed: !b.exists(\"test2.txt\")")})((!(await $b.exists("test2.txt"))))};
-      (await $b.put("test2.txt","Bar"));
+      (await $b.put("test2.txt", "Bar"));
       {((cond) => {if (!cond) throw new Error("assertion failed: b.exists(\"test2.txt\")")})((await $b.exists("test2.txt")))};
       (await $b.delete("test1.txt"));
       {((cond) => {if (!cond) throw new Error("assertion failed: !b.exists(\"test1.txt\")")})((!(await $b.exists("test1.txt"))))};
@@ -81,11 +81,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -116,8 +116,8 @@ class $Root extends $stdlib.std.Resource {
         super._registerOnLift(host, ops);
       }
     }
-    const b = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this,"cloud.Bucket");
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:exists",new $Closure1(this,"$Closure1"));
+    const b = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this, "cloud.Bucket");
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:exists", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/metadata.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/metadata.test.w_compile_tf-aws.md
@@ -11,10 +11,10 @@ module.exports = function({ $b }) {
       return $obj;
     }
     async handle() {
-      (await $b.put("file1.main.w","Foo"));
-      (await $b.put("file2.txt","Bar"));
-      (await $b.put("file3.txt","Baz",({"contentType": "application/json"})));
-      (await $b.putJson("file4.txt","Qux"));
+      (await $b.put("file1.main.w", "Foo"));
+      (await $b.put("file2.txt", "Bar"));
+      (await $b.put("file3.txt", "Baz", ({"contentType": "application/json"})));
+      (await $b.putJson("file4.txt", "Qux"));
       const file1Metadata = (await $b.metadata("file1.main.w"));
       {((cond) => {if (!cond) throw new Error("assertion failed: file1Metadata.size == 3")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(file1Metadata.size,3)))};
       {((cond) => {if (!cond) throw new Error("assertion failed: file1Metadata.contentType == \"application/octet-stream\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(file1Metadata.contentType,"application/octet-stream")))};
@@ -101,11 +101,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -136,8 +136,8 @@ class $Root extends $stdlib.std.Resource {
         super._registerOnLift(host, ops);
       }
     }
-    const b = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this,"cloud.Bucket");
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:metadata()",new $Closure1(this,"$Closure1"));
+    const b = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this, "cloud.Bucket");
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:metadata()", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/public_url.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/public_url.test.w_compile_tf-aws.md
@@ -25,14 +25,14 @@ module.exports = function({ $http_Util, $privateBucket, $publicBucket, $util_Uti
       }
       ;
       const BUCKET_NOT_PUBLIC_ERROR = "Cannot provide public url for a non-public bucket";
-      (await $publicBucket.put("file1.txt","Foo"));
-      (await $privateBucket.put("file2.txt","Bar"));
+      (await $publicBucket.put("file1.txt", "Foo"));
+      (await $privateBucket.put("file2.txt", "Bar"));
       const publicUrl = (await $publicBucket.publicUrl("file1.txt"));
       {((cond) => {if (!cond) throw new Error("assertion failed: publicUrl != \"\"")})((((a,b) => { try { return require('assert').notDeepStrictEqual(a,b) === undefined; } catch { return false; } })(publicUrl,"")))};
       if ((((a,b) => { try { return require('assert').notDeepStrictEqual(a,b) === undefined; } catch { return false; } })((await $util_Util.env("WING_TARGET")),"sim"))) {
         {((cond) => {if (!cond) throw new Error("assertion failed: http.get(publicUrl).body ==  \"Foo\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $http_Util.get(publicUrl)).body,"Foo")))};
       }
-      (await assertThrows(BUCKET_NOT_PUBLIC_ERROR,async () => {
+      (await assertThrows(BUCKET_NOT_PUBLIC_ERROR, async () => {
         (await $privateBucket.publicUrl("file2.txt"));
       }
       ));
@@ -141,11 +141,11 @@ const cloud = $stdlib.cloud;
 const http = $stdlib.http;
 const util = $stdlib.util;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -180,9 +180,9 @@ class $Root extends $stdlib.std.Resource {
         super._registerOnLift(host, ops);
       }
     }
-    const publicBucket = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this,"publicBucket",{ public: true });
-    const privateBucket = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this,"privateBucket");
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:publicUrl",new $Closure1(this,"$Closure1"));
+    const publicBucket = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this, "publicBucket", { public: true });
+    const privateBucket = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this, "privateBucket");
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:publicUrl", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/put.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/put.test.w_compile_tf-aws.md
@@ -11,8 +11,8 @@ module.exports = function({ $b }) {
       return $obj;
     }
     async handle() {
-      (await $b.put("test1.txt","Foo"));
-      (await $b.put("test2.txt","Bar"));
+      (await $b.put("test1.txt", "Foo"));
+      (await $b.put("test2.txt", "Bar"));
       const first = (await $b.get("test1.txt"));
       const second = (await $b.get("test2.txt"));
       {((cond) => {if (!cond) throw new Error("assertion failed: first == \"Foo\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(first,"Foo")))};
@@ -21,7 +21,7 @@ module.exports = function({ $b }) {
       const files = (await $b.list());
       {((cond) => {if (!cond) throw new Error("assertion failed: files.contains(\"test1.txt\") == false")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(files.includes("test1.txt"),false)))};
       {((cond) => {if (!cond) throw new Error("assertion failed: files.contains(\"test2.txt\") == true")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(files.includes("test2.txt"),true)))};
-      (await $b.put("test2.txt","Baz"));
+      (await $b.put("test2.txt", "Baz"));
       const third = (await $b.get("test2.txt"));
       {((cond) => {if (!cond) throw new Error("assertion failed: third == \"Baz\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(third,"Baz")))};
     }
@@ -87,11 +87,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -122,8 +122,8 @@ class $Root extends $stdlib.std.Resource {
         super._registerOnLift(host, ops);
       }
     }
-    const b = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this,"cloud.Bucket");
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:put",new $Closure1(this,"$Closure1"));
+    const b = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this, "cloud.Bucket");
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:put", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/put_json.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/put_json.test.w_compile_tf-aws.md
@@ -13,14 +13,14 @@ module.exports = function({ $b }) {
     async handle() {
       const jsonObj1 = ({"test": "test1"});
       const jsonObj2 = ({"test": "test2"});
-      (await $b.putJson("test1.txt",jsonObj1));
-      (await $b.putJson("test2.txt",jsonObj2));
+      (await $b.putJson("test1.txt", jsonObj1));
+      (await $b.putJson("test2.txt", jsonObj2));
       const testJson1 = (await $b.getJson("test1.txt"));
       const testJson2 = (await $b.getJson("test2.txt"));
       {((cond) => {if (!cond) throw new Error("assertion failed: testJson1.get(\"test\") == jsonObj1.get(\"test\")")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(((obj, args) => { if (obj[args] === undefined) throw new Error(`Json property "${args}" does not exist`); return obj[args] })(testJson1, "test"),((obj, args) => { if (obj[args] === undefined) throw new Error(`Json property "${args}" does not exist`); return obj[args] })(jsonObj1, "test"))))};
       {((cond) => {if (!cond) throw new Error("assertion failed: testJson2.get(\"test\") == jsonObj2.get(\"test\")")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(((obj, args) => { if (obj[args] === undefined) throw new Error(`Json property "${args}" does not exist`); return obj[args] })(testJson2, "test"),((obj, args) => { if (obj[args] === undefined) throw new Error(`Json property "${args}" does not exist`); return obj[args] })(jsonObj2, "test"))))};
       const jsonObj3 = ({"test": "test3"});
-      (await $b.putJson("test3.txt",jsonObj3));
+      (await $b.putJson("test3.txt", jsonObj3));
       const testJson3 = (await $b.getJson("test3.txt"));
       {((cond) => {if (!cond) throw new Error("assertion failed: testJson3.get(\"test\") == jsonObj3.get(\"test\")")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(((obj, args) => { if (obj[args] === undefined) throw new Error(`Json property "${args}" does not exist`); return obj[args] })(testJson3, "test"),((obj, args) => { if (obj[args] === undefined) throw new Error(`Json property "${args}" does not exist`); return obj[args] })(jsonObj3, "test"))))};
       (await $b.delete("test1.txt"));
@@ -90,11 +90,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -125,8 +125,8 @@ class $Root extends $stdlib.std.Resource {
         super._registerOnLift(host, ops);
       }
     }
-    const b = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this,"cloud.Bucket");
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:putJson",new $Closure1(this,"$Closure1"));
+    const b = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this, "cloud.Bucket");
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:putJson", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/signed_url.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/signed_url.test.w_compile_tf-aws.md
@@ -12,7 +12,7 @@ module.exports = function({ $http_Util, $testBucket, $util_Util }) {
     }
     async handle() {
       let error = "";
-      (await $testBucket.put("file1.txt","Foo"));
+      (await $testBucket.put("file1.txt", "Foo"));
       if ((((a,b) => { try { return require('assert').notDeepStrictEqual(a,b) === undefined; } catch { return false; } })((await $util_Util.env("WING_TARGET")),"sim"))) {
         const signedUrl = (await $testBucket.signedUrl("file1.txt"));
         {((cond) => {if (!cond) throw new Error("assertion failed: http.get(signedUrl).body ==  \"Foo\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $http_Util.get(signedUrl)).body,"Foo")))};
@@ -141,11 +141,11 @@ const cloud = $stdlib.cloud;
 const http = $stdlib.http;
 const util = $stdlib.util;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -179,8 +179,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure2 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -212,9 +212,9 @@ class $Root extends $stdlib.std.Resource {
         super._registerOnLift(host, ops);
       }
     }
-    const testBucket = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this,"testBucket",{ public: true });
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:signedUrl",new $Closure1(this,"$Closure1"));
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:signedUrl for non existent key",new $Closure2(this,"$Closure2"));
+    const testBucket = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this, "testBucket", { public: true });
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:signedUrl", new $Closure1(this, "$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:signedUrl for non existent key", new $Closure2(this, "$Closure2"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/try_delete.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/try_delete.test.w_compile_tf-aws.md
@@ -12,12 +12,12 @@ module.exports = function({ $b }) {
     }
     async handle() {
       const jsonObj2 = ({"key2": "value2"});
-      (await $b.put("file1.txt","Foo"));
+      (await $b.put("file1.txt", "Foo"));
       {((cond) => {if (!cond) throw new Error("assertion failed: b.tryDelete(\"file1.txt\") == true")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $b.tryDelete("file1.txt")),true)))};
       {((cond) => {if (!cond) throw new Error("assertion failed: b.tryDelete(\"file1.txt\") == false")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $b.tryDelete("file1.txt")),false)))};
       {((cond) => {if (!cond) throw new Error("assertion failed: b.tryDelete(\"random\") == false")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $b.tryDelete("random")),false)))};
-      (await $b.put("file2.txt","Bar"));
-      (await $b.putJson("file2.json",jsonObj2));
+      (await $b.put("file2.txt", "Bar"));
+      (await $b.putJson("file2.json", jsonObj2));
       {((cond) => {if (!cond) throw new Error("assertion failed: b.tryDelete(\"file2.txt\") == true")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $b.tryDelete("file2.txt")),true)))};
       {((cond) => {if (!cond) throw new Error("assertion failed: b.tryDelete(\"file2.json\") == true")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $b.tryDelete("file2.json")),true)))};
       {((cond) => {if (!cond) throw new Error("assertion failed: b.tryDelete(\"file2.txt\") == false")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $b.tryDelete("file2.txt")),false)))};
@@ -85,11 +85,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -120,8 +120,8 @@ class $Root extends $stdlib.std.Resource {
         super._registerOnLift(host, ops);
       }
     }
-    const b = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this,"cloud.Bucket");
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:tryDelete",new $Closure1(this,"$Closure1"));
+    const b = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this, "cloud.Bucket");
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:tryDelete", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/try_get.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/try_get.test.w_compile_tf-aws.md
@@ -11,10 +11,10 @@ module.exports = function({ $b }) {
       return $obj;
     }
     async handle() {
-      (await $b.put("test1.txt","Foo"));
+      (await $b.put("test1.txt", "Foo"));
       {((cond) => {if (!cond) throw new Error("assertion failed: b.tryGet(\"test1.txt\") == \"Foo\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $b.tryGet("test1.txt")),"Foo")))};
       {((cond) => {if (!cond) throw new Error("assertion failed: b.tryGet(\"test2.txt\") == nil")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $b.tryGet("test2.txt")),undefined)))};
-      (await $b.put("test2.txt","Bar"));
+      (await $b.put("test2.txt", "Bar"));
       {((cond) => {if (!cond) throw new Error("assertion failed: b.tryGet(\"test2.txt\") == \"Bar\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $b.tryGet("test2.txt")),"Bar")))};
       (await $b.delete("test1.txt"));
       {((cond) => {if (!cond) throw new Error("assertion failed: b.tryGet(\"test1.txt\") == nil")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $b.tryGet("test1.txt")),undefined)))};
@@ -81,11 +81,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -116,8 +116,8 @@ class $Root extends $stdlib.std.Resource {
         super._registerOnLift(host, ops);
       }
     }
-    const b = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this,"cloud.Bucket");
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:tryGet",new $Closure1(this,"$Closure1"));
+    const b = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this, "cloud.Bucket");
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:tryGet", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/try_get_json.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/try_get_json.test.w_compile_tf-aws.md
@@ -13,10 +13,10 @@ module.exports = function({ $b, $std_Json }) {
     async handle() {
       const jsonObj1 = ({"key1": "value1"});
       const jsonObj2 = ({"key2": "value2"});
-      (await $b.putJson("file1.json",jsonObj1));
+      (await $b.putJson("file1.json", jsonObj1));
       {((cond) => {if (!cond) throw new Error("assertion failed: Json.stringify(b.tryGetJson(\"file1.json\")) == Json.stringify(jsonObj1)")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(((args) => { return JSON.stringify(args[0], null, args[1]?.indent) })([(await $b.tryGetJson("file1.json"))]),((args) => { return JSON.stringify(args[0], null, args[1]?.indent) })([jsonObj1]))))};
       {((cond) => {if (!cond) throw new Error("assertion failed: b.tryGetJson(\"file2.json\") == nil")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $b.tryGetJson("file2.json")),undefined)))};
-      (await $b.putJson("file2.json",jsonObj2));
+      (await $b.putJson("file2.json", jsonObj2));
       {((cond) => {if (!cond) throw new Error("assertion failed: Json.stringify(b.tryGetJson(\"file2.json\")) == Json.stringify(jsonObj2)")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(((args) => { return JSON.stringify(args[0], null, args[1]?.indent) })([(await $b.tryGetJson("file2.json"))]),((args) => { return JSON.stringify(args[0], null, args[1]?.indent) })([jsonObj2]))))};
       (await $b.delete("file1.json"));
       (await $b.delete("file2.json"));
@@ -85,11 +85,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -121,8 +121,8 @@ class $Root extends $stdlib.std.Resource {
         super._registerOnLift(host, ops);
       }
     }
-    const b = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this,"cloud.Bucket");
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:tryGetJson",new $Closure1(this,"$Closure1"));
+    const b = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this, "cloud.Bucket");
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:tryGetJson", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/counter/dec.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/counter/dec.test.w_compile_tf-aws.md
@@ -38,10 +38,10 @@ module.exports = function({ $counter }) {
     async handle() {
       const key = "my-key";
       {((cond) => {if (!cond) throw new Error("assertion failed: counter.peek(key) == 1")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $counter.peek(key)),1)))};
-      const dec1 = (await $counter.dec(undefined,key));
+      const dec1 = (await $counter.dec(undefined, key));
       {((cond) => {if (!cond) throw new Error("assertion failed: counter.peek(key) == 0")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $counter.peek(key)),0)))};
       {((cond) => {if (!cond) throw new Error("assertion failed: dec1 == 1")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(dec1,1)))};
-      const dec2 = (await $counter.dec(2,key));
+      const dec2 = (await $counter.dec(2, key));
       {((cond) => {if (!cond) throw new Error("assertion failed: counter.peek(key) == -2")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $counter.peek(key)),(-2))))};
       {((cond) => {if (!cond) throw new Error("assertion failed: dec2 == 0")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(dec2,0)))};
     }
@@ -114,11 +114,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -150,8 +150,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure2 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -182,9 +182,9 @@ class $Root extends $stdlib.std.Resource {
         super._registerOnLift(host, ops);
       }
     }
-    const counter = this.node.root.newAbstract("@winglang/sdk.cloud.Counter",this,"cloud.Counter",{ initial: 1 });
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:dec",new $Closure1(this,"$Closure1"));
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:key dec",new $Closure2(this,"$Closure2"));
+    const counter = this.node.root.newAbstract("@winglang/sdk.cloud.Counter",this, "cloud.Counter", { initial: 1 });
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:dec", new $Closure1(this, "$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:key dec", new $Closure2(this, "$Closure2"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/counter/inc.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/counter/inc.test.w_compile_tf-aws.md
@@ -43,16 +43,16 @@ module.exports = function({ $counter }) {
     async handle() {
       const key = "my-key";
       {((cond) => {if (!cond) throw new Error("assertion failed: counter.peek(key) == 0")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $counter.peek(key)),0)))};
-      const r0 = (await $counter.inc(undefined,key));
+      const r0 = (await $counter.inc(undefined, key));
       {((cond) => {if (!cond) throw new Error("assertion failed: r0 == 0")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(r0,0)))};
       {((cond) => {if (!cond) throw new Error("assertion failed: counter.peek(key) == 1")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $counter.peek(key)),1)))};
-      const r1 = (await $counter.inc(undefined,key));
+      const r1 = (await $counter.inc(undefined, key));
       {((cond) => {if (!cond) throw new Error("assertion failed: r1 == 1")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(r1,1)))};
       {((cond) => {if (!cond) throw new Error("assertion failed: counter.peek(key) == 2")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $counter.peek(key)),2)))};
-      const r2 = (await $counter.inc(10,key));
+      const r2 = (await $counter.inc(10, key));
       {((cond) => {if (!cond) throw new Error("assertion failed: r2 == 2")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(r2,2)))};
       {((cond) => {if (!cond) throw new Error("assertion failed: counter.peek(key) == 12")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $counter.peek(key)),12)))};
-      const r3 = (await $counter.inc(undefined,key));
+      const r3 = (await $counter.inc(undefined, key));
       {((cond) => {if (!cond) throw new Error("assertion failed: r3 == 12")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(r3,12)))};
     }
   }
@@ -124,11 +124,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -160,8 +160,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure2 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -192,9 +192,9 @@ class $Root extends $stdlib.std.Resource {
         super._registerOnLift(host, ops);
       }
     }
-    const counter = this.node.root.newAbstract("@winglang/sdk.cloud.Counter",this,"cloud.Counter",{ initial: 0 });
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:inc",new $Closure1(this,"$Closure1"));
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:key inc",new $Closure2(this,"$Closure2"));
+    const counter = this.node.root.newAbstract("@winglang/sdk.cloud.Counter",this, "cloud.Counter", { initial: 0 });
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:inc", new $Closure1(this, "$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:key inc", new $Closure2(this, "$Closure2"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/counter/initial.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/counter/initial.test.w_compile_tf-aws.md
@@ -154,11 +154,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -190,8 +190,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure2 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -223,8 +223,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure3 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -255,12 +255,12 @@ class $Root extends $stdlib.std.Resource {
         super._registerOnLift(host, ops);
       }
     }
-    const counterA = this.node.root.newAbstract("@winglang/sdk.cloud.Counter",this,"counterA");
-    const counterB = this.node.root.newAbstract("@winglang/sdk.cloud.Counter",this,"counterB",{ initial: 500 });
-    const counterC = this.node.root.newAbstract("@winglang/sdk.cloud.Counter",this,"counterC",{ initial: (-198) });
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:initial:default",new $Closure1(this,"$Closure1"));
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:initial:positive-value",new $Closure2(this,"$Closure2"));
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:initial:negative-value",new $Closure3(this,"$Closure3"));
+    const counterA = this.node.root.newAbstract("@winglang/sdk.cloud.Counter",this, "counterA");
+    const counterB = this.node.root.newAbstract("@winglang/sdk.cloud.Counter",this, "counterB", { initial: 500 });
+    const counterC = this.node.root.newAbstract("@winglang/sdk.cloud.Counter",this, "counterC", { initial: (-198) });
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:initial:default", new $Closure1(this, "$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:initial:positive-value", new $Closure2(this, "$Closure2"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:initial:negative-value", new $Closure3(this, "$Closure3"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/counter/peek.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/counter/peek.test.w_compile_tf-aws.md
@@ -36,7 +36,7 @@ module.exports = function({ $c }) {
       const key = "my-key";
       {((cond) => {if (!cond) throw new Error("assertion failed: c.peek(key) == 0")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $c.peek(key)),0)))};
       {((cond) => {if (!cond) throw new Error("assertion failed: c.peek(key) == 0")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $c.peek(key)),0)))};
-      (await $c.inc(undefined,key));
+      (await $c.inc(undefined, key));
       {((cond) => {if (!cond) throw new Error("assertion failed: c.peek(key) == 1")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $c.peek(key)),1)))};
     }
   }
@@ -108,11 +108,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -144,8 +144,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure2 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -176,9 +176,9 @@ class $Root extends $stdlib.std.Resource {
         super._registerOnLift(host, ops);
       }
     }
-    const c = this.node.root.newAbstract("@winglang/sdk.cloud.Counter",this,"cloud.Counter");
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:peek",new $Closure1(this,"$Closure1"));
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:key peek",new $Closure2(this,"$Closure2"));
+    const c = this.node.root.newAbstract("@winglang/sdk.cloud.Counter",this, "cloud.Counter");
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:peek", new $Closure1(this, "$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:key peek", new $Closure2(this, "$Closure2"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/counter/set.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/counter/set.test.w_compile_tf-aws.md
@@ -40,13 +40,13 @@ module.exports = function({ $counter }) {
     async handle() {
       const key = "my-key";
       {((cond) => {if (!cond) throw new Error("assertion failed: counter.peek(key) == 0")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $counter.peek(key)),0)))};
-      (await $counter.inc(undefined,key));
+      (await $counter.inc(undefined, key));
       {((cond) => {if (!cond) throw new Error("assertion failed: counter.peek(key) == 1")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $counter.peek(key)),1)))};
-      (await $counter.inc(undefined,key));
+      (await $counter.inc(undefined, key));
       {((cond) => {if (!cond) throw new Error("assertion failed: counter.peek(key) == 2")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $counter.peek(key)),2)))};
-      (await $counter.inc(10,key));
+      (await $counter.inc(10, key));
       {((cond) => {if (!cond) throw new Error("assertion failed: counter.peek(key) == 12")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $counter.peek(key)),12)))};
-      (await $counter.set(88,key));
+      (await $counter.set(88, key));
       {((cond) => {if (!cond) throw new Error("assertion failed: counter.peek(key) == 88")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $counter.peek(key)),88)))};
     }
   }
@@ -118,11 +118,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -154,8 +154,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure2 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -186,9 +186,9 @@ class $Root extends $stdlib.std.Resource {
         super._registerOnLift(host, ops);
       }
     }
-    const counter = this.node.root.newAbstract("@winglang/sdk.cloud.Counter",this,"cloud.Counter",{ initial: 0 });
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:set",new $Closure1(this,"$Closure1"));
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:key set",new $Closure2(this,"$Closure2"));
+    const counter = this.node.root.newAbstract("@winglang/sdk.cloud.Counter",this, "cloud.Counter", { initial: 0 });
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:set", new $Closure1(this, "$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:key set", new $Closure2(this, "$Closure2"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/dynamodb-table/query.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/dynamodb-table/query.test.w_compile_tf-aws.md
@@ -96,11 +96,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const ex = $stdlib.ex;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -131,8 +131,8 @@ class $Root extends $stdlib.std.Resource {
         super._registerOnLift(host, ops);
       }
     }
-    const t1 = this.node.root.newAbstract("@winglang/sdk.ex.DynamodbTable",this,"ex.DynamodbTable",{ name: "test1", attributeDefinitions: ({"k1": "S","k2": "S"}), hashKey: "k1", rangeKey: "k2" });
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:query",new $Closure1(this,"$Closure1"));
+    const t1 = this.node.root.newAbstract("@winglang/sdk.ex.DynamodbTable",this, "ex.DynamodbTable", { name: "test1", attributeDefinitions: ({"k1": "S","k2": "S"}), hashKey: "k1", rangeKey: "k2" });
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:query", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/dynamodb-table/transaction.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/dynamodb-table/transaction.test.w_compile_tf-aws.md
@@ -99,11 +99,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const ex = $stdlib.ex;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -134,8 +134,8 @@ class $Root extends $stdlib.std.Resource {
         super._registerOnLift(host, ops);
       }
     }
-    const t1 = this.node.root.newAbstract("@winglang/sdk.ex.DynamodbTable",this,"ex.DynamodbTable",{ name: "test1", attributeDefinitions: ({"k1": "S","k2": "S"}), hashKey: "k1", rangeKey: "k2" });
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:transactWriteItems",new $Closure1(this,"$Closure1"));
+    const t1 = this.node.root.newAbstract("@winglang/sdk.ex.DynamodbTable",this, "ex.DynamodbTable", { name: "test1", attributeDefinitions: ({"k1": "S","k2": "S"}), hashKey: "k1", rangeKey: "k2" });
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:transactWriteItems", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/fs/basic.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/fs/basic.test.w_compile_tf-aws.md
@@ -13,7 +13,7 @@ module.exports = function({ $data, $fs_Util }) {
     async handle() {
       const tmpdir = (await $fs_Util.mkdtemp());
       const filepath = String.raw({ raw: ["", "/hello-inflight.txt"] }, tmpdir);
-      (await $fs_Util.writeFile(filepath,$data));
+      (await $fs_Util.writeFile(filepath, $data));
       {((cond) => {if (!cond) throw new Error("assertion failed: fs.exists(filepath) == true")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $fs_Util.exists(filepath)),true)))};
       const content = (await $fs_Util.readFile(filepath));
       {((cond) => {if (!cond) throw new Error("assertion failed: content == data")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(content,$data)))};
@@ -21,7 +21,7 @@ module.exports = function({ $data, $fs_Util }) {
       {((cond) => {if (!cond) throw new Error("assertion failed: fs.exists(filepath) == false")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $fs_Util.exists(filepath)),false)))};
       const nilContent = (await $fs_Util.tryReadFile(filepath));
       {((cond) => {if (!cond) throw new Error("assertion failed: nilContent == nil")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(nilContent,undefined)))};
-      (await $fs_Util.remove(tmpdir,({"recursive": true})));
+      (await $fs_Util.remove(tmpdir, ({"recursive": true})));
       {((cond) => {if (!cond) throw new Error("assertion failed: fs.exists(tmpdir) == false")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $fs_Util.exists(tmpdir)),false)))};
     }
   }
@@ -72,11 +72,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const fs = $stdlib.fs;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -111,7 +111,7 @@ class $Root extends $stdlib.std.Resource {
     const tmpdir = (fs.Util.mkdtemp());
     const filepath = String.raw({ raw: ["", "/hello-preflight.txt"] }, tmpdir);
     const data = "Hello, Wing!";
-    (fs.Util.writeFile(filepath,data));
+    (fs.Util.writeFile(filepath, data));
     {((cond) => {if (!cond) throw new Error("assertion failed: fs.exists(filepath) == true")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((fs.Util.exists(filepath)),true)))};
     const content = (fs.Util.readFile(filepath));
     {((cond) => {if (!cond) throw new Error("assertion failed: content == data")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(content,data)))};
@@ -119,9 +119,9 @@ class $Root extends $stdlib.std.Resource {
     {((cond) => {if (!cond) throw new Error("assertion failed: fs.exists(filepath) == false")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((fs.Util.exists(filepath)),false)))};
     const nilContent = (fs.Util.tryReadFile(filepath));
     {((cond) => {if (!cond) throw new Error("assertion failed: nilContent == nil")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(nilContent,undefined)))};
-    (fs.Util.remove(tmpdir,({"recursive": true})));
+    (fs.Util.remove(tmpdir, ({"recursive": true})));
     {((cond) => {if (!cond) throw new Error("assertion failed: fs.exists(tmpdir) == false")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((fs.Util.exists(tmpdir)),false)))};
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:inflight file basic operations",new $Closure1(this,"$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:inflight file basic operations", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/fs/directory.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/fs/directory.test.w_compile_tf-aws.md
@@ -20,12 +20,12 @@ module.exports = function({ $filename, $fs_Util, $regex_Util }) {
       }
       catch ($error_e) {
         const e = $error_e.message;
-        {((cond) => {if (!cond) throw new Error("assertion failed: regex.match(\"^EEXIST: file already exists\", e) == true")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $regex_Util.match("^EEXIST: file already exists",e)),true)))};
+        {((cond) => {if (!cond) throw new Error("assertion failed: regex.match(\"^EEXIST: file already exists\", e) == true")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $regex_Util.match("^EEXIST: file already exists", e)),true)))};
       }
-      (await $fs_Util.writeFile((await $fs_Util.join(dirpath,$filename)),""));
+      (await $fs_Util.writeFile((await $fs_Util.join(dirpath, $filename)), ""));
       const files = (await $fs_Util.readdir(dirpath));
       {((cond) => {if (!cond) throw new Error("assertion failed: files.length == 1")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(files.length,1)))};
-      (await $fs_Util.remove(dirpath,({"recursive": true})));
+      (await $fs_Util.remove(dirpath, ({"recursive": true})));
       {((cond) => {if (!cond) throw new Error("assertion failed: fs.exists(dirpath) == false")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $fs_Util.exists(dirpath)),false)))};
       const nilFiles = (await $fs_Util.tryReaddir(dirpath));
       {((cond) => {if (!cond) throw new Error("assertion failed: nilFiles == nil")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(nilFiles,undefined)))};
@@ -79,11 +79,11 @@ const std = $stdlib.std;
 const fs = $stdlib.fs;
 const regex = $stdlib.regex;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -126,16 +126,16 @@ class $Root extends $stdlib.std.Resource {
     }
     catch ($error_e) {
       const e = $error_e.message;
-      {((cond) => {if (!cond) throw new Error("assertion failed: regex.match(\"^EEXIST: file already exists\", e) == true")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((regex.Util.match("^EEXIST: file already exists",e)),true)))};
+      {((cond) => {if (!cond) throw new Error("assertion failed: regex.match(\"^EEXIST: file already exists\", e) == true")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((regex.Util.match("^EEXIST: file already exists", e)),true)))};
     }
-    (fs.Util.writeFile((fs.Util.join(dirpath,filename)),""));
+    (fs.Util.writeFile((fs.Util.join(dirpath, filename)), ""));
     const files = (fs.Util.readdir(dirpath));
     {((cond) => {if (!cond) throw new Error("assertion failed: files.length == 1")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(files.length,1)))};
-    (fs.Util.remove(dirpath,({"recursive": true})));
+    (fs.Util.remove(dirpath, ({"recursive": true})));
     {((cond) => {if (!cond) throw new Error("assertion failed: fs.exists(dirpath) == false")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((fs.Util.exists(dirpath)),false)))};
     const nilFiles = (fs.Util.tryReaddir(dirpath));
     {((cond) => {if (!cond) throw new Error("assertion failed: nilFiles == nil")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(nilFiles,undefined)))};
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:inflight create normal directory",new $Closure1(this,"$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:inflight create normal directory", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/fs/json.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/fs/json.test.w_compile_tf-aws.md
@@ -14,21 +14,21 @@ module.exports = function({ $data, $fs_Util, $regex_Util, $std_Json }) {
       const tmpdir = (await $fs_Util.mkdtemp());
       const filepath = String.raw({ raw: ["", "/test-inflight.json"] }, tmpdir);
       try {
-        (await $fs_Util.writeFile(filepath,"invalid content"));
+        (await $fs_Util.writeFile(filepath, "invalid content"));
         (await $fs_Util.readJson(filepath));
       }
       catch ($error_e) {
         const e = $error_e.message;
-        {((cond) => {if (!cond) throw new Error("assertion failed: regex.match(\"^Unexpected token\", e) == true")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $regex_Util.match("^Unexpected token",e)),true)))};
+        {((cond) => {if (!cond) throw new Error("assertion failed: regex.match(\"^Unexpected token\", e) == true")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $regex_Util.match("^Unexpected token", e)),true)))};
       }
-      (await $fs_Util.writeJson(filepath,$data));
+      (await $fs_Util.writeJson(filepath, $data));
       {((cond) => {if (!cond) throw new Error("assertion failed: fs.exists(filepath) == true")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $fs_Util.exists(filepath)),true)))};
       const obj = (await $fs_Util.readJson(filepath));
       {((cond) => {if (!cond) throw new Error("assertion failed: Json.stringify(obj) == Json.stringify(data)")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(((args) => { return JSON.stringify(args[0], null, args[1]?.indent) })([obj]),((args) => { return JSON.stringify(args[0], null, args[1]?.indent) })([$data]))))};
       (await $fs_Util.remove(filepath));
       {((cond) => {if (!cond) throw new Error("assertion failed: fs.exists(filepath) == false")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $fs_Util.exists(filepath)),false)))};
       {((cond) => {if (!cond) throw new Error("assertion failed: fs.tryReadJson(filepath) == nil")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $fs_Util.tryReadJson(filepath)),undefined)))};
-      (await $fs_Util.remove(tmpdir,({"recursive": true})));
+      (await $fs_Util.remove(tmpdir, ({"recursive": true})));
       {((cond) => {if (!cond) throw new Error("assertion failed: fs.exists(tmpdir) == false")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $fs_Util.exists(tmpdir)),false)))};
     }
   }
@@ -80,11 +80,11 @@ const std = $stdlib.std;
 const fs = $stdlib.fs;
 const regex = $stdlib.regex;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -122,23 +122,23 @@ class $Root extends $stdlib.std.Resource {
     const filepath = String.raw({ raw: ["", "/test-preflight.json"] }, tmpdir);
     const data = ({"foo": "bar","arr": [1, 2, 3, "test", ({"foo": "bar"})]});
     try {
-      (fs.Util.writeFile(filepath,"invalid content"));
+      (fs.Util.writeFile(filepath, "invalid content"));
       (fs.Util.readJson(filepath));
     }
     catch ($error_e) {
       const e = $error_e.message;
-      {((cond) => {if (!cond) throw new Error("assertion failed: regex.match(\"^Unexpected token\", e) == true")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((regex.Util.match("^Unexpected token",e)),true)))};
+      {((cond) => {if (!cond) throw new Error("assertion failed: regex.match(\"^Unexpected token\", e) == true")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((regex.Util.match("^Unexpected token", e)),true)))};
     }
-    (fs.Util.writeJson(filepath,data));
+    (fs.Util.writeJson(filepath, data));
     {((cond) => {if (!cond) throw new Error("assertion failed: fs.exists(filepath) == true")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((fs.Util.exists(filepath)),true)))};
     const obj = (fs.Util.readJson(filepath));
     {((cond) => {if (!cond) throw new Error("assertion failed: Json.stringify(obj) == Json.stringify(data)")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(((args) => { return JSON.stringify(args[0], null, args[1]?.indent) })([obj]),((args) => { return JSON.stringify(args[0], null, args[1]?.indent) })([data]))))};
     (fs.Util.remove(filepath));
     {((cond) => {if (!cond) throw new Error("assertion failed: fs.exists(filepath) == false")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((fs.Util.exists(filepath)),false)))};
     {((cond) => {if (!cond) throw new Error("assertion failed: fs.tryReadJson(filepath) == nil")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((fs.Util.tryReadJson(filepath)),undefined)))};
-    (fs.Util.remove(tmpdir,({"recursive": true})));
+    (fs.Util.remove(tmpdir, ({"recursive": true})));
     {((cond) => {if (!cond) throw new Error("assertion failed: fs.exists(tmpdir) == false")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((fs.Util.exists(tmpdir)),false)))};
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:inflight json operations",new $Closure1(this,"$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:inflight json operations", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/fs/path.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/fs/path.test.w_compile_tf-aws.md
@@ -11,16 +11,16 @@ module.exports = function({ $from, $fs_Util, $regex_Util, $to }) {
       return $obj;
     }
     async handle() {
-      let result = (await $fs_Util.join($from,$to));
+      let result = (await $fs_Util.join($from, $to));
       {((cond) => {if (!cond) throw new Error("assertion failed: result == \"/a/b/c/d/a/b/e/f\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(result,"/a/b/c/d/a/b/e/f")))};
-      result = (await $fs_Util.relative($from,$to));
+      result = (await $fs_Util.relative($from, $to));
       {((cond) => {if (!cond) throw new Error("assertion failed: result == \"../../e/f\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(result,"../../e/f")))};
       result = (await $fs_Util.dirname($from));
       {((cond) => {if (!cond) throw new Error("assertion failed: result == \"/a/b/c\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(result,"/a/b/c")))};
       result = (await $fs_Util.basename($from));
       {((cond) => {if (!cond) throw new Error("assertion failed: result == \"d\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(result,"d")))};
-      result = (await $fs_Util.resolve($from,$to));
-      {((cond) => {if (!cond) throw new Error("assertion failed: regex.match(\"/a/b/e/f\", result)")})((await $regex_Util.match("/a/b/e/f",result)))};
+      result = (await $fs_Util.resolve($from, $to));
+      {((cond) => {if (!cond) throw new Error("assertion failed: regex.match(\"/a/b/e/f\", result)")})((await $regex_Util.match("/a/b/e/f", result)))};
     }
   }
   return $Closure1;
@@ -71,11 +71,11 @@ const std = $stdlib.std;
 const fs = $stdlib.fs;
 const regex = $stdlib.regex;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -112,17 +112,17 @@ class $Root extends $stdlib.std.Resource {
     }
     const from = "/a/b/c/d";
     const to = "/a/b/e/f";
-    let result = (fs.Util.join(from,to));
+    let result = (fs.Util.join(from, to));
     {((cond) => {if (!cond) throw new Error("assertion failed: result == \"/a/b/c/d/a/b/e/f\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(result,"/a/b/c/d/a/b/e/f")))};
-    result = (fs.Util.relative(from,to));
+    result = (fs.Util.relative(from, to));
     {((cond) => {if (!cond) throw new Error("assertion failed: result == \"../../e/f\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(result,"../../e/f")))};
     result = (fs.Util.dirname(from));
     {((cond) => {if (!cond) throw new Error("assertion failed: result == \"/a/b/c\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(result,"/a/b/c")))};
     result = (fs.Util.basename(from));
     {((cond) => {if (!cond) throw new Error("assertion failed: result == \"d\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(result,"d")))};
-    result = (fs.Util.resolve(from,to));
-    {((cond) => {if (!cond) throw new Error("assertion failed: regex.match(\"/a/b/e/f\", result)")})((regex.Util.match("/a/b/e/f",result)))};
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:inflight path conversion",new $Closure1(this,"$Closure1"));
+    result = (fs.Util.resolve(from, to));
+    {((cond) => {if (!cond) throw new Error("assertion failed: regex.match(\"/a/b/e/f\", result)")})((regex.Util.match("/a/b/e/f", result)))};
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:inflight path conversion", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/fs/temp_dir.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/fs/temp_dir.test.w_compile_tf-aws.md
@@ -13,7 +13,7 @@ module.exports = function({ $fs_Util }) {
     async handle() {
       const tmpdir = (await $fs_Util.mkdtemp());
       {((cond) => {if (!cond) throw new Error("assertion failed: fs.exists(tmpdir) == true")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $fs_Util.exists(tmpdir)),true)))};
-      (await $fs_Util.remove(tmpdir,({"recursive": true})));
+      (await $fs_Util.remove(tmpdir, ({"recursive": true})));
       {((cond) => {if (!cond) throw new Error("assertion failed: fs.exists(tmpdir) == false")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $fs_Util.exists(tmpdir)),false)))};
     }
   }
@@ -64,11 +64,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const fs = $stdlib.fs;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -95,9 +95,9 @@ class $Root extends $stdlib.std.Resource {
     }
     const tmpdir = (fs.Util.mkdtemp());
     {((cond) => {if (!cond) throw new Error("assertion failed: fs.exists(tmpdir) == true")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((fs.Util.exists(tmpdir)),true)))};
-    (fs.Util.remove(tmpdir,({"recursive": true})));
+    (fs.Util.remove(tmpdir, ({"recursive": true})));
     {((cond) => {if (!cond) throw new Error("assertion failed: fs.exists(tmpdir) == false")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((fs.Util.exists(tmpdir)),false)))};
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:inflight create temporary directory",new $Closure1(this,"$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:inflight create temporary directory", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/fs/yaml.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/fs/yaml.test.w_compile_tf-aws.md
@@ -13,7 +13,7 @@ module.exports = function({ $data, $fs_Util, $std_Json }) {
     async handle() {
       const tmpdir = (await $fs_Util.mkdtemp());
       const filepath = String.raw({ raw: ["", "/test-inflight.yaml"] }, tmpdir);
-      (await $fs_Util.writeYaml(filepath,$data,$data));
+      (await $fs_Util.writeYaml(filepath, $data, $data));
       {((cond) => {if (!cond) throw new Error("assertion failed: fs.exists(filepath) == true")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $fs_Util.exists(filepath)),true)))};
       const objs = (await $fs_Util.readYaml(filepath));
       {((cond) => {if (!cond) throw new Error("assertion failed: objs.length == 2")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(objs.length,2)))};
@@ -21,7 +21,7 @@ module.exports = function({ $data, $fs_Util, $std_Json }) {
       {((cond) => {if (!cond) throw new Error("assertion failed: Json.stringify(objs.at(1)) == Json.stringify(data)")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(((args) => { return JSON.stringify(args[0], null, args[1]?.indent) })([(await objs.at(1))]),((args) => { return JSON.stringify(args[0], null, args[1]?.indent) })([$data]))))};
       (await $fs_Util.remove(filepath));
       {((cond) => {if (!cond) throw new Error("assertion failed: fs.exists(filepath) == false")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $fs_Util.exists(filepath)),false)))};
-      (await $fs_Util.remove(tmpdir,({"recursive": true})));
+      (await $fs_Util.remove(tmpdir, ({"recursive": true})));
       {((cond) => {if (!cond) throw new Error("assertion failed: fs.exists(tmpdir) == false")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $fs_Util.exists(tmpdir)),false)))};
     }
   }
@@ -73,11 +73,11 @@ const std = $stdlib.std;
 const fs = $stdlib.fs;
 const regex = $stdlib.regex;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -113,15 +113,15 @@ class $Root extends $stdlib.std.Resource {
     const tmpdir = (fs.Util.mkdtemp());
     const filepath = String.raw({ raw: ["", "/test-preflight.yaml"] }, tmpdir);
     const data = ({"foo": "bar","arr": [1, 2, 3, "test", ({"foo": "bar"})]});
-    (fs.Util.writeFile(filepath,"invalid: {{ content }}, invalid"));
+    (fs.Util.writeFile(filepath, "invalid: {{ content }}, invalid"));
     try {
       (fs.Util.readYaml(filepath));
     }
     catch ($error_e) {
       const e = $error_e.message;
-      {((cond) => {if (!cond) throw new Error("assertion failed: regex.match(\"^bad indentation\", e)")})((regex.Util.match("^bad indentation",e)))};
+      {((cond) => {if (!cond) throw new Error("assertion failed: regex.match(\"^bad indentation\", e)")})((regex.Util.match("^bad indentation", e)))};
     }
-    (fs.Util.writeYaml(filepath,data,data));
+    (fs.Util.writeYaml(filepath, data, data));
     {((cond) => {if (!cond) throw new Error("assertion failed: fs.exists(filepath) == true")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((fs.Util.exists(filepath)),true)))};
     const objs = (fs.Util.readYaml(filepath));
     {((cond) => {if (!cond) throw new Error("assertion failed: objs.length == 2")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(objs.length,2)))};
@@ -129,9 +129,9 @@ class $Root extends $stdlib.std.Resource {
     {((cond) => {if (!cond) throw new Error("assertion failed: Json.stringify(objs.at(1)) == Json.stringify(data)")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(((args) => { return JSON.stringify(args[0], null, args[1]?.indent) })([(objs.at(1))]),((args) => { return JSON.stringify(args[0], null, args[1]?.indent) })([data]))))};
     (fs.Util.remove(filepath));
     {((cond) => {if (!cond) throw new Error("assertion failed: fs.exists(filepath) == false")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((fs.Util.exists(filepath)),false)))};
-    (fs.Util.remove(tmpdir,({"recursive": true})));
+    (fs.Util.remove(tmpdir, ({"recursive": true})));
     {((cond) => {if (!cond) throw new Error("assertion failed: fs.exists(tmpdir) == false")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((fs.Util.exists(tmpdir)),false)))};
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:inflight yaml operations",new $Closure1(this,"$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:inflight yaml operations", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/function/env.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/function/env.test.w_compile_tf-aws.md
@@ -189,11 +189,11 @@ const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 const util = $stdlib.util;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -219,8 +219,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure2 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -251,10 +251,10 @@ class $Root extends $stdlib.std.Resource {
         super._registerOnLift(host, ops);
       }
     }
-    const f1 = this.node.root.newAbstract("@winglang/sdk.cloud.Function",this,"cloud.Function",new $Closure1(this,"$Closure1"),{ env: ({"FOO1": "bar"}) });
-    (f1.addEnvironment("FOO1","bar"));
-    (f1.addEnvironment("FOO2","baz"));
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:addEnvironment",new $Closure2(this,"$Closure2"));
+    const f1 = this.node.root.newAbstract("@winglang/sdk.cloud.Function",this, "cloud.Function", new $Closure1(this, "$Closure1"), { env: ({"FOO1": "bar"}) });
+    (f1.addEnvironment("FOO1", "bar"));
+    (f1.addEnvironment("FOO2", "baz"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:addEnvironment", new $Closure2(this, "$Closure2"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/function/invoke.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/function/invoke.test.w_compile_tf-aws.md
@@ -190,11 +190,11 @@ const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 const util = $stdlib.util;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -220,8 +220,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure2 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -254,8 +254,8 @@ class $Root extends $stdlib.std.Resource {
     }
     const payload = "hello";
     {console.log("log preflight")};
-    const f = this.node.root.newAbstract("@winglang/sdk.cloud.Function",this,"cloud.Function",new $Closure1(this,"$Closure1"));
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:invoke",new $Closure2(this,"$Closure2"));
+    const f = this.node.root.newAbstract("@winglang/sdk.cloud.Function",this, "cloud.Function", new $Closure1(this, "$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:invoke", new $Closure2(this, "$Closure2"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/function/logging.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/function/logging.test.w_compile_tf-aws.md
@@ -304,11 +304,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class Util extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
       }
       static _toInflightType(context) {
         return `
@@ -332,8 +332,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -358,8 +358,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure2 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -391,8 +391,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure3 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -425,9 +425,9 @@ class $Root extends $stdlib.std.Resource {
         super._registerOnLift(host, ops);
       }
     }
-    const f1 = this.node.root.newAbstract("@winglang/sdk.cloud.Function",this,"f1",new $Closure1(this,"$Closure1"));
-    const f2 = this.node.root.newAbstract("@winglang/sdk.cloud.Function",this,"f2",new $Closure2(this,"$Closure2"));
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:logging",new $Closure3(this,"$Closure3"));
+    const f1 = this.node.root.newAbstract("@winglang/sdk.cloud.Function",this, "f1", new $Closure1(this, "$Closure1"));
+    const f2 = this.node.root.newAbstract("@winglang/sdk.cloud.Function",this, "f2", new $Closure2(this, "$Closure2"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:logging", new $Closure3(this, "$Closure3"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/function/memory_and_env.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/function/memory_and_env.test.w_compile_tf-aws.md
@@ -322,11 +322,11 @@ const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 const util = $stdlib.util;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -358,8 +358,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure2 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -392,8 +392,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure3 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -428,14 +428,14 @@ class $Root extends $stdlib.std.Resource {
         super._registerOnLift(host, ops);
       }
     }
-    const c = this.node.root.newAbstract("@winglang/sdk.cloud.Counter",this,"cloud.Counter");
-    const b = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this,"cloud.Bucket");
-    const f1 = this.node.root.newAbstract("@winglang/sdk.cloud.Function",this,"memory fn",new $Closure1(this,"$Closure1"),({"memory": 128}));
-    const f2 = this.node.root.newAbstract("@winglang/sdk.cloud.Function",this,"env fn",new $Closure2(this,"$Closure2"),{ env: ({"catName": "Tion"}) });
-    (f2.addEnvironment("catAge","2"));
+    const c = this.node.root.newAbstract("@winglang/sdk.cloud.Counter",this, "cloud.Counter");
+    const b = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this, "cloud.Bucket");
+    const f1 = this.node.root.newAbstract("@winglang/sdk.cloud.Function",this, "memory fn", new $Closure1(this, "$Closure1"), ({"memory": 128}));
+    const f2 = this.node.root.newAbstract("@winglang/sdk.cloud.Function",this, "env fn", new $Closure2(this, "$Closure2"), { env: ({"catName": "Tion"}) });
+    (f2.addEnvironment("catAge", "2"));
     {((cond) => {if (!cond) throw new Error("assertion failed: f2.env.get(\"catAge\") == \"2\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(((obj, key) => { if (!(key in obj)) throw new Error(`Map does not contain key: "${key}"`); return obj[key]; })(f2.env, "catAge"),"2")))};
     {((cond) => {if (!cond) throw new Error("assertion failed: f2.env.get(\"catName\") == \"Tion\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(((obj, key) => { if (!(key in obj)) throw new Error(`Map does not contain key: "${key}"`); return obj[key]; })(f2.env, "catName"),"Tion")))};
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:function with memory and function with env can be invoked",new $Closure3(this,"$Closure3"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:function with memory and function with env can be invoked", new $Closure3(this, "$Closure3"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/http/url.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/http/url.test.w_compile_tf-aws.md
@@ -30,7 +30,7 @@ module.exports = function({ $http_Util }) {
       const urlStruct = ({"href": URL_STRING,"protocol": "http:","host": "www.example.com:3000","hostname": "www.example.com","port": "3000","pathname": "/pathname","search": "?search=test","hash": "#hash","origin": "http://www.example.com:3000","username": "username","password": "password"});
       const parsedUrlStruct = (await $http_Util.parseUrl(URL_STRING));
       {((cond) => {if (!cond) throw new Error("assertion failed: urlStruct == parsedUrlStruct")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(urlStruct,parsedUrlStruct)))};
-      (await assertThrows(INVALID_URL_ERROR,async () => {
+      (await assertThrows(INVALID_URL_ERROR, async () => {
         const invalidUrlStruct = (await $http_Util.parseUrl(INVALID_URL_STRING));
       }
       ));
@@ -67,16 +67,16 @@ module.exports = function({ $http_Util }) {
       ;
       const UNABLE_TO_FORMAT_URL_STRUCT_ERROR = "Unable to format URL Struct: Invalid URL";
       const urlStruct = (await $http_Util.parseUrl("https://a:b@測試.com/path?query=1#fragment"));
-      {((cond) => {if (!cond) throw new Error("assertion failed: http.formatUrl(urlStruct, { unicode: false }) == \"https://a:b@xn--g6w251d.com/path?query=1#fragment\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $http_Util.formatUrl(urlStruct,({"unicode": false}))),"https://a:b@xn--g6w251d.com/path?query=1#fragment")))};
-      {((cond) => {if (!cond) throw new Error("assertion failed: http.formatUrl(urlStruct, { unicode: true }) == \"https://a:b@測試.com/path?query=1#fragment\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $http_Util.formatUrl(urlStruct,({"unicode": true}))),"https://a:b@測試.com/path?query=1#fragment")))};
-      {((cond) => {if (!cond) throw new Error("assertion failed: http.formatUrl(urlStruct, { fragment: false }) == \"https://a:b@xn--g6w251d.com/path?query=1\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $http_Util.formatUrl(urlStruct,({"fragment": false}))),"https://a:b@xn--g6w251d.com/path?query=1")))};
-      {((cond) => {if (!cond) throw new Error("assertion failed: http.formatUrl(urlStruct, { fragment: true }) == \"https://a:b@xn--g6w251d.com/path?query=1#fragment\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $http_Util.formatUrl(urlStruct,({"fragment": true}))),"https://a:b@xn--g6w251d.com/path?query=1#fragment")))};
-      {((cond) => {if (!cond) throw new Error("assertion failed: http.formatUrl(urlStruct, { search: false }) == \"https://a:b@xn--g6w251d.com/path#fragment\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $http_Util.formatUrl(urlStruct,({"search": false}))),"https://a:b@xn--g6w251d.com/path#fragment")))};
-      {((cond) => {if (!cond) throw new Error("assertion failed: http.formatUrl(urlStruct, { search: true }) == \"https://a:b@xn--g6w251d.com/path?query=1#fragment\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $http_Util.formatUrl(urlStruct,({"search": true}))),"https://a:b@xn--g6w251d.com/path?query=1#fragment")))};
-      {((cond) => {if (!cond) throw new Error("assertion failed: http.formatUrl(urlStruct, { auth: false }) == \"https://xn--g6w251d.com/path?query=1#fragment\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $http_Util.formatUrl(urlStruct,({"auth": false}))),"https://xn--g6w251d.com/path?query=1#fragment")))};
-      {((cond) => {if (!cond) throw new Error("assertion failed: http.formatUrl(urlStruct, { auth: true }) == \"https://a:b@xn--g6w251d.com/path?query=1#fragment\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $http_Util.formatUrl(urlStruct,({"auth": true}))),"https://a:b@xn--g6w251d.com/path?query=1#fragment")))};
+      {((cond) => {if (!cond) throw new Error("assertion failed: http.formatUrl(urlStruct, { unicode: false }) == \"https://a:b@xn--g6w251d.com/path?query=1#fragment\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $http_Util.formatUrl(urlStruct, ({"unicode": false}))),"https://a:b@xn--g6w251d.com/path?query=1#fragment")))};
+      {((cond) => {if (!cond) throw new Error("assertion failed: http.formatUrl(urlStruct, { unicode: true }) == \"https://a:b@測試.com/path?query=1#fragment\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $http_Util.formatUrl(urlStruct, ({"unicode": true}))),"https://a:b@測試.com/path?query=1#fragment")))};
+      {((cond) => {if (!cond) throw new Error("assertion failed: http.formatUrl(urlStruct, { fragment: false }) == \"https://a:b@xn--g6w251d.com/path?query=1\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $http_Util.formatUrl(urlStruct, ({"fragment": false}))),"https://a:b@xn--g6w251d.com/path?query=1")))};
+      {((cond) => {if (!cond) throw new Error("assertion failed: http.formatUrl(urlStruct, { fragment: true }) == \"https://a:b@xn--g6w251d.com/path?query=1#fragment\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $http_Util.formatUrl(urlStruct, ({"fragment": true}))),"https://a:b@xn--g6w251d.com/path?query=1#fragment")))};
+      {((cond) => {if (!cond) throw new Error("assertion failed: http.formatUrl(urlStruct, { search: false }) == \"https://a:b@xn--g6w251d.com/path#fragment\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $http_Util.formatUrl(urlStruct, ({"search": false}))),"https://a:b@xn--g6w251d.com/path#fragment")))};
+      {((cond) => {if (!cond) throw new Error("assertion failed: http.formatUrl(urlStruct, { search: true }) == \"https://a:b@xn--g6w251d.com/path?query=1#fragment\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $http_Util.formatUrl(urlStruct, ({"search": true}))),"https://a:b@xn--g6w251d.com/path?query=1#fragment")))};
+      {((cond) => {if (!cond) throw new Error("assertion failed: http.formatUrl(urlStruct, { auth: false }) == \"https://xn--g6w251d.com/path?query=1#fragment\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $http_Util.formatUrl(urlStruct, ({"auth": false}))),"https://xn--g6w251d.com/path?query=1#fragment")))};
+      {((cond) => {if (!cond) throw new Error("assertion failed: http.formatUrl(urlStruct, { auth: true }) == \"https://a:b@xn--g6w251d.com/path?query=1#fragment\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $http_Util.formatUrl(urlStruct, ({"auth": true}))),"https://a:b@xn--g6w251d.com/path?query=1#fragment")))};
       const invalidUrlStruct = ({"href": "hello world","protocol": urlStruct.protocol,"host": urlStruct.host,"hostname": urlStruct.hostname,"port": urlStruct.hostname,"pathname": urlStruct.pathname,"search": urlStruct.search,"hash": urlStruct.hash,"origin": urlStruct.origin,"username": urlStruct.username,"password": urlStruct.password});
-      (await assertThrows(UNABLE_TO_FORMAT_URL_STRUCT_ERROR,async () => {
+      (await assertThrows(UNABLE_TO_FORMAT_URL_STRUCT_ERROR, async () => {
         (await $http_Util.formatUrl(invalidUrlStruct));
       }
       ));
@@ -129,11 +129,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const http = $stdlib.http;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -159,8 +159,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure2 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -185,8 +185,8 @@ class $Root extends $stdlib.std.Resource {
         return ["handle", "$inflight_init"];
       }
     }
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:parseUrl()",new $Closure1(this,"$Closure1"));
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:formatUrl()",new $Closure2(this,"$Closure2"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:parseUrl()", new $Closure1(this, "$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:formatUrl()", new $Closure2(this, "$Closure2"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/abs.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/abs.test.w_compile_tf-aws.md
@@ -62,11 +62,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const math = $stdlib.math;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -104,7 +104,7 @@ class $Root extends $stdlib.std.Resource {
     const y = 5;
     {((cond) => {if (!cond) throw new Error("assertion failed: math.abs(y - x) == 2")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((math.Util.abs((y - x))),2)))};
     {((cond) => {if (!cond) throw new Error("assertion failed: math.abs(x - y) == 2")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((math.Util.abs((x - y))),2)))};
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:inflight absolute",new $Closure1(this,"$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:inflight absolute", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/acos.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/acos.test.w_compile_tf-aws.md
@@ -79,11 +79,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const math = $stdlib.math;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -127,7 +127,7 @@ class $Root extends $stdlib.std.Resource {
       const e = $error_e.message;
       {((cond) => {if (!cond) throw new Error("assertion failed: e == \"Input value must be between -1 and 1, inclusive.\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(e,"Input value must be between -1 and 1, inclusive.")))};
     }
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:inflight arc cosine",new $Closure1(this,"$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:inflight arc cosine", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/acot.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/acot.test.w_compile_tf-aws.md
@@ -65,11 +65,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const math = $stdlib.math;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -99,7 +99,7 @@ class $Root extends $stdlib.std.Resource {
     {((cond) => {if (!cond) throw new Error("assertion failed: math.acot(math.PI) == 0.30816907111598496")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((math.Util.acot(math.Util.PI)),0.30816907111598496)))};
     {((cond) => {if (!cond) throw new Error("assertion failed: math.acot(math.TAU) == 0.15783119028815887")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((math.Util.acot(math.Util.TAU)),0.15783119028815887)))};
     {((cond) => {if (!cond) throw new Error("assertion failed: math.acot(-0) == -1.5707963267948966")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((math.Util.acot((-0))),(-1.5707963267948966))))};
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:inflight arc cotgent",new $Closure1(this,"$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:inflight arc cotgent", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/acsc.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/acsc.test.w_compile_tf-aws.md
@@ -72,11 +72,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const math = $stdlib.math;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -113,7 +113,7 @@ class $Root extends $stdlib.std.Resource {
     {((cond) => {if (!cond) throw new Error("assertion failed: math.acsc(math.PI) == 0.3239461069319807")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((math.Util.acsc(math.Util.PI)),0.3239461069319807)))};
     {((cond) => {if (!cond) throw new Error("assertion failed: math.acsc(math.TAU) == 0.15983462638513704")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((math.Util.acsc(math.Util.TAU)),0.15983462638513704)))};
     {((cond) => {if (!cond) throw new Error("assertion failed: math.acsc(-1) == -1.5707963267948966")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((math.Util.acsc((-1))),(-1.5707963267948966))))};
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:inflight arc cosecant",new $Closure1(this,"$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:inflight arc cosecant", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/angular_conversion.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/angular_conversion.test.w_compile_tf-aws.md
@@ -72,11 +72,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const math = $stdlib.math;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -113,7 +113,7 @@ class $Root extends $stdlib.std.Resource {
     {((cond) => {if (!cond) throw new Error("assertion failed: math.round(math.radiansToDegrees(math.PI / 3)) == 60")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((math.Util.round((math.Util.radiansToDegrees((math.Util.PI / 3))))),60)))};
     {((cond) => {if (!cond) throw new Error("assertion failed: math.radiansToDegrees(math.PI / 4) == 45")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((math.Util.radiansToDegrees((math.Util.PI / 4))),45)))};
     {((cond) => {if (!cond) throw new Error("assertion failed: math.round(math.radiansToDegrees(math.PI / 6)) == 30")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((math.Util.round((math.Util.radiansToDegrees((math.Util.PI / 6))))),30)))};
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:inflight angular conversions",new $Closure1(this,"$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:inflight angular conversions", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/asec.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/asec.test.w_compile_tf-aws.md
@@ -73,11 +73,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const math = $stdlib.math;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -115,7 +115,7 @@ class $Root extends $stdlib.std.Resource {
     {((cond) => {if (!cond) throw new Error("assertion failed: math.asec(-math.PI) == 1.8947424337268775")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((math.Util.asec((-math.Util.PI))),1.8947424337268775)))};
     {((cond) => {if (!cond) throw new Error("assertion failed: math.asec(-1) == math.PI")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((math.Util.asec((-1))),math.Util.PI)))};
     {((cond) => {if (!cond) throw new Error("assertion failed: math.asec(-2) == 2.0943951023931957")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((math.Util.asec((-2))),2.0943951023931957)))};
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:inflight arc cosecant",new $Closure1(this,"$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:inflight arc cosecant", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/asin.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/asin.test.w_compile_tf-aws.md
@@ -79,11 +79,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const math = $stdlib.math;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -127,7 +127,7 @@ class $Root extends $stdlib.std.Resource {
       const e = $error_e.message;
       {((cond) => {if (!cond) throw new Error("assertion failed: e == \"Input value must be between -1 and 1, inclusive.\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(e,"Input value must be between -1 and 1, inclusive.")))};
     }
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:inflight arc sine",new $Closure1(this,"$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:inflight arc sine", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/atan.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/atan.test.w_compile_tf-aws.md
@@ -64,11 +64,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const math = $stdlib.math;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -97,7 +97,7 @@ class $Root extends $stdlib.std.Resource {
     {((cond) => {if (!cond) throw new Error("assertion failed: math.atan(-0) == -0")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((math.Util.atan((-0))),(-0))))};
     {((cond) => {if (!cond) throw new Error("assertion failed: math.atan(0) == 0")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((math.Util.atan(0)),0)))};
     {((cond) => {if (!cond) throw new Error("assertion failed: math.atan(1) == 0.7853981633974483")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((math.Util.atan(1)),0.7853981633974483)))};
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:inflight arc tangent",new $Closure1(this,"$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:inflight arc tangent", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/atan2.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/atan2.test.w_compile_tf-aws.md
@@ -11,13 +11,13 @@ module.exports = function({ $math_Util }) {
       return $obj;
     }
     async handle() {
-      {((cond) => {if (!cond) throw new Error("assertion failed: math.atan2(90, 15) == 1.4056476493802699")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $math_Util.atan2(90,15)),1.4056476493802699)))};
-      {((cond) => {if (!cond) throw new Error("assertion failed: math.atan2(15, 90) == 0.16514867741462683")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $math_Util.atan2(15,90)),0.16514867741462683)))};
-      {((cond) => {if (!cond) throw new Error("assertion failed: math.atan2(-1, -1) == -1 * math.PI * 3 / 4")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $math_Util.atan2((-1),(-1))),((((-1) * $math_Util.PI) * 3) / 4))))};
-      {((cond) => {if (!cond) throw new Error("assertion failed: math.atan2(-0, -1) == -1 * math.PI")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $math_Util.atan2((-0),(-1))),((-1) * $math_Util.PI))))};
-      {((cond) => {if (!cond) throw new Error("assertion failed: math.atan2(0, -1) == math.PI")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $math_Util.atan2(0,(-1))),$math_Util.PI)))};
-      {((cond) => {if (!cond) throw new Error("assertion failed: math.atan2(1, -1) == math.PI * 3 / 4")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $math_Util.atan2(1,(-1))),(($math_Util.PI * 3) / 4))))};
-      {((cond) => {if (!cond) throw new Error("assertion failed: math.atan2(0, 0) == 0")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $math_Util.atan2(0,0)),0)))};
+      {((cond) => {if (!cond) throw new Error("assertion failed: math.atan2(90, 15) == 1.4056476493802699")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $math_Util.atan2(90, 15)),1.4056476493802699)))};
+      {((cond) => {if (!cond) throw new Error("assertion failed: math.atan2(15, 90) == 0.16514867741462683")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $math_Util.atan2(15, 90)),0.16514867741462683)))};
+      {((cond) => {if (!cond) throw new Error("assertion failed: math.atan2(-1, -1) == -1 * math.PI * 3 / 4")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $math_Util.atan2((-1), (-1))),((((-1) * $math_Util.PI) * 3) / 4))))};
+      {((cond) => {if (!cond) throw new Error("assertion failed: math.atan2(-0, -1) == -1 * math.PI")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $math_Util.atan2((-0), (-1))),((-1) * $math_Util.PI))))};
+      {((cond) => {if (!cond) throw new Error("assertion failed: math.atan2(0, -1) == math.PI")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $math_Util.atan2(0, (-1))),$math_Util.PI)))};
+      {((cond) => {if (!cond) throw new Error("assertion failed: math.atan2(1, -1) == math.PI * 3 / 4")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $math_Util.atan2(1, (-1))),(($math_Util.PI * 3) / 4))))};
+      {((cond) => {if (!cond) throw new Error("assertion failed: math.atan2(0, 0) == 0")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $math_Util.atan2(0, 0)),0)))};
     }
   }
   return $Closure1;
@@ -67,11 +67,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const math = $stdlib.math;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -96,14 +96,14 @@ class $Root extends $stdlib.std.Resource {
         return ["handle", "$inflight_init"];
       }
     }
-    {((cond) => {if (!cond) throw new Error("assertion failed: math.atan2(90, 15) == 1.4056476493802699")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((math.Util.atan2(90,15)),1.4056476493802699)))};
-    {((cond) => {if (!cond) throw new Error("assertion failed: math.atan2(15, 90) == 0.16514867741462683")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((math.Util.atan2(15,90)),0.16514867741462683)))};
-    {((cond) => {if (!cond) throw new Error("assertion failed: math.atan2(-1, -1) == -1 * math.PI * 3 / 4")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((math.Util.atan2((-1),(-1))),((((-1) * math.Util.PI) * 3) / 4))))};
-    {((cond) => {if (!cond) throw new Error("assertion failed: math.atan2(-0, -1) == -1 * math.PI")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((math.Util.atan2((-0),(-1))),((-1) * math.Util.PI))))};
-    {((cond) => {if (!cond) throw new Error("assertion failed: math.atan2(0, -1) == math.PI")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((math.Util.atan2(0,(-1))),math.Util.PI)))};
-    {((cond) => {if (!cond) throw new Error("assertion failed: math.atan2(1, -1) == math.PI * 3 / 4")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((math.Util.atan2(1,(-1))),((math.Util.PI * 3) / 4))))};
-    {((cond) => {if (!cond) throw new Error("assertion failed: math.atan2(0, 0) == 0")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((math.Util.atan2(0,0)),0)))};
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:inflight arc tangent 2",new $Closure1(this,"$Closure1"));
+    {((cond) => {if (!cond) throw new Error("assertion failed: math.atan2(90, 15) == 1.4056476493802699")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((math.Util.atan2(90, 15)),1.4056476493802699)))};
+    {((cond) => {if (!cond) throw new Error("assertion failed: math.atan2(15, 90) == 0.16514867741462683")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((math.Util.atan2(15, 90)),0.16514867741462683)))};
+    {((cond) => {if (!cond) throw new Error("assertion failed: math.atan2(-1, -1) == -1 * math.PI * 3 / 4")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((math.Util.atan2((-1), (-1))),((((-1) * math.Util.PI) * 3) / 4))))};
+    {((cond) => {if (!cond) throw new Error("assertion failed: math.atan2(-0, -1) == -1 * math.PI")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((math.Util.atan2((-0), (-1))),((-1) * math.Util.PI))))};
+    {((cond) => {if (!cond) throw new Error("assertion failed: math.atan2(0, -1) == math.PI")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((math.Util.atan2(0, (-1))),math.Util.PI)))};
+    {((cond) => {if (!cond) throw new Error("assertion failed: math.atan2(1, -1) == math.PI * 3 / 4")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((math.Util.atan2(1, (-1))),((math.Util.PI * 3) / 4))))};
+    {((cond) => {if (!cond) throw new Error("assertion failed: math.atan2(0, 0) == 0")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((math.Util.atan2(0, 0)),0)))};
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:inflight arc tangent 2", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/combinations.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/combinations.test.w_compile_tf-aws.md
@@ -11,7 +11,7 @@ module.exports = function({ $math_Util, $population, $subset }) {
       return $obj;
     }
     async handle() {
-      {((cond) => {if (!cond) throw new Error("assertion failed: math.combinations(population, subset) == 10")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $math_Util.combinations($population,$subset)),10)))};
+      {((cond) => {if (!cond) throw new Error("assertion failed: math.combinations(population, subset) == 10")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $math_Util.combinations($population, $subset)),10)))};
     }
   }
   return $Closure1;
@@ -61,11 +61,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const math = $stdlib.math;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -101,8 +101,8 @@ class $Root extends $stdlib.std.Resource {
     }
     const population = 5;
     const subset = 3;
-    {((cond) => {if (!cond) throw new Error("assertion failed: math.combinations(population, subset) == 10")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((math.Util.combinations(population,subset)),10)))};
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:inflight combinations",new $Closure1(this,"$Closure1"));
+    {((cond) => {if (!cond) throw new Error("assertion failed: math.combinations(population, subset) == 10")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((math.Util.combinations(population, subset)),10)))};
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:inflight combinations", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/cos.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/cos.test.w_compile_tf-aws.md
@@ -66,11 +66,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const math = $stdlib.math;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -101,7 +101,7 @@ class $Root extends $stdlib.std.Resource {
     {((cond) => {if (!cond) throw new Error("assertion failed: math.cos(-5) == 0.28366218546322625")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((math.Util.cos((-5))),0.28366218546322625)))};
     {((cond) => {if (!cond) throw new Error("assertion failed: math.cos(math.PI) == -1")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((math.Util.cos(math.Util.PI)),(-1))))};
     {((cond) => {if (!cond) throw new Error("assertion failed: math.cos(math.PI * 2) == 1")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((math.Util.cos((math.Util.PI * 2))),1)))};
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:inflight cosine",new $Closure1(this,"$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:inflight cosine", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/cot.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/cot.test.w_compile_tf-aws.md
@@ -64,11 +64,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const math = $stdlib.math;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -97,7 +97,7 @@ class $Root extends $stdlib.std.Resource {
     {((cond) => {if (!cond) throw new Error("assertion failed: math.round(math.cot(math.PI / 4)) == 1")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((math.Util.round((math.Util.cot((math.Util.PI / 4))))),1)))};
     {((cond) => {if (!cond) throw new Error("assertion failed: math.round(math.cot(math.PI * 3 / 4)) == -1")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((math.Util.round((math.Util.cot(((math.Util.PI * 3) / 4))))),(-1))))};
     {((cond) => {if (!cond) throw new Error("assertion failed: math.cot(-0) == -math.INF")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((math.Util.cot((-0))),(-math.Util.INF))))};
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:inflight cotangent",new $Closure1(this,"$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:inflight cotangent", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/csc.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/csc.test.w_compile_tf-aws.md
@@ -68,11 +68,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const math = $stdlib.math;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -105,7 +105,7 @@ class $Root extends $stdlib.std.Resource {
     {((cond) => {if (!cond) throw new Error("assertion failed: math.csc(math.TAU / 4) == 1")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((math.Util.csc((math.Util.TAU / 4))),1)))};
     {((cond) => {if (!cond) throw new Error("assertion failed: math.csc(math.PI * 3 / 2) == -1")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((math.Util.csc(((math.Util.PI * 3) / 2))),(-1))))};
     {((cond) => {if (!cond) throw new Error("assertion failed: math.csc(math.TAU * 3 / 4) == -1")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((math.Util.csc(((math.Util.TAU * 3) / 4))),(-1))))};
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:inflight cosecant",new $Closure1(this,"$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:inflight cosecant", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/euler.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/euler.test.w_compile_tf-aws.md
@@ -30,7 +30,7 @@ module.exports = function({ $compoundOneYear, $interest, $math_Util, $value }) {
       return $obj;
     }
     async handle() {
-      {((cond) => {if (!cond) throw new Error("assertion failed: math.round(compoundOneYear(interest, value), decimalPlaces: 2) == 105.13")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $math_Util.round((await $compoundOneYear($interest,$value)),{ decimalPlaces: 2 })),105.13)))};
+      {((cond) => {if (!cond) throw new Error("assertion failed: math.round(compoundOneYear(interest, value), decimalPlaces: 2) == 105.13")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $math_Util.round((await $compoundOneYear($interest, $value)), { decimalPlaces: 2 })),105.13)))};
     }
   }
   return $Closure2;
@@ -80,11 +80,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const math = $stdlib.math;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -110,8 +110,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure2 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -149,9 +149,9 @@ class $Root extends $stdlib.std.Resource {
     }
     const interest = 0.05;
     const value = 100;
-    const compoundOneYear = new $Closure1(this,"$Closure1");
-    {((cond) => {if (!cond) throw new Error("assertion failed: math.round(math.E, decimalPlaces: 3) == 2.718")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((math.Util.round(math.Util.E,{ decimalPlaces: 3 })),2.718)))};
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:EULER",new $Closure2(this,"$Closure2"));
+    const compoundOneYear = new $Closure1(this, "$Closure1");
+    {((cond) => {if (!cond) throw new Error("assertion failed: math.round(math.E, decimalPlaces: 3) == 2.718")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((math.Util.round(math.Util.E, { decimalPlaces: 3 })),2.718)))};
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:EULER", new $Closure2(this, "$Closure2"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/factorial.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/factorial.test.w_compile_tf-aws.md
@@ -66,11 +66,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const math = $stdlib.math;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -101,7 +101,7 @@ class $Root extends $stdlib.std.Resource {
     {((cond) => {if (!cond) throw new Error("assertion failed: math.factorial(3) == 6")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((math.Util.factorial(3)),6)))};
     {((cond) => {if (!cond) throw new Error("assertion failed: math.factorial(4) == 24")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((math.Util.factorial(4)),24)))};
     {((cond) => {if (!cond) throw new Error("assertion failed: math.factorial(5) == 120")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((math.Util.factorial(5)),120)))};
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:inflight factorial",new $Closure1(this,"$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:inflight factorial", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/fibonacci.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/fibonacci.test.w_compile_tf-aws.md
@@ -71,11 +71,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const math = $stdlib.math;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -111,7 +111,7 @@ class $Root extends $stdlib.std.Resource {
     {((cond) => {if (!cond) throw new Error("assertion failed: math.fibonacci(8) == 21")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((math.Util.fibonacci(8)),21)))};
     {((cond) => {if (!cond) throw new Error("assertion failed: math.fibonacci(9) == 34")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((math.Util.fibonacci(9)),34)))};
     {((cond) => {if (!cond) throw new Error("assertion failed: math.fibonacci(10) == 55")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((math.Util.fibonacci(10)),55)))};
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:inflight fibonacci",new $Closure1(this,"$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:inflight fibonacci", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/floor_ceil_round.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/floor_ceil_round.test.w_compile_tf-aws.md
@@ -17,11 +17,11 @@ module.exports = function({ $__x_, $__y_, $math_Util, $x, $y }) {
       {((cond) => {if (!cond) throw new Error("assertion failed: math.round(y) == 6")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $math_Util.round($y)),6)))};
       {((cond) => {if (!cond) throw new Error("assertion failed: math.round(-x) == -5")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $math_Util.round($__x_)),(-5))))};
       {((cond) => {if (!cond) throw new Error("assertion failed: math.round(-y) == -6")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $math_Util.round($__y_)),(-6))))};
-      {((cond) => {if (!cond) throw new Error("assertion failed: math.round(math.E, decimalPlaces: 1) == 2.7")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $math_Util.round($math_Util.E,{ decimalPlaces: 1 })),2.7)))};
-      {((cond) => {if (!cond) throw new Error("assertion failed: math.round(math.E, decimalPlaces: 2) == 2.72")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $math_Util.round($math_Util.E,{ decimalPlaces: 2 })),2.72)))};
-      {((cond) => {if (!cond) throw new Error("assertion failed: math.round(math.E, decimalPlaces: 3) == 2.718")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $math_Util.round($math_Util.E,{ decimalPlaces: 3 })),2.718)))};
-      {((cond) => {if (!cond) throw new Error("assertion failed: math.round(math.E, decimalPlaces: 4) == 2.7183")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $math_Util.round($math_Util.E,{ decimalPlaces: 4 })),2.7183)))};
-      {((cond) => {if (!cond) throw new Error("assertion failed: math.round(math.E, decimalPlaces: 5) == 2.71828")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $math_Util.round($math_Util.E,{ decimalPlaces: 5 })),2.71828)))};
+      {((cond) => {if (!cond) throw new Error("assertion failed: math.round(math.E, decimalPlaces: 1) == 2.7")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $math_Util.round($math_Util.E, { decimalPlaces: 1 })),2.7)))};
+      {((cond) => {if (!cond) throw new Error("assertion failed: math.round(math.E, decimalPlaces: 2) == 2.72")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $math_Util.round($math_Util.E, { decimalPlaces: 2 })),2.72)))};
+      {((cond) => {if (!cond) throw new Error("assertion failed: math.round(math.E, decimalPlaces: 3) == 2.718")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $math_Util.round($math_Util.E, { decimalPlaces: 3 })),2.718)))};
+      {((cond) => {if (!cond) throw new Error("assertion failed: math.round(math.E, decimalPlaces: 4) == 2.7183")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $math_Util.round($math_Util.E, { decimalPlaces: 4 })),2.7183)))};
+      {((cond) => {if (!cond) throw new Error("assertion failed: math.round(math.E, decimalPlaces: 5) == 2.71828")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $math_Util.round($math_Util.E, { decimalPlaces: 5 })),2.71828)))};
     }
   }
   return $Closure1;
@@ -71,11 +71,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const math = $stdlib.math;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -122,12 +122,12 @@ class $Root extends $stdlib.std.Resource {
     {((cond) => {if (!cond) throw new Error("assertion failed: math.round(-x) == -5")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((math.Util.round((-x))),(-5))))};
     {((cond) => {if (!cond) throw new Error("assertion failed: math.round(-y) == -6")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((math.Util.round((-y))),(-6))))};
     {((cond) => {if (!cond) throw new Error("assertion failed: math.round(math.E) == 3")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((math.Util.round(math.Util.E)),3)))};
-    {((cond) => {if (!cond) throw new Error("assertion failed: math.round(math.E, decimalPlaces: 1) == 2.7")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((math.Util.round(math.Util.E,{ decimalPlaces: 1 })),2.7)))};
-    {((cond) => {if (!cond) throw new Error("assertion failed: math.round(math.E, decimalPlaces: 2) == 2.72")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((math.Util.round(math.Util.E,{ decimalPlaces: 2 })),2.72)))};
-    {((cond) => {if (!cond) throw new Error("assertion failed: math.round(math.E, decimalPlaces: 3) == 2.718")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((math.Util.round(math.Util.E,{ decimalPlaces: 3 })),2.718)))};
-    {((cond) => {if (!cond) throw new Error("assertion failed: math.round(math.E, decimalPlaces: 4) == 2.7183")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((math.Util.round(math.Util.E,{ decimalPlaces: 4 })),2.7183)))};
-    {((cond) => {if (!cond) throw new Error("assertion failed: math.round(math.E, decimalPlaces: 5) == 2.71828")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((math.Util.round(math.Util.E,{ decimalPlaces: 5 })),2.71828)))};
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:inflight floor/ceil/round",new $Closure1(this,"$Closure1"));
+    {((cond) => {if (!cond) throw new Error("assertion failed: math.round(math.E, decimalPlaces: 1) == 2.7")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((math.Util.round(math.Util.E, { decimalPlaces: 1 })),2.7)))};
+    {((cond) => {if (!cond) throw new Error("assertion failed: math.round(math.E, decimalPlaces: 2) == 2.72")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((math.Util.round(math.Util.E, { decimalPlaces: 2 })),2.72)))};
+    {((cond) => {if (!cond) throw new Error("assertion failed: math.round(math.E, decimalPlaces: 3) == 2.718")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((math.Util.round(math.Util.E, { decimalPlaces: 3 })),2.718)))};
+    {((cond) => {if (!cond) throw new Error("assertion failed: math.round(math.E, decimalPlaces: 4) == 2.7183")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((math.Util.round(math.Util.E, { decimalPlaces: 4 })),2.7183)))};
+    {((cond) => {if (!cond) throw new Error("assertion failed: math.round(math.E, decimalPlaces: 5) == 2.71828")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((math.Util.round(math.Util.E, { decimalPlaces: 5 })),2.71828)))};
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:inflight floor/ceil/round", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/hypot.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/hypot.test.w_compile_tf-aws.md
@@ -13,7 +13,7 @@ module.exports = function({ $math_Util }) {
     async handle() {
       {((cond) => {if (!cond) throw new Error("assertion failed: math.hypot([3, 4]) == 5")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $math_Util.hypot([3, 4])),5)))};
       {((cond) => {if (!cond) throw new Error("assertion failed: math.hypot([5, 12]) == 13")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $math_Util.hypot([5, 12])),13)))};
-      {((cond) => {if (!cond) throw new Error("assertion failed: math.round(math.hypot([3, 4, 5]), decimalPlaces: 2) == 7.07")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $math_Util.round((await $math_Util.hypot([3, 4, 5])),{ decimalPlaces: 2 })),7.07)))};
+      {((cond) => {if (!cond) throw new Error("assertion failed: math.round(math.hypot([3, 4, 5]), decimalPlaces: 2) == 7.07")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $math_Util.round((await $math_Util.hypot([3, 4, 5])), { decimalPlaces: 2 })),7.07)))};
       {((cond) => {if (!cond) throw new Error("assertion failed: math.hypot([-5]) == 5")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $math_Util.hypot([(-5)])),5)))};
     }
   }
@@ -64,11 +64,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const math = $stdlib.math;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -95,9 +95,9 @@ class $Root extends $stdlib.std.Resource {
     }
     {((cond) => {if (!cond) throw new Error("assertion failed: math.hypot([3, 4]) == 5")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((math.Util.hypot([3, 4])),5)))};
     {((cond) => {if (!cond) throw new Error("assertion failed: math.hypot([5, 12]) == 13")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((math.Util.hypot([5, 12])),13)))};
-    {((cond) => {if (!cond) throw new Error("assertion failed: math.round(math.hypot([3, 4, 5]), decimalPlaces: 2) == 7.07")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((math.Util.round((math.Util.hypot([3, 4, 5])),{ decimalPlaces: 2 })),7.07)))};
+    {((cond) => {if (!cond) throw new Error("assertion failed: math.round(math.hypot([3, 4, 5]), decimalPlaces: 2) == 7.07")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((math.Util.round((math.Util.hypot([3, 4, 5])), { decimalPlaces: 2 })),7.07)))};
     {((cond) => {if (!cond) throw new Error("assertion failed: math.hypot([-5]) == 5")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((math.Util.hypot([(-5)])),5)))};
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:inflight hypot",new $Closure1(this,"$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:inflight hypot", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/median_mode_mean.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/median_mode_mean.test.w_compile_tf-aws.md
@@ -107,11 +107,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const math = $stdlib.math;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -146,8 +146,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure2 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -190,8 +190,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure3 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -227,7 +227,7 @@ class $Root extends $stdlib.std.Resource {
     {((cond) => {if (!cond) throw new Error("assertion failed: math.median(odd_arr) == 6")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((math.Util.median(odd_arr)),6)))};
     const even_arr = [1, 2, 3, 4, 5, 6, 8, 9];
     {((cond) => {if (!cond) throw new Error("assertion failed: math.median(even_arr) == 4.5")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((math.Util.median(even_arr)),4.5)))};
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:inflight median",new $Closure1(this,"$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:inflight median", new $Closure1(this, "$Closure1"));
     const modal_arr = [1, 2, 2, 3, 4, 7, 9];
     {((cond) => {if (!cond) throw new Error("assertion failed: math.mode(modal_arr).at(0) == 2")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(((math.Util.mode(modal_arr)).at(0)),2)))};
     const bimodal_arr = [1, 2, 2, 3, 4, 7, 7, 9, 7, 2];
@@ -239,12 +239,12 @@ class $Root extends $stdlib.std.Resource {
     {((cond) => {if (!cond) throw new Error("assertion failed: multimodal.at(0) == 2")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((multimodal.at(0)),2)))};
     {((cond) => {if (!cond) throw new Error("assertion failed: multimodal.at(1) == 7")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((multimodal.at(1)),7)))};
     {((cond) => {if (!cond) throw new Error("assertion failed: multimodal.at(2) == 9")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((multimodal.at(2)),9)))};
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:inflight mode",new $Closure2(this,"$Closure2"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:inflight mode", new $Closure2(this, "$Closure2"));
     const mean_arr = [4, 36, 45, 50, 75];
     {((cond) => {if (!cond) throw new Error("assertion failed: math.arithmeticMean(mean_arr) == 42")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((math.Util.arithmeticMean(mean_arr)),42)))};
     {((cond) => {if (!cond) throw new Error("assertion failed: math.geometricMean(mean_arr) == 30")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((math.Util.geometricMean(mean_arr)),30)))};
     {((cond) => {if (!cond) throw new Error("assertion failed: math.harmonicMean(mean_arr) == 15")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((math.Util.harmonicMean(mean_arr)),15)))};
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:inflight mean",new $Closure3(this,"$Closure3"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:inflight mean", new $Closure3(this, "$Closure3"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/min_max.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/min_max.test.w_compile_tf-aws.md
@@ -62,11 +62,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const math = $stdlib.math;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -101,7 +101,7 @@ class $Root extends $stdlib.std.Resource {
     const myArray = [1, 2, 3, 4, 5];
     {((cond) => {if (!cond) throw new Error("assertion failed: math.min(myArray) == 1")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((math.Util.min(myArray)),1)))};
     {((cond) => {if (!cond) throw new Error("assertion failed: math.max(myArray) == 5")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((math.Util.max(myArray)),5)))};
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:inflight min/max",new $Closure1(this,"$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:inflight min/max", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/pi.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/pi.test.w_compile_tf-aws.md
@@ -30,7 +30,7 @@ module.exports = function({ $circumference, $math_Util, $r }) {
       return $obj;
     }
     async handle() {
-      {((cond) => {if (!cond) throw new Error("assertion failed: math.round(circumference(r), decimalPlaces: 2) == 62.83")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $math_Util.round((await $circumference($r)),{ decimalPlaces: 2 })),62.83)))};
+      {((cond) => {if (!cond) throw new Error("assertion failed: math.round(circumference(r), decimalPlaces: 2) == 62.83")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $math_Util.round((await $circumference($r)), { decimalPlaces: 2 })),62.83)))};
     }
   }
   return $Closure2;
@@ -80,11 +80,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const math = $stdlib.math;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -110,8 +110,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure2 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -146,9 +146,9 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     const r = 10;
-    const circumference = new $Closure1(this,"$Closure1");
-    {((cond) => {if (!cond) throw new Error("assertion failed: math.round(math.PI, decimalPlaces: 3) == 3.142")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((math.Util.round(math.Util.PI,{ decimalPlaces: 3 })),3.142)))};
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:PI",new $Closure2(this,"$Closure2"));
+    const circumference = new $Closure1(this, "$Closure1");
+    {((cond) => {if (!cond) throw new Error("assertion failed: math.round(math.PI, decimalPlaces: 3) == 3.142")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((math.Util.round(math.Util.PI, { decimalPlaces: 3 })),3.142)))};
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:PI", new $Closure2(this, "$Closure2"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/prime.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/prime.test.w_compile_tf-aws.md
@@ -67,11 +67,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const math = $stdlib.math;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -103,7 +103,7 @@ class $Root extends $stdlib.std.Resource {
     {((cond) => {if (!cond) throw new Error("assertion failed: math.isPrime(10) == false")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((math.Util.isPrime(10)),false)))};
     {((cond) => {if (!cond) throw new Error("assertion failed: math.isPrime(11) == true")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((math.Util.isPrime(11)),true)))};
     {((cond) => {if (!cond) throw new Error("assertion failed: math.isPrime(12) == false")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((math.Util.isPrime(12)),false)))};
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:inflight prime numbers",new $Closure1(this,"$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:inflight prime numbers", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/random.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/random.test.w_compile_tf-aws.md
@@ -62,11 +62,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const math = $stdlib.math;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -93,7 +93,7 @@ class $Root extends $stdlib.std.Resource {
     }
     {((cond) => {if (!cond) throw new Error("assertion failed: math.random() >= 0")})(((math.Util.random()) >= 0))};
     {((cond) => {if (!cond) throw new Error("assertion failed: math.random() < 1")})(((math.Util.random()) < 1))};
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:inflight absolute",new $Closure1(this,"$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:inflight absolute", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/sec.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/sec.test.w_compile_tf-aws.md
@@ -66,11 +66,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const math = $stdlib.math;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -101,7 +101,7 @@ class $Root extends $stdlib.std.Resource {
     {((cond) => {if (!cond) throw new Error("assertion failed: math.sec(-5) == 3.5253200858160887")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((math.Util.sec((-5))),3.5253200858160887)))};
     {((cond) => {if (!cond) throw new Error("assertion failed: math.sec(math.PI) == -1")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((math.Util.sec(math.Util.PI)),(-1))))};
     {((cond) => {if (!cond) throw new Error("assertion failed: math.sec(math.TAU) == 1")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((math.Util.sec(math.Util.TAU)),1)))};
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:inflight secant",new $Closure1(this,"$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:inflight secant", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/sin.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/sin.test.w_compile_tf-aws.md
@@ -65,11 +65,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const math = $stdlib.math;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -99,7 +99,7 @@ class $Root extends $stdlib.std.Resource {
     {((cond) => {if (!cond) throw new Error("assertion failed: math.sin(1) == 0.8414709848078965")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((math.Util.sin(1)),0.8414709848078965)))};
     {((cond) => {if (!cond) throw new Error("assertion failed: math.sin(-5) == 0.9589242746631385")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((math.Util.sin((-5))),0.9589242746631385)))};
     {((cond) => {if (!cond) throw new Error("assertion failed: math.sin(math.PI / 2) == 1")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((math.Util.sin((math.Util.PI / 2))),1)))};
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:inflight sine",new $Closure1(this,"$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:inflight sine", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/sqrt.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/sqrt.test.w_compile_tf-aws.md
@@ -73,11 +73,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const math = $stdlib.math;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -115,7 +115,7 @@ class $Root extends $stdlib.std.Resource {
     {((cond) => {if (!cond) throw new Error("assertion failed: math.sqrt(2) == 1.4142135623730951")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((math.Util.sqrt(2)),1.4142135623730951)))};
     {((cond) => {if (!cond) throw new Error("assertion failed: math.sqrt(9) == 3")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((math.Util.sqrt(9)),3)))};
     {((cond) => {if (!cond) throw new Error("assertion failed: math.sqrt(math.INF) == math.INF")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((math.Util.sqrt(math.Util.INF)),math.Util.INF)))};
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:inflight square root",new $Closure1(this,"$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:inflight square root", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/tan.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/tan.test.w_compile_tf-aws.md
@@ -64,11 +64,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const math = $stdlib.math;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -97,7 +97,7 @@ class $Root extends $stdlib.std.Resource {
     {((cond) => {if (!cond) throw new Error("assertion failed: math.tan(0) == 0")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((math.Util.tan(0)),0)))};
     {((cond) => {if (!cond) throw new Error("assertion failed: math.tan(1) == 1.5574077246549023")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((math.Util.tan(1)),1.5574077246549023)))};
     {((cond) => {if (!cond) throw new Error("assertion failed: math.tan(math.PI / 4) == 0.9999999999999999")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((math.Util.tan((math.Util.PI / 4))),0.9999999999999999)))};
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:inflight tangent",new $Closure1(this,"$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:inflight tangent", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/tau.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/math/tau.test.w_compile_tf-aws.md
@@ -64,11 +64,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const math = $stdlib.math;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -97,7 +97,7 @@ class $Root extends $stdlib.std.Resource {
     {((cond) => {if (!cond) throw new Error("assertion failed: math.TAU / 2 == math.PI")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((math.Util.TAU / 2),math.Util.PI)))};
     {((cond) => {if (!cond) throw new Error("assertion failed: math.TAU * 3 / 4 == math.PI * 3 / 2")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(((math.Util.TAU * 3) / 4),((math.Util.PI * 3) / 2))))};
     {((cond) => {if (!cond) throw new Error("assertion failed: math.TAU == math.PI * 2")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(math.Util.TAU,(math.Util.PI * 2))))};
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:TAU",new $Closure1(this,"$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:TAU", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/on_deploy/execute_after.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/on_deploy/execute_after.test.w_compile_tf-aws.md
@@ -337,11 +337,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -373,8 +373,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure2 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -406,8 +406,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure3 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -438,10 +438,10 @@ class $Root extends $stdlib.std.Resource {
         super._registerOnLift(host, ops);
       }
     }
-    const counter = this.node.root.newAbstract("@winglang/sdk.cloud.Counter",this,"cloud.Counter");
-    const init1 = this.node.root.newAbstract("@winglang/sdk.cloud.OnDeploy",this,"init1",new $Closure1(this,"$Closure1"));
-    const init2 = this.node.root.newAbstract("@winglang/sdk.cloud.OnDeploy",this,"init2",new $Closure2(this,"$Closure2"),{ executeAfter: [init1] });
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:counter",new $Closure3(this,"$Closure3"));
+    const counter = this.node.root.newAbstract("@winglang/sdk.cloud.Counter",this, "cloud.Counter");
+    const init1 = this.node.root.newAbstract("@winglang/sdk.cloud.OnDeploy",this, "init1", new $Closure1(this, "$Closure1"));
+    const init2 = this.node.root.newAbstract("@winglang/sdk.cloud.OnDeploy",this, "init2", new $Closure2(this, "$Closure2"), { executeAfter: [init1] });
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:counter", new $Closure3(this, "$Closure3"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/queue/pop.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/queue/pop.test.w_compile_tf-aws.md
@@ -11,7 +11,7 @@ module.exports = function({ $q, $timeout, $util_Util }) {
       return $obj;
     }
     async handle() {
-      (await $q.push("Foo","Bar"));
+      (await $q.push("Foo", "Bar"));
       const first = (await $q.pop());
       const second = (await $q.pop());
       (await $util_Util.sleep($timeout));
@@ -84,11 +84,11 @@ const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 const util = $stdlib.util;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -123,8 +123,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     const timeout = (std.Duration.fromSeconds(3));
-    const q = this.node.root.newAbstract("@winglang/sdk.cloud.Queue",this,"cloud.Queue",{ timeout: timeout });
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:pop",new $Closure1(this,"$Closure1"));
+    const q = this.node.root.newAbstract("@winglang/sdk.cloud.Queue",this, "cloud.Queue", { timeout: timeout });
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:pop", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/queue/purge.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/queue/purge.test.w_compile_tf-aws.md
@@ -100,11 +100,11 @@ const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 const util = $stdlib.util;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -137,8 +137,8 @@ class $Root extends $stdlib.std.Resource {
         super._registerOnLift(host, ops);
       }
     }
-    const q = this.node.root.newAbstract("@winglang/sdk.cloud.Queue",this,"cloud.Queue");
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:purge",new $Closure1(this,"$Closure1"));
+    const q = this.node.root.newAbstract("@winglang/sdk.cloud.Queue",this, "cloud.Queue");
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:purge", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/queue/push.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/queue/push.test.w_compile_tf-aws.md
@@ -21,7 +21,7 @@ module.exports = function({ $q, $std_Duration, $util_Util }) {
         {((cond) => {if (!cond) throw new Error("assertion failed: e == \"Empty messages are not allowed\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(e,"Empty messages are not allowed")))};
       }
       try {
-        (await $q.push("Foo",""));
+        (await $q.push("Foo", ""));
         {((cond) => {if (!cond) throw new Error("assertion failed: false")})(false)};
       }
       catch ($error_e) {
@@ -34,14 +34,14 @@ module.exports = function({ $q, $std_Duration, $util_Util }) {
       }
       )))};
       (await $q.pop());
-      (await $q.push("Bar","Baz"));
+      (await $q.push("Bar", "Baz"));
       {((cond) => {if (!cond) throw new Error("assertion failed: util.waitUntil((): bool => {\n    return q.approxSize() == 2;\n  })")})((await $util_Util.waitUntil(async () => {
         return (((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $q.approxSize()),2));
       }
       )))};
       (await $q.purge());
       (await $util_Util.sleep((await $std_Duration.fromSeconds(60))));
-      (await $q.push("123","\r",String.raw({ raw: ["", ""] }, JSON.stringify(obj))));
+      (await $q.push("123", "\r", String.raw({ raw: ["", ""] }, JSON.stringify(obj))));
       {((cond) => {if (!cond) throw new Error("assertion failed: util.waitUntil((): bool => {\n    return q.approxSize() == 3;\n  })")})((await $util_Util.waitUntil(async () => {
         return (((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $q.approxSize()),3));
       }
@@ -111,11 +111,11 @@ const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 const util = $stdlib.util;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -148,8 +148,8 @@ class $Root extends $stdlib.std.Resource {
         super._registerOnLift(host, ops);
       }
     }
-    const q = this.node.root.newAbstract("@winglang/sdk.cloud.Queue",this,"cloud.Queue");
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"push",new $Closure1(this,"$Closure1"),({"timeout": (std.Duration.fromSeconds(180))}));
+    const q = this.node.root.newAbstract("@winglang/sdk.cloud.Queue",this, "cloud.Queue");
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "push", new $Closure1(this, "$Closure1"), ({"timeout": (std.Duration.fromSeconds(180))}));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/queue/retention_period.main.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/queue/retention_period.main.w_compile_tf-aws.md
@@ -11,7 +11,7 @@ module.exports = function({ $q, $retentionPeriod, $util_Util }) {
       return $obj;
     }
     async handle() {
-      (await $q.push("hello","world"));
+      (await $q.push("hello", "world"));
       (await $util_Util.sleep($retentionPeriod));
       {((cond) => {if (!cond) throw new Error("assertion failed: util.waitUntil(() => {\n    return q.approxSize() == 0;\n  })")})((await $util_Util.waitUntil(async () => {
         return (((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $q.approxSize()),0));
@@ -82,11 +82,11 @@ const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 const util = $stdlib.util;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -122,8 +122,8 @@ class $Root extends $stdlib.std.Resource {
     }
     let timeout = (std.Duration.fromSeconds(30));
     let retentionPeriod = (std.Duration.fromSeconds(60));
-    const q = this.node.root.newAbstract("@winglang/sdk.cloud.Queue",this,"cloud.Queue",{ timeout: timeout, retentionPeriod: retentionPeriod });
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"retentionPeriod",new $Closure1(this,"$Closure1"),{ timeout: (std.Duration.fromSeconds(120)) });
+    const q = this.node.root.newAbstract("@winglang/sdk.cloud.Queue",this, "cloud.Queue", { timeout: timeout, retentionPeriod: retentionPeriod });
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "retentionPeriod", new $Closure1(this, "$Closure1"), { timeout: (std.Duration.fromSeconds(120)) });
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/queue/set_consumer.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/queue/set_consumer.test.w_compile_tf-aws.md
@@ -259,11 +259,11 @@ const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 const util = $stdlib.util;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class Predicate extends $stdlib.std.Resource {
-      constructor(scope, id, c) {
-        super(scope, id);
+      constructor($scope, $id, c) {
+        super($scope, $id);
         this.c = c;
       }
       static _toInflightType(context) {
@@ -298,8 +298,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -331,8 +331,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure2 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -367,11 +367,11 @@ class $Root extends $stdlib.std.Resource {
         super._registerOnLift(host, ops);
       }
     }
-    const q = this.node.root.newAbstract("@winglang/sdk.cloud.Queue",this,"cloud.Queue");
-    const c = this.node.root.newAbstract("@winglang/sdk.cloud.Counter",this,"cloud.Counter");
-    (q.setConsumer(new $Closure1(this,"$Closure1")));
-    const predicate = new Predicate(this,"Predicate",c);
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:setConsumer",new $Closure2(this,"$Closure2"));
+    const q = this.node.root.newAbstract("@winglang/sdk.cloud.Queue",this, "cloud.Queue");
+    const c = this.node.root.newAbstract("@winglang/sdk.cloud.Counter",this, "cloud.Counter");
+    (q.setConsumer(new $Closure1(this, "$Closure1")));
+    const predicate = new Predicate(this, "Predicate", c);
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:setConsumer", new $Closure2(this, "$Closure2"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/regex/match.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/regex/match.test.w_compile_tf-aws.md
@@ -11,16 +11,16 @@ module.exports = function({ $regex_Util }) {
       return $obj;
     }
     async handle() {
-      const matches1 = (await $regex_Util.match("p[a-z]+ch","peach"));
-      const matches2 = (await $regex_Util.match("[0-9]+","0923"));
-      const matches3 = (await $regex_Util.match("[0-9]+","0a923"));
-      const matches4 = (await $regex_Util.match("^([a-zA-Z0-9_.-]+)@[a-z]+.[a-z]+\$","james_bond007@wing.com"));
-      const matches5 = (await $regex_Util.match("p([a-z]+)ch","leach"));
-      const matches6 = (await $regex_Util.match("^([a-zA-Z0-9_.-]+)@[a-z]+.[a-z]+","@james_bond007@gmail.com"));
-      const matches7 = (await $regex_Util.match("^Mary","Mary had a little lamb"));
-      const matches8 = (await $regex_Util.match("lamb\$","Mary had a little lamb"));
-      const matches9 = (await $regex_Util.match("lamb\$","Mary had a little hamb"));
-      const matches10 = (await $regex_Util.match("^([a-zA-Z0-9_.-]+)@[a-z]+.[a-z]+\$","james_bond007@gmail.com123"));
+      const matches1 = (await $regex_Util.match("p[a-z]+ch", "peach"));
+      const matches2 = (await $regex_Util.match("[0-9]+", "0923"));
+      const matches3 = (await $regex_Util.match("[0-9]+", "0a923"));
+      const matches4 = (await $regex_Util.match("^([a-zA-Z0-9_.-]+)@[a-z]+.[a-z]+\$", "james_bond007@wing.com"));
+      const matches5 = (await $regex_Util.match("p([a-z]+)ch", "leach"));
+      const matches6 = (await $regex_Util.match("^([a-zA-Z0-9_.-]+)@[a-z]+.[a-z]+", "@james_bond007@gmail.com"));
+      const matches7 = (await $regex_Util.match("^Mary", "Mary had a little lamb"));
+      const matches8 = (await $regex_Util.match("lamb\$", "Mary had a little lamb"));
+      const matches9 = (await $regex_Util.match("lamb\$", "Mary had a little hamb"));
+      const matches10 = (await $regex_Util.match("^([a-zA-Z0-9_.-]+)@[a-z]+.[a-z]+\$", "james_bond007@gmail.com123"));
       {((cond) => {if (!cond) throw new Error("assertion failed: matches1 == true ")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(matches1,true)))};
       {((cond) => {if (!cond) throw new Error("assertion failed: matches2 == true ")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(matches2,true)))};
       {((cond) => {if (!cond) throw new Error("assertion failed: matches3 == true ")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(matches3,true)))};
@@ -80,11 +80,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const regex = $stdlib.regex;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -109,16 +109,16 @@ class $Root extends $stdlib.std.Resource {
         return ["handle", "$inflight_init"];
       }
     }
-    const matches1 = (regex.Util.match("p[a-z]+ch","peach"));
-    const matches2 = (regex.Util.match("[0-9]+","0923"));
-    const matches3 = (regex.Util.match("[0-9]+","0a923"));
-    const matches4 = (regex.Util.match("^([a-zA-Z0-9_.-]+)@[a-z]+.[a-z]+\$","james_bond007@wing.com"));
-    const matches5 = (regex.Util.match("p([a-z]+)ch","leach"));
-    const matches6 = (regex.Util.match("^([a-zA-Z0-9_.-]+)@[a-z]+.[a-z]+","@james_bond007@gmail.com"));
-    const matches7 = (regex.Util.match("^Mary","Mary had a little lamb"));
-    const matches8 = (regex.Util.match("lamb\$","Mary had a little lamb"));
-    const matches9 = (regex.Util.match("lamb\$","Mary had a little hamb"));
-    const matches10 = (regex.Util.match("^([a-zA-Z0-9_.-]+)@[a-z]+.[a-z]+\$","james_bond007@gmail.com123"));
+    const matches1 = (regex.Util.match("p[a-z]+ch", "peach"));
+    const matches2 = (regex.Util.match("[0-9]+", "0923"));
+    const matches3 = (regex.Util.match("[0-9]+", "0a923"));
+    const matches4 = (regex.Util.match("^([a-zA-Z0-9_.-]+)@[a-z]+.[a-z]+\$", "james_bond007@wing.com"));
+    const matches5 = (regex.Util.match("p([a-z]+)ch", "leach"));
+    const matches6 = (regex.Util.match("^([a-zA-Z0-9_.-]+)@[a-z]+.[a-z]+", "@james_bond007@gmail.com"));
+    const matches7 = (regex.Util.match("^Mary", "Mary had a little lamb"));
+    const matches8 = (regex.Util.match("lamb\$", "Mary had a little lamb"));
+    const matches9 = (regex.Util.match("lamb\$", "Mary had a little hamb"));
+    const matches10 = (regex.Util.match("^([a-zA-Z0-9_.-]+)@[a-z]+.[a-z]+\$", "james_bond007@gmail.com123"));
     {((cond) => {if (!cond) throw new Error("assertion failed: matches1 == true ")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(matches1,true)))};
     {((cond) => {if (!cond) throw new Error("assertion failed: matches2 == true ")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(matches2,true)))};
     {((cond) => {if (!cond) throw new Error("assertion failed: matches3 == true ")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(matches3,true)))};
@@ -129,7 +129,7 @@ class $Root extends $stdlib.std.Resource {
     {((cond) => {if (!cond) throw new Error("assertion failed: matches8 == true ")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(matches8,true)))};
     {((cond) => {if (!cond) throw new Error("assertion failed: matches9 == false")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(matches9,false)))};
     {((cond) => {if (!cond) throw new Error("assertion failed: matches10 == false")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(matches10,false)))};
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:inflight match",new $Closure1(this,"$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:inflight match", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/schedule/on_tick.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/schedule/on_tick.test.w_compile_tf-aws.md
@@ -397,11 +397,11 @@ const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 const util = $stdlib.util;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -433,8 +433,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure2 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -466,8 +466,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure3 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -502,13 +502,13 @@ class $Root extends $stdlib.std.Resource {
         super._registerOnLift(host, ops);
       }
     }
-    const from_cron = this.node.root.newAbstract("@winglang/sdk.cloud.Schedule",this,"from_cron",{ cron: "* * * * ?" });
-    const from_rate = this.node.root.newAbstract("@winglang/sdk.cloud.Schedule",this,"from_rate",{ rate: (std.Duration.fromSeconds(60)) });
-    const c1 = this.node.root.newAbstract("@winglang/sdk.cloud.Counter",this,"c1");
-    const c2 = this.node.root.newAbstract("@winglang/sdk.cloud.Counter",this,"c2");
-    (from_cron.onTick(new $Closure1(this,"$Closure1")));
-    (from_rate.onTick(new $Closure2(this,"$Closure2")));
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"on tick is called both for rate and cron schedules",new $Closure3(this,"$Closure3"),({"timeout": (std.Duration.fromSeconds(120))}));
+    const from_cron = this.node.root.newAbstract("@winglang/sdk.cloud.Schedule",this, "from_cron", { cron: "* * * * ?" });
+    const from_rate = this.node.root.newAbstract("@winglang/sdk.cloud.Schedule",this, "from_rate", { rate: (std.Duration.fromSeconds(60)) });
+    const c1 = this.node.root.newAbstract("@winglang/sdk.cloud.Counter",this, "c1");
+    const c2 = this.node.root.newAbstract("@winglang/sdk.cloud.Counter",this, "c2");
+    (from_cron.onTick(new $Closure1(this, "$Closure1")));
+    (from_rate.onTick(new $Closure2(this, "$Closure2")));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "on tick is called both for rate and cron schedules", new $Closure3(this, "$Closure3"), ({"timeout": (std.Duration.fromSeconds(120))}));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/service/callbacks.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/service/callbacks.test.w_compile_tf-aws.md
@@ -11,10 +11,10 @@ module.exports = function({ $b, $startCounter, $started, $status, $stopped }) {
       return $obj;
     }
     async handle() {
-      (await $b.put($status,$started));
+      (await $b.put($status, $started));
       (await $startCounter.inc());
       return async () => {
-        (await $b.put($status,$stopped));
+        (await $b.put($status, $stopped));
         (await $startCounter.dec());
       }
       ;
@@ -138,17 +138,17 @@ const cloud = $stdlib.cloud;
 const util = $stdlib.util;
 const http = $stdlib.http;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     if ((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((util.Util.env("WING_TARGET")),"sim"))) {
-      const b = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this,"cloud.Bucket");
-      const startCounter = this.node.root.newAbstract("@winglang/sdk.cloud.Counter",this,"cloud.Counter");
+      const b = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this, "cloud.Bucket");
+      const startCounter = this.node.root.newAbstract("@winglang/sdk.cloud.Counter",this, "cloud.Counter");
       const status = "status";
       const started = "started";
       const stopped = "stopped";
       class $Closure1 extends $stdlib.std.Resource {
-        constructor(scope, id, ) {
-          super(scope, id);
+        constructor($scope, $id, ) {
+          super($scope, $id);
           (std.Node.of(this)).hidden = true;
         }
         static _toInflightType(context) {
@@ -187,10 +187,10 @@ class $Root extends $stdlib.std.Resource {
           super._registerOnLift(host, ops);
         }
       }
-      const s = this.node.root.newAbstract("@winglang/sdk.cloud.Service",this,"cloud.Service",new $Closure1(this,"$Closure1"),{ autoStart: false });
+      const s = this.node.root.newAbstract("@winglang/sdk.cloud.Service",this, "cloud.Service", new $Closure1(this, "$Closure1"), { autoStart: false });
       class $Closure2 extends $stdlib.std.Resource {
-        constructor(scope, id, ) {
-          super(scope, id);
+        constructor($scope, $id, ) {
+          super($scope, $id);
           (std.Node.of(this)).hidden = true;
         }
         static _toInflightType(context) {
@@ -223,10 +223,10 @@ class $Root extends $stdlib.std.Resource {
           super._registerOnLift(host, ops);
         }
       }
-      this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:does not start automatically if autoStart is false",new $Closure2(this,"$Closure2"));
+      this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:does not start automatically if autoStart is false", new $Closure2(this, "$Closure2"));
       class $Closure3 extends $stdlib.std.Resource {
-        constructor(scope, id, ) {
-          super(scope, id);
+        constructor($scope, $id, ) {
+          super($scope, $id);
           (std.Node.of(this)).hidden = true;
         }
         static _toInflightType(context) {
@@ -265,10 +265,10 @@ class $Root extends $stdlib.std.Resource {
           super._registerOnLift(host, ops);
         }
       }
-      this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:start() calls onStart() idempotently",new $Closure3(this,"$Closure3"));
+      this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:start() calls onStart() idempotently", new $Closure3(this, "$Closure3"));
       class $Closure4 extends $stdlib.std.Resource {
-        constructor(scope, id, ) {
-          super(scope, id);
+        constructor($scope, $id, ) {
+          super($scope, $id);
           (std.Node.of(this)).hidden = true;
         }
         static _toInflightType(context) {
@@ -307,7 +307,7 @@ class $Root extends $stdlib.std.Resource {
           super._registerOnLift(host, ops);
         }
       }
-      this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:stop() calls onStop()",new $Closure4(this,"$Closure4"));
+      this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:stop() calls onStop()", new $Closure4(this, "$Closure4"));
     }
   }
 }

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/service/http-server.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/service/http-server.test.w_compile_tf-aws.md
@@ -15,7 +15,7 @@ module.exports = function({ $MyService, $__parent_this_1_b, $__parent_this_1_bod
       const server = (await $MyService.createServer($__parent_this_1_body));
       const port = (await server.address()).port;
       {console.log(String.raw({ raw: ["listening on port ", ""] }, port))};
-      (await $__parent_this_1_b.put("port",String.raw({ raw: ["", ""] }, port)));
+      (await $__parent_this_1_b.put("port", String.raw({ raw: ["", ""] }, port)));
       return async () => {
         {console.log("closing server...")};
         (await server.close());
@@ -142,18 +142,18 @@ const cloud = $stdlib.cloud;
 const util = $stdlib.util;
 const http = $stdlib.http;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     if ((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((util.Util.env("WING_TARGET")),"sim"))) {
       class MyService extends $stdlib.std.Resource {
-        constructor(scope, id, body) {
-          super(scope, id);
-          this.b = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this,"cloud.Bucket");
+        constructor($scope, $id, body) {
+          super($scope, $id);
+          this.b = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this, "cloud.Bucket");
           this.body = body;
           const __parent_this_1 = this;
           class $Closure1 extends $stdlib.std.Resource {
-            constructor(scope, id, ) {
-              super(scope, id);
+            constructor($scope, $id, ) {
+              super($scope, $id);
               (std.Node.of(this)).hidden = true;
             }
             static _toInflightType(context) {
@@ -188,7 +188,7 @@ class $Root extends $stdlib.std.Resource {
               super._registerOnLift(host, ops);
             }
           }
-          this.s = this.node.root.newAbstract("@winglang/sdk.cloud.Service",this,"cloud.Service",new $Closure1(this,"$Closure1"));
+          this.s = this.node.root.newAbstract("@winglang/sdk.cloud.Service",this, "cloud.Service", new $Closure1(this, "$Closure1"));
         }
         static _toInflightType(context) {
           return `
@@ -222,10 +222,10 @@ class $Root extends $stdlib.std.Resource {
           super._registerOnLift(host, ops);
         }
       }
-      const foo = new MyService(this,"MyService","bang bang!");
+      const foo = new MyService(this, "MyService", "bang bang!");
       class $Closure2 extends $stdlib.std.Resource {
-        constructor(scope, id, ) {
-          super(scope, id);
+        constructor($scope, $id, ) {
+          super($scope, $id);
           (std.Node.of(this)).hidden = true;
         }
         static _toInflightType(context) {
@@ -257,10 +257,10 @@ class $Root extends $stdlib.std.Resource {
           super._registerOnLift(host, ops);
         }
       }
-      this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:http server is started with the service",new $Closure2(this,"$Closure2"));
+      this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:http server is started with the service", new $Closure2(this, "$Closure2"));
       class $Closure3 extends $stdlib.std.Resource {
-        constructor(scope, id, ) {
-          super(scope, id);
+        constructor($scope, $id, ) {
+          super($scope, $id);
           (std.Node.of(this)).hidden = true;
         }
         static _toInflightType(context) {
@@ -294,7 +294,7 @@ class $Root extends $stdlib.std.Resource {
           super._registerOnLift(host, ops);
         }
       }
-      this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:service.stop() closes the http server",new $Closure3(this,"$Closure3"));
+      this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:service.stop() closes the http server", new $Closure3(this, "$Closure3"));
     }
   }
 }

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/service/minimal.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/service/minimal.test.w_compile_tf-aws.md
@@ -87,12 +87,12 @@ const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 const util = $stdlib.util;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     if ((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((util.Util.env("WING_TARGET")),"sim"))) {
       class $Closure1 extends $stdlib.std.Resource {
-        constructor(scope, id, ) {
-          super(scope, id);
+        constructor($scope, $id, ) {
+          super($scope, $id);
           (std.Node.of(this)).hidden = true;
         }
         static _toInflightType(context) {
@@ -116,10 +116,10 @@ class $Root extends $stdlib.std.Resource {
           return ["handle", "$inflight_init"];
         }
       }
-      const s = this.node.root.newAbstract("@winglang/sdk.cloud.Service",this,"cloud.Service",new $Closure1(this,"$Closure1"));
+      const s = this.node.root.newAbstract("@winglang/sdk.cloud.Service",this, "cloud.Service", new $Closure1(this, "$Closure1"));
       class $Closure2 extends $stdlib.std.Resource {
-        constructor(scope, id, ) {
-          super(scope, id);
+        constructor($scope, $id, ) {
+          super($scope, $id);
           (std.Node.of(this)).hidden = true;
         }
         static _toInflightType(context) {
@@ -150,7 +150,7 @@ class $Root extends $stdlib.std.Resource {
           super._registerOnLift(host, ops);
         }
       }
-      this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:start and stop",new $Closure2(this,"$Closure2"));
+      this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:start and stop", new $Closure2(this, "$Closure2"));
     }
   }
 }

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/service/stateful.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/service/stateful.test.w_compile_tf-aws.md
@@ -13,7 +13,7 @@ module.exports = function({ $__parent_this_1_b, $std_Duration, $util_Util }) {
     async handle() {
       {console.log("starting service")};
       (await $util_Util.sleep((await $std_Duration.fromSeconds(1))));
-      (await $__parent_this_1_b.put("ready","true"));
+      (await $__parent_this_1_b.put("ready", "true"));
       const state = 456;
       return async () => {
         {console.log("stopping service")};
@@ -111,18 +111,18 @@ const cloud = $stdlib.cloud;
 const util = $stdlib.util;
 const http = $stdlib.http;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     if ((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((util.Util.env("WING_TARGET")),"sim"))) {
       class MyService extends $stdlib.std.Resource {
-        constructor(scope, id, body) {
-          super(scope, id);
-          this.b = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this,"cloud.Bucket");
+        constructor($scope, $id, body) {
+          super($scope, $id);
+          this.b = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this, "cloud.Bucket");
           this.body = body;
           const __parent_this_1 = this;
           class $Closure1 extends $stdlib.std.Resource {
-            constructor(scope, id, ) {
-              super(scope, id);
+            constructor($scope, $id, ) {
+              super($scope, $id);
               (std.Node.of(this)).hidden = true;
             }
             static _toInflightType(context) {
@@ -155,7 +155,7 @@ class $Root extends $stdlib.std.Resource {
               super._registerOnLift(host, ops);
             }
           }
-          this.s = this.node.root.newAbstract("@winglang/sdk.cloud.Service",this,"cloud.Service",new $Closure1(this,"$Closure1"));
+          this.s = this.node.root.newAbstract("@winglang/sdk.cloud.Service",this, "cloud.Service", new $Closure1(this, "$Closure1"));
         }
         static _toInflightType(context) {
           return `
@@ -192,10 +192,10 @@ class $Root extends $stdlib.std.Resource {
           super._registerOnLift(host, ops);
         }
       }
-      const foo = new MyService(this,"MyService","bang bang!");
+      const foo = new MyService(this, "MyService", "bang bang!");
       class $Closure2 extends $stdlib.std.Resource {
-        constructor(scope, id, ) {
-          super(scope, id);
+        constructor($scope, $id, ) {
+          super($scope, $id);
           (std.Node.of(this)).hidden = true;
         }
         static _toInflightType(context) {
@@ -226,7 +226,7 @@ class $Root extends $stdlib.std.Resource {
           super._registerOnLift(host, ops);
         }
       }
-      this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:service is ready only after onStart finishes",new $Closure2(this,"$Closure2"));
+      this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:service is ready only after onStart finishes", new $Closure2(this, "$Closure2"));
     }
   }
 }

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/service/tokens.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/service/tokens.test.w_compile_tf-aws.md
@@ -31,7 +31,7 @@ module.exports = function({ $api_url, $b, $http_Util }) {
     }
     async handle() {
       const result = (await $http_Util.get($api_url));
-      (await $b.put("service.txt",(result.body ?? "")));
+      (await $b.put("service.txt", (result.body ?? "")));
     }
   }
   return $Closure2;
@@ -106,14 +106,14 @@ const cloud = $stdlib.cloud;
 const util = $stdlib.util;
 const http = $stdlib.http;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     if ((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((util.Util.env("WING_TARGET")),"sim"))) {
-      const b = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this,"cloud.Bucket");
-      const api = this.node.root.newAbstract("@winglang/sdk.cloud.Api",this,"cloud.Api");
+      const b = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this, "cloud.Bucket");
+      const api = this.node.root.newAbstract("@winglang/sdk.cloud.Api",this, "cloud.Api");
       class $Closure1 extends $stdlib.std.Resource {
-        constructor(scope, id, ) {
-          super(scope, id);
+        constructor($scope, $id, ) {
+          super($scope, $id);
           (std.Node.of(this)).hidden = true;
         }
         static _toInflightType(context) {
@@ -137,10 +137,10 @@ class $Root extends $stdlib.std.Resource {
           return ["handle", "$inflight_init"];
         }
       }
-      (api.get("/",new $Closure1(this,"$Closure1")));
+      (api.get("/", new $Closure1(this, "$Closure1")));
       class $Closure2 extends $stdlib.std.Resource {
-        constructor(scope, id, ) {
-          super(scope, id);
+        constructor($scope, $id, ) {
+          super($scope, $id);
           (std.Node.of(this)).hidden = true;
         }
         static _toInflightType(context) {
@@ -174,10 +174,10 @@ class $Root extends $stdlib.std.Resource {
           super._registerOnLift(host, ops);
         }
       }
-      const s = this.node.root.newAbstract("@winglang/sdk.cloud.Service",this,"cloud.Service",new $Closure2(this,"$Closure2"));
+      const s = this.node.root.newAbstract("@winglang/sdk.cloud.Service",this, "cloud.Service", new $Closure2(this, "$Closure2"));
       class $Closure3 extends $stdlib.std.Resource {
-        constructor(scope, id, ) {
-          super(scope, id);
+        constructor($scope, $id, ) {
+          super($scope, $id);
           (std.Node.of(this)).hidden = true;
         }
         static _toInflightType(context) {
@@ -209,7 +209,7 @@ class $Root extends $stdlib.std.Resource {
           super._registerOnLift(host, ops);
         }
       }
-      this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:will bind and use tokens",new $Closure3(this,"$Closure3"));
+      this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:will bind and use tokens", new $Closure3(this, "$Closure3"));
     }
   }
 }

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/state/get.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/state/get.test.w_compile_tf-aws.md
@@ -11,7 +11,7 @@ module.exports = function({ $__parent_this_1_startTimeKey, $__parent_this_1_stat
       return $obj;
     }
     async handle() {
-      (await $__parent_this_1_state.set($__parent_this_1_startTimeKey,"2023-10-16T20:47:39.511Z"));
+      (await $__parent_this_1_state.set($__parent_this_1_startTimeKey, "2023-10-16T20:47:39.511Z"));
     }
   }
   return $Closure1;
@@ -120,13 +120,13 @@ const std = $stdlib.std;
 const my = require("./preflight.myservice-1.js")({ $stdlib });
 const util = $stdlib.util;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     if ((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((util.Util.env("WING_TARGET")),"sim"))) {
-      const svc = new my.MyService(this,"my.MyService");
+      const svc = new my.MyService(this, "my.MyService");
       class $Closure1 extends $stdlib.std.Resource {
-        constructor(scope, id, ) {
-          super(scope, id);
+        constructor($scope, $id, ) {
+          super($scope, $id);
           (std.Node.of(this)).hidden = true;
         }
         static _toInflightType(context) {
@@ -159,10 +159,10 @@ class $Root extends $stdlib.std.Resource {
           super._registerOnLift(host, ops);
         }
       }
-      this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:state.get() returns the runtime value",new $Closure1(this,"$Closure1"));
+      this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:state.get() returns the runtime value", new $Closure1(this, "$Closure1"));
       class $Closure2 extends $stdlib.std.Resource {
-        constructor(scope, id, ) {
-          super(scope, id);
+        constructor($scope, $id, ) {
+          super($scope, $id);
           (std.Node.of(this)).hidden = true;
         }
         static _toInflightType(context) {
@@ -193,7 +193,7 @@ class $Root extends $stdlib.std.Resource {
           super._registerOnLift(host, ops);
         }
       }
-      this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:state.tryGet() return nil if there is no value",new $Closure2(this,"$Closure2"));
+      this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:state.tryGet() return nil if there is no value", new $Closure2(this, "$Closure2"));
     }
   }
 }
@@ -211,14 +211,14 @@ module.exports = function({ $stdlib }) {
   const cloud = $stdlib.cloud;
   const util = $stdlib.util;
   class MyService extends $stdlib.std.Resource {
-    constructor(scope, id, ) {
-      super(scope, id);
-      this.state = this.node.root.new("@winglang/sdk.sim.State",sim.State,this,"sim.State");
+    constructor($scope, $id, ) {
+      super($scope, $id);
+      this.state = this.node.root.new("@winglang/sdk.sim.State",sim.State,this, "sim.State");
       this.startTimeKey = "start_time";
       const __parent_this_1 = this;
       class $Closure1 extends $stdlib.std.Resource {
-        constructor(scope, id, ) {
-          super(scope, id);
+        constructor($scope, $id, ) {
+          super($scope, $id);
           (std.Node.of(this)).hidden = true;
         }
         static _toInflightType(context) {
@@ -251,7 +251,7 @@ module.exports = function({ $stdlib }) {
           super._registerOnLift(host, ops);
         }
       }
-      this.node.root.newAbstract("@winglang/sdk.cloud.Service",this,"cloud.Service",new $Closure1(this,"$Closure1"));
+      this.node.root.newAbstract("@winglang/sdk.cloud.Service",this, "cloud.Service", new $Closure1(this, "$Closure1"));
       this.startTime = (this.state.token(this.startTimeKey));
     }
     static _toInflightType(context) {

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/state/my-service.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/state/my-service.w_compile_tf-aws.md
@@ -11,7 +11,7 @@ module.exports = function({ $__parent_this_1_startTimeKey, $__parent_this_1_stat
       return $obj;
     }
     async handle() {
-      (await $__parent_this_1_state.set($__parent_this_1_startTimeKey,"2023-10-16T20:47:39.511Z"));
+      (await $__parent_this_1_state.set($__parent_this_1_startTimeKey, "2023-10-16T20:47:39.511Z"));
     }
   }
   return $Closure1;
@@ -46,14 +46,14 @@ module.exports = function({ $stdlib }) {
   const cloud = $stdlib.cloud;
   const util = $stdlib.util;
   class MyService extends $stdlib.std.Resource {
-    constructor(scope, id, ) {
-      super(scope, id);
-      this.state = this.node.root.new("@winglang/sdk.sim.State",sim.State,this,"sim.State");
+    constructor($scope, $id, ) {
+      super($scope, $id);
+      this.state = this.node.root.new("@winglang/sdk.sim.State",sim.State,this, "sim.State");
       this.startTimeKey = "start_time";
       const __parent_this_1 = this;
       class $Closure1 extends $stdlib.std.Resource {
-        constructor(scope, id, ) {
-          super(scope, id);
+        constructor($scope, $id, ) {
+          super($scope, $id);
           (std.Node.of(this)).hidden = true;
         }
         static _toInflightType(context) {
@@ -86,7 +86,7 @@ module.exports = function({ $stdlib }) {
           super._registerOnLift(host, ops);
         }
       }
-      this.node.root.newAbstract("@winglang/sdk.cloud.Service",this,"cloud.Service",new $Closure1(this,"$Closure1"));
+      this.node.root.newAbstract("@winglang/sdk.cloud.Service",this, "cloud.Service", new $Closure1(this, "$Closure1"));
       this.startTime = (this.state.token(this.startTimeKey));
     }
     static _toInflightType(context) {

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/state/set.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/state/set.test.w_compile_tf-aws.md
@@ -11,7 +11,7 @@ module.exports = function({ $__parent_this_1_startTimeKey, $__parent_this_1_stat
       return $obj;
     }
     async handle() {
-      (await $__parent_this_1_state.set($__parent_this_1_startTimeKey,"2023-10-16T20:47:39.511Z"));
+      (await $__parent_this_1_state.set($__parent_this_1_startTimeKey, "2023-10-16T20:47:39.511Z"));
     }
   }
   return $Closure1;
@@ -100,13 +100,13 @@ const std = $stdlib.std;
 const my = require("./preflight.myservice-1.js")({ $stdlib });
 const util = $stdlib.util;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     if ((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((util.Util.env("WING_TARGET")),"sim"))) {
-      const svc = new my.MyService(this,"my.MyService");
+      const svc = new my.MyService(this, "my.MyService");
       class $Closure1 extends $stdlib.std.Resource {
-        constructor(scope, id, ) {
-          super(scope, id);
+        constructor($scope, $id, ) {
+          super($scope, $id);
           (std.Node.of(this)).hidden = true;
         }
         static _toInflightType(context) {
@@ -137,7 +137,7 @@ class $Root extends $stdlib.std.Resource {
           super._registerOnLift(host, ops);
         }
       }
-      this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:token resolved at runtime",new $Closure1(this,"$Closure1"));
+      this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:token resolved at runtime", new $Closure1(this, "$Closure1"));
     }
   }
 }
@@ -155,14 +155,14 @@ module.exports = function({ $stdlib }) {
   const cloud = $stdlib.cloud;
   const util = $stdlib.util;
   class MyService extends $stdlib.std.Resource {
-    constructor(scope, id, ) {
-      super(scope, id);
-      this.state = this.node.root.new("@winglang/sdk.sim.State",sim.State,this,"sim.State");
+    constructor($scope, $id, ) {
+      super($scope, $id);
+      this.state = this.node.root.new("@winglang/sdk.sim.State",sim.State,this, "sim.State");
       this.startTimeKey = "start_time";
       const __parent_this_1 = this;
       class $Closure1 extends $stdlib.std.Resource {
-        constructor(scope, id, ) {
-          super(scope, id);
+        constructor($scope, $id, ) {
+          super($scope, $id);
           (std.Node.of(this)).hidden = true;
         }
         static _toInflightType(context) {
@@ -195,7 +195,7 @@ module.exports = function({ $stdlib }) {
           super._registerOnLift(host, ops);
         }
       }
-      this.node.root.newAbstract("@winglang/sdk.cloud.Service",this,"cloud.Service",new $Closure1(this,"$Closure1"));
+      this.node.root.newAbstract("@winglang/sdk.cloud.Service",this, "cloud.Service", new $Closure1(this, "$Closure1"));
       this.startTime = (this.state.token(this.startTimeKey));
     }
     static _toInflightType(context) {

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/std/array.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/std/array.test.w_compile_tf-aws.md
@@ -159,14 +159,14 @@ module.exports = function({  }) {
       const INDEX_OUT_OF_BOUNDS_ERROR = "Index out of bounds";
       const mutArr = [1, 3, 5, 7, 9];
       {((cond) => {if (!cond) throw new Error("assertion failed: mutArr.at(0) == 1")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await mutArr.at(0)),1)))};
-      ((obj, args) => { if (args[0] < 0 || args[0] >= mutArr.length) throw new Error("Index out of bounds"); obj[args[0]] = args[1]; })(mutArr, [0,2]);
+      ((obj, args) => { if (args[0] < 0 || args[0] >= mutArr.length) throw new Error("Index out of bounds"); obj[args[0]] = args[1]; })(mutArr, [0, 2]);
       {((cond) => {if (!cond) throw new Error("assertion failed: mutArr.at(0) == 2")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await mutArr.at(0)),2)))};
-      (await assertThrows(INDEX_OUT_OF_BOUNDS_ERROR,async () => {
-        ((obj, args) => { if (args[0] < 0 || args[0] >= mutArr.length) throw new Error("Index out of bounds"); obj[args[0]] = args[1]; })(mutArr, [(-1),1]);
+      (await assertThrows(INDEX_OUT_OF_BOUNDS_ERROR, async () => {
+        ((obj, args) => { if (args[0] < 0 || args[0] >= mutArr.length) throw new Error("Index out of bounds"); obj[args[0]] = args[1]; })(mutArr, [(-1), 1]);
       }
       ));
-      (await assertThrows(INDEX_OUT_OF_BOUNDS_ERROR,async () => {
-        ((obj, args) => { if (args[0] < 0 || args[0] >= mutArr.length) throw new Error("Index out of bounds"); obj[args[0]] = args[1]; })(mutArr, [5,11]);
+      (await assertThrows(INDEX_OUT_OF_BOUNDS_ERROR, async () => {
+        ((obj, args) => { if (args[0] < 0 || args[0] >= mutArr.length) throw new Error("Index out of bounds"); obj[args[0]] = args[1]; })(mutArr, [5, 11]);
       }
       ));
     }
@@ -202,21 +202,21 @@ module.exports = function({  }) {
       ;
       const INDEX_OUT_OF_BOUNDS_ERROR = "Index out of bounds";
       const mutArr = [5, 10, 20];
-      ((obj, args) => { if (args[0] < 0 || args[0] > mutArr.length) throw new Error("Index out of bounds"); obj.splice(args[0], 0, args[1]); })(mutArr, [2,15]);
+      ((obj, args) => { if (args[0] < 0 || args[0] > mutArr.length) throw new Error("Index out of bounds"); obj.splice(args[0], 0, args[1]); })(mutArr, [2, 15]);
       {((cond) => {if (!cond) throw new Error("assertion failed: mutArr.length == 4")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(mutArr.length,4)))};
       {((cond) => {if (!cond) throw new Error("assertion failed: mutArr.at(2) == 15")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await mutArr.at(2)),15)))};
       {((cond) => {if (!cond) throw new Error("assertion failed: mutArr.at(3) == 20")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await mutArr.at(3)),20)))};
-      (await assertThrows(INDEX_OUT_OF_BOUNDS_ERROR,async () => {
-        ((obj, args) => { if (args[0] < 0 || args[0] > mutArr.length) throw new Error("Index out of bounds"); obj.splice(args[0], 0, args[1]); })(mutArr, [(-3),15]);
+      (await assertThrows(INDEX_OUT_OF_BOUNDS_ERROR, async () => {
+        ((obj, args) => { if (args[0] < 0 || args[0] > mutArr.length) throw new Error("Index out of bounds"); obj.splice(args[0], 0, args[1]); })(mutArr, [(-3), 15]);
       }
       ));
       {((cond) => {if (!cond) throw new Error("assertion failed: mutArr.length == 4")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(mutArr.length,4)))};
-      (await assertThrows(INDEX_OUT_OF_BOUNDS_ERROR,async () => {
-        ((obj, args) => { if (args[0] < 0 || args[0] > mutArr.length) throw new Error("Index out of bounds"); obj.splice(args[0], 0, args[1]); })(mutArr, [7,15]);
+      (await assertThrows(INDEX_OUT_OF_BOUNDS_ERROR, async () => {
+        ((obj, args) => { if (args[0] < 0 || args[0] > mutArr.length) throw new Error("Index out of bounds"); obj.splice(args[0], 0, args[1]); })(mutArr, [7, 15]);
       }
       ));
       {((cond) => {if (!cond) throw new Error("assertion failed: mutArr.length == 4")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(mutArr.length,4)))};
-      ((obj, args) => { if (args[0] < 0 || args[0] > mutArr.length) throw new Error("Index out of bounds"); obj.splice(args[0], 0, args[1]); })(mutArr, [4,25]);
+      ((obj, args) => { if (args[0] < 0 || args[0] > mutArr.length) throw new Error("Index out of bounds"); obj.splice(args[0], 0, args[1]); })(mutArr, [4, 25]);
       {((cond) => {if (!cond) throw new Error("assertion failed: mutArr.length == 5")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(mutArr.length,5)))};
       {((cond) => {if (!cond) throw new Error("assertion failed: mutArr.at(4) == 25")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await mutArr.at(4)),25)))};
     }
@@ -330,11 +330,11 @@ module.exports = function({  }) {
       {((cond) => {if (!cond) throw new Error("assertion failed: item == \"hello\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(item,"hello")))};
       {((cond) => {if (!cond) throw new Error("assertion failed: mutArr.length == 1")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(mutArr.length,1)))};
       {((cond) => {if (!cond) throw new Error("assertion failed: mutArr.at(0) == \"world\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await mutArr.at(0)),"world")))};
-      (await assertThrows(INDEX_OUT_OF_BOUNDS_ERROR,async () => {
+      (await assertThrows(INDEX_OUT_OF_BOUNDS_ERROR, async () => {
         ((obj, args) => { if (args[0] < 0 || args[0] >= mutArr.length) throw new Error("Index out of bounds"); return obj.splice(args[0], 1)[0]; })(mutArr, [(-3)]);
       }
       ));
-      (await assertThrows(INDEX_OUT_OF_BOUNDS_ERROR,async () => {
+      (await assertThrows(INDEX_OUT_OF_BOUNDS_ERROR, async () => {
         ((obj, args) => { if (args[0] < 0 || args[0] >= mutArr.length) throw new Error("Index out of bounds"); return obj.splice(args[0], 1)[0]; })(mutArr, [3]);
       }
       ));
@@ -537,11 +537,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -566,8 +566,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure2 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -592,8 +592,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure3 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -618,8 +618,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure4 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -644,8 +644,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure5 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -670,8 +670,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure6 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -696,8 +696,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure7 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -722,8 +722,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure8 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -748,8 +748,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure9 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -774,8 +774,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure10 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -800,8 +800,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure11 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -826,8 +826,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure12 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -852,8 +852,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure13 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -878,8 +878,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure14 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -904,8 +904,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure15 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -930,8 +930,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure16 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -956,8 +956,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure17 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -981,18 +981,18 @@ class $Root extends $stdlib.std.Resource {
         return ["handle", "$inflight_init"];
       }
     }
-    const bucket = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this,"myBucket");
+    const bucket = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this, "myBucket");
     const buckets = [bucket];
-    const anotherBucket = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this,"mySecondBucket");
+    const anotherBucket = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this, "mySecondBucket");
     const anotherBuckets = [anotherBucket];
     {((cond) => {if (!cond) throw new Error("assertion failed: buckets.length == 1")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(buckets.length,1)))};
     {((cond) => {if (!cond) throw new Error("assertion failed: [1,2,3].length == 3")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })([1, 2, 3].length,3)))};
     {((cond) => {if (!cond) throw new Error("assertion failed: MutArray<num>[1,2,3].length == 3")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })([1, 2, 3].length,3)))};
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:length",new $Closure1(this,"$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:length", new $Closure1(this, "$Closure1"));
     {((cond) => {if (!cond) throw new Error("assertion failed: [\"hello\"].at(0) == \"hello\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((["hello"].at(0)),"hello")))};
     {((cond) => {if (!cond) throw new Error("assertion failed: MutArray<str>[\"hello\", \"world\"].at(1) == \"world\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((["hello", "world"].at(1)),"world")))};
     {((cond) => {if (!cond) throw new Error("assertion failed: buckets.at(0).node.id == \"myBucket\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((buckets.at(0)).node.id,"myBucket")))};
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:at()",new $Closure2(this,"$Closure2"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:at()", new $Closure2(this, "$Closure2"));
     const a = ["hello"];
     {((cond) => {if (!cond) throw new Error("assertion failed: a.length == 1")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(a.length,1)))};
     (a.push("world"));
@@ -1003,8 +1003,8 @@ class $Root extends $stdlib.std.Resource {
     {((cond) => {if (!cond) throw new Error("assertion failed: item == \"world\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(item,"world")))};
     {((cond) => {if (!cond) throw new Error("assertion failed: a.length == 1")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(a.length,1)))};
     {((cond) => {if (!cond) throw new Error("assertion failed: a.at(0) == \"hello\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((a.at(0)),"hello")))};
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:pushAndPop()",new $Closure3(this,"$Closure3"));
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:popAt()",new $Closure4(this,"$Closure4"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:pushAndPop()", new $Closure3(this, "$Closure3"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:popAt()", new $Closure4(this, "$Closure4"));
     const array = ["hello"];
     {((cond) => {if (!cond) throw new Error("assertion failed: array.length == 1")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(array.length,1)))};
     const mergedArray = (array.concat(["wing"]));
@@ -1021,28 +1021,28 @@ class $Root extends $stdlib.std.Resource {
     {((cond) => {if (!cond) throw new Error("assertion failed: mergedBuckets.length == 2")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(mergedBuckets.length,2)))};
     {((cond) => {if (!cond) throw new Error("assertion failed: mergedBuckets.at(0).node.id == \"myBucket\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((mergedBuckets.at(0)).node.id,"myBucket")))};
     {((cond) => {if (!cond) throw new Error("assertion failed: mergedBuckets.at(1).node.id == \"mySecondBucket\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((mergedBuckets.at(1)).node.id,"mySecondBucket")))};
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:concatMutArray()",new $Closure5(this,"$Closure5"));
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:concatArray()",new $Closure6(this,"$Closure6"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:concatMutArray()", new $Closure5(this, "$Closure5"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:concatArray()", new $Closure6(this, "$Closure6"));
     const e = ["hello", "wing"];
     {((cond) => {if (!cond) throw new Error("assertion failed: e.contains(\"wing\")")})(e.includes("wing"))};
     {((cond) => {if (!cond) throw new Error("assertion failed: !e.contains(\"NotThere\")")})((!e.includes("NotThere")))};
     {((cond) => {if (!cond) throw new Error("assertion failed: buckets.contains(buckets.at(0))")})(buckets.includes((buckets.at(0))))};
-    const dummyBucket = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this,"cloud.Bucket");
+    const dummyBucket = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this, "cloud.Bucket");
     {((cond) => {if (!cond) throw new Error("assertion failed: !buckets.contains(dummyBucket)")})((!buckets.includes(dummyBucket)))};
     const h = ["hello", "wing"];
     {((cond) => {if (!cond) throw new Error("assertion failed: h.contains(\"wing\")")})(h.includes("wing"))};
     {((cond) => {if (!cond) throw new Error("assertion failed: !h.contains(\"NotThere\")")})((!h.includes("NotThere")))};
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:contains()",new $Closure7(this,"$Closure7"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:contains()", new $Closure7(this, "$Closure7"));
     const g = ["hello", "wing"];
     {((cond) => {if (!cond) throw new Error("assertion failed: g.indexOf(\"wing\") == 1")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(g.indexOf("wing"),1)))};
     {((cond) => {if (!cond) throw new Error("assertion failed: g.indexOf(\"notThere\") == -1")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(g.indexOf("notThere"),(-1))))};
     {((cond) => {if (!cond) throw new Error("assertion failed: buckets.indexOf(bucket) == 0")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(buckets.indexOf(bucket),0)))};
     {((cond) => {if (!cond) throw new Error("assertion failed: buckets.indexOf(dummyBucket) == -1")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(buckets.indexOf(dummyBucket),(-1))))};
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:indexOf()",new $Closure8(this,"$Closure8"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:indexOf()", new $Closure8(this, "$Closure8"));
     const q = ["hello", "wing"];
     {((cond) => {if (!cond) throw new Error("assertion failed: q.indexOf(\"wing\") == 1")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(q.indexOf("wing"),1)))};
     {((cond) => {if (!cond) throw new Error("assertion failed: q.indexOf(\"notThere\") == -1")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(q.indexOf("notThere"),(-1))))};
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:indexOfArray()",new $Closure9(this,"$Closure9"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:indexOfArray()", new $Closure9(this, "$Closure9"));
     const m = ["hello", "wing"];
     const delimeter = ";";
     const joinedString = (m.join(delimeter));
@@ -1053,8 +1053,8 @@ class $Root extends $stdlib.std.Resource {
     const joinedStringWithDefault = (m.join());
     const expectedStringWithDefault = (((m.at(0)) + separator) + (m.at(1)));
     {((cond) => {if (!cond) throw new Error("assertion failed: joinedStringWithDefault == expectedStringWithDefault")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(joinedStringWithDefault,expectedStringWithDefault)))};
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:join()",new $Closure10(this,"$Closure10"));
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:joinWithDefaultSeparator()",new $Closure11(this,"$Closure11"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:join()", new $Closure10(this, "$Closure10"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:joinWithDefaultSeparator()", new $Closure11(this, "$Closure11"));
     const o = ["hello", "wing"];
     const p = [...(o)];
     {((cond) => {if (!cond) throw new Error("assertion failed: o.length == p.length")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(o.length,p.length)))};
@@ -1062,12 +1062,12 @@ class $Root extends $stdlib.std.Resource {
     const copiedBuckets = [...(buckets)];
     {((cond) => {if (!cond) throw new Error("assertion failed: copiedBuckets.length == 1")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(copiedBuckets.length,1)))};
     {((cond) => {if (!cond) throw new Error("assertion failed: copiedBuckets.at(0).node.id == \"myBucket\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((copiedBuckets.at(0)).node.id,"myBucket")))};
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:copy()",new $Closure12(this,"$Closure12"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:copy()", new $Closure12(this, "$Closure12"));
     const v = ["hello", "wing"];
     const r = [...(v)];
     {((cond) => {if (!cond) throw new Error("assertion failed: q.length == r.length")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(q.length,r.length)))};
     {((cond) => {if (!cond) throw new Error("assertion failed: q.at(0) == r.at(0)")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((q.at(0)),(r.at(0)))))};
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:copyMut()",new $Closure13(this,"$Closure13"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:copyMut()", new $Closure13(this, "$Closure13"));
     const lastStr = "wing";
     const s = ["hello", lastStr, lastStr];
     {((cond) => {if (!cond) throw new Error("assertion failed: s.lastIndexOf(lastStr) == 2")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(s.lastIndexOf(lastStr),2)))};
@@ -1075,10 +1075,10 @@ class $Root extends $stdlib.std.Resource {
     const multipleBuckets = [bucket, bucket, anotherBucket];
     {((cond) => {if (!cond) throw new Error("assertion failed: multipleBuckets.lastIndexOf(bucket) == 1")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(multipleBuckets.lastIndexOf(bucket),1)))};
     {((cond) => {if (!cond) throw new Error("assertion failed: multipleBuckets.lastIndexOf(dummyBucket) == -1")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(multipleBuckets.lastIndexOf(dummyBucket),(-1))))};
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:lastIndexOf()",new $Closure14(this,"$Closure14"));
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:set()",new $Closure15(this,"$Closure15"));
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:insert()",new $Closure16(this,"$Closure16"));
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:removeFirst()",new $Closure17(this,"$Closure17"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:lastIndexOf()", new $Closure14(this, "$Closure14"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:set()", new $Closure15(this, "$Closure15"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:insert()", new $Closure16(this, "$Closure16"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:removeFirst()", new $Closure17(this, "$Closure17"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/std/bool.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/std/bool.test.w_compile_tf-aws.md
@@ -70,11 +70,11 @@ const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -122,12 +122,12 @@ class $Root extends $stdlib.std.Resource {
     const PARSE_ERROR = "unable to parse bool";
     const t = (std.Boolean.fromJson((JSON.parse("true"))));
     {((cond) => {if (!cond) throw new Error("assertion failed: t == true")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(t,true)))};
-    (assertThrows(PARSE_ERROR,(() => {
+    (assertThrows(PARSE_ERROR, (() => {
       (std.Boolean.fromJson(123));
     })));
     const f = (std.Boolean.fromJson((JSON.parse("false"))));
     {((cond) => {if (!cond) throw new Error("assertion failed: f == false")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(f,false)))};
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:fromJson()",new $Closure1(this,"$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:fromJson()", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/std/datetime.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/std/datetime.test.w_compile_tf-aws.md
@@ -84,11 +84,11 @@ const cloud = $stdlib.cloud;
 const util = $stdlib.util;
 const math = $stdlib.math;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -152,7 +152,7 @@ class $Root extends $stdlib.std.Resource {
     {((cond) => {if (!cond) throw new Error("assertion failed: d4.month == 6")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(d4.month,6)))};
     {((cond) => {if (!cond) throw new Error("assertion failed: d4.year == 2023")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(d4.year,2023)))};
     {((cond) => {if (!cond) throw new Error("assertion failed: d4.toUtc().hours == (d4.hours + (d4.timezone / 60))")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((d4.toUtc()).hours,(d4.hours + (d4.timezone / 60)))))};
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:inflight datetime",new $Closure1(this,"$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:inflight datetime", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/std/duration.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/std/duration.test.w_compile_tf-aws.md
@@ -158,11 +158,11 @@ const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -207,7 +207,7 @@ class $Root extends $stdlib.std.Resource {
     {((cond) => {if (!cond) throw new Error("assertion failed: 1s.days == 1 / (60 * 60 * 24)")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((std.Duration.fromSeconds(1)).days,(1 / ((60 * 60) * 24)))))};
     {((cond) => {if (!cond) throw new Error("assertion failed: 1s.months == 1 / ((60 * 60 * 24 * 365) / 12)")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((std.Duration.fromSeconds(1)).months,(1 / ((((60 * 60) * 24) * 365) / 12)))))};
     {((cond) => {if (!cond) throw new Error("assertion failed: 1s.years == 1 / (60 * 60 * 24 * 365)")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((std.Duration.fromSeconds(1)).years,(1 / (((60 * 60) * 24) * 365)))))};
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:duration",new $Closure1(this,"$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:duration", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/std/json.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/std/json.test.w_compile_tf-aws.md
@@ -12,8 +12,8 @@ module.exports = function({ $std_Json }) {
     }
     async handle() {
       const obj = ({"key1": 1,"key2": 2});
-      {((cond) => {if (!cond) throw new Error("assertion failed: Json.has(obj, \"key1\") == true")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(((args) => { return args[0].hasOwnProperty(args[1]); })([obj,"key1"]),true)))};
-      {((cond) => {if (!cond) throw new Error("assertion failed: Json.has(obj, \"key3\") == false")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(((args) => { return args[0].hasOwnProperty(args[1]); })([obj,"key3"]),false)))};
+      {((cond) => {if (!cond) throw new Error("assertion failed: Json.has(obj, \"key1\") == true")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(((args) => { return args[0].hasOwnProperty(args[1]); })([obj, "key1"]),true)))};
+      {((cond) => {if (!cond) throw new Error("assertion failed: Json.has(obj, \"key3\") == false")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(((args) => { return args[0].hasOwnProperty(args[1]); })([obj, "key3"]),false)))};
     }
   }
   return $Closure1;
@@ -37,7 +37,7 @@ module.exports = function({ $std_Json }) {
       const copy = JSON.parse(JSON.stringify(original));
       const copyMut = (JSON.parse(JSON.stringify(original)));
       {((cond) => {if (!cond) throw new Error("assertion failed: copy == copyMut")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(copy,copyMut)))};
-      ((obj, args) => { obj[args[0]] = args[1]; })(copyMut, ["object",mutation]);
+      ((obj, args) => { obj[args[0]] = args[1]; })(copyMut, ["object", mutation]);
       {((cond) => {if (!cond) throw new Error("assertion failed: copy != copyMut")})((((a,b) => { try { return require('assert').notDeepStrictEqual(a,b) === undefined; } catch { return false; } })(copy,copyMut)))};
       {((cond) => {if (!cond) throw new Error("assertion failed: copyMut.get(\"object\") == mutation")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(((obj, args) => { if (obj[args] === undefined) throw new Error(`Json property "${args}" does not exist`); return obj[args] })(copyMut, "object"),mutation)))};
     }
@@ -76,11 +76,11 @@ module.exports = function({  }) {
       const mutObj = ({"a": 1,"b": 2});
       {((cond) => {if (!cond) throw new Error("assertion failed: obj.get(\"b\") == 2")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(((obj, args) => { if (obj[args] === undefined) throw new Error(`Json property "${args}" does not exist`); return obj[args] })(obj, "b"),2)))};
       {((cond) => {if (!cond) throw new Error("assertion failed: mutObj.get(\"b\") == 2")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(((obj, args) => { if (obj[args] === undefined) throw new Error(`Json property "${args}" does not exist`); return obj[args] })(mutObj, "b"),2)))};
-      (await assertThrows(JSON_PROPERTY_DOES_NOT_EXIST_ERROR,async () => {
+      (await assertThrows(JSON_PROPERTY_DOES_NOT_EXIST_ERROR, async () => {
         ((obj, args) => { if (obj[args] === undefined) throw new Error(`Json property "${args}" does not exist`); return obj[args] })(obj, "c");
       }
       ));
-      (await assertThrows(JSON_PROPERTY_DOES_NOT_EXIST_ERROR,async () => {
+      (await assertThrows(JSON_PROPERTY_DOES_NOT_EXIST_ERROR, async () => {
         ((obj, args) => { if (obj[args] === undefined) throw new Error(`Json property "${args}" does not exist`); return obj[args] })(mutObj, "c");
       }
       ));
@@ -120,7 +120,7 @@ module.exports = function({  }) {
       const mutJsonArray = [1, 2, 3];
       {((cond) => {if (!cond) throw new Error("assertion failed: jsonArray.getAt(2) == \"baz\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(((obj, args) => { if (obj[args] === undefined) throw new Error("Index out of bounds"); return obj[args] })(jsonArray, 2),"baz")))};
       {((cond) => {if (!cond) throw new Error("assertion failed: mutJsonArray.getAt(2) == 3")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(((obj, args) => { if (obj[args] === undefined) throw new Error("Index out of bounds"); return obj[args] })(mutJsonArray, 2),3)))};
-      (await assertThrows(INDEX_OUT_OF_BOUNDS_ERROR,async () => {
+      (await assertThrows(INDEX_OUT_OF_BOUNDS_ERROR, async () => {
         ((obj, args) => { if (obj[args] === undefined) throw new Error("Index out of bounds"); return obj[args] })(jsonArray, 3);
         ((obj, args) => { if (obj[args] === undefined) throw new Error("Index out of bounds"); return obj[args] })(mutJsonArray, 3);
       }
@@ -144,8 +144,8 @@ module.exports = function({  }) {
     }
     async handle() {
       const mutObj = ({"x": 1,"y": 2});
-      ((obj, args) => { obj[args[0]] = args[1]; })(mutObj, ["x",(-1)]);
-      ((obj, args) => { obj[args[0]] = args[1]; })(mutObj, ["z",3]);
+      ((obj, args) => { obj[args[0]] = args[1]; })(mutObj, ["x", (-1)]);
+      ((obj, args) => { obj[args[0]] = args[1]; })(mutObj, ["z", 3]);
       {((cond) => {if (!cond) throw new Error("assertion failed: mutObj.get(\"x\") == -1")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(((obj, args) => { if (obj[args] === undefined) throw new Error(`Json property "${args}" does not exist`); return obj[args] })(mutObj, "x"),(-1))))};
       {((cond) => {if (!cond) throw new Error("assertion failed: mutObj.get(\"z\") == 3")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(((obj, args) => { if (obj[args] === undefined) throw new Error(`Json property "${args}" does not exist`); return obj[args] })(mutObj, "z"),3)))};
     }
@@ -167,8 +167,8 @@ module.exports = function({  }) {
     }
     async handle() {
       const mutJsonArray = [1, 2, 3];
-      ((obj, args) => { obj[args[0]] = args[1]; })(mutJsonArray, [0,(-1)]);
-      ((obj, args) => { obj[args[0]] = args[1]; })(mutJsonArray, [3,3]);
+      ((obj, args) => { obj[args[0]] = args[1]; })(mutJsonArray, [0, (-1)]);
+      ((obj, args) => { obj[args[0]] = args[1]; })(mutJsonArray, [3, 3]);
       {((cond) => {if (!cond) throw new Error("assertion failed: mutJsonArray.getAt(0) == -1")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(((obj, args) => { if (obj[args] === undefined) throw new Error("Index out of bounds"); return obj[args] })(mutJsonArray, 0),(-1))))};
       {((cond) => {if (!cond) throw new Error("assertion failed: mutJsonArray.getAt(3) == 3")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(((obj, args) => { if (obj[args] === undefined) throw new Error("Index out of bounds"); return obj[args] })(mutJsonArray, 3),3)))};
     }
@@ -191,7 +191,7 @@ module.exports = function({ $std_Json }) {
     async handle() {
       const obj = ({"a": 1,"b": 2});
       const stringified = ((args) => { return JSON.stringify(args[0], null, args[1]?.indent) })([obj]);
-      const stringifiedIndent = ((args) => { return JSON.stringify(args[0], null, args[1]?.indent) })([obj,{ indent: 2 }]);
+      const stringifiedIndent = ((args) => { return JSON.stringify(args[0], null, args[1]?.indent) })([obj, { indent: 2 }]);
       {((cond) => {if (!cond) throw new Error("assertion failed: stringified == \"{\\\"a\\\":1,\\\"b\\\":2}\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(stringified,"{\"a\":1,\"b\":2}")))};
       {((cond) => {if (!cond) throw new Error("assertion failed: stringifiedIndent == \"{\\n  \\\"a\\\": 1,\\n  \\\"b\\\": 2\\n}\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(stringifiedIndent,"{\n  \"a\": 1,\n  \"b\": 2\n}")))};
     }
@@ -320,11 +320,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -350,8 +350,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure2 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -376,8 +376,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure3 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -402,8 +402,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure4 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -428,8 +428,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure5 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -454,8 +454,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure6 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -481,8 +481,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure7 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -508,8 +508,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure8 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -535,8 +535,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure9 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -562,8 +562,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure10 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -588,16 +588,16 @@ class $Root extends $stdlib.std.Resource {
         return ["handle", "$inflight_init"];
       }
     }
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:has()",new $Closure1(this,"$Closure1"));
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:get()",new $Closure2(this,"$Closure2"));
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:getAt()",new $Closure3(this,"$Closure3"));
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:set()",new $Closure4(this,"$Closure4"));
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:setAt()",new $Closure5(this,"$Closure5"));
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:stringify()",new $Closure6(this,"$Closure6"));
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:keys(), values(), entries()",new $Closure7(this,"$Closure7"));
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:parse()",new $Closure8(this,"$Closure8"));
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:tryParse()",new $Closure9(this,"$Closure9"));
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:deepCopy(), deepCopyMut()",new $Closure10(this,"$Closure10"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:has()", new $Closure1(this, "$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:get()", new $Closure2(this, "$Closure2"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:getAt()", new $Closure3(this, "$Closure3"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:set()", new $Closure4(this, "$Closure4"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:setAt()", new $Closure5(this, "$Closure5"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:stringify()", new $Closure6(this, "$Closure6"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:keys(), values(), entries()", new $Closure7(this, "$Closure7"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:parse()", new $Closure8(this, "$Closure8"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:tryParse()", new $Closure9(this, "$Closure9"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:deepCopy(), deepCopyMut()", new $Closure10(this, "$Closure10"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/std/map.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/std/map.test.w_compile_tf-aws.md
@@ -31,7 +31,7 @@ module.exports = function({  }) {
     }
     async handle() {
       const senate = ({"chancellor": "palpatine"});
-      ((obj, args) => { obj[args[0]] = args[1]; })(senate, ["senator","organa"]);
+      ((obj, args) => { obj[args[0]] = args[1]; })(senate, ["senator", "organa"]);
       {((cond) => {if (!cond) throw new Error("assertion failed: senate.get(\"senator\") == \"organa\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(((obj, key) => { if (!(key in obj)) throw new Error(`MutMap does not contain key: "${key}"`); return obj[key]; })(senate, "senator"),"organa")))};
       {((cond) => {if (!cond) throw new Error("assertion failed: senate.size() == 2")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(Object.keys(senate).length,2)))};
     }
@@ -100,9 +100,9 @@ module.exports = function({  }) {
       (delete (apprentices)["plagueis"]);
       {((cond) => {if (!cond) throw new Error("assertion failed: apprentices.size() == 1")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(Object.keys(apprentices).length,1)))};
       {((cond) => {if (!cond) throw new Error("assertion failed: apprentices.copy() == Map<str> {\"dooku\" => \"ventress\"}")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(({...(apprentices)}),({"dooku": "ventress"}))))};
-      ((obj, args) => { obj[args[0]] = args[1]; })(apprentices, ["sidious","dooku"]);
+      ((obj, args) => { obj[args[0]] = args[1]; })(apprentices, ["sidious", "dooku"]);
       {((cond) => {if (!cond) throw new Error("assertion failed: apprentices.get(\"sidious\")  == \"dooku\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(((obj, key) => { if (!(key in obj)) throw new Error(`MutMap does not contain key: "${key}"`); return obj[key]; })(apprentices, "sidious"),"dooku")))};
-      ((obj, args) => { obj[args[0]] = args[1]; })(apprentices, ["sidious","maul"]);
+      ((obj, args) => { obj[args[0]] = args[1]; })(apprentices, ["sidious", "maul"]);
       {((cond) => {if (!cond) throw new Error("assertion failed: apprentices.get(\"sidious\") == \"maul\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(((obj, key) => { if (!(key in obj)) throw new Error(`MutMap does not contain key: "${key}"`); return obj[key]; })(apprentices, "sidious"),"maul")))};
       ((map) => { for(const k in map){delete map[k]}; })(apprentices);
       {((cond) => {if (!cond) throw new Error("assertion failed: apprentices == MutMap<str>{}")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(apprentices,({}))))};
@@ -346,11 +346,11 @@ const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -375,8 +375,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure2 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -401,8 +401,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure3 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -427,8 +427,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure4 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -453,8 +453,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure5 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -479,8 +479,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure6 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -505,8 +505,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure7 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -531,8 +531,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure8 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -557,8 +557,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure9 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -583,8 +583,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure10 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -609,8 +609,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure11 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -635,8 +635,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure12 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -670,25 +670,25 @@ class $Root extends $stdlib.std.Resource {
     {((cond) => {if (!cond) throw new Error("assertion failed: mvalues.at(0) == 123")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((mvalues.at(0)),123)))};
     {((cond) => {if (!cond) throw new Error("assertion failed: mvalues.at(1) == 99")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((mvalues.at(1)),99)))};
     {((cond) => {if (!cond) throw new Error("assertion failed: Map<str>{} == MutMap<str>{}")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(({}),({}))))};
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:equality",new $Closure1(this,"$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:equality", new $Closure1(this, "$Closure1"));
     const apprentices = ({"plagueis": "sidious","dooku": "ventress"});
     (delete (apprentices)["plagueis"]);
     {((cond) => {if (!cond) throw new Error("assertion failed: apprentices.size() == 1")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(Object.keys(apprentices).length,1)))};
     {((cond) => {if (!cond) throw new Error("assertion failed: apprentices.copy() == Map<str> {\"dooku\" => \"ventress\"}")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(({...(apprentices)}),({"dooku": "ventress"}))))};
-    ((obj, args) => { obj[args[0]] = args[1]; })(apprentices, ["sidious","dooku"]);
+    ((obj, args) => { obj[args[0]] = args[1]; })(apprentices, ["sidious", "dooku"]);
     {((cond) => {if (!cond) throw new Error("assertion failed: apprentices.get(\"sidious\")  == \"dooku\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(((obj, key) => { if (!(key in obj)) throw new Error(`MutMap does not contain key: "${key}"`); return obj[key]; })(apprentices, "sidious"),"dooku")))};
-    ((obj, args) => { obj[args[0]] = args[1]; })(apprentices, ["sidious","maul"]);
+    ((obj, args) => { obj[args[0]] = args[1]; })(apprentices, ["sidious", "maul"]);
     {((cond) => {if (!cond) throw new Error("assertion failed: apprentices.get(\"sidious\") == \"maul\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(((obj, key) => { if (!(key in obj)) throw new Error(`MutMap does not contain key: "${key}"`); return obj[key]; })(apprentices, "sidious"),"maul")))};
     ((map) => { for(const k in map){delete map[k]}; })(apprentices);
     {((cond) => {if (!cond) throw new Error("assertion failed: apprentices == MutMap<str>{}")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(apprentices,({}))))};
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:mutability",new $Closure2(this,"$Closure2"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:mutability", new $Closure2(this, "$Closure2"));
     const trilogies = ({"PT": 2,"OT": 1,"ST": 3});
     {((cond) => {if (!cond) throw new Error("assertion failed: trilogies.size() == 3")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(Object.keys(trilogies).length,3)))};
     const mutTrilogies = ({"PT": 2,"OT": 1,"ST": 3});
     {((cond) => {if (!cond) throw new Error("assertion failed: mutTrilogies.size() == 3")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(Object.keys(mutTrilogies).length,3)))};
     (delete (mutTrilogies)["ST"]);
     {((cond) => {if (!cond) throw new Error("assertion failed: mutTrilogies.size() == 2")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(Object.keys(mutTrilogies).length,2)))};
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:size()",new $Closure3(this,"$Closure3"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:size()", new $Closure3(this, "$Closure3"));
     const greeting = ({"hello": "there!"});
     {((cond) => {if (!cond) throw new Error("assertion failed: greeting.get(\"hello\") == \"there!\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(((obj, key) => { if (!(key in obj)) throw new Error(`Map does not contain key: "${key}"`); return obj[key]; })(greeting, "hello"),"there!")))};
     try {
@@ -704,7 +704,7 @@ class $Root extends $stdlib.std.Resource {
     {((cond) => {if (!cond) throw new Error("assertion failed: mutGreeting.get(\"general\") == \"kenobi\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(((obj, key) => { if (!(key in obj)) throw new Error(`MutMap does not contain key: "${key}"`); return obj[key]; })(mutGreeting, "general"),"kenobi")))};
     const Viceroy = (mutGreeting)["gunray"];
     {((cond) => {if (!cond) throw new Error("assertion failed: Viceroy == nil")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(Viceroy,undefined)))};
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:get()",new $Closure4(this,"$Closure4"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:get()", new $Closure4(this, "$Closure4"));
     const legion501 = ({"fives": "CT-5555","rex": "CT-7567","appo": "CC-1119","jesse": "CT-5597"});
     {((cond) => {if (!cond) throw new Error("assertion failed: legion501.has(\"fives\") == true")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(("fives" in (legion501)),true)))};
     {((cond) => {if (!cond) throw new Error("assertion failed: legion501.has(\"rex\") == legion501.has(\"jesse\")")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(("rex" in (legion501)),("jesse" in (legion501)))))};
@@ -714,7 +714,7 @@ class $Root extends $stdlib.std.Resource {
     {((cond) => {if (!cond) throw new Error("assertion failed: padawans.has(\"qui gon\") == padawans.has(\"dooku\") == padawans.has(\"anakin\")")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(("qui gon" in (padawans)),("dooku" in (padawans)))),("anakin" in (padawans)))))};
     {((cond) => {if (!cond) throw new Error("assertion failed: padawans.has(\"windu\") == padawans.has(\"sifo dyas\")")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(("windu" in (padawans)),("sifo dyas" in (padawans)))))};
     {((cond) => {if (!cond) throw new Error("assertion failed: padawans.has(\"revan\") == false")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(("revan" in (padawans)),false)))};
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:has()",new $Closure5(this,"$Closure5"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:has()", new $Closure5(this, "$Closure5"));
     const forceUsers = ({"sith": ["malak", "vader", "bane"],"jedi": ["sunrider", "bastila", "bindo"]});
     const userKeys = Object.values(forceUsers);
     const valArr = [["malak", "vader", "bane"], ["sunrider", "bastila", "bindo"]];
@@ -729,7 +729,7 @@ class $Root extends $stdlib.std.Resource {
     for (const i of $stdlib.std.Range.of(0, saberformNames.length, false)) {
       {((cond) => {if (!cond) throw new Error("assertion failed: saberformNames.at(i) == nameArr.at(i)")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((saberformNames.at(i)),(nameArr.at(i)))))};
     }
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:values()",new $Closure6(this,"$Closure6"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:values()", new $Closure6(this, "$Closure6"));
     const lightsaberColorMap = ({"red": "sith","blue": "jedi"});
     const lightsaberColors = Object.keys(lightsaberColorMap);
     const colorArr = ["red", "blue"];
@@ -744,34 +744,34 @@ class $Root extends $stdlib.std.Resource {
     for (const i of $stdlib.std.Range.of(0, mandalorianKeys.length, false)) {
       {((cond) => {if (!cond) throw new Error("assertion failed: mandalorianKeys.at(i) == keysArr.at(i)")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((mandalorianKeys.at(i)),(keysArr.at(i)))))};
     }
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:keys()",new $Closure7(this,"$Closure7"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:keys()", new $Closure7(this, "$Closure7"));
     const ruleOfTwo = ({"master": "apprentice"});
     const mutRuleOfTwo = {...(ruleOfTwo)};
     {((cond) => {if (!cond) throw new Error("assertion failed: mutRuleOfTwo.copy() == ruleOfTwo")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(({...(mutRuleOfTwo)}),ruleOfTwo)))};
     {((cond) => {if (!cond) throw new Error("assertion failed: mutRuleOfTwo.delete(\"master\") == true")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((delete (mutRuleOfTwo)["master"]),true)))};
     {((cond) => {if (!cond) throw new Error("assertion failed: mutRuleOfTwo.size() == 0")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(Object.keys(mutRuleOfTwo).length,0)))};
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:copyMut()",new $Closure8(this,"$Closure8"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:copyMut()", new $Closure8(this, "$Closure8"));
     const authority = ({"republic": "senate","empire": "emperor"});
     const immutAuthority = ({...(authority)});
     {((cond) => {if (!cond) throw new Error("assertion failed: immutAuthority.copyMut() == authority")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })({...(immutAuthority)},authority)))};
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:copy()",new $Closure9(this,"$Closure9"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:copy()", new $Closure9(this, "$Closure9"));
     const senate = ({"chancellor": "palpatine"});
-    ((obj, args) => { obj[args[0]] = args[1]; })(senate, ["senator","organa"]);
+    ((obj, args) => { obj[args[0]] = args[1]; })(senate, ["senator", "organa"]);
     {((cond) => {if (!cond) throw new Error("assertion failed: senate.get(\"senator\") == \"organa\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(((obj, key) => { if (!(key in obj)) throw new Error(`MutMap does not contain key: "${key}"`); return obj[key]; })(senate, "senator"),"organa")))};
     {((cond) => {if (!cond) throw new Error("assertion failed: senate.size() == 2")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(Object.keys(senate).length,2)))};
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:set()",new $Closure10(this,"$Closure10"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:set()", new $Closure10(this, "$Closure10"));
     const position = ({"librarian": "jocasta"});
     ((map) => { for(const k in map){delete map[k]}; })(position);
     {((cond) => {if (!cond) throw new Error("assertion failed: position.size() == 0")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(Object.keys(position).length,0)))};
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:clear()",new $Closure11(this,"$Closure11"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:clear()", new $Closure11(this, "$Closure11"));
     const sithTriumvirate = ({"traya": "lord of betrayal","nihilus": "lord of hunger","sion": "lord of pain"});
     (delete (sithTriumvirate)["nihilus"]);
     {((cond) => {if (!cond) throw new Error("assertion failed: sithTriumvirate.size() == 2")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(Object.keys(sithTriumvirate).length,2)))};
     (delete (sithTriumvirate)["sion"]);
     {((cond) => {if (!cond) throw new Error("assertion failed: sithTriumvirate == MutMap<str> { \"traya\" => \"lord of betrayal\" }")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(sithTriumvirate,({"traya": "lord of betrayal"}))))};
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:delete()",new $Closure12(this,"$Closure12"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:delete()", new $Closure12(this, "$Closure12"));
     const mapOfOptionalString = ({});
-    ((obj, args) => { obj[args[0]] = args[1]; })(mapOfOptionalString, ["a",undefined]);
+    ((obj, args) => { obj[args[0]] = args[1]; })(mapOfOptionalString, ["a", undefined]);
     const b = ((obj, key) => { if (!(key in obj)) throw new Error(`MutMap does not contain key: "${key}"`); return obj[key]; })(mapOfOptionalString, "a");
     {((cond) => {if (!cond) throw new Error("assertion failed: b == nil")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(b,undefined)))};
   }

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/std/number.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/std/number.test.w_compile_tf-aws.md
@@ -79,11 +79,11 @@ const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -109,8 +109,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure2 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -136,9 +136,9 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     {((cond) => {if (!cond) throw new Error("assertion failed: num.fromJson(Json 12) == 12")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((std.Number.fromJson(12)),12)))};
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:fromJson",new $Closure1(this,"$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:fromJson", new $Closure1(this, "$Closure1"));
     {((cond) => {if (!cond) throw new Error("assertion failed: num.fromStr(\"42\") == 42")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(((args) => { if (isNaN(args)) {throw new Error("unable to parse \"" + args + "\" as a number")}; return parseInt(args) })("42"),42)))};
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:fromStr",new $Closure2(this,"$Closure2"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:fromStr", new $Closure2(this, "$Closure2"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/std/range.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/std/range.test.w_compile_tf-aws.md
@@ -11,7 +11,7 @@ module.exports = function({ $std_Range }) {
       return $obj;
     }
     async handle() {
-      {((cond) => {if (!cond) throw new Error("assertion failed: std.Range.of(1,5,true).join() == \"1,2,3,4,5\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await (await $std_Range.of(1,5,true)).join()),"1,2,3,4,5")))};
+      {((cond) => {if (!cond) throw new Error("assertion failed: std.Range.of(1,5,true).join() == \"1,2,3,4,5\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await (await $std_Range.of(1, 5, true)).join()),"1,2,3,4,5")))};
     }
   }
   return $Closure1;
@@ -53,7 +53,7 @@ module.exports = function({ $std_Range }) {
       return $obj;
     }
     async handle() {
-      {((cond) => {if (!cond) throw new Error("assertion failed: std.Range.of(1, 5).join() == std.Range.of(1, 5, false).join()")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await (await $std_Range.of(1,5)).join()),(await (await $std_Range.of(1,5,false)).join()))))};
+      {((cond) => {if (!cond) throw new Error("assertion failed: std.Range.of(1, 5).join() == std.Range.of(1, 5, false).join()")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await (await $std_Range.of(1, 5)).join()),(await (await $std_Range.of(1, 5, false)).join()))))};
     }
   }
   return $Closure2;
@@ -72,7 +72,7 @@ module.exports = function({ $std_Range }) {
       return $obj;
     }
     async handle() {
-      {((cond) => {if (!cond) throw new Error("assertion failed: std.Range.of(1,5,false).join() == \"1,2,3,4\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await (await $std_Range.of(1,5,false)).join()),"1,2,3,4")))};
+      {((cond) => {if (!cond) throw new Error("assertion failed: std.Range.of(1,5,false).join() == \"1,2,3,4\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await (await $std_Range.of(1, 5, false)).join()),"1,2,3,4")))};
     }
   }
   return $Closure3;
@@ -91,7 +91,7 @@ module.exports = function({ $std_Range }) {
       return $obj;
     }
     async handle() {
-      {((cond) => {if (!cond) throw new Error("assertion failed: std.Range.of(1,5).join() == \"1,2,3,4\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await (await $std_Range.of(1,5)).join()),"1,2,3,4")))};
+      {((cond) => {if (!cond) throw new Error("assertion failed: std.Range.of(1,5).join() == \"1,2,3,4\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await (await $std_Range.of(1, 5)).join()),"1,2,3,4")))};
     }
   }
   return $Closure4;
@@ -110,7 +110,7 @@ module.exports = function({ $std_Range }) {
       return $obj;
     }
     async handle() {
-      {((cond) => {if (!cond) throw new Error("assertion failed: std.Range.of(-3,3,true).join() == \"-3,-2,-1,0,1,2,3\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await (await $std_Range.of((-3),3,true)).join()),"-3,-2,-1,0,1,2,3")))};
+      {((cond) => {if (!cond) throw new Error("assertion failed: std.Range.of(-3,3,true).join() == \"-3,-2,-1,0,1,2,3\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await (await $std_Range.of((-3), 3, true)).join()),"-3,-2,-1,0,1,2,3")))};
     }
   }
   return $Closure5;
@@ -129,7 +129,7 @@ module.exports = function({ $std_Range }) {
       return $obj;
     }
     async handle() {
-      {((cond) => {if (!cond) throw new Error("assertion failed: std.Range.of(-3,3,false).join() == \"-3,-2,-1,0,1,2\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await (await $std_Range.of((-3),3,false)).join()),"-3,-2,-1,0,1,2")))};
+      {((cond) => {if (!cond) throw new Error("assertion failed: std.Range.of(-3,3,false).join() == \"-3,-2,-1,0,1,2\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await (await $std_Range.of((-3), 3, false)).join()),"-3,-2,-1,0,1,2")))};
     }
   }
   return $Closure6;
@@ -148,7 +148,7 @@ module.exports = function({ $std_Range }) {
       return $obj;
     }
     async handle() {
-      {((cond) => {if (!cond) throw new Error("assertion failed: std.Range.of(5,0,true).join() == \"5,4,3,2,1,0\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await (await $std_Range.of(5,0,true)).join()),"5,4,3,2,1,0")))};
+      {((cond) => {if (!cond) throw new Error("assertion failed: std.Range.of(5,0,true).join() == \"5,4,3,2,1,0\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await (await $std_Range.of(5, 0, true)).join()),"5,4,3,2,1,0")))};
     }
   }
   return $Closure7;
@@ -167,7 +167,7 @@ module.exports = function({ $std_Range }) {
       return $obj;
     }
     async handle() {
-      {((cond) => {if (!cond) throw new Error("assertion failed: std.Range.of(5,0,false).join() == \"5,4,3,2,1\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await (await $std_Range.of(5,0,false)).join()),"5,4,3,2,1")))};
+      {((cond) => {if (!cond) throw new Error("assertion failed: std.Range.of(5,0,false).join() == \"5,4,3,2,1\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await (await $std_Range.of(5, 0, false)).join()),"5,4,3,2,1")))};
     }
   }
   return $Closure8;
@@ -239,11 +239,11 @@ const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -269,8 +269,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure2 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -296,8 +296,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure3 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -323,8 +323,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure4 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -350,8 +350,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure5 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -377,8 +377,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure6 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -404,8 +404,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure7 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -431,8 +431,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure8 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -458,8 +458,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure9 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -484,8 +484,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure10 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -509,34 +509,34 @@ class $Root extends $stdlib.std.Resource {
         return ["handle", "$inflight_init"];
       }
     }
-    {((cond) => {if (!cond) throw new Error("assertion failed: std.Range.of(1,5,true).join() == \"1,2,3,4,5\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(((std.Range.of(1,5,true)).join()),"1,2,3,4,5")))};
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:rangeOf",new $Closure1(this,"$Closure1"));
-    {((cond) => {if (!cond) throw new Error("assertion failed: std.Range.of(1, 5).join() == std.Range.of(1, 5, false).join()")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(((std.Range.of(1,5)).join()),((std.Range.of(1,5,false)).join()))))};
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:defaultRange",new $Closure2(this,"$Closure2"));
-    {((cond) => {if (!cond) throw new Error("assertion failed: std.Range.of(1,5,false).join() == \"1,2,3,4\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(((std.Range.of(1,5,false)).join()),"1,2,3,4")))};
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:rangeOfWithoutLastNumber",new $Closure3(this,"$Closure3"));
-    {((cond) => {if (!cond) throw new Error("assertion failed: std.Range.of(1,5).join() == \"1,2,3,4\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(((std.Range.of(1,5)).join()),"1,2,3,4")))};
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:rangeOfWithoutLastNumberDefault",new $Closure4(this,"$Closure4"));
-    {((cond) => {if (!cond) throw new Error("assertion failed: std.Range.of(-3,3,true).join() == \"-3,-2,-1,0,1,2,3\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(((std.Range.of((-3),3,true)).join()),"-3,-2,-1,0,1,2,3")))};
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:rangeOfWithNegativeRange",new $Closure5(this,"$Closure5"));
-    {((cond) => {if (!cond) throw new Error("assertion failed: std.Range.of(-3,3,false).join() == \"-3,-2,-1,0,1,2\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(((std.Range.of((-3),3,false)).join()),"-3,-2,-1,0,1,2")))};
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:rangeOfWithNegativeRangeDefault",new $Closure6(this,"$Closure6"));
-    {((cond) => {if (!cond) throw new Error("assertion failed: std.Range.of(5,0,true).join() == \"5,4,3,2,1,0\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(((std.Range.of(5,0,true)).join()),"5,4,3,2,1,0")))};
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:rangeOfDecreasingNumbers",new $Closure7(this,"$Closure7"));
-    {((cond) => {if (!cond) throw new Error("assertion failed: std.Range.of(5,0,false).join() == \"5,4,3,2,1\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(((std.Range.of(5,0,false)).join()),"5,4,3,2,1")))};
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:rangeOfDecreasingNumbersWithDefault",new $Closure8(this,"$Closure8"));
+    {((cond) => {if (!cond) throw new Error("assertion failed: std.Range.of(1,5,true).join() == \"1,2,3,4,5\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(((std.Range.of(1, 5, true)).join()),"1,2,3,4,5")))};
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:rangeOf", new $Closure1(this, "$Closure1"));
+    {((cond) => {if (!cond) throw new Error("assertion failed: std.Range.of(1, 5).join() == std.Range.of(1, 5, false).join()")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(((std.Range.of(1, 5)).join()),((std.Range.of(1, 5, false)).join()))))};
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:defaultRange", new $Closure2(this, "$Closure2"));
+    {((cond) => {if (!cond) throw new Error("assertion failed: std.Range.of(1,5,false).join() == \"1,2,3,4\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(((std.Range.of(1, 5, false)).join()),"1,2,3,4")))};
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:rangeOfWithoutLastNumber", new $Closure3(this, "$Closure3"));
+    {((cond) => {if (!cond) throw new Error("assertion failed: std.Range.of(1,5).join() == \"1,2,3,4\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(((std.Range.of(1, 5)).join()),"1,2,3,4")))};
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:rangeOfWithoutLastNumberDefault", new $Closure4(this, "$Closure4"));
+    {((cond) => {if (!cond) throw new Error("assertion failed: std.Range.of(-3,3,true).join() == \"-3,-2,-1,0,1,2,3\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(((std.Range.of((-3), 3, true)).join()),"-3,-2,-1,0,1,2,3")))};
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:rangeOfWithNegativeRange", new $Closure5(this, "$Closure5"));
+    {((cond) => {if (!cond) throw new Error("assertion failed: std.Range.of(-3,3,false).join() == \"-3,-2,-1,0,1,2\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(((std.Range.of((-3), 3, false)).join()),"-3,-2,-1,0,1,2")))};
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:rangeOfWithNegativeRangeDefault", new $Closure6(this, "$Closure6"));
+    {((cond) => {if (!cond) throw new Error("assertion failed: std.Range.of(5,0,true).join() == \"5,4,3,2,1,0\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(((std.Range.of(5, 0, true)).join()),"5,4,3,2,1,0")))};
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:rangeOfDecreasingNumbers", new $Closure7(this, "$Closure7"));
+    {((cond) => {if (!cond) throw new Error("assertion failed: std.Range.of(5,0,false).join() == \"5,4,3,2,1\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(((std.Range.of(5, 0, false)).join()),"5,4,3,2,1")))};
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:rangeOfDecreasingNumbersWithDefault", new $Closure8(this, "$Closure8"));
     let i = 0;
     for (const x of $stdlib.std.Range.of(0, 5, false)) {
       i += 1;
     }
     {((cond) => {if (!cond) throw new Error("assertion failed: i==5")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(i,5)))};
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:forWithRange",new $Closure9(this,"$Closure9"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:forWithRange", new $Closure9(this, "$Closure9"));
     let n = 0;
     for (const x of $stdlib.std.Range.of(0, 5, true)) {
       n += 1;
     }
     {((cond) => {if (!cond) throw new Error("assertion failed: n==6")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(n,6)))};
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:forWithRangeIncludeLastNumber",new $Closure10(this,"$Closure10"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:forWithRangeIncludeLastNumber", new $Closure10(this, "$Closure10"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/std/set.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/std/set.test.w_compile_tf-aws.md
@@ -285,11 +285,11 @@ const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -314,8 +314,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure2 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -340,8 +340,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure3 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -366,8 +366,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure4 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -392,8 +392,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure5 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -418,8 +418,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure6 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -444,8 +444,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure7 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -470,8 +470,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure8 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -496,8 +496,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure9 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -522,8 +522,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure10 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -563,7 +563,7 @@ class $Root extends $stdlib.std.Resource {
     {((cond) => {if (!cond) throw new Error("assertion failed: myArrayFromMutSet.length == 3")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(myArrayFromMutSet.length,3)))};
     {((cond) => {if (!cond) throw new Error("assertion failed: Set<num>{1, 2} == MutSet<num>{1, 2}")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(new Set([1, 2]),new Set([1, 2]))))};
     {((cond) => {if (!cond) throw new Error("assertion failed: Set<bool>{true, false} == MutSet<bool>{false, true}")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(new Set([true, false]),new Set([false, true]))))};
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:equality",new $Closure1(this,"$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:equality", new $Closure1(this, "$Closure1"));
     const openings = new Set(["A Cruel Angel's Thesis", "Lilium", "Unravel", "TOP"]);
     const immutOpenings = new Set(openings);
     {((cond) => {if (!cond) throw new Error("assertion failed: immutOpenings.copyMut() == openings")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(new Set(immutOpenings),openings)))};
@@ -573,7 +573,7 @@ class $Root extends $stdlib.std.Resource {
     {((cond) => {if (!cond) throw new Error("assertion failed: openings.has(\"TOP\") == false")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((openings.has("TOP")),false)))};
     (openings.clear());
     {((cond) => {if (!cond) throw new Error("assertion failed: openings.size == 0")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(openings.size,0)))};
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:mutability",new $Closure2(this,"$Closure2"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:mutability", new $Closure2(this, "$Closure2"));
     const maleVA = new Set(["Kenjiro Tsuda", "Akira Ishida", "Yoshitsugu Matsuoka"]);
     {((cond) => {if (!cond) throw new Error("assertion failed: maleVA.size == 3")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(maleVA.size,3)))};
     const femaleVA = new Set(["Saori Hayami", "Miyuki Sawashiro"]);
@@ -582,7 +582,7 @@ class $Root extends $stdlib.std.Resource {
     {((cond) => {if (!cond) throw new Error("assertion failed: femaleVA.size == 3")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(femaleVA.size,3)))};
     (femaleVA.clear());
     {((cond) => {if (!cond) throw new Error("assertion failed: femaleVA.size == 0")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(femaleVA.size,0)))};
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:size()",new $Closure3(this,"$Closure3"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:size()", new $Closure3(this, "$Closure3"));
     const genre = new Set(["isekai", "mecha", "cyberpunk"]);
     {((cond) => {if (!cond) throw new Error("assertion failed: genre.has(\"drama\") == false")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((genre.has("drama")),false)))};
     {((cond) => {if (!cond) throw new Error("assertion failed: genre.has(\"mecha\")")})((genre.has("mecha")))};
@@ -593,7 +593,7 @@ class $Root extends $stdlib.std.Resource {
     (mutGenre.add("psychological"));
     {((cond) => {if (!cond) throw new Error("assertion failed: mutGenre.has(\"psychological\")")})((mutGenre.has("psychological")))};
     {((cond) => {if (!cond) throw new Error("assertion failed: mutGenre.has(\"rom-com\") == false")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((mutGenre.has("rom-com")),false)))};
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:has()",new $Closure4(this,"$Closure4"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:has()", new $Closure4(this, "$Closure4"));
     const endings = new Set([]);
     {((cond) => {if (!cond) throw new Error("assertion failed: endings.toArray() == Array<bool>[]")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })([...(endings)],[])))};
     const strEndings = new Set(["Somewhere, Faraway, Everyone is Listening to a Ballad"]);
@@ -606,35 +606,35 @@ class $Root extends $stdlib.std.Resource {
     {((cond) => {if (!cond) throw new Error("assertion failed: mutEndings.toArray() == [[\"Fly Me To The Moon\", \"Slump\"], [\"Heikousen\"], [\"Wagamama\"]]")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })([...(mutEndings)],[["Fly Me To The Moon", "Slump"], ["Heikousen"], ["Wagamama"]])))};
     const immutEndings = new Set(mutEndings);
     {((cond) => {if (!cond) throw new Error("assertion failed: immutEndings.toArray() == mutEndings.toArray()")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })([...(immutEndings)],[...(mutEndings)])))};
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:toArray()",new $Closure5(this,"$Closure5"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:toArray()", new $Closure5(this, "$Closure5"));
     const talkingQuirks = new Set(["dattebane", "battebayo", "dattebasa"]);
     {((cond) => {if (!cond) throw new Error("assertion failed: talkingQuirks.copyMut() == MutSet<str> {\"dattebane\", \"battebayo\", \"dattebasa\"}")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(new Set(talkingQuirks),new Set(["dattebane", "battebayo", "dattebasa"]))))};
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:copyMut()",new $Closure6(this,"$Closure6"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:copyMut()", new $Closure6(this, "$Closure6"));
     const evaRebuild = new Set([1.11, 2.22, 3.33]);
     (evaRebuild.add((3 + 1)));
     {((cond) => {if (!cond) throw new Error("assertion failed: evaRebuild.has(3.0+1.0)")})((evaRebuild.has((3 + 1))))};
     {((cond) => {if (!cond) throw new Error("assertion failed: evaRebuild == MutSet<num>{1.11, 2.22, 3.33, 3.0+1.0}")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(evaRebuild,new Set([1.11, 2.22, 3.33, (3 + 1)]))))};
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:add()",new $Closure7(this,"$Closure7"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:add()", new $Closure7(this, "$Closure7"));
     const studios = new Set(["Gainax", "Ghibli", "Production I.G.", "Shaft"]);
     {((cond) => {if (!cond) throw new Error("assertion failed: studios.delete(\"Gainax\")")})((studios.delete("Gainax")))};
     {((cond) => {if (!cond) throw new Error("assertion failed: studios.has(\"Gainax\") == false")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((studios.has("Gainax")),false)))};
     {((cond) => {if (!cond) throw new Error("assertion failed: studios.delete(\"Sunrise\") == false")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((studios.delete("Sunrise")),false)))};
     {((cond) => {if (!cond) throw new Error("assertion failed: studios.size == 3")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(studios.size,3)))};
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:delete()",new $Closure8(this,"$Closure8"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:delete()", new $Closure8(this, "$Closure8"));
     const demographics = new Set(["shounen", "shoujo", "josei", "seinen"]);
     (demographics.clear());
     {((cond) => {if (!cond) throw new Error("assertion failed: demographics.size == 0")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(demographics.size,0)))};
     (demographics.add("kodomo"));
     (demographics.clear());
     {((cond) => {if (!cond) throw new Error("assertion failed: demographics.has(\"kodomo\") == false")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((demographics.has("kodomo")),false)))};
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:clear()",new $Closure9(this,"$Closure9"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:clear()", new $Closure9(this, "$Closure9"));
     const acronyms = new Set([({"SEL": "Serial Experiments Lain","NGE": "Neon Genesis Evangelion"})]);
     const copyAcronyms = new Set(acronyms);
     {((cond) => {if (!cond) throw new Error("assertion failed: copyAcronyms == {{\"SEL\" => \"Serial Experiments Lain\", \"NGE\" => \"Neon Genesis Evangelion\"}}")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(copyAcronyms,new Set([({"SEL": "Serial Experiments Lain","NGE": "Neon Genesis Evangelion"})]))))};
     (acronyms.add(({"DomeKano": "Domestic na Kanojo"})));
     const copyAcronymsNew = new Set(new Set(acronyms));
     {((cond) => {if (!cond) throw new Error("assertion failed: copyAcronymsNew == acronyms")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(copyAcronymsNew,acronyms)))};
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:copy()",new $Closure10(this,"$Closure10"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:copy()", new $Closure10(this, "$Closure10"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/std/string.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/std/string.test.w_compile_tf-aws.md
@@ -58,8 +58,8 @@ module.exports = function({  }) {
       return $obj;
     }
     async handle() {
-      {((cond) => {if (!cond) throw new Error("assertion failed: \"hello wing\".substring(0, 5) == \"hello\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await "hello wing".substring(0,5)),"hello")))};
-      {((cond) => {if (!cond) throw new Error("assertion failed: \"hello wing\".substring(0, 100) == \"hello wing\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await "hello wing".substring(0,100)),"hello wing")))};
+      {((cond) => {if (!cond) throw new Error("assertion failed: \"hello wing\".substring(0, 5) == \"hello\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await "hello wing".substring(0, 5)),"hello")))};
+      {((cond) => {if (!cond) throw new Error("assertion failed: \"hello wing\".substring(0, 100) == \"hello wing\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await "hello wing".substring(0, 100)),"hello wing")))};
     }
   }
   return $Closure11;
@@ -121,11 +121,11 @@ module.exports = function({  }) {
       return $obj;
     }
     async handle() {
-      {((cond) => {if (!cond) throw new Error("assertion failed: \"hello world\".replace(\"world\", \"wing\") == \"hello wing\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })("hello world".replace("world","wing"),"hello wing")))};
-      {((cond) => {if (!cond) throw new Error("assertion failed: \"pʅɹoʍ oʅʅǝɥ\".replace(\"pʅɹoʍ\", \"ɓuᴉʍ\") == \"ɓuᴉʍ oʅʅǝɥ\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })("pʅɹoʍ oʅʅǝɥ".replace("pʅɹoʍ","ɓuᴉʍ"),"ɓuᴉʍ oʅʅǝɥ")))};
-      {((cond) => {if (!cond) throw new Error("assertion failed: \"hello world\".replace(\"wing\", \"☁\") == \"hello world\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })("hello world".replace("wing","☁"),"hello world")))};
-      {((cond) => {if (!cond) throw new Error("assertion failed: \"hello world\".replace(\" \", \"-\") == \"hello-world\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })("hello world".replace(" ","-"),"hello-world")))};
-      {((cond) => {if (!cond) throw new Error("assertion failed: \"\".replace(\"\", \"hello world\") == \"hello world\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })("".replace("","hello world"),"hello world")))};
+      {((cond) => {if (!cond) throw new Error("assertion failed: \"hello world\".replace(\"world\", \"wing\") == \"hello wing\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })("hello world".replace("world", "wing"),"hello wing")))};
+      {((cond) => {if (!cond) throw new Error("assertion failed: \"pʅɹoʍ oʅʅǝɥ\".replace(\"pʅɹoʍ\", \"ɓuᴉʍ\") == \"ɓuᴉʍ oʅʅǝɥ\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })("pʅɹoʍ oʅʅǝɥ".replace("pʅɹoʍ", "ɓuᴉʍ"),"ɓuᴉʍ oʅʅǝɥ")))};
+      {((cond) => {if (!cond) throw new Error("assertion failed: \"hello world\".replace(\"wing\", \"☁\") == \"hello world\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })("hello world".replace("wing", "☁"),"hello world")))};
+      {((cond) => {if (!cond) throw new Error("assertion failed: \"hello world\".replace(\" \", \"-\") == \"hello-world\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })("hello world".replace(" ", "-"),"hello-world")))};
+      {((cond) => {if (!cond) throw new Error("assertion failed: \"\".replace(\"\", \"hello world\") == \"hello world\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })("".replace("", "hello world"),"hello world")))};
     }
   }
   return $Closure14;
@@ -357,11 +357,11 @@ const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -394,8 +394,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure2 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -420,8 +420,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure3 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -453,8 +453,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure4 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -479,8 +479,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure5 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -505,8 +505,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure6 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -531,8 +531,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure7 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -557,8 +557,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure8 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -583,8 +583,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure9 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -609,8 +609,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure10 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -635,8 +635,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure11 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -661,8 +661,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure12 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -687,8 +687,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure13 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -713,8 +713,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure14 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -752,42 +752,42 @@ class $Root extends $stdlib.std.Resource {
     });
     const PARSE_ERROR = "unable to parse string";
     {((cond) => {if (!cond) throw new Error("assertion failed: str.fromJson(Json \"Hello\") == \"Hello\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((std.String.fromJson("Hello")),"Hello")))};
-    (assertThrows(PARSE_ERROR,(() => {
+    (assertThrows(PARSE_ERROR, (() => {
       (std.String.fromJson(123));
     })));
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:fromJson",new $Closure1(this,"$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:fromJson", new $Closure1(this, "$Closure1"));
     {((cond) => {if (!cond) throw new Error("assertion failed: \"hello\".length == 5")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })("hello".length,5)))};
     {((cond) => {if (!cond) throw new Error("assertion failed: \"\".length == 0")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })("".length,0)))};
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:length",new $Closure2(this,"$Closure2"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:length", new $Closure2(this, "$Closure2"));
     const INDEX_OUT_OF_BOUNDS_ERROR = "index out of bounds";
     {((cond) => {if (!cond) throw new Error("assertion failed: \"boom\".at(2) == \"o\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(((args) => { if (2 >= "boom".length || 2 + "boom".length < 0) {throw new Error("index out of bounds")}; return "boom".at(2) })(2),"o")))};
     {((cond) => {if (!cond) throw new Error("assertion failed: \"boom\".at(-4) == \"b\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(((args) => { if ((-4) >= "boom".length || (-4) + "boom".length < 0) {throw new Error("index out of bounds")}; return "boom".at((-4)) })((-4)),"b")))};
     {((cond) => {if (!cond) throw new Error("assertion failed: \"boom\".at(-1) == \"m\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(((args) => { if ((-1) >= "boom".length || (-1) + "boom".length < 0) {throw new Error("index out of bounds")}; return "boom".at((-1)) })((-1)),"m")))};
-    (assertThrows(INDEX_OUT_OF_BOUNDS_ERROR,(() => {
+    (assertThrows(INDEX_OUT_OF_BOUNDS_ERROR, (() => {
       ((args) => { if (4 >= "boom".length || 4 + "boom".length < 0) {throw new Error("index out of bounds")}; return "boom".at(4) })(4);
     })));
-    (assertThrows(INDEX_OUT_OF_BOUNDS_ERROR,(() => {
+    (assertThrows(INDEX_OUT_OF_BOUNDS_ERROR, (() => {
       ((args) => { if ((-5) >= "boom".length || (-5) + "boom".length < 0) {throw new Error("index out of bounds")}; return "boom".at((-5)) })((-5));
     })));
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:at()",new $Closure3(this,"$Closure3"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:at()", new $Closure3(this, "$Closure3"));
     {((cond) => {if (!cond) throw new Error("assertion failed: \"boom\".concat(\"boom\") == \"boomboom\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(("boom".concat("boom")),"boomboom")))};
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:concat()",new $Closure4(this,"$Closure4"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:concat()", new $Closure4(this, "$Closure4"));
     {((cond) => {if (!cond) throw new Error("assertion failed: \"boom\".endsWith(\"m\")")})("boom".endsWith("m"))};
     {((cond) => {if (!cond) throw new Error("assertion failed: !\"boom\".endsWith(\"b\")")})((!"boom".endsWith("b")))};
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:endsWith()",new $Closure5(this,"$Closure5"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:endsWith()", new $Closure5(this, "$Closure5"));
     {((cond) => {if (!cond) throw new Error("assertion failed: \"boom\".indexOf(\"m\") == 3")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })("boom".indexOf("m"),3)))};
     {((cond) => {if (!cond) throw new Error("assertion failed: \"boom\".indexOf(\"a\") == -1")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })("boom".indexOf("a"),(-1))))};
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:indexOf()",new $Closure6(this,"$Closure6"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:indexOf()", new $Closure6(this, "$Closure6"));
     {((cond) => {if (!cond) throw new Error("assertion failed: \"BOOM\".lowercase() == \"boom\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })("BOOM".toLocaleLowerCase(),"boom")))};
     {((cond) => {if (!cond) throw new Error("assertion failed: \"BooM\".lowercase() == \"boom\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })("BooM".toLocaleLowerCase(),"boom")))};
     {((cond) => {if (!cond) throw new Error("assertion failed: \"boom\".lowercase() == \"boom\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })("boom".toLocaleLowerCase(),"boom")))};
     {((cond) => {if (!cond) throw new Error("assertion failed: \"123#@\".lowercase() == \"123#@\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })("123#@".toLocaleLowerCase(),"123#@")))};
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:lowercase()",new $Closure7(this,"$Closure7"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:lowercase()", new $Closure7(this, "$Closure7"));
     {((cond) => {if (!cond) throw new Error("assertion failed: \"BOOM\".uppercase() == \"BOOM\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })("BOOM".toLocaleUpperCase(),"BOOM")))};
     {((cond) => {if (!cond) throw new Error("assertion failed: \"BooM\".uppercase() == \"BOOM\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })("BooM".toLocaleUpperCase(),"BOOM")))};
     {((cond) => {if (!cond) throw new Error("assertion failed: \"boom\".uppercase() == \"BOOM\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })("boom".toLocaleUpperCase(),"BOOM")))};
     {((cond) => {if (!cond) throw new Error("assertion failed: \"123#@\".uppercase() == \"123#@\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })("123#@".toLocaleUpperCase(),"123#@")))};
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:uppercase()",new $Closure8(this,"$Closure8"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:uppercase()", new $Closure8(this, "$Closure8"));
     {((cond) => {if (!cond) throw new Error("assertion failed: \"hello;wing\".split(\";\").at(0) == \"hello\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((("hello;wing".split(";")).at(0)),"hello")))};
     {((cond) => {if (!cond) throw new Error("assertion failed: \"hello;wing\".split(\";\").at(1) == \"wing\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((("hello;wing".split(";")).at(1)),"wing")))};
     {((cond) => {if (!cond) throw new Error("assertion failed: \"hello wing\".split(\" \").at(0) == \"hello\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((("hello wing".split(" ")).at(0)),"hello")))};
@@ -795,29 +795,29 @@ class $Root extends $stdlib.std.Resource {
     {((cond) => {if (!cond) throw new Error("assertion failed: \"hello wing\".split(\"\").length == 10")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(("hello wing".split("")).length,10)))};
     {((cond) => {if (!cond) throw new Error("assertion failed: \"hello wing\".split(\"\").at(0) == \"h\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((("hello wing".split("")).at(0)),"h")))};
     {((cond) => {if (!cond) throw new Error("assertion failed: \"hello wing\".split(\"\").at(1) == \"e\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((("hello wing".split("")).at(1)),"e")))};
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:split()",new $Closure9(this,"$Closure9"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:split()", new $Closure9(this, "$Closure9"));
     {((cond) => {if (!cond) throw new Error("assertion failed: \"hello wing\".startsWith(\"h\")")})("hello wing".startsWith("h"))};
     {((cond) => {if (!cond) throw new Error("assertion failed: !\"hello wing\".startsWith(\"H\")")})((!"hello wing".startsWith("H")))};
     {((cond) => {if (!cond) throw new Error("assertion failed: !\"hello wing\".startsWith(\"w\")")})((!"hello wing".startsWith("w")))};
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:startsWith()",new $Closure10(this,"$Closure10"));
-    {((cond) => {if (!cond) throw new Error("assertion failed: \"hello wing\".substring(0, 5) == \"hello\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(("hello wing".substring(0,5)),"hello")))};
-    {((cond) => {if (!cond) throw new Error("assertion failed: \"hello wing\".substring(0, 100) == \"hello wing\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(("hello wing".substring(0,100)),"hello wing")))};
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:substring()",new $Closure11(this,"$Closure11"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:startsWith()", new $Closure10(this, "$Closure10"));
+    {((cond) => {if (!cond) throw new Error("assertion failed: \"hello wing\".substring(0, 5) == \"hello\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(("hello wing".substring(0, 5)),"hello")))};
+    {((cond) => {if (!cond) throw new Error("assertion failed: \"hello wing\".substring(0, 100) == \"hello wing\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(("hello wing".substring(0, 100)),"hello wing")))};
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:substring()", new $Closure11(this, "$Closure11"));
     {((cond) => {if (!cond) throw new Error("assertion failed: \"hello wing         \".trim() == \"hello wing\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(("hello wing         ".trim()),"hello wing")))};
     {((cond) => {if (!cond) throw new Error("assertion failed: \"hello wing\".trim() == \"hello wing\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(("hello wing".trim()),"hello wing")))};
     {((cond) => {if (!cond) throw new Error("assertion failed: \"\".trim() == \"\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(("".trim()),"")))};
     {((cond) => {if (!cond) throw new Error("assertion failed: \"\\thello wing\\n\".trim() == \"hello wing\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(("\thello wing\n".trim()),"hello wing")))};
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:trim()",new $Closure12(this,"$Closure12"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:trim()", new $Closure12(this, "$Closure12"));
     {((cond) => {if (!cond) throw new Error("assertion failed: \"hello wing\".contains(\"hello\")")})("hello wing".includes("hello"))};
     {((cond) => {if (!cond) throw new Error("assertion failed: !\"hello wing\".contains(\"Hello\")")})((!"hello wing".includes("Hello")))};
     {((cond) => {if (!cond) throw new Error("assertion failed: \"hello wing\".contains(\"w\")")})("hello wing".includes("w"))};
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:contains()",new $Closure13(this,"$Closure13"));
-    {((cond) => {if (!cond) throw new Error("assertion failed: \"hello world\".replace(\"world\", \"wing\") == \"hello wing\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })("hello world".replace("world","wing"),"hello wing")))};
-    {((cond) => {if (!cond) throw new Error("assertion failed: \"pʅɹoʍ oʅʅǝɥ\".replace(\"pʅɹoʍ\", \"ɓuᴉʍ\") == \"ɓuᴉʍ oʅʅǝɥ\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })("pʅɹoʍ oʅʅǝɥ".replace("pʅɹoʍ","ɓuᴉʍ"),"ɓuᴉʍ oʅʅǝɥ")))};
-    {((cond) => {if (!cond) throw new Error("assertion failed: \"hello world\".replace(\"wing\", \"☁\") == \"hello world\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })("hello world".replace("wing","☁"),"hello world")))};
-    {((cond) => {if (!cond) throw new Error("assertion failed: \"hello world\".replace(\" \", \"-\") == \"hello-world\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })("hello world".replace(" ","-"),"hello-world")))};
-    {((cond) => {if (!cond) throw new Error("assertion failed: \"\".replace(\"\", \"hello world\") == \"hello world\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })("".replace("","hello world"),"hello world")))};
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:replace()",new $Closure14(this,"$Closure14"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:contains()", new $Closure13(this, "$Closure13"));
+    {((cond) => {if (!cond) throw new Error("assertion failed: \"hello world\".replace(\"world\", \"wing\") == \"hello wing\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })("hello world".replace("world", "wing"),"hello wing")))};
+    {((cond) => {if (!cond) throw new Error("assertion failed: \"pʅɹoʍ oʅʅǝɥ\".replace(\"pʅɹoʍ\", \"ɓuᴉʍ\") == \"ɓuᴉʍ oʅʅǝɥ\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })("pʅɹoʍ oʅʅǝɥ".replace("pʅɹoʍ", "ɓuᴉʍ"),"ɓuᴉʍ oʅʅǝɥ")))};
+    {((cond) => {if (!cond) throw new Error("assertion failed: \"hello world\".replace(\"wing\", \"☁\") == \"hello world\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })("hello world".replace("wing", "☁"),"hello world")))};
+    {((cond) => {if (!cond) throw new Error("assertion failed: \"hello world\".replace(\" \", \"-\") == \"hello-world\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })("hello world".replace(" ", "-"),"hello-world")))};
+    {((cond) => {if (!cond) throw new Error("assertion failed: \"\".replace(\"\", \"hello world\") == \"hello world\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })("".replace("", "hello world"),"hello world")))};
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:replace()", new $Closure14(this, "$Closure14"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/table/add_row.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/table/add_row.test.w_compile_tf-aws.md
@@ -112,11 +112,11 @@ const std = $stdlib.std;
 const ex = $stdlib.ex;
 const util = $stdlib.util;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -155,12 +155,12 @@ class $Root extends $stdlib.std.Resource {
         super._registerOnLift(host, ops);
       }
     }
-    const table = this.node.root.newAbstract("@winglang/sdk.ex.Table",this,"ex.Table",{ name: "users", primaryKey: "name", columns: ({"gender": ex.ColumnType.STRING,"role": ex.ColumnType.STRING}) });
+    const table = this.node.root.newAbstract("@winglang/sdk.ex.Table",this, "ex.Table", { name: "users", primaryKey: "name", columns: ({"gender": ex.ColumnType.STRING,"role": ex.ColumnType.STRING}) });
     const marioInfo = ({"gender": "male","role": "plumber"});
     const peachInfo = ({"gender": "female","role": "princess"});
-    (table.addRow("mario",marioInfo));
-    (table.addRow("peach",peachInfo));
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:addRow",new $Closure1(this,"$Closure1"));
+    (table.addRow("mario", marioInfo));
+    (table.addRow("peach", peachInfo));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:addRow", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/table/get.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/table/get.test.w_compile_tf-aws.md
@@ -29,9 +29,9 @@ module.exports = function({ $table }) {
         {((cond) => {if (!cond) throw new Error("assertion failed: error")})(error)};
       }
       ;
-      (await $table.insert(VALID_KEY,({"gender": COLUMN_VALUE})));
+      (await $table.insert(VALID_KEY, ({"gender": COLUMN_VALUE})));
       {((cond) => {if (!cond) throw new Error("assertion failed: table.get(VALID_KEY).get(COLUMN_NAME) == COLUMN_VALUE")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(((obj, args) => { if (obj[args] === undefined) throw new Error(`Json property "${args}" does not exist`); return obj[args] })((await $table.get(VALID_KEY)), COLUMN_NAME),COLUMN_VALUE)))};
-      (await assertThrows(ROW_DOES_NOT_EXIST_ERROR,async () => {
+      (await assertThrows(ROW_DOES_NOT_EXIST_ERROR, async () => {
         (await $table.get(NON_EXISTENT_KEY));
       }
       ));
@@ -109,11 +109,11 @@ const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 const ex = $stdlib.ex;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -144,8 +144,8 @@ class $Root extends $stdlib.std.Resource {
         super._registerOnLift(host, ops);
       }
     }
-    const table = this.node.root.newAbstract("@winglang/sdk.ex.Table",this,"ex.Table",{ name: "users", primaryKey: "name", columns: ({"gender": ex.ColumnType.STRING}) });
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:get",new $Closure1(this,"$Closure1"));
+    const table = this.node.root.newAbstract("@winglang/sdk.ex.Table",this, "ex.Table", { name: "users", primaryKey: "name", columns: ({"gender": ex.ColumnType.STRING}) });
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:get", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/table/list.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/table/list.test.w_compile_tf-aws.md
@@ -11,11 +11,11 @@ module.exports = function({ $std_String, $table }) {
       return $obj;
     }
     async handle() {
-      (await $table.insert("eyal",({"gender": "male"})));
-      (await $table.insert("revital",({"gender": "female"})));
+      (await $table.insert("eyal", ({"gender": "male"})));
+      (await $table.insert("revital", ({"gender": "female"})));
       const unorderded = ({});
       for (const u of (await $table.list())) {
-        ((obj, args) => { obj[args[0]] = args[1]; })(unorderded, [(await $std_String.fromJson(((obj, args) => { if (obj[args] === undefined) throw new Error(`Json property "${args}" does not exist`); return obj[args] })(u, "name"))),u]);
+        ((obj, args) => { obj[args[0]] = args[1]; })(unorderded, [(await $std_String.fromJson(((obj, args) => { if (obj[args] === undefined) throw new Error(`Json property "${args}" does not exist`); return obj[args] })(u, "name"))), u]);
       }
       const revital = ((obj, args) => { if (obj[args] === undefined) throw new Error(`Json property "${args}" does not exist`); return obj[args] })(unorderded, "revital");
       const eyal = ((obj, args) => { if (obj[args] === undefined) throw new Error(`Json property "${args}" does not exist`); return obj[args] })(unorderded, "eyal");
@@ -94,11 +94,11 @@ const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 const ex = $stdlib.ex;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -130,8 +130,8 @@ class $Root extends $stdlib.std.Resource {
         super._registerOnLift(host, ops);
       }
     }
-    const table = this.node.root.newAbstract("@winglang/sdk.ex.Table",this,"ex.Table",{ name: "users", primaryKey: "name", columns: ({"gender": ex.ColumnType.STRING}) });
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:list",new $Closure1(this,"$Closure1"));
+    const table = this.node.root.newAbstract("@winglang/sdk.ex.Table",this, "ex.Table", { name: "users", primaryKey: "name", columns: ({"gender": ex.ColumnType.STRING}) });
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:list", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/table/upsert.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/table/upsert.test.w_compile_tf-aws.md
@@ -26,19 +26,19 @@ module.exports = function({ $table }) {
       ;
       const JSON_PROPERTY_ROLE_DOES_NOT_EXIST_ERROR = "Json property \"role\" does not exist";
       const JSON_PROPERTY_GENDER_DOES_NOT_EXIST_ERROR = "Json property \"gender\" does not exist";
-      (await $table.upsert("mario",({})));
-      (await $table.upsert("luigi",({"role": "ghostbuster"})));
-      (await $table.upsert("peach",({"gender": "female","role": "princess"})));
-      (await assertThrows(JSON_PROPERTY_ROLE_DOES_NOT_EXIST_ERROR,async () => {
+      (await $table.upsert("mario", ({})));
+      (await $table.upsert("luigi", ({"role": "ghostbuster"})));
+      (await $table.upsert("peach", ({"gender": "female","role": "princess"})));
+      (await assertThrows(JSON_PROPERTY_ROLE_DOES_NOT_EXIST_ERROR, async () => {
         ((obj, args) => { if (obj[args] === undefined) throw new Error(`Json property "${args}" does not exist`); return obj[args] })((await $table.get("mario")), "role");
       }
       ));
-      (await assertThrows(JSON_PROPERTY_GENDER_DOES_NOT_EXIST_ERROR,async () => {
+      (await assertThrows(JSON_PROPERTY_GENDER_DOES_NOT_EXIST_ERROR, async () => {
         ((obj, args) => { if (obj[args] === undefined) throw new Error(`Json property "${args}" does not exist`); return obj[args] })((await $table.get("mario")), "gender");
       }
       ));
       {((cond) => {if (!cond) throw new Error("assertion failed: table.get(\"luigi\").get(\"role\") == \"ghostbuster\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(((obj, args) => { if (obj[args] === undefined) throw new Error(`Json property "${args}" does not exist`); return obj[args] })((await $table.get("luigi")), "role"),"ghostbuster")))};
-      (await assertThrows(JSON_PROPERTY_GENDER_DOES_NOT_EXIST_ERROR,async () => {
+      (await assertThrows(JSON_PROPERTY_GENDER_DOES_NOT_EXIST_ERROR, async () => {
         ((obj, args) => { if (obj[args] === undefined) throw new Error(`Json property "${args}" does not exist`); return obj[args] })((await $table.get("luigi")), "gender");
       }
       ));
@@ -140,11 +140,11 @@ const std = $stdlib.std;
 const ex = $stdlib.ex;
 const util = $stdlib.util;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -175,10 +175,10 @@ class $Root extends $stdlib.std.Resource {
         super._registerOnLift(host, ops);
       }
     }
-    const table = this.node.root.newAbstract("@winglang/sdk.ex.Table",this,"ex.Table",{ name: "users", primaryKey: "name", columns: ({"gender": ex.ColumnType.STRING,"role": ex.ColumnType.STRING}) });
-    (table.addRow("mario",({"gender": "male","role": "plumber"})));
-    (table.addRow("luigi",({"gender": "male","role": "plumber"})));
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:upsert",new $Closure1(this,"$Closure1"));
+    const table = this.node.root.newAbstract("@winglang/sdk.ex.Table",this, "ex.Table", { name: "users", primaryKey: "name", columns: ({"gender": ex.ColumnType.STRING,"role": ex.ColumnType.STRING}) });
+    (table.addRow("mario", ({"gender": "male","role": "plumber"})));
+    (table.addRow("luigi", ({"gender": "male","role": "plumber"})));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:upsert", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/topic/on_message.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/topic/on_message.test.w_compile_tf-aws.md
@@ -394,11 +394,11 @@ const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 const util = $stdlib.util;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class Predicate extends $stdlib.std.Resource {
-      constructor(scope, id, c) {
-        super(scope, id);
+      constructor($scope, $id, c) {
+        super($scope, $id);
         this.c = c;
       }
       static _toInflightType(context) {
@@ -433,8 +433,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -466,8 +466,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure2 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -499,8 +499,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure3 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -535,12 +535,12 @@ class $Root extends $stdlib.std.Resource {
         super._registerOnLift(host, ops);
       }
     }
-    const t = this.node.root.newAbstract("@winglang/sdk.cloud.Topic",this,"cloud.Topic");
-    const c = this.node.root.newAbstract("@winglang/sdk.cloud.Counter",this,"cloud.Counter");
-    (t.onMessage(new $Closure1(this,"$Closure1")));
-    (t.onMessage(new $Closure2(this,"$Closure2")));
-    const predicate = new Predicate(this,"Predicate",c);
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:onMessage",new $Closure3(this,"$Closure3"));
+    const t = this.node.root.newAbstract("@winglang/sdk.cloud.Topic",this, "cloud.Topic");
+    const c = this.node.root.newAbstract("@winglang/sdk.cloud.Counter",this, "cloud.Counter");
+    (t.onMessage(new $Closure1(this, "$Closure1")));
+    (t.onMessage(new $Closure2(this, "$Closure2")));
+    const predicate = new Predicate(this, "Predicate", c);
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:onMessage", new $Closure3(this, "$Closure3"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/util/base64.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/util/base64.test.w_compile_tf-aws.md
@@ -13,9 +13,9 @@ module.exports = function({ $util_Util }) {
     async handle() {
       const string = "https://www.winglang.io/docs";
       const base64Encode = (await $util_Util.base64Encode(string));
-      const base64urlEncode = (await $util_Util.base64Encode(string,true));
+      const base64urlEncode = (await $util_Util.base64Encode(string, true));
       const base64Decode = (await $util_Util.base64Decode("aHR0cHM6Ly93d3cud2luZ2xhbmcuaW8vZG9jcw=="));
-      const base64urlDecode = (await $util_Util.base64Decode("aHR0cHM6Ly93d3cud2luZ2xhbmcuaW8vZG9jcw",true));
+      const base64urlDecode = (await $util_Util.base64Decode("aHR0cHM6Ly93d3cud2luZ2xhbmcuaW8vZG9jcw", true));
       {((cond) => {if (!cond) throw new Error("assertion failed: base64Encode == \"aHR0cHM6Ly93d3cud2luZ2xhbmcuaW8vZG9jcw==\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(base64Encode,"aHR0cHM6Ly93d3cud2luZ2xhbmcuaW8vZG9jcw==")))};
       {((cond) => {if (!cond) throw new Error("assertion failed: base64urlEncode == \"aHR0cHM6Ly93d3cud2luZ2xhbmcuaW8vZG9jcw\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(base64urlEncode,"aHR0cHM6Ly93d3cud2luZ2xhbmcuaW8vZG9jcw")))};
       {((cond) => {if (!cond) throw new Error("assertion failed: base64Decode == string")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(base64Decode,string)))};
@@ -69,11 +69,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const util = $stdlib.util;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -100,14 +100,14 @@ class $Root extends $stdlib.std.Resource {
     }
     const string = "https://www.winglang.io/docs";
     const base64Encode = (util.Util.base64Encode(string));
-    const base64urlEncode = (util.Util.base64Encode(string,true));
+    const base64urlEncode = (util.Util.base64Encode(string, true));
     const base64Decode = (util.Util.base64Decode("aHR0cHM6Ly93d3cud2luZ2xhbmcuaW8vZG9jcw=="));
-    const base64urlDecode = (util.Util.base64Decode("aHR0cHM6Ly93d3cud2luZ2xhbmcuaW8vZG9jcw",true));
+    const base64urlDecode = (util.Util.base64Decode("aHR0cHM6Ly93d3cud2luZ2xhbmcuaW8vZG9jcw", true));
     {((cond) => {if (!cond) throw new Error("assertion failed: base64Encode == \"aHR0cHM6Ly93d3cud2luZ2xhbmcuaW8vZG9jcw==\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(base64Encode,"aHR0cHM6Ly93d3cud2luZ2xhbmcuaW8vZG9jcw==")))};
     {((cond) => {if (!cond) throw new Error("assertion failed: base64urlEncode == \"aHR0cHM6Ly93d3cud2luZ2xhbmcuaW8vZG9jcw\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(base64urlEncode,"aHR0cHM6Ly93d3cud2luZ2xhbmcuaW8vZG9jcw")))};
     {((cond) => {if (!cond) throw new Error("assertion failed: base64Decode == string")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(base64Decode,string)))};
     {((cond) => {if (!cond) throw new Error("assertion failed: base64urlDecode == string")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(base64urlDecode,string)))};
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:inflight base64",new $Closure1(this,"$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:inflight base64", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/util/env.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/util/env.test.w_compile_tf-aws.md
@@ -63,11 +63,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const util = $stdlib.util;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -117,7 +117,7 @@ class $Root extends $stdlib.std.Resource {
     {((cond) => {if (!cond) throw new Error("assertion failed: failed")})(failed)};
     const no_value = ((util.Util.tryEnv(RANDOM)) ?? NIL);
     {((cond) => {if (!cond) throw new Error("assertion failed: no_value == NIL")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(no_value,NIL)))};
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:use util from inflight",new $Closure1(this,"$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:use util from inflight", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/util/nanoid.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/util/nanoid.test.w_compile_tf-aws.md
@@ -74,11 +74,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const util = $stdlib.util;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -117,7 +117,7 @@ class $Root extends $stdlib.std.Resource {
         {((cond) => {if (!cond) throw new Error("assertion failed: false")})(false)};
       }
     }
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:inflight nanoid",new $Closure1(this,"$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:inflight nanoid", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/util/sha256.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/util/sha256.test.w_compile_tf-aws.md
@@ -62,11 +62,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const util = $stdlib.util;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -93,7 +93,7 @@ class $Root extends $stdlib.std.Resource {
     }
     const data = (util.Util.sha256("winglang"));
     {((cond) => {if (!cond) throw new Error("assertion failed: data == \"9796cc32487d74729dad64ec6090f6fb9b9f577dc61a40f9f58efa437acbd8ed\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(data,"9796cc32487d74729dad64ec6090f6fb9b9f577dc61a40f9f58efa437acbd8ed")))};
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:inflight sha256",new $Closure1(this,"$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:inflight sha256", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/util/sleep.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/util/sleep.test.w_compile_tf-aws.md
@@ -81,11 +81,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const util = $stdlib.util;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class JSHelper extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
       }
       static _toInflightType(context) {
         return `
@@ -109,8 +109,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -145,7 +145,7 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     const oneHundredMiliseconds = (std.Duration.fromSeconds(0.1));
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:sleep 100 mili seconds",new $Closure1(this,"$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:sleep 100 mili seconds", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/util/uuidv4.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/util/uuidv4.test.w_compile_tf-aws.md
@@ -91,11 +91,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const util = $stdlib.util;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class JSHelper extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
       }
       static validateUUIDv4(uuidv4) {
         return (require("<ABSOLUTE_PATH>/uuidv4-helper.js")["validateUUIDv4"])(uuidv4)
@@ -122,8 +122,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class JSHelperInflight extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
       }
       static _toInflightType(context) {
         return `
@@ -147,8 +147,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -182,7 +182,7 @@ class $Root extends $stdlib.std.Resource {
     }
     const data = (util.Util.uuidv4());
     {((cond) => {if (!cond) throw new Error("assertion failed: JSHelper.validateUUIDv4(data) == true")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((JSHelper.validateUUIDv4(data)),true)))};
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:inflight uuidv4",new $Closure1(this,"$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:inflight uuidv4", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/util/wait-until.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/util/wait-until.test.w_compile_tf-aws.md
@@ -43,7 +43,7 @@ module.exports = function({ $JSHelper, $oneSecond, $util_Util }) {
       if ((await $util_Util.waitUntil(async () => {
         return false;
       }
-      ,{ timeout: $oneSecond }))) {
+      , { timeout: $oneSecond }))) {
         {((cond) => {if (!cond) throw new Error("assertion failed: false")})(false)};
       }
       else {
@@ -73,7 +73,7 @@ module.exports = function({ $JSHelper, $invokeCounter, $oneSecond, $util_Util })
         return (((await $JSHelper.getTime()) - start) > (3 * 1000));
       }
       ;
-      if ((await $util_Util.waitUntil(returnTrueAfter3Seconds,{ interval: $oneSecond }))) {
+      if ((await $util_Util.waitUntil(returnTrueAfter3Seconds, { interval: $oneSecond }))) {
         const invocations = (await $invokeCounter.peek());
         {((cond) => {if (!cond) throw new Error("assertion failed:  invocations > 1 && invocations < 10 ")})(((invocations > 1) && (invocations < 10)))};
       }
@@ -104,7 +104,7 @@ module.exports = function({ $JSHelper, $fiveSeconds, $invokeCounter, $oneSecond,
         return false;
       }
       ;
-      if ((await $util_Util.waitUntil(returnFalse,{ interval: $oneSecond, timeout: $fiveSeconds }))) {
+      if ((await $util_Util.waitUntil(returnFalse, { interval: $oneSecond, timeout: $fiveSeconds }))) {
         {((cond) => {if (!cond) throw new Error("assertion failed: false")})(false)};
       }
       else {
@@ -227,11 +227,11 @@ const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 const util = $stdlib.util;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class JSHelper extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
       }
       static _toInflightType(context) {
         return `
@@ -255,8 +255,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -289,8 +289,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure2 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -325,8 +325,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure3 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -363,8 +363,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure4 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -403,8 +403,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure5 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -436,15 +436,15 @@ class $Root extends $stdlib.std.Resource {
         super._registerOnLift(host, ops);
       }
     }
-    const invokeCounter = this.node.root.newAbstract("@winglang/sdk.cloud.Counter",this,"cloud.Counter");
+    const invokeCounter = this.node.root.newAbstract("@winglang/sdk.cloud.Counter",this, "cloud.Counter");
     const oneHundredMiliseconds = (std.Duration.fromSeconds(0.1));
     const oneSecond = (std.Duration.fromSeconds(1));
     const fiveSeconds = (std.Duration.fromSeconds(5));
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:returns true immediately",new $Closure1(this,"$Closure1"));
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:returns false goes to timeout",new $Closure2(this,"$Closure2"));
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:returns after some time waiting",new $Closure3(this,"$Closure3"));
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:setting props",new $Closure4(this,"$Closure4"));
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:throwing exception from predicate should throw immediately",new $Closure5(this,"$Closure5"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:returns true immediately", new $Closure1(this, "$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:returns false goes to timeout", new $Closure2(this, "$Closure2"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:returns after some time waiting", new $Closure3(this, "$Closure3"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:setting props", new $Closure4(this, "$Closure4"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:throwing exception from predicate should throw immediately", new $Closure5(this, "$Closure5"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/website/react-app.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/website/react-app.test.w_compile_tf-aws.md
@@ -444,11 +444,11 @@ const ex = $stdlib.ex;
 const cloud = $stdlib.cloud;
 const http = $stdlib.http;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -473,8 +473,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure2 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -510,13 +510,13 @@ class $Root extends $stdlib.std.Resource {
         super._registerOnLift(host, ops);
       }
     }
-    const api = this.node.root.newAbstract("@winglang/sdk.cloud.Api",this,"cloud.Api");
-    (api.get("/",new $Closure1(this,"$Closure1")));
-    const website = this.node.root.newAbstract("@winglang/sdk.ex.ReactApp",this,"ex.ReactApp",{ projectPath: "./react-website", buildDir: "/build/public", useBuildCommand: true });
+    const api = this.node.root.newAbstract("@winglang/sdk.cloud.Api",this, "cloud.Api");
+    (api.get("/", new $Closure1(this, "$Closure1")));
+    const website = this.node.root.newAbstract("@winglang/sdk.ex.ReactApp",this, "ex.ReactApp", { projectPath: "./react-website", buildDir: "/build/public", useBuildCommand: true });
     const preflightVariable = "preflight variable";
-    (website.addEnvironment("apiUrl",api.url));
-    (website.addEnvironment("anotherEnvVar",preflightVariable));
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:website is working",new $Closure2(this,"$Closure2"));
+    (website.addEnvironment("apiUrl", api.url));
+    (website.addEnvironment("anotherEnvVar", preflightVariable));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:website is working", new $Closure2(this, "$Closure2"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/website/two_websites.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/website/two_websites.test.w_compile_tf-aws.md
@@ -401,11 +401,11 @@ const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 const http = $stdlib.http;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -439,9 +439,9 @@ class $Root extends $stdlib.std.Resource {
         super._registerOnLift(host, ops);
       }
     }
-    const w1 = this.node.root.newAbstract("@winglang/sdk.cloud.Website",this,"cloud.Website",{ path: "./website" });
-    const w2 = this.node.root.newAbstract("@winglang/sdk.cloud.Website",this,"website-2",{ path: "./website" });
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:deploying two websites",new $Closure1(this,"$Closure1"));
+    const w1 = this.node.root.newAbstract("@winglang/sdk.cloud.Website",this, "cloud.Website", { path: "./website" });
+    const w2 = this.node.root.newAbstract("@winglang/sdk.cloud.Website",this, "website-2", { path: "./website" });
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:deploying two websites", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/website/website.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/website/website.test.w_compile_tf-aws.md
@@ -274,11 +274,11 @@ const cloud = $stdlib.cloud;
 const http = $stdlib.http;
 const fs = $stdlib.fs;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -319,15 +319,15 @@ class $Root extends $stdlib.std.Resource {
         super._registerOnLift(host, ops);
       }
     }
-    const w = this.node.root.newAbstract("@winglang/sdk.cloud.Website",this,"cloud.Website",{ path: "./website" });
+    const w = this.node.root.newAbstract("@winglang/sdk.cloud.Website",this, "cloud.Website", { path: "./website" });
     const config = ({"json": 1});
     const htmlContent = "<html>Hello World!</html>";
     const indexFile = (fs.Util.readFile(String.raw({ raw: ["", "/index.html"] }, w.path)));
     const otherFile = (fs.Util.readFile(String.raw({ raw: ["", "/inner-folder/other.html"] }, w.path)));
-    (w.addJson("config.json",config));
-    (w.addFile("another-file.html",htmlContent,{ contentType: "text/html" }));
+    (w.addJson("config.json", config));
+    (w.addFile("another-file.html", htmlContent, { contentType: "text/html" }));
     {((cond) => {if (!cond) throw new Error("assertion failed: w.path.endsWith(\"sdk_tests/website/website\") || w.path.endsWith(\"sdk_tests\\\\website\\\\website\")")})((w.path.endsWith("sdk_tests/website/website") || w.path.endsWith("sdk_tests\\website\\website")))};
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:access files on the website",new $Closure1(this,"$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:access files on the website", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/valid/anon_function.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/anon_function.test.w_compile_tf-aws.md
@@ -41,8 +41,8 @@ const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     const myfunc = ((x) => {
       {console.log(String.raw({ raw: ["", ""] }, x))};
       x = (x + 1);

--- a/tools/hangar/__snapshots__/test_corpus/valid/api.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/api.test.w_compile_tf-aws.md
@@ -439,11 +439,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -476,8 +476,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure2 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -509,13 +509,13 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class A extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
-        this.api = this.node.root.newAbstract("@winglang/sdk.cloud.Api",this,"cloud.Api");
+      constructor($scope, $id, ) {
+        super($scope, $id);
+        this.api = this.node.root.newAbstract("@winglang/sdk.cloud.Api",this, "cloud.Api");
         const __parent_this_3 = this;
         class $Closure3 extends $stdlib.std.Resource {
-          constructor(scope, id, ) {
-            super(scope, id);
+          constructor($scope, $id, ) {
+            super($scope, $id);
             (std.Node.of(this)).hidden = true;
           }
           static _toInflightType(context) {
@@ -546,7 +546,7 @@ class $Root extends $stdlib.std.Resource {
             super._registerOnLift(host, ops);
           }
         }
-        (this.api.get("/endpoint1",new $Closure3(this,"$Closure3")));
+        (this.api.get("/endpoint1", new $Closure3(this, "$Closure3")));
       }
       static _toInflightType(context) {
         return `
@@ -569,12 +569,12 @@ class $Root extends $stdlib.std.Resource {
         return ["$inflight_init"];
       }
     }
-    const api = this.node.root.newAbstract("@winglang/sdk.cloud.Api",this,"cloud.Api");
-    const counter = this.node.root.newAbstract("@winglang/sdk.cloud.Counter",this,"cloud.Counter");
-    const handler = new $Closure1(this,"$Closure1");
-    (api.get("/hello/world",handler));
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:api url",new $Closure2(this,"$Closure2"));
-    new A(this,"A");
+    const api = this.node.root.newAbstract("@winglang/sdk.cloud.Api",this, "cloud.Api");
+    const counter = this.node.root.newAbstract("@winglang/sdk.cloud.Counter",this, "cloud.Counter");
+    const handler = new $Closure1(this, "$Closure1");
+    (api.get("/hello/world", handler));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:api url", new $Closure2(this, "$Closure2"));
+    new A(this, "A");
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/valid/api_cors_custom.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/api_cors_custom.test.w_compile_tf-aws.md
@@ -32,10 +32,10 @@ module.exports = function({ $api_url, $http_Util, $t_Assert }) {
     async handle() {
       const response = (await $http_Util.get(($api_url + "/users")));
       const headers = response.headers;
-      (await $t_Assert.equalNum(response.status,200));
-      (await $t_Assert.equalStr(((obj, key) => { if (!(key in obj)) throw new Error(`Map does not contain key: "${key}"`); return obj[key]; })(headers, "access-control-allow-origin"),"winglang.io"));
-      (await $t_Assert.equalStr(((obj, key) => { if (!(key in obj)) throw new Error(`Map does not contain key: "${key}"`); return obj[key]; })(headers, "access-control-allow-credentials"),"true"));
-      (await $t_Assert.equalStr(((obj, key) => { if (!(key in obj)) throw new Error(`Map does not contain key: "${key}"`); return obj[key]; })(headers, "access-control-expose-headers"),"Content-Type"));
+      (await $t_Assert.equalNum(response.status, 200));
+      (await $t_Assert.equalStr(((obj, key) => { if (!(key in obj)) throw new Error(`Map does not contain key: "${key}"`); return obj[key]; })(headers, "access-control-allow-origin"), "winglang.io"));
+      (await $t_Assert.equalStr(((obj, key) => { if (!(key in obj)) throw new Error(`Map does not contain key: "${key}"`); return obj[key]; })(headers, "access-control-allow-credentials"), "true"));
+      (await $t_Assert.equalStr(((obj, key) => { if (!(key in obj)) throw new Error(`Map does not contain key: "${key}"`); return obj[key]; })(headers, "access-control-expose-headers"), "Content-Type"));
       (await $t_Assert.isNil((headers)["access-control-allow-headers"]));
       (await $t_Assert.isNil((headers)["access-control-allow-methods"]));
     }
@@ -56,12 +56,12 @@ module.exports = function({ $api_url, $http_HttpMethod, $http_Util, $t_Assert })
       return $obj;
     }
     async handle() {
-      const response = (await $http_Util.fetch(($api_url + "/users"),({"method": $http_HttpMethod.OPTIONS})));
+      const response = (await $http_Util.fetch(($api_url + "/users"), ({"method": $http_HttpMethod.OPTIONS})));
       const headers = response.headers;
-      (await $t_Assert.equalNum(response.status,204));
-      (await $t_Assert.equalStr(((obj, key) => { if (!(key in obj)) throw new Error(`Map does not contain key: "${key}"`); return obj[key]; })(headers, "access-control-allow-methods"),"GET,POST,OPTIONS"));
-      (await $t_Assert.equalStr(((obj, key) => { if (!(key in obj)) throw new Error(`Map does not contain key: "${key}"`); return obj[key]; })(headers, "access-control-allow-headers"),"Content-Type,Authorization,X-Custom-Header"));
-      (await $t_Assert.equalStr(((obj, key) => { if (!(key in obj)) throw new Error(`Map does not contain key: "${key}"`); return obj[key]; })(headers, "access-control-allow-origin"),"winglang.io"));
+      (await $t_Assert.equalNum(response.status, 204));
+      (await $t_Assert.equalStr(((obj, key) => { if (!(key in obj)) throw new Error(`Map does not contain key: "${key}"`); return obj[key]; })(headers, "access-control-allow-methods"), "GET,POST,OPTIONS"));
+      (await $t_Assert.equalStr(((obj, key) => { if (!(key in obj)) throw new Error(`Map does not contain key: "${key}"`); return obj[key]; })(headers, "access-control-allow-headers"), "Content-Type,Authorization,X-Custom-Header"));
+      (await $t_Assert.equalStr(((obj, key) => { if (!(key in obj)) throw new Error(`Map does not contain key: "${key}"`); return obj[key]; })(headers, "access-control-allow-origin"), "winglang.io"));
       (await $t_Assert.isNil((headers)["access-control-expose-headers"]));
       (await $t_Assert.isNil((headers)["access-control-allow-credentials"]));
     }
@@ -82,12 +82,12 @@ module.exports = function({ $api_url, $http_HttpMethod, $http_Util, $t_Assert })
       return $obj;
     }
     async handle() {
-      const response = (await $http_Util.fetch(($api_url + "/users"),({"method": $http_HttpMethod.OPTIONS,"headers": ({"Access-Control-Request-Method": "PUT","Access-Control-Request-Headers": "Content-Type,Authorization,X-Custom-Foo"})})));
+      const response = (await $http_Util.fetch(($api_url + "/users"), ({"method": $http_HttpMethod.OPTIONS,"headers": ({"Access-Control-Request-Method": "PUT","Access-Control-Request-Headers": "Content-Type,Authorization,X-Custom-Foo"})})));
       const headers = response.headers;
-      (await $t_Assert.equalNum(response.status,204));
-      (await $t_Assert.equalStr(((obj, key) => { if (!(key in obj)) throw new Error(`Map does not contain key: "${key}"`); return obj[key]; })(headers, "access-control-allow-methods"),"GET,POST,OPTIONS"));
-      (await $t_Assert.equalStr(((obj, key) => { if (!(key in obj)) throw new Error(`Map does not contain key: "${key}"`); return obj[key]; })(headers, "access-control-allow-headers"),"Content-Type,Authorization,X-Custom-Header"));
-      (await $t_Assert.equalStr(((obj, key) => { if (!(key in obj)) throw new Error(`Map does not contain key: "${key}"`); return obj[key]; })(headers, "access-control-allow-origin"),"winglang.io"));
+      (await $t_Assert.equalNum(response.status, 204));
+      (await $t_Assert.equalStr(((obj, key) => { if (!(key in obj)) throw new Error(`Map does not contain key: "${key}"`); return obj[key]; })(headers, "access-control-allow-methods"), "GET,POST,OPTIONS"));
+      (await $t_Assert.equalStr(((obj, key) => { if (!(key in obj)) throw new Error(`Map does not contain key: "${key}"`); return obj[key]; })(headers, "access-control-allow-headers"), "Content-Type,Authorization,X-Custom-Header"));
+      (await $t_Assert.equalStr(((obj, key) => { if (!(key in obj)) throw new Error(`Map does not contain key: "${key}"`); return obj[key]; })(headers, "access-control-allow-origin"), "winglang.io"));
     }
   }
   return $Closure4;
@@ -346,8 +346,8 @@ module.exports = function({  }) {
 module.exports = function({ $stdlib }) {
   const std = $stdlib.std;
   class Assert extends $stdlib.std.Resource {
-    constructor(scope, id, ) {
-      super(scope, id);
+    constructor($scope, $id, ) {
+      super($scope, $id);
     }
     static _toInflightType(context) {
       return `
@@ -388,11 +388,11 @@ const ex = $stdlib.ex;
 const http = $stdlib.http;
 const t = require("./preflight.assertions-1.js")({ $stdlib });
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -417,8 +417,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure2 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -452,8 +452,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure3 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -488,8 +488,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure4 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -523,11 +523,11 @@ class $Root extends $stdlib.std.Resource {
         super._registerOnLift(host, ops);
       }
     }
-    const api = this.node.root.newAbstract("@winglang/sdk.cloud.Api",this,"cloud.Api",{ cors: true, corsOptions: ({"allowOrigin": ["winglang.io"],"allowMethods": [cloud.HttpMethod.GET, cloud.HttpMethod.POST, cloud.HttpMethod.OPTIONS],"allowHeaders": ["Content-Type", "Authorization", "X-Custom-Header"],"allowCredentials": true,"exposeHeaders": ["Content-Type"]}) });
-    (api.get("/users",new $Closure1(this,"$Closure1")));
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:GET /users has cors headers",new $Closure2(this,"$Closure2"));
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:OPTIONS /users has cors headers",new $Closure3(this,"$Closure3"));
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:OPTIONS /users responds with proper headers for requested",new $Closure4(this,"$Closure4"));
+    const api = this.node.root.newAbstract("@winglang/sdk.cloud.Api",this, "cloud.Api", { cors: true, corsOptions: ({"allowOrigin": ["winglang.io"],"allowMethods": [cloud.HttpMethod.GET, cloud.HttpMethod.POST, cloud.HttpMethod.OPTIONS],"allowHeaders": ["Content-Type", "Authorization", "X-Custom-Header"],"allowCredentials": true,"exposeHeaders": ["Content-Type"]}) });
+    (api.get("/users", new $Closure1(this, "$Closure1")));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:GET /users has cors headers", new $Closure2(this, "$Closure2"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:OPTIONS /users has cors headers", new $Closure3(this, "$Closure3"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:OPTIONS /users responds with proper headers for requested", new $Closure4(this, "$Closure4"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/valid/api_cors_default.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/api_cors_default.test.w_compile_tf-aws.md
@@ -32,10 +32,10 @@ module.exports = function({ $apiDefaultCors_url, $http_Util, $t_Assert }) {
     async handle() {
       const response = (await $http_Util.get(($apiDefaultCors_url + "/users")));
       const headers = response.headers;
-      (await $t_Assert.equalNum(response.status,200));
-      (await $t_Assert.equalStr(((obj, key) => { if (!(key in obj)) throw new Error(`Map does not contain key: "${key}"`); return obj[key]; })(headers, "access-control-allow-origin"),"*"));
-      (await $t_Assert.equalStr(((obj, key) => { if (!(key in obj)) throw new Error(`Map does not contain key: "${key}"`); return obj[key]; })(headers, "access-control-allow-credentials"),"false"));
-      (await $t_Assert.equalStr(((obj, key) => { if (!(key in obj)) throw new Error(`Map does not contain key: "${key}"`); return obj[key]; })(headers, "access-control-expose-headers"),""));
+      (await $t_Assert.equalNum(response.status, 200));
+      (await $t_Assert.equalStr(((obj, key) => { if (!(key in obj)) throw new Error(`Map does not contain key: "${key}"`); return obj[key]; })(headers, "access-control-allow-origin"), "*"));
+      (await $t_Assert.equalStr(((obj, key) => { if (!(key in obj)) throw new Error(`Map does not contain key: "${key}"`); return obj[key]; })(headers, "access-control-allow-credentials"), "false"));
+      (await $t_Assert.equalStr(((obj, key) => { if (!(key in obj)) throw new Error(`Map does not contain key: "${key}"`); return obj[key]; })(headers, "access-control-expose-headers"), ""));
       (await $t_Assert.isNil((headers)["access-control-allow-headers"]));
       (await $t_Assert.isNil((headers)["access-control-allow-methods"]));
     }
@@ -56,12 +56,12 @@ module.exports = function({ $apiDefaultCors_url, $http_HttpMethod, $http_Util, $
       return $obj;
     }
     async handle() {
-      const response = (await $http_Util.fetch(($apiDefaultCors_url + "/users"),({"method": $http_HttpMethod.OPTIONS})));
+      const response = (await $http_Util.fetch(($apiDefaultCors_url + "/users"), ({"method": $http_HttpMethod.OPTIONS})));
       const headers = response.headers;
-      (await $t_Assert.equalNum(response.status,204));
-      (await $t_Assert.equalStr(((obj, key) => { if (!(key in obj)) throw new Error(`Map does not contain key: "${key}"`); return obj[key]; })(headers, "access-control-allow-headers"),"Content-Type,Authorization,X-Requested-With"));
-      (await $t_Assert.equalStr(((obj, key) => { if (!(key in obj)) throw new Error(`Map does not contain key: "${key}"`); return obj[key]; })(headers, "access-control-allow-methods"),"GET,POST,PUT,DELETE,HEAD,OPTIONS"));
-      (await $t_Assert.equalStr(((obj, key) => { if (!(key in obj)) throw new Error(`Map does not contain key: "${key}"`); return obj[key]; })(headers, "access-control-allow-origin"),"*"));
+      (await $t_Assert.equalNum(response.status, 204));
+      (await $t_Assert.equalStr(((obj, key) => { if (!(key in obj)) throw new Error(`Map does not contain key: "${key}"`); return obj[key]; })(headers, "access-control-allow-headers"), "Content-Type,Authorization,X-Requested-With"));
+      (await $t_Assert.equalStr(((obj, key) => { if (!(key in obj)) throw new Error(`Map does not contain key: "${key}"`); return obj[key]; })(headers, "access-control-allow-methods"), "GET,POST,PUT,DELETE,HEAD,OPTIONS"));
+      (await $t_Assert.equalStr(((obj, key) => { if (!(key in obj)) throw new Error(`Map does not contain key: "${key}"`); return obj[key]; })(headers, "access-control-allow-origin"), "*"));
       (await $t_Assert.isNil((headers)["access-control-allow-credentials"]));
       (await $t_Assert.isNil((headers)["access-control-expose-headers"]));
     }
@@ -322,8 +322,8 @@ module.exports = function({  }) {
 module.exports = function({ $stdlib }) {
   const std = $stdlib.std;
   class Assert extends $stdlib.std.Resource {
-    constructor(scope, id, ) {
-      super(scope, id);
+    constructor($scope, $id, ) {
+      super($scope, $id);
     }
     static _toInflightType(context) {
       return `
@@ -364,11 +364,11 @@ const ex = $stdlib.ex;
 const http = $stdlib.http;
 const t = require("./preflight.assertions-1.js")({ $stdlib });
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -393,8 +393,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure2 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -428,8 +428,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure3 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -463,10 +463,10 @@ class $Root extends $stdlib.std.Resource {
         super._registerOnLift(host, ops);
       }
     }
-    const apiDefaultCors = this.node.root.newAbstract("@winglang/sdk.cloud.Api",this,"cloud.Api",{ cors: true });
-    (apiDefaultCors.get("/users",new $Closure1(this,"$Closure1")));
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:GET /users has default cors headers",new $Closure2(this,"$Closure2"));
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:OPTIONS /users has default cors headers",new $Closure3(this,"$Closure3"));
+    const apiDefaultCors = this.node.root.newAbstract("@winglang/sdk.cloud.Api",this, "cloud.Api", { cors: true });
+    (apiDefaultCors.get("/users", new $Closure1(this, "$Closure1")));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:GET /users has default cors headers", new $Closure2(this, "$Closure2"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:OPTIONS /users has default cors headers", new $Closure3(this, "$Closure3"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/valid/api_valid_path.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/api_valid_path.test.w_compile_tf-aws.md
@@ -377,11 +377,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -405,13 +405,13 @@ class $Root extends $stdlib.std.Resource {
         return ["handle", "$inflight_init"];
       }
     }
-    const api = this.node.root.newAbstract("@winglang/sdk.cloud.Api",this,"cloud.Api");
-    const handler = new $Closure1(this,"$Closure1");
+    const api = this.node.root.newAbstract("@winglang/sdk.cloud.Api",this, "cloud.Api");
+    const handler = new $Closure1(this, "$Closure1");
     const testInvalidPath = ((path) => {
       let error = "";
       const expected = String.raw({ raw: ["Invalid path ", ". Url parts can only contain alpha-numeric chars, \"-\", \"_\" and \".\". Params can only contain alpha-numeric chars and \"_\"."] }, path);
       try {
-        (api.get(path,handler));
+        (api.get(path, handler));
       }
       catch ($error_e) {
         const e = $error_e.message;
@@ -422,7 +422,7 @@ class $Root extends $stdlib.std.Resource {
     const testValidPath = ((path) => {
       let error = "";
       try {
-        (api.get(path,handler));
+        (api.get(path, handler));
       }
       catch ($error_e) {
         const e = $error_e.message;

--- a/tools/hangar/__snapshots__/test_corpus/valid/assert.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/assert.test.w_compile_tf-aws.md
@@ -74,11 +74,11 @@ const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -128,7 +128,7 @@ class $Root extends $stdlib.std.Resource {
     {((cond) => {if (!cond) throw new Error("assertion failed: \"${s1}a\" != \"${s1}b\"")})((((a,b) => { try { return require('assert').notDeepStrictEqual(a,b) === undefined; } catch { return false; } })(String.raw({ raw: ["", "a"] }, s1),String.raw({ raw: ["", "b"] }, s1))))};
     {((cond) => {if (!cond) throw new Error("assertion failed: \"`\'${s1}\" == \"`\'${s1}\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(String.raw({ raw: ["`'", ""] }, s1),String.raw({ raw: ["`'", ""] }, s1))))};
     {((cond) => {if (!cond) throw new Error("assertion failed: \"a${s1}b${s2}c\" == \"a${s1}b${s2}c\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(String.raw({ raw: ["a", "b", "c"] }, s1, s2),String.raw({ raw: ["a", "b", "c"] }, s1, s2))))};
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:assert works inflight",new $Closure1(this,"$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:assert works inflight", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/valid/assertions.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/assertions.w_compile_tf-aws.md
@@ -46,8 +46,8 @@ module.exports = function({  }) {
 module.exports = function({ $stdlib }) {
   const std = $stdlib.std;
   class Assert extends $stdlib.std.Resource {
-    constructor(scope, id, ) {
-      super(scope, id);
+    constructor($scope, $id, ) {
+      super($scope, $id);
     }
     static _toInflightType(context) {
       return `

--- a/tools/hangar/__snapshots__/test_corpus/valid/asynchronous_model_implicit_await_in_functions.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/asynchronous_model_implicit_await_in_functions.test.w_compile_tf-aws.md
@@ -277,11 +277,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -306,8 +306,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure2 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -338,9 +338,9 @@ class $Root extends $stdlib.std.Resource {
         super._registerOnLift(host, ops);
       }
     }
-    const q = this.node.root.newAbstract("@winglang/sdk.cloud.Queue",this,"cloud.Queue");
-    const strToStr = this.node.root.newAbstract("@winglang/sdk.cloud.Function",this,"strToStr",new $Closure1(this,"$Closure1"));
-    const func = this.node.root.newAbstract("@winglang/sdk.cloud.Function",this,"func",new $Closure2(this,"$Closure2"));
+    const q = this.node.root.newAbstract("@winglang/sdk.cloud.Queue",this, "cloud.Queue");
+    const strToStr = this.node.root.newAbstract("@winglang/sdk.cloud.Function",this, "strToStr", new $Closure1(this, "$Closure1"));
+    const func = this.node.root.newAbstract("@winglang/sdk.cloud.Function",this, "func", new $Closure2(this, "$Closure2"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/valid/baz.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/baz.w_compile_tf-aws.md
@@ -19,8 +19,8 @@ module.exports = function({  }) {
 module.exports = function({ $stdlib }) {
   const std = $stdlib.std;
   class Baz extends $stdlib.std.Resource {
-    constructor(scope, id, ) {
-      super(scope, id);
+    constructor($scope, $id, ) {
+      super($scope, $id);
     }
     static baz() {
       return "baz";

--- a/tools/hangar/__snapshots__/test_corpus/valid/bring_awscdk.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/bring_awscdk.test.w_compile_tf-aws.md
@@ -55,12 +55,12 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const awscdk = require("aws-cdk-lib");
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class CdkDockerImageFunction extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
-        this.function = this.node.root.new("aws-cdk-lib.aws_lambda.DockerImageFunction",awscdk.aws_lambda.DockerImageFunction,this,"DockerImageFunction",({"code": (awscdk.aws_lambda.DockerImageCode.fromImageAsset("./test.ts"))}));
+      constructor($scope, $id, ) {
+        super($scope, $id);
+        this.function = this.node.root.new("aws-cdk-lib.aws_lambda.DockerImageFunction",awscdk.aws_lambda.DockerImageFunction,this, "DockerImageFunction", ({"code": (awscdk.aws_lambda.DockerImageCode.fromImageAsset("./test.ts"))}));
       }
       static _toInflightType(context) {
         return `

--- a/tools/hangar/__snapshots__/test_corpus/valid/bring_cdk8s.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/bring_cdk8s.test.w_compile_tf-aws.md
@@ -43,11 +43,11 @@ const std = $stdlib.std;
 const cdk8s = require("cdk8s");
 const kplus = require("cdk8s-plus-27");
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     const app = this.node.root.new("cdk8s.App",cdk8s.App,);
-    const chart = this.node.root.new("cdk8s.Chart",cdk8s.Chart,this,"cdk8s.Chart");
-    const deploy = this.node.root.new("cdk8s-plus-27.Deployment",kplus.Deployment,chart,"kplus.Deployment");
+    const chart = this.node.root.new("cdk8s.Chart",cdk8s.Chart,this, "cdk8s.Chart");
+    const deploy = this.node.root.new("cdk8s-plus-27.Deployment",kplus.Deployment,chart, "kplus.Deployment");
     (deploy.addContainer(({"image": "hashicorp/http-echo","args": ["-text", "text"],"portNumber": 5678})));
   }
 }

--- a/tools/hangar/__snapshots__/test_corpus/valid/bring_cdktf.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/bring_cdktf.test.w_compile_tf-aws.md
@@ -73,12 +73,12 @@ const std = $stdlib.std;
 const aws = require("@cdktf/provider-aws");
 const cdktf = require("cdktf");
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class Foo extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
-        this.node.root.new("cdktf.S3Backend",cdktf.S3Backend,this,({"bucket": "foo","key": "bar"}));
+      constructor($scope, $id, ) {
+        super($scope, $id);
+        this.node.root.new("cdktf.S3Backend",cdktf.S3Backend,this, ({"bucket": "foo","key": "bar"}));
       }
       static _toInflightType(context) {
         return `
@@ -101,7 +101,7 @@ class $Root extends $stdlib.std.Resource {
         return ["$inflight_init"];
       }
     }
-    this.node.root.new("@cdktf/provider-aws.s3Bucket.S3Bucket",aws.s3Bucket.S3Bucket,this,"Bucket",{ bucketPrefix: "hello", versioning: ({"enabled": true,"mfaDelete": true}) });
+    this.node.root.new("@cdktf/provider-aws.s3Bucket.S3Bucket",aws.s3Bucket.S3Bucket,this, "Bucket", { bucketPrefix: "hello", versioning: ({"enabled": true,"mfaDelete": true}) });
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/valid/bring_jsii.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/bring_jsii.test.w_compile_tf-aws.md
@@ -64,11 +64,11 @@ const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 const stuff = require("jsii-code-samples");
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -102,7 +102,7 @@ class $Root extends $stdlib.std.Resource {
     }
     const hello = new stuff.HelloWorld();
     const greeting = (hello.sayHello("wingnuts"));
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:sayHello",new $Closure1(this,"$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:sayHello", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/valid/bring_local.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/bring_local.test.w_compile_tf-aws.md
@@ -11,7 +11,7 @@ module.exports = function({ $__parent_this_1_b }) {
       return $obj;
     }
     async handle() {
-      (await $__parent_this_1_b.put("data.txt","<empty>"));
+      (await $__parent_this_1_b.put("data.txt", "<empty>"));
     }
   }
   return $Closure1;
@@ -63,7 +63,7 @@ module.exports = function({  }) {
       this.$this_b = $this_b;
     }
     async store(data) {
-      (await this.$this_b.put("data.txt",data));
+      (await this.$this_b.put("data.txt", data));
     }
   }
   return Store;
@@ -295,11 +295,11 @@ const file2 = require("./preflight.subfile-3.js")({ $stdlib });
 const file3 = require("./preflight.empty-1.js")({ $stdlib });
 const math = $stdlib.math;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -331,8 +331,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class Triangle extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
       }
       area() {
         return 1;
@@ -359,8 +359,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class Util extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
       }
       static _toInflightType(context) {
         return `
@@ -383,13 +383,13 @@ class $Root extends $stdlib.std.Resource {
         return ["$inflight_init"];
       }
     }
-    const store = new file1.Store(this,"file1.Store");
-    const q = new file2.Q(this,"file2.Q");
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:add data to store",new $Closure1(this,"$Closure1"));
+    const store = new file1.Store(this, "file1.Store");
+    const q = new file2.Q(this, "file2.Q");
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:add data to store", new $Closure1(this, "$Closure1"));
     const s = ({"x": 1,"y": 2});
     const c = file1.Color.BLUE;
     {((cond) => {if (!cond) throw new Error("assertion failed: c != file1.Color.RED")})((((a,b) => { try { return require('assert').notDeepStrictEqual(a,b) === undefined; } catch { return false; } })(c,file1.Color.RED)))};
-    const t = new Triangle(this,"Triangle");
+    const t = new Triangle(this, "Triangle");
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);
@@ -406,8 +406,8 @@ module.exports = function({ $stdlib }) {
   const math = $stdlib.math;
   const cloud = $stdlib.cloud;
   class Util extends $stdlib.std.Resource {
-    constructor(scope, id, ) {
-      super(scope, id);
+    constructor($scope, $id, ) {
+      super($scope, $id);
     }
     static _toInflightType(context) {
       return `
@@ -431,13 +431,13 @@ module.exports = function({ $stdlib }) {
     }
   }
   class Store extends $stdlib.std.Resource {
-    constructor(scope, id, ) {
-      super(scope, id);
-      this.b = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this,"cloud.Bucket");
+    constructor($scope, $id, ) {
+      super($scope, $id);
+      this.b = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this, "cloud.Bucket");
       const __parent_this_1 = this;
       class $Closure1 extends $stdlib.std.Resource {
-        constructor(scope, id, ) {
-          super(scope, id);
+        constructor($scope, $id, ) {
+          super($scope, $id);
           (std.Node.of(this)).hidden = true;
         }
         static _toInflightType(context) {
@@ -468,7 +468,7 @@ module.exports = function({ $stdlib }) {
           super._registerOnLift(host, ops);
         }
       }
-      const prefill = this.node.root.newAbstract("@winglang/sdk.cloud.OnDeploy",this,"cloud.OnDeploy",new $Closure1(this,"$Closure1"));
+      const prefill = this.node.root.newAbstract("@winglang/sdk.cloud.OnDeploy",this, "cloud.OnDeploy", new $Closure1(this, "$Closure1"));
     }
     static _toInflightType(context) {
       return `
@@ -521,8 +521,8 @@ module.exports = function({ $stdlib }) {
   const std = $stdlib.std;
   const math = $stdlib.math;
   class Q extends $stdlib.std.Resource {
-    constructor(scope, id, ) {
-      super(scope, id);
+    constructor($scope, $id, ) {
+      super($scope, $id);
     }
     static _toInflightType(context) {
       return `

--- a/tools/hangar/__snapshots__/test_corpus/valid/bring_local_dir.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/bring_local_dir.test.w_compile_tf-aws.md
@@ -92,8 +92,8 @@ module.exports = function({ $stdlib }) {
   const blah = require("./preflight.inner-2.js")({ $stdlib });
   const util = $stdlib.util;
   class Foo extends $stdlib.std.Resource {
-    constructor(scope, id, ) {
-      super(scope, id);
+    constructor($scope, $id, ) {
+      super($scope, $id);
     }
     foo() {
       return "foo";
@@ -134,8 +134,8 @@ module.exports = function({ $stdlib }) {
   const std = $stdlib.std;
   const util = $stdlib.util;
   class Bar extends $stdlib.std.Resource {
-    constructor(scope, id, ) {
-      super(scope, id);
+    constructor($scope, $id, ) {
+      super($scope, $id);
     }
     bar() {
       return "bar";
@@ -162,8 +162,8 @@ module.exports = function({ $stdlib }) {
     }
   }
   class Foo extends $stdlib.std.Resource {
-    constructor(scope, id, ) {
-      super(scope, id);
+    constructor($scope, $id, ) {
+      super($scope, $id);
     }
     static _toInflightType(context) {
       return `
@@ -214,15 +214,15 @@ const std = $stdlib.std;
 const w = require("./preflight.widget-1.js")({ $stdlib });
 const subdir = require("./preflight.subdir2-5.js")({ $stdlib });
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
-    const widget1 = new w.Widget(this,"w.Widget");
+  constructor($scope, $id) {
+    super($scope, $id);
+    const widget1 = new w.Widget(this, "w.Widget");
     {((cond) => {if (!cond) throw new Error("assertion failed: widget1.compute() == 42")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((widget1.compute()),42)))};
-    const foo = new subdir.Foo(this,"subdir.Foo");
+    const foo = new subdir.Foo(this, "subdir.Foo");
     {((cond) => {if (!cond) throw new Error("assertion failed: foo.foo() == \"foo\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((foo.foo()),"foo")))};
-    const bar = new subdir.Bar(this,"subdir.Bar");
+    const bar = new subdir.Bar(this, "subdir.Bar");
     {((cond) => {if (!cond) throw new Error("assertion failed: bar.bar() == \"bar\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((bar.bar()),"bar")))};
-    const widget2 = new subdir.inner.Widget(this,"subdir.inner.Widget");
+    const widget2 = new subdir.inner.Widget(this, "subdir.inner.Widget");
     {((cond) => {if (!cond) throw new Error("assertion failed: widget2.compute() == 42")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((widget2.compute()),42)))};
     {((cond) => {if (!cond) throw new Error("assertion failed: foo.checkWidget(widget2) == 1379")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((foo.checkWidget(widget2)),1379)))};
   }
@@ -252,8 +252,8 @@ module.exports = function({ $stdlib }) {
 module.exports = function({ $stdlib }) {
   const std = $stdlib.std;
   class Widget extends $stdlib.std.Resource {
-    constructor(scope, id, ) {
-      super(scope, id);
+    constructor($scope, $id, ) {
+      super($scope, $id);
     }
     compute() {
       return 42;

--- a/tools/hangar/__snapshots__/test_corpus/valid/bring_local_normalization.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/bring_local_normalization.test.w_compile_tf-aws.md
@@ -77,8 +77,8 @@ module.exports = function({  }) {
 module.exports = function({ $stdlib }) {
   const std = $stdlib.std;
   class Bar extends $stdlib.std.Resource {
-    constructor(scope, id, ) {
-      super(scope, id);
+    constructor($scope, $id, ) {
+      super($scope, $id);
     }
     static bar() {
       return "bar";
@@ -115,8 +115,8 @@ module.exports = function({ $stdlib }) {
 module.exports = function({ $stdlib }) {
   const std = $stdlib.std;
   class Baz extends $stdlib.std.Resource {
-    constructor(scope, id, ) {
-      super(scope, id);
+    constructor($scope, $id, ) {
+      super($scope, $id);
     }
     static baz() {
       return "baz";
@@ -155,8 +155,8 @@ module.exports = function({ $stdlib }) {
   const bar = require("./preflight.bar-1.js")({ $stdlib });
   const baz = require("./preflight.baz-2.js")({ $stdlib });
   class Foo extends $stdlib.std.Resource {
-    constructor(scope, id, ) {
-      super(scope, id);
+    constructor($scope, $id, ) {
+      super($scope, $id);
     }
     static foo() {
       return "foo";
@@ -205,8 +205,8 @@ const foo = require("./preflight.foo-3.js")({ $stdlib });
 const bar = require("./preflight.bar-1.js")({ $stdlib });
 const baz = require("./preflight.baz-2.js")({ $stdlib });
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     {((cond) => {if (!cond) throw new Error("assertion failed: foo.Foo.foo() == \"foo\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((foo.Foo.foo()),"foo")))};
     {((cond) => {if (!cond) throw new Error("assertion failed: foo.Foo.bar() == \"bar\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((foo.Foo.bar()),"bar")))};
     {((cond) => {if (!cond) throw new Error("assertion failed: foo.Foo.baz() == \"baz\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((foo.Foo.baz()),"baz")))};

--- a/tools/hangar/__snapshots__/test_corpus/valid/bring_projen.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/bring_projen.test.w_compile_tf-aws.md
@@ -42,8 +42,8 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const projen = require("projen");
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     {((cond) => {if (!cond) throw new Error("assertion failed: projen.LogLevel.OFF != projen.LogLevel.VERBOSE")})((((a,b) => { try { return require('assert').notDeepStrictEqual(a,b) === undefined; } catch { return false; } })(projen.LogLevel.OFF,projen.LogLevel.VERBOSE)))};
   }
 }

--- a/tools/hangar/__snapshots__/test_corpus/valid/bring_wing_library.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/bring_wing_library.test.w_compile_tf-aws.md
@@ -31,7 +31,7 @@ module.exports = function({ $myutil_Util }) {
       return (require("<ABSOLUTE_PATH>/util.js")["makeKeyInflight"])(name)
     }
     async set(message) {
-      (await this.$this_data.put("data.txt",(await $myutil_Util.double(message))));
+      (await this.$this_data.put("data.txt", (await $myutil_Util.double(message))));
     }
   }
   return Store;
@@ -128,11 +128,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const fixture = require("./preflight.wingfixture-5.js")({ $stdlib });
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -163,10 +163,10 @@ class $Root extends $stdlib.std.Resource {
         super._registerOnLift(host, ops);
       }
     }
-    new fixture.Store(this,"fixture.Store");
+    new fixture.Store(this, "fixture.Store");
     const fave_num = fixture.FavoriteNumbers.SEVEN;
     {((cond) => {if (!cond) throw new Error("assertion failed: fixture.Store.makeKey(\"hello\") == \"data/hello.json\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((fixture.Store.makeKey("hello")),"data/hello.json")))};
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:makeKeyInflight",new $Closure1(this,"$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:makeKeyInflight", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);
@@ -182,9 +182,9 @@ module.exports = function({ $stdlib }) {
   const cloud = $stdlib.cloud;
   const myutil = require("./preflight.util-2.js")({ $stdlib });
   class Store extends $stdlib.std.Resource {
-    constructor(scope, id, ) {
-      super(scope, id);
-      this.data = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this,"cloud.Bucket");
+    constructor($scope, $id, ) {
+      super($scope, $id);
+      this.data = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this, "cloud.Bucket");
     }
     static makeKey(name) {
       return (require("<ABSOLUTE_PATH>/util.js")["makeKey"])(name)
@@ -245,8 +245,8 @@ module.exports = function({ $stdlib }) {
 module.exports = function({ $stdlib }) {
   const std = $stdlib.std;
   class Util extends $stdlib.std.Resource {
-    constructor(scope, id, ) {
-      super(scope, id);
+    constructor($scope, $id, ) {
+      super($scope, $id);
     }
     static _toInflightType(context) {
       return `

--- a/tools/hangar/__snapshots__/test_corpus/valid/bucket_events.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/bucket_events.test.w_compile_tf-aws.md
@@ -68,7 +68,7 @@ module.exports = function({ $other }) {
       return $obj;
     }
     async handle(key, event) {
-      (await $other.put(String.raw({ raw: ["last_", "_key"] }, event),key));
+      (await $other.put(String.raw({ raw: ["last_", "_key"] }, event), key));
     }
   }
   return $Closure4;
@@ -106,10 +106,10 @@ module.exports = function({ $b }) {
       return $obj;
     }
     async handle() {
-      (await $b.put("a","1"));
-      (await $b.put("b","1"));
-      (await $b.put("b","100"));
-      (await $b.put("c","1"));
+      (await $b.put("a", "1"));
+      (await $b.put("b", "1"));
+      (await $b.put("b", "100"));
+      (await $b.put("c", "1"));
       (await $b.delete("c"));
     }
   }
@@ -1324,11 +1324,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -1353,8 +1353,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure2 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -1379,8 +1379,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure3 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -1405,8 +1405,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure4 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -1438,8 +1438,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure5 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -1464,8 +1464,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure6 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -1496,14 +1496,14 @@ class $Root extends $stdlib.std.Resource {
         super._registerOnLift(host, ops);
       }
     }
-    const other = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this,"other");
-    const b = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this,"b");
-    (b.onDelete(new $Closure1(this,"$Closure1")));
-    (b.onUpdate(new $Closure2(this,"$Closure2")));
-    (b.onCreate(new $Closure3(this,"$Closure3")));
-    (b.onEvent(new $Closure4(this,"$Closure4")));
-    (other.onEvent(new $Closure5(this,"$Closure5")));
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:putting and deleting from a bucket to trigger bucket events",new $Closure6(this,"$Closure6"));
+    const other = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this, "other");
+    const b = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this, "b");
+    (b.onDelete(new $Closure1(this, "$Closure1")));
+    (b.onUpdate(new $Closure2(this, "$Closure2")));
+    (b.onCreate(new $Closure3(this, "$Closure3")));
+    (b.onEvent(new $Closure4(this, "$Closure4")));
+    (other.onEvent(new $Closure5(this, "$Closure5")));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:putting and deleting from a bucket to trigger bucket events", new $Closure6(this, "$Closure6"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/valid/bucket_keys.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/bucket_keys.test.w_compile_tf-aws.md
@@ -11,11 +11,11 @@ module.exports = function({ $b }) {
       return $obj;
     }
     async handle() {
-      (await $b.put("foo","text"));
-      (await $b.put("foo/","text"));
-      (await $b.put("foo/bar","text"));
-      (await $b.put("foo/bar/","text"));
-      (await $b.put("foo/bar/baz","text"));
+      (await $b.put("foo", "text"));
+      (await $b.put("foo/", "text"));
+      (await $b.put("foo/bar", "text"));
+      (await $b.put("foo/bar/", "text"));
+      (await $b.put("foo/bar/baz", "text"));
       const objs = (await $b.list());
       {((cond) => {if (!cond) throw new Error("assertion failed: objs.at(0) == \"foo\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await objs.at(0)),"foo")))};
       {((cond) => {if (!cond) throw new Error("assertion failed: objs.at(1) == \"foo/\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await objs.at(1)),"foo/")))};
@@ -85,11 +85,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -120,8 +120,8 @@ class $Root extends $stdlib.std.Resource {
         super._registerOnLift(host, ops);
       }
     }
-    const b = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this,"cloud.Bucket");
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:test",new $Closure1(this,"$Closure1"));
+    const b = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this, "cloud.Bucket");
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:test", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/valid/call_static_of_myself.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/call_static_of_myself.test.w_compile_tf-aws.md
@@ -109,11 +109,11 @@ const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class Foo extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
       }
       static _toInflightType(context) {
         return `
@@ -149,8 +149,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class Bar extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
       }
       static _toInflightType(context) {
         return `
@@ -174,8 +174,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -209,8 +209,8 @@ class $Root extends $stdlib.std.Resource {
         super._registerOnLift(host, ops);
       }
     }
-    const foo = new Foo(this,"Foo");
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:test",new $Closure1(this,"$Closure1"));
+    const foo = new Foo(this, "Foo");
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:test", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/valid/calling_inflight_variants.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/calling_inflight_variants.test.w_compile_tf-aws.md
@@ -121,15 +121,15 @@ const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class Foo extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         const __parent_this_1 = this;
         class $Closure1 extends $stdlib.std.Resource {
-          constructor(scope, id, ) {
-            super(scope, id);
+          constructor($scope, $id, ) {
+            super($scope, $id);
             (std.Node.of(this)).hidden = true;
           }
           static _toInflightType(context) {
@@ -153,7 +153,7 @@ class $Root extends $stdlib.std.Resource {
             return ["handle", "$inflight_init"];
           }
         }
-        this.inflight1 = new $Closure1(this,"$Closure1");
+        this.inflight1 = new $Closure1(this, "$Closure1");
       }
       static _toInflightType(context) {
         return `
@@ -196,8 +196,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure2 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -228,8 +228,8 @@ class $Root extends $stdlib.std.Resource {
         super._registerOnLift(host, ops);
       }
     }
-    const foo = new Foo(this,"Foo");
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:calling different types of inflights",new $Closure2(this,"$Closure2"));
+    const foo = new Foo(this, "Foo");
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:calling different types of inflights", new $Closure2(this, "$Closure2"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/valid/capture_containers.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/capture_containers.test.w_compile_tf-aws.md
@@ -69,11 +69,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -125,7 +125,7 @@ class $Root extends $stdlib.std.Resource {
     const myMap = ({"hello": 123,"world": 999});
     const arrOfMap = [({"bang": 123})];
     const j = ({"a": "hello","b": "world"});
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:capture_containers",new $Closure1(this,"$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:capture_containers", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/valid/capture_in_binary.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/capture_in_binary.test.w_compile_tf-aws.md
@@ -11,7 +11,7 @@ module.exports = function({ $b, $x }) {
       return $obj;
     }
     async handle() {
-      (await $b.put("file","foo"));
+      (await $b.put("file", "foo"));
       {((cond) => {if (!cond) throw new Error("assertion failed: b.get(\"file\") == \"foo\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $b.get("file")),"foo")))};
       {((cond) => {if (!cond) throw new Error("assertion failed: 12 == x")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(12,$x)))};
     }
@@ -77,11 +77,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -114,9 +114,9 @@ class $Root extends $stdlib.std.Resource {
         super._registerOnLift(host, ops);
       }
     }
-    const b = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this,"cloud.Bucket");
+    const b = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this, "cloud.Bucket");
     const x = 12;
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:binary expressions",new $Closure1(this,"$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:binary expressions", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/valid/capture_mutables.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/capture_mutables.test.w_compile_tf-aws.md
@@ -82,11 +82,11 @@ const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -124,8 +124,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure2 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -160,8 +160,8 @@ class $Root extends $stdlib.std.Resource {
     const s = new Set([12]);
     const m = ({"hello": true});
     const aCloned = [...(["hello"])];
-    const handler = new $Closure1(this,"$Closure1");
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:main",new $Closure2(this,"$Closure2"));
+    const handler = new $Closure1(this, "$Closure1");
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:main", new $Closure2(this, "$Closure2"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/valid/capture_primitives.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/capture_primitives.test.w_compile_tf-aws.md
@@ -179,11 +179,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -231,8 +231,8 @@ class $Root extends $stdlib.std.Resource {
     const myBool = true;
     const mySecondBool = false;
     const myDur = (std.Duration.fromSeconds(600));
-    const handler = new $Closure1(this,"$Closure1");
-    this.node.root.newAbstract("@winglang/sdk.cloud.Function",this,"cloud.Function",handler);
+    const handler = new $Closure1(this, "$Closure1");
+    this.node.root.newAbstract("@winglang/sdk.cloud.Function",this, "cloud.Function", handler);
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/valid/capture_reassigable_class_field.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/capture_reassigable_class_field.test.w_compile_tf-aws.md
@@ -29,7 +29,7 @@ module.exports = function({ $counter }) {
       return $obj;
     }
     async handle(key) {
-      (await $counter.inc(1,key));
+      (await $counter.inc(1, key));
     }
   }
   return $Closure2;
@@ -48,8 +48,8 @@ module.exports = function({ $counter, $kv, $util_Util }) {
       return $obj;
     }
     async handle() {
-      (await $kv.set("k",({"value": "v"})));
-      (await $kv.set("k2",({"value": "v"})));
+      (await $kv.set("k", ({"value": "v"})));
+      (await $kv.set("k2", ({"value": "v"})));
       (await $kv.get("k"));
       (await $kv.get("k"));
       (await $kv.get("k2"));
@@ -82,7 +82,7 @@ module.exports = function({  }) {
       return (await this.$this_bucket.getJson(key));
     }
     async set(key, value) {
-      (await this.$this_bucket.putJson(key,value));
+      (await this.$this_bucket.putJson(key, value));
     }
   }
   return KeyValueStore;
@@ -166,16 +166,16 @@ const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 const util = $stdlib.util;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class KeyValueStore extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
-        this.bucket = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this,"cloud.Bucket");
+      constructor($scope, $id, ) {
+        super($scope, $id);
+        this.bucket = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this, "cloud.Bucket");
         const __parent_this_1 = this;
         class $Closure1 extends $stdlib.std.Resource {
-          constructor(scope, id, ) {
-            super(scope, id);
+          constructor($scope, $id, ) {
+            super($scope, $id);
             (std.Node.of(this)).hidden = true;
           }
           static _toInflightType(context) {
@@ -199,7 +199,7 @@ class $Root extends $stdlib.std.Resource {
             return ["handle", "$inflight_init"];
           }
         }
-        this.onUpdateCallback = new $Closure1(this,"$Closure1");
+        this.onUpdateCallback = new $Closure1(this, "$Closure1");
       }
       onUpdate(fn) {
         this.onUpdateCallback = fn;
@@ -242,8 +242,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure2 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -275,8 +275,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure3 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -310,10 +310,10 @@ class $Root extends $stdlib.std.Resource {
         super._registerOnLift(host, ops);
       }
     }
-    const kv = new KeyValueStore(this,"KeyValueStore");
-    const counter = this.node.root.newAbstract("@winglang/sdk.cloud.Counter",this,"sasa");
-    (kv.onUpdate(new $Closure2(this,"$Closure2")));
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:main",new $Closure3(this,"$Closure3"));
+    const kv = new KeyValueStore(this, "KeyValueStore");
+    const counter = this.node.root.newAbstract("@winglang/sdk.cloud.Counter",this, "sasa");
+    (kv.onUpdate(new $Closure2(this, "$Closure2")));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:main", new $Closure3(this, "$Closure3"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/valid/capture_reassignable.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/capture_reassignable.test.w_compile_tf-aws.md
@@ -80,11 +80,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -116,8 +116,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure2 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -149,8 +149,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     let x = 5;
-    const handler = new $Closure1(this,"$Closure1");
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:main",new $Closure2(this,"$Closure2"));
+    const handler = new $Closure1(this, "$Closure1");
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:main", new $Closure2(this, "$Closure2"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/valid/capture_resource_and_data.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/capture_resource_and_data.test.w_compile_tf-aws.md
@@ -12,7 +12,7 @@ module.exports = function({ $data_size, $queue, $res }) {
     }
     async handle() {
       {((cond) => {if (!cond) throw new Error("assertion failed: data.size == 3")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })($data_size,3)))};
-      (await $res.put("file.txt","world"));
+      (await $res.put("file.txt", "world"));
       {((cond) => {if (!cond) throw new Error("assertion failed: res.get(\"file.txt\") == \"world\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $res.get("file.txt")),"world")))};
       (await $queue.push("spirulina"));
     }
@@ -91,11 +91,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -131,9 +131,9 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     const data = new Set([1, 2, 3]);
-    const res = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this,"cloud.Bucket");
-    const queue = this.node.root.newAbstract("@winglang/sdk.cloud.Queue",this,"cloud.Queue");
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:resource and data",new $Closure1(this,"$Closure1"));
+    const res = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this, "cloud.Bucket");
+    const queue = this.node.root.newAbstract("@winglang/sdk.cloud.Queue",this, "cloud.Queue");
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:resource and data", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/valid/capture_resource_with_no_inflight.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/capture_resource_with_no_inflight.test.w_compile_tf-aws.md
@@ -102,13 +102,13 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class A extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         this.field = "hey";
-        this.counter = this.node.root.newAbstract("@winglang/sdk.cloud.Counter",this,"cloud.Counter");
+        this.counter = this.node.root.newAbstract("@winglang/sdk.cloud.Counter",this, "cloud.Counter");
       }
       static _toInflightType(context) {
         return `
@@ -142,8 +142,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -176,8 +176,8 @@ class $Root extends $stdlib.std.Resource {
         super._registerOnLift(host, ops);
       }
     }
-    const a = new A(this,"A");
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:test",new $Closure1(this,"$Closure1"));
+    const a = new A(this, "A");
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:test", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/valid/capture_tokens.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/capture_tokens.test.w_compile_tf-aws.md
@@ -195,12 +195,12 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class MyResource extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
-        this.api = this.node.root.newAbstract("@winglang/sdk.cloud.Api",this,"cloud.Api");
+      constructor($scope, $id, ) {
+        super($scope, $id);
+        this.api = this.node.root.newAbstract("@winglang/sdk.cloud.Api",this, "cloud.Api");
         this.url = this.api.url;
       }
       static _toInflightType(context) {
@@ -239,8 +239,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -272,8 +272,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure2 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -308,11 +308,11 @@ class $Root extends $stdlib.std.Resource {
         super._registerOnLift(host, ops);
       }
     }
-    const r = new MyResource(this,"MyResource");
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:inflight class",new $Closure1(this,"$Closure1"));
-    const api = this.node.root.newAbstract("@winglang/sdk.cloud.Api",this,"cloud.Api");
+    const r = new MyResource(this, "MyResource");
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:inflight class", new $Closure1(this, "$Closure1"));
+    const api = this.node.root.newAbstract("@winglang/sdk.cloud.Api",this, "cloud.Api");
     const url = api.url;
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:inflight globals",new $Closure2(this,"$Closure2"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:inflight globals", new $Closure2(this, "$Closure2"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/valid/captures.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/captures.test.w_compile_tf-aws.md
@@ -11,7 +11,7 @@ module.exports = function({ $bucket1, $bucket2, $bucket3 }) {
       return $obj;
     }
     async handle(event) {
-      (await $bucket1.put("file.txt","data"));
+      (await $bucket1.put("file.txt", "data"));
       (await $bucket2.get("file.txt"));
       (await $bucket2.get("file2.txt"));
       (await $bucket3.get("file3.txt"));
@@ -599,11 +599,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -639,8 +639,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure2 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -671,18 +671,18 @@ class $Root extends $stdlib.std.Resource {
         super._registerOnLift(host, ops);
       }
     }
-    const bucket1 = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this,"cloud.Bucket");
-    const bucket2 = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this,"PublicBucket",({"public": true}));
-    const bucket3 = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this,"PrivateBucket",{ public: false });
-    const queue = this.node.root.newAbstract("@winglang/sdk.cloud.Queue",this,"cloud.Queue");
-    const handler = new $Closure1(this,"$Closure1");
-    (queue.setConsumer(handler,{ batchSize: 5 }));
-    this.node.root.newAbstract("@winglang/sdk.cloud.Function",this,"cloud.Function",handler,{ env: ({}) });
+    const bucket1 = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this, "cloud.Bucket");
+    const bucket2 = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this, "PublicBucket", ({"public": true}));
+    const bucket3 = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this, "PrivateBucket", { public: false });
+    const queue = this.node.root.newAbstract("@winglang/sdk.cloud.Queue",this, "cloud.Queue");
+    const handler = new $Closure1(this, "$Closure1");
+    (queue.setConsumer(handler, { batchSize: 5 }));
+    this.node.root.newAbstract("@winglang/sdk.cloud.Function",this, "cloud.Function", handler, { env: ({}) });
     const emptyEnv = ({});
-    this.node.root.newAbstract("@winglang/sdk.cloud.Function",this,"AnotherFunction",handler,{ env: emptyEnv });
+    this.node.root.newAbstract("@winglang/sdk.cloud.Function",this, "AnotherFunction", handler, { env: emptyEnv });
     const headers = ({"my-fancy-header": "my-fancy-value","not-even-real\"": "wow` !"});
-    const api = this.node.root.newAbstract("@winglang/sdk.cloud.Api",this,"cloud.Api");
-    (api.get("/hello",new $Closure2(this,"$Closure2")));
+    const api = this.node.root.newAbstract("@winglang/sdk.cloud.Api",this, "cloud.Api");
+    (api.get("/hello", new $Closure2(this, "$Closure2")));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/valid/casting.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/casting.test.w_compile_tf-aws.md
@@ -63,12 +63,12 @@ const cloud = $stdlib.cloud;
 const util = $stdlib.util;
 const aws = require("@cdktf/provider-aws");
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
-    const b = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this,"cloud.Bucket");
+  constructor($scope, $id) {
+    super($scope, $id);
+    const b = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this, "cloud.Bucket");
     if ((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((util.Util.env("WING_TARGET")),"tf-aws"))) {
       const s3Bucket = (b.node.findChild("Default"));
-      (s3Bucket.addOverride("bucket_prefix","my-prefix-"));
+      (s3Bucket.addOverride("bucket_prefix", "my-prefix-"));
       {console.log(s3Bucket.node.path)};
     }
   }

--- a/tools/hangar/__snapshots__/test_corpus/valid/class.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/class.test.w_compile_tf-aws.md
@@ -355,11 +355,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class C1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
       }
       static _toInflightType(context) {
         return `
@@ -383,8 +383,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class C2 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         this.x = 1;
       }
       static _toInflightType(context) {
@@ -409,8 +409,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class C3 extends $stdlib.std.Resource {
-      constructor(scope, id, a, b) {
-        super(scope, id);
+      constructor($scope, $id, a, b) {
+        super($scope, $id);
         this.x = a;
         if (true) {
           this.y = b;
@@ -438,8 +438,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class C4 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
       }
       static m() {
         return 1;
@@ -466,8 +466,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class C5 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
       }
       static _toInflightType(context) {
         return `
@@ -491,8 +491,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -524,8 +524,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class Person extends $stdlib.std.Resource {
-      constructor(scope, id, name) {
-        super(scope, id);
+      constructor($scope, $id, name) {
+        super($scope, $id);
         this.name = name;
       }
       static _toInflightType(context) {
@@ -550,8 +550,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class Student extends Person {
-      constructor(scope, id, name, major) {
-        super(scope,id,name);
+      constructor($scope, $id, name, major) {
+        super($scope, $id, name);
         this.major = major;
       }
       static _toInflightType(context) {
@@ -577,8 +577,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class PaidStudent extends Student {
-      constructor(scope, id, name, major, hrlyWage) {
-        super(scope,id,name,major);
+      constructor($scope, $id, name, major, hrlyWage) {
+        super($scope, $id, name, major);
         this.hrlyWage = hrlyWage;
       }
       static _toInflightType(context) {
@@ -604,8 +604,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure2 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -641,8 +641,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class TeacherAid extends PaidStudent {
-      constructor(scope, id, name, major, hrlyWage) {
-        super(scope,id,name,major,hrlyWage);
+      constructor($scope, $id, name, major, hrlyWage) {
+        super($scope, $id, name, major, hrlyWage);
         this.hrlyWage = 10;
       }
       static _toInflightType(context) {
@@ -668,8 +668,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure3 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -701,8 +701,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class A extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
       }
       static _toInflightType(context) {
         return `
@@ -732,8 +732,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class B extends A {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
       }
       static _toInflightType(context) {
         return `
@@ -758,8 +758,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure4 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -785,8 +785,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class Bar extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
       }
       static _toInflightType(context) {
         return `
@@ -810,8 +810,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class Foo extends Bar {
-      constructor(scope, id, ) {
-        super(scope,id,);
+      constructor($scope, $id, ) {
+        super($scope, $id, );
       }
       static _toInflightType(context) {
         return `
@@ -836,8 +836,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class Baz extends Bar {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
       }
       static _toInflightType(context) {
         return `
@@ -862,8 +862,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class Boom extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
       }
       static _toInflightType(context) {
         return `
@@ -887,8 +887,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class Bam extends Boom {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
       }
       static _toInflightType(context) {
         return `
@@ -912,22 +912,22 @@ class $Root extends $stdlib.std.Resource {
         return ["$inflight_init"];
       }
     }
-    new C1(this,"C1");
-    const c2 = new C2(this,"C2");
+    new C1(this, "C1");
+    const c2 = new C2(this, "C2");
     {((cond) => {if (!cond) throw new Error("assertion failed: c2.x == 1")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(c2.x,1)))};
-    const c3 = new C3(this,"C3",1,2);
+    const c3 = new C3(this, "C3", 1, 2);
     {((cond) => {if (!cond) throw new Error("assertion failed: c3.x == 1")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(c3.x,1)))};
     {((cond) => {if (!cond) throw new Error("assertion failed: c3.y == 2")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(c3.y,2)))};
     {((cond) => {if (!cond) throw new Error("assertion failed: C4.m() == 1")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((C4.m()),1)))};
-    const c5 = new C5(this,"C5");
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:access inflight field",new $Closure1(this,"$Closure1"));
-    const student = new PaidStudent(this,"PaidStudent","Tom","MySpace",38);
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:check derived class instance variables",new $Closure2(this,"$Closure2"));
-    const ta = new TeacherAid(this,"TeacherAid","John","Rock'n Roll",50);
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:devived class init body happens after super",new $Closure3(this,"$Closure3"));
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:inflight super constructor",new $Closure4(this,"$Closure4"));
-    new Foo(this,"Foo");
-    new Baz(this,"Baz");
+    const c5 = new C5(this, "C5");
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:access inflight field", new $Closure1(this, "$Closure1"));
+    const student = new PaidStudent(this, "PaidStudent", "Tom", "MySpace", 38);
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:check derived class instance variables", new $Closure2(this, "$Closure2"));
+    const ta = new TeacherAid(this, "TeacherAid", "John", "Rock'n Roll", 50);
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:devived class init body happens after super", new $Closure3(this, "$Closure3"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:inflight super constructor", new $Closure4(this, "$Closure4"));
+    new Foo(this, "Foo");
+    new Baz(this, "Baz");
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/valid/closure_class.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/closure_class.test.w_compile_tf-aws.md
@@ -83,11 +83,11 @@ const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class MyClosure extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
       }
       static _toInflightType(context) {
         return `
@@ -111,8 +111,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -143,8 +143,8 @@ class $Root extends $stdlib.std.Resource {
         super._registerOnLift(host, ops);
       }
     }
-    const fn = new MyClosure(this,"MyClosure");
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:test",new $Closure1(this,"$Closure1"));
+    const fn = new MyClosure(this, "MyClosure");
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:test", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/valid/construct-base.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/construct-base.test.w_compile_tf-aws.md
@@ -69,11 +69,11 @@ const cloud = $stdlib.cloud;
 const cx = require("constructs");
 const aws = require("@cdktf/provider-aws");
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class WingResource extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         {console.log(String.raw({ raw: ["my id is ", ""] }, this.node.id))};
       }
       static _toInflightType(context) {
@@ -103,8 +103,8 @@ class $Root extends $stdlib.std.Resource {
     const getDisplayName = ((r) => {
       return (std.Node.of(r)).title;
     });
-    const q = this.node.root.new("@cdktf/provider-aws.sqsQueue.SqsQueue",aws.sqsQueue.SqsQueue,this,"aws.sqsQueue.SqsQueue");
-    const wr = new WingResource(this,"WingResource");
+    const q = this.node.root.new("@cdktf/provider-aws.sqsQueue.SqsQueue",aws.sqsQueue.SqsQueue,this, "aws.sqsQueue.SqsQueue");
+    const wr = new WingResource(this, "WingResource");
     const another_resource = wr;
     {console.log(String.raw({ raw: ["path of sqs.queue: ", ""] }, (getPath(q))))};
     {console.log(String.raw({ raw: ["path of wing resource: ", ""] }, (getPath(wr))))};

--- a/tools/hangar/__snapshots__/test_corpus/valid/container_types.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/container_types.test.w_compile_tf-aws.md
@@ -76,11 +76,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
-    const bucket1 = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this,"bucket1");
-    const bucket2 = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this,"bucket2");
-    const bucket3 = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this,"bucket3");
+  constructor($scope, $id) {
+    super($scope, $id);
+    const bucket1 = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this, "bucket1");
+    const bucket2 = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this, "bucket2");
+    const bucket3 = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this, "bucket3");
     const emptyArray = [];
     {((cond) => {if (!cond) throw new Error("assertion failed: emptyArray.length == 0")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(emptyArray.length,0)))};
     const emptyArray2 = [];

--- a/tools/hangar/__snapshots__/test_corpus/valid/custom_obj_id.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/custom_obj_id.test.w_compile_tf-aws.md
@@ -54,11 +54,11 @@ const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class Foo extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
       }
       static _toInflightType(context) {
         return `
@@ -81,8 +81,8 @@ class $Root extends $stdlib.std.Resource {
         return ["$inflight_init"];
       }
     }
-    const foo1 = new Foo(this,"Foo");
-    const bar2 = new Foo(this,"bar2");
+    const foo1 = new Foo(this, "Foo");
+    const bar2 = new Foo(this, "bar2");
     {((cond) => {if (!cond) throw new Error("assertion failed: foo1.node.id == \"Foo\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(foo1.node.id,"Foo")))};
     {((cond) => {if (!cond) throw new Error("assertion failed: bar2.node.id == \"bar2\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(bar2.node.id,"bar2")))};
   }

--- a/tools/hangar/__snapshots__/test_corpus/valid/debug_env.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/debug_env.test.w_compile_tf-aws.md
@@ -55,12 +55,12 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class A extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
-        this.b = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this,"cloud.Bucket");
+      constructor($scope, $id, ) {
+        super($scope, $id);
+        this.b = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this, "cloud.Bucket");
       }
       static _toInflightType(context) {
         return `

--- a/tools/hangar/__snapshots__/test_corpus/valid/deep_equality.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/deep_equality.test.w_compile_tf-aws.md
@@ -283,11 +283,11 @@ const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -325,8 +325,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure2 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -364,8 +364,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure3 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -399,8 +399,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure4 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -436,8 +436,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure5 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -471,8 +471,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure6 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -508,8 +508,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure7 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -543,8 +543,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure8 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -580,8 +580,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure9 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -615,8 +615,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure10 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -652,8 +652,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure11 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -687,8 +687,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure12 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -729,33 +729,33 @@ class $Root extends $stdlib.std.Resource {
     const strA = "wing";
     const strB = "wing";
     const strC = "wingnuts";
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:Primitive types with the same value",new $Closure1(this,"$Closure1"));
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:Primitive types with different values",new $Closure2(this,"$Closure2"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:Primitive types with the same value", new $Closure1(this, "$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:Primitive types with different values", new $Closure2(this, "$Closure2"));
     const jsonA = ({"a": 1});
     const jsonB = ({"a": 1});
     const jsonC = [1, 2, 3];
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:Json with the same value",new $Closure3(this,"$Closure3"));
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:Json with different values",new $Closure4(this,"$Closure4"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:Json with the same value", new $Closure3(this, "$Closure3"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:Json with different values", new $Closure4(this, "$Closure4"));
     const setA = new Set([1, 2, 3]);
     const setB = new Set([1, 2, 3]);
     const setC = new Set([4, 5, 6]);
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:Set types with the same value",new $Closure5(this,"$Closure5"));
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:Set types with different values",new $Closure6(this,"$Closure6"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:Set types with the same value", new $Closure5(this, "$Closure5"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:Set types with different values", new $Closure6(this, "$Closure6"));
     const mapA = ({"a": 1,"b": 2});
     const mapB = ({"a": 1,"b": 2});
     const mapC = ({"c": 10,"b": 2});
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:Map with the same value",new $Closure7(this,"$Closure7"));
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:Map with different values",new $Closure8(this,"$Closure8"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:Map with the same value", new $Closure7(this, "$Closure7"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:Map with different values", new $Closure8(this, "$Closure8"));
     const arrayA = [1, 2, 3];
     const arrayB = [1, 2, 3];
     const arrayC = [4, 5, 6];
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:Array with the same value",new $Closure9(this,"$Closure9"));
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:Array with different values",new $Closure10(this,"$Closure10"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:Array with the same value", new $Closure9(this, "$Closure9"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:Array with different values", new $Closure10(this, "$Closure10"));
     const cat1 = ({"name": "Mittens","age": 3});
     const cat2 = ({"name": "Mittens","age": 3});
     const cat3 = ({"name": "Simba","age": 5});
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:Struct with the same value",new $Closure11(this,"$Closure11"));
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:Struct with different values",new $Closure12(this,"$Closure12"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:Struct with the same value", new $Closure11(this, "$Closure11"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:Struct with different values", new $Closure12(this, "$Closure12"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/valid/double_reference.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/double_reference.test.w_compile_tf-aws.md
@@ -119,11 +119,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class Foo extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
       }
       static _toInflightType(context) {
         return `
@@ -154,9 +154,9 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class Bar extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
-        this.foo = new Foo(this,"Foo");
+      constructor($scope, $id, ) {
+        super($scope, $id);
+        this.foo = new Foo(this, "Foo");
       }
       static _toInflightType(context) {
         return `
@@ -190,8 +190,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -226,9 +226,9 @@ class $Root extends $stdlib.std.Resource {
         super._registerOnLift(host, ops);
       }
     }
-    const initCount = this.node.root.newAbstract("@winglang/sdk.cloud.Counter",this,"cloud.Counter");
-    const bar = new Bar(this,"Bar");
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:hello",new $Closure1(this,"$Closure1"));
+    const initCount = this.node.root.newAbstract("@winglang/sdk.cloud.Counter",this, "cloud.Counter");
+    const bar = new Bar(this, "Bar");
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:hello", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/valid/doubler.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/doubler.test.w_compile_tf-aws.md
@@ -257,11 +257,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class Doubler extends $stdlib.std.Resource {
-      constructor(scope, id, func) {
-        super(scope, id);
+      constructor($scope, $id, func) {
+        super($scope, $id);
         this.func = func;
       }
       static _toInflightType(context) {
@@ -296,8 +296,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -322,14 +322,14 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class Doubler2 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
       }
       makeFunc(handler) {
         const __parent_this_2 = this;
         class $Closure2 extends $stdlib.std.Resource {
-          constructor(scope, id, ) {
-            super(scope, id);
+          constructor($scope, $id, ) {
+            super($scope, $id);
             (std.Node.of(this)).hidden = true;
           }
           static _toInflightType(context) {
@@ -362,7 +362,7 @@ class $Root extends $stdlib.std.Resource {
             super._registerOnLift(host, ops);
           }
         }
-        return this.node.root.newAbstract("@winglang/sdk.cloud.Function",this,"cloud.Function",new $Closure2(this,"$Closure2"));
+        return this.node.root.newAbstract("@winglang/sdk.cloud.Function",this, "cloud.Function", new $Closure2(this, "$Closure2"));
       }
       static _toInflightType(context) {
         return `
@@ -386,8 +386,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure3 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -412,8 +412,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure4 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -444,10 +444,10 @@ class $Root extends $stdlib.std.Resource {
         super._registerOnLift(host, ops);
       }
     }
-    const fn = new Doubler(this,"Doubler",new $Closure1(this,"$Closure1"));
-    const doubler2 = new Doubler2(this,"Doubler2");
-    const f = (doubler2.makeFunc(new $Closure3(this,"$Closure3")));
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:f(2) == 8",new $Closure4(this,"$Closure4"));
+    const fn = new Doubler(this, "Doubler", new $Closure1(this, "$Closure1"));
+    const doubler2 = new Doubler2(this, "Doubler2");
+    const f = (doubler2.makeFunc(new $Closure3(this, "$Closure3")));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:f(2) == 8", new $Closure4(this, "$Closure4"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/valid/enums.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/enums.test.w_compile_tf-aws.md
@@ -61,11 +61,11 @@ const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -109,7 +109,7 @@ class $Root extends $stdlib.std.Resource {
     ;
     const one = SomeEnum.ONE;
     const two = SomeEnum.TWO;
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:inflight",new $Closure1(this,"$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:inflight", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/valid/expressions_binary_operators.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/expressions_binary_operators.test.w_compile_tf-aws.md
@@ -41,8 +41,8 @@ const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     const x = (-1);
     const y = (2 * x);
     const z = ((x + y) - 1);

--- a/tools/hangar/__snapshots__/test_corpus/valid/expressions_string_interpolation.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/expressions_string_interpolation.test.w_compile_tf-aws.md
@@ -41,8 +41,8 @@ const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     const regularString = "str\n\"";
     const emptyString = "";
     const number = 1;

--- a/tools/hangar/__snapshots__/test_corpus/valid/extern_implementation.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/extern_implementation.test.w_compile_tf-aws.md
@@ -58,7 +58,7 @@ module.exports = function({  }) {
       return (require("<ABSOLUTE_PATH>/external_js.js")["print"])(msg)
     }
     async call() {
-      {((cond) => {if (!cond) throw new Error("assertion failed: Foo.regexInflight(\"[a-z]+-\\\\d+\", \"abc-123\")")})((await Foo.regexInflight("[a-z]+-\\d+","abc-123")))};
+      {((cond) => {if (!cond) throw new Error("assertion failed: Foo.regexInflight(\"[a-z]+-\\\\d+\", \"abc-123\")")})((await Foo.regexInflight("[a-z]+-\\d+", "abc-123")))};
       const uuid = (await Foo.getUuid());
       {((cond) => {if (!cond) throw new Error("assertion failed: uuid.length == 36")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(uuid.length,36)))};
       {((cond) => {if (!cond) throw new Error("assertion failed: Foo.getData() == \"Cool data!\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await Foo.getData()),"Cool data!")))};
@@ -111,11 +111,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class Foo extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
       }
       static getGreeting(name) {
         return (require("<ABSOLUTE_PATH>/external_js.js")["getGreeting"])(name)
@@ -148,8 +148,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -181,8 +181,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure2 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -214,9 +214,9 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     {((cond) => {if (!cond) throw new Error("assertion failed: Foo.getGreeting(\"Wingding\") == \"Hello, Wingding!\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((Foo.getGreeting("Wingding")),"Hello, Wingding!")))};
-    const f = new Foo(this,"Foo");
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:call",new $Closure1(this,"$Closure1"));
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:console",new $Closure2(this,"$Closure2"));
+    const f = new Foo(this, "Foo");
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:call", new $Closure1(this, "$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:console", new $Closure2(this, "$Closure2"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/valid/file_counter.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/file_counter.test.w_compile_tf-aws.md
@@ -13,7 +13,7 @@ module.exports = function({ $bucket, $counter }) {
     async handle(body) {
       const next = (await $counter.inc());
       const key = String.raw({ raw: ["myfile-", ".txt"] }, "hi");
-      (await $bucket.put(key,body));
+      (await $bucket.put(key, body));
     }
   }
   return $Closure1;
@@ -224,11 +224,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -261,10 +261,10 @@ class $Root extends $stdlib.std.Resource {
         super._registerOnLift(host, ops);
       }
     }
-    const bucket = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this,"cloud.Bucket");
-    const counter = this.node.root.newAbstract("@winglang/sdk.cloud.Counter",this,"cloud.Counter",{ initial: 100 });
-    const queue = this.node.root.newAbstract("@winglang/sdk.cloud.Queue",this,"cloud.Queue",{ timeout: (std.Duration.fromSeconds(10)) });
-    const handler = new $Closure1(this,"$Closure1");
+    const bucket = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this, "cloud.Bucket");
+    const counter = this.node.root.newAbstract("@winglang/sdk.cloud.Counter",this, "cloud.Counter", { initial: 100 });
+    const queue = this.node.root.newAbstract("@winglang/sdk.cloud.Queue",this, "cloud.Queue", { timeout: (std.Duration.fromSeconds(10)) });
+    const handler = new $Closure1(this, "$Closure1");
     (queue.setConsumer(handler));
   }
 }

--- a/tools/hangar/__snapshots__/test_corpus/valid/for_loop.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/for_loop.test.w_compile_tf-aws.md
@@ -187,11 +187,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -216,8 +216,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class Foo extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
       }
       static _toInflightType(context) {
         return `
@@ -379,7 +379,7 @@ class $Root extends $stdlib.std.Resource {
       {((cond) => {if (!cond) throw new Error("assertion failed: x > 0")})((x > 0))};
       {console.log(String.raw({ raw: ["", ""] }, x))};
     }
-    this.node.root.newAbstract("@winglang/sdk.cloud.Function",this,"cloud.Function",new $Closure1(this,"$Closure1"));
+    this.node.root.newAbstract("@winglang/sdk.cloud.Function",this, "cloud.Function", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/valid/forward_decl.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/forward_decl.test.w_compile_tf-aws.md
@@ -54,11 +54,11 @@ const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class R extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         this.f = "Hello World!!!";
       }
       method2() {
@@ -92,7 +92,7 @@ class $Root extends $stdlib.std.Resource {
     const x = "hi";
     if (true) {
       {console.log(String.raw({ raw: ["", ""] }, x))};
-      const y = new R(this,"R");
+      const y = new R(this, "R");
     }
   }
 }

--- a/tools/hangar/__snapshots__/test_corpus/valid/function_returns_function.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/function_returns_function.test.w_compile_tf-aws.md
@@ -71,11 +71,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -108,7 +108,7 @@ class $Root extends $stdlib.std.Resource {
     const dingFn = (fn("ding"));
     {((cond) => {if (!cond) throw new Error("assertion failed: wingFn()")})((wingFn()))};
     {((cond) => {if (!cond) throw new Error("assertion failed: !dingFn()")})((!(dingFn())))};
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:inflight functions can return other inflight functions",new $Closure1(this,"$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:inflight functions can return other inflight functions", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/valid/function_type.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/function_type.test.w_compile_tf-aws.md
@@ -112,11 +112,11 @@ const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -141,8 +141,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure2 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -167,8 +167,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure3 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -193,8 +193,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class C extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
       }
       my_method(x) {
       }
@@ -229,9 +229,9 @@ class $Root extends $stdlib.std.Resource {
     });
     const my_func4 = ((x) => {
     });
-    const my_func5 = new $Closure1(this,"$Closure1");
-    const my_func6 = new $Closure2(this,"$Closure2");
-    const my_func7 = new $Closure3(this,"$Closure3");
+    const my_func5 = new $Closure1(this, "$Closure1");
+    const my_func6 = new $Closure2(this, "$Closure2");
+    const my_func7 = new $Closure3(this, "$Closure3");
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/valid/function_variadic_arguments.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/function_variadic_arguments.test.w_compile_tf-aws.md
@@ -103,11 +103,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class A extends $stdlib.std.Resource {
-      constructor(scope, id, msg) {
-        super(scope, id);
+      constructor($scope, $id, msg) {
+        super($scope, $id);
         this.message = msg;
       }
       static _toInflightType(context) {
@@ -132,8 +132,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class B extends A {
-      constructor(scope, id, msg) {
-        super(scope, id);
+      constructor($scope, $id, msg) {
+        super($scope, $id);
         this.message = msg;
       }
       static _toInflightType(context) {
@@ -158,14 +158,14 @@ class $Root extends $stdlib.std.Resource {
         return ["$inflight_init"];
       }
     }
-    const bucket1 = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this,"bucket1");
-    const bucket2 = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this,"bucket2");
-    const bucket3 = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this,"bucket3");
-    (bucket3.node.addDependency(bucket1,bucket2));
+    const bucket1 = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this, "bucket1");
+    const bucket2 = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this, "bucket2");
+    const bucket3 = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this, "bucket3");
+    (bucket3.node.addDependency(bucket1, bucket2));
     const funcBucket = ((...buckets) => {
       {((cond) => {if (!cond) throw new Error("assertion failed: buckets.length == 2")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(buckets.length,2)))};
     });
-    (funcBucket(bucket1,bucket2));
+    (funcBucket(bucket1, bucket2));
     const func1 = ((x, y, ...args) => {
       {((cond) => {if (!cond) throw new Error("assertion failed: x == 1")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(x,1)))};
       {((cond) => {if (!cond) throw new Error("assertion failed: y == \"something\" || y == nil")})(((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(y,"something")) || (((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(y,undefined))))};
@@ -176,8 +176,8 @@ class $Root extends $stdlib.std.Resource {
       (args.push(10));
       {((cond) => {if (!cond) throw new Error("assertion failed: args.at(4) == 10")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((args.at(4)),10)))};
     });
-    (func1(1,"something",1,2,3,4));
-    (func1(1,undefined,1,2,3,4));
+    (func1(1, "something", 1, 2, 3, 4));
+    (func1(1, undefined, 1, 2, 3, 4));
     const addNums = ((...nums) => {
       let total = 0;
       for (const n of nums) {
@@ -185,23 +185,23 @@ class $Root extends $stdlib.std.Resource {
       }
       return total;
     });
-    {((cond) => {if (!cond) throw new Error("assertion failed: addNums(1, 2, 3) == 6")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((addNums(1,2,3)),6)))};
+    {((cond) => {if (!cond) throw new Error("assertion failed: addNums(1, 2, 3) == 6")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((addNums(1, 2, 3)),6)))};
     {((cond) => {if (!cond) throw new Error("assertion failed: addNums() == 0")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((addNums()),0)))};
     const arityFunc = ((n, b, ...events) => {
       {((cond) => {if (!cond) throw new Error("assertion failed: events.at(-1) == \"d\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((events.at((-1))),"d")))};
     });
-    (arityFunc(1,true,"a","b","c","d"));
+    (arityFunc(1, true, "a", "b", "c", "d"));
     const subTypeFunc = ((...events) => {
       {((cond) => {if (!cond) throw new Error("assertion failed: events.at(0).message == \"this is A\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((events.at(0)).message,"this is A")))};
       {((cond) => {if (!cond) throw new Error("assertion failed: events.at(1).message == \"this is B\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((events.at(1)).message,"this is B")))};
     });
-    (subTypeFunc(new A(this,"A","this is A"),new B(this,"B","this is B")));
+    (subTypeFunc(new A(this, "A", "this is A"), new B(this, "B", "this is B")));
     const jsonCastingFunc = ((...events) => {
       {((cond) => {if (!cond) throw new Error("assertion failed: events.at(0) == \"str\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((events.at(0)),"str")))};
       {((cond) => {if (!cond) throw new Error("assertion failed: events.at(1) == \"json str\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((events.at(1)),"json str")))};
     });
     const jsonStr = "json str";
-    (jsonCastingFunc("str",jsonStr));
+    (jsonCastingFunc("str", jsonStr));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/valid/hello.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/hello.test.w_compile_tf-aws.md
@@ -11,7 +11,7 @@ module.exports = function({ $bucket }) {
       return $obj;
     }
     async handle(message) {
-      (await $bucket.put("wing.txt",String.raw({ raw: ["Hello, ", ""] }, message)));
+      (await $bucket.put("wing.txt", String.raw({ raw: ["Hello, ", ""] }, message)));
     }
   }
   return $Closure1;
@@ -202,11 +202,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -237,9 +237,9 @@ class $Root extends $stdlib.std.Resource {
         super._registerOnLift(host, ops);
       }
     }
-    const bucket = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this,"cloud.Bucket");
-    const queue = this.node.root.newAbstract("@winglang/sdk.cloud.Queue",this,"cloud.Queue");
-    (queue.setConsumer(new $Closure1(this,"$Closure1")));
+    const bucket = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this, "cloud.Bucket");
+    const queue = this.node.root.newAbstract("@winglang/sdk.cloud.Queue",this, "cloud.Queue");
+    (queue.setConsumer(new $Closure1(this, "$Closure1")));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/valid/identical_inflights.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/identical_inflights.test.w_compile_tf-aws.md
@@ -77,11 +77,11 @@ const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -106,8 +106,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure2 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -131,8 +131,8 @@ class $Root extends $stdlib.std.Resource {
         return ["handle", "$inflight_init"];
       }
     }
-    const x = new $Closure1(this,"$Closure1");
-    const y = new $Closure2(this,"$Closure2");
+    const x = new $Closure1(this, "$Closure1");
+    const y = new $Closure2(this, "$Closure2");
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/valid/impl_interface.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/impl_interface.test.w_compile_tf-aws.md
@@ -129,11 +129,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class A extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
       }
       static _toInflightType(context) {
         return `
@@ -157,8 +157,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -190,8 +190,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class r extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
       }
       method1(x) {
         return x;
@@ -221,8 +221,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class Dog extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
       }
       static _toInflightType(context) {
         return `
@@ -246,8 +246,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class Terrier extends Dog {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
       }
       static _toInflightType(context) {
         return `
@@ -271,10 +271,10 @@ class $Root extends $stdlib.std.Resource {
         return ["eat", "$inflight_init"];
       }
     }
-    const x = new A(this,"A");
-    const y = new $Closure1(this,"$Closure1");
-    const z = new Dog(this,"Dog");
-    const w = new Terrier(this,"Terrier");
+    const x = new A(this, "A");
+    const y = new $Closure1(this, "$Closure1");
+    const z = new Dog(this, "Dog");
+    const w = new Terrier(this, "Terrier");
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/valid/implicit_std.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/implicit_std.test.w_compile_tf-aws.md
@@ -41,8 +41,8 @@ const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     const d = (std.Duration.fromMinutes(5));
     const n = ((args) => { if (isNaN(args)) {throw new Error("unable to parse \"" + args + "\" as a number")}; return parseInt(args) })("12");
     {((cond) => {if (!cond) throw new Error("assertion failed: d.seconds == 5 * 60")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(d.seconds,(5 * 60))))};

--- a/tools/hangar/__snapshots__/test_corpus/valid/inference.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/inference.test.w_compile_tf-aws.md
@@ -234,11 +234,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -283,9 +283,9 @@ class $Root extends $stdlib.std.Resource {
     const emptySet = new Set([(clonedArray2.at(2))]);
     const clonedSet = new Set(emptySet);
     (clonedSet.add(4));
-    const api = this.node.root.newAbstract("@winglang/sdk.cloud.Api",this,"cloud.Api");
-    const func = new $Closure1(this,"$Closure1");
-    (api.get("/hello/world",func));
+    const api = this.node.root.newAbstract("@winglang/sdk.cloud.Api",this, "cloud.Api");
+    const func = new $Closure1(this, "$Closure1");
+    (api.get("/hello/world", func));
     const argReturn = ((n) => {
       return n;
     });

--- a/tools/hangar/__snapshots__/test_corpus/valid/inflight-subscribers.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/inflight-subscribers.test.w_compile_tf-aws.md
@@ -327,11 +327,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -356,8 +356,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure2 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -381,8 +381,8 @@ class $Root extends $stdlib.std.Resource {
         return ["handle", "$inflight_init"];
       }
     }
-    (this.node.root.newAbstract("@winglang/sdk.cloud.Topic",this,"cloud.Topic").onMessage(new $Closure1(this,"$Closure1"),{ timeout: (std.Duration.fromSeconds(180)) }));
-    (this.node.root.newAbstract("@winglang/sdk.cloud.Queue",this,"cloud.Queue").setConsumer(new $Closure2(this,"$Closure2"),{ timeout: (std.Duration.fromSeconds(180)) }));
+    (this.node.root.newAbstract("@winglang/sdk.cloud.Topic",this, "cloud.Topic").onMessage(new $Closure1(this, "$Closure1"), { timeout: (std.Duration.fromSeconds(180)) }));
+    (this.node.root.newAbstract("@winglang/sdk.cloud.Queue",this, "cloud.Queue").setConsumer(new $Closure2(this, "$Closure2"), { timeout: (std.Duration.fromSeconds(180)) }));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/valid/inflight_capture_static.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/inflight_capture_static.test.w_compile_tf-aws.md
@@ -162,11 +162,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const util = $stdlib.util;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class Preflight extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
       }
       static _toInflightType(context) {
         return `
@@ -190,8 +190,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class OuterInflight extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
       }
       static _toInflightType(context) {
         return `
@@ -215,8 +215,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -248,8 +248,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure2 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -275,8 +275,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure3 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -301,8 +301,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure4 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -327,10 +327,10 @@ class $Root extends $stdlib.std.Resource {
         return ["handle", "$inflight_init"];
       }
     }
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:call static method of preflight",new $Closure1(this,"$Closure1"));
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:call static method of an outer inflight class",new $Closure2(this,"$Closure2"));
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:call static method of an inner inflight class",new $Closure3(this,"$Closure3"));
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:call static method of a namespaced type",new $Closure4(this,"$Closure4"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:call static method of preflight", new $Closure1(this, "$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:call static method of an outer inflight class", new $Closure2(this, "$Closure2"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:call static method of an inner inflight class", new $Closure3(this, "$Closure3"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:call static method of a namespaced type", new $Closure4(this, "$Closure4"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/valid/inflight_class_as_struct_members.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/inflight_class_as_struct_members.test.w_compile_tf-aws.md
@@ -94,11 +94,11 @@ const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class Foo extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
       }
       static _toInflightType(context) {
         return `
@@ -122,8 +122,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -149,8 +149,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure2 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -181,8 +181,8 @@ class $Root extends $stdlib.std.Resource {
         super._registerOnLift(host, ops);
       }
     }
-    const getBar = new $Closure1(this,"$Closure1");
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:test",new $Closure2(this,"$Closure2"));
+    const getBar = new $Closure1(this, "$Closure1");
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:test", new $Closure2(this, "$Closure2"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/valid/inflight_class_capture_const.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/inflight_class_capture_const.test.w_compile_tf-aws.md
@@ -76,11 +76,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class Foo extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
       }
       static _toInflightType(context) {
         return `
@@ -111,8 +111,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -145,7 +145,7 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     const myConst = "bang bang";
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:inflight class captures const",new $Closure1(this,"$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:inflight class captures const", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/valid/inflight_class_capture_preflight_object.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/inflight_class_capture_preflight_object.test.w_compile_tf-aws.md
@@ -41,8 +41,8 @@ const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/valid/inflight_class_definitions.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/inflight_class_definitions.test.w_compile_tf-aws.md
@@ -183,11 +183,11 @@ const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class A extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
       }
       foo() {
         return "a1";
@@ -214,8 +214,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class B extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
       }
       static _toInflightType(context) {
         return `
@@ -239,8 +239,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -265,11 +265,11 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class D extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         class E extends $stdlib.std.Resource {
-          constructor(scope, id, ) {
-            super(scope, id);
+          constructor($scope, $id, ) {
+            super($scope, $id);
           }
           foo() {
             return "e1";
@@ -295,11 +295,11 @@ class $Root extends $stdlib.std.Resource {
             return ["$inflight_init"];
           }
         }
-        const pb = new E(this,"E");
+        const pb = new E(this, "E");
         {((cond) => {if (!cond) throw new Error("assertion failed: pb.foo() == \"e1\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((pb.foo()),"e1")))};
         class F extends $stdlib.std.Resource {
-          constructor(scope, id, ) {
-            super(scope, id);
+          constructor($scope, $id, ) {
+            super($scope, $id);
           }
           static _toInflightType(context) {
             return `
@@ -324,8 +324,8 @@ class $Root extends $stdlib.std.Resource {
         }
         const __parent_this_2 = this;
         class $Closure2 extends $stdlib.std.Resource {
-          constructor(scope, id, ) {
-            super(scope, id);
+          constructor($scope, $id, ) {
+            super($scope, $id);
             (std.Node.of(this)).hidden = true;
           }
           static _toInflightType(context) {
@@ -350,7 +350,7 @@ class $Root extends $stdlib.std.Resource {
             return ["handle", "$inflight_init"];
           }
         }
-        this.inner = new $Closure2(this,"$Closure2");
+        this.inner = new $Closure2(this, "$Closure2");
       }
       getInner() {
         return this.inner;
@@ -387,8 +387,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure3 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -426,12 +426,12 @@ class $Root extends $stdlib.std.Resource {
         super._registerOnLift(host, ops);
       }
     }
-    const a = new A(this,"A");
+    const a = new A(this, "A");
     {((cond) => {if (!cond) throw new Error("assertion failed: a.foo() == \"a1\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((a.foo()),"a1")))};
-    const fn = new $Closure1(this,"$Closure1");
-    const d = new D(this,"D");
+    const fn = new $Closure1(this, "$Closure1");
+    const d = new D(this, "D");
     const innerD = (d.getInner());
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:test",new $Closure3(this,"$Closure3"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:test", new $Closure3(this, "$Closure3"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/valid/inflight_class_inner_capture_mutable.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/inflight_class_inner_capture_mutable.test.w_compile_tf-aws.md
@@ -72,11 +72,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -100,7 +100,7 @@ class $Root extends $stdlib.std.Resource {
         return ["handle", "$inflight_init"];
       }
     }
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:inner inflight class capture immutable",new $Closure1(this,"$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:inner inflight class capture immutable", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/valid/inflight_class_inside_inflight_closure.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/inflight_class_inside_inflight_closure.test.w_compile_tf-aws.md
@@ -11,7 +11,7 @@ module.exports = function({ $__parent_this_1_b }) {
       return $obj;
     }
     async handle(payload) {
-      (await $__parent_this_1_b.put("k","v"));
+      (await $__parent_this_1_b.put("k", "v"));
       class InflightClass {
         async method() {
           {((cond) => {if (!cond) throw new Error("assertion failed: this.field == \"value\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(this.field,"value")))};
@@ -247,18 +247,18 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class PreflightClass extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
-        this.b = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this,"cloud.Bucket");
+      constructor($scope, $id, ) {
+        super($scope, $id);
+        this.b = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this, "cloud.Bucket");
       }
       preflight_method() {
         const __parent_this_1 = this;
         class $Closure1 extends $stdlib.std.Resource {
-          constructor(scope, id, ) {
-            super(scope, id);
+          constructor($scope, $id, ) {
+            super($scope, $id);
             (std.Node.of(this)).hidden = true;
           }
           static _toInflightType(context) {
@@ -289,8 +289,8 @@ class $Root extends $stdlib.std.Resource {
             super._registerOnLift(host, ops);
           }
         }
-        const inflight_closure = new $Closure1(this,"$Closure1");
-        return this.node.root.newAbstract("@winglang/sdk.cloud.Function",this,"cloud.Function",inflight_closure);
+        const inflight_closure = new $Closure1(this, "$Closure1");
+        return this.node.root.newAbstract("@winglang/sdk.cloud.Function",this, "cloud.Function", inflight_closure);
       }
       static _toInflightType(context) {
         return `
@@ -314,8 +314,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure2 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -347,8 +347,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure3 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -372,10 +372,10 @@ class $Root extends $stdlib.std.Resource {
         return ["handle", "$inflight_init"];
       }
     }
-    const p = new PreflightClass(this,"PreflightClass");
+    const p = new PreflightClass(this, "PreflightClass");
     const f = (p.preflight_method());
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:it works",new $Closure2(this,"$Closure2"));
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:inflight class inside closure captures from closure",new $Closure3(this,"$Closure3"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:it works", new $Closure2(this, "$Closure2"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:inflight class inside closure captures from closure", new $Closure3(this, "$Closure3"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/valid/inflight_class_modifiers.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/inflight_class_modifiers.test.w_compile_tf-aws.md
@@ -59,11 +59,11 @@ const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class C extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
       }
       static _toInflightType(context) {
         return `

--- a/tools/hangar/__snapshots__/test_corpus/valid/inflight_class_outside_inflight_closure.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/inflight_class_outside_inflight_closure.test.w_compile_tf-aws.md
@@ -11,7 +11,7 @@ module.exports = function({ $BinaryOperation }) {
       return $obj;
     }
     async handle() {
-      const op = (await (async () => {const o = new $BinaryOperation(10,20); await o.$inflight_init?.(); return o; })());
+      const op = (await (async () => {const o = new $BinaryOperation(10, 20); await o.$inflight_init?.(); return o; })());
       {((cond) => {if (!cond) throw new Error("assertion failed: op.add() == 30")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await op.add()),30)))};
     }
   }
@@ -82,11 +82,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class BinaryOperation extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
       }
       static _toInflightType(context) {
         return `
@@ -119,8 +119,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -145,7 +145,7 @@ class $Root extends $stdlib.std.Resource {
         return ["handle", "$inflight_init"];
       }
     }
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:inflight class outside inflight closure",new $Closure1(this,"$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:inflight class outside inflight closure", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/valid/inflight_class_structural_interace_handler.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/inflight_class_structural_interace_handler.test.w_compile_tf-aws.md
@@ -86,11 +86,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class NotGoo extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
       }
       static _toInflightType(context) {
         return `
@@ -114,8 +114,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -140,7 +140,7 @@ class $Root extends $stdlib.std.Resource {
         return ["handle", "$inflight_init"];
       }
     }
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:structure interface types for 'handle'",new $Closure1(this,"$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:structure interface types for 'handle'", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/valid/inflight_class_without_init.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/inflight_class_without_init.test.w_compile_tf-aws.md
@@ -72,11 +72,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class Foo extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
       }
       static _toInflightType(context) {
         return `
@@ -100,8 +100,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -126,7 +126,7 @@ class $Root extends $stdlib.std.Resource {
         return ["handle", "$inflight_init"];
       }
     }
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:inflight class without init",new $Closure1(this,"$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:inflight class without init", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/valid/inflight_concat.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/inflight_concat.test.w_compile_tf-aws.md
@@ -59,11 +59,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class R extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         this.s1 = "hello";
       }
       static _toInflightType(context) {
@@ -97,7 +97,7 @@ class $Root extends $stdlib.std.Resource {
         super._registerOnLift(host, ops);
       }
     }
-    const r = new R(this,"R");
+    const r = new R(this, "R");
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/valid/inflight_init.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/inflight_init.test.w_compile_tf-aws.md
@@ -98,14 +98,14 @@ module.exports = function({ $jsii_fixture_JsiiClass }) {
           }
         }
       }
-      const f = (await (async () => {const o = new Foo(1,"Foo"); await o.$inflight_init?.(); return o; })());
+      const f = (await (async () => {const o = new Foo(1, "Foo"); await o.$inflight_init?.(); return o; })());
       {((cond) => {if (!cond) throw new Error("assertion failed: f.foo_str == \"Foo 1\" && f.field() == 1 && f.foo_num == 6")})((((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(f.foo_str,"Foo 1")) && (((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await f.field()),1))) && (((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(f.foo_num,6))))};
       class FooChild extends Foo {
         constructor(){
-          super(2,"FooChild");
+          super(2, "FooChild");
           this.super_$inflight_init = this.$inflight_init;
           this.$inflight_init = async () => {
-            await this.super_$inflight_init?.(2,"FooChild");
+            await this.super_$inflight_init?.(2, "FooChild");
             this.child_field = ((await this.get_six()) + 1);
           }
         }
@@ -200,11 +200,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const jsii_fixture = require("jsii-fixture");
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class Foo extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
       }
       static _toInflightType(context) {
         return `
@@ -234,8 +234,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class FooChild extends Foo {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
       }
       static _toInflightType(context) {
         return `
@@ -266,8 +266,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -293,8 +293,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure2 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -320,8 +320,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure3 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -346,8 +346,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure4 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -372,10 +372,10 @@ class $Root extends $stdlib.std.Resource {
         return ["handle", "$inflight_init"];
       }
     }
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:inflight class init",new $Closure1(this,"$Closure1"));
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:inflight calls parent's init",new $Closure2(this,"$Closure2"));
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:inflight calls parent's init when non exists",new $Closure3(this,"$Closure3"));
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:inflight class inherits form JSII class",new $Closure4(this,"$Closure4"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:inflight class init", new $Closure1(this, "$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:inflight calls parent's init", new $Closure2(this, "$Closure2"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:inflight calls parent's init when non exists", new $Closure3(this, "$Closure3"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:inflight class inherits form JSII class", new $Closure4(this, "$Closure4"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/valid/inflights_calling_inflights.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/inflights_calling_inflights.test.w_compile_tf-aws.md
@@ -11,7 +11,7 @@ module.exports = function({ $globalBucket }) {
       return $obj;
     }
     async handle(event, file) {
-      (await $globalBucket.put(file,event));
+      (await $globalBucket.put(file, event));
     }
   }
   return $Closure1;
@@ -30,7 +30,7 @@ module.exports = function({ $storeInBucket }) {
       return $obj;
     }
     async handle(event) {
-      (await $storeInBucket(event,"file1"));
+      (await $storeInBucket(event, "file1"));
     }
   }
   return $Closure2;
@@ -272,11 +272,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -308,8 +308,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure2 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -341,8 +341,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure3 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -376,12 +376,12 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class MyResource extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         const __parent_this_4 = this;
         class $Closure4 extends $stdlib.std.Resource {
-          constructor(scope, id, ) {
-            super(scope, id);
+          constructor($scope, $id, ) {
+            super($scope, $id);
             (std.Node.of(this)).hidden = true;
           }
           static _toInflightType(context) {
@@ -412,7 +412,7 @@ class $Root extends $stdlib.std.Resource {
             super._registerOnLift(host, ops);
           }
         }
-        this.closure = new $Closure4(this,"$Closure4");
+        this.closure = new $Closure4(this, "$Closure4");
       }
       static _toInflightType(context) {
         return `
@@ -446,8 +446,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure5 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -478,13 +478,13 @@ class $Root extends $stdlib.std.Resource {
         super._registerOnLift(host, ops);
       }
     }
-    const globalBucket = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this,"cloud.Bucket");
-    const storeInBucket = new $Closure1(this,"$Closure1");
-    const handler1 = new $Closure2(this,"$Closure2");
-    const func1 = this.node.root.newAbstract("@winglang/sdk.cloud.Function",this,"func1",handler1);
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:inflights can call other inflights",new $Closure3(this,"$Closure3"));
-    const x = new MyResource(this,"MyResource");
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:variable can be an inflight closure",new $Closure5(this,"$Closure5"));
+    const globalBucket = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this, "cloud.Bucket");
+    const storeInBucket = new $Closure1(this, "$Closure1");
+    const handler1 = new $Closure2(this, "$Closure2");
+    const func1 = this.node.root.newAbstract("@winglang/sdk.cloud.Function",this, "func1", handler1);
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:inflights can call other inflights", new $Closure3(this, "$Closure3"));
+    const x = new MyResource(this, "MyResource");
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:variable can be an inflight closure", new $Closure5(this, "$Closure5"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/valid/interface.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/interface.test.w_compile_tf-aws.md
@@ -41,8 +41,8 @@ const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/valid/issue_2889.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/issue_2889.test.w_compile_tf-aws.md
@@ -258,11 +258,11 @@ const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 const http = $stdlib.http;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -288,8 +288,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure2 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -322,9 +322,9 @@ class $Root extends $stdlib.std.Resource {
         super._registerOnLift(host, ops);
       }
     }
-    const api = this.node.root.newAbstract("@winglang/sdk.cloud.Api",this,"cloud.Api");
-    (api.get("/foo",new $Closure1(this,"$Closure1")));
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:api should return a valid stringified json",new $Closure2(this,"$Closure2"));
+    const api = this.node.root.newAbstract("@winglang/sdk.cloud.Api",this, "cloud.Api");
+    (api.get("/foo", new $Closure1(this, "$Closure1")));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:api should return a valid stringified json", new $Closure2(this, "$Closure2"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/valid/json.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/json.test.w_compile_tf-aws.md
@@ -69,11 +69,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class Foo extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         this.SumStr = "wow!";
       }
       static _toInflightType(context) {
@@ -107,7 +107,7 @@ class $Root extends $stdlib.std.Resource {
     }
     const jsonMutObj = ({"hello": 123,"world": [1, "cat", 3],"boom boom": ({"hello": 1233})});
     const message = "Coolness";
-    ((obj, args) => { obj[args[0]] = args[1]; })(jsonMutObj, ["hello",message]);
+    ((obj, args) => { obj[args[0]] = args[1]; })(jsonMutObj, ["hello", message]);
     {((cond) => {if (!cond) throw new Error("assertion failed: jsonMutObj.get(\"hello\") == message")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(((obj, args) => { if (obj[args] === undefined) throw new Error(`Json property "${args}" does not exist`); return obj[args] })(jsonMutObj, "hello"),message)))};
     const someNumber = 999;
     const jj = someNumber;
@@ -118,16 +118,16 @@ class $Root extends $stdlib.std.Resource {
     });
     const jj3 = (getStr());
     {((cond) => {if (!cond) throw new Error("assertion failed: jj3 == Json \"hello\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(jj3,"hello")))};
-    const f = new Foo(this,"Foo");
+    const f = new Foo(this, "Foo");
     const jj4 = f.SumStr;
     {((cond) => {if (!cond) throw new Error("assertion failed: jj4 == Json \"wow!\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(jj4,"wow!")))};
     const someJson = ({"x": someNumber});
     {((cond) => {if (!cond) throw new Error("assertion failed: someJson.get(\"x\") == someNumber")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(((obj, args) => { if (obj[args] === undefined) throw new Error(`Json property "${args}" does not exist`); return obj[args] })(someJson, "x"),someNumber)))};
-    ((obj, args) => { obj[args[0]] = args[1]; })(someJson, ["x",111]);
+    ((obj, args) => { obj[args[0]] = args[1]; })(someJson, ["x", 111]);
     {((cond) => {if (!cond) throw new Error("assertion failed: someJson.get(\"x\") == 111")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(((obj, args) => { if (obj[args] === undefined) throw new Error(`Json property "${args}" does not exist`); return obj[args] })(someJson, "x"),111)))};
     const x = ({"cool": "beans"});
     const nestedJson = ({"a": "hello","b": ({"c": "world","d": ({"foo": "foo","bar": 123})})});
-    ((obj, args) => { obj[args[0]] = args[1]; })(((obj, args) => { if (obj[args] === undefined) throw new Error(`Json property "${args}" does not exist`); return obj[args] })(((obj, args) => { if (obj[args] === undefined) throw new Error(`Json property "${args}" does not exist`); return obj[args] })(nestedJson, "b"), "d"), ["foo","tastic"]);
+    ((obj, args) => { obj[args[0]] = args[1]; })(((obj, args) => { if (obj[args] === undefined) throw new Error(`Json property "${args}" does not exist`); return obj[args] })(((obj, args) => { if (obj[args] === undefined) throw new Error(`Json property "${args}" does not exist`); return obj[args] })(nestedJson, "b"), "d"), ["foo", "tastic"]);
     {((cond) => {if (!cond) throw new Error("assertion failed: nestedJson.get(\"b\").get(\"d\").get(\"foo\") == \"tastic\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(((obj, args) => { if (obj[args] === undefined) throw new Error(`Json property "${args}" does not exist`); return obj[args] })(((obj, args) => { if (obj[args] === undefined) throw new Error(`Json property "${args}" does not exist`); return obj[args] })(((obj, args) => { if (obj[args] === undefined) throw new Error(`Json property "${args}" does not exist`); return obj[args] })(nestedJson, "b"), "d"), "foo"),"tastic")))};
     {((cond) => {if (!cond) throw new Error("assertion failed: nestedJson.get(\"b\").get(\"d\").get(\"bar\") == 123")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(((obj, args) => { if (obj[args] === undefined) throw new Error(`Json property "${args}" does not exist`); return obj[args] })(((obj, args) => { if (obj[args] === undefined) throw new Error(`Json property "${args}" does not exist`); return obj[args] })(((obj, args) => { if (obj[args] === undefined) throw new Error(`Json property "${args}" does not exist`); return obj[args] })(nestedJson, "b"), "d"), "bar"),123)))};
     const b = "buckle";
@@ -140,12 +140,12 @@ class $Root extends $stdlib.std.Resource {
     const emptyJsonArr = [];
     const emptyMutJson = ({});
     const emptyMutJsonArr = [];
-    ((obj, args) => { obj[args[0]] = args[1]; })(emptyMutJson, ["cool",({"a": 1,"b": 2})]);
-    ((obj, args) => { obj[args[0]] = args[1]; })(((obj, args) => { if (obj[args] === undefined) throw new Error(`Json property "${args}" does not exist`); return obj[args] })(emptyMutJson, "cool"), ["a",3]);
-    ((obj, args) => { obj[args[0]] = args[1]; })(emptyMutJsonArr, [0,({"a": 1,"b": 2})]);
-    ((obj, args) => { obj[args[0]] = args[1]; })(((obj, args) => { if (obj[args] === undefined) throw new Error("Index out of bounds"); return obj[args] })(emptyMutJsonArr, 0), ["a",3]);
+    ((obj, args) => { obj[args[0]] = args[1]; })(emptyMutJson, ["cool", ({"a": 1,"b": 2})]);
+    ((obj, args) => { obj[args[0]] = args[1]; })(((obj, args) => { if (obj[args] === undefined) throw new Error(`Json property "${args}" does not exist`); return obj[args] })(emptyMutJson, "cool"), ["a", 3]);
+    ((obj, args) => { obj[args[0]] = args[1]; })(emptyMutJsonArr, [0, ({"a": 1,"b": 2})]);
+    ((obj, args) => { obj[args[0]] = args[1]; })(((obj, args) => { if (obj[args] === undefined) throw new Error("Index out of bounds"); return obj[args] })(emptyMutJsonArr, 0), ["a", 3]);
     const theTowerOfJson = ({"a": ({}),"b": ({"c": ({}),"d": [[[({})]]]}),"e": ({"f": ({"g": ({}),"h": [({}), []]})})});
-    ((obj, args) => { obj[args[0]] = args[1]; })(((obj, args) => { if (obj[args] === undefined) throw new Error("Index out of bounds"); return obj[args] })(((obj, args) => { if (obj[args] === undefined) throw new Error(`Json property "${args}" does not exist`); return obj[args] })(((obj, args) => { if (obj[args] === undefined) throw new Error(`Json property "${args}" does not exist`); return obj[args] })(((obj, args) => { if (obj[args] === undefined) throw new Error(`Json property "${args}" does not exist`); return obj[args] })(theTowerOfJson, "e"), "f"), "h"), 0), ["a",1]);
+    ((obj, args) => { obj[args[0]] = args[1]; })(((obj, args) => { if (obj[args] === undefined) throw new Error("Index out of bounds"); return obj[args] })(((obj, args) => { if (obj[args] === undefined) throw new Error(`Json property "${args}" does not exist`); return obj[args] })(((obj, args) => { if (obj[args] === undefined) throw new Error(`Json property "${args}" does not exist`); return obj[args] })(((obj, args) => { if (obj[args] === undefined) throw new Error(`Json property "${args}" does not exist`); return obj[args] })(theTowerOfJson, "e"), "f"), "h"), 0), ["a", 1]);
     const thatSuperNestedValue = ((obj, args) => { if (obj[args] === undefined) throw new Error(`Json property "${args}" does not exist`); return obj[args] })(((obj, args) => { if (obj[args] === undefined) throw new Error("Index out of bounds"); return obj[args] })(((obj, args) => { if (obj[args] === undefined) throw new Error(`Json property "${args}" does not exist`); return obj[args] })(((obj, args) => { if (obj[args] === undefined) throw new Error(`Json property "${args}" does not exist`); return obj[args] })(((obj, args) => { if (obj[args] === undefined) throw new Error(`Json property "${args}" does not exist`); return obj[args] })(theTowerOfJson, "e"), "f"), "h"), 0), "a");
     {((cond) => {if (!cond) throw new Error("assertion failed: num.fromJson(thatSuperNestedValue) == 1")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((std.Number.fromJson(thatSuperNestedValue)),1)))};
     const unestedJsonArr = [1, 2, 3];
@@ -217,7 +217,7 @@ class $Root extends $stdlib.std.Resource {
     const notSpecified = ({"foo": "bar"});
     {((cond) => {if (!cond) throw new Error("assertion failed: notSpecified.get(\"foo\") == \"bar\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(((obj, args) => { if (obj[args] === undefined) throw new Error(`Json property "${args}" does not exist`); return obj[args] })(notSpecified, "foo"),"bar")))};
     const empty = ({});
-    {((cond) => {if (!cond) throw new Error("assertion failed: Json.has(empty, \"something\") == false")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(((args) => { return args[0].hasOwnProperty(args[1]); })([empty,"something"]),false)))};
+    {((cond) => {if (!cond) throw new Error("assertion failed: Json.has(empty, \"something\") == false")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(((args) => { return args[0].hasOwnProperty(args[1]); })([empty, "something"]),false)))};
     const arrayStruct = [({"foo": "","stuff": []})];
     const setStruct = new Set([({"foo": "","stuff": []})]);
     const mapStruct = ({"1": ({"foo": "","stuff": []})});
@@ -225,7 +225,7 @@ class $Root extends $stdlib.std.Resource {
     const notJsonMissingField = ({"foo": "bar","stuff": []});
     const notJson = ({"foo": "bar","stuff": [1, 2, 3],"maybe": ({"good": true,"inner_stuff": [({"hi": 1,"base": "base"})]})});
     let mutableJson = ({"foo": "bar","stuff": [1, 2, 3],"maybe": ({"good": true,"inner_stuff": [({"hi": 1,"base": "base"})]})});
-    const hasBucket = ({"a": ({"a": this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this,"cloud.Bucket")})});
+    const hasBucket = ({"a": ({"a": this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this, "cloud.Bucket")})});
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/valid/json_bucket.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/json_bucket.test.w_compile_tf-aws.md
@@ -31,7 +31,7 @@ module.exports = function({ $b, $fileName, $getJson, $j }) {
       return $obj;
     }
     async handle() {
-      (await $b.putJson($fileName,$j));
+      (await $b.putJson($fileName, $j));
       (await $getJson.invoke(""));
     }
   }
@@ -197,11 +197,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -235,8 +235,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure2 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -273,11 +273,11 @@ class $Root extends $stdlib.std.Resource {
         super._registerOnLift(host, ops);
       }
     }
-    const b = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this,"cloud.Bucket");
+    const b = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this, "cloud.Bucket");
     const fileName = "file.json";
     const j = ({"persons": [({"age": 30,"name": "hasan","fears": ["heights", "failure"]})]});
-    const getJson = this.node.root.newAbstract("@winglang/sdk.cloud.Function",this,"cloud.Function",new $Closure1(this,"$Closure1"));
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:put",new $Closure2(this,"$Closure2"));
+    const getJson = this.node.root.newAbstract("@winglang/sdk.cloud.Function",this, "cloud.Function", new $Closure1(this, "$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:put", new $Closure2(this, "$Closure2"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/valid/json_static.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/json_static.test.w_compile_tf-aws.md
@@ -32,8 +32,8 @@ module.exports = function({ $std_Json }) {
     }
     async handle() {
       const hasCheck = ({"a": "hello","b": "wing"});
-      {((cond) => {if (!cond) throw new Error("assertion failed: Json.has(hasCheck, \"a\") == true")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(((args) => { return args[0].hasOwnProperty(args[1]); })([hasCheck,"a"]),true)))};
-      {((cond) => {if (!cond) throw new Error("assertion failed: Json.has(hasCheck, \"c\") == false")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(((args) => { return args[0].hasOwnProperty(args[1]); })([hasCheck,"c"]),false)))};
+      {((cond) => {if (!cond) throw new Error("assertion failed: Json.has(hasCheck, \"a\") == true")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(((args) => { return args[0].hasOwnProperty(args[1]); })([hasCheck, "a"]),true)))};
+      {((cond) => {if (!cond) throw new Error("assertion failed: Json.has(hasCheck, \"c\") == false")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(((args) => { return args[0].hasOwnProperty(args[1]); })([hasCheck, "c"]),false)))};
     }
   }
   return $Closure2;
@@ -83,11 +83,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -120,8 +120,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure2 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -152,13 +152,13 @@ class $Root extends $stdlib.std.Resource {
     const v = (Object.values(x));
     {((cond) => {if (!cond) throw new Error("assertion failed: v.at(0) == 123")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((v.at(0)),123)))};
     const m = (JSON.parse(JSON.stringify(x)));
-    ((obj, args) => { obj[args[0]] = args[1]; })(m, ["a",321]);
+    ((obj, args) => { obj[args[0]] = args[1]; })(m, ["a", 321]);
     {((cond) => {if (!cond) throw new Error("assertion failed: m.get(\"a\") == 321")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(((obj, args) => { if (obj[args] === undefined) throw new Error(`Json property "${args}" does not exist`); return obj[args] })(m, "a"),321)))};
     const n = JSON.parse(JSON.stringify(m));
     {((cond) => {if (!cond) throw new Error("assertion failed: m == n")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(m,n)))};
     let k2 = (Object.keys(m));
     {((cond) => {if (!cond) throw new Error("assertion failed: k2.length == 2")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(k2.length,2)))};
-    ((args) => { delete (args[0])[args[1]]; })([m,"b"]);
+    ((args) => { delete (args[0])[args[1]]; })([m, "b"]);
     k2 = (Object.keys(m));
     {((cond) => {if (!cond) throw new Error("assertion failed: k2.length == 1")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(k2.length,1)))};
     const s = "{\"a\": 123, \"b\": {\"c\": 456, \"d\": 789}}";
@@ -170,14 +170,14 @@ class $Root extends $stdlib.std.Resource {
     const jj = ({"a": 123,"b": ({"c": 456,"d": 789})});
     const ss = ((args) => { return JSON.stringify(args[0], null, args[1]?.indent) })([jj]);
     {((cond) => {if (!cond) throw new Error("assertion failed: ss == \"{\\\"a\\\":123,\\\"b\\\":{\\\"c\\\":456,\\\"d\\\":789}}\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(ss,"{\"a\":123,\"b\":{\"c\":456,\"d\":789}}")))};
-    const ss2 = ((args) => { return JSON.stringify(args[0], null, args[1]?.indent) })([jj,{ indent: 2 }]);
+    const ss2 = ((args) => { return JSON.stringify(args[0], null, args[1]?.indent) })([jj, { indent: 2 }]);
     {((cond) => {if (!cond) throw new Error("assertion failed: ss2 == \"{\\n  \\\"a\\\": 123,\\n  \\\"b\\\": {\\n    \\\"c\\\": 456,\\n    \\\"d\\\": 789\\n  }\\n}\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(ss2,"{\n  \"a\": 123,\n  \"b\": {\n    \"c\": 456,\n    \"d\": 789\n  }\n}")))};
     const jsonOfMany = ({"a": 123,"b": "hello","c": true});
     {((cond) => {if (!cond) throw new Error("assertion failed: str.fromJson(jsonOfMany.get(\"b\")) == \"hello\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((std.String.fromJson(((obj, args) => { if (obj[args] === undefined) throw new Error(`Json property "${args}" does not exist`); return obj[args] })(jsonOfMany, "b"))),"hello")))};
     {((cond) => {if (!cond) throw new Error("assertion failed: num.fromJson(jsonOfMany.get(\"a\")) == 123")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((std.Number.fromJson(((obj, args) => { if (obj[args] === undefined) throw new Error(`Json property "${args}" does not exist`); return obj[args] })(jsonOfMany, "a"))),123)))};
     {((cond) => {if (!cond) throw new Error("assertion failed: bool.fromJson(jsonOfMany.get(\"c\"))")})((std.Boolean.fromJson(((obj, args) => { if (obj[args] === undefined) throw new Error(`Json property "${args}" does not exist`); return obj[args] })(jsonOfMany, "c"))))};
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:Access Json static inflight",new $Closure1(this,"$Closure1"));
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:has key or not",new $Closure2(this,"$Closure2"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:Access Json static inflight", new $Closure1(this, "$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:has key or not", new $Closure2(this, "$Closure2"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/valid/json_string_interpolation.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/json_string_interpolation.test.w_compile_tf-aws.md
@@ -41,8 +41,8 @@ const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     const obj = ({"strValue": "test","numValue": 1});
     const notStringifyStrValue = String.raw({ raw: ["string: ", ""] }, JSON.stringify(((obj, args) => { if (obj[args] === undefined) throw new Error(`Json property "${args}" does not exist`); return obj[args] })(obj, "strValue")));
     {((cond) => {if (!cond) throw new Error("assertion failed: notStringifyStrValue == \"string: \\\"test\\\"\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(notStringifyStrValue,"string: \"test\"")))};

--- a/tools/hangar/__snapshots__/test_corpus/valid/lift_expr_with_this.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/lift_expr_with_this.test.w_compile_tf-aws.md
@@ -74,11 +74,11 @@ const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class Foo extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         this.value = "hello";
       }
       static _toInflightType(context) {
@@ -103,8 +103,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -138,8 +138,8 @@ class $Root extends $stdlib.std.Resource {
         super._registerOnLift(host, ops);
       }
     }
-    const foo_this = new Foo(this,"Foo");
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:test",new $Closure1(this,"$Closure1"));
+    const foo_this = new Foo(this, "Foo");
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:test", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/valid/lift_redefinition.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/lift_redefinition.test.w_compile_tf-aws.md
@@ -62,11 +62,11 @@ const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -98,7 +98,7 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     const y = "hello";
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:test",new $Closure1(this,"$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:test", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/valid/lift_this.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/lift_this.test.w_compile_tf-aws.md
@@ -82,11 +82,11 @@ const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class Foo extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
       }
       static _toInflightType(context) {
         return `
@@ -116,8 +116,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -148,8 +148,8 @@ class $Root extends $stdlib.std.Resource {
         super._registerOnLift(host, ops);
       }
     }
-    const f = new Foo(this,"Foo");
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:test",new $Closure1(this,"$Closure1"));
+    const f = new Foo(this, "Foo");
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:test", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/valid/lift_via_closure.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/lift_via_closure.test.w_compile_tf-aws.md
@@ -11,7 +11,7 @@ module.exports = function({ $bucket2 }) {
       return $obj;
     }
     async handle() {
-      (await $bucket2.put("hello","world"));
+      (await $bucket2.put("hello", "world"));
     }
   }
   return $Closure1;
@@ -77,10 +77,10 @@ module.exports = function({ $bucket2 }) {
     }
     async putFile() {
       {console.log("putFile called")};
-      (await this.$this_bucket.put("hello","world"));
+      (await this.$this_bucket.put("hello", "world"));
     }
     async listFiles() {
-      (await $bucket2.put("b2","world"));
+      (await $bucket2.put("b2", "world"));
       return (await this.$this_bucket.list());
     }
   }
@@ -155,11 +155,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -191,9 +191,9 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class MyClosure extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
-        this.bucket = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this,"cloud.Bucket");
+      constructor($scope, $id, ) {
+        super($scope, $id);
+        this.bucket = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this, "cloud.Bucket");
       }
       static _toInflightType(context) {
         return `
@@ -235,8 +235,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure2 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -268,8 +268,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure3 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -304,11 +304,11 @@ class $Root extends $stdlib.std.Resource {
         super._registerOnLift(host, ops);
       }
     }
-    const bucket2 = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this,"cloud.Bucket");
-    const fn = new $Closure1(this,"$Closure1");
-    const fn2 = new MyClosure(this,"MyClosure");
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:call synthetic closure class as a function",new $Closure2(this,"$Closure2"));
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:call non-synthetic closure as a function",new $Closure3(this,"$Closure3"));
+    const bucket2 = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this, "cloud.Bucket");
+    const fn = new $Closure1(this, "$Closure1");
+    const fn2 = new MyClosure(this, "MyClosure");
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:call synthetic closure class as a function", new $Closure2(this, "$Closure2"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:call non-synthetic closure as a function", new $Closure3(this, "$Closure3"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/valid/lift_via_closure_explicit.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/lift_via_closure_explicit.test.w_compile_tf-aws.md
@@ -96,12 +96,12 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class MyClosure extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
-        this.q = this.node.root.newAbstract("@winglang/sdk.cloud.Queue",this,"cloud.Queue");
+      constructor($scope, $id, ) {
+        super($scope, $id);
+        this.q = this.node.root.newAbstract("@winglang/sdk.cloud.Queue",this, "cloud.Queue");
       }
       static _toInflightType(context) {
         return `
@@ -135,8 +135,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -167,8 +167,8 @@ class $Root extends $stdlib.std.Resource {
         super._registerOnLift(host, ops);
       }
     }
-    const fn = new MyClosure(this,"MyClosure");
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:test",new $Closure1(this,"$Closure1"));
+    const fn = new MyClosure(this, "MyClosure");
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:test", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/valid/mut_container_types.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/mut_container_types.test.w_compile_tf-aws.md
@@ -76,11 +76,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
-    const bucket1 = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this,"bucket1");
-    const bucket2 = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this,"bucket2");
-    const bucket3 = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this,"bucket3");
+  constructor($scope, $id) {
+    super($scope, $id);
+    const bucket1 = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this, "bucket1");
+    const bucket2 = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this, "bucket2");
+    const bucket3 = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this, "bucket3");
     const arr1 = ["a", "b", "c"];
     const arr2 = [1, 2, 3];
     const arr3 = [bucket1, bucket2];
@@ -111,8 +111,8 @@ class $Root extends $stdlib.std.Resource {
     {((cond) => {if (!cond) throw new Error("assertion failed: m3.get(\"b1\") == bucket1")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(((obj, key) => { if (!(key in obj)) throw new Error(`MutMap does not contain key: "${key}"`); return obj[key]; })(m3, "b1"),bucket1)))};
     {((cond) => {if (!cond) throw new Error("assertion failed: m4.size() == 1")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(Object.keys(m4).length,1)))};
     {((cond) => {if (!cond) throw new Error("assertion failed: m6.get(\"a\").get(\"hello\") == \"world\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(((obj, key) => { if (!(key in obj)) throw new Error(`MutMap does not contain key: "${key}"`); return obj[key]; })(((obj, key) => { if (!(key in obj)) throw new Error(`MutMap does not contain key: "${key}"`); return obj[key]; })(m6, "a"), "hello"),"world")))};
-    ((obj, args) => { obj[args[0]] = args[1]; })(m1, ["hello","goodbye"]);
-    ((obj, args) => { obj[args[0]] = args[1]; })(m6, ["a",({"foo": "bar"})]);
+    ((obj, args) => { obj[args[0]] = args[1]; })(m1, ["hello", "goodbye"]);
+    ((obj, args) => { obj[args[0]] = args[1]; })(m6, ["a", ({"foo": "bar"})]);
     ((map) => { for(const k in map){delete map[k]}; })(m2);
     {((cond) => {if (!cond) throw new Error("assertion failed: m2.size() == 0")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(Object.keys(m2).length,0)))};
     {((cond) => {if (!cond) throw new Error("assertion failed: m1.get(\"hello\") == \"goodbye\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(((obj, key) => { if (!(key in obj)) throw new Error(`MutMap does not contain key: "${key}"`); return obj[key]; })(m1, "hello"),"goodbye")))};

--- a/tools/hangar/__snapshots__/test_corpus/valid/nil.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/nil.test.w_compile_tf-aws.md
@@ -115,11 +115,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class Foo extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
       }
       static _toInflightType(context) {
         return `
@@ -143,8 +143,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -176,8 +176,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure2 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -208,9 +208,9 @@ class $Root extends $stdlib.std.Resource {
         super._registerOnLift(host, ops);
       }
     }
-    const foo = new Foo(this,"Foo");
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:nil return",new $Closure1(this,"$Closure1"));
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:optional instance variable",new $Closure2(this,"$Closure2"));
+    const foo = new Foo(this, "Foo");
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:nil return", new $Closure1(this, "$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:optional instance variable", new $Closure2(this, "$Closure2"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/valid/optionals.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/optionals.test.w_compile_tf-aws.md
@@ -13,7 +13,7 @@ module.exports = function({ $__payloadWithBucket_c_____null_, $__payloadWithoutO
     async handle() {
       {((cond) => {if (!cond) throw new Error("assertion failed: payloadWithoutOptions.b? == false")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })($__payloadWithoutOptions_b_____null_,false)))};
       if ($__payloadWithBucket_c_____null_) {
-        (await $payloadWithBucket_c?.put?.("x.txt","something"));
+        (await $payloadWithBucket_c?.put?.("x.txt", "something"));
       }
     }
   }
@@ -132,11 +132,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class Super extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         this.name = "Super";
       }
       static _toInflightType(context) {
@@ -161,8 +161,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class Sub extends Super {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         this.name = "Sub";
       }
       static _toInflightType(context) {
@@ -188,8 +188,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class Sub1 extends Super {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         this.name = "Sub";
       }
       static _toInflightType(context) {
@@ -215,8 +215,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class Node extends $stdlib.std.Resource {
-      constructor(scope, id, value, left, right) {
-        super(scope, id);
+      constructor($scope, $id, value, left, right) {
+        super($scope, $id);
         this.value = value;
         this.left = left;
         this.right = right;
@@ -243,8 +243,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -285,8 +285,8 @@ class $Root extends $stdlib.std.Resource {
     {((cond) => {if (!cond) throw new Error("assertion failed: x ?? 5 == 4")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((x ?? 5),4)))};
     const y = (x ?? 5);
     {((cond) => {if (!cond) throw new Error("assertion failed: y == 4")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(y,4)))};
-    const optionalSup = new Super(this,"Super");
-    const s = (optionalSup ?? new Sub(this,"Sub"));
+    const optionalSup = new Super(this, "Super");
+    const s = (optionalSup ?? new Sub(this, "Sub"));
     {((cond) => {if (!cond) throw new Error("assertion failed: s.name == \"Super\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(s.name,"Super")))};
     let name = ({"first": "John","last": "Doe"});
     {
@@ -434,7 +434,7 @@ class $Root extends $stdlib.std.Resource {
     });
     {((cond) => {if (!cond) throw new Error("assertion failed: fun(\"hello\") == \"hello\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((fun("hello")),"hello")))};
     {((cond) => {if (!cond) throw new Error("assertion failed: fun(nil) == \"default\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((fun(undefined)),"default")))};
-    const tree = new Node(this,"eight",8,new Node(this,"three",3,new Node(this,"one",1,undefined,undefined),new Node(this,"six",6,undefined,undefined)),new Node(this,"ten",10,undefined,new Node(this,"fourteen",14,new Node(this,"thirteen",13,undefined,undefined),undefined)));
+    const tree = new Node(this, "eight", 8, new Node(this, "three", 3, new Node(this, "one", 1, undefined, undefined), new Node(this, "six", 6, undefined, undefined)), new Node(this, "ten", 10, undefined, new Node(this, "fourteen", 14, new Node(this, "thirteen", 13, undefined, undefined), undefined)));
     const thirteen = tree.right?.right?.left?.value;
     const notThere = tree.right?.right?.right;
     {((cond) => {if (!cond) throw new Error("assertion failed: thirteen == 13")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(thirteen,13)))};
@@ -447,8 +447,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     const payloadWithoutOptions = ({"a": "a"});
-    const payloadWithBucket = ({"a": "a","c": this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this,"orange bucket")});
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:t",new $Closure1(this,"$Closure1"));
+    const payloadWithBucket = ({"a": "a","c": this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this, "orange bucket")});
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:t", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/valid/primitive_methods.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/primitive_methods.test.w_compile_tf-aws.md
@@ -41,8 +41,8 @@ const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     const dur = (std.Duration.fromSeconds(60));
     const dur2 = (std.Duration.fromSeconds(600));
     const f = ((d) => {

--- a/tools/hangar/__snapshots__/test_corpus/valid/print.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/print.test.w_compile_tf-aws.md
@@ -82,11 +82,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -111,8 +111,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure2 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -137,8 +137,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     {console.log("preflight log")};
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:log1",new $Closure1(this,"$Closure1"));
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:log2",new $Closure2(this,"$Closure2"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:log1", new $Closure1(this, "$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:log2", new $Closure2(this, "$Closure2"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/valid/reassignment.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/reassignment.test.w_compile_tf-aws.md
@@ -54,11 +54,11 @@ const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class R extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         if (true) {
           this.f = 1;
           this.f1 = 0;
@@ -97,7 +97,7 @@ class $Root extends $stdlib.std.Resource {
     {((cond) => {if (!cond) throw new Error("assertion failed: z == 3")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(z,3)))};
     z -= 1;
     {((cond) => {if (!cond) throw new Error("assertion failed: z == 2")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(z,2)))};
-    const r = new R(this,"R");
+    const r = new R(this, "R");
     (r.inc());
     {((cond) => {if (!cond) throw new Error("assertion failed: r.f == 2")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(r.f,2)))};
     const f = ((arg) => {

--- a/tools/hangar/__snapshots__/test_corpus/valid/redis.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/redis.test.w_compile_tf-aws.md
@@ -11,7 +11,7 @@ module.exports = function({ $r }) {
       return $obj;
     }
     async handle(message) {
-      (await $r.set("hello",message));
+      (await $r.set("hello", message));
     }
   }
   return $Closure1;
@@ -31,10 +31,10 @@ module.exports = function({ $queue, $r, $r2, $util_Util }) {
     }
     async handle() {
       const connection = (await $r.rawClient());
-      (await connection.set("wing","does redis"));
+      (await connection.set("wing", "does redis"));
       const value = (await connection.get("wing"));
       {((cond) => {if (!cond) throw new Error("assertion failed: value == \"does redis\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(value,"does redis")))};
-      (await $r2.set("wing","does redis again"));
+      (await $r2.set("wing", "does redis again"));
       const value2 = (await $r2.get("wing"));
       {((cond) => {if (!cond) throw new Error("assertion failed: value2 == \"does redis again\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(value2,"does redis again")))};
       (await $queue.push("world!"));
@@ -558,11 +558,11 @@ const cloud = $stdlib.cloud;
 const util = $stdlib.util;
 const ex = $stdlib.ex;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -594,8 +594,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure2 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -631,11 +631,11 @@ class $Root extends $stdlib.std.Resource {
         super._registerOnLift(host, ops);
       }
     }
-    const r = this.node.root.newAbstract("@winglang/sdk.ex.Redis",this,"ex.Redis");
-    const r2 = this.node.root.newAbstract("@winglang/sdk.ex.Redis",this,"r2");
-    const queue = this.node.root.newAbstract("@winglang/sdk.cloud.Queue",this,"cloud.Queue");
-    (queue.setConsumer(new $Closure1(this,"$Closure1"),{ timeout: (std.Duration.fromSeconds(3)) }));
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:testing Redis",new $Closure2(this,"$Closure2"));
+    const r = this.node.root.newAbstract("@winglang/sdk.ex.Redis",this, "ex.Redis");
+    const r2 = this.node.root.newAbstract("@winglang/sdk.ex.Redis",this, "r2");
+    const queue = this.node.root.newAbstract("@winglang/sdk.cloud.Queue",this, "cloud.Queue");
+    (queue.setConsumer(new $Closure1(this, "$Closure1"), { timeout: (std.Duration.fromSeconds(3)) }));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:testing Redis", new $Closure2(this, "$Closure2"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/valid/resource.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/resource.test.w_compile_tf-aws.md
@@ -35,7 +35,7 @@ module.exports = function({ $__parent_this_2_b }) {
       return $obj;
     }
     async handle() {
-      (await $__parent_this_2_b.put("foo1.txt","bar"));
+      (await $__parent_this_2_b.put("foo1.txt", "bar"));
     }
   }
   return $Closure2;
@@ -54,7 +54,7 @@ module.exports = function({ $__parent_this_3_b }) {
       return $obj;
     }
     async handle() {
-      (await $__parent_this_3_b.put("foo2.txt","bar"));
+      (await $__parent_this_3_b.put("foo2.txt", "bar"));
     }
   }
   return $Closure3;
@@ -117,7 +117,7 @@ module.exports = function({ $Foo, $MyEnum }) {
     async myMethod() {
       (await this.$this_foo.fooInc());
       const s = (await $Foo.fooStatic());
-      (await this.$this_b.put("foo",String.raw({ raw: ["counter is: ", ""] }, (await this.$this_foo.fooGet()))));
+      (await this.$this_b.put("foo", String.raw({ raw: ["counter is: ", ""] }, (await this.$this_foo.fooGet()))));
       return (await this.$this_b.get("foo"));
     }
     async testTypeAccess() {
@@ -147,7 +147,7 @@ module.exports = function({  }) {
     async publish(s) {
       (await this.$this_t.publish(s));
       (await this.$this_q.push(s));
-      (await this.$this_b2.put("foo",s));
+      (await this.$this_b2.put("foo", s));
     }
     async getObjectCount() {
       return (await this.$this_b.list()).length;
@@ -699,12 +699,12 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class Foo extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
-        this.c = this.node.root.newAbstract("@winglang/sdk.cloud.Counter",this,"cloud.Counter");
+      constructor($scope, $id, ) {
+        super($scope, $id);
+        this.c = this.node.root.newAbstract("@winglang/sdk.cloud.Counter",this, "cloud.Counter");
       }
       static _toInflightType(context) {
         return `
@@ -741,11 +741,11 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class Bar extends $stdlib.std.Resource {
-      constructor(scope, id, name, b, e) {
-        super(scope, id);
+      constructor($scope, $id, name, b, e) {
+        super($scope, $id);
         this.name = name;
         this.b = b;
-        this.foo = new Foo(this,"Foo");
+        this.foo = new Foo(this, "Foo");
         this.e = e;
       }
       static _toInflightType(context) {
@@ -793,8 +793,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -830,16 +830,16 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class BigPublisher extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
-        this.b = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this,"cloud.Bucket");
-        this.b2 = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this,"b2");
-        this.q = this.node.root.newAbstract("@winglang/sdk.cloud.Queue",this,"cloud.Queue");
-        this.t = this.node.root.newAbstract("@winglang/sdk.cloud.Topic",this,"cloud.Topic");
+      constructor($scope, $id, ) {
+        super($scope, $id);
+        this.b = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this, "cloud.Bucket");
+        this.b2 = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this, "b2");
+        this.q = this.node.root.newAbstract("@winglang/sdk.cloud.Queue",this, "cloud.Queue");
+        this.t = this.node.root.newAbstract("@winglang/sdk.cloud.Topic",this, "cloud.Topic");
         const __parent_this_2 = this;
         class $Closure2 extends $stdlib.std.Resource {
-          constructor(scope, id, ) {
-            super(scope, id);
+          constructor($scope, $id, ) {
+            super($scope, $id);
             (std.Node.of(this)).hidden = true;
           }
           static _toInflightType(context) {
@@ -870,11 +870,11 @@ class $Root extends $stdlib.std.Resource {
             super._registerOnLift(host, ops);
           }
         }
-        (this.t.onMessage(new $Closure2(this,"$Closure2")));
+        (this.t.onMessage(new $Closure2(this, "$Closure2")));
         const __parent_this_3 = this;
         class $Closure3 extends $stdlib.std.Resource {
-          constructor(scope, id, ) {
-            super(scope, id);
+          constructor($scope, $id, ) {
+            super($scope, $id);
             (std.Node.of(this)).hidden = true;
           }
           static _toInflightType(context) {
@@ -905,11 +905,11 @@ class $Root extends $stdlib.std.Resource {
             super._registerOnLift(host, ops);
           }
         }
-        (this.q.setConsumer(new $Closure3(this,"$Closure3")));
+        (this.q.setConsumer(new $Closure3(this, "$Closure3")));
         const __parent_this_4 = this;
         class $Closure4 extends $stdlib.std.Resource {
-          constructor(scope, id, ) {
-            super(scope, id);
+          constructor($scope, $id, ) {
+            super($scope, $id);
             (std.Node.of(this)).hidden = true;
           }
           static _toInflightType(context) {
@@ -940,7 +940,7 @@ class $Root extends $stdlib.std.Resource {
             super._registerOnLift(host, ops);
           }
         }
-        (this.b2.onCreate(new $Closure4(this,"$Closure4")));
+        (this.b2.onCreate(new $Closure4(this, "$Closure4")));
       }
       static _toInflightType(context) {
         return `
@@ -985,8 +985,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure5 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -1018,11 +1018,11 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class Dummy extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
       }
       static getInstance(scope) {
-        return new Dummy(scope,"StaticDummy");
+        return new Dummy(scope, "StaticDummy");
       }
       static _toInflightType(context) {
         return `
@@ -1046,16 +1046,16 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class ScopeAndIdTestClass extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
-        const d1 = new Dummy(this,"Dummy");
+      constructor($scope, $id, ) {
+        super($scope, $id);
+        const d1 = new Dummy(this, "Dummy");
         {((cond) => {if (!cond) throw new Error("assertion failed: d1.node.path.endsWith(\"/ScopeAndIdTestClass/Dummy\")")})(d1.node.path.endsWith("/ScopeAndIdTestClass/Dummy"))};
-        const d2 = new Dummy(d1,"Dummy");
+        const d2 = new Dummy(d1, "Dummy");
         {((cond) => {if (!cond) throw new Error("assertion failed: d2.node.path.endsWith(\"/ScopeAndIdTestClass/Dummy/Dummy\")")})(d2.node.path.endsWith("/ScopeAndIdTestClass/Dummy/Dummy"))};
-        const d3 = new Dummy((Dummy.getInstance(d2)),"Dummy");
+        const d3 = new Dummy((Dummy.getInstance(d2)), "Dummy");
         {((cond) => {if (!cond) throw new Error("assertion failed: d3.node.path.endsWith(\"/ScopeAndIdTestClass/Dummy/Dummy/StaticDummy/Dummy\")")})(d3.node.path.endsWith("/ScopeAndIdTestClass/Dummy/Dummy/StaticDummy/Dummy"))};
         for (const i of $stdlib.std.Range.of(0, 3, false)) {
-          const x = new Dummy(this,String.raw({ raw: ["tc", ""] }, i));
+          const x = new Dummy(this, String.raw({ raw: ["tc", ""] }, i));
           const expected_path = String.raw({ raw: ["/ScopeAndIdTestClass/tc", ""] }, i);
           {((cond) => {if (!cond) throw new Error("assertion failed: x.node.path.endsWith(expected_path)")})(x.node.path.endsWith(expected_path))};
         }
@@ -1089,12 +1089,12 @@ class $Root extends $stdlib.std.Resource {
         return tmp;
       })({})
     ;
-    const bucket = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this,"cloud.Bucket");
-    const res = new Bar(this,"Bar","Arr",bucket,MyEnum.B);
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:test",new $Closure1(this,"$Closure1"));
-    const bigOlPublisher = new BigPublisher(this,"BigPublisher");
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:dependency cycles",new $Closure5(this,"$Closure5"));
-    new ScopeAndIdTestClass(this,"ScopeAndIdTestClass");
+    const bucket = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this, "cloud.Bucket");
+    const res = new Bar(this, "Bar", "Arr", bucket, MyEnum.B);
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:test", new $Closure1(this, "$Closure1"));
+    const bigOlPublisher = new BigPublisher(this, "BigPublisher");
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:dependency cycles", new $Closure5(this, "$Closure5"));
+    new ScopeAndIdTestClass(this, "ScopeAndIdTestClass");
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/valid/resource_as_inflight_literal.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/resource_as_inflight_literal.test.w_compile_tf-aws.md
@@ -184,11 +184,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class Foo extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
       }
       static _toInflightType(context) {
         return `
@@ -212,8 +212,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -244,8 +244,8 @@ class $Root extends $stdlib.std.Resource {
         super._registerOnLift(host, ops);
       }
     }
-    const fn = this.node.root.newAbstract("@winglang/sdk.cloud.Function",this,"cloud.Function",new Foo(this,"Foo"));
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:test",new $Closure1(this,"$Closure1"));
+    const fn = this.node.root.newAbstract("@winglang/sdk.cloud.Function",this, "cloud.Function", new Foo(this, "Foo"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:test", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/valid/resource_call_static.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/resource_call_static.test.w_compile_tf-aws.md
@@ -98,11 +98,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class Another extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
       }
       static _toInflightType(context) {
         return `
@@ -133,8 +133,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -165,8 +165,8 @@ class $Root extends $stdlib.std.Resource {
         super._registerOnLift(host, ops);
       }
     }
-    const globalCounter = this.node.root.newAbstract("@winglang/sdk.cloud.Counter",this,"cloud.Counter");
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:access cloud resource through static methods only",new $Closure1(this,"$Closure1"));
+    const globalCounter = this.node.root.newAbstract("@winglang/sdk.cloud.Counter",this, "cloud.Counter");
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:access cloud resource through static methods only", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/valid/resource_captures.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/resource_captures.test.w_compile_tf-aws.md
@@ -111,7 +111,7 @@ module.exports = function({  }) {
       {((cond) => {if (!cond) throw new Error("assertion failed: this.myOptStr ?? \"\" == \"myOptString\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(this.$_this_myOptStr_______,"myOptString")))};
     }
     async testCaptureResource() {
-      (await this.$this_myResource.put("f1.txt","f1"));
+      (await this.$this_myResource.put("f1.txt", "f1"));
       {((cond) => {if (!cond) throw new Error("assertion failed: this.myResource.get(\"f1.txt\") == \"f1\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await this.$this_myResource.get("f1.txt")),"f1")))};
       {((cond) => {if (!cond) throw new Error("assertion failed: this.myResource.list().length == 1")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await this.$this_myResource.list()).length,1)))};
     }
@@ -121,7 +121,7 @@ module.exports = function({  }) {
     }
     async testNestedResource() {
       {((cond) => {if (!cond) throw new Error("assertion failed: this.another.first.myResource.list().length == 0")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await this.$this_another_first_myResource.list()).length,0)))};
-      (await this.$this_another_first_myResource.put("hello",this.$this_myStr));
+      (await this.$this_another_first_myResource.put("hello", this.$this_myStr));
       {console.log(String.raw({ raw: ["this.another.first.myResource:", ""] }, (await this.$this_another_first_myResource.get("hello"))))};
     }
     async testExpressionRecursive() {
@@ -255,12 +255,12 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class First extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
-        this.myResource = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this,"cloud.Bucket");
+      constructor($scope, $id, ) {
+        super($scope, $id);
+        this.myResource = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this, "cloud.Bucket");
       }
       static _toInflightType(context) {
         return `
@@ -284,10 +284,10 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class Another extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         this.myField = "hello!";
-        this.first = new First(this,"First");
+        this.first = new First(this, "First");
       }
       static _toInflightType(context) {
         return `
@@ -311,9 +311,9 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class MyResource extends $stdlib.std.Resource {
-      constructor(scope, id, externalBucket, externalNum) {
-        super(scope, id);
-        this.myResource = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this,"cloud.Bucket");
+      constructor($scope, $id, externalBucket, externalNum) {
+        super($scope, $id);
+        this.myResource = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this, "cloud.Bucket");
         this.myStr = "myString";
         this.myNum = 42;
         this.myBool = true;
@@ -321,11 +321,11 @@ class $Root extends $stdlib.std.Resource {
         this.arrayOfStr = ["s1", "s2"];
         this.mapOfNum = ({"k1": 11,"k2": 22});
         this.setOfStr = new Set(["s1", "s2", "s1"]);
-        this.another = new Another(this,"Another");
-        this.myQueue = this.node.root.newAbstract("@winglang/sdk.cloud.Queue",this,"cloud.Queue");
+        this.another = new Another(this, "Another");
+        this.myQueue = this.node.root.newAbstract("@winglang/sdk.cloud.Queue",this, "cloud.Queue");
         this.extBucket = externalBucket;
         this.extNum = externalNum;
-        this.unusedResource = this.node.root.newAbstract("@winglang/sdk.cloud.Counter",this,"cloud.Counter");
+        this.unusedResource = this.node.root.newAbstract("@winglang/sdk.cloud.Counter",this, "cloud.Counter");
       }
       helloPreflight() {
         return this.another;
@@ -434,8 +434,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -466,9 +466,9 @@ class $Root extends $stdlib.std.Resource {
         super._registerOnLift(host, ops);
       }
     }
-    const b = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this,"cloud.Bucket");
-    const r = new MyResource(this,"MyResource",b,12);
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:test",new $Closure1(this,"$Closure1"));
+    const b = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this, "cloud.Bucket");
+    const r = new MyResource(this, "MyResource", b, 12);
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:test", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/valid/resource_captures_globals.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/resource_captures_globals.test.w_compile_tf-aws.md
@@ -84,7 +84,7 @@ module.exports = function({ $Another, $__obj__key_______if____key_in_obj___throw
     }
     async myPut() {
       (await this.$this_localTopic.publish("hello"));
-      (await $globalBucket.put("key","value"));
+      (await $globalBucket.put("key", "value"));
       {((cond) => {if (!cond) throw new Error("assertion failed: globalStr == \"hello\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })($globalStr,"hello")))};
       {((cond) => {if (!cond) throw new Error("assertion failed: globalBool == true")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })($globalBool,true)))};
       {((cond) => {if (!cond) throw new Error("assertion failed: globalNum == 42")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })($globalNum,42)))};
@@ -92,7 +92,7 @@ module.exports = function({ $Another, $__obj__key_______if____key_in_obj___throw
       {((cond) => {if (!cond) throw new Error("assertion failed: globalMapOfNum.get(\"a\") == -5")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })($__obj__key_______if____key_in_obj___throw_new_Error__Map_does_not_contain_key_____key______return_obj_key______globalMapOfNum___a__,(-5))))};
       {((cond) => {if (!cond) throw new Error("assertion failed: globalSetOfStr.has(\"a\")")})($_globalSetOfStr_has__a___)};
       {((cond) => {if (!cond) throw new Error("assertion failed: globalAnother.myField == \"hello!\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })($globalAnother_myField,"hello!")))};
-      (await $globalAnother_first_myResource.put("key","value"));
+      (await $globalAnother_first_myResource.put("key", "value"));
       {((cond) => {if (!cond) throw new Error("assertion failed: globalAnother.myMethod() > 0")})(((await $globalAnother.myMethod()) > 0))};
       {((cond) => {if (!cond) throw new Error("assertion failed: Another.myStaticMethod() > 0")})(((await $Another.myStaticMethod()) > 0))};
     }
@@ -364,12 +364,12 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class First extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
-        this.myResource = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this,"cloud.Bucket");
+      constructor($scope, $id, ) {
+        super($scope, $id);
+        this.myResource = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this, "cloud.Bucket");
       }
       static _toInflightType(context) {
         return `
@@ -393,10 +393,10 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class Another extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         this.myField = "hello!";
-        this.first = new First(this,"First");
+        this.first = new First(this, "First");
       }
       static _toInflightType(context) {
         return `
@@ -436,14 +436,14 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class MyResource extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
-        this.localTopic = this.node.root.newAbstract("@winglang/sdk.cloud.Topic",this,"cloud.Topic");
-        this.localCounter = this.node.root.newAbstract("@winglang/sdk.cloud.Counter",this,"cloud.Counter");
+      constructor($scope, $id, ) {
+        super($scope, $id);
+        this.localTopic = this.node.root.newAbstract("@winglang/sdk.cloud.Topic",this, "cloud.Topic");
+        this.localCounter = this.node.root.newAbstract("@winglang/sdk.cloud.Counter",this, "cloud.Counter");
         const $parentThis = this;
         class R extends $stdlib.std.Resource {
-          constructor(scope, id, ) {
-            super(scope, id);
+          constructor($scope, $id, ) {
+            super($scope, $id);
           }
           static _toInflightType(context) {
             return `
@@ -475,7 +475,7 @@ class $Root extends $stdlib.std.Resource {
             super._registerOnLift(host, ops);
           }
         }
-        (this.localTopic.onMessage(new R(this,"R")));
+        (this.localTopic.onMessage(new R(this, "R")));
       }
       static _toInflightType(context) {
         return `
@@ -531,8 +531,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -564,8 +564,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure2 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -596,18 +596,18 @@ class $Root extends $stdlib.std.Resource {
         super._registerOnLift(host, ops);
       }
     }
-    const globalBucket = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this,"cloud.Bucket");
-    const globalCounter = this.node.root.newAbstract("@winglang/sdk.cloud.Counter",this,"cloud.Counter");
+    const globalBucket = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this, "cloud.Bucket");
+    const globalCounter = this.node.root.newAbstract("@winglang/sdk.cloud.Counter",this, "cloud.Counter");
     const globalStr = "hello";
     const globalBool = true;
     const globalNum = 42;
     const globalArrayOfStr = ["hello", "world"];
     const globalMapOfNum = ({"a": (-5),"b": 2});
     const globalSetOfStr = new Set(["a", "b"]);
-    const globalAnother = new Another(this,"Another");
-    const res = new MyResource(this,"MyResource");
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:test",new $Closure1(this,"$Closure1"));
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:access cloud resource through static methods only",new $Closure2(this,"$Closure2"));
+    const globalAnother = new Another(this, "Another");
+    const res = new MyResource(this, "MyResource");
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:test", new $Closure1(this, "$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:access cloud resource through static methods only", new $Closure2(this, "$Closure2"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/valid/service.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/service.test.w_compile_tf-aws.md
@@ -41,8 +41,8 @@ const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/valid/shadowing.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/shadowing.test.w_compile_tf-aws.md
@@ -92,11 +92,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -128,8 +128,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure2 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -162,8 +162,8 @@ class $Root extends $stdlib.std.Resource {
     }
     const bar = "hola!";
     const foo = "not captured";
-    const fn = new $Closure1(this,"$Closure1");
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:capture shadow interaction",new $Closure2(this,"$Closure2"));
+    const fn = new $Closure1(this, "$Closure1");
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:capture shadow interaction", new $Closure2(this, "$Closure2"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/valid/statements_if.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/statements_if.test.w_compile_tf-aws.md
@@ -80,11 +80,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -132,7 +132,7 @@ class $Root extends $stdlib.std.Resource {
         {((cond) => {if (!cond) throw new Error("assertion failed: false")})(false)};
       }
     }
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:test",new $Closure1(this,"$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:test", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/valid/statements_variable_declarations.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/statements_variable_declarations.test.w_compile_tf-aws.md
@@ -45,6 +45,8 @@ class $Root extends $stdlib.std.Resource {
     super($scope, $id);
     const x = 2;
     const y = x;
+    const id = 1;
+    const scope = id;
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/valid/statements_variable_declarations.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/statements_variable_declarations.test.w_compile_tf-aws.md
@@ -41,8 +41,8 @@ const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     const x = 2;
     const y = x;
   }

--- a/tools/hangar/__snapshots__/test_corpus/valid/static_members.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/static_members.test.w_compile_tf-aws.md
@@ -87,11 +87,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class Foo extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         this.instanceField = 100;
       }
       static m() {
@@ -119,8 +119,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -144,10 +144,10 @@ class $Root extends $stdlib.std.Resource {
         return ["handle", "$inflight_init"];
       }
     }
-    const foo = new Foo(this,"Foo");
+    const foo = new Foo(this, "Foo");
     {((cond) => {if (!cond) throw new Error("assertion failed: foo.instanceField == 100")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(foo.instanceField,100)))};
     {((cond) => {if (!cond) throw new Error("assertion failed: Foo.m() == 99")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((Foo.m()),99)))};
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:test",new $Closure1(this,"$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:test", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/valid/std_containers.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/std_containers.test.w_compile_tf-aws.md
@@ -82,11 +82,11 @@ const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class Animal extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
       }
       static _toInflightType(context) {
         return `
@@ -110,8 +110,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class Cat extends Animal {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
       }
       static _toInflightType(context) {
         return `
@@ -136,8 +136,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class Dog extends Animal {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
       }
       static _toInflightType(context) {
         return `
@@ -195,16 +195,16 @@ class $Root extends $stdlib.std.Resource {
     const sMap = ({"one": 1,"two": 2});
     const nestedMap = ({"a": ({"b": ({"c": "hello"})})});
     const mutMap = {...(sMap)};
-    ((obj, args) => { obj[args[0]] = args[1]; })(mutMap, ["five",5]);
+    ((obj, args) => { obj[args[0]] = args[1]; })(mutMap, ["five", 5]);
     const immutMap = ({...(mutMap)});
     {((cond) => {if (!cond) throw new Error("assertion failed: sMap.get(\"one\") == 1")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(((obj, key) => { if (!(key in obj)) throw new Error(`Map does not contain key: "${key}"`); return obj[key]; })(sMap, "one"),1)))};
     {((cond) => {if (!cond) throw new Error("assertion failed: sMap.size() == 2")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(Object.keys(sMap).length,2)))};
     {((cond) => {if (!cond) throw new Error("assertion failed: immutMap.size() == 3")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(Object.keys(immutMap).length,3)))};
     {((cond) => {if (!cond) throw new Error("assertion failed: nestedMap.get(\"a\").get(\"b\").get(\"c\") == \"hello\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(((obj, args) => { if (obj[args] === undefined) throw new Error(`Json property "${args}" does not exist`); return obj[args] })(((obj, key) => { if (!(key in obj)) throw new Error(`Map does not contain key: "${key}"`); return obj[key]; })(((obj, key) => { if (!(key in obj)) throw new Error(`Map does not contain key: "${key}"`); return obj[key]; })(nestedMap, "a"), "b"), "c"),"hello")))};
-    const heterogeneousArray = [new Cat(this,"C1"), new Dog(this,"D1")];
-    const heterogeneousDoubleArray = [[new Cat(this,"C2")], [new Cat(this,"C3"), new Dog(this,"D2")], [new Animal(this,"A1")]];
-    const heterogeneousSet = new Set([new Cat(this,"C4"), new Dog(this,"D3")]);
-    const heterogeneousMap = ({"cat": new Cat(this,"C5"),"dog": new Dog(this,"D4")});
+    const heterogeneousArray = [new Cat(this, "C1"), new Dog(this, "D1")];
+    const heterogeneousDoubleArray = [[new Cat(this, "C2")], [new Cat(this, "C3"), new Dog(this, "D2")], [new Animal(this, "A1")]];
+    const heterogeneousSet = new Set([new Cat(this, "C4"), new Dog(this, "D3")]);
+    const heterogeneousMap = ({"cat": new Cat(this, "C5"),"dog": new Dog(this, "D4")});
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/valid/std_string.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/std_string.test.w_compile_tf-aws.md
@@ -62,11 +62,11 @@ const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -114,12 +114,12 @@ class $Root extends $stdlib.std.Resource {
     {((cond) => {if (!cond) throw new Error("assertion failed: s1.split(\" \").at(0) == \"some\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(((s1.split(" ")).at(0)),"some")))};
     {((cond) => {if (!cond) throw new Error("assertion failed: s1.startsWith(\"some\")")})(s1.startsWith("some"))};
     {((cond) => {if (!cond) throw new Error("assertion failed: s1.substring(5) == \"string\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((s1.substring(5)),"string")))};
-    {((cond) => {if (!cond) throw new Error("assertion failed: s1.substring(5, 7) == \"st\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((s1.substring(5,7)),"st")))};
+    {((cond) => {if (!cond) throw new Error("assertion failed: s1.substring(5, 7) == \"st\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((s1.substring(5, 7)),"st")))};
     {((cond) => {if (!cond) throw new Error("assertion failed: \"   some string   \".trim() == \"some string\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(("   some string   ".trim()),"some string")))};
     {((cond) => {if (!cond) throw new Error("assertion failed: \"Some String\".uppercase() == \"SOME STRING\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })("Some String".toLocaleUpperCase(),"SOME STRING")))};
     {((cond) => {if (!cond) throw new Error("assertion failed: \"hello\" + \" world\" == \"hello world\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(("hello" + " world"),"hello world")))};
     {((cond) => {if (!cond) throw new Error("assertion failed: \n\"hello ${\"funky\"}\n world\" == \"hello funky\\n world\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(String.raw({ raw: ["hello ", "\n world"] }, "funky"),"hello funky\n world")))};
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:string",new $Closure1(this,"$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:string", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/valid/store.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/store.w_compile_tf-aws.md
@@ -11,7 +11,7 @@ module.exports = function({ $__parent_this_1_b }) {
       return $obj;
     }
     async handle() {
-      (await $__parent_this_1_b.put("data.txt","<empty>"));
+      (await $__parent_this_1_b.put("data.txt", "<empty>"));
     }
   }
   return $Closure1;
@@ -28,7 +28,7 @@ module.exports = function({  }) {
       this.$this_b = $this_b;
     }
     async store(data) {
-      (await this.$this_b.put("data.txt",data));
+      (await this.$this_b.put("data.txt", data));
     }
   }
   return Store;
@@ -68,8 +68,8 @@ module.exports = function({ $stdlib }) {
   const math = $stdlib.math;
   const cloud = $stdlib.cloud;
   class Util extends $stdlib.std.Resource {
-    constructor(scope, id, ) {
-      super(scope, id);
+    constructor($scope, $id, ) {
+      super($scope, $id);
     }
     static _toInflightType(context) {
       return `
@@ -93,13 +93,13 @@ module.exports = function({ $stdlib }) {
     }
   }
   class Store extends $stdlib.std.Resource {
-    constructor(scope, id, ) {
-      super(scope, id);
-      this.b = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this,"cloud.Bucket");
+    constructor($scope, $id, ) {
+      super($scope, $id);
+      this.b = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this, "cloud.Bucket");
       const __parent_this_1 = this;
       class $Closure1 extends $stdlib.std.Resource {
-        constructor(scope, id, ) {
-          super(scope, id);
+        constructor($scope, $id, ) {
+          super($scope, $id);
           (std.Node.of(this)).hidden = true;
         }
         static _toInflightType(context) {
@@ -130,7 +130,7 @@ module.exports = function({ $stdlib }) {
           super._registerOnLift(host, ops);
         }
       }
-      const prefill = this.node.root.newAbstract("@winglang/sdk.cloud.OnDeploy",this,"cloud.OnDeploy",new $Closure1(this,"$Closure1"));
+      const prefill = this.node.root.newAbstract("@winglang/sdk.cloud.OnDeploy",this, "cloud.OnDeploy", new $Closure1(this, "$Closure1"));
     }
     static _toInflightType(context) {
       return `

--- a/tools/hangar/__snapshots__/test_corpus/valid/struct_from_json.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/struct_from_json.test.w_compile_tf-aws.md
@@ -118,10 +118,10 @@ module.exports = function({ $Student, $std_Boolean, $std_Number, $std_String }) 
       return $obj;
     }
     async handle() {
-      (await $std_String.fromJson(10,{ unsafe: true }));
-      (await $std_Boolean.fromJson(10,{ unsafe: true }));
-      (await $std_Number.fromJson("cool",{ unsafe: true }));
-      ((json, validateOptions) => ($Student._fromJson(json, validateOptions)))(({"obviously": "not a student"}),{ unsafe: true });
+      (await $std_String.fromJson(10, { unsafe: true }));
+      (await $std_Boolean.fromJson(10, { unsafe: true }));
+      (await $std_Number.fromJson("cool", { unsafe: true }));
+      ((json, validateOptions) => ($Student._fromJson(json, validateOptions)))(({"obviously": "not a student"}), { unsafe: true });
     }
   }
   return $Closure5;
@@ -186,8 +186,8 @@ const cloud = $stdlib.cloud;
 const externalStructs = require("./preflight.structs-1.js")({ $stdlib });
 const otherExternalStructs = require("./preflight.structs2-2.js")({ $stdlib });
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     const Bar = $stdlib.std.Struct._createJsonSchema({id:"/Bar",type:"object",properties:{b:{type:"number"},f:{type:"string"},},required:["b","f",]});
     const Foo = $stdlib.std.Struct._createJsonSchema({id:"/Foo",type:"object",properties:{f:{type:"string"},},required:["f",]});
     const Foosible = $stdlib.std.Struct._createJsonSchema({id:"/Foosible",type:"object",properties:{f:{type:"string"},},required:[]});
@@ -197,8 +197,8 @@ class $Root extends $stdlib.std.Resource {
     const cloud_BucketProps = $stdlib.std.Struct._createJsonSchema({id:"/BucketProps",type:"object",properties:{public:{type:"boolean"},},required:[]});
     const externalStructs_MyOtherStruct = $stdlib.std.Struct._createJsonSchema({id:"/MyOtherStruct",type:"object",properties:{data:{type:"object",properties:{val:{type:"number"},},required:["val",]},},required:["data",]});
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -231,8 +231,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure2 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -258,8 +258,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure3 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -292,8 +292,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure4 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -331,8 +331,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure5 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -363,7 +363,7 @@ class $Root extends $stdlib.std.Resource {
     const j = ({"public": false});
     const x = ((json, validateOptions) => (cloud_BucketProps._fromJson(json, validateOptions)))(j);
     {((cond) => {if (!cond) throw new Error("assertion failed: x.public == false")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(x.public,false)))};
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:inflight jsii struct conversion",new $Closure1(this,"$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:inflight jsii struct conversion", new $Closure1(this, "$Closure1"));
     const jFoo = ({"f": "bar"});
     {((cond) => {if (!cond) throw new Error("assertion failed: Foo.fromJson(jFoo).f == \"bar\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(((json, validateOptions) => (Foo._fromJson(json, validateOptions)))(jFoo).f,"bar")))};
     const jFoosible = ({});
@@ -463,8 +463,8 @@ class $Root extends $stdlib.std.Resource {
         {((cond) => {if (!cond) throw new Error("assertion failed: false")})(false)};
       }
     }
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:flight school student :)",new $Closure2(this,"$Closure2"));
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:lifting a student",new $Closure3(this,"$Closure3"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:flight school student :)", new $Closure2(this, "$Closure2"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:lifting a student", new $Closure3(this, "$Closure3"));
     const jj1 = ({"data": ({"val": 10})});
     const externalBar = ((json, validateOptions) => (externalStructs_MyOtherStruct._fromJson(json, validateOptions)))(jj1);
     {((cond) => {if (!cond) throw new Error("assertion failed: externalBar.data.val == 10")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(externalBar.data.val,10)))};
@@ -476,13 +476,13 @@ class $Root extends $stdlib.std.Resource {
     (schema.validate(jMyStruct));
     const expectedSchema = ({"id": "/MyStruct","type": "object","properties": ({"m1": ({"type": "object","properties": ({"val": ({"type": "number"})}),"required": ["val"]}),"m2": ({"type": "object","properties": ({"val": ({"type": "string"})}),"required": ["val"]})}),"required": ["m1", "m2"]});
     {((cond) => {if (!cond) throw new Error("assertion failed: schema.asStr() == Json.stringify(expectedSchema)")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((schema.asStr()),((args) => { return JSON.stringify(args[0], null, args[1]?.indent) })([expectedSchema]))))};
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:inflight schema usage",new $Closure4(this,"$Closure4"));
-    (std.String.fromJson(10,{ unsafe: true }));
-    (std.Boolean.fromJson(10,{ unsafe: true }));
-    (std.Number.fromJson("cool",{ unsafe: true }));
-    ((json, validateOptions) => (Student._fromJson(json, validateOptions)))(({"obviously": "not a student"}),{ unsafe: true });
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:unsafe flight",new $Closure5(this,"$Closure5"));
-    new otherExternalStructs.UsesStructInImportedFile(this,"otherExternalStructs.UsesStructInImportedFile");
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:inflight schema usage", new $Closure4(this, "$Closure4"));
+    (std.String.fromJson(10, { unsafe: true }));
+    (std.Boolean.fromJson(10, { unsafe: true }));
+    (std.Number.fromJson("cool", { unsafe: true }));
+    ((json, validateOptions) => (Student._fromJson(json, validateOptions)))(({"obviously": "not a student"}), { unsafe: true });
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:unsafe flight", new $Closure5(this, "$Closure5"));
+    new otherExternalStructs.UsesStructInImportedFile(this, "otherExternalStructs.UsesStructInImportedFile");
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);
@@ -522,8 +522,8 @@ module.exports = function({ $stdlib }) {
   const cloud_BucketProps = $stdlib.std.Struct._createJsonSchema({id:"/BucketProps",type:"object",properties:{public:{type:"boolean"},},required:[]});
   const externalStructs_MyOtherStruct = $stdlib.std.Struct._createJsonSchema({id:"/MyOtherStruct",type:"object",properties:{data:{type:"object",properties:{val:{type:"number"},},required:["val",]},},required:["data",]});
   class UsesStructInImportedFile extends $stdlib.std.Resource {
-    constructor(scope, id, ) {
-      super(scope, id);
+    constructor($scope, $id, ) {
+      super($scope, $id);
       this.someStruct = ((json, validateOptions) => (SomeStruct._fromJson(json, validateOptions)))(({"foo": "123"}));
     }
     static _toInflightType(context) {

--- a/tools/hangar/__snapshots__/test_corpus/valid/structs.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/structs.test.w_compile_tf-aws.md
@@ -78,11 +78,11 @@ const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class Foo extends $stdlib.std.Resource {
-      constructor(scope, id, b) {
-        super(scope, id);
+      constructor($scope, $id, b) {
+        super($scope, $id);
         this.data = b;
       }
       static _toInflightType(context) {
@@ -117,8 +117,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -148,7 +148,7 @@ class $Root extends $stdlib.std.Resource {
     {((cond) => {if (!cond) throw new Error("assertion failed: y.field1 == 1")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(y.field1,1)))};
     {((cond) => {if (!cond) throw new Error("assertion failed: y.field3.field0 == \"foo\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(y.field3.field0,"foo")))};
     const s = ({"a": "Boom baby"});
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:struct definitions are phase independant",new $Closure1(this,"$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:struct definitions are phase independant", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/valid/super_call.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/super_call.test.w_compile_tf-aws.md
@@ -133,7 +133,7 @@ module.exports = function({ $BaseClass, $b }) {
       super({  });
     }
     async do() {
-      (await $b.put("k","value"));
+      (await $b.put("k", "value"));
       return (await super.do());
     }
   }
@@ -226,11 +226,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class A extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         this.message = "A message from your ancestor";
       }
       static _toInflightType(context) {
@@ -255,8 +255,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class B extends A {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
       }
       description() {
         return "B";
@@ -284,8 +284,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class C extends B {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
       }
       description() {
         return String.raw({ raw: ["C extends ", ""] }, (super.description()));
@@ -313,8 +313,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class D extends C {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
       }
       static _toInflightType(context) {
         return `
@@ -339,8 +339,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class E extends D {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
       }
       description() {
         return String.raw({ raw: ["E extends ", ""] }, (super.description()));
@@ -368,8 +368,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class InflightA extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
       }
       static _toInflightType(context) {
         return `
@@ -393,8 +393,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class InflightB extends InflightA {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
       }
       static _toInflightType(context) {
         return `
@@ -419,8 +419,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -446,8 +446,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class BaseClass extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
       }
       static _toInflightType(context) {
         return `
@@ -478,8 +478,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class ExtendedClass extends BaseClass {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
       }
       static _toInflightType(context) {
         return `
@@ -511,8 +511,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure2 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -543,12 +543,12 @@ class $Root extends $stdlib.std.Resource {
         super._registerOnLift(host, ops);
       }
     }
-    const e = new E(this,"E");
+    const e = new E(this, "E");
     {((cond) => {if (!cond) throw new Error("assertion failed: e.description() == \"E extends C extends B\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((e.description()),"E extends C extends B")))};
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:super call inflight",new $Closure1(this,"$Closure1"));
-    const b = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this,"cloud.Bucket");
-    const extended = new ExtendedClass(this,"ExtendedClass");
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:super call sets binding permissions",new $Closure2(this,"$Closure2"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:super call inflight", new $Closure1(this, "$Closure1"));
+    const b = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this, "cloud.Bucket");
+    const extended = new ExtendedClass(this, "ExtendedClass");
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:super call sets binding permissions", new $Closure2(this, "$Closure2"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/valid/symbol_shadow.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/symbol_shadow.test.w_compile_tf-aws.md
@@ -132,17 +132,17 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class A extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         const s = "inResource";
         {((cond) => {if (!cond) throw new Error("assertion failed: s == \"inResource\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(s,"inResource")))};
         const __parent_this_2 = this;
         class $Closure2 extends $stdlib.std.Resource {
-          constructor(scope, id, ) {
-            super(scope, id);
+          constructor($scope, $id, ) {
+            super($scope, $id);
             (std.Node.of(this)).hidden = true;
           }
           static _toInflightType(context) {
@@ -173,7 +173,7 @@ class $Root extends $stdlib.std.Resource {
             super._registerOnLift(host, ops);
           }
         }
-        this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:inflight in resource should capture the right scoped var",new $Closure2(this,"$Closure2"));
+        this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:inflight in resource should capture the right scoped var", new $Closure2(this, "$Closure2"));
       }
       static _toInflightType(context) {
         return `
@@ -197,8 +197,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure3 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -230,8 +230,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure4 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -260,8 +260,8 @@ class $Root extends $stdlib.std.Resource {
       const s = "inner";
       {((cond) => {if (!cond) throw new Error("assertion failed: s == \"inner\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(s,"inner")))};
       class $Closure1 extends $stdlib.std.Resource {
-        constructor(scope, id, ) {
-          super(scope, id);
+        constructor($scope, $id, ) {
+          super($scope, $id);
           (std.Node.of(this)).hidden = true;
         }
         static _toInflightType(context) {
@@ -292,12 +292,12 @@ class $Root extends $stdlib.std.Resource {
           super._registerOnLift(host, ops);
         }
       }
-      this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:inflight nested should not capture the shadowed var",new $Closure1(this,"$Closure1"));
+      this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:inflight nested should not capture the shadowed var", new $Closure1(this, "$Closure1"));
     }
     {((cond) => {if (!cond) throw new Error("assertion failed: s == \"top\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(s,"top")))};
-    new A(this,"A");
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:inflight on top should capture top",new $Closure3(this,"$Closure3"));
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:insideInflight should capture the right scope",new $Closure4(this,"$Closure4"));
+    new A(this, "A");
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:inflight on top should capture top", new $Closure3(this, "$Closure3"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:insideInflight should capture the right scope", new $Closure4(this, "$Closure4"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/valid/table.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/table.test.w_compile_tf-aws.md
@@ -63,9 +63,9 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const ex = $stdlib.ex;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
-    const t = this.node.root.newAbstract("@winglang/sdk.ex.Table",this,"ex.Table",{ name: "simple-table", primaryKey: "id", columns: ({"id": ex.ColumnType.STRING,"name": ex.ColumnType.STRING,"age": ex.ColumnType.NUMBER}) });
+  constructor($scope, $id) {
+    super($scope, $id);
+    const t = this.node.root.newAbstract("@winglang/sdk.ex.Table",this, "ex.Table", { name: "simple-table", primaryKey: "id", columns: ({"id": ex.ColumnType.STRING,"name": ex.ColumnType.STRING,"age": ex.ColumnType.NUMBER}) });
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/valid/test_bucket.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/test_bucket.test.w_compile_tf-aws.md
@@ -12,7 +12,7 @@ module.exports = function({ $b }) {
     }
     async handle() {
       {((cond) => {if (!cond) throw new Error("assertion failed: b.list().length == 0")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $b.list()).length,0)))};
-      (await $b.put("hello.txt","world"));
+      (await $b.put("hello.txt", "world"));
       {((cond) => {if (!cond) throw new Error("assertion failed: b.list().length == 1")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $b.list()).length,1)))};
     }
   }
@@ -32,7 +32,7 @@ module.exports = function({ $b }) {
       return $obj;
     }
     async handle() {
-      (await $b.put("hello.txt","world"));
+      (await $b.put("hello.txt", "world"));
       {((cond) => {if (!cond) throw new Error("assertion failed: b.get(\"hello.txt\") == \"world\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((await $b.get("hello.txt")),"world")))};
     }
   }
@@ -97,11 +97,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -133,8 +133,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure2 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -165,9 +165,9 @@ class $Root extends $stdlib.std.Resource {
         super._registerOnLift(host, ops);
       }
     }
-    const b = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this,"cloud.Bucket");
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:put",new $Closure1(this,"$Closure1"));
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:get",new $Closure2(this,"$Closure2"));
+    const b = this.node.root.newAbstract("@winglang/sdk.cloud.Bucket",this, "cloud.Bucket");
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:put", new $Closure1(this, "$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:get", new $Closure2(this, "$Closure2"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/valid/test_without_bring.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/test_without_bring.test.w_compile_tf-aws.md
@@ -60,11 +60,11 @@ const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -88,7 +88,7 @@ class $Root extends $stdlib.std.Resource {
         return ["handle", "$inflight_init"];
       }
     }
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:hello test",new $Closure1(this,"$Closure1"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:hello test", new $Closure1(this, "$Closure1"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/valid/try_catch.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/try_catch.test.w_compile_tf-aws.md
@@ -41,8 +41,8 @@ const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     let x = "";
     try {
       throw new Error("hello");

--- a/tools/hangar/__snapshots__/test_corpus/valid/use_inflight_method_inside_init_closure.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/use_inflight_method_inside_init_closure.test.w_compile_tf-aws.md
@@ -180,15 +180,15 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class Foo extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         const __parent_this_1 = this;
         class $Closure1 extends $stdlib.std.Resource {
-          constructor(scope, id, ) {
-            super(scope, id);
+          constructor($scope, $id, ) {
+            super($scope, $id);
             (std.Node.of(this)).hidden = true;
           }
           static _toInflightType(context) {
@@ -219,7 +219,7 @@ class $Root extends $stdlib.std.Resource {
             super._registerOnLift(host, ops);
           }
         }
-        this.node.root.newAbstract("@winglang/sdk.cloud.Function",this,"cloud.Function",new $Closure1(this,"$Closure1"));
+        this.node.root.newAbstract("@winglang/sdk.cloud.Function",this, "cloud.Function", new $Closure1(this, "$Closure1"));
       }
       static _toInflightType(context) {
         return `
@@ -242,7 +242,7 @@ class $Root extends $stdlib.std.Resource {
         return ["bar", "$inflight_init"];
       }
     }
-    new Foo(this,"Foo");
+    new Foo(this, "Foo");
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/valid/website_with_api.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/website_with_api.test.w_compile_tf-aws.md
@@ -34,7 +34,7 @@ module.exports = function({ $std_Json, $usersTable }) {
       if ((((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(((obj, args) => { if (obj[args] === undefined) throw new Error(`Json property "${args}" does not exist`); return obj[args] })(body, "name"),"")) || (((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(((obj, args) => { if (obj[args] === undefined) throw new Error(`Json property "${args}" does not exist`); return obj[args] })(body, "age"),""))) || (((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(((obj, args) => { if (obj[args] === undefined) throw new Error(`Json property "${args}" does not exist`); return obj[args] })(body, "id"),"")))) {
         return ({"body": ((args) => { return JSON.stringify(args[0], null, args[1]?.indent) })([({"error": "incomplete details"})]),"status": 400});
       }
-      (await $usersTable.insert(((args) => { return JSON.stringify(args[0], null, args[1]?.indent) })([((obj, args) => { if (obj[args] === undefined) throw new Error(`Json property "${args}" does not exist`); return obj[args] })(body, "id")]),body));
+      (await $usersTable.insert(((args) => { return JSON.stringify(args[0], null, args[1]?.indent) })([((obj, args) => { if (obj[args] === undefined) throw new Error(`Json property "${args}" does not exist`); return obj[args] })(body, "id")]), body));
       return ({"body": ((args) => { return JSON.stringify(args[0], null, args[1]?.indent) })([({"user": ((obj, args) => { if (obj[args] === undefined) throw new Error(`Json property "${args}" does not exist`); return obj[args] })(body, "id")})]),"status": 201});
     }
   }
@@ -54,12 +54,12 @@ module.exports = function({ $api_url, $http_HttpMethod, $http_Util, $t_Assert })
       return $obj;
     }
     async handle() {
-      const response = (await $http_Util.fetch(($api_url + "/users"),({"method": $http_HttpMethod.GET,"headers": ({"Content-Type": "text/json"})})));
+      const response = (await $http_Util.fetch(($api_url + "/users"), ({"method": $http_HttpMethod.GET,"headers": ({"Content-Type": "text/json"})})));
       const headers = response.headers;
-      (await $t_Assert.equalNum(response.status,200));
-      (await $t_Assert.equalStr(((obj, key) => { if (!(key in obj)) throw new Error(`Map does not contain key: "${key}"`); return obj[key]; })(headers, "access-control-allow-origin"),"*"));
-      (await $t_Assert.equalStr(((obj, key) => { if (!(key in obj)) throw new Error(`Map does not contain key: "${key}"`); return obj[key]; })(headers, "access-control-expose-headers"),"Content-Type"));
-      (await $t_Assert.equalStr(((obj, key) => { if (!(key in obj)) throw new Error(`Map does not contain key: "${key}"`); return obj[key]; })(headers, "access-control-allow-credentials"),"false"));
+      (await $t_Assert.equalNum(response.status, 200));
+      (await $t_Assert.equalStr(((obj, key) => { if (!(key in obj)) throw new Error(`Map does not contain key: "${key}"`); return obj[key]; })(headers, "access-control-allow-origin"), "*"));
+      (await $t_Assert.equalStr(((obj, key) => { if (!(key in obj)) throw new Error(`Map does not contain key: "${key}"`); return obj[key]; })(headers, "access-control-expose-headers"), "Content-Type"));
+      (await $t_Assert.equalStr(((obj, key) => { if (!(key in obj)) throw new Error(`Map does not contain key: "${key}"`); return obj[key]; })(headers, "access-control-allow-credentials"), "false"));
       (await $t_Assert.isNil((headers)["access-control-allow-headers"]));
       (await $t_Assert.isNil((headers)["access-control-allow-methods"]));
     }
@@ -80,11 +80,11 @@ module.exports = function({ $api_url, $http_HttpMethod, $http_Util, $t_Assert })
       return $obj;
     }
     async handle() {
-      const response = (await $http_Util.fetch(($api_url + "/users"),({"method": $http_HttpMethod.OPTIONS,"headers": ({"Content-Type": "text/json"})})));
+      const response = (await $http_Util.fetch(($api_url + "/users"), ({"method": $http_HttpMethod.OPTIONS,"headers": ({"Content-Type": "text/json"})})));
       const headers = response.headers;
-      (await $t_Assert.equalNum(response.status,204));
-      (await $t_Assert.equalStr(((obj, key) => { if (!(key in obj)) throw new Error(`Map does not contain key: "${key}"`); return obj[key]; })(headers, "access-control-allow-methods"),"GET,POST,OPTIONS"));
-      (await $t_Assert.equalStr(((obj, key) => { if (!(key in obj)) throw new Error(`Map does not contain key: "${key}"`); return obj[key]; })(headers, "access-control-allow-headers"),"Content-Type"));
+      (await $t_Assert.equalNum(response.status, 204));
+      (await $t_Assert.equalStr(((obj, key) => { if (!(key in obj)) throw new Error(`Map does not contain key: "${key}"`); return obj[key]; })(headers, "access-control-allow-methods"), "GET,POST,OPTIONS"));
+      (await $t_Assert.equalStr(((obj, key) => { if (!(key in obj)) throw new Error(`Map does not contain key: "${key}"`); return obj[key]; })(headers, "access-control-allow-headers"), "Content-Type"));
     }
   }
   return $Closure4;
@@ -629,8 +629,8 @@ module.exports = function({  }) {
 module.exports = function({ $stdlib }) {
   const std = $stdlib.std;
   class Assert extends $stdlib.std.Resource {
-    constructor(scope, id, ) {
-      super(scope, id);
+    constructor($scope, $id, ) {
+      super($scope, $id);
     }
     static _toInflightType(context) {
       return `
@@ -671,11 +671,11 @@ const ex = $stdlib.ex;
 const http = $stdlib.http;
 const t = require("./preflight.assertions-1.js")({ $stdlib });
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -708,8 +708,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure2 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -742,8 +742,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure3 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -778,8 +778,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     class $Closure4 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -813,16 +813,16 @@ class $Root extends $stdlib.std.Resource {
         super._registerOnLift(host, ops);
       }
     }
-    const api = this.node.root.newAbstract("@winglang/sdk.cloud.Api",this,"cloud.Api",{ cors: true, corsOptions: ({"allowOrigin": ["*"],"allowMethods": [cloud.HttpMethod.GET, cloud.HttpMethod.POST, cloud.HttpMethod.OPTIONS],"allowHeaders": ["Content-Type"],"allowCredentials": false,"exposeHeaders": ["Content-Type"],"maxAge": (std.Duration.fromSeconds(600))}) });
-    const website = this.node.root.newAbstract("@winglang/sdk.cloud.Website",this,"cloud.Website",{ path: "./website_with_api" });
-    const usersTable = this.node.root.newAbstract("@winglang/sdk.ex.Table",this,"ex.Table",{ name: "users-table", primaryKey: "id", columns: ({"id": ex.ColumnType.STRING,"name": ex.ColumnType.STRING,"age": ex.ColumnType.NUMBER}) });
-    const getHandler = new $Closure1(this,"$Closure1");
-    const postHandler = new $Closure2(this,"$Closure2");
-    (api.get("/users",getHandler));
-    (api.post("/users",postHandler));
-    (website.addJson("config.json",({"apiUrl": api.url})));
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:GET /users",new $Closure3(this,"$Closure3"));
-    this.node.root.new("@winglang/sdk.std.Test",std.Test,this,"test:OPTIONS /users",new $Closure4(this,"$Closure4"));
+    const api = this.node.root.newAbstract("@winglang/sdk.cloud.Api",this, "cloud.Api", { cors: true, corsOptions: ({"allowOrigin": ["*"],"allowMethods": [cloud.HttpMethod.GET, cloud.HttpMethod.POST, cloud.HttpMethod.OPTIONS],"allowHeaders": ["Content-Type"],"allowCredentials": false,"exposeHeaders": ["Content-Type"],"maxAge": (std.Duration.fromSeconds(600))}) });
+    const website = this.node.root.newAbstract("@winglang/sdk.cloud.Website",this, "cloud.Website", { path: "./website_with_api" });
+    const usersTable = this.node.root.newAbstract("@winglang/sdk.ex.Table",this, "ex.Table", { name: "users-table", primaryKey: "id", columns: ({"id": ex.ColumnType.STRING,"name": ex.ColumnType.STRING,"age": ex.ColumnType.NUMBER}) });
+    const getHandler = new $Closure1(this, "$Closure1");
+    const postHandler = new $Closure2(this, "$Closure2");
+    (api.get("/users", getHandler));
+    (api.post("/users", postHandler));
+    (website.addJson("config.json", ({"apiUrl": api.url})));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:GET /users", new $Closure3(this, "$Closure3"));
+    this.node.root.new("@winglang/sdk.std.Test",std.Test,this, "test:OPTIONS /users", new $Closure4(this, "$Closure4"));
   }
 }
 const $App = $stdlib.core.App.for(process.env.WING_TARGET);

--- a/tools/hangar/__snapshots__/test_corpus/valid/while.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/while.test.w_compile_tf-aws.md
@@ -41,8 +41,8 @@ const $outdir = process.env.WING_SYNTH_DIR ?? ".";
 const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     while (false) {
       const x = 1;
     }

--- a/tools/hangar/__snapshots__/test_corpus/valid/while_loop_await.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/while_loop_await.test.w_compile_tf-aws.md
@@ -198,11 +198,11 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const cloud = $stdlib.cloud;
 class $Root extends $stdlib.std.Resource {
-  constructor(scope, id) {
-    super(scope, id);
+  constructor($scope, $id) {
+    super($scope, $id);
     class $Closure1 extends $stdlib.std.Resource {
-      constructor(scope, id, ) {
-        super(scope, id);
+      constructor($scope, $id, ) {
+        super($scope, $id);
         (std.Node.of(this)).hidden = true;
       }
       static _toInflightType(context) {
@@ -226,8 +226,8 @@ class $Root extends $stdlib.std.Resource {
         return ["handle", "$inflight_init"];
       }
     }
-    const queue = this.node.root.newAbstract("@winglang/sdk.cloud.Queue",this,"cloud.Queue");
-    const handler = new $Closure1(this,"$Closure1");
+    const queue = this.node.root.newAbstract("@winglang/sdk.cloud.Queue",this, "cloud.Queue");
+    const handler = new $Closure1(this, "$Closure1");
     (queue.setConsumer(handler));
   }
 }


### PR DESCRIPTION
fix #3026
renamed generated scope and id ctor arguments to `$scope` and `$id`.

## Checklist

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [x] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
