### PR TITLE
fix(sdk): lengthen test sleep for stabilization

### DIFF
--- a/examples/tests/sdk_tests/bucket/copy.test.w
+++ b/examples/tests/sdk_tests/bucket/copy.test.w
@@ -27,8 +27,8 @@ test "copy()" {
   let file1SrcMetadata = b.metadata(KEY1);
   let file2SrcMetadata = b.metadata(KEY2);
 
-  // Sleep 5s to ensure 'metadata.lastModified' changes upon copy.
-  util.sleep(5s);
+  // Sleep 2s to ensure 'metadata.lastModified' changes upon copy.
+  util.sleep(2s);
 
   b.copy(KEY1, KEY1);
   b.copy(KEY2, "dir/${KEY2}");

--- a/examples/tests/sdk_tests/bucket/copy.test.w
+++ b/examples/tests/sdk_tests/bucket/copy.test.w
@@ -27,8 +27,8 @@ test "copy()" {
   let file1SrcMetadata = b.metadata(KEY1);
   let file2SrcMetadata = b.metadata(KEY2);
 
-  // Sleep 100ms to ensure 'metadata.lastModified' changes upon copy.
-  util.sleep(100ms);
+  // Sleep 5s to ensure 'metadata.lastModified' changes upon copy.
+  util.sleep(5s);
 
   b.copy(KEY1, KEY1);
   b.copy(KEY2, "dir/${KEY2}");


### PR DESCRIPTION
## Description
lengthen test sleep for stabilization, we're waiting many seconds in many tests- so those extra 5s won't make a negative difference (probably even a positive difference- since we won't need to re-run the tests)

## Checklist

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [ ] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
