### PR TITLE
fix(sdk): popping queue in aws can sometimes throw

### DIFF
--- a/libs/wingsdk/src/shared-aws/queue.inflight.ts
+++ b/libs/wingsdk/src/shared-aws/queue.inflight.ts
@@ -63,7 +63,7 @@ export class QueueClient implements IQueueClient {
       MaxNumberOfMessages: 1,
     });
     const data = await this.client.send(receiveCommand);
-    if (!data.Messages) {
+    if (!data.Messages || data.Messages.length === 0) {
       return undefined;
     }
 


### PR DESCRIPTION
See https://github.com/winglang/wing/actions/runs/6853870493/job/18635846024

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
