### PR TITLE
fix(console): appears to be loading if the app is empty 

### DIFF
--- a/apps/wing-console/console/ui/src/layout/use-layout.tsx
+++ b/apps/wing-console/console/ui/src/layout/use-layout.tsx
@@ -83,9 +83,7 @@ export const useLayout = ({ cloudAppState }: UseLayoutProps) => {
 
   useEffect(() => {
     setLoading(
-      cloudAppState === "loadingSimulator" ||
-        cloudAppState === "compiling" ||
-        items.length === 0,
+      cloudAppState === "loadingSimulator" || cloudAppState === "compiling",
     ),
       [cloudAppState, items.length];
   });

--- a/apps/wing-console/console/ui/src/ui/elk-map.tsx
+++ b/apps/wing-console/console/ui/src/ui/elk-map.tsx
@@ -286,7 +286,7 @@ const Graph = memo(
           "relative",
           "transition-all",
           "rounded-lg",
-          "bg-slate-100 dark:bg-slate-500",
+          nodeList.length > 0 && "bg-slate-100 dark:bg-slate-500",
           durationClass,
         )}
         style={{

--- a/apps/wing-console/console/ui/src/ui/explorer.tsx
+++ b/apps/wing-console/console/ui/src/ui/explorer.tsx
@@ -13,6 +13,7 @@ import { ExplorerItem } from "@wingconsole/server";
 import classNames from "classnames";
 import { memo, useMemo } from "react";
 
+import { NoResources } from "./no-resources.js";
 import { TreeMenuItem } from "./use-tree-menu-items.js";
 
 const renderTreeItems = (items: TreeMenuItem[]) => {
@@ -114,6 +115,7 @@ export const Explorer = memo((props: ExplorerProps) => {
             )}
           >
             <div className="flex flex-col">
+              {expandedItems.length === 0 && <NoResources />}
               <TreeView
                 expandedItems={expandedItems}
                 onExpandedItemsChange={onExpandedItemsChange}

--- a/apps/wing-console/console/ui/src/ui/no-resources.tsx
+++ b/apps/wing-console/console/ui/src/ui/no-resources.tsx
@@ -7,7 +7,7 @@ export const NoResources = () => {
     <div
       className={classNames(
         theme.text2,
-        "flex flex-col text-2xs px-3 py-2 font-mono items-center",
+        "flex flex-col text-xs px-3 py-2 items-center",
       )}
     >
       <div>There are no resources.</div>

--- a/apps/wing-console/console/ui/src/ui/no-resources.tsx
+++ b/apps/wing-console/console/ui/src/ui/no-resources.tsx
@@ -1,0 +1,27 @@
+import { useTheme } from "@wingconsole/design-system";
+import classNames from "classnames";
+
+export const NoResources = () => {
+  const { theme } = useTheme();
+  return (
+    <div
+      className={classNames(
+        theme.text2,
+        "flex flex-col text-2xs px-3 py-2 font-mono items-center",
+      )}
+    >
+      <div>There are no resources.</div>
+      <div>
+        <span>Learn how to add resources </span>
+        <a
+          className="text-sky-500 hover:text-sky-600"
+          href="https://www.winglang.io/docs/category/cloud-library"
+          target="_blank"
+          rel="noreferrer"
+        >
+          here.
+        </a>
+      </div>
+    </div>
+  );
+};

--- a/apps/wing-console/console/ui/src/ui/no-tests.tsx
+++ b/apps/wing-console/console/ui/src/ui/no-tests.tsx
@@ -7,7 +7,7 @@ export const NoTests = () => {
     <div
       className={classNames(
         theme.text2,
-        "flex flex-col text-2xs px-3 py-2 font-mono items-center",
+        "flex flex-col text-xs px-3 py-2 items-center",
       )}
     >
       <div>There are no tests.</div>


### PR DESCRIPTION
Resolves https://github.com/winglang/wing/issues/4868.

* Removes the loading indicator when the app is empty
* Removes the map background
* Adds a warning in the Explorer when the app is empty

<img width="990" alt="image" src="https://github.com/winglang/wing/assets/5547636/030ccc53-9361-42c7-ae72-3ead713512ee">

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
