### PR TITLE
fix(platforms): custom platform fails for wing test

### DIFF
--- a/libs/wingsdk/src/std/resource.ts
+++ b/libs/wingsdk/src/std/resource.ts
@@ -201,8 +201,8 @@ export abstract class Resource extends Construct implements IResource {
     let appScope: App | undefined;
     let findScope: IConstruct | undefined = scope;
     while (findScope !== undefined) {
-      if (findScope instanceof App) {
-        appScope = findScope;
+      if ((findScope as any)._isApp) {
+        appScope = findScope as App;
         break;
       }
       findScope = findScope.node.scope;


### PR DESCRIPTION
Quick fix to use the _isApp hack for determining App node in tree

Closes: https://github.com/winglang/wing/issues/5028

## Checklist

- [ ] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [ ] Description explains motivation and solution
- [ ] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
