### PR TITLE
fix(sdk): public bucket settings in awscdk

### DIFF
--- a/libs/wingsdk/src/target-awscdk/bucket.ts
+++ b/libs/wingsdk/src/target-awscdk/bucket.ts
@@ -237,7 +237,14 @@ export function createEncryptedBucket(
 
   return new S3Bucket(scope, name, {
     encryption: BucketEncryption.S3_MANAGED,
-    blockPublicAccess: isPublic ? undefined : BlockPublicAccess.BLOCK_ALL,
+    blockPublicAccess: isPublic
+      ? {
+          blockPublicAcls: false,
+          blockPublicPolicy: false,
+          ignorePublicAcls: false,
+          restrictPublicBuckets: false,
+        }
+      : BlockPublicAccess.BLOCK_ALL,
     publicReadAccess: isPublic ? true : false,
     removalPolicy: RemovalPolicy.DESTROY,
     autoDeleteObjects: isTestEnvironment ? true : false,

--- a/libs/wingsdk/test/target-awscdk/__snapshots__/bucket.test.ts.snap
+++ b/libs/wingsdk/test/target-awscdk/__snapshots__/bucket.test.ts.snap
@@ -27,6 +27,12 @@ exports[`bucket is public 1`] = `
             },
           ],
         },
+        "PublicAccessBlockConfiguration": {
+          "BlockPublicAcls": false,
+          "BlockPublicPolicy": false,
+          "IgnorePublicAcls": false,
+          "RestrictPublicBuckets": false,
+        },
       },
       "Type": "AWS::S3::Bucket",
       "UpdateReplacePolicy": "Delete",
@@ -2128,6 +2134,12 @@ exports[`bucket with two preflight files 1`] = `
             },
           ],
         },
+        "PublicAccessBlockConfiguration": {
+          "BlockPublicAcls": false,
+          "BlockPublicPolicy": false,
+          "IgnorePublicAcls": false,
+          "RestrictPublicBuckets": false,
+        },
         "Tags": [
           {
             "Key": "aws-cdk:cr-owned:573ee45c",
@@ -2472,6 +2484,12 @@ exports[`bucket with two preflight objects 1`] = `
               },
             },
           ],
+        },
+        "PublicAccessBlockConfiguration": {
+          "BlockPublicAcls": false,
+          "BlockPublicPolicy": false,
+          "IgnorePublicAcls": false,
+          "RestrictPublicBuckets": false,
         },
         "Tags": [
           {


### PR DESCRIPTION
When creating a public bucket, the `blockPublicAccess` property of the Bucket object was not being correctly filled.

Closes #4745 

## Checklist

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [x] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
