### PR TITLE
feat!: constructors are now called `new()` instead of `init()`

### DIFF
--- a/docs/docs/02-concepts/01-preflight-and-inflight.md
+++ b/docs/docs/02-concepts/01-preflight-and-inflight.md
@@ -171,7 +171,7 @@ class ReplayableQueue {
   bucket: cloud.Bucket; 
   counter: cloud.Counter;
   
-  init() {
+  new() {
     this.queue = new cloud.Queue();
     this.bucket = new cloud.Bucket();
     this.counter = new cloud.Counter();
@@ -208,7 +208,7 @@ inflight () => {
     name: str;
     age: num;
 
-    init(name: str, age: num) {
+    new(name: str, age: num) {
       this.name = name;
       this.age = age;
     }

--- a/docs/docs/02-concepts/02-application-tree.md
+++ b/docs/docs/02-concepts/02-application-tree.md
@@ -18,13 +18,13 @@ New classes introduce new scopes, so the same name can be used for different res
 
 ```js
 class Group1 {
-  init() {
+  new() {
     new cloud.Bucket() as "Store";
   }
 }
 
 class Group2 {
-  init() {
+  new() {
     new cloud.Bucket() as "Store";
   }
 }

--- a/docs/docs/03-language-reference.md
+++ b/docs/docs/03-language-reference.md
@@ -677,7 +677,7 @@ Inner classes or closures can access private members of their containing class.
 class Foo {
   private_field: num; // This is private by default
   
-  init() {this.private_field = 1;}
+  new() {this.private_field = 1;}
   
   method() {
     log(this.private_field); // We can access `private_field` since we're in Foo
@@ -854,7 +854,7 @@ class Foo {
   myOpt: num?;
   var myVar: str?;
 
-  init(opt: num?) {
+  new(opt: num?) {
     this.myOpt = opt;
     this.myVar = nil; // everything must be initialized, so you can use `nil` to indicate that there is no value
   }
@@ -1358,7 +1358,7 @@ inflight class Name extends Base impl IMyInterface1, IMyInterface2 {
   _field1: num;
   _field2: str;
   
-  init() {
+  new() {
     // constructor implementation
     // order is up to user
     this._field1 = 1;
@@ -1371,7 +1371,7 @@ inflight class Name extends Base impl IMyInterface1, IMyInterface2 {
   publicMethod(arg:type, arg:type, ...) { /* impl */ }
 }
 ```
-If no `init()` is defined, the class will have a default constructor that does nothing.
+If no `new()` is defined, the class will have a default constructor that does nothing.
 
 Implicit default field initialization does not exist in Wing. All member fields must be
 initialized in the constructor. Absent initialization is a compile error. All
@@ -1380,12 +1380,12 @@ field types, including the optional types must be initialized.
 ```TS
 class Foo {
   x: num;
-  init() { this.x = 1; }
+  new() { this.x = 1; }
 }
 class Bar {
   y: num;
   z: Foo;
-  init() {
+  new() {
     this.y = 1;
     this.z = new Foo();
     this.log(); // OK to call here
@@ -1410,11 +1410,11 @@ their "strict" mode.
 ```TS
 class Foo {
   x: num;
-  init() { this.x = 0; }
+  new() { this.x = 0; }
   pub method() { }
 }
 class Boo extends Foo {
-  init() {
+  new() {
     // this.x = 10; // compile error
     super();
     this.x = 10; // OK
@@ -1428,11 +1428,11 @@ Classes can implement interfaces iff the interfaces do not contain `inflight`.
 ```TS
 class Foo {
   x: num;
-  init() { this.x = 0; }
+  new() { this.x = 0; }
   pub method() { }
 }
 class Boo extends Foo {
-  init() { super(); this.x = 10; }
+  new() { super(); this.x = 10; }
 }
 
 ```
@@ -1483,7 +1483,7 @@ class Foo {
   inflight field8: bool;
 
   // preflight constructor
-  init(field1: num, field2: str, field3: bool, field4: num, field5: str) { 
+  new(field1: num, field2: str, field3: bool, field4: num, field5: str) { 
     /* initialize preflight fields */
     this.field1 = field1;
     this.field2 = field2;
@@ -1493,7 +1493,7 @@ class Foo {
   } 
 
   // inflight constructor
-  inflight init() { 
+  inflight new() { 
     /* initialize inflight fields */
     this.field6 = 123;
     this.field7 = "hello";
@@ -1584,7 +1584,7 @@ Interface fields are not supported.
 >   field1: num;
 >   field2: str;
 >
->   init(x: num) {
+>   new(x: num) {
 >     this.field1 = x;
 >     this.field2 = "sample";
 >   }
@@ -2020,7 +2020,7 @@ Two class instances or interface-satisfying objects are equal if they are the sa
 ```js
 class Shop {
   hats: num;
-  init(hats: num) {
+  new(hats: num) {
     this.hats = hats;
   }
 }

--- a/docs/docs/07-examples/08-classes.md
+++ b/docs/docs/07-examples/08-classes.md
@@ -14,7 +14,7 @@ class Foo  {
   var field2: num; // <-- reassignable
   inflight field3: Array<str>;
 
-  init() {
+  new() {
     this.field1 = "hello";
     this.field2 = 123;
   }
@@ -23,7 +23,7 @@ class Foo  {
     this.field2 = value;
   }
 
-  inflight init() {
+  inflight new() {
     this.field3 = ["value created on inflight init"];
     log("at inflight init");
   }
@@ -81,7 +81,7 @@ interface IKVStore extends std.IResource { // https://github.com/winglang/wing/i
 
 class BucketBasedKeyValueStore impl IKVStore {
   bucket: cloud.Bucket;
-  init() {
+  new() {
     this.bucket = new cloud.Bucket();
   }
   pub inflight get(key: str): Json {
@@ -105,7 +105,7 @@ interface IKVStore extends std.IResource {
 
 class BucketBasedKeyValueStore impl IKVStore {
   bucket: cloud.Bucket;
-  init() {
+  new() {
     this.bucket = new cloud.Bucket();
   }
   pub inflight get(key: str): Json {
@@ -118,7 +118,7 @@ class BucketBasedKeyValueStore impl IKVStore {
 
 class TableBasedKeyValueStore impl IKVStore {
   table: cloud.Table;
-  init() {
+  new() {
     this.table = new cloud.Table(
       name: "table",
       primaryKey: "key",

--- a/docs/docs/999-faq/020-supported-clouds-services-and-engines/025-kubernetes-support.md
+++ b/docs/docs/999-faq/020-supported-clouds-services-and-engines/025-kubernetes-support.md
@@ -5,15 +5,20 @@ id: kubernetes-support
 keywords: [faq, supported provisioning engines, Winglang, Wing programming language, Wing language, Kubernetes, K8S]
 ---
 
-## Short answer
-We don't support Kubernetes yet, but we will in the future. 
-Our roadmap is [here](https://www.winglang.io/contributing/status).
+## Deploying Wing workloads to Kubernetes
 
-## Long answer
-There are a different kinds of Kubernetes support with varying levels of maturity in Wing:
-1. Creation and configuration of K8S clusters through the [K8S Terraform Provider](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs). Since Wing supports any Terraform provider, it should work, but we have not officially tested it yet.
-2. Using Kubernetes to run long-running services. This is not yet supported. You can add your vote for it on [this issue](https://github.com/winglang/wing/issues/2319) to help increase its priority.
-3. Using Kubernetes as a provisioning engine, which means it will be a built-in compilation target for cloud services. You can add your vote for it on [this issue](https://github.com/winglang/wing/issues/2066) to help increase its priority. 
+Yes, Wing supports Kubernetes through the `Workload` resource which is a high-level representation
+of containerized workloads. When deployed to AWS, workloads are scheduled into a Kubernetes/EKS
+cluster via Helm.
 
-Wing currently has full support for Terraform. AWS CDK (based on CloudFormation) is also supported by the community.
+## Synthesizing Kubernetes manifests through Wing using CDK8s
 
+Since Wing has native support for constructs, you can technically use [CDK for
+Kubernetes](https://cdk8s.io) (CDK8s) to synthesize Kubernetes manifests and apply them to your
+cluster.
+
+See [#678](https://github.com/winglang/wing/issues/678) for details.
+
+## Creating Kubernetes cluster infrastructure with Wing
+
+The [Kubernetes Terraform Provider](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs) can be used in Wing to provision complete clusters.

--- a/examples/proposed/cacheable-function.w
+++ b/examples/proposed/cacheable-function.w
@@ -1,15 +1,15 @@
 bring cloud;
 
-resource CachableFunction extends cloud.Function {
+class CachableFunction extends cloud.Function {
     _func: cloud.Function;
     _cache: cloud.Bucket;
 
-    init(inflight: inflight (event: any) => any, props: cloud.FunctionProps) {
+    new(inflight: inflight (event: any) => any, props: cloud.FunctionProps) {
         super(inflight, props);
         this._cache = new cloud.Bucket();
     }
 
-    pub override inflight invoke(event: any): any {
+    pub inflight invoke(event: any): any {
         let key = hashof(event);
         let cached = this._cache.try_get(key);
         if cached {

--- a/examples/proposed/counting-semaphore.w
+++ b/examples/proposed/counting-semaphore.w
@@ -4,13 +4,13 @@ struct CountingSemaphoreProps {
   availableResources: num;
 }
 
-resource CountingSemaphore {
+class CountingSemaphore {
   pub limit: num;
   _counter: cloud.Counter;
 
   // need some ttl solution here,
   // probably in-house once replaced with a key-value store
-  init(props: CountingSemaphoreProps) {
+  new(props: CountingSemaphoreProps) {
     // pseudocode: input validation
     this.limit = props.availableResources;
     this._counter = new cloud.Counter();

--- a/examples/proposed/lock.w
+++ b/examples/proposed/lock.w
@@ -18,13 +18,13 @@ bring cloud;
  */
 resource Lock {
   counter: cloud.Counter;
-  init() {
+  new() {
     this.counter = new cloud.Counter();
   }
 
   pub inflight var is_locked: bool;
 
-  inflight init() {
+  inflight new() {
     this.is_locked = false;
   }
 

--- a/examples/proposed/replayable-queue.w
+++ b/examples/proposed/replayable-queue.w
@@ -8,7 +8,7 @@ class ReplayableQueue {
   bucket: cloud.Bucket; 
   counter: cloud.Counter;
   
-  init() {
+  new() {
     this.queue = new cloud.Queue();
     this.bucket = new cloud.Bucket();
     this.counter = new cloud.Counter();
@@ -33,7 +33,7 @@ class ReplayableQueue {
 
 // how to use the queue
 class RemoteControl { 
-  init(q: ReplayableQueue){
+  new(q: ReplayableQueue){
     let f = inflight (m: str): str => {
       log("setConsumer got triggered with ${m}");
     };

--- a/examples/proposed/task-manager.w
+++ b/examples/proposed/task-manager.w
@@ -17,7 +17,7 @@ resource TaskManager {
   fn: cloud.Function;
   state: cloud.Bucket;
 
-  init(handler: inflight (str): void) {
+  new(handler: inflight (str): void) {
     this.bucket = new cloud.Bucket();
 
     let wrapper = inflight (id: str, input: str) => {

--- a/examples/proposed/url-shortener.w
+++ b/examples/proposed/url-shortener.w
@@ -5,7 +5,7 @@ bring http;
 class UrlShortener {
   lookup: cloud.Bucket;
 
-  init() {
+  new() {
     // map from ids to urls
     this.lookup = new cloud.Bucket() as "IdLookup";
   }
@@ -37,7 +37,7 @@ class UrlShortenerApi {
   api: cloud.Api;
   shortener: UrlShortener;
 
-  init(shortener: UrlShortener) {
+  new(shortener: UrlShortener) {
     this.shortener = shortener;
     this.api = new cloud.Api();
 

--- a/examples/tests/invalid/access_modifiers.test.w
+++ b/examples/tests/invalid/access_modifiers.test.w
@@ -9,7 +9,7 @@ class Foo impl SomeInterface {
   private_field: str;
   pub public_field: str;
 
-  init() {
+  new() {
     this.protected_field = "hello";
     this.private_field = "world";
     this.public_field = "!";

--- a/examples/tests/invalid/access_static_from_instance.test.w
+++ b/examples/tests/invalid/access_static_from_instance.test.w
@@ -9,7 +9,7 @@ class Foo {
   }
 
 
-  init() {
+  new() {
     this.instanceField = 1;
   }
 }

--- a/examples/tests/invalid/bring_non_std_construct.test.w
+++ b/examples/tests/invalid/bring_non_std_construct.test.w
@@ -9,7 +9,7 @@ new cdktf.S3Backend();
 //^ Expected 1 positional argument(s) but got 0
 
 class Foo {
-  init() {
+  new() {
     new cdktf.S3Backend(this, cdktf.S3BackendConfig {bucket: "foo", key: "bar"}) as "s3_backend";
                                                                                   //^ Cannot set id of non-standard preflight class "S3Backend" using `as`
     new cdktf.S3Backend(this, cdktf.S3BackendConfig {bucket: "foo", key: "bar"}) in this;

--- a/examples/tests/invalid/class.test.w
+++ b/examples/tests/invalid/class.test.w
@@ -14,7 +14,7 @@ new C9(token: "1");
 //^^^^^^^ Expected 0 named argument(s)"
 
 class C10 {
-  init(foo: str)
+  new(foo: str)
 }
 new C10(); 
 //^^^^^^^ Expected 1 required positional arguments but got 0 when instantiating "C5"
@@ -27,7 +27,7 @@ new C10("hello", foo: "bar");
 
 class C3 {
   x: num;
-  init() {
+  new() {
     this.x = "Hi";
            //^^^^ Expected type to be "num", but got "str" instead
   }
@@ -43,7 +43,7 @@ class C4 {
 class C5 {
   inflight x: num;
          //^ Inflight field "x" is not initialized
-  inflight init() {}
+  inflight new() {}
 }
 
 class C6 {
@@ -52,12 +52,12 @@ class C6 {
   y: num;
 //^ Preflight field "y" is not initialized  
   
-  init() {
+  new() {
     this.x = 1;
        //^ "x" cannot be initialized in the Preflight initializer
   }
 
-  inflight init() {
+  inflight new() {
     this.y = 1;
        //^ "y" cannot be initialized in the Inflight initializer
   }
@@ -82,7 +82,7 @@ class C11 extends C11 {
 class Student {
   name: str;
   major: str;
-  init(name: str, major: str) {
+  new(name: str, major: str) {
     super();
 //  ^^^^^^^^ Calls to super constructor can only be made from derived classes
     this.name = name;
@@ -93,7 +93,7 @@ class Student {
 class PaidStudent extends Student {
   hrlyWage: num;
   
-  init(name: str, major: str, hrlyWage: num) {
+  new(name: str, major: str, hrlyWage: num) {
     this.hrlyWage = hrlyWage;
     super(name, major);
 //  ^^^^^^^^^^^^^^^^^^^ Expected call to super to be first statement in constructor
@@ -112,14 +112,14 @@ let s = new PaidStudent("x", "y", 3);
 // Typechecking super calls
 class One {
   someNum: num;
-  init(someNum: num) {
+  new(someNum: num) {
     this.someNum = someNum;
   }
 }
 
 class Two extends One {
   someStr: str;
-  init(someNum: num, someStr: str) {
+  new(someNum: num, someStr: str) {
     super(someStr);
 //        ^^^^^^^ Expected type to be "num", but got "str" instead
     this.someStr = someStr;
@@ -128,7 +128,7 @@ class Two extends One {
 
 class Three extends One {
   someStr: str;
-  init(someNum: num, someStr: str) {
+  new(someNum: num, someStr: str) {
     super();
 //  ^^^^^^^^ Expected 1 positional argument(s) but got 0
     this.someStr = someStr;
@@ -137,7 +137,7 @@ class Three extends One {
 
 class Four extends One {
   someStr: str;
-  init(someNum: num, someStr: str) {
+  new(someNum: num, someStr: str) {
     super(someNum, someStr);
 //  ^^^^^^^^^^^^^^^^^^^^^^^^ Expected 1 arguments but got 2
     this.someStr = someStr;
@@ -147,13 +147,13 @@ class Four extends One {
 // Super inflight
 inflight class Plane {
   year: num;
-  init(year: num) {
+  new(year: num) {
     this.year = year;
   }
 }
 
 inflight class Jet extends Plane{
-  init(year: num) {
+  new(year: num) {
     super();
 //  ^^^^^^^^ Expected 1 positional argument(s) but got 0
   }

--- a/examples/tests/invalid/inflight_class_created_in_preflight.test.w
+++ b/examples/tests/invalid/inflight_class_created_in_preflight.test.w
@@ -4,7 +4,7 @@ new Foo();
 
 // ^^^^^^^^^ Cannot create inflight class "Foo" in preflight phase
 class PreflightClass {
-  init() {
+  new() {
     new Foo();
 //  ^^^^^^^^^ Cannot create inflight class "Foo" in preflight phase
   }

--- a/examples/tests/invalid/inflight_class_dup_init.test.w
+++ b/examples/tests/invalid/inflight_class_dup_init.test.w
@@ -1,9 +1,9 @@
 inflight class Foo {
-  init() {
+  new() {
 
   }
 
-  inflight init() {
+  inflight new() {
 
   }
 //^ Multiple inflight initializers defined in class Foo

--- a/examples/tests/invalid/inflight_ref_explicit_ops.test.w
+++ b/examples/tests/invalid/inflight_ref_explicit_ops.test.w
@@ -22,7 +22,7 @@ class Test {
   array: Array<cloud.Bucket>;
   justStr: str;
 
-  init() {
+  new() {
     this.b = new cloud.Bucket() as "b1";
     this.justBucket = new cloud.Bucket() as "b2";
     this.another = new Another();

--- a/examples/tests/invalid/inflight_ref_resource_sub_method.test.w
+++ b/examples/tests/invalid/inflight_ref_resource_sub_method.test.w
@@ -23,7 +23,7 @@ class Another {
 class Test {
   another: Another;
 
-  init() {
+  new() {
     this.another = new Another();
   }
 

--- a/examples/tests/invalid/inflight_ref_unknown_op.test.w
+++ b/examples/tests/invalid/inflight_ref_unknown_op.test.w
@@ -5,7 +5,7 @@ let globalB = new cloud.Bucket();
 class Test {
   b: cloud.Bucket;
 
-  init() {
+  new() {
     this.b = new cloud.Bucket();
   }
 

--- a/examples/tests/invalid/nil.test.w
+++ b/examples/tests/invalid/nil.test.w
@@ -5,7 +5,7 @@ let x: str = nil;
 
 class Foo {
   inflight var bar: num;
-  inflight init() {
+  inflight new() {
     this.bar = 1;
   }
 

--- a/examples/tests/invalid/preflight_from_inflight.test.w
+++ b/examples/tests/invalid/preflight_from_inflight.test.w
@@ -7,7 +7,7 @@ class MyResource {
 class Test {
   r: MyResource;
 
-  init() {
+  new() {
     this.r = new MyResource();
   }
 

--- a/examples/tests/invalid/reassign_to_nonreassignable.test.w
+++ b/examples/tests/invalid/reassign_to_nonreassignable.test.w
@@ -4,7 +4,7 @@ x = x + 1;
 
 class InnerR {
   pub inflight inner: num;
-  inflight init() {
+  inflight new() {
     this.inner = 1;
   }
 }
@@ -15,12 +15,12 @@ class R {
   innerR: InnerR;
   inflight inflightF: num;
   
-  init() {
+  new() {
     this.f = 1;
     this.innerR = new InnerR();
   }
 
-  inflight init() {
+  inflight new() {
     this.inflightF = 1;
   }
   

--- a/examples/tests/invalid/resource_access_field_as_method.test.w
+++ b/examples/tests/invalid/resource_access_field_as_method.test.w
@@ -1,6 +1,6 @@
 class SomeResource {
     pub name: str;
-    init() {
+    new() {
         this.name = "John Doe";
     }
 }

--- a/examples/tests/invalid/resource_captures.test.w
+++ b/examples/tests/invalid/resource_captures.test.w
@@ -4,7 +4,7 @@ class Foo {
   bucket: cloud.Bucket;
   collectionOfResources: Array<cloud.Bucket>;
 
-  init() {
+  new() {
     this.bucket = new cloud.Bucket();
     this.collectionOfResources = Array<cloud.Bucket>[];
   }

--- a/examples/tests/invalid/resource_init.test.w
+++ b/examples/tests/invalid/resource_init.test.w
@@ -1,11 +1,11 @@
 class R {
-  init() {}
-  init() {}
+  new() {}
+  new() {}
 //^-- can't have multiple inits
-  inflight init() {}
-  inflight init() {}
+  inflight new() {}
+  inflight new() {}
         // ^-- can't have multiple inflight inits
 
-  inflight init(x: num) {}
+  inflight new(x: num) {}
              // ^-- can't have inflight init with args
 }

--- a/examples/tests/invalid/unknown_symbol.test.w
+++ b/examples/tests/invalid/unknown_symbol.test.w
@@ -12,7 +12,7 @@ let x = 2 + y;
 class SomeResource {
   bucket: cloud.Bucket;
 
-  init() {
+  new() {
     this.bucket = new cloud.Bucket();
   }
 

--- a/examples/tests/sdk_tests/expect/assert.test.w
+++ b/examples/tests/sdk_tests/expect/assert.test.w
@@ -178,7 +178,7 @@ class MyClass {
     a: num;
     b: str;
 
-    init(a: num, b: str) {
+    new(a: num, b: str) {
         this.a = a;
         this.b = b;
     }
@@ -197,7 +197,7 @@ expect.notEqual(myClass, new MyClass(1, "hello world") as "yet another my class"
 //     a: num;
 //     b: str;
 
-//     init(a: num, b: str) {
+//     new(a: num, b: str) {
 //         this.a = a;
 //         this.b = b;
 //     }

--- a/examples/tests/sdk_tests/queue/set_consumer.test.w
+++ b/examples/tests/sdk_tests/queue/set_consumer.test.w
@@ -8,7 +8,7 @@ let c = new cloud.Counter();
 // had to wrap the inflight ():bool => { c.peek == 2 } inflight method with a the Predicate resource
 class Predicate {
   c: cloud.Counter;
-  init(c: cloud.Counter){
+  new(c: cloud.Counter){
     this.c = c;
   }
 

--- a/examples/tests/sdk_tests/service/http-server.test.w
+++ b/examples/tests/sdk_tests/service/http-server.test.w
@@ -20,7 +20,7 @@ if util.env("WING_TARGET") == "sim" {
 
     pub s: cloud.Service;
 
-    init(body: str) {
+    new(body: str) {
       this.b = new cloud.Bucket();
       this.body = body;
 

--- a/examples/tests/sdk_tests/service/stateful.test.w
+++ b/examples/tests/sdk_tests/service/stateful.test.w
@@ -10,7 +10,7 @@ if util.env("WING_TARGET") == "sim" {
 
     pub s: cloud.Service;
 
-    init(body: str) {
+    new(body: str) {
       this.b = new cloud.Bucket();
       this.body = body;
 

--- a/examples/tests/sdk_tests/state/my-service.w
+++ b/examples/tests/sdk_tests/state/my-service.w
@@ -7,7 +7,7 @@ pub class MyService {
   startTimeKey: str;
   pub startTime: str;
   
-  init() {
+  new() {
     // use `sim.State` to store in-memory data
     this.state = new sim.State();
 

--- a/examples/tests/valid/api.test.w
+++ b/examples/tests/valid/api.test.w
@@ -32,7 +32,7 @@ test "api url" {
 // Initialize the API in resource
 class A {
   api: cloud.Api;
-  init() {
+  new() {
     this.api = new cloud.Api();
     this.api.get("/endpoint1", inflight (req: cloud.ApiRequest): cloud.ApiResponse => {
       let text = "${this.api.url}/endpoint2";

--- a/examples/tests/valid/bring_awscdk.test.w
+++ b/examples/tests/valid/bring_awscdk.test.w
@@ -3,7 +3,7 @@ bring "aws-cdk-lib" as awscdk;
 class CdkDockerImageFunction {
     function:  awscdk.aws_lambda.DockerImageFunction;
 
-    init() {
+    new() {
         this.function = new awscdk.aws_lambda.DockerImageFunction({
             code: awscdk.aws_lambda.DockerImageCode.fromImageAsset("./test.ts"),
         }) as "DockerImageFunction";

--- a/examples/tests/valid/bring_cdktf.test.w
+++ b/examples/tests/valid/bring_cdktf.test.w
@@ -10,7 +10,7 @@ new aws.s3Bucket.S3Bucket(
 ) as "Bucket";
 
 class Foo {
-  init() {
+  new() {
     // Test importing a non-standard Construct that doesn't have a `scope`/`id` property pair as its first two arguments
     // Some of cdktf's backend constructs are like this.
     new cdktf.S3Backend(this, cdktf.S3BackendConfig {bucket: "foo", key: "bar"});

--- a/examples/tests/valid/calling_inflight_variants.test.w
+++ b/examples/tests/valid/calling_inflight_variants.test.w
@@ -1,6 +1,6 @@
 class Foo {
   inflight1: inflight (): num;
-  init() {
+  new() {
     // here is an inflight function created during preflight
     this.inflight1 = inflight (): num => {
       return 1;
@@ -8,7 +8,7 @@ class Foo {
   }
 
   inflight inflight2: inflight (): num;
-  inflight init() {
+  inflight new() {
     // here is an inflight function created during inflight
     this.inflight2 = (): num => {
       return 2;

--- a/examples/tests/valid/capture_reassigable_class_field.test.w
+++ b/examples/tests/valid/capture_reassigable_class_field.test.w
@@ -4,7 +4,7 @@ bring util;
 class KeyValueStore {
   bucket: cloud.Bucket;
   var onUpdateCallback : inflight (str): void;
-  init() {
+  new() {
     this.bucket = new cloud.Bucket();
     this.onUpdateCallback = inflight (k: str) => {};
   }

--- a/examples/tests/valid/capture_resource_with_no_inflight.test.w
+++ b/examples/tests/valid/capture_resource_with_no_inflight.test.w
@@ -4,7 +4,7 @@ class A {
   pub field: str;
   counter: cloud.Counter;
 
-  init() { 
+  new() { 
     this.field = "hey"; 
     this.counter = new cloud.Counter();
   }

--- a/examples/tests/valid/capture_tokens.test.w
+++ b/examples/tests/valid/capture_tokens.test.w
@@ -6,7 +6,7 @@ class MyResource {
 
   extern "./url_utils.js" pub static inflight isValidUrl(url: str): bool;
 
-  init() {
+  new() {
     this.api = new cloud.Api();
     this.url = this.api.url;  
   }

--- a/examples/tests/valid/class.test.w
+++ b/examples/tests/valid/class.test.w
@@ -7,7 +7,7 @@ new C1();
 // class with init and no arguments
 class C2 {
   pub x: num;
-  init() {
+  new() {
     this.x = 1;
   }
 }
@@ -18,7 +18,7 @@ assert(c2.x == 1);
 class C3 {
   pub x: num;
   pub y: num;
-  init(a: num, b: num) {
+  new(a: num, b: num) {
     this.x = a;
     if true {
       this.y = b;
@@ -39,7 +39,7 @@ assert(C4.m() == 1);
 class C5 {
   pub inflight x: num;
   pub inflight var y: num;
-  inflight init() {
+  inflight new() {
     this.x = 123;
     this.y = 321;
   }
@@ -58,7 +58,7 @@ test "access inflight field" {
 
 class Person {
   pub name: str;
-  init(name: str) {
+  new(name: str) {
     this.name = name;
   }
 }
@@ -66,7 +66,7 @@ class Person {
 class Student extends Person {
   pub major: str;
 
-  init(name: str, major: str) {
+  new(name: str, major: str) {
     super(name);
     this.major = major;
   }
@@ -74,7 +74,7 @@ class Student extends Person {
 
 class PaidStudent extends Student {
   pub hrlyWage: num;
-  init(name: str, major: str, hrlyWage: num) {
+  new(name: str, major: str, hrlyWage: num) {
     super(name, major);
     this.hrlyWage = hrlyWage;
   }
@@ -89,7 +89,7 @@ test "check derived class instance variables" {
 }
 
 class TeacherAid extends PaidStudent {
-  init(name: str, major: str, hrlyWage: num) {
+  new(name: str, major: str, hrlyWage: num) {
     super(name, major, hrlyWage);
     this.hrlyWage = 10; // should overwrite the super set value
   }
@@ -105,13 +105,13 @@ test "devived class init body happens after super" {
 inflight class A {
   pub sound: str;
 
-  inflight init(sound: str) {
+  inflight new(sound: str) {
     this.sound = sound;
   }
 }
 
 inflight class B extends A {
-  inflight init(sound: str) {
+  inflight new(sound: str) {
     super(sound);
   }
 }
@@ -124,7 +124,7 @@ test "inflight super constructor" {
 // derived preflight class with inflight methods
 class Bar {}
 class Foo extends Bar  {
-  init() {
+  new() {
     super();
   }
 
@@ -138,6 +138,6 @@ class Baz extends Bar {}
 new Baz();
 
 class Boom {
-  init() { }
+  new() { }
 }
 class Bam extends Boom {}

--- a/examples/tests/valid/construct-base.test.w
+++ b/examples/tests/valid/construct-base.test.w
@@ -4,7 +4,7 @@ bring "constructs" as cx;
 bring "@cdktf/provider-aws" as aws;
 
 class WingResource {
-  init() {
+  new() {
     log("my id is ${this.node.id}");
   }
 }

--- a/examples/tests/valid/debug_env.test.w
+++ b/examples/tests/valid/debug_env.test.w
@@ -2,7 +2,7 @@ bring cloud;
 
 class A {
   b: cloud.Bucket;
-  init() {
+  new() {
     this.b = new cloud.Bucket();
     🗺️;
   }

--- a/examples/tests/valid/double_reference.test.w
+++ b/examples/tests/valid/double_reference.test.w
@@ -3,7 +3,7 @@ bring cloud;
 let initCount = new cloud.Counter();
 
 class Foo {
-  inflight init() {
+  inflight new() {
     initCount.inc();
   }
 
@@ -12,7 +12,7 @@ class Foo {
 
 class Bar {
   pub foo: Foo;
-  init() {
+  new() {
     this.foo = new Foo();
   }
 

--- a/examples/tests/valid/doubler.test.w
+++ b/examples/tests/valid/doubler.test.w
@@ -4,7 +4,7 @@ bring cloud;
 
 class Doubler {
   func: cloud.IFunctionHandler;
-  init(func: cloud.IFunctionHandler) {
+  new(func: cloud.IFunctionHandler) {
     this.func = func;
   }
   inflight invoke(message: str): str {

--- a/examples/tests/valid/dynamo.test.w
+++ b/examples/tests/valid/dynamo.test.w
@@ -22,7 +22,7 @@ struct Attribute {
 class DynamoTable {
   table: tfaws.dynamodbTable.DynamodbTable;
   tableName: str;
-  init() {
+  new() {
     let target = util.env("WING_TARGET");
     if target != "tf-aws" {
       throw "Unsupported target: ${target} (expected 'tf-aws')";

--- a/examples/tests/valid/dynamo_awscdk.test.w
+++ b/examples/tests/valid/dynamo_awscdk.test.w
@@ -22,7 +22,7 @@ struct Attribute {
 class DynamoTable {
   table: awscdk.aws_dynamodb.Table;
   tableName: str;
-  init() {
+  new() {
     let target = util.env("WING_TARGET");
     if target != "awscdk" {
       throw "Unsupported target: ${target} (expected 'awscdk')";

--- a/examples/tests/valid/forward_decl.test.w
+++ b/examples/tests/valid/forward_decl.test.w
@@ -17,7 +17,7 @@ class R {
     this.method2(); // we can call ourselves because we are defined in an outer scope
   }
   f: str;
-  init(/* empty */) {
+  new(/* empty */) {
     this.f = "Hello World!!!";
   }
   method1() {}

--- a/examples/tests/valid/function_variadic_arguments.test.w
+++ b/examples/tests/valid/function_variadic_arguments.test.w
@@ -43,13 +43,13 @@ arityFunc(1, true, "a", "b", "c", "d"); // variadic args should be considered co
 class A {
   pub message: str;
 
-  init(msg: str) {
+  new(msg: str) {
     this.message = msg;
   }
 }
 
 class B extends A {
-  init(msg: str) {
+  new(msg: str) {
     this.message = msg;
   }
 }

--- a/examples/tests/valid/inflight_class_definitions.test.w
+++ b/examples/tests/valid/inflight_class_definitions.test.w
@@ -22,7 +22,7 @@ let fn = inflight () => {
 class D {
   inner: inflight (): str;
 
-  init() {
+  new() {
     class E {
       pub foo(): str { return "e1"; }
     }

--- a/examples/tests/valid/inflight_class_inside_inflight_closure.test.w
+++ b/examples/tests/valid/inflight_class_inside_inflight_closure.test.w
@@ -2,7 +2,7 @@ bring cloud;
 
 class PreflightClass {
   b: cloud.Bucket;
-  init() {
+  new() {
     this.b = new cloud.Bucket();
   }
   pub preflight_method(): cloud.Function {
@@ -10,7 +10,7 @@ class PreflightClass {
       this.b.put("k","v");  // Here `this` is the parent class instance
       inflight class InflightClass {
         field: str;
-        init() {
+        new() {
           this.field = "value";
         }
         pub inflight method() {

--- a/examples/tests/valid/inflight_class_modifiers.test.w
+++ b/examples/tests/valid/inflight_class_modifiers.test.w
@@ -2,7 +2,7 @@
 
 inflight class C {
   inflight field: num;
-  init() {
+  new() {
     this.field = 12;
   }
   inflight method() {}

--- a/examples/tests/valid/inflight_class_outside_inflight_closure.test.w
+++ b/examples/tests/valid/inflight_class_outside_inflight_closure.test.w
@@ -4,7 +4,7 @@ inflight class BinaryOperation {
   lhs: num;
   rhs: num;
 
-  init(lhs: num, rhs: num) {
+  new(lhs: num, rhs: num) {
     this.lhs = lhs;
     this.rhs = rhs;
   }

--- a/examples/tests/valid/inflight_concat.test.w
+++ b/examples/tests/valid/inflight_concat.test.w
@@ -2,7 +2,7 @@ bring cloud;
 
 class R {
   s1: str;
-  init() {
+  new() {
     this.s1 = "hello";
   }
   inflight foo() {

--- a/examples/tests/valid/inflight_init.test.w
+++ b/examples/tests/valid/inflight_init.test.w
@@ -8,7 +8,7 @@ inflight class Foo {
     return 6;
   }
 
-  init(f2: num) {
+  new(f2: num) {
     this.field1 = this.get_six();
     this.field2 = f2;
   }
@@ -17,7 +17,7 @@ inflight class Foo {
 inflight class FooChild extends Foo {
   pub field3: num;
 
-  init() {
+  new() {
     super(5);
     this.field3 = 4;
   }
@@ -46,7 +46,7 @@ test "inflight calls parent's init when non exists" {
   class FooChild extends FooNoInit {
     pub field: num;
 
-    init() {
+    new() {
       super();
       this.field = this.leet();
     }
@@ -66,7 +66,7 @@ test "inflight class inherits form JSII class" {
       return 6;
     }
 
-    init(x: num, y: str) {
+    new(x: num, y: str) {
       super(x); // Call non-inflight parent's init
       this.foo_str = "${y} ${x}"; // Use init args in inflight's init 
       this.foo_num = this.get_six(); // Call inflight method in inflight's init
@@ -80,7 +80,7 @@ test "inflight class inherits form JSII class" {
   class FooChild extends Foo {
     pub child_field: num;
 
-    init() {
+    new() {
       super(2, "FooChild"); // Call parent's init which will also handle the JSII class's init
       this.child_field = this.get_six() + 1;
     }

--- a/examples/tests/valid/inflights_calling_inflights.test.w
+++ b/examples/tests/valid/inflights_calling_inflights.test.w
@@ -22,7 +22,7 @@ test "inflights can call other inflights" {
 class MyResource {
   closure: inflight (str): str;
 
-  init() {
+  new() {
     this.closure = inflight (s: str): str => {
       globalBucket.list();
       return "hello";

--- a/examples/tests/valid/json.test.w
+++ b/examples/tests/valid/json.test.w
@@ -42,7 +42,7 @@ assert(jj3 == Json "hello");
 
 class Foo {
   pub SumStr: str;
-  init() {
+  new() {
     this.SumStr = "wow!";
   }
 }

--- a/examples/tests/valid/lift_expr_with_this.test.w
+++ b/examples/tests/valid/lift_expr_with_this.test.w
@@ -1,6 +1,6 @@
 class Foo {
   pub value: str;
-  init() { this.value = "hello"; }
+  new() { this.value = "hello"; }
 }
 
 let foo_this = new Foo();

--- a/examples/tests/valid/lift_this.test.w
+++ b/examples/tests/valid/lift_this.test.w
@@ -1,6 +1,6 @@
 class Foo {
   inflight x: num;
-  inflight init() {
+  inflight new() {
     this.x = 42;
   }
   inflight bar(): num { 

--- a/examples/tests/valid/lift_via_closure.test.w
+++ b/examples/tests/valid/lift_via_closure.test.w
@@ -9,7 +9,7 @@ let fn = inflight () => {
 class MyClosure {
   pub bucket: cloud.Bucket;
   
-  init() {
+  new() {
     this.bucket = new cloud.Bucket();
   }
 

--- a/examples/tests/valid/lift_via_closure_explicit.test.w
+++ b/examples/tests/valid/lift_via_closure_explicit.test.w
@@ -2,7 +2,7 @@ bring cloud;
 
 class MyClosure {
   q: cloud.Queue;
-  init() {
+  new() {
     this.q = new cloud.Queue();
   }
 

--- a/examples/tests/valid/nil.test.w
+++ b/examples/tests/valid/nil.test.w
@@ -3,7 +3,7 @@ bring cloud;
 class Foo {
   inflight var optionalVar: str?;
   
-  inflight init() {
+  inflight new() {
     this.optionalVar = nil;
   }
 

--- a/examples/tests/valid/optionals.test.w
+++ b/examples/tests/valid/optionals.test.w
@@ -11,13 +11,13 @@ assert(y == 4);
 
 class Super {
   pub name: str;
-  init() { this.name = "Super"; }
+  new() { this.name = "Super"; }
 }
 class Sub extends Super {
-  init() { this.name = "Sub"; }
+  new() { this.name = "Sub"; }
 }
 class Sub1 extends Super {
-  init() { this.name = "Sub"; }
+  new() { this.name = "Sub"; }
 }
 
 let optionalSup: Super? = new Super();
@@ -140,7 +140,7 @@ class Node {
   pub left: Node?;
   pub right: Node?;
 
-  init(value: num, left: Node?, right: Node?) {
+  new(value: num, left: Node?, right: Node?) {
     this.value = value;
     this.left = left;
     this.right = right;

--- a/examples/tests/valid/reassignment.test.w
+++ b/examples/tests/valid/reassignment.test.w
@@ -14,7 +14,7 @@ assert(z == 2);
 class R {
   pub var f: num;
   f1: num;
-  init() {
+  new() {
     // Initialize fields in `init` but in an inner scope to make sure 
     // we treat the special case of `this` access from init correctly at all scope levels
     if true {

--- a/examples/tests/valid/resource.test.w
+++ b/examples/tests/valid/resource.test.w
@@ -5,12 +5,12 @@ class Foo {
   c: cloud.Counter; // Use SDK built in resource in the user defined resource
   pub inflight inflightField: num;
 
-  init() {
+  new() {
     this.c = new cloud.Counter();
   }
 
   // Inflight init
-  inflight init() {
+  inflight new() {
     this.inflightField = 123;
     // Access a cloud resource from inflight init
     this.c.inc(110);
@@ -47,7 +47,7 @@ class Bar {
   // Use an enum inside a user defined resource to verify enum capturing works
   e: MyEnum;
   
-  init(name: str, b: cloud.Bucket, e: MyEnum) {
+  new(name: str, b: cloud.Bucket, e: MyEnum) {
     this.name = name;
     this.b = b;
     this.foo = new Foo();
@@ -105,7 +105,7 @@ class BigPublisher {
   q: cloud.Queue;
   t: cloud.Topic;
 
-  init() {
+  new() {
     this.b = new cloud.Bucket();
     this.b2 = new cloud.Bucket() as "b2";
     this.q = new cloud.Queue();
@@ -150,7 +150,7 @@ class Dummy {
   }
 }
 class ScopeAndIdTestClass {
-  init() {
+  new() {
     // Create a Dummy in my scope
     let d1 = new Dummy();
     assert(d1.node.path.endsWith("/ScopeAndIdTestClass/Dummy"));

--- a/examples/tests/valid/resource_captures.test.w
+++ b/examples/tests/valid/resource_captures.test.w
@@ -3,7 +3,7 @@ bring cloud;
 class First {
   pub myResource: cloud.Bucket;
 
-  init() {
+  new() {
     this.myResource = new cloud.Bucket();
   }
 }
@@ -43,11 +43,11 @@ class MyResource {
   extNum: num;
 
   inflight inflightField: num;
-  inflight init() {
+  inflight new() {
     this.inflightField = 123;
   }
 
-  init(externalBucket: cloud.Bucket, externalNum: num) {
+  new(externalBucket: cloud.Bucket, externalNum: num) {
     this.myResource = new cloud.Bucket();
     this.myStr = "myString";
     this.myNum = 42;

--- a/examples/tests/valid/resource_captures_globals.test.w
+++ b/examples/tests/valid/resource_captures_globals.test.w
@@ -12,7 +12,7 @@ let globalSetOfStr = Set<str>{ "a", "b" };
 class First {
   pub myResource: cloud.Bucket;
 
-  init() {
+  new() {
     this.myResource = new cloud.Bucket();
   }
 }
@@ -26,7 +26,7 @@ class Another {
     this.first = new First();
   }
 
-  inflight init() {
+  inflight new() {
     assert(globalCounter.peek() == 0);
   }
 
@@ -45,7 +45,7 @@ let globalAnother = new Another();
 class MyResource {
   localTopic: cloud.Topic;
   localCounter: cloud.Counter;
-  init() {
+  new() {
     this.localTopic = new cloud.Topic();
     this.localCounter = new cloud.Counter();
     let $parentThis = this;

--- a/examples/tests/valid/static_members.test.w
+++ b/examples/tests/valid/static_members.test.w
@@ -9,7 +9,7 @@ class Foo {
 
   pub static m(): num { return 99; }
 
-  init() {
+  new() {
     this.instanceField = 100;
   }
 
@@ -26,7 +26,7 @@ assert(Foo.m() == 99);
 
 test "test" {
   inflight class InflightClass {
-    init() {}
+    new() {}
     pub inflight inflightMethod(): str {
       return "Inflight method";
     }

--- a/examples/tests/valid/store.w
+++ b/examples/tests/valid/store.w
@@ -9,7 +9,7 @@ pub class Util {}
 
 pub class Store {
   b: cloud.Bucket;
-  init() {
+  new() {
     this.b = new cloud.Bucket();
 
     let prefill = new cloud.OnDeploy(inflight () => {

--- a/examples/tests/valid/structs.test.w
+++ b/examples/tests/valid/structs.test.w
@@ -24,7 +24,7 @@ let y = B {
 class Foo {
   data: B;
 
-  init(b: B) {
+  new(b: B) {
     this.data = b;
   }
 

--- a/examples/tests/valid/subdir/structs_2.w
+++ b/examples/tests/valid/subdir/structs_2.w
@@ -9,7 +9,7 @@ pub struct SomeStruct {
 pub class UsesStructInImportedFile {
   someStruct: SomeStruct;
 
-  init() {
+  new() {
     this.someStruct = SomeStruct.fromJson({foo: "123"});
   }
 }

--- a/examples/tests/valid/super_call.test.w
+++ b/examples/tests/valid/super_call.test.w
@@ -3,7 +3,7 @@ bring expect;
 class A {
   message: str;
 
-  init() {
+  new() {
     this.message = "A message from your ancestor";
   }
 }

--- a/examples/tests/valid/symbol_shadow.test.w
+++ b/examples/tests/valid/symbol_shadow.test.w
@@ -11,7 +11,7 @@ if true {
 assert(s == "top");
 
 class A {
-  init(){
+  new(){
     let s = "inResource";
     assert(s == "inResource");
     test "inflight in resource should capture the right scoped var" {

--- a/examples/tests/valid/use_inflight_method_inside_init_closure.test.w
+++ b/examples/tests/valid/use_inflight_method_inside_init_closure.test.w
@@ -1,7 +1,7 @@
 bring cloud;
 
 class Foo {
-  init() {
+  new() {
     new cloud.Function(inflight () => {
       this.bar();
     });

--- a/examples/wing-fixture/store.w
+++ b/examples/wing-fixture/store.w
@@ -3,7 +3,7 @@ bring "./subdir/util.w" as myutil;
 
 pub class Store {
   data: cloud.Bucket;
-  init() {
+  new() {
     this.data = new cloud.Bucket();
   }
 

--- a/libs/tree-sitter-wing/grammar.js
+++ b/libs/tree-sitter-wing/grammar.js
@@ -462,7 +462,7 @@ module.exports = grammar({
     initializer: ($) =>
       seq(
         optional(field("inflight", $.inflight_specifier)),
-        "init",
+        "new",
         field("parameter_list", $.parameter_list),
         field("block", $.block)
       ),

--- a/libs/tree-sitter-wing/queries/highlights.scm
+++ b/libs/tree-sitter-wing/queries/highlights.scm
@@ -82,7 +82,7 @@
   "for"
   "if"
   "in"
-  "init"
+  "new"
   "let"
   "new"
   "return"

--- a/libs/tree-sitter-wing/test/corpus/statements/class_and_resource.txt
+++ b/libs/tree-sitter-wing/test/corpus/statements/class_and_resource.txt
@@ -3,7 +3,7 @@ Inflight class definition
 ================================================================================
 
 inflight class A {
-    init() {}
+    new() {}
     inflight do_something() {}
     a_member: str;
     var b_member: num;
@@ -70,8 +70,8 @@ Preflight class definition
 ================================================================================
 
 class A {
-    init() {}
-    inflight init() {}
+    new() {}
+    inflight new() {}
     preflight_func() {}
     pub preflight_func2() {}
     inflight inflight_func() {}

--- a/libs/wingsdk/src/cloud/workload.md
+++ b/libs/wingsdk/src/cloud/workload.md
@@ -1,0 +1,375 @@
+---
+title: Workload
+id: workload
+description: A built-in resource for handling containerized workloads
+keywords:
+  [
+    Wing reference,
+    Wing language,
+    language,
+    Wing standard library,
+    Wing programming language,
+    Kubernetes,
+    Containers,
+    Docker,
+    EKS,
+    ECS,
+    AKS
+    GKE
+  ]
+sidebar_position: 1
+---
+
+The `Workload` resource represents a scalable containerized service deployed and managed by a
+container orchestration system such as Kubernetes.
+
+When running locally within the **Wing Simulator**, either during development or during builds,
+workloads are implemented using local docker images.
+
+When running on the cloud, workloads become [Kubernetes](https://kubernetes.io/) applications, built
+and published to an image registry and deployed to a Kubernetes cluster using
+[Helm](https://helm.sh/). We currently only support AWS/EKS but support for other platforms are
+planned.
+
+It will also be possible for platforms to implement workloads using any other compatible container
+orchestration system such as [Amazon ECS](https://aws.amazon.com/ecs/), [fly.io](https://fly.io) or
+[ControlPlane](https://controlplane.com/).
+
+> :warning: This resource is still experimental. Please ping the team on [Wing
+> Slack](https://t.winglang.io/slack) if you encounter any issues or have any questions and let us
+> know what you think. See [roadmap](#roadmap) below for more details about our plans.
+
+## Installation
+
+For the time being, in order to use this resource you will first first need to install
+[@winglibs/containers](https://www.npmjs.com/package/@winglibs/containers) from npm:
+
+```sh
+npm i @winglibs/containers
+```
+
+You will also need [Docker](https://www.docker.com/) or [OrbStack](https://orbstack.dev/) installed
+on your system in order for workloads to work in the Wing Simulator.
+
+## Usage
+
+In your code, just `bring containers` and define workloads using the `containers.Workload` class.
+
+Check out a few examples below or jump to the full [API Reference](#api-reference).
+
+### Using an image from a registry
+
+Let's start with a simple example which defines a workload based on the
+[hashicorp/http-echo](https://github.com/hashicorp/http-echo) image. It is a simple HTTP server
+listening on port 5678 that responds with a message.
+
+```js
+bring containers;
+
+let hello = new containers.Workload(
+  name: "hello",
+  image: "hashicorp/http-echo",
+  port: 5678,
+  public: true,
+  args: ["-text=hello, wingnuts!"],
+);
+```
+
+In order to test this workload, we can use `publicUrl` which resolves to a publicly accessible route
+into your container. And if you were wondering: Yes, this also works on the cloud! Every workload
+with `public: true` will have a URL that can be used to access it from the web.
+
+```js
+bring http;
+bring expect;
+
+test "message is returned in http body" {
+  let url = hello.publicUrl ?? "FAIL";
+  let body = http.get(url).body ?? "FAIL";
+  log(body);
+  expect.equal(body, "hello, wingnuts!\n");
+}
+```
+
+### Building an image from source
+
+Workloads can also be be based on an image defined through a dockerfile within your project. The
+image is automatically built during compilation and published to a container registry during
+deployment.
+
+Let's define a workload which based on the docker image built from the dockerfile in the `./backend`
+directory:
+
+```js
+bring containers;
+
+new containers.Workload(
+  name: "backend",
+  image: "./backend",
+  port: 3000,
+  public: true
+);
+```
+
+Under `./backend`, create:
+
+`backend/Dockerfile`:
+
+```dockerfile
+FROM node:20.8.0-alpine
+EXPOSE 3000
+ADD index.js /app/index.js
+ENTRYPOINT [ "node", "/app/index.js" ]
+```
+
+`backend/index.js`:
+
+```js
+const http = require('http');
+
+process.on('SIGINT', () => process.exit(0));
+
+const server = http.createServer((req, res) => {
+  console.log(`request received: ${req.method} ${req.url}`);
+  res.end('Hello, Wingnuts!');
+});
+
+console.log('listening on port 3000');
+server.listen(3000);
+```
+
+### Defining multiple workloads as microservices
+
+Using `privateUrl`, it is possible to reach workloads without having to expose them publicly.
+
+Let's combine the last two examples by deploying the `http-echo` container and ping it from within
+our docker image:
+
+```js
+bring containers;
+
+let echo = new containers.Workload(
+  name: "echo",
+  image: "hashicorp/http-echo",
+  port: 5678,
+  args: ["-text=hello, wingnuts!"],
+) as "echo";
+
+let backend = new containers.Workload(
+  name: "backend",
+  image: "./backend",
+  port: 3000,
+  public: true,
+  env: {
+    ECHO_URL: echo.internalUrl
+  }
+) as "backend";
+```
+
+In `backend/index.js` file, we can access the internal URL of the `echo` workload
+through `process.env.ECHO_URL`.
+
+Check out the full microservice example
+[here](https://github.com/winglang/containers/blob/main/test/microservices.test.w).
+
+## API Reference
+
+### `name: str`
+
+This is a required option and must be a a unique name for the workload within the application. 
+
+In the `tf-aws` target, this name will be used as the name of the Helm chart and the name of all the
+resources associated with the workload in your Kubernetes cluster.
+
+### `image: str`
+
+This is another required option and can either be the name of a publicly available docker image or a
+relative path to a docker build context directory (with a Dockerfile in it).
+
+### `port: num?`
+
+* `port: num?` (optional): internal port number listening. This is required to connect to a server
+  running inside the container.
+
+### `public: bool?`
+
+If this option is enabled, this workload will be accessible from the public internet through the URL
+returned from `publicUrl`.  When disabled, the container can only be accessed by other workloads in
+the application via its `privateUrl`.
+
+When running in `sim`, the container will be accessible through a `localhost` port.
+
+When running on tf-aws (EKS), an
+[Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) resource will be defined
+for this workload and an ALB (Application Load Balancer) will be allocated. The `publicUrl` of this
+workload will contain the fully qualified host name that can be used to access the container from
+the public internet.
+
+By default, containers are only accessible from within the same application through their
+`privateUrl`.
+
+When `public` is enabled, `port` must also be set.
+
+### `readiness: str?`
+
+If this is specified, it is the URL path to send HTTP GET requests to in order to determine that the
+workload has finished initialization.
+
+When deployed to Kubernetes, this is implemented using a [readiness
+probe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-readiness-probes).
+
+By default, readiness probes are disabled.
+
+### `replicas: num?`
+
+Defines the number of container instances needed for this workload.
+
+When running in the simulator, this option is ignored and there is always a single container.
+
+When running in Kubernetes, this is implemented by setting `replicas` in the [Deployment
+resource](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/) that defines this
+workload.
+
+By default this is set to 1 replica.
+
+### `sources: Array<str>?`
+
+A list of [glob patterns](https://en.wikipedia.org/wiki/Glob_(programming)) which are used to match
+the source files of the container. If any of these files change, the image is rebuilt and
+invalidated. This is only relevant if the image is built from source.
+
+By default, this is all the files under the image directory.
+
+### `args` and `env`
+
+* `args: Array<str>?` (optional): arguments to pass to the entrypoint.
+* `env: Map<str>?` (optional): environment variables.
+
+## Target-specific details
+
+### Simulator (`sim`)
+
+When executed in the Wing Simulator, the workload is started within a local Docker container.
+
+### AWS (`tf-aws`)
+
+Workloads are deployed to a Kubernetes cluster running on [Amazon EKS](https://aws.amazon.com/eks/).
+
+For each application, a Helm chart is synthesized with a
+[Deployment](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/),
+[Service](https://kubernetes.io/docs/concepts/services-networking/service/) and if the workload is
+public, an [Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) as well.
+
+By default, a new Amazon EKS cluster will be provisioned *for each Wing application*. This might be
+okay in a situation where your cluster hosts only a single application, but it is very common to
+share a single cluster across multiple applications.
+
+#### Creating a new EKS cluster
+
+To share a single EKS cluster across multiple Wing applications, you will first need to create a
+cluster in your AWS account. If you already have a cluster, jump to [Deploying into an existing
+cluster](#deploying-into-an-existing-eks-cluster) below.
+
+To create a compatible EKS cluster manually, we recommend to use use the `tfaws.Cluster` resource:
+
+`eks.main.w`:
+
+```js
+bring containers;
+new containers.Cluster("my-wing-cluster");
+```
+
+And provision it using Terraform (this operation could take up to 20 minutes...):
+
+```sh
+wing compile -t tf-aws eks.main.w
+cd target/eks.main.tfaws
+terraform init
+terraform apply
+```
+
+To connect to our new cluster through `kubectl`, use `update-kubeconfig`:
+
+```sh
+aws eks update-kubeconfig --name my-wing-cluster
+```
+
+Then:
+
+```sh
+$ kubectl get all
+NAME                 TYPE        CLUSTER-IP   EXTERNAL-IP   PORT(S)   AGE
+service/kubernetes   ClusterIP   172.20.0.1   <none>        443/TCP   36m
+```
+
+#### Deploying into an existing EKS cluster
+
+To deploy a workload into an the EKS cluster you just created or to an already existing cluster, you
+will need to set the following platform values (this can be done using `-v X=Y` or `--values
+values.yml`):
+
+* `eks.cluster_name`: The name of the cluster
+* `eks.endpoint`: The URL of the Kubernetes API endpoint of the cluster
+* `eks.certificate`: The certificate authority of this cluster.
+
+You can use the [eks-values.sh](https://github.com/winglang/containers/blob/main/eks-values.sh)
+script to obtain the attributes of your EKS cluster.
+
+Install:
+
+```sh
+$ curl https://raw.githubusercontent.com/winglang/containers/main/eks-values.sh > eks-values.sh
+$ chmod +x ./eks-values.sh
+```
+
+Use:
+
+```sh
+$ ./eks-values.sh CLUSTER-NAME > values.yaml
+$ wing compile -t tf-aws --values ./values.yaml main.w
+```
+
+### Azure (`tf-azure`)
+
+Not supported yet.
+
+### GCP (`tf-gcp`)
+
+Not supported yet.
+
+## Roadmap
+
+The following is a non-exhaustive list of capabilities we are looking to add to this resource:
+
+### Scaling
+
+- [ ] Constraints
+- [ ] Autoscaling
+
+### Networking
+
+- [ ] Access `cloud.*` resources from workloads (e.g. put an object in a bucket, poll a queue).
+- [ ] Access something like `Redis` from a workload (unify VPCs)
+- [ ] Access non-public workloads from `cloud.Function`
+
+### API
+
+- [ ] Allow defining workloads using inflights (`cloud.Service`)
+
+### Runtime
+
+- [ ] Logs
+- [ ] Sidecar containers
+
+### Endpoints
+
+- [ ] SSL
+- [ ] Custom domains
+
+### Platforms
+
+- [ ] ECS
+- [ ] GKE
+- [ ] AKS
+- [ ] fly.io
+- [ ] ControlPlane

--- a/libs/wingsdk/src/target-sim/state.md
+++ b/libs/wingsdk/src/target-sim/state.md
@@ -40,7 +40,7 @@ bring sim;
 class MyService {
   startTime: str;
 
-  init() {
+  new() {
     let state = new sim.State();
 
     new cloud.Service(inflight () => {


### PR DESCRIPTION
Class constructors are now called `new()` instead of `init()`.

Resolves #4780

## Checklist

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [x] Tests added (always)
- [x] Docs updated (only required for features)
- [x] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
