### PR TITLE
fix(sdk): add (back in) scope id to react app

### DIFF
--- a/libs/wingsdk/src/target-sim/react-app.ts
+++ b/libs/wingsdk/src/target-sim/react-app.ts
@@ -23,7 +23,7 @@ export class ReactApp extends ex.ReactApp implements ISimulatorResource {
 
     if (this._useBuildCommand) {
       // In the future we can create an host (proxy like) for the development one if needed
-      this._host = new cloud.Website(this, "host", {
+      this._host = new cloud.Website(this, `${this.node.id}-host`, {
         ...this._hostProps,
         path: this._buildPath,
       });


### PR DESCRIPTION
See failing test here https://github.com/winglang/wing/actions/runs/6990660035/job/19020417470

Previous PR removed this as part of a larger effort to remove redundant ids (no functional reason to re-add your parents' id). This caused a test to fail, and I realized that in this case it is kinda useful to carry the name forward. So let's call this an exception.

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
