### PR TITLE
feat(cli): add testing for failed analytics

### DIFF
--- a/apps/wing/src/cli.ts
+++ b/apps/wing/src/cli.ts
@@ -7,7 +7,7 @@ import { currentPackage } from "./util";
 export const PACKAGE_VERSION = currentPackage.version;
 let analyticsExportFile: Promise<string | undefined>;
 
-if (PACKAGE_VERSION == "0.0.0" && !process.env.DEBUG) {
+if (PACKAGE_VERSION == "0.0.0" && !process.env.WING_ANALYTICS_FORCE_EXPORT) {
   process.env.WING_DISABLE_ANALYTICS = "1";
 }
 

--- a/tools/hangar/src/analytics-export.test.ts
+++ b/tools/hangar/src/analytics-export.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from "vitest";
+import * as path from "path";
+import { runWingCommand } from "./utils";
+import { sdkTests } from "./paths";
+
+describe("analytics export", () => {
+  describe("when run in detached mode", () => {
+    test("invalid analytics reporting does not throw an error", async () => {
+      const args = ["compile"];
+      const platforms = ["sim"];
+      const appFile = path.join(sdkTests, "std", "bool.test.w");
+      
+      await runWingCommand({
+        cwd: sdkTests,
+        platforms,
+        wingFile: appFile,
+        args,
+        expectFailure: false, // should not fail even though analytics export fails
+        enableAnalytics: true,
+        env: {
+          WING_SEGMENT_WRITE_KEY: "uber-fake-key",
+          WING_ANALYTICS_FORCE_FAIL: "1",
+          WING_ANALYTICS_FORCE_EXPORT: "1",
+        }
+      });
+    });
+  });
+
+  describe("when run in attached mode", () => {
+    test("throws an error if the export fails", async () => {
+      const args = ["compile"];
+      const platforms = ["sim"];
+      const appFile = path.join(sdkTests, "std", "bool.test.w");
+      
+      await runWingCommand({
+        cwd: sdkTests,
+        platforms,
+        wingFile: appFile,
+        args,
+        expectFailure: true,
+        enableAnalytics: true,
+        env: {
+          WING_SEGMENT_WRITE_KEY: "uber-fake-key",
+          WING_ANALYTICS_RUN_ATTACHED: "1",
+          WING_ANALYTICS_FORCE_FAIL: "1",
+          WING_ANALYTICS_FORCE_EXPORT: "1",
+        }
+      });
+
+    });
+
+    test("throws an error when unable to reach segment host", async () => {
+      const args = ["compile"];
+      const platforms = ["sim"];
+      const appFile = path.join(sdkTests, "std", "bool.test.w");
+      
+      await runWingCommand({
+        cwd: sdkTests,
+        platforms,
+        wingFile: appFile,
+        args,
+        expectFailure: true,
+        enableAnalytics: true,
+        env: {
+          WING_ANALYTICS_RUN_ATTACHED: "1",
+          WING_SEGMENT_WRITE_KEY: "uber-fake-key",
+          WING_ANALYTICS_HOST: "localhost/invalid",
+          WING_ANALYTICS_FORCE_EXPORT: "1",
+        }
+      });
+    });
+  });
+});

--- a/tools/hangar/src/utils.ts
+++ b/tools/hangar/src/utils.ts
@@ -9,6 +9,7 @@ export interface RunWingCommandOptions {
   wingFile?: string;
   args: string[];
   expectFailure: boolean;
+  enableAnalytics?: boolean;
   platforms?: string[];
   env?: Record<string, string>;
 }
@@ -17,11 +18,12 @@ export async function runWingCommand(options: RunWingCommandOptions) {
   const platformOptions: string[] = [];
   options.platforms?.forEach((p) => platformOptions.push(...["-t", `${p}`])) ??
     [];
+  const analyticsOptions = options.enableAnalytics ? [] : ["--no-analytics"];
   const out = await execa(
     wingBin,
     [
       "--no-update-check",
-      "--no-analytics",
+      ...analyticsOptions,
       ...options.args,
       options.wingFile ?? "",
       ...platformOptions,


### PR DESCRIPTION
Initial work for more testing around analytics exporting.

## TODO
- [ ] add workflow that runs in attached mode to check for failures

## Checklist

- [ ] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [ ] Description explains motivation and solution
- [ ] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
