### PR TITLE
fix(platforms): require platform flag multiple times

### DIFF
--- a/apps/wing/src/cli.ts
+++ b/apps/wing/src/cli.ts
@@ -32,6 +32,11 @@ function runSubCommand(subCommand: string, path: string = subCommand) {
   };
 }
 
+// Required to support --option x --option y --option z rather than --option x y z
+function collectVariadic(value: string, previous: string[]) {
+  return previous.concat([value]);
+}
+
 async function collectAnalyticsHook(cmd: Command) {
   if (process.env.WING_DISABLE_ANALYTICS) {
     return;
@@ -138,11 +143,11 @@ async function main() {
     .command("compile")
     .description("Compiles a Wing program")
     .argument("[entrypoint]", "program .w entrypoint")
-    .addOption(
-      new Option(
-        "-t, --platform <platform...>",
-        "Target platform provider (builtin: sim, tf-aws, tf-azure, tf-gcp, awscdk)"
-      ).default(["sim"])
+    .option(
+      "-t, --platform <platform> --platform <platform>",
+      "Target platform provider (builtin: sim, tf-aws, tf-azure, tf-gcp, awscdk) (default: [sim])",
+      collectVariadic,
+      []
     )
     .option("-r, --rootId <rootId>", "App root id")
     .option("-v, --value <value>", "Platform-specific value in the form KEY=VALUE", addValue, [])
@@ -157,11 +162,11 @@ async function main() {
       "Compiles a Wing program and runs all functions with the word 'test' or start with 'test:' in their resource identifiers"
     )
     .argument("[entrypoint...]", "all files to test (globs are supported)")
-    .addOption(
-      new Option(
-        "-t, --platform <platform...>",
-        "Target platform provider (builtin: sim, tf-aws, tf-azure, tf-gcp, awscdk)"
-      ).default(["sim"])
+    .option(
+      "-t, --platform <platform> --platform <platform>",
+      "Target platform provider (builtin: sim, tf-aws, tf-azure, tf-gcp, awscdk) (default: [sim])",
+      collectVariadic,
+      []
     )
     .option("-r, --rootId <rootId>", "App root id")
     .option(

--- a/apps/wing/src/commands/compile.ts
+++ b/apps/wing/src/commands/compile.ts
@@ -81,12 +81,13 @@ export async function compile(entrypoint?: string, options?: CompileOptions): Pr
   }
 
   const coloring = chalk.supportsColor ? chalk.supportsColor.hasBasic : false;
+  const platforms = options?.platform ?? [];
   try {
     return await wingCompiler.compile(entrypoint, {
       ...options,
       log,
       color: coloring,
-      platform: options?.platform || [wingCompiler.BuiltinPlatform.SIM],
+      platform: platforms.length == 0 ? [wingCompiler.BuiltinPlatform.SIM] : platforms,
     });
   } catch (error) {
     if (error instanceof wingCompiler.CompileError) {

--- a/docs/docs/02-concepts/03-platforms.md
+++ b/docs/docs/02-concepts/03-platforms.md
@@ -21,7 +21,7 @@ Arguments:
   entrypoint                    program .w entrypoint
 
 Options:
-  -t, --platform <platform...>  Target platform provider (builtin: sim, tf-aws, tf-azure, tf-gcp, awscdk) (default: ["sim"])
+  -t, --platform <platform> --platform <platform>  Target platform provider (builtin: sim, tf-aws, tf-azure, tf-gcp, awscdk) (default: [sim])
   -h, --help                    display help for command
 ```
 
@@ -31,10 +31,10 @@ These providers contain a combination of provision engine and cloud environment 
 
 ### Specifying Multiple Platforms
 
-You may have noticed that the `--platform` option accepts multiple arguments. This means you can specify multiple platforms to compile your application to. For example, if you wanted to compile your application using multiple platforms
+You may have noticed that the `--platform` option can be provided multiple times. This means you can specify multiple platforms to compile your application to. For example, if you wanted to compile your application using multiple platforms
 
 ```sh
-wing compile app.main.w --platform tf-aws platform-foo platform-bar
+wing compile app.main.w --platform tf-aws --platform platform-foo --platform platform-bar
 ```
 The order in which platforms are evaluated is important. 
 
@@ -129,7 +129,7 @@ When running the `wing compile` command, the `--platform` option is used to spec
 The specified platform can be a built-in platform, or a path to a custom platform. For example, if you have a custom platform named `my-platform`, you can specify it as follows:
 
 ```sh
-wing compile --platform tf-aws ../my-platform
+wing compile --platform tf-aws --platform ../my-platform
 ```
 
 ### Synthesis Hooks

--- a/tools/hangar/src/utils.ts
+++ b/tools/hangar/src/utils.ts
@@ -14,6 +14,8 @@ export interface RunWingCommandOptions {
 }
 
 export async function runWingCommand(options: RunWingCommandOptions) {
+  const platformOptions: string[] = [];
+  options.platforms?.forEach((p) => platformOptions.push(...["-t",  `${p}`])) ?? [];
   const out = await execa(
     wingBin,
     [
@@ -21,8 +23,7 @@ export async function runWingCommand(options: RunWingCommandOptions) {
       "--no-analytics",
       ...options.args,
       options.wingFile ?? "",
-      "-t",
-      ...options.platforms ?? []
+      ...platformOptions
     ],
     {
       cwd: options.cwd,


### PR DESCRIPTION
Requires multiple platforms to each be specified with their own option

I.E.
`wing compile --platform x y z` is now done as `wing compile --platform x --platform y --platform z`
## Checklist

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [x] Tests added (always)
- [x] Docs updated (only required for features)
- [x] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
