### PR TITLE
fix: lsp subcommand does not work

### DIFF
--- a/apps/wing/src/analytics/collect.ts
+++ b/apps/wing/src/analytics/collect.ts
@@ -26,7 +26,7 @@ export async function collectCommandAnalytics(cmd: Command): Promise<string | un
     appEntrypoint: cmd.args.length > 0 ? cmd.args[0] : ".",
   });
 
-  const platform = cmd.opts().platform;
+  const platform = cmd.opts().platform ?? [];
   let target = "";
   if (platform) {
     target = determineTargetFromPlatforms(platform);

--- a/apps/wing/src/analytics/collectors/cli-collector.ts
+++ b/apps/wing/src/analytics/collectors/cli-collector.ts
@@ -23,12 +23,11 @@ export class CLICollector extends Collector {
   }
 
   async collect(): Promise<CLIData> {
+    const platform: string[] = this.cmd.opts().platform ?? [];
+
     return {
-      platform: this.cmd
-        .opts()
-        .platform.map((p: string) => basename(p))
-        .join(","), // only report the platform name, not the full path
-      target: determineTargetFromPlatforms(this.cmd.opts().platform),
+      platform: platform.map((p: string) => basename(p)).join(","), // only report the platform name, not the full path
+      target: determineTargetFromPlatforms(platform),
       options: `${JSON.stringify(this.cmd.opts())}`,
       version: PACKAGE_VERSION,
       wing_sdk_version: this.tryGetModuleVersion("@winglang/sdk/package.json"),

--- a/apps/wing/src/cli.ts
+++ b/apps/wing/src/cli.ts
@@ -53,7 +53,12 @@ async function collectAnalyticsHook(cmd: Command) {
   try {
     optionallyDisplayDisclaimer();
     const analyticsModule = await import("./analytics/collect");
-    analyticsExportFile = analyticsModule.collectCommandAnalytics(cmd);
+    analyticsExportFile = analyticsModule.collectCommandAnalytics(cmd).catch((err) => {
+      if (process.env.DEBUG) {
+        console.error(err);
+      }
+      return undefined;
+    });
   } catch (err) {
     if (process.env.DEBUG) {
       console.error(err);


### PR DESCRIPTION
Fixes #4787

`wing lsp` does not have a platform, which broke analytics.

Analytics broke the whole program because we awaited a failing promise outside of our try/catch handling.

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
