### PR TITLE
fix(compiler): `async` method modifier never used

### DIFF
--- a/libs/tree-sitter-wing/grammar.js
+++ b/libs/tree-sitter-wing/grammar.js
@@ -473,7 +473,6 @@ module.exports = grammar({
 
     method_signature: ($) =>
       seq(
-        optional(field("async", $.async_modifier)),
         field("name", $.identifier),
         field("parameter_list", $.parameter_list),
         optional($._return_type),
@@ -485,7 +484,6 @@ module.exports = grammar({
         optional(field("extern_modifier", $.extern_modifier)),
         optional(field("access_modifier", $.access_modifier)),
         optional(field("static", $.static)),
-        optional(field("async", $.async_modifier)),
         field("name", $.identifier),
         field("parameter_list", $.parameter_list),
         optional($._return_type),
@@ -512,8 +510,6 @@ module.exports = grammar({
         optional($._return_type),
         choice(field("block", $.block), $._semicolon)
       ),
-
-    async_modifier: ($) => "async",
 
     access_modifier: ($) => choice("pub", "protected", "internal"),
 

--- a/libs/tree-sitter-wing/test/corpus/statements/class_and_resource.txt
+++ b/libs/tree-sitter-wing/test/corpus/statements/class_and_resource.txt
@@ -73,7 +73,6 @@ class A {
     init() {}
     inflight init() {}
     preflight_func() {}
-    async preflight_func() {}
     pub preflight_func2() {}
     inflight inflight_func() {}
     pub inflight inflight_func2(): num {}
@@ -101,11 +100,6 @@ class A {
         parameter_list: (parameter_list)
         block: (block))
       (method_definition
-        name: (identifier)
-        parameter_list: (parameter_list)
-        block: (block))
-      (method_definition
-        async: (async_modifier)
         name: (identifier)
         parameter_list: (parameter_list)
         block: (block))


### PR DESCRIPTION
The `async` method modifier wasn't being used anywhere in the code and wasn't marked as  reserved word in parser.rs anyway.
The wing way is basically that everything inflight is `async` anyway and everything preflight isn't.
The only thing I'm not sure of is whether we should add `async` as a reserved word just as a space-holder. I think not.

This is a minor cleanup related to #3329.

## Checklist

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [x] Tests added (always) (fixed grammar test)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
