### PR TITLE
feat(compiler): support padding in number literals

### DIFF
--- a/apps/vscode-wing/syntaxes/wing.tmLanguage.json
+++ b/apps/vscode-wing/syntaxes/wing.tmLanguage.json
@@ -149,7 +149,7 @@
       "patterns": [
         {
           "name": "constant.numeric.wing",
-          "match": "(-?[0-9]+(\\.[0-9]+)?(s|ms|h|m)?\\b)"
+          "match": "(-?[0-9][0-9_]*(\\.[0-9][0-9_]*)?(s|ms|h|m)?\\b)"
         }
       ]
     },

--- a/docs/docs/03-language-reference.md
+++ b/docs/docs/03-language-reference.md
@@ -74,8 +74,8 @@ import TOCInline from '@theme/TOCInline';
 > let q: num? = nil;          // q is an optional num
 > ```
 
-Numeric literals can be formatted and padded with extra zeroes or underscores to make them easier to read.
-These don't affect the value of the number:
+Numeric literals can be formatted and padded with extra zeroes or underscores to make them easier to read in source code.
+These don't affect the value of the number or how they are printed:
 
 > ```TS
 > let price = 0012.34;

--- a/docs/docs/03-language-reference.md
+++ b/docs/docs/03-language-reference.md
@@ -74,6 +74,15 @@ import TOCInline from '@theme/TOCInline';
 > let q: num? = nil;          // q is an optional num
 > ```
 
+Numeric literals can be formatted and padded with extra zeroes or underscores to make them easier to read.
+These don't affect the value of the number:
+
+> ```TS
+> let price = 0012.34;
+> let twentyThousand = 20_000;
+> let aBitMore = 20_000.000_1;
+> ```
+
 [`▲ top`][top]
 
 ---

--- a/examples/tests/valid/expressions_binary_operators.test.w
+++ b/examples/tests/valid/expressions_binary_operators.test.w
@@ -17,3 +17,6 @@ assert(xyznfj == -5);
 let xynfj = -501.9 \ (-99.1 - 0.91);
 assert(xynfj == 5);
 
+let price = 0012.34;
+let twentyThousand = 20_000;
+let aBitMore = 20_000.000_1;

--- a/libs/tree-sitter-wing/grammar.js
+++ b/libs/tree-sitter-wing/grammar.js
@@ -337,8 +337,8 @@ module.exports = grammar({
       choice($.string, $.number, $.bool, $.duration, $.nil_value),
 
     number: ($) => choice($._integer, $._decimal),
-    _integer: ($) => choice("0", /[1-9]\d*/),
-    _decimal: ($) => choice(/0\.\d+/, /[1-9]\d*\.\d+/),
+    _integer: ($) => /\d[\d_]*/,
+    _decimal: ($) => /\d[\d_]*\.\d[\d_]*/,
 
     bool: ($) => choice("true", "false"),
 

--- a/libs/wingc/src/parser.rs
+++ b/libs/wingc/src/parser.rs
@@ -2000,9 +2000,7 @@ impl<'s> Parser<'s> {
 				))
 			}
 			"number" => Ok(Expr::new(
-				ExprKind::Literal(Literal::Number(
-					self.node_text(&expression_node).parse().expect("Number string"),
-				)),
+				ExprKind::Literal(Literal::Number(parse_number(self.node_text(&expression_node)))),
 				expression_span,
 			)),
 			"nil_value" => Ok(Expr::new(ExprKind::Literal(Literal::Nil), expression_span)),
@@ -2521,6 +2519,12 @@ pub fn normalize_path(path: &Utf8Path, relative_to: Option<&Utf8Path>) -> Utf8Pa
 	}
 
 	normalized
+}
+
+fn parse_number(s: &str) -> f64 {
+	// remove all underscores from the string
+	let s = s.replace("_", "");
+	return s.parse().expect("Number string");
 }
 
 #[cfg(test)]

--- a/tools/hangar/__snapshots__/test_corpus/valid/expressions_binary_operators.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/expressions_binary_operators.test.w_compile_tf-aws.md
@@ -60,6 +60,9 @@ class $Root extends $stdlib.std.Resource {
     {((cond) => {if (!cond) throw new Error("assertion failed: xyznfj == -5")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(xyznfj,(-5))))};
     const xynfj = Math.trunc((-501.9) / ((-99.1) - 0.91));
     {((cond) => {if (!cond) throw new Error("assertion failed: xynfj == 5")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(xynfj,5)))};
+    const price = 12.34;
+    const twentyThousand = 20000;
+    const aBitMore = 20000.0001;
   }
 }
 const $PlatformManager = new $stdlib.platform.PlatformManager({platformPaths: $platforms});


### PR DESCRIPTION
Add support for padding numeric literals with underscores or zeros. (inspired by Swift, Rust)

## Checklist

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [x] Tests added (always)
- [x] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
