### PR TITLE
fix(sdk): external platforms may have error when lifting resources

### DIFF
--- a/libs/wingsdk/src/std/resource.ts
+++ b/libs/wingsdk/src/std/resource.ts
@@ -169,6 +169,14 @@ export abstract class Resource extends Construct implements IResource {
           return;
         }
 
+        // structs are just plain objects
+        if (obj.constructor.name === "Object") {
+          Object.values(obj).forEach((item) =>
+            this._registerOnLiftObject(item, host, ops)
+          );
+          return;
+        }
+
         // if the object is a resource, register a lifting between it and the host.
         if (typeof obj._addOnLift === "function") {
           // Explicitly register the resource's `$inflight_init` op, which is a special op that can be used to makes sure
@@ -177,13 +185,6 @@ export abstract class Resource extends Construct implements IResource {
           return;
         }
 
-        // structs are just plain objects
-        if (obj.constructor.name === "Object") {
-          Object.values(obj).forEach((item) =>
-            this._registerOnLiftObject(item, host, ops)
-          );
-          return;
-        }
         break;
 
       case "function":

--- a/libs/wingsdk/src/std/resource.ts
+++ b/libs/wingsdk/src/std/resource.ts
@@ -170,10 +170,10 @@ export abstract class Resource extends Construct implements IResource {
         }
 
         // if the object is a resource, register a lifting between it and the host.
-        if (obj instanceof Resource) {
+        if (typeof obj._addOnLift === "function") {
           // Explicitly register the resource's `$inflight_init` op, which is a special op that can be used to makes sure
           // the host can instantiate a client for this resource.
-          (obj as any)._addOnLift(host, [...ops, "$inflight_init"]);
+          obj._addOnLift(host, [...ops, "$inflight_init"]);
           return;
         }
 


### PR DESCRIPTION
Fixes #5064

`instanceof` strikes again.

Technically hangar already tests the case that failed here, but the test did not fail in hangar. I don't actually have an answer for why this is. My guess is that the cwd hangar runs in affected the modules loaded.

I did not add any testing here because afaik we are not currently equipped to test this scenario properly (we need https://github.com/winglang/wing/issues/3390), so I only tested that this fix worked locally.

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
