### PR TITLE
fix(docs): link in the `simulator` section broken

### DIFF
--- a/docs/docs/02-concepts/05-simulator.md
+++ b/docs/docs/02-concepts/05-simulator.md
@@ -5,7 +5,7 @@ description: A facility for executing Wing applications on the local machine for
 keywords: [Wing simulator, simulator]
 ---
 
-The simulator is a built-in [platform provider](./03-platform-provider.md) that comes
+The simulator is a built-in [platform provider](./03-platforms.md) that comes
 provided in Wing for testing applications locally. The simulator does not
 require you to deploy resources to any cloud providers. Since it's a simulation,
 the simulator does not provide the same guarantees as running your application
@@ -14,7 +14,7 @@ application.
 
 There are two main ways to interact with the simulator:
 
-* Running inflight [unit tests](/02-concepts/04-tests.md) with the `wing test` command.
+* Running inflight [unit tests](./04-tests.md) with the `wing test` command.
 * Interacting with the simulated application through the Wing Console
 
 The simulator is also available as a set of APIs exported through the


### PR DESCRIPTION
The link in the `Simulator` section (`platform provider`) is broken.  It has the wrong file path name target.

Also, the `unit tests` link can be shortened to match the `platform provider`.

## Checklist

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [x] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
