### PR TITLE
fix(cli): fix unsupported color

### DIFF
--- a/apps/wing/src/commands/test/results.ts
+++ b/apps/wing/src/commands/test/results.ts
@@ -51,7 +51,11 @@ export function printResults(
       ...[...failing, ...unsupportedFiles].map(({ testName, results }) =>
         [
           `At ${testName}`,
-          results.filter(({ pass }) => !pass).map(({ error }) => chalk.red(error)),
+          results.reduce(
+            (acc: string[], { pass, error, unsupported }) =>
+              pass ? acc : unsupported && error ? [...acc, error] : [...acc, chalk.red(error)],
+            []
+          ),
         ].join("\n")
       )
     );


### PR DESCRIPTION
Before: 
unsupported:
<img width="608" alt="image" src="https://github.com/winglang/wing/assets/39455181/910fa57f-f8fa-4840-a573-b99fe819316d">
error:
<img width="604" alt="image" src="https://github.com/winglang/wing/assets/39455181/47714f9c-df24-4dd3-83c4-0384ff6ed46b">


After: 
<img width="617" alt="image" src="https://github.com/winglang/wing/assets/39455181/726ac1f3-2ab9-4d41-885e-b7e2d641fa93">

(errors look the same:)
<img width="613" alt="image" src="https://github.com/winglang/wing/assets/39455181/669c797c-1e86-43ea-8b4d-fb6e2519ee98">


## Checklist

- [ ] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [ ] Description explains motivation and solution
- [ ] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
