### PR TITLE
chore(sdk): fix node.test.w test on windows 

### DIFF
--- a/examples/tests/sdk_tests/std/node.test.w
+++ b/examples/tests/sdk_tests/std/node.test.w
@@ -8,7 +8,7 @@ let root = std.Node.of(bucket).root;
 assert(app.workdir.endsWith(".wing"));
 expect.equal(app.workdir, root.workdir);
 
-assert(app.entrypointDir.endsWith("/sdk_tests/std"));
+assert(app.entrypointDir.endsWith("/sdk_tests/std") || app.entrypointDir.endsWith("\\sdk_tests\\std"));
 expect.equal(app.entrypointDir, root.entrypointDir);
 
 app.isTestEnvironment; // don't care if it's true or false, just that it compiles


### PR DESCRIPTION
Chose not to `.replace("\\", "/")` to make the intention as explicit as possible

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
