### PR TITLE
fix(vscode): invalid completions for types that look like builtins

### DIFF
--- a/libs/wingc/src/lsp/snapshots/completions/no_completion_wrong_builtin.snap
+++ b/libs/wingc/src/lsp/snapshots/completions/no_completion_wrong_builtin.snap
@@ -1,0 +1,5 @@
+---
+source: libs/wingc/src/lsp/completions.rs
+---
+[]
+

--- a/libs/wingc/src/lsp/snapshots/completions/type_parameter.snap
+++ b/libs/wingc/src/lsp/snapshots/completions/type_parameter.snap
@@ -1,0 +1,70 @@
+---
+source: libs/wingc/src/lsp/completions.rs
+---
+- label: Json
+  kind: 14
+  sortText: kl|zyJson
+- label: MutJson
+  kind: 14
+  sortText: kl|zyMutJson
+- label: bool
+  kind: 14
+  sortText: kl|zybool
+- label: duration
+  kind: 14
+  sortText: kl|zyduration
+- label: num
+  kind: 14
+  sortText: kl|zynum
+- label: str
+  kind: 14
+  sortText: kl|zystr
+- label: Array<T>
+  kind: 14
+  sortText: kl|zzArray
+  insertText: Array<$1>
+  insertTextFormat: 2
+  command:
+    title: triggerCompletion
+    command: editor.action.triggerSuggest
+- label: Map<T>
+  kind: 14
+  sortText: kl|zzMap
+  insertText: Map<$1>
+  insertTextFormat: 2
+  command:
+    title: triggerCompletion
+    command: editor.action.triggerSuggest
+- label: MutArray<T>
+  kind: 14
+  sortText: kl|zzMutArray
+  insertText: MutArray<$1>
+  insertTextFormat: 2
+  command:
+    title: triggerCompletion
+    command: editor.action.triggerSuggest
+- label: MutMap<T>
+  kind: 14
+  sortText: kl|zzMutMap
+  insertText: MutMap<$1>
+  insertTextFormat: 2
+  command:
+    title: triggerCompletion
+    command: editor.action.triggerSuggest
+- label: MutSet<T>
+  kind: 14
+  sortText: kl|zzMutSet
+  insertText: MutSet<$1>
+  insertTextFormat: 2
+  command:
+    title: triggerCompletion
+    command: editor.action.triggerSuggest
+- label: Set<T>
+  kind: 14
+  sortText: kl|zzSet
+  insertText: Set<$1>
+  insertTextFormat: 2
+  command:
+    title: triggerCompletion
+    command: editor.action.triggerSuggest
+

--- a/libs/wingc/src/lsp/symbol_locator.rs
+++ b/libs/wingc/src/lsp/symbol_locator.rs
@@ -135,7 +135,7 @@ impl<'a> SymbolLocator<'a> {
 			| Type::String
 			| Type::Duration
 			| Type::Boolean => {
-				if let Some((std_type, ..)) = self.types.get_std_class(&type_.to_string()) {
+				if let Some((std_type, ..)) = self.types.get_std_class(&type_) {
 					if let Some(t) = std_type.as_type_ref() {
 						if let Some(c) = t.as_class() {
 							let env = c.get_env();

--- a/libs/wingc/src/type_check.rs
+++ b/libs/wingc/src/type_check.rs
@@ -1651,7 +1651,7 @@ impl Types {
 		}
 	}
 
-	/// Given an unqualified type name of a builtin type, return the full type info.
+	/// Given a builtin type, return the full class info from the standard library.
 	///
 	/// This is needed because our builtin types have no API.
 	/// So we have to get the API from the std lib
@@ -1659,10 +1659,36 @@ impl Types {
 	/// https://github.com/winglang/wing/issues/1780
 	///
 	/// Note: This doesn't handle generics (i.e. this keeps the `T1`)
-	pub fn get_std_class(&self, type_: &str) -> Option<(&SymbolKind, symbol_env::SymbolLookupInfo)> {
-		let type_name = fully_qualify_std_type(type_);
+	pub fn get_std_class(&self, type_: &TypeRef) -> Option<(&SymbolKind, symbol_env::SymbolLookupInfo)> {
+		let type_name = match &**type_ {
+			Type::Number => "Number",
+			Type::String => "String",
+			Type::Boolean => "Boolean",
+			Type::Duration => "Duration",
+			Type::Json(_) => "Json",
+			Type::MutJson => "MutJson",
+			Type::Array(_) => "Array",
+			Type::MutArray(_) => "MutArray",
+			Type::Map(_) => "Map",
+			Type::MutMap(_) => "MutMap",
+			Type::Set(_) => "Set",
+			Type::MutSet(_) => "MutSet",
+			Type::Struct(_) => "Struct",
 
-		let fqn = format!("{WINGSDK_ASSEMBLY_NAME}.{type_name}");
+			Type::Optional(t) => return self.get_std_class(t),
+
+			Type::Function(_)
+			| Type::Class(_)
+			| Type::Interface(_)
+			| Type::Enum(_)
+			| Type::Void
+			| Type::Nil
+			| Type::Anything
+			| Type::Unresolved
+			| Type::Inferred(_) => return None,
+		};
+
+		let fqn = format!("{WINGSDK_ASSEMBLY_NAME}.{WINGSDK_STD_MODULE}.{type_name}");
 
 		self.libraries.lookup_nested_str(fqn.as_str(), None).ok()
 	}
@@ -5703,34 +5729,32 @@ pub fn import_udt_from_jsii(
 /// https://github.com/winglang/wing/issues/1780
 pub fn fully_qualify_std_type(type_: &str) -> String {
 	// Additionally, this doesn't handle for generics
-	let type_name = type_.to_string();
-	let type_name = if let Some((prefix, _)) = type_name.split_once(" ") {
-		prefix
-	} else {
-		&type_name
-	};
-	let type_name = if let Some((prefix, _)) = type_name.split_once("<") {
-		prefix
-	} else {
-		&type_name
-	};
-
-	let type_name = match type_name {
+	let type_ = match type_ {
 		"str" => "String",
 		"duration" => "Duration",
 		"datetime" => "Datetime",
 		"bool" => "Boolean",
 		"num" => "Number",
-		_ => type_name,
+		_ => {
+			// Check for generics or Json
+			let type_ = if let Some((prefix, _)) = type_.split_once(" ") {
+				prefix
+			} else {
+				type_
+			};
+			let type_ = if let Some((prefix, _)) = type_.split_once("<") {
+				prefix
+			} else {
+				type_
+			};
+			match type_ {
+				"Json" | "MutJson" | "MutArray" | "MutMap" | "MutSet" | "Array" | "Map" | "Set" => type_,
+				_ => return type_.to_owned(),
+			}
+		}
 	};
 
-	match type_name {
-		"Json" | "MutJson" | "MutArray" | "MutMap" | "MutSet" | "Array" | "Map" | "Set" | "String" | "Duration"
-		| "Boolean" | "Number" | "Struct" => {
-			format!("{WINGSDK_STD_MODULE}.{type_name}")
-		}
-		_ => type_name.to_string(),
-	}
+	format!("{WINGSDK_STD_MODULE}.{type_}")
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Previously, text like `String.` would always show completions as if it were `str.`, which is incorrect. Additionally, I noticed that completions for types would not show up inside the brackets of types like `Array<>` so that's fixed as well.

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
