### PR TITLE
chore: remove some ceremony from bug template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -6,10 +6,12 @@ body:
   attributes:
     value: |
        :pray: Thanks for taking the time to fill out this bug report! Feel free to ping us on [Wing Slack](https://t.winglang.io/slack) if you have any questions or need help.
+
 - type: markdown
   attributes:
     value: |
        ## Bug Report
+
 - type: textarea
   id: i-tried-this
   attributes:
@@ -17,13 +19,15 @@ body:
     placeholder: "What did you try to do? A code snippet or exact command line is ideal."
   validations:
     required: true
+
 - type: textarea
   id: instead-what-happened
   attributes:
     label: "This happened:"
-    placeholder: "What happend instead of what you've expected?"
+    placeholder: "What happened instead of what you've expected?"
   validations:
     required: true
+
 - type: textarea
   id: what-did-you-expect
   attributes:
@@ -31,33 +35,19 @@ body:
     placeholder: "What did you expect to happen? Describe the output or behavior you expected to see."
   validations:
     required: true    
+
 - type: textarea
   id: workaround
   attributes:
     label: "Is there a workaround?"
     placeholder: "What's the workaround to avoid this issue?"
-- type: dropdown
-  id: Component
+
+- type: textarea
   attributes:
-    label: "Component"
-    description: "Which component(s) in the toolchain is this related to?"
-    multiple: true
-    options:
-    - Language Design
-    - Compiler
-    - SDK
-    - Wing Console
-    - Playground
-    - Tutorial
-    - IDE Extension
-    - CLI
-    - Plugins
-    - Documentation
-    - Development Environment
-    - Contributor Experience
-    - Other
-  validations:
-    required: true
+    label: Anything else?
+    placeholder: |
+      Links? References? Logs? Anything that will give us more context about the issue you are encountering.
+      Tip: You can attach images or log files by dragging files in.
 
 - type: markdown
   attributes:
@@ -86,20 +76,6 @@ body:
       - Linux
       - Windows
       - Other
-
-- type: markdown
-  attributes:
-    value: |
-       ## Misc
-
-- type: textarea
-  attributes:
-    label: Anything else?
-    placeholder: |
-      Links? References? Logs? Anything that will give us more context about the issue you are encountering.
-      Tip: You can attach images or log files by dragging files in.
-  validations:
-    required: false
 
 - type: textarea
   attributes:


### PR DESCRIPTION
- Removed the "component" section. 
  - IMO it's not the responsibility of a bug reporter to know how maintainers categorize issues. This is better suited for labels at our discretion.
- Moved the "Anything Else" to be next to the rest of the actual bug report.
  - This additional context is likely more useful than the version information and putting it before that increases the chances of it being filled in
  - Removed `## Misc` since it didn't really matter without the "Anything Else"
- Added whitespace to make it consistent
- Fixed minor typo

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
