### PR TITLE
feat(console): add layout for wingcloud integration

### DIFF
--- a/apps/wing-console/console/ui/src/layout/layout-provider.tsx
+++ b/apps/wing-console/console/ui/src/layout/layout-provider.tsx
@@ -7,7 +7,7 @@ export enum LayoutType {
   Playground,
   Tutorial,
   Vscode,
-  wingcloud,
+  WingCloud,
 }
 
 export const LayoutContext = createContext(LayoutType.Default);
@@ -85,7 +85,7 @@ export function LayoutProvider({
       };
       break;
     }
-    case LayoutType.wingcloud: {
+    case LayoutType.WingCloud: {
       layoutConfig = {
         statusBar: {
           hide: true,

--- a/apps/wing-console/console/ui/src/layout/layout-provider.tsx
+++ b/apps/wing-console/console/ui/src/layout/layout-provider.tsx
@@ -7,6 +7,7 @@ export enum LayoutType {
   Playground,
   Tutorial,
   Vscode,
+  wingcloud,
 }
 
 export const LayoutContext = createContext(LayoutType.Default);
@@ -78,6 +79,14 @@ export function LayoutProvider({
         bottomPanel: {
           hide: true,
         },
+        statusBar: {
+          hide: true,
+        },
+      };
+      break;
+    }
+    case LayoutType.wingcloud: {
+      layoutConfig = {
         statusBar: {
           hide: true,
         },


### PR DESCRIPTION
Hides the console status bar when using the console inside wingcloud.

<img width="1225" alt="image" src="https://github.com/winglang/wing/assets/5547636/730985e9-17fc-4819-8f22-27060ce8a02e">


*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
