### PR TITLE
chore(cli): tidy `wing test` tests

### DIFF
--- a/apps/wing/src/commands/test/test.test.ts
+++ b/apps/wing/src/commands/test/test.test.ts
@@ -69,64 +69,55 @@ describe("test options", () => {
   test("wing test (default entrypoint)", async () => {
     const outDir = await mkdtemp(join(tmpdir(), "-wing-compile-test"));
 
-    try {
-      process.chdir(outDir);
-      fs.writeFileSync("foo.test.w", "bring cloud;");
-      fs.writeFileSync("bar.test.w", "bring cloud;");
-      fs.writeFileSync("baz.test.w", "bring cloud;");
+    process.chdir(outDir);
+    fs.writeFileSync("foo.test.w", "bring cloud;");
+    fs.writeFileSync("bar.test.w", "bring cloud;");
+    fs.writeFileSync("baz.test.w", "bring cloud;");
 
-      await wingTest([], { clean: true, target: Target.SIM });
+    await wingTest([], { clean: true, target: Target.SIM });
 
-      expect(logSpy).toHaveBeenCalledWith("pass ─ foo.test.wsim (no tests)");
-      expect(logSpy).toHaveBeenCalledWith("pass ─ bar.test.wsim (no tests)");
-      expect(logSpy).toHaveBeenCalledWith("pass ─ baz.test.wsim (no tests)");
-    } finally {
-    }
+    expect(logSpy).toHaveBeenCalledWith("pass ─ foo.test.wsim (no tests)");
+    expect(logSpy).toHaveBeenCalledWith("pass ─ bar.test.wsim (no tests)");
+    expect(logSpy).toHaveBeenCalledWith("pass ─ baz.test.wsim (no tests)");
   });
 
   test("wing test with output file calls writeResultsToFile", async () => {
     const outDir = await mkdtemp(join(tmpdir(), "-wing-compile-test"));
 
-    try {
-      process.chdir(outDir);
-      fs.writeFileSync("test.test.w", EXAMPLE_TEST);
+    process.chdir(outDir);
+    fs.writeFileSync("test.test.w", EXAMPLE_TEST);
 
-      const outputFile = "out.json";
+    const outputFile = "out.json";
 
-      await wingTest(["test.test.w"], {
-        clean: true,
-        target: Target.SIM,
-        outputFile,
-      });
+    await wingTest(["test.test.w"], {
+      clean: true,
+      target: Target.SIM,
+      outputFile,
+    });
 
-      expect(writeResultsSpy).toBeCalledTimes(1);
-      const { testName, results } = writeResultsSpy.mock.calls[0][0][0];
-      expect(results).toMatchObject(BUCKET_TEST_RESULT);
-      expect(testName).toBe("test.test.w");
-      expect(writeResultsSpy.mock.calls[0][2]).toBe(outputFile);
+    expect(writeResultsSpy).toBeCalledTimes(1);
+    const { testName, results } = writeResultsSpy.mock.calls[0][0][0];
+    expect(results).toMatchObject(BUCKET_TEST_RESULT);
+    expect(testName).toBe("test.test.w");
+    expect(writeResultsSpy.mock.calls[0][2]).toBe(outputFile);
 
-      expect(writeFileSpy).toBeCalledTimes(1);
-      const [filePath, output] = writeFileSpy.mock.calls[0];
-      expect(filePath).toBe(resolve("out.json"));
-      expect(JSON.parse(output as string)).toMatchObject(OUTPUT_FILE);
-    } finally {
-    }
+    expect(writeFileSpy).toBeCalledTimes(1);
+    const [filePath, output] = writeFileSpy.mock.calls[0];
+    expect(filePath).toBe(resolve("out.json"));
+    expect(JSON.parse(output as string)).toMatchObject(OUTPUT_FILE);
   });
 
   test("wing test without output file calls writeResultsToFile", async () => {
     const outDir = await mkdtemp(join(tmpdir(), "-wing-compile-test"));
 
-    try {
-      process.chdir(outDir);
-      fs.writeFileSync("test.test.w", EXAMPLE_TEST);
+    process.chdir(outDir);
+    fs.writeFileSync("test.test.w", EXAMPLE_TEST);
 
-      await wingTest(["test.test.w"], {
-        clean: true,
-        target: Target.SIM,
-      });
-      expect(writeResultsSpy).toBeCalledTimes(0);
-    } finally {
-    }
+    await wingTest(["test.test.w"], {
+      clean: true,
+      target: Target.SIM,
+    });
+    expect(writeResultsSpy).toBeCalledTimes(0);
   });
 
   test("validate output file", () => {

--- a/apps/wing/src/commands/test/test.test.ts
+++ b/apps/wing/src/commands/test/test.test.ts
@@ -5,7 +5,7 @@ import { join, resolve } from "path";
 import { Target } from "@winglang/compiler";
 import { TestResult, TraceType } from "@winglang/sdk/lib/std";
 import chalk from "chalk";
-import { describe, test, expect, beforeEach, afterEach, vi } from "vitest";
+import { describe, test, expect, beforeEach, afterEach, vi, SpyInstance } from "vitest";
 import { filterTests, pickOneTestPerEnvironment, renderTestReport, test as wingTest } from ".";
 import * as resultsFn from "./results";
 
@@ -47,18 +47,27 @@ describe("printing test reports", () => {
 });
 
 describe("test options", () => {
+  let logSpy: SpyInstance;
+  let writeResultsSpy: SpyInstance;
+  let writeFileSpy: SpyInstance;
+
   beforeEach(() => {
     chalk.level = 0;
+    logSpy = vi.spyOn(console, "log");
+    writeResultsSpy = vi.spyOn(resultsFn, "writeResultsToFile");
+    writeFileSpy = vi.spyOn(fs, "writeFile").mockImplementation(() => null);
   });
 
   afterEach(() => {
     chalk.level = defaultChalkLevel;
     process.chdir(cwd);
+    logSpy.mockRestore();
+    writeResultsSpy.mockRestore();
+    writeFileSpy.mockRestore();
   });
 
   test("wing test (default entrypoint)", async () => {
     const outDir = await mkdtemp(join(tmpdir(), "-wing-compile-test"));
-    const logSpy = vi.spyOn(console, "log");
 
     try {
       process.chdir(outDir);
@@ -72,69 +81,54 @@ describe("test options", () => {
       expect(logSpy).toHaveBeenCalledWith("pass ─ bar.test.wsim (no tests)");
       expect(logSpy).toHaveBeenCalledWith("pass ─ baz.test.wsim (no tests)");
     } finally {
-      logSpy.mockRestore();
     }
   });
 
-  test(
-    "wing test with output file calls writeResultsToFile",
-    async () => {
-      const outDir = await mkdtemp(join(tmpdir(), "-wing-compile-test"));
-      const writeResults = vi.spyOn(resultsFn, "writeResultsToFile");
-      const writeFile = vi.spyOn(fs, "writeFile").mockImplementation(() => null);
+  test("wing test with output file calls writeResultsToFile", async () => {
+    const outDir = await mkdtemp(join(tmpdir(), "-wing-compile-test"));
 
-      try {
-        process.chdir(outDir);
-        fs.writeFileSync("test.test.w", EXAMPLE_TEST);
+    try {
+      process.chdir(outDir);
+      fs.writeFileSync("test.test.w", EXAMPLE_TEST);
 
-        const outputFile = "out.json";
+      const outputFile = "out.json";
 
-        await wingTest(["test.test.w"], {
-          clean: true,
-          target: Target.SIM,
-          outputFile,
-        });
+      await wingTest(["test.test.w"], {
+        clean: true,
+        target: Target.SIM,
+        outputFile,
+      });
 
-        expect(writeResults).toBeCalledTimes(1);
-        const { testName, results } = writeResults.mock.calls[0][0][0];
-        expect(results).toMatchObject(BUCKET_TEST_RESULT);
-        expect(testName).toBe("test.test.w");
-        expect(writeResults.mock.calls[0][2]).toBe(outputFile);
+      expect(writeResultsSpy).toBeCalledTimes(1);
+      const { testName, results } = writeResultsSpy.mock.calls[0][0][0];
+      expect(results).toMatchObject(BUCKET_TEST_RESULT);
+      expect(testName).toBe("test.test.w");
+      expect(writeResultsSpy.mock.calls[0][2]).toBe(outputFile);
 
-        expect(writeFile).toBeCalledTimes(1);
-        const [filePath, output] = writeFile.mock.calls[0];
-        expect(filePath).toBe(resolve("out.json"));
-        expect(JSON.parse(output as string)).toMatchObject(OUTPUT_FILE);
-      } finally {
-        writeResults.mockClear();
-      }
-    },
-    { timeout: 10000 }
-  );
+      expect(writeFileSpy).toBeCalledTimes(1);
+      const [filePath, output] = writeFileSpy.mock.calls[0];
+      expect(filePath).toBe(resolve("out.json"));
+      expect(JSON.parse(output as string)).toMatchObject(OUTPUT_FILE);
+    } finally {
+    }
+  });
 
-  test(
-    "wing test without output file calls writeResultsToFile",
-    async () => {
-      const writeResults = vi.spyOn(resultsFn, "writeResultsToFile");
-      const outDir = await mkdtemp(join(tmpdir(), "-wing-compile-test"));
-      const prevdir = process.cwd();
+  test("wing test without output file calls writeResultsToFile", async () => {
+    const outDir = await mkdtemp(join(tmpdir(), "-wing-compile-test"));
 
-      try {
-        process.chdir(outDir);
-        fs.writeFileSync("test.test.w", EXAMPLE_TEST);
+    try {
+      process.chdir(outDir);
+      fs.writeFileSync("test.test.w", EXAMPLE_TEST);
 
-        await wingTest(["test.test.w"], {
-          clean: true,
-          target: Target.SIM,
-        });
-        expect(writeResults).toBeCalledTimes(0);
-        writeResults.mockClear();
-      } finally {
-        process.chdir(prevdir);
-      }
-    },
-    { timeout: 10000 }
-  );
+      await wingTest(["test.test.w"], {
+        clean: true,
+        target: Target.SIM,
+      });
+      expect(writeResultsSpy).toBeCalledTimes(0);
+      writeResultsSpy.mockClear();
+    } finally {
+    }
+  });
 
   test("validate output file", () => {
     expect(resultsFn.validateOutputFilePath("/path/out.json")).toBeUndefined();

--- a/apps/wing/src/commands/test/test.test.ts
+++ b/apps/wing/src/commands/test/test.test.ts
@@ -125,7 +125,6 @@ describe("test options", () => {
         target: Target.SIM,
       });
       expect(writeResultsSpy).toBeCalledTimes(0);
-      writeResultsSpy.mockClear();
     } finally {
     }
   });

--- a/apps/wing/vitest.config.ts
+++ b/apps/wing/vitest.config.ts
@@ -4,5 +4,6 @@ export default defineConfig({
   test: {
     // Some tests use process.chdir which is not supported in vitest's multi-thread mode
     threads: false,
+    testTimeout: 200_000,
   },
 });


### PR DESCRIPTION
Removing duplicate code and setting global timeout to `200_000` ms like the other wing projects.

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
