### PR TITLE
fix(sdk): add missing `super.onLift()` for `awscdk` counter

### DIFF
--- a/libs/wingsdk/src/target-awscdk/counter.ts
+++ b/libs/wingsdk/src/target-awscdk/counter.ts
@@ -46,6 +46,8 @@ export class Counter extends cloud.Counter {
     );
 
     host.addEnvironment(this.envName(), this.table.tableName);
+
+    super.onLift(host, ops);
   }
 
   /** @internal */


### PR DESCRIPTION
I've noticed that `super.onLift()` is present on all other resources so I believe it must be missing.

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
