### PR TITLE
feat(vscode): goto file in bring statement

### DIFF
--- a/libs/wingc/src/lsp/goto_definition.rs
+++ b/libs/wingc/src/lsp/goto_definition.rs
@@ -67,15 +67,6 @@ pub fn on_goto_definition(params: GotoDefinitionParams) -> Vec<LocationLink> {
 						let path = &path[1..path.len() - 1];
 
 						if let Ok(extern_uri) = uri.join(path) {
-							// make sure it's not a directory
-							if extern_uri
-								.to_file_path()
-								.expect("LSP only works on real filesystems")
-								.is_dir()
-							{
-								return vec![];
-							}
-
 							let node_start = node.start_position();
 							let node_end = node.end_position();
 

--- a/libs/wingc/src/lsp/snapshots/goto_definition/goto_module_path.snap
+++ b/libs/wingc/src/lsp/snapshots/goto_definition/goto_module_path.snap
@@ -1,0 +1,26 @@
+---
+source: libs/wingc/src/lsp/goto_definition.rs
+---
+- originSelectionRange:
+    start:
+      line: 1
+      character: 6
+    end:
+      line: 1
+      character: 16
+  targetUri: "file:///blah.w"
+  targetRange:
+    start:
+      line: 0
+      character: 0
+    end:
+      line: 0
+      character: 0
+  targetSelectionRange:
+    start:
+      line: 0
+      character: 0
+    end:
+      line: 0
+      character: 0
+


### PR DESCRIPTION
Closes #4899

Logic is the same as the extern modifier.
The behavior for a directory is a bit awkward but I decided to leave it in. Ideally, it'd be nice if it just "revealed" the dir in the file explorer, but that'd have to be implemented on a per-editor basis and not part of the LSP.

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
