### PR TITLE
fix(sdk): add missing `module` object to platform vm context

### DIFF
--- a/libs/wingsdk/src/platform/platform-manager.ts
+++ b/libs/wingsdk/src/platform/platform-manager.ts
@@ -159,11 +159,14 @@ export function _loadCustomPlatform(customPlatformPath: string): any {
 
   platformRequire.resolve = requireResolve;
 
-  const platformExports = {};
+  const platformModule = {
+    exports: {},
+  };
   const context = vm.createContext({
     require: platformRequire,
     console,
-    exports: platformExports,
+    exports: platformModule.exports,
+    module: platformModule,
     process,
     __dirname: customPlatformPath,
   });
@@ -172,7 +175,7 @@ export function _loadCustomPlatform(customPlatformPath: string): any {
     const platformCode = readFileSync(fullCustomPlatformPath, "utf-8");
     const script = new vm.Script(platformCode);
     script.runInContext(context);
-    return new (platformExports as any).Platform();
+    return new (platformModule.exports as any).Platform();
   } catch (error) {
     console.error(
       "An error occurred while loading the custom platform:",


### PR DESCRIPTION
CommonJS scripts can export via `exports` or `module.exports`. The latter was missing from the VM created by the platform manager.
