### PR TITLE
fix(cli): load test runner for custom platform

### DIFF
--- a/apps/wing/src/commands/test/test.test.ts
+++ b/apps/wing/src/commands/test/test.test.ts
@@ -46,6 +46,48 @@ describe("printing test reports", () => {
   });
 });
 
+describe("wing test (custom platform)", () => {
+  let logSpy: SpyInstance;
+
+  beforeEach(() => {
+    chalk.level = 0;
+    logSpy = vi.spyOn(console, "log");
+  });
+
+  afterEach(() => {
+    chalk.level = defaultChalkLevel;
+    process.chdir(cwd);
+    logSpy.mockRestore();
+  });
+
+  test("test runner is loaded properly for customized tf-aws platform", async () => {
+    const outDir = await fsPromises.mkdtemp(join(tmpdir(), "-wing-compile-test"));
+
+    // can't be resolved within tmp directory
+    const targetTfAws = require.resolve("@winglang/sdk/lib/target-tf-aws");
+
+    process.chdir(outDir);
+    fs.writeFileSync("foo.test.w", `bring cloud;`);
+    fs.writeFileSync("custom-platform.js", `
+      const tfaws = require("${targetTfAws}");
+      class Platform {
+        target = "tf-aws";
+
+        newApp(appProps) {
+          return new tfaws.App(appProps);
+        }
+      }
+      module.exports = { Platform }`
+    );
+
+    await wingTest([], { clean: true, platform: ["./custom-platform.js"] });
+
+    expect(logSpy).toHaveBeenCalledWith(
+      expect.stringMatching(/^pass ─ foo\.test\.tfaws\.\d+ \(no tests\)$/)
+    );
+  });
+});
+
 describe("wing test (no options)", () => {
   let logSpy: SpyInstance;
 

--- a/apps/wing/src/commands/test/test.test.ts
+++ b/apps/wing/src/commands/test/test.test.ts
@@ -68,7 +68,9 @@ describe("wing test (custom platform)", () => {
 
     process.chdir(outDir);
     fs.writeFileSync("foo.test.w", `bring cloud;`);
-    fs.writeFileSync("custom-platform.js", `
+    fs.writeFileSync(
+      "custom-platform.js",
+      `
       const tfaws = require("${targetTfAws}");
       class Platform {
         target = "tf-aws";

--- a/apps/wing/src/commands/test/test.ts
+++ b/apps/wing/src/commands/test/test.ts
@@ -315,10 +315,11 @@ async function testTf(synthDir: string, options: TestOptions): Promise<std.TestR
     await withSpinner("terraform apply", () => terraformApply(synthDir));
 
     const [testRunner, tests] = await withSpinner("Setting up test runner...", async () => {
+      const target = determineTargetFromPlatforms(platform);
+      const testRunnerPath = `@winglang/sdk/lib/${targetFolder[target]}/test-runner.inflight`;
+
       const testArns = await terraformOutput(synthDir, ENV_WING_TEST_RUNNER_FUNCTION_IDENTIFIERS);
-      const { TestRunnerClient } = await import(
-        `@winglang/sdk/lib/${targetFolder[platform[0]]}/test-runner.inflight`
-      );
+      const { TestRunnerClient } = await import(testRunnerPath);
       const runner = new TestRunnerClient(testArns);
 
       const allTests = await runner.listTests();


### PR DESCRIPTION
fixes `wing test -t @my-custom/platform main.w`, where `@my-custom/platform` extends the `tf-aws` platform. The error which occurred after `terraform apply`:

```
Cannot find module '@winglang/sdk/lib/undefined/test-runner.inflight'
```

## Checklist

- [ ] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [ ] Description explains motivation and solution
- [ ] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
