### PR TITLE
rfc: set syntax proposal

### DIFF
--- a/docs/docs/03-language-reference.md
+++ b/docs/docs/03-language-reference.md
@@ -80,22 +80,22 @@ import TOCInline from '@theme/TOCInline';
 
 #### 1.1.2 Container Types
 
-| Name          | Extra information                     |
-| ------------- | ------------------------------------- |
-| `Set<T>`      | set type (set of unique items)        |
-| `Map<T>`      | map type (key-value with string keys) |
-| `Array<T>`    | variable size array of a certain type |
-| `MutSet<T>`   | mutable set type                      |
-| `MutMap<T>`   | mutable map type                      |
-| `MutArray<T>` | mutable array type                    |
+| Name          | Extra information                               |
+| ------------- | ----------------------------------------------- |
+| `Array<T>`    | variable size array of a certain type           |
+| `Map<T>`      | map type (key-value with string keys)           |
+| `Set<T>`      | set type (unordered collection of unique items) |
+| `MutArray<T>` | mutable array type                              |
+| `MutMap<T>`   | mutable map type                                |
+| `MutSet<T>`   | mutable set type                                |
 
 > ```TS
-> let z = {1, 2, 3};               // immutable set, Set<Num> is inferred
-> let zm = MutSet<num>{};          // mutable set
-> let y = {"a" => 1, "b" => 2};    // immutable map, Map<num> is inferred
-> let ym = MutMap<num>{};          // mutable map
-> let x = [1, 2, 3];               // immutable array, Array<num> is inferred
-> let xm = MutArray<num>[];        // mutable array
+> let y = [1, 2, 3];               // immutable array, Array<num> is inferred
+> let ym = MutArray<num>[1, 2, 3]; // mutable array
+> let x = {"a" => 1, "b" => 2};    // immutable map, Map<num> is inferred
+> let xm = MutMap<num>{};          // mutable map
+> let z = Set<num>[1, 2, 3];       // immutable set
+> let zm = MutSet<num>[1, 2, 3];   // mutable set
 > let w = new SampleClass();       // class instance (mutability unknown)
 > ```
 
@@ -1244,11 +1244,11 @@ The loop invariant in for loops is implicitly re-assignable (`var`).
 > ```TS
 > // Wing program:
 > let arr = [1, 2, 3];
-> let set = {1, 2, 3};
+> let items = Set<num>[1, 2, 3];
 > for item in arr {
 >   log("${item}");
 > }
-> for item in set {
+> for item in items {
 >   log("${item}");
 > }
 > for item in 0..100 {
@@ -1966,8 +1966,8 @@ assert(MutArray<num>[1, 2, 3] == Array<num>[1, 2, 3]);
 assert(Map<str>{"a": "1", "b": "2"} == Map<str>{"a": "1", "b": "2"});
 assert(Map<str>{"a": "1", "b": "2"} == Map<str>{"b": "2", "a": "1"});
 
-assert(Set<num>{1, 2, 3} == Set<num>{1, 2, 3});
-assert(Set<num>{1, 2, 3} == Set<num>{3, 2, 1});
+assert(Set<num>[1, 2, 3] == Set<num>[1, 2, 3]);
+assert(Set<num>[1, 2, 3] == Set<num>[3, 2, 1]);
 ```
 
 > *Note*: Collection type equality checking is not fully implemented. See [#2867](https://github.com/winglang/wing/issues/2867), [#2940](https://github.com/winglang/wing/issues/2940).


### PR DESCRIPTION
The current syntax for declaring sets in Wing uses curly braces, and allows the type annotation to be omitted if it can be inferred:
```js
let items = {1, 2, 3}; // Set<num>
let names = MutSet<str>{"alice", "bob", "charlie"};
```

This syntax matches the mathematical syntax for [sets](https://en.wikipedia.org/wiki/Set_(mathematics)) which also typically use curly braces, and it makes it convenient to create immutable set constants.

But the syntax has some drawbacks:
1. An empty set always requires a type annotation, or else `{}` will be interpreted as `Json` - this can be surprising to new users.
2. The set syntax collides with the desire for [punning in struct/Json literals](https://github.com/winglang/wing/issues/247), a feature many users have requested where the syntax `{ foo, bar }` would represent an object whose keys "foo" and "bar" are supplied by the "foo" and "bar" variables in the current scope.

This PR proposes changing the set literal syntax to use square brackets instead:

```js
let items = Set<num>[1, 2, 3];
let names = MutSet<str>["alice", "bob", "charlie"];
```

The syntax is inspired by Swift's [`Set` syntax](https://developer.apple.com/documentation/swift/set), which also uses square brackets, and [recent enhancements in C# 12](https://learn.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-12#collection-expressions) to support simpler collection expressions.

While this implies square brackets will not always refer to `Array` or `Json` arrays, in practice it would be okay since sets are used much less commonly than arrays in most Wing programs, and the `Set` annotation would always be required if the collection refers to a set.

In the future we may be able to simplify the syntax further by allowing the element type to be omitted (`Set [1, 2, 3]`) and/or specify the set in [lowercase](https://github.com/winglang/wing/issues/1468) (`set [1, 2, 3]`).

## Checklist

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [ ] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
