### PR TITLE
chore(repo): add platforms as valid pr scope

### DIFF
--- a/.github/workflows/pull-request-lint.yml
+++ b/.github/workflows/pull-request-lint.yml
@@ -30,7 +30,7 @@ jobs:
             playground
             tutorial
             vscode
-            plugins
+            platforms
             console
           types: |-
             feat


### PR DESCRIPTION
Want to title my Platforms PR with the scope of Platforms, need to merge this change first

## Checklist

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [x] Tests added (always)
- [x] Docs updated (only required for features)
- [x] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
