### PR TITLE
chore: increased timeout for sdk spec tests

### DIFF
--- a/.github/workflows/tf-aws-test.yml
+++ b/.github/workflows/tf-aws-test.yml
@@ -160,7 +160,7 @@ jobs:
         with:
           max_attempts: 3
           retry_on: error
-          timeout_minutes: 45
+          timeout_minutes: 60
           command: |
             if  ${{ env.MANUAL == 'true' }}
             then


### PR DESCRIPTION
The azure tests can take an extremely long time

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
