### PR TITLE
fix(cli): make sim default platform for test command

### DIFF
--- a/apps/wing/src/cli.ts
+++ b/apps/wing/src/cli.ts
@@ -16,6 +16,8 @@ if (!SUPPORTED_NODE_VERSION) {
   throw new Error("couldn't parse engines.node version from package.json");
 }
 
+const DEFAULT_PLATFORM = ["sim"];
+
 function runSubCommand(subCommand: string, path: string = subCommand) {
   return async (...args: any[]) => {
     try {
@@ -30,6 +32,12 @@ function runSubCommand(subCommand: string, path: string = subCommand) {
       process.exit(1);
     }
   };
+}
+
+let platformOptionCount = 0;
+// Removes default if a platform option is provided by user
+function collectPlatformVariadic(value: string, previous: string[]) {
+  return platformOptionCount++ == 0 ? [value] : collectVariadic(value, previous);
 }
 
 // Required to support --option x --option y --option z rather than --option x y z
@@ -145,9 +153,9 @@ async function main() {
     .argument("[entrypoint]", "program .w entrypoint")
     .option(
       "-t, --platform <platform> --platform <platform>",
-      "Target platform provider (builtin: sim, tf-aws, tf-azure, tf-gcp, awscdk) (default: [sim])",
-      collectVariadic,
-      []
+      "Target platform provider (builtin: sim, tf-aws, tf-azure, tf-gcp, awscdk)",
+      collectPlatformVariadic,
+      DEFAULT_PLATFORM
     )
     .option("-r, --rootId <rootId>", "App root id")
     .option("-v, --value <value>", "Platform-specific value in the form KEY=VALUE", addValue, [])
@@ -164,9 +172,9 @@ async function main() {
     .argument("[entrypoint...]", "all files to test (globs are supported)")
     .option(
       "-t, --platform <platform> --platform <platform>",
-      "Target platform provider (builtin: sim, tf-aws, tf-azure, tf-gcp, awscdk) (default: [sim])",
-      collectVariadic,
-      []
+      "Target platform provider (builtin: sim, tf-aws, tf-azure, tf-gcp, awscdk)",
+      collectPlatformVariadic,
+      DEFAULT_PLATFORM
     )
     .option("-r, --rootId <rootId>", "App root id")
     .option(

--- a/apps/wing/src/commands/compile.ts
+++ b/apps/wing/src/commands/compile.ts
@@ -86,7 +86,7 @@ export async function compile(entrypoint?: string, options?: CompileOptions): Pr
       ...options,
       log,
       color: coloring,
-      platform: options!.platform
+      platform: options?.platform ?? ["sim"],
     });
   } catch (error) {
     if (error instanceof wingCompiler.CompileError) {

--- a/apps/wing/src/commands/compile.ts
+++ b/apps/wing/src/commands/compile.ts
@@ -81,13 +81,12 @@ export async function compile(entrypoint?: string, options?: CompileOptions): Pr
   }
 
   const coloring = chalk.supportsColor ? chalk.supportsColor.hasBasic : false;
-  const platforms = options?.platform ?? [];
   try {
     return await wingCompiler.compile(entrypoint, {
       ...options,
       log,
       color: coloring,
-      platform: platforms.length == 0 ? [wingCompiler.BuiltinPlatform.SIM] : platforms,
+      platform: options!.platform
     });
   } catch (error) {
     if (error instanceof wingCompiler.CompileError) {

--- a/tools/hangar/__snapshots__/test_corpus/valid/bucket_events.test.w_test_sim.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/bucket_events.test.w_test_sim.md
@@ -7,7 +7,8 @@ pass ┌ bucket_events.test.wsim » root/env0/test:putting and deleting from a b
      │ created b
      │ other bucket event called!
      │ updated b
-     └ other bucket event called!
+     │ other bucket event called!
+     └ created c
  
  
 Tests 1 passed (1)

--- a/tools/hangar/__snapshots__/test_corpus/valid/bucket_events.test.w_test_sim.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/bucket_events.test.w_test_sim.md
@@ -7,8 +7,7 @@ pass ┌ bucket_events.test.wsim » root/env0/test:putting and deleting from a b
      │ created b
      │ other bucket event called!
      │ updated b
-     │ other bucket event called!
-     └ created c
+     └ other bucket event called!
  
  
 Tests 1 passed (1)


### PR DESCRIPTION
Fix to make sure same default platform are used for any command using `collectPlatformVaridaic` 

## Checklist

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [x] Tests added (always)
- [x] Docs updated (only required for features)
- [x] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
