### PR TITLE
fix(console): remove top padding for the root node

### DIFF
--- a/apps/wing-console/console/ui/src/ui/elk-map.tsx
+++ b/apps/wing-console/console/ui/src/ui/elk-map.tsx
@@ -37,7 +37,7 @@ const layoutOptions: LayoutOptions = {
   "elk.nodeSize.constraints": "USE_MINIMUM_SIZE",
   "elk.layered.spacing.baseValue": "32",
   "elk.edgeRouting": "ORTHOGONAL",
-  "elk.padding": "[top=52,left=20,bottom=20,right=20]",
+  "elk.padding": "[top=20,left=20,bottom=20,right=20]",
 };
 
 export type NodeItemProps<T> = {


### PR DESCRIPTION
There was a top padding in the root node of the map view that wasn't removed.