### PR TITLE
chore: make "expected" field optional in bug report

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -34,7 +34,6 @@ body:
     label: "I expected this:"
     placeholder: "What did you expect to happen? Describe the output or behavior you expected to see (unless it's obvious)."
   validations:
-    required: false    
 
 - type: textarea
   id: workaround

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -33,7 +33,6 @@ body:
   attributes:
     label: "I expected this:"
     placeholder: "What did you expect to happen? Describe the output or behavior you expected to see (unless it's obvious)."
-  validations:
 
 - type: textarea
   id: workaround

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -32,9 +32,9 @@ body:
   id: what-did-you-expect
   attributes:
     label: "I expected this:"
-    placeholder: "What did you expect to happen? Describe the output or behavior you expected to see."
+    placeholder: "What did you expect to happen? Describe the output or behavior you expected to see (unless it's obvious)."
   validations:
-    required: true    
+    required: false    
 
 - type: textarea
   id: workaround


### PR DESCRIPTION
Many times it's obvious

## Checklist

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [x] Tests added (always)
- [x] Docs updated (only required for features)
- [x] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
