### PR TITLE
fix(console): can not run wing it when file path includes src

### DIFF
--- a/apps/wing-console/console/server/src/utils/compiler.ts
+++ b/apps/wing-console/console/server/src/utils/compiler.ts
@@ -62,14 +62,8 @@ export const createCompiler = (wingfile: string): Compiler => {
 
   const dirname = path.dirname(wingfile);
   //TODO: infer React App resource folders from source files https://github.com/winglang/wing/issues/3956
-  const ignoreList = [
-    "**/target/**",
-    "**/node_modules/**",
-    "**/**/wing.js",
-    "**/src/**",
-    "**/build/**",
-    "**/public/**",
-  ];
+  console.log("dirname", dirname);
+  const ignoreList = [`${dirname}/target/**`, "**/node_modules/**"];
   const watcher = chokidar.watch(dirname, {
     ignored: ignoreList,
   });


### PR DESCRIPTION
resolves: https://github.com/winglang/wing/issues/4882
also adjust the console watcher to watch all changes in the wing file parent directory except changes made in node_modules and target dirs

## Checklist

- [ ] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [ ] Description explains motivation and solution
- [ ] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
