### PR TITLE
fix(console): unnecessary compilations during init

### DIFF
--- a/apps/wing-console/console/server/src/utils/compiler.ts
+++ b/apps/wing-console/console/server/src/utils/compiler.ts
@@ -68,6 +68,7 @@ export const createCompiler = (wingfile: string): Compiler => {
   const ignoreList = [`${dirname}/target/**`, "**/node_modules/**"];
   const watcher = chokidar.watch(dirname, {
     ignored: ignoreList,
+    ignoreInitial: true,
   });
   watcher.on("change", recompile);
   watcher.on("add", recompile);
@@ -77,6 +78,8 @@ export const createCompiler = (wingfile: string): Compiler => {
     }
     void recompile();
   });
+
+  void recompile();
 
   return {
     async start() {

--- a/apps/wing-console/console/server/src/utils/compiler.ts
+++ b/apps/wing-console/console/server/src/utils/compiler.ts
@@ -65,7 +65,11 @@ export const createCompiler = (wingfile: string): Compiler => {
 
   const dirname = path.dirname(wingfile);
   //TODO: infer React App resource folders from source files https://github.com/winglang/wing/issues/3956
-  const ignoreList = [`${dirname}/target/**`, "**/node_modules/**"];
+  const ignoreList = [
+    `${dirname}/target/**`,
+    "**/node_modules/**",
+    "**/.git/**",
+  ];
   const watcher = chokidar.watch(dirname, {
     ignored: ignoreList,
     ignoreInitial: true,


### PR DESCRIPTION
The Console Server triggers some compilations during the initialization of the watcher.

Also, it now ignores the `.git` directory.