### PR TITLE
chore(sdk): align bucket force destroy behaviour for `tf-gcp` target

### DIFF
--- a/libs/wingsdk/src/target-tf-gcp/bucket.ts
+++ b/libs/wingsdk/src/target-tf-gcp/bucket.ts
@@ -61,12 +61,15 @@ export class Bucket extends cloud.Bucket {
       byteLength: 4, // 4 bytes = 8 hex characters
     });
 
+    const isTestEnvironment = App.of(scope).isTestEnvironment;
+
     this.bucket = new StorageBucket(this, "Default", {
       name: bucketName + "-" + randomId.hex,
       location: (App.of(this) as App).region,
       // recommended by GCP: https://cloud.google.com/storage/docs/uniform-bucket-level-access#should-you-use
       uniformBucketLevelAccess: true,
       publicAccessPrevention: props.public ? "inherited" : "enforced",
+      forceDestroy: isTestEnvironment ? true : false,
     });
 
     if (props.public) {


### PR DESCRIPTION
Aligning bucket force destroy behaviour to [tf-aws target](https://github.com/winglang/wing/blob/main/libs/wingsdk/src/target-tf-aws/bucket.ts#L167).

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
