### PR TITLE
fix: error when calling inherited inflight methods

### DIFF
--- a/examples/tests/valid/inheritance_class_inflight.test.w
+++ b/examples/tests/valid/inheritance_class_inflight.test.w
@@ -1,0 +1,19 @@
+bring expect;
+
+class FooBase {
+  pub inflight bug(): num { return 42; }
+  pub inflight over_inflight(): num { return 123; }
+}
+
+class Foo extends FooBase {
+  pub inflight bang(): Array<str> { return ["hi"]; }
+  pub inflight over_inflight(): num { return 456; }
+}
+
+let foo = new Foo();
+
+test "class inheritence" {
+  expect.equal(foo.bang(), ["hi"]);
+  expect.equal(foo.bug(), 42);
+  expect.equal(foo.over_inflight(), 456);
+}

--- a/examples/tests/valid/inheritance_class_preflight.test.w
+++ b/examples/tests/valid/inheritance_class_preflight.test.w
@@ -1,0 +1,17 @@
+bring expect;
+
+class FooBase {
+  pub bar(): str { return "bar"; }
+  pub over(): str { return "base"; }
+}
+
+class Foo extends FooBase {
+  pub baz(): bool { return true; }
+  pub over(): str { return "derived"; }
+}
+
+let foo = new Foo();
+expect.equal(foo.bar(), "bar");
+expect.equal(foo.baz(), true);
+expect.equal(foo.over(), "derived");
+

--- a/libs/wingc/src/jsify.rs
+++ b/libs/wingc/src/jsify.rs
@@ -1491,7 +1491,7 @@ impl<'a> JSifier<'a> {
 			ops.push(format!("\"{}\"", method.name.as_ref().unwrap().name));
 		}
 
-		code.line(format!("return [{}];", ops.join(", ")));
+		code.line(format!("return [...super._supportedOps(), {}];", ops.join(", ")));
 		code.close("}");
 		code
 	}

--- a/libs/wingc/src/jsify/snapshots/access_methods_and_properties_on_collections.snap
+++ b/libs/wingc/src/jsify/snapshots/access_methods_and_properties_on_collections.snap
@@ -74,7 +74,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {

--- a/libs/wingc/src/jsify/snapshots/access_property_on_primitive.snap
+++ b/libs/wingc/src/jsify/snapshots/access_property_on_primitive.snap
@@ -70,7 +70,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {

--- a/libs/wingc/src/jsify/snapshots/access_property_on_value_returned_from_collection.snap
+++ b/libs/wingc/src/jsify/snapshots/access_property_on_value_returned_from_collection.snap
@@ -70,7 +70,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {

--- a/libs/wingc/src/jsify/snapshots/base_class_captures_inflight.snap
+++ b/libs/wingc/src/jsify/snapshots/base_class_captures_inflight.snap
@@ -91,7 +91,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["bar", "$inflight_init"];
+        return [...super._supportedOps(), "bar", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("bar")) {
@@ -123,7 +123,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["foo", "$inflight_init"];
+        return [...super._supportedOps(), "foo", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("foo")) {

--- a/libs/wingc/src/jsify/snapshots/base_class_captures_preflight.snap
+++ b/libs/wingc/src/jsify/snapshots/base_class_captures_preflight.snap
@@ -87,7 +87,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["$inflight_init"];
+        return [...super._supportedOps(), "$inflight_init"];
       }
     }
     class Derived extends Base {
@@ -116,7 +116,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["$inflight_init"];
+        return [...super._supportedOps(), "$inflight_init"];
       }
     }
     const x = "hello";

--- a/libs/wingc/src/jsify/snapshots/base_class_lift_indirect.snap
+++ b/libs/wingc/src/jsify/snapshots/base_class_lift_indirect.snap
@@ -101,7 +101,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["put", "$inflight_init"];
+        return [...super._supportedOps(), "put", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("$inflight_init")) {
@@ -136,7 +136,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["foo", "$inflight_init"];
+        return [...super._supportedOps(), "foo", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("foo")) {

--- a/libs/wingc/src/jsify/snapshots/base_class_with_fields_inflight.snap
+++ b/libs/wingc/src/jsify/snapshots/base_class_with_fields_inflight.snap
@@ -99,7 +99,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["f", "$inflight_init"];
+        return [...super._supportedOps(), "f", "$inflight_init"];
       }
     }
     class Derived extends Base {
@@ -125,7 +125,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["g", "foo", "$inflight_init"];
+        return [...super._supportedOps(), "g", "foo", "$inflight_init"];
       }
     }
   }

--- a/libs/wingc/src/jsify/snapshots/base_class_with_fields_preflight.snap
+++ b/libs/wingc/src/jsify/snapshots/base_class_with_fields_preflight.snap
@@ -90,7 +90,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["$inflight_init"];
+        return [...super._supportedOps(), "$inflight_init"];
       }
     }
     class Derived extends Base {
@@ -121,7 +121,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["$inflight_init"];
+        return [...super._supportedOps(), "$inflight_init"];
       }
     }
   }

--- a/libs/wingc/src/jsify/snapshots/base_class_with_lifted_field_object.snap
+++ b/libs/wingc/src/jsify/snapshots/base_class_with_lifted_field_object.snap
@@ -91,7 +91,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["$inflight_init"];
+        return [...super._supportedOps(), "$inflight_init"];
       }
     }
     class Derived extends Base {
@@ -118,7 +118,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["foo", "$inflight_init"];
+        return [...super._supportedOps(), "foo", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("$inflight_init")) {

--- a/libs/wingc/src/jsify/snapshots/base_class_with_lifted_fields.snap
+++ b/libs/wingc/src/jsify/snapshots/base_class_with_lifted_fields.snap
@@ -90,7 +90,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["$inflight_init"];
+        return [...super._supportedOps(), "$inflight_init"];
       }
     }
     class Derived extends Base {
@@ -117,7 +117,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["foo", "$inflight_init"];
+        return [...super._supportedOps(), "foo", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("$inflight_init")) {

--- a/libs/wingc/src/jsify/snapshots/builtins.snap
+++ b/libs/wingc/src/jsify/snapshots/builtins.snap
@@ -67,7 +67,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
     }
     this.node.root.new("@winglang/sdk.std.Test", std.Test, this, "test:test", new $Closure1(this, "$Closure1"));

--- a/libs/wingc/src/jsify/snapshots/call_static_inflight_from_static_inflight.snap
+++ b/libs/wingc/src/jsify/snapshots/call_static_inflight_from_static_inflight.snap
@@ -83,7 +83,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["foo", "$inflight_init"];
+        return [...super._supportedOps(), "foo", "$inflight_init"];
       }
     }
     class B extends $stdlib.std.Resource {
@@ -109,7 +109,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["bar", "$inflight_init"];
+        return [...super._supportedOps(), "bar", "$inflight_init"];
       }
       static _registerOnLift(host, ops) {
         if (ops.includes("bar")) {

--- a/libs/wingc/src/jsify/snapshots/calls_methods_on_preflight_object.snap
+++ b/libs/wingc/src/jsify/snapshots/calls_methods_on_preflight_object.snap
@@ -74,7 +74,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {

--- a/libs/wingc/src/jsify/snapshots/capture_from_inside_an_inflight_closure.snap
+++ b/libs/wingc/src/jsify/snapshots/capture_from_inside_an_inflight_closure.snap
@@ -74,7 +74,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {

--- a/libs/wingc/src/jsify/snapshots/capture_identifier_closure_from_preflight_scope.snap
+++ b/libs/wingc/src/jsify/snapshots/capture_identifier_closure_from_preflight_scope.snap
@@ -87,7 +87,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
     }
     class $Closure2 extends $stdlib.std.Resource {
@@ -115,7 +115,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {

--- a/libs/wingc/src/jsify/snapshots/capture_identifier_from_preflight_scope.snap
+++ b/libs/wingc/src/jsify/snapshots/capture_identifier_from_preflight_scope.snap
@@ -69,7 +69,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {

--- a/libs/wingc/src/jsify/snapshots/capture_identifier_from_preflight_scope_with_method_call.snap
+++ b/libs/wingc/src/jsify/snapshots/capture_identifier_from_preflight_scope_with_method_call.snap
@@ -86,7 +86,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["bar", "$inflight_init"];
+        return [...super._supportedOps(), "bar", "$inflight_init"];
       }
     }
     class $Closure1 extends $stdlib.std.Resource {
@@ -114,7 +114,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {

--- a/libs/wingc/src/jsify/snapshots/capture_identifier_from_preflight_scope_with_nested_object.snap
+++ b/libs/wingc/src/jsify/snapshots/capture_identifier_from_preflight_scope_with_nested_object.snap
@@ -91,7 +91,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["$inflight_init"];
+        return [...super._supportedOps(), "$inflight_init"];
       }
     }
     class $Closure1 extends $stdlib.std.Resource {
@@ -119,7 +119,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {

--- a/libs/wingc/src/jsify/snapshots/capture_identifier_from_preflight_scope_with_property.snap
+++ b/libs/wingc/src/jsify/snapshots/capture_identifier_from_preflight_scope_with_property.snap
@@ -69,7 +69,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {

--- a/libs/wingc/src/jsify/snapshots/capture_in_keyword_args.snap
+++ b/libs/wingc/src/jsify/snapshots/capture_in_keyword_args.snap
@@ -75,7 +75,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {

--- a/libs/wingc/src/jsify/snapshots/capture_object_with_this_in_name.snap
+++ b/libs/wingc/src/jsify/snapshots/capture_object_with_this_in_name.snap
@@ -71,7 +71,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {

--- a/libs/wingc/src/jsify/snapshots/capture_token.snap
+++ b/libs/wingc/src/jsify/snapshots/capture_token.snap
@@ -70,7 +70,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {

--- a/libs/wingc/src/jsify/snapshots/capture_type_inflight_class_sibling_from_init.snap
+++ b/libs/wingc/src/jsify/snapshots/capture_type_inflight_class_sibling_from_init.snap
@@ -92,7 +92,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
     }
     this.node.root.new("@winglang/sdk.std.Test", std.Test, this, "test:test", new $Closure1(this, "$Closure1"));

--- a/libs/wingc/src/jsify/snapshots/capture_type_inflight_class_sibling_from_method.snap
+++ b/libs/wingc/src/jsify/snapshots/capture_type_inflight_class_sibling_from_method.snap
@@ -78,7 +78,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
     }
     this.node.root.new("@winglang/sdk.std.Test", std.Test, this, "test:test", new $Closure1(this, "$Closure1"));

--- a/libs/wingc/src/jsify/snapshots/capture_type_new_inflight_class_inner_no_capture.snap
+++ b/libs/wingc/src/jsify/snapshots/capture_type_new_inflight_class_inner_no_capture.snap
@@ -70,7 +70,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
     }
     this.node.root.new("@winglang/sdk.std.Test", std.Test, this, "test:test", new $Closure1(this, "$Closure1"));

--- a/libs/wingc/src/jsify/snapshots/capture_type_new_inflight_class_outer.snap
+++ b/libs/wingc/src/jsify/snapshots/capture_type_new_inflight_class_outer.snap
@@ -79,7 +79,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["$inflight_init"];
+        return [...super._supportedOps(), "$inflight_init"];
       }
     }
     class $Closure1 extends $stdlib.std.Resource {
@@ -107,7 +107,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
     }
     this.node.root.new("@winglang/sdk.std.Test", std.Test, this, "test:test", new $Closure1(this, "$Closure1"));

--- a/libs/wingc/src/jsify/snapshots/capture_type_static_method.snap
+++ b/libs/wingc/src/jsify/snapshots/capture_type_static_method.snap
@@ -86,7 +86,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["bars", "$inflight_init"];
+        return [...super._supportedOps(), "bars", "$inflight_init"];
       }
     }
     class $Closure1 extends $stdlib.std.Resource {
@@ -114,7 +114,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {

--- a/libs/wingc/src/jsify/snapshots/capture_type_static_method_inflight_class.snap
+++ b/libs/wingc/src/jsify/snapshots/capture_type_static_method_inflight_class.snap
@@ -84,7 +84,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["bar", "$inflight_init"];
+        return [...super._supportedOps(), "bar", "$inflight_init"];
       }
     }
     class $Closure1 extends $stdlib.std.Resource {
@@ -112,7 +112,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
     }
     this.node.root.new("@winglang/sdk.std.Test", std.Test, this, "test:test", new $Closure1(this, "$Closure1"));

--- a/libs/wingc/src/jsify/snapshots/capture_var_from_method_inflight.snap
+++ b/libs/wingc/src/jsify/snapshots/capture_var_from_method_inflight.snap
@@ -75,7 +75,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
     }
     this.node.root.new("@winglang/sdk.std.Test", std.Test, this, "test:test", new $Closure1(this, "$Closure1"));

--- a/libs/wingc/src/jsify/snapshots/closed_inflight_class_extends_outer_inflight_class.snap
+++ b/libs/wingc/src/jsify/snapshots/closed_inflight_class_extends_outer_inflight_class.snap
@@ -82,7 +82,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["$inflight_init"];
+        return [...super._supportedOps(), "$inflight_init"];
       }
     }
     class $Closure1 extends $stdlib.std.Resource {
@@ -110,7 +110,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
     }
     this.node.root.new("@winglang/sdk.std.Test", std.Test, this, "test:test", new $Closure1(this, "$Closure1"));

--- a/libs/wingc/src/jsify/snapshots/closure_field.snap
+++ b/libs/wingc/src/jsify/snapshots/closure_field.snap
@@ -134,7 +134,7 @@ class $Root extends $stdlib.std.Resource {
             `;
           }
           _supportedOps() {
-            return ["handle", "$inflight_init"];
+            return [...super._supportedOps(), "handle", "$inflight_init"];
           }
           _registerOnLift(host, ops) {
             if (ops.includes("handle")) {
@@ -164,7 +164,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["foo", "$inflight_init"];
+        return [...super._supportedOps(), "foo", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("$inflight_init")) {
@@ -201,7 +201,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {

--- a/libs/wingc/src/jsify/snapshots/enum_value.snap
+++ b/libs/wingc/src/jsify/snapshots/enum_value.snap
@@ -74,7 +74,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {

--- a/libs/wingc/src/jsify/snapshots/free_inflight_obj_from_inflight.snap
+++ b/libs/wingc/src/jsify/snapshots/free_inflight_obj_from_inflight.snap
@@ -80,7 +80,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
     }
     this.node.root.new("@winglang/sdk.std.Test", std.Test, this, "test:test", new $Closure1(this, "$Closure1"));

--- a/libs/wingc/src/jsify/snapshots/free_preflight_object_from_preflight.snap
+++ b/libs/wingc/src/jsify/snapshots/free_preflight_object_from_preflight.snap
@@ -64,7 +64,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["$inflight_init"];
+        return [...super._supportedOps(), "$inflight_init"];
       }
     }
     const x = "hello";

--- a/libs/wingc/src/jsify/snapshots/func_returns_func.snap
+++ b/libs/wingc/src/jsify/snapshots/func_returns_func.snap
@@ -75,7 +75,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
     }
     this.node.root.new("@winglang/sdk.std.Test", std.Test, this, "test:test", new $Closure1(this, "$Closure1"));

--- a/libs/wingc/src/jsify/snapshots/identify_field.snap
+++ b/libs/wingc/src/jsify/snapshots/identify_field.snap
@@ -73,7 +73,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["foo", "$inflight_init"];
+        return [...super._supportedOps(), "foo", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("$inflight_init")) {

--- a/libs/wingc/src/jsify/snapshots/implicit_lift_inflight_init.snap
+++ b/libs/wingc/src/jsify/snapshots/implicit_lift_inflight_init.snap
@@ -91,7 +91,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["myField2", "incCounter", "dontTouchCounter", "$inflight_init"];
+        return [...super._supportedOps(), "myField2", "incCounter", "dontTouchCounter", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("$inflight_init")) {

--- a/libs/wingc/src/jsify/snapshots/indirect_capture.snap
+++ b/libs/wingc/src/jsify/snapshots/indirect_capture.snap
@@ -105,7 +105,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["foo", "goo", "$inflight_init"];
+        return [...super._supportedOps(), "foo", "goo", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("foo")) {
@@ -142,7 +142,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {

--- a/libs/wingc/src/jsify/snapshots/inflight_class_extends_both_inside_inflight_closure.snap
+++ b/libs/wingc/src/jsify/snapshots/inflight_class_extends_both_inside_inflight_closure.snap
@@ -71,7 +71,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
     }
     this.node.root.new("@winglang/sdk.std.Test", std.Test, this, "test:test", new $Closure1(this, "$Closure1"));

--- a/libs/wingc/src/jsify/snapshots/inflight_class_extends_inflight_class.snap
+++ b/libs/wingc/src/jsify/snapshots/inflight_class_extends_inflight_class.snap
@@ -68,7 +68,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["$inflight_init"];
+        return [...super._supportedOps(), "$inflight_init"];
       }
     }
     class B extends A {
@@ -94,7 +94,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["$inflight_init"];
+        return [...super._supportedOps(), "$inflight_init"];
       }
     }
   }

--- a/libs/wingc/src/jsify/snapshots/inflight_constructor.snap
+++ b/libs/wingc/src/jsify/snapshots/inflight_constructor.snap
@@ -73,7 +73,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["x", "foo", "$inflight_init"];
+        return [...super._supportedOps(), "x", "foo", "$inflight_init"];
       }
     }
   }

--- a/libs/wingc/src/jsify/snapshots/inflight_field.snap
+++ b/libs/wingc/src/jsify/snapshots/inflight_field.snap
@@ -72,7 +72,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["x", "method", "$inflight_init"];
+        return [...super._supportedOps(), "x", "method", "$inflight_init"];
       }
     }
   }

--- a/libs/wingc/src/jsify/snapshots/inflight_field_from_inflight.snap
+++ b/libs/wingc/src/jsify/snapshots/inflight_field_from_inflight.snap
@@ -71,7 +71,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["s", "foo", "$inflight_init"];
+        return [...super._supportedOps(), "s", "foo", "$inflight_init"];
       }
     }
   }

--- a/libs/wingc/src/jsify/snapshots/inflight_field_from_inflight_class.snap
+++ b/libs/wingc/src/jsify/snapshots/inflight_field_from_inflight_class.snap
@@ -70,7 +70,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["field", "getField", "$inflight_init"];
+        return [...super._supportedOps(), "field", "getField", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("$inflight_init")) {

--- a/libs/wingc/src/jsify/snapshots/inline_inflight_class.snap
+++ b/libs/wingc/src/jsify/snapshots/inline_inflight_class.snap
@@ -100,7 +100,7 @@ class $Root extends $stdlib.std.Resource {
             `;
           }
           _supportedOps() {
-            return ["handle", "$inflight_init"];
+            return [...super._supportedOps(), "handle", "$inflight_init"];
           }
           _registerOnLift(host, ops) {
             if (ops.includes("handle")) {
@@ -129,7 +129,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["$inflight_init"];
+        return [...super._supportedOps(), "$inflight_init"];
       }
     }
   }

--- a/libs/wingc/src/jsify/snapshots/json_object.snap
+++ b/libs/wingc/src/jsify/snapshots/json_object.snap
@@ -71,7 +71,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {

--- a/libs/wingc/src/jsify/snapshots/lift_binary_preflight_and_inflight_expression.snap
+++ b/libs/wingc/src/jsify/snapshots/lift_binary_preflight_and_inflight_expression.snap
@@ -71,7 +71,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {

--- a/libs/wingc/src/jsify/snapshots/lift_binary_preflight_expression.snap
+++ b/libs/wingc/src/jsify/snapshots/lift_binary_preflight_expression.snap
@@ -71,7 +71,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {

--- a/libs/wingc/src/jsify/snapshots/lift_element_from_collection_as_field.snap
+++ b/libs/wingc/src/jsify/snapshots/lift_element_from_collection_as_field.snap
@@ -74,7 +74,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["foo", "$inflight_init"];
+        return [...super._supportedOps(), "foo", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("$inflight_init")) {

--- a/libs/wingc/src/jsify/snapshots/lift_element_from_collection_of_objects.snap
+++ b/libs/wingc/src/jsify/snapshots/lift_element_from_collection_of_objects.snap
@@ -72,7 +72,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {

--- a/libs/wingc/src/jsify/snapshots/lift_inflight_closure.snap
+++ b/libs/wingc/src/jsify/snapshots/lift_inflight_closure.snap
@@ -88,7 +88,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
     }
     class $Closure2 extends $stdlib.std.Resource {
@@ -116,7 +116,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {

--- a/libs/wingc/src/jsify/snapshots/lift_inside_preflight_method.snap
+++ b/libs/wingc/src/jsify/snapshots/lift_inside_preflight_method.snap
@@ -104,7 +104,7 @@ class $Root extends $stdlib.std.Resource {
             `;
           }
           _supportedOps() {
-            return ["handle", "$inflight_init"];
+            return [...super._supportedOps(), "handle", "$inflight_init"];
           }
           _registerOnLift(host, ops) {
             if (ops.includes("handle")) {
@@ -133,7 +133,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["$inflight_init"];
+        return [...super._supportedOps(), "$inflight_init"];
       }
     }
   }

--- a/libs/wingc/src/jsify/snapshots/lift_self_reference.snap
+++ b/libs/wingc/src/jsify/snapshots/lift_self_reference.snap
@@ -68,7 +68,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["static_method", "bar", "$inflight_init"];
+        return [...super._supportedOps(), "static_method", "bar", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("bar")) {

--- a/libs/wingc/src/jsify/snapshots/lift_string.snap
+++ b/libs/wingc/src/jsify/snapshots/lift_string.snap
@@ -69,7 +69,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {

--- a/libs/wingc/src/jsify/snapshots/lift_this.snap
+++ b/libs/wingc/src/jsify/snapshots/lift_this.snap
@@ -103,7 +103,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["x", "bar", "foo", "$inflight_init"];
+        return [...super._supportedOps(), "x", "bar", "foo", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("foo")) {
@@ -137,7 +137,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {

--- a/libs/wingc/src/jsify/snapshots/lift_var_with_this.snap
+++ b/libs/wingc/src/jsify/snapshots/lift_var_with_this.snap
@@ -87,7 +87,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["$inflight_init"];
+        return [...super._supportedOps(), "$inflight_init"];
       }
     }
     class $Closure1 extends $stdlib.std.Resource {
@@ -115,7 +115,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("$inflight_init")) {

--- a/libs/wingc/src/jsify/snapshots/lift_via_closure.snap
+++ b/libs/wingc/src/jsify/snapshots/lift_via_closure.snap
@@ -97,7 +97,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {
@@ -131,7 +131,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {

--- a/libs/wingc/src/jsify/snapshots/lift_via_closure_class_explicit.snap
+++ b/libs/wingc/src/jsify/snapshots/lift_via_closure_class_explicit.snap
@@ -112,7 +112,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "another", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "another", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("$inflight_init")) {
@@ -152,7 +152,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {

--- a/libs/wingc/src/jsify/snapshots/namespaced_static_from_inflight.snap
+++ b/libs/wingc/src/jsify/snapshots/namespaced_static_from_inflight.snap
@@ -70,7 +70,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
     }
     this.node.root.new("@winglang/sdk.std.Test", std.Test, this, "test:test", new $Closure1(this, "$Closure1"));

--- a/libs/wingc/src/jsify/snapshots/nested_inflight_after_preflight_operation.snap
+++ b/libs/wingc/src/jsify/snapshots/nested_inflight_after_preflight_operation.snap
@@ -93,7 +93,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["b", "$inflight_init"];
+        return [...super._supportedOps(), "b", "$inflight_init"];
       }
     }
     class $Closure1 extends $stdlib.std.Resource {
@@ -121,7 +121,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {

--- a/libs/wingc/src/jsify/snapshots/nested_preflight_operation.snap
+++ b/libs/wingc/src/jsify/snapshots/nested_preflight_operation.snap
@@ -111,7 +111,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["$inflight_init"];
+        return [...super._supportedOps(), "$inflight_init"];
       }
     }
     class MyType extends $stdlib.std.Resource {
@@ -137,7 +137,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["$inflight_init"];
+        return [...super._supportedOps(), "$inflight_init"];
       }
     }
     class $Closure1 extends $stdlib.std.Resource {
@@ -165,7 +165,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {

--- a/libs/wingc/src/jsify/snapshots/new_inflight_object.snap
+++ b/libs/wingc/src/jsify/snapshots/new_inflight_object.snap
@@ -79,7 +79,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["$inflight_init"];
+        return [...super._supportedOps(), "$inflight_init"];
       }
     }
     class $Closure1 extends $stdlib.std.Resource {
@@ -107,7 +107,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
     }
     this.node.root.new("@winglang/sdk.std.Test", std.Test, this, "test:test", new $Closure1(this, "$Closure1"));

--- a/libs/wingc/src/jsify/snapshots/no_capture_inside_methods.snap
+++ b/libs/wingc/src/jsify/snapshots/no_capture_inside_methods.snap
@@ -73,7 +73,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
     }
     this.node.root.new("@winglang/sdk.std.Test", std.Test, this, "test:test", new $Closure1(this, "$Closure1"));

--- a/libs/wingc/src/jsify/snapshots/no_capture_of_identifier_from_inner_scope.snap
+++ b/libs/wingc/src/jsify/snapshots/no_capture_of_identifier_from_inner_scope.snap
@@ -73,7 +73,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
     }
     this.node.root.new("@winglang/sdk.std.Test", std.Test, this, "test:test", new $Closure1(this, "$Closure1"));

--- a/libs/wingc/src/jsify/snapshots/no_capture_of_identifier_from_same_scope.snap
+++ b/libs/wingc/src/jsify/snapshots/no_capture_of_identifier_from_same_scope.snap
@@ -69,7 +69,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
     }
     this.node.root.new("@winglang/sdk.std.Test", std.Test, this, "test:test", new $Closure1(this, "$Closure1"));

--- a/libs/wingc/src/jsify/snapshots/no_capture_shadow_inside_inner_scopes.snap
+++ b/libs/wingc/src/jsify/snapshots/no_capture_shadow_inside_inner_scopes.snap
@@ -81,7 +81,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
     }
     this.node.root.new("@winglang/sdk.std.Test", std.Test, this, "test:testing", new $Closure1(this, "$Closure1"));

--- a/libs/wingc/src/jsify/snapshots/no_lift_shadow_inside_inner_scopes.snap
+++ b/libs/wingc/src/jsify/snapshots/no_lift_shadow_inside_inner_scopes.snap
@@ -80,7 +80,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {

--- a/libs/wingc/src/jsify/snapshots/preflight_class_extends_preflight_class.snap
+++ b/libs/wingc/src/jsify/snapshots/preflight_class_extends_preflight_class.snap
@@ -73,7 +73,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["$inflight_init"];
+        return [...super._supportedOps(), "$inflight_init"];
       }
     }
     class Derived extends Base {
@@ -99,7 +99,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["$inflight_init"];
+        return [...super._supportedOps(), "$inflight_init"];
       }
     }
   }

--- a/libs/wingc/src/jsify/snapshots/preflight_collection.snap
+++ b/libs/wingc/src/jsify/snapshots/preflight_collection.snap
@@ -72,7 +72,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {

--- a/libs/wingc/src/jsify/snapshots/preflight_collection_of_preflight_objects.snap
+++ b/libs/wingc/src/jsify/snapshots/preflight_collection_of_preflight_objects.snap
@@ -77,7 +77,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {

--- a/libs/wingc/src/jsify/snapshots/preflight_nested_object_with_operations.snap
+++ b/libs/wingc/src/jsify/snapshots/preflight_nested_object_with_operations.snap
@@ -91,7 +91,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["$inflight_init"];
+        return [...super._supportedOps(), "$inflight_init"];
       }
     }
     class $Closure1 extends $stdlib.std.Resource {
@@ -119,7 +119,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {

--- a/libs/wingc/src/jsify/snapshots/preflight_object.snap
+++ b/libs/wingc/src/jsify/snapshots/preflight_object.snap
@@ -90,7 +90,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["hello", "goodbye", "$inflight_init"];
+        return [...super._supportedOps(), "hello", "goodbye", "$inflight_init"];
       }
     }
     class $Closure1 extends $stdlib.std.Resource {
@@ -118,7 +118,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {

--- a/libs/wingc/src/jsify/snapshots/preflight_object_through_property.snap
+++ b/libs/wingc/src/jsify/snapshots/preflight_object_through_property.snap
@@ -92,7 +92,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["$inflight_init"];
+        return [...super._supportedOps(), "$inflight_init"];
       }
     }
     class $Closure1 extends $stdlib.std.Resource {
@@ -120,7 +120,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {

--- a/libs/wingc/src/jsify/snapshots/preflight_object_with_operations.snap
+++ b/libs/wingc/src/jsify/snapshots/preflight_object_with_operations.snap
@@ -73,7 +73,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {

--- a/libs/wingc/src/jsify/snapshots/preflight_object_with_operations_multiple_methods.snap
+++ b/libs/wingc/src/jsify/snapshots/preflight_object_with_operations_multiple_methods.snap
@@ -76,7 +76,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["put", "list", "$inflight_init"];
+        return [...super._supportedOps(), "put", "list", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("list")) {

--- a/libs/wingc/src/jsify/snapshots/preflight_value_field.snap
+++ b/libs/wingc/src/jsify/snapshots/preflight_value_field.snap
@@ -97,7 +97,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["$inflight_init"];
+        return [...super._supportedOps(), "$inflight_init"];
       }
     }
     class $Closure1 extends $stdlib.std.Resource {
@@ -127,7 +127,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {

--- a/libs/wingc/src/jsify/snapshots/read_primitive_value.snap
+++ b/libs/wingc/src/jsify/snapshots/read_primitive_value.snap
@@ -70,7 +70,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {

--- a/libs/wingc/src/jsify/snapshots/reassign_captured_variable.snap
+++ b/libs/wingc/src/jsify/snapshots/reassign_captured_variable.snap
@@ -78,7 +78,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
     }
     this.node.root.new("@winglang/sdk.std.Test", std.Test, this, "test:test", new $Closure1(this, "$Closure1"));

--- a/libs/wingc/src/jsify/snapshots/ref_std_macro.snap
+++ b/libs/wingc/src/jsify/snapshots/ref_std_macro.snap
@@ -70,7 +70,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {

--- a/libs/wingc/src/jsify/snapshots/reference_from_static_inflight.snap
+++ b/libs/wingc/src/jsify/snapshots/reference_from_static_inflight.snap
@@ -67,7 +67,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["staticMethod", "$inflight_init"];
+        return [...super._supportedOps(), "staticMethod", "$inflight_init"];
       }
       static _registerOnLift(host, ops) {
         if (ops.includes("staticMethod")) {

--- a/libs/wingc/src/jsify/snapshots/reference_inflight_class.snap
+++ b/libs/wingc/src/jsify/snapshots/reference_inflight_class.snap
@@ -84,7 +84,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["a", "$inflight_init"];
+        return [...super._supportedOps(), "a", "$inflight_init"];
       }
     }
     class $Closure1 extends $stdlib.std.Resource {
@@ -112,7 +112,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
     }
     this.node.root.new("@winglang/sdk.std.Test", std.Test, this, "test:test", new $Closure1(this, "$Closure1"));

--- a/libs/wingc/src/jsify/snapshots/reference_inflight_field.snap
+++ b/libs/wingc/src/jsify/snapshots/reference_inflight_field.snap
@@ -73,7 +73,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["x", "method", "$inflight_init"];
+        return [...super._supportedOps(), "x", "method", "$inflight_init"];
       }
     }
   }

--- a/libs/wingc/src/jsify/snapshots/reference_inflight_from_inflight.snap
+++ b/libs/wingc/src/jsify/snapshots/reference_inflight_from_inflight.snap
@@ -97,7 +97,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["foofoo1", "$inflight_init"];
+        return [...super._supportedOps(), "foofoo1", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("foofoo1")) {
@@ -131,7 +131,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
     }
     const s = "hello";

--- a/libs/wingc/src/jsify/snapshots/reference_preflight_field.snap
+++ b/libs/wingc/src/jsify/snapshots/reference_preflight_field.snap
@@ -73,7 +73,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["method", "$inflight_init"];
+        return [...super._supportedOps(), "method", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("$inflight_init")) {

--- a/libs/wingc/src/jsify/snapshots/reference_preflight_field_call_independent_method.snap
+++ b/libs/wingc/src/jsify/snapshots/reference_preflight_field_call_independent_method.snap
@@ -73,7 +73,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["method", "$inflight_init"];
+        return [...super._supportedOps(), "method", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("$inflight_init")) {

--- a/libs/wingc/src/jsify/snapshots/reference_preflight_fields.snap
+++ b/libs/wingc/src/jsify/snapshots/reference_preflight_fields.snap
@@ -92,7 +92,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["boom", "bam", "$inflight_init"];
+        return [...super._supportedOps(), "boom", "bam", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("$inflight_init")) {

--- a/libs/wingc/src/jsify/snapshots/reference_preflight_free_variable_with_this_in_the_expression.snap
+++ b/libs/wingc/src/jsify/snapshots/reference_preflight_free_variable_with_this_in_the_expression.snap
@@ -78,7 +78,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["method", "$inflight_init"];
+        return [...super._supportedOps(), "method", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("$inflight_init")) {

--- a/libs/wingc/src/jsify/snapshots/reference_preflight_object_from_static_inflight.snap
+++ b/libs/wingc/src/jsify/snapshots/reference_preflight_object_from_static_inflight.snap
@@ -70,7 +70,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["addToQueue", "$inflight_init"];
+        return [...super._supportedOps(), "addToQueue", "$inflight_init"];
       }
       static _registerOnLift(host, ops) {
         if (ops.includes("addToQueue")) {

--- a/libs/wingc/src/jsify/snapshots/reference_static_inflight.snap
+++ b/libs/wingc/src/jsify/snapshots/reference_static_inflight.snap
@@ -85,7 +85,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["myStaticMethod", "$inflight_init"];
+        return [...super._supportedOps(), "myStaticMethod", "$inflight_init"];
       }
     }
     class $Closure1 extends $stdlib.std.Resource {
@@ -113,7 +113,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {

--- a/libs/wingc/src/jsify/snapshots/reference_static_inflight_which_references_preflight_object.snap
+++ b/libs/wingc/src/jsify/snapshots/reference_static_inflight_which_references_preflight_object.snap
@@ -96,7 +96,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["staticMethod", "$inflight_init"];
+        return [...super._supportedOps(), "staticMethod", "$inflight_init"];
       }
       static _registerOnLift(host, ops) {
         if (ops.includes("staticMethod")) {
@@ -130,7 +130,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {

--- a/libs/wingc/src/jsify/snapshots/static_external_inflight_class.snap
+++ b/libs/wingc/src/jsify/snapshots/static_external_inflight_class.snap
@@ -95,7 +95,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["foo", "$inflight_init"];
+        return [...super._supportedOps(), "foo", "$inflight_init"];
       }
     }
     class $Closure1 extends $stdlib.std.Resource {
@@ -123,7 +123,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
     }
     this.node.root.new("@winglang/sdk.std.Test", std.Test, this, "test:test", new $Closure1(this, "$Closure1"));

--- a/libs/wingc/src/jsify/snapshots/static_external_preflight_class.snap
+++ b/libs/wingc/src/jsify/snapshots/static_external_preflight_class.snap
@@ -94,7 +94,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["foo", "$inflight_init"];
+        return [...super._supportedOps(), "foo", "$inflight_init"];
       }
     }
     class $Closure1 extends $stdlib.std.Resource {
@@ -122,7 +122,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {

--- a/libs/wingc/src/jsify/snapshots/static_inflight_operation.snap
+++ b/libs/wingc/src/jsify/snapshots/static_inflight_operation.snap
@@ -93,7 +93,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["myop", "$inflight_init"];
+        return [...super._supportedOps(), "myop", "$inflight_init"];
       }
       static _registerOnLift(host, ops) {
         if (ops.includes("myop")) {
@@ -127,7 +127,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {

--- a/libs/wingc/src/jsify/snapshots/static_local_inflight_class.snap
+++ b/libs/wingc/src/jsify/snapshots/static_local_inflight_class.snap
@@ -89,7 +89,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
     }
     this.node.root.new("@winglang/sdk.std.Test", std.Test, this, "test:test", new $Closure1(this, "$Closure1"));

--- a/libs/wingc/src/jsify/snapshots/static_on_std_type.snap
+++ b/libs/wingc/src/jsify/snapshots/static_on_std_type.snap
@@ -71,7 +71,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
     }
     this.node.root.new("@winglang/sdk.std.Test", std.Test, this, "test:test", new $Closure1(this, "$Closure1"));

--- a/libs/wingc/src/jsify/snapshots/transitive_reference.snap
+++ b/libs/wingc/src/jsify/snapshots/transitive_reference.snap
@@ -112,7 +112,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["isEmpty", "checkIfEmpty", "$inflight_init"];
+        return [...super._supportedOps(), "isEmpty", "checkIfEmpty", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("$inflight_init")) {
@@ -152,7 +152,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {

--- a/libs/wingc/src/jsify/snapshots/transitive_reference_via_inflight_class.snap
+++ b/libs/wingc/src/jsify/snapshots/transitive_reference_via_inflight_class.snap
@@ -94,7 +94,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["putInBucket", "$inflight_init"];
+        return [...super._supportedOps(), "putInBucket", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("putInBucket")) {
@@ -128,7 +128,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
     }
     const b = this.node.root.new("@winglang/sdk.cloud.Bucket", cloud.Bucket, this, "cloud.Bucket");

--- a/libs/wingc/src/jsify/snapshots/transitive_reference_via_static.snap
+++ b/libs/wingc/src/jsify/snapshots/transitive_reference_via_static.snap
@@ -118,7 +118,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["putInBucket", "$inflight_init"];
+        return [...super._supportedOps(), "putInBucket", "$inflight_init"];
       }
       static _registerOnLift(host, ops) {
         if (ops.includes("putInBucket")) {
@@ -150,7 +150,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["putIndirect", "$inflight_init"];
+        return [...super._supportedOps(), "putIndirect", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("putIndirect")) {
@@ -184,7 +184,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {

--- a/libs/wingc/src/jsify/snapshots/two_identical_lifts.snap
+++ b/libs/wingc/src/jsify/snapshots/two_identical_lifts.snap
@@ -79,7 +79,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {

--- a/libs/wingc/src/jsify/snapshots/unqualified_lift_of_collection.snap
+++ b/libs/wingc/src/jsify/snapshots/unqualified_lift_of_collection.snap
@@ -70,7 +70,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {

--- a/libs/wingc/src/jsify/snapshots/use_util_functions.snap
+++ b/libs/wingc/src/jsify/snapshots/use_util_functions.snap
@@ -69,7 +69,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
     }
     this.node.root.new("@winglang/sdk.std.Test", std.Test, this, "test:test", new $Closure1(this, "$Closure1"));

--- a/libs/wingc/src/jsify/snapshots/var_inflight_field_from_inflight.snap
+++ b/libs/wingc/src/jsify/snapshots/var_inflight_field_from_inflight.snap
@@ -73,7 +73,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["s", "foo", "$inflight_init"];
+        return [...super._supportedOps(), "s", "foo", "$inflight_init"];
       }
     }
   }

--- a/libs/wingc/src/jsify/snapshots/wait_util.snap
+++ b/libs/wingc/src/jsify/snapshots/wait_util.snap
@@ -76,7 +76,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
     }
     const foo = "test";

--- a/libs/wingsdk/src/std/resource.ts
+++ b/libs/wingsdk/src/std/resource.ts
@@ -280,7 +280,8 @@ export abstract class Resource extends Construct implements IResource {
    */ // @ts-ignore
   private _addOnLift(host: IInflightHost, ops: string[]) {
     log(
-      `Registering a binding for a resource (${this.node.path}) to a host (${host.node.path
+      `Registering a binding for a resource (${this.node.path}) to a host (${
+        host.node.path
       }) with ops: ${JSON.stringify(ops)}`
     );
 

--- a/libs/wingsdk/src/std/resource.ts
+++ b/libs/wingsdk/src/std/resource.ts
@@ -231,10 +231,9 @@ export abstract class Resource extends Construct implements IResource {
 
   /**
    * @internal
-   * @abstract
    * */
   public _supportedOps(): string[] {
-    throw new AbstractMemberError();
+    return [];
   }
 
   /**
@@ -281,8 +280,7 @@ export abstract class Resource extends Construct implements IResource {
    */ // @ts-ignore
   private _addOnLift(host: IInflightHost, ops: string[]) {
     log(
-      `Registering a binding for a resource (${this.node.path}) to a host (${
-        host.node.path
+      `Registering a binding for a resource (${this.node.path}) to a host (${host.node.path
       }) with ops: ${JSON.stringify(ops)}`
     );
 

--- a/tools/hangar/__snapshots__/test_corpus/valid/api.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/api.test.w_compile_tf-aws.md
@@ -477,7 +477,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {
@@ -511,7 +511,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {
@@ -550,7 +550,7 @@ class $Root extends $stdlib.std.Resource {
             `;
           }
           _supportedOps() {
-            return ["handle", "$inflight_init"];
+            return [...super._supportedOps(), "handle", "$inflight_init"];
           }
           _registerOnLift(host, ops) {
             if (ops.includes("handle")) {
@@ -579,7 +579,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["$inflight_init"];
+        return [...super._supportedOps(), "$inflight_init"];
       }
     }
     const api = this.node.root.new("@winglang/sdk.cloud.Api", cloud.Api, this, "cloud.Api");

--- a/tools/hangar/__snapshots__/test_corpus/valid/api_cors_custom.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/api_cors_custom.test.w_compile_tf-aws.md
@@ -344,7 +344,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
     }
     class $Closure2 extends $stdlib.std.Resource {
@@ -374,7 +374,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {
@@ -411,7 +411,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {
@@ -448,7 +448,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {

--- a/tools/hangar/__snapshots__/test_corpus/valid/api_cors_default.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/api_cors_default.test.w_compile_tf-aws.md
@@ -320,7 +320,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
     }
     class $Closure2 extends $stdlib.std.Resource {
@@ -350,7 +350,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {
@@ -387,7 +387,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {

--- a/tools/hangar/__snapshots__/test_corpus/valid/api_valid_path.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/api_valid_path.test.w_compile_tf-aws.md
@@ -421,7 +421,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
     }
     const api = this.node.root.new("@winglang/sdk.cloud.Api", cloud.Api, this, "cloud.Api");

--- a/tools/hangar/__snapshots__/test_corpus/valid/assert.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/assert.test.w_compile_tf-aws.md
@@ -102,7 +102,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {

--- a/tools/hangar/__snapshots__/test_corpus/valid/asynchronous_model_implicit_await_in_functions.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/asynchronous_model_implicit_await_in_functions.test.w_compile_tf-aws.md
@@ -307,7 +307,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
     }
     class $Closure2 extends $stdlib.std.Resource {
@@ -335,7 +335,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {

--- a/tools/hangar/__snapshots__/test_corpus/valid/baz.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/baz.w_compile_tf-aws.md
@@ -43,7 +43,7 @@ module.exports = function({ $stdlib }) {
       `;
     }
     _supportedOps() {
-      return ["$inflight_init"];
+      return [...super._supportedOps(), "$inflight_init"];
     }
   }
   return { Baz };

--- a/tools/hangar/__snapshots__/test_corpus/valid/bring_awscdk.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/bring_awscdk.test.w_compile_tf-aws.md
@@ -80,7 +80,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["$inflight_init"];
+        return [...super._supportedOps(), "$inflight_init"];
       }
     }
     this.node.root.new("aws-cdk-lib.App", awscdk.App, );

--- a/tools/hangar/__snapshots__/test_corpus/valid/bring_cdktf.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/bring_cdktf.test.w_compile_tf-aws.md
@@ -98,7 +98,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["$inflight_init"];
+        return [...super._supportedOps(), "$inflight_init"];
       }
     }
     this.node.root.new("@cdktf/provider-aws.s3Bucket.S3Bucket", aws.s3Bucket.S3Bucket, this, "Bucket", { bucketPrefix: "hello", versioning: ({"enabled": true, "mfaDelete": true}) });

--- a/tools/hangar/__snapshots__/test_corpus/valid/bring_jsii.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/bring_jsii.test.w_compile_tf-aws.md
@@ -92,7 +92,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {

--- a/tools/hangar/__snapshots__/test_corpus/valid/bring_local.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/bring_local.test.w_compile_tf-aws.md
@@ -324,7 +324,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {
@@ -358,7 +358,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["$inflight_init"];
+        return [...super._supportedOps(), "$inflight_init"];
       }
     }
     class Util extends $stdlib.std.Resource {
@@ -383,7 +383,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["$inflight_init"];
+        return [...super._supportedOps(), "$inflight_init"];
       }
     }
     const store = new file1.Store(this, "file1.Store");
@@ -431,7 +431,7 @@ module.exports = function({ $stdlib }) {
       `;
     }
     _supportedOps() {
-      return ["$inflight_init"];
+      return [...super._supportedOps(), "$inflight_init"];
     }
   }
   class Store extends $stdlib.std.Resource {
@@ -464,7 +464,7 @@ module.exports = function({ $stdlib }) {
           `;
         }
         _supportedOps() {
-          return ["handle", "$inflight_init"];
+          return [...super._supportedOps(), "handle", "$inflight_init"];
         }
         _registerOnLift(host, ops) {
           if (ops.includes("handle")) {
@@ -494,7 +494,7 @@ module.exports = function({ $stdlib }) {
       `;
     }
     _supportedOps() {
-      return ["store", "$inflight_init"];
+      return [...super._supportedOps(), "store", "$inflight_init"];
     }
     _registerOnLift(host, ops) {
       if (ops.includes("$inflight_init")) {
@@ -547,7 +547,7 @@ module.exports = function({ $stdlib }) {
       `;
     }
     _supportedOps() {
-      return ["greet", "$inflight_init"];
+      return [...super._supportedOps(), "greet", "$inflight_init"];
     }
   }
   return { Q };

--- a/tools/hangar/__snapshots__/test_corpus/valid/bring_local_dir.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/bring_local_dir.test.w_compile_tf-aws.md
@@ -120,7 +120,7 @@ module.exports = function({ $stdlib }) {
       `;
     }
     _supportedOps() {
-      return ["$inflight_init"];
+      return [...super._supportedOps(), "$inflight_init"];
     }
   }
   return { Foo };
@@ -160,7 +160,7 @@ module.exports = function({ $stdlib }) {
       `;
     }
     _supportedOps() {
-      return ["$inflight_init"];
+      return [...super._supportedOps(), "$inflight_init"];
     }
   }
   class Foo extends $stdlib.std.Resource {
@@ -185,7 +185,7 @@ module.exports = function({ $stdlib }) {
       `;
     }
     _supportedOps() {
-      return ["$inflight_init"];
+      return [...super._supportedOps(), "$inflight_init"];
     }
   }
   return { Bar };
@@ -282,7 +282,7 @@ module.exports = function({ $stdlib }) {
       `;
     }
     _supportedOps() {
-      return ["$inflight_init"];
+      return [...super._supportedOps(), "$inflight_init"];
     }
   }
   return { Widget };

--- a/tools/hangar/__snapshots__/test_corpus/valid/bring_local_normalization.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/bring_local_normalization.test.w_compile_tf-aws.md
@@ -101,7 +101,7 @@ module.exports = function({ $stdlib }) {
       `;
     }
     _supportedOps() {
-      return ["$inflight_init"];
+      return [...super._supportedOps(), "$inflight_init"];
     }
   }
   return { Bar };
@@ -139,7 +139,7 @@ module.exports = function({ $stdlib }) {
       `;
     }
     _supportedOps() {
-      return ["$inflight_init"];
+      return [...super._supportedOps(), "$inflight_init"];
     }
   }
   return { Baz };
@@ -185,7 +185,7 @@ module.exports = function({ $stdlib }) {
       `;
     }
     _supportedOps() {
-      return ["$inflight_init"];
+      return [...super._supportedOps(), "$inflight_init"];
     }
   }
   return { Foo };

--- a/tools/hangar/__snapshots__/test_corpus/valid/bring_wing_library.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/bring_wing_library.test.w_compile_tf-aws.md
@@ -157,7 +157,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {
@@ -215,7 +215,7 @@ module.exports = function({ $stdlib }) {
       `;
     }
     _supportedOps() {
-      return ["makeKeyInflight", "set", "$inflight_init"];
+      return [...super._supportedOps(), "makeKeyInflight", "set", "$inflight_init"];
     }
     _registerOnLift(host, ops) {
       if (ops.includes("$inflight_init")) {
@@ -286,7 +286,7 @@ module.exports = function({ $stdlib }) {
       `;
     }
     _supportedOps() {
-      return ["double", "$inflight_init"];
+      return [...super._supportedOps(), "double", "$inflight_init"];
     }
   }
   return { Util };

--- a/tools/hangar/__snapshots__/test_corpus/valid/bucket_keys.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/bucket_keys.test.w_compile_tf-aws.md
@@ -112,7 +112,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {

--- a/tools/hangar/__snapshots__/test_corpus/valid/call_static_of_myself.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/call_static_of_myself.test.w_compile_tf-aws.md
@@ -133,7 +133,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["foo", "bar", "callThis", "$inflight_init"];
+        return [...super._supportedOps(), "foo", "bar", "callThis", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("callThis")) {
@@ -170,7 +170,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["bar", "callThis", "$inflight_init"];
+        return [...super._supportedOps(), "bar", "callThis", "$inflight_init"];
       }
     }
     class $Closure1 extends $stdlib.std.Resource {
@@ -200,7 +200,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {

--- a/tools/hangar/__snapshots__/test_corpus/valid/calling_inflight_variants.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/calling_inflight_variants.test.w_compile_tf-aws.md
@@ -150,7 +150,7 @@ class $Root extends $stdlib.std.Resource {
             `;
           }
           _supportedOps() {
-            return ["handle", "$inflight_init"];
+            return [...super._supportedOps(), "handle", "$inflight_init"];
           }
         }
         this.inflight1 = new $Closure1(this, "$Closure1");
@@ -174,7 +174,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["inflight2", "makeFn", "callFn", "callFn2", "$inflight_init"];
+        return [...super._supportedOps(), "inflight2", "makeFn", "callFn", "callFn2", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("$inflight_init")) {
@@ -220,7 +220,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {

--- a/tools/hangar/__snapshots__/test_corpus/valid/capture_containers.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/capture_containers.test.w_compile_tf-aws.md
@@ -104,7 +104,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {

--- a/tools/hangar/__snapshots__/test_corpus/valid/capture_in_binary.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/capture_in_binary.test.w_compile_tf-aws.md
@@ -105,7 +105,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {

--- a/tools/hangar/__snapshots__/test_corpus/valid/capture_mutables.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/capture_mutables.test.w_compile_tf-aws.md
@@ -112,7 +112,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {
@@ -149,7 +149,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {

--- a/tools/hangar/__snapshots__/test_corpus/valid/capture_primitives.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/capture_primitives.test.w_compile_tf-aws.md
@@ -214,7 +214,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {

--- a/tools/hangar/__snapshots__/test_corpus/valid/capture_reassigable_class_field.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/capture_reassigable_class_field.test.w_compile_tf-aws.md
@@ -195,7 +195,7 @@ class $Root extends $stdlib.std.Resource {
             `;
           }
           _supportedOps() {
-            return ["handle", "$inflight_init"];
+            return [...super._supportedOps(), "handle", "$inflight_init"];
           }
         }
         this.onUpdateCallback = new $Closure1(this, "$Closure1");
@@ -223,7 +223,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["get", "set", "$inflight_init"];
+        return [...super._supportedOps(), "get", "set", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("$inflight_init")) {
@@ -265,7 +265,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {
@@ -301,7 +301,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {

--- a/tools/hangar/__snapshots__/test_corpus/valid/capture_reassignable.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/capture_reassignable.test.w_compile_tf-aws.md
@@ -107,7 +107,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {
@@ -141,7 +141,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {

--- a/tools/hangar/__snapshots__/test_corpus/valid/capture_resource_and_data.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/capture_resource_and_data.test.w_compile_tf-aws.md
@@ -120,7 +120,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {

--- a/tools/hangar/__snapshots__/test_corpus/valid/capture_resource_with_no_inflight.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/capture_resource_with_no_inflight.test.w_compile_tf-aws.md
@@ -129,7 +129,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["incCounter", "bar", "$inflight_init"];
+        return [...super._supportedOps(), "incCounter", "bar", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("$inflight_init")) {
@@ -167,7 +167,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {

--- a/tools/hangar/__snapshots__/test_corpus/valid/capture_tokens.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/capture_tokens.test.w_compile_tf-aws.md
@@ -229,7 +229,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["isValidUrl", "foo", "$inflight_init"];
+        return [...super._supportedOps(), "isValidUrl", "foo", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("$inflight_init")) {
@@ -269,7 +269,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {
@@ -305,7 +305,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {

--- a/tools/hangar/__snapshots__/test_corpus/valid/captures.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/captures.test.w_compile_tf-aws.md
@@ -639,7 +639,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {
@@ -675,7 +675,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {

--- a/tools/hangar/__snapshots__/test_corpus/valid/class.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/class.test.w_compile_tf-aws.md
@@ -379,7 +379,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["$inflight_init"];
+        return [...super._supportedOps(), "$inflight_init"];
       }
     }
     class C2 extends $stdlib.std.Resource {
@@ -405,7 +405,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["$inflight_init"];
+        return [...super._supportedOps(), "$inflight_init"];
       }
     }
     class C3 extends $stdlib.std.Resource {
@@ -434,7 +434,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["$inflight_init"];
+        return [...super._supportedOps(), "$inflight_init"];
       }
     }
     class C4 extends $stdlib.std.Resource {
@@ -462,7 +462,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["$inflight_init"];
+        return [...super._supportedOps(), "$inflight_init"];
       }
     }
     class C5 extends $stdlib.std.Resource {
@@ -487,7 +487,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["x", "y", "set", "$inflight_init"];
+        return [...super._supportedOps(), "x", "y", "set", "$inflight_init"];
       }
     }
     class $Closure1 extends $stdlib.std.Resource {
@@ -515,7 +515,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {
@@ -547,7 +547,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["$inflight_init"];
+        return [...super._supportedOps(), "$inflight_init"];
       }
     }
     class Student extends Person {
@@ -574,7 +574,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["$inflight_init"];
+        return [...super._supportedOps(), "$inflight_init"];
       }
     }
     class PaidStudent extends Student {
@@ -601,7 +601,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["$inflight_init"];
+        return [...super._supportedOps(), "$inflight_init"];
       }
     }
     class $Closure2 extends $stdlib.std.Resource {
@@ -631,7 +631,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {
@@ -666,7 +666,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["$inflight_init"];
+        return [...super._supportedOps(), "$inflight_init"];
       }
     }
     class $Closure3 extends $stdlib.std.Resource {
@@ -694,7 +694,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {
@@ -725,7 +725,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["sound", "$inflight_init"];
+        return [...super._supportedOps(), "sound", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("$inflight_init")) {
@@ -757,7 +757,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["$inflight_init"];
+        return [...super._supportedOps(), "$inflight_init"];
       }
     }
     class $Closure4 extends $stdlib.std.Resource {
@@ -785,7 +785,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
     }
     class Bar extends $stdlib.std.Resource {
@@ -810,7 +810,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["$inflight_init"];
+        return [...super._supportedOps(), "$inflight_init"];
       }
     }
     class Foo extends Bar {
@@ -836,7 +836,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["doStuff", "$inflight_init"];
+        return [...super._supportedOps(), "doStuff", "$inflight_init"];
       }
     }
     class Baz extends Bar {
@@ -862,7 +862,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["$inflight_init"];
+        return [...super._supportedOps(), "$inflight_init"];
       }
     }
     class Boom extends $stdlib.std.Resource {
@@ -887,7 +887,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["$inflight_init"];
+        return [...super._supportedOps(), "$inflight_init"];
       }
     }
     class Bam extends Boom {
@@ -913,7 +913,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["$inflight_init"];
+        return [...super._supportedOps(), "$inflight_init"];
       }
     }
     new C1(this, "C1");

--- a/tools/hangar/__snapshots__/test_corpus/valid/closure_class.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/closure_class.test.w_compile_tf-aws.md
@@ -108,7 +108,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["another", "handle", "$inflight_init"];
+        return [...super._supportedOps(), "another", "handle", "$inflight_init"];
       }
     }
     class $Closure1 extends $stdlib.std.Resource {
@@ -136,7 +136,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {

--- a/tools/hangar/__snapshots__/test_corpus/valid/construct-base.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/construct-base.test.w_compile_tf-aws.md
@@ -94,7 +94,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["$inflight_init"];
+        return [...super._supportedOps(), "$inflight_init"];
       }
     }
     const getPath = ((c) => {

--- a/tools/hangar/__snapshots__/test_corpus/valid/custom_obj_id.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/custom_obj_id.test.w_compile_tf-aws.md
@@ -78,7 +78,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["$inflight_init"];
+        return [...super._supportedOps(), "$inflight_init"];
       }
     }
     const foo1 = new Foo(this, "Foo");

--- a/tools/hangar/__snapshots__/test_corpus/valid/debug_env.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/debug_env.test.w_compile_tf-aws.md
@@ -80,7 +80,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["$inflight_init"];
+        return [...super._supportedOps(), "$inflight_init"];
       }
     }
   }

--- a/tools/hangar/__snapshots__/test_corpus/valid/deep_equality.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/deep_equality.test.w_compile_tf-aws.md
@@ -313,7 +313,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {
@@ -353,7 +353,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {
@@ -391,7 +391,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {
@@ -428,7 +428,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {
@@ -465,7 +465,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {
@@ -502,7 +502,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {
@@ -539,7 +539,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {
@@ -576,7 +576,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {
@@ -613,7 +613,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {
@@ -650,7 +650,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {
@@ -687,7 +687,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {
@@ -724,7 +724,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {

--- a/tools/hangar/__snapshots__/test_corpus/valid/double_reference.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/double_reference.test.w_compile_tf-aws.md
@@ -144,7 +144,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["method", "$inflight_init"];
+        return [...super._supportedOps(), "method", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("$inflight_init")) {
@@ -177,7 +177,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["callFoo", "$inflight_init"];
+        return [...super._supportedOps(), "callFoo", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("$inflight_init")) {
@@ -216,7 +216,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {

--- a/tools/hangar/__snapshots__/test_corpus/valid/doubler.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/doubler.test.w_compile_tf-aws.md
@@ -285,7 +285,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["invoke", "$inflight_init"];
+        return [...super._supportedOps(), "invoke", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("$inflight_init")) {
@@ -321,7 +321,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
     }
     class Doubler2 extends $stdlib.std.Resource {
@@ -357,7 +357,7 @@ class $Root extends $stdlib.std.Resource {
             `;
           }
           _supportedOps() {
-            return ["handle", "$inflight_init"];
+            return [...super._supportedOps(), "handle", "$inflight_init"];
           }
           _registerOnLift(host, ops) {
             if (ops.includes("handle")) {
@@ -386,7 +386,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["$inflight_init"];
+        return [...super._supportedOps(), "$inflight_init"];
       }
     }
     class $Closure3 extends $stdlib.std.Resource {
@@ -413,7 +413,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
     }
     class $Closure4 extends $stdlib.std.Resource {
@@ -441,7 +441,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {

--- a/tools/hangar/__snapshots__/test_corpus/valid/enums.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/enums.test.w_compile_tf-aws.md
@@ -90,7 +90,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {

--- a/tools/hangar/__snapshots__/test_corpus/valid/extern_implementation.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/extern_implementation.test.w_compile_tf-aws.md
@@ -138,7 +138,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["regexInflight", "getUuid", "getData", "print", "call", "$inflight_init"];
+        return [...super._supportedOps(), "regexInflight", "getUuid", "getData", "print", "call", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("call")) {
@@ -172,7 +172,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {
@@ -206,7 +206,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {

--- a/tools/hangar/__snapshots__/test_corpus/valid/file_counter.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/file_counter.test.w_compile_tf-aws.md
@@ -254,7 +254,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {

--- a/tools/hangar/__snapshots__/test_corpus/valid/for_loop.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/for_loop.test.w_compile_tf-aws.md
@@ -215,7 +215,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
     }
     class Foo extends $stdlib.std.Resource {
@@ -240,7 +240,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["hello", "$inflight_init"];
+        return [...super._supportedOps(), "hello", "$inflight_init"];
       }
     }
     const words = ["wing", "lang", "dang"];

--- a/tools/hangar/__snapshots__/test_corpus/valid/forward_decl.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/forward_decl.test.w_compile_tf-aws.md
@@ -86,7 +86,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["$inflight_init"];
+        return [...super._supportedOps(), "$inflight_init"];
       }
     }
     const x = "hi";

--- a/tools/hangar/__snapshots__/test_corpus/valid/function_returns_function.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/function_returns_function.test.w_compile_tf-aws.md
@@ -95,7 +95,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
     }
     const fn = ((s) => {

--- a/tools/hangar/__snapshots__/test_corpus/valid/function_type.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/function_type.test.w_compile_tf-aws.md
@@ -138,7 +138,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
     }
     class $Closure2 extends $stdlib.std.Resource {
@@ -165,7 +165,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
     }
     class $Closure3 extends $stdlib.std.Resource {
@@ -192,7 +192,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
     }
     class C extends $stdlib.std.Resource {
@@ -221,7 +221,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["my_method3", "my_method4", "$inflight_init"];
+        return [...super._supportedOps(), "my_method3", "my_method4", "$inflight_init"];
       }
     }
     const my_func = ((callback) => {

--- a/tools/hangar/__snapshots__/test_corpus/valid/function_variadic_arguments.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/function_variadic_arguments.test.w_compile_tf-aws.md
@@ -128,7 +128,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["$inflight_init"];
+        return [...super._supportedOps(), "$inflight_init"];
       }
     }
     class B extends A {
@@ -155,7 +155,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["$inflight_init"];
+        return [...super._supportedOps(), "$inflight_init"];
       }
     }
     const bucket1 = this.node.root.new("@winglang/sdk.cloud.Bucket", cloud.Bucket, this, "bucket1");

--- a/tools/hangar/__snapshots__/test_corpus/valid/hello.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/hello.test.w_compile_tf-aws.md
@@ -231,7 +231,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {

--- a/tools/hangar/__snapshots__/test_corpus/valid/identical_inflights.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/identical_inflights.test.w_compile_tf-aws.md
@@ -103,7 +103,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
     }
     class $Closure2 extends $stdlib.std.Resource {
@@ -130,7 +130,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
     }
     const x = new $Closure1(this, "$Closure1");

--- a/tools/hangar/__snapshots__/test_corpus/valid/impl_interface.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/impl_interface.test.w_compile_tf-aws.md
@@ -154,7 +154,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
     }
     class $Closure1 extends $stdlib.std.Resource {
@@ -182,7 +182,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {
@@ -219,7 +219,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["method2", "$inflight_init"];
+        return [...super._supportedOps(), "method2", "$inflight_init"];
       }
     }
     class Dog extends $stdlib.std.Resource {
@@ -244,7 +244,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["eat", "$inflight_init"];
+        return [...super._supportedOps(), "eat", "$inflight_init"];
       }
     }
     class Terrier extends Dog {
@@ -270,7 +270,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["eat", "$inflight_init"];
+        return [...super._supportedOps(), "eat", "$inflight_init"];
       }
     }
     const x = new A(this, "A");

--- a/tools/hangar/__snapshots__/test_corpus/valid/in_scope_construct.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/in_scope_construct.test.w_compile_tf-aws.md
@@ -79,7 +79,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["$inflight_init"];
+        return [...super._supportedOps(), "$inflight_init"];
       }
     }
     new MyClass(this.node.root.new("constructs.Construct", c.Construct, this, "c.Construct"), "MyClass");

--- a/tools/hangar/__snapshots__/test_corpus/valid/inference.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/inference.test.w_compile_tf-aws.md
@@ -265,7 +265,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
     }
     const preflightClosure = ((nice) => {

--- a/tools/hangar/__snapshots__/test_corpus/valid/inflight-subscribers.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/inflight-subscribers.test.w_compile_tf-aws.md
@@ -357,7 +357,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
     }
     class $Closure2 extends $stdlib.std.Resource {
@@ -384,7 +384,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
     }
     (this.node.root.new("@winglang/sdk.cloud.Topic", cloud.Topic, this, "cloud.Topic").onMessage(new $Closure1(this, "$Closure1"), { timeout: (std.Duration.fromSeconds(180)) }));

--- a/tools/hangar/__snapshots__/test_corpus/valid/inflight_capture_static.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/inflight_capture_static.test.w_compile_tf-aws.md
@@ -186,7 +186,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["staticMethod", "$inflight_init"];
+        return [...super._supportedOps(), "staticMethod", "$inflight_init"];
       }
     }
     class OuterInflight extends $stdlib.std.Resource {
@@ -211,7 +211,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["staticMethod", "$inflight_init"];
+        return [...super._supportedOps(), "staticMethod", "$inflight_init"];
       }
     }
     class $Closure1 extends $stdlib.std.Resource {
@@ -239,7 +239,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {
@@ -273,7 +273,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
     }
     class $Closure3 extends $stdlib.std.Resource {
@@ -300,7 +300,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
     }
     class $Closure4 extends $stdlib.std.Resource {
@@ -328,7 +328,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
     }
     this.node.root.new("@winglang/sdk.std.Test", std.Test, this, "test:call static method of preflight", new $Closure1(this, "$Closure1"));

--- a/tools/hangar/__snapshots__/test_corpus/valid/inflight_class_capture_const.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/inflight_class_capture_const.test.w_compile_tf-aws.md
@@ -101,7 +101,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["getValue", "$inflight_init"];
+        return [...super._supportedOps(), "getValue", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("getValue")) {
@@ -136,7 +136,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {

--- a/tools/hangar/__snapshots__/test_corpus/valid/inflight_class_definitions.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/inflight_class_definitions.test.w_compile_tf-aws.md
@@ -210,7 +210,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["goo", "$inflight_init"];
+        return [...super._supportedOps(), "goo", "$inflight_init"];
       }
     }
     class B extends $stdlib.std.Resource {
@@ -235,7 +235,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["foo", "$inflight_init"];
+        return [...super._supportedOps(), "foo", "$inflight_init"];
       }
     }
     class $Closure1 extends $stdlib.std.Resource {
@@ -262,7 +262,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
     }
     class D extends $stdlib.std.Resource {
@@ -293,7 +293,7 @@ class $Root extends $stdlib.std.Resource {
             `;
           }
           _supportedOps() {
-            return ["$inflight_init"];
+            return [...super._supportedOps(), "$inflight_init"];
           }
         }
         const pb = new E(this, "E");
@@ -320,7 +320,7 @@ class $Root extends $stdlib.std.Resource {
             `;
           }
           _supportedOps() {
-            return ["foo", "$inflight_init"];
+            return [...super._supportedOps(), "foo", "$inflight_init"];
           }
         }
         const __parent_this_2 = this;
@@ -349,7 +349,7 @@ class $Root extends $stdlib.std.Resource {
             `;
           }
           _supportedOps() {
-            return ["handle", "$inflight_init"];
+            return [...super._supportedOps(), "handle", "$inflight_init"];
           }
         }
         this.inner = new $Closure2(this, "$Closure2");
@@ -376,7 +376,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["callInner", "$inflight_init"];
+        return [...super._supportedOps(), "callInner", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("$inflight_init")) {
@@ -417,7 +417,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {

--- a/tools/hangar/__snapshots__/test_corpus/valid/inflight_class_inner_capture_mutable.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/inflight_class_inner_capture_mutable.test.w_compile_tf-aws.md
@@ -98,7 +98,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
     }
     this.node.root.new("@winglang/sdk.std.Test", std.Test, this, "test:inner inflight class capture immutable", new $Closure1(this, "$Closure1"));

--- a/tools/hangar/__snapshots__/test_corpus/valid/inflight_class_inside_inflight_closure.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/inflight_class_inside_inflight_closure.test.w_compile_tf-aws.md
@@ -283,7 +283,7 @@ class $Root extends $stdlib.std.Resource {
             `;
           }
           _supportedOps() {
-            return ["handle", "$inflight_init"];
+            return [...super._supportedOps(), "handle", "$inflight_init"];
           }
           _registerOnLift(host, ops) {
             if (ops.includes("handle")) {
@@ -313,7 +313,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["$inflight_init"];
+        return [...super._supportedOps(), "$inflight_init"];
       }
     }
     class $Closure2 extends $stdlib.std.Resource {
@@ -341,7 +341,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {
@@ -374,7 +374,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
     }
     const p = new PreflightClass(this, "PreflightClass");

--- a/tools/hangar/__snapshots__/test_corpus/valid/inflight_class_modifiers.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/inflight_class_modifiers.test.w_compile_tf-aws.md
@@ -83,7 +83,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["field", "method", "$inflight_init"];
+        return [...super._supportedOps(), "field", "method", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("$inflight_init")) {

--- a/tools/hangar/__snapshots__/test_corpus/valid/inflight_class_outside_inflight_closure.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/inflight_class_outside_inflight_closure.test.w_compile_tf-aws.md
@@ -106,7 +106,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["lhs", "rhs", "add", "$inflight_init"];
+        return [...super._supportedOps(), "lhs", "rhs", "add", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("$inflight_init")) {
@@ -143,7 +143,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
     }
     this.node.root.new("@winglang/sdk.std.Test", std.Test, this, "test:inflight class outside inflight closure", new $Closure1(this, "$Closure1"));

--- a/tools/hangar/__snapshots__/test_corpus/valid/inflight_class_structural_interace_handler.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/inflight_class_structural_interace_handler.test.w_compile_tf-aws.md
@@ -110,7 +110,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
     }
     class $Closure1 extends $stdlib.std.Resource {
@@ -138,7 +138,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
     }
     this.node.root.new("@winglang/sdk.std.Test", std.Test, this, "test:structure interface types for 'handle'", new $Closure1(this, "$Closure1"));

--- a/tools/hangar/__snapshots__/test_corpus/valid/inflight_class_without_init.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/inflight_class_without_init.test.w_compile_tf-aws.md
@@ -96,7 +96,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["$inflight_init"];
+        return [...super._supportedOps(), "$inflight_init"];
       }
     }
     class $Closure1 extends $stdlib.std.Resource {
@@ -124,7 +124,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
     }
     this.node.root.new("@winglang/sdk.std.Test", std.Test, this, "test:inflight class without init", new $Closure1(this, "$Closure1"));

--- a/tools/hangar/__snapshots__/test_corpus/valid/inflight_closure_inside_preflight_closure.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/inflight_closure_inside_preflight_closure.test.w_compile_tf-aws.md
@@ -103,7 +103,7 @@ class $Root extends $stdlib.std.Resource {
               `;
             }
             _supportedOps() {
-              return ["handle", "$inflight_init"];
+              return [...super._supportedOps(), "handle", "$inflight_init"];
             }
           }
           new $Closure1(this, "$Closure1");
@@ -127,7 +127,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["$inflight_init"];
+        return [...super._supportedOps(), "$inflight_init"];
       }
     }
     new Foo(this, "Foo");

--- a/tools/hangar/__snapshots__/test_corpus/valid/inflight_concat.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/inflight_concat.test.w_compile_tf-aws.md
@@ -85,7 +85,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["foo", "$inflight_init"];
+        return [...super._supportedOps(), "foo", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("$inflight_init")) {

--- a/tools/hangar/__snapshots__/test_corpus/valid/inflight_init.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/inflight_init.test.w_compile_tf-aws.md
@@ -224,7 +224,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["field1", "field2", "get_six", "$inflight_init"];
+        return [...super._supportedOps(), "field1", "field2", "get_six", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("$inflight_init")) {
@@ -256,7 +256,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["field3", "$inflight_init"];
+        return [...super._supportedOps(), "field3", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("$inflight_init")) {
@@ -290,7 +290,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
     }
     class $Closure2 extends $stdlib.std.Resource {
@@ -318,7 +318,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
     }
     class $Closure3 extends $stdlib.std.Resource {
@@ -345,7 +345,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
     }
     class $Closure4 extends $stdlib.std.Resource {
@@ -373,7 +373,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
     }
     this.node.root.new("@winglang/sdk.std.Test", std.Test, this, "test:inflight class init", new $Closure1(this, "$Closure1"));

--- a/tools/hangar/__snapshots__/test_corpus/valid/inflights_calling_inflights.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/inflights_calling_inflights.test.w_compile_tf-aws.md
@@ -301,7 +301,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {
@@ -335,7 +335,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {
@@ -370,7 +370,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {
@@ -409,7 +409,7 @@ class $Root extends $stdlib.std.Resource {
             `;
           }
           _supportedOps() {
-            return ["handle", "$inflight_init"];
+            return [...super._supportedOps(), "handle", "$inflight_init"];
           }
           _registerOnLift(host, ops) {
             if (ops.includes("handle")) {
@@ -439,7 +439,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["foo", "$inflight_init"];
+        return [...super._supportedOps(), "foo", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("$inflight_init")) {
@@ -476,7 +476,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {

--- a/tools/hangar/__snapshots__/test_corpus/valid/inherit_stdlib_class.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/inherit_stdlib_class.test.w_compile_tf-aws.md
@@ -299,7 +299,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["$inflight_init"];
+        return [...super._supportedOps(), "$inflight_init"];
       }
     }
     class $Closure1 extends $stdlib.std.Resource {
@@ -326,7 +326,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
     }
     class $Closure2 extends $stdlib.std.Resource {
@@ -355,7 +355,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {

--- a/tools/hangar/__snapshots__/test_corpus/valid/inheritance_class_inflight.test.w_test_sim.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/inheritance_class_inflight.test.w_test_sim.md
@@ -1,0 +1,12 @@
+# [inheritance_class_inflight.test.w](../../../../../examples/tests/valid/inheritance_class_inflight.test.w) | test | sim
+
+## stdout.log
+```log
+pass ─ inheritance_class_inflight.test.wsim » root/env0/test:class inheritence
+ 
+ 
+Tests 1 passed (1)
+Test Files 1 passed (1)
+Duration <DURATION>
+```
+

--- a/tools/hangar/__snapshots__/test_corpus/valid/inheritance_class_preflight.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/inheritance_class_preflight.test.w_compile_tf-aws.md
@@ -1,0 +1,148 @@
+# [inheritance_class_preflight.test.w](../../../../../examples/tests/valid/inheritance_class_preflight.test.w) | compile | tf-aws
+
+## inflight.Foo-1.js
+```js
+"use strict";
+module.exports = function({ $FooBase }) {
+  class Foo extends $FooBase {
+    constructor({  }) {
+      super({  });
+    }
+  }
+  return Foo;
+}
+//# sourceMappingURL=inflight.Foo-1.js.map
+```
+
+## inflight.FooBase-1.js
+```js
+"use strict";
+module.exports = function({  }) {
+  class FooBase {
+    constructor({  }) {
+    }
+  }
+  return FooBase;
+}
+//# sourceMappingURL=inflight.FooBase-1.js.map
+```
+
+## main.tf.json
+```json
+{
+  "//": {
+    "metadata": {
+      "backend": "local",
+      "stackName": "root",
+      "version": "0.17.0"
+    },
+    "outputs": {
+      "root": {
+        "Default": {
+          "cloud.TestRunner": {
+            "TestFunctionArns": "WING_TEST_RUNNER_FUNCTION_IDENTIFIERS"
+          }
+        }
+      }
+    }
+  },
+  "output": {
+    "WING_TEST_RUNNER_FUNCTION_IDENTIFIERS": {
+      "value": "[]"
+    }
+  },
+  "provider": {
+    "aws": [
+      {}
+    ]
+  }
+}
+```
+
+## preflight.js
+```js
+"use strict";
+const $stdlib = require('@winglang/sdk');
+const $platforms = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLATFORMS);
+const $outdir = process.env.WING_SYNTH_DIR ?? ".";
+const $wing_is_test = process.env.WING_IS_TEST === "true";
+const std = $stdlib.std;
+const expect = $stdlib.expect;
+class $Root extends $stdlib.std.Resource {
+  constructor($scope, $id) {
+    super($scope, $id);
+    class FooBase extends $stdlib.std.Resource {
+      constructor($scope, $id, ) {
+        super($scope, $id);
+      }
+      bar() {
+        return "bar";
+      }
+      over() {
+        return "base";
+      }
+      static _toInflightType() {
+        return `
+          require("./inflight.FooBase-1.js")({
+          })
+        `;
+      }
+      _toInflight() {
+        return `
+          (await (async () => {
+            const FooBaseClient = ${FooBase._toInflightType(this)};
+            const client = new FooBaseClient({
+            });
+            if (client.$inflight_init) { await client.$inflight_init(); }
+            return client;
+          })())
+        `;
+      }
+      _supportedOps() {
+        return [...super._supportedOps(), "$inflight_init"];
+      }
+    }
+    class Foo extends FooBase {
+      constructor($scope, $id, ) {
+        super($scope, $id);
+      }
+      baz() {
+        return true;
+      }
+      over() {
+        return "derived";
+      }
+      static _toInflightType() {
+        return `
+          require("./inflight.Foo-1.js")({
+            $FooBase: ${$stdlib.core.liftObject(FooBase)},
+          })
+        `;
+      }
+      _toInflight() {
+        return `
+          (await (async () => {
+            const FooClient = ${Foo._toInflightType(this)};
+            const client = new FooClient({
+            });
+            if (client.$inflight_init) { await client.$inflight_init(); }
+            return client;
+          })())
+        `;
+      }
+      _supportedOps() {
+        return [...super._supportedOps(), "$inflight_init"];
+      }
+    }
+    const foo = new Foo(this, "Foo");
+    (expect.Util.equal((foo.bar()), "bar"));
+    (expect.Util.equal((foo.baz()), true));
+    (expect.Util.equal((foo.over()), "derived"));
+  }
+}
+const $PlatformManager = new $stdlib.platform.PlatformManager({platformPaths: $platforms});
+const $APP = $PlatformManager.createApp({ outdir: $outdir, name: "inheritance_class_preflight.test", rootConstruct: $Root, isTestEnvironment: $wing_is_test, entrypointDir: process.env['WING_SOURCE_DIR'], rootId: process.env['WING_ROOT_ID'] });
+$APP.synth();
+//# sourceMappingURL=preflight.js.map
+```
+

--- a/tools/hangar/__snapshots__/test_corpus/valid/inheritance_class_preflight.test.w_test_sim.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/inheritance_class_preflight.test.w_test_sim.md
@@ -1,0 +1,12 @@
+# [inheritance_class_preflight.test.w](../../../../../examples/tests/valid/inheritance_class_preflight.test.w) | test | sim
+
+## stdout.log
+```log
+pass ─ inheritance_class_preflight.test.wsim (no tests)
+ 
+ 
+Tests 1 passed (1)
+Test Files 1 passed (1)
+Duration <DURATION>
+```
+

--- a/tools/hangar/__snapshots__/test_corpus/valid/issue_2889.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/issue_2889.test.w_compile_tf-aws.md
@@ -290,7 +290,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
     }
     class $Closure2 extends $stdlib.std.Resource {
@@ -320,7 +320,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {

--- a/tools/hangar/__snapshots__/test_corpus/valid/json.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/json.test.w_compile_tf-aws.md
@@ -94,7 +94,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["$inflight_init"];
+        return [...super._supportedOps(), "$inflight_init"];
       }
     }
     const jsonNumber = 123;

--- a/tools/hangar/__snapshots__/test_corpus/valid/json_bucket.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/json_bucket.test.w_compile_tf-aws.md
@@ -227,7 +227,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {
@@ -265,7 +265,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {

--- a/tools/hangar/__snapshots__/test_corpus/valid/json_static.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/json_static.test.w_compile_tf-aws.md
@@ -111,7 +111,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {
@@ -145,7 +145,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
     }
     const x = ({"a": 123, "b": ({"c": 456, "d": 789})});

--- a/tools/hangar/__snapshots__/test_corpus/valid/lift_expr_with_this.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/lift_expr_with_this.test.w_compile_tf-aws.md
@@ -99,7 +99,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["$inflight_init"];
+        return [...super._supportedOps(), "$inflight_init"];
       }
     }
     class $Closure1 extends $stdlib.std.Resource {
@@ -127,7 +127,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("$inflight_init")) {

--- a/tools/hangar/__snapshots__/test_corpus/valid/lift_redefinition.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/lift_redefinition.test.w_compile_tf-aws.md
@@ -89,7 +89,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {

--- a/tools/hangar/__snapshots__/test_corpus/valid/lift_this.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/lift_this.test.w_compile_tf-aws.md
@@ -106,7 +106,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["x", "bar", "foo", "$inflight_init"];
+        return [...super._supportedOps(), "x", "bar", "foo", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("foo")) {
@@ -140,7 +140,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {

--- a/tools/hangar/__snapshots__/test_corpus/valid/lift_via_closure.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/lift_via_closure.test.w_compile_tf-aws.md
@@ -182,7 +182,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {
@@ -217,7 +217,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "putFile", "listFiles", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "putFile", "listFiles", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("$inflight_init")) {
@@ -261,7 +261,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {
@@ -297,7 +297,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {

--- a/tools/hangar/__snapshots__/test_corpus/valid/lift_via_closure_explicit.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/lift_via_closure_explicit.test.w_compile_tf-aws.md
@@ -123,7 +123,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("$inflight_init")) {
@@ -160,7 +160,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {

--- a/tools/hangar/__snapshots__/test_corpus/valid/new_in_static.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/new_in_static.test.w_compile_tf-aws.md
@@ -139,7 +139,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["$inflight_init"];
+        return [...super._supportedOps(), "$inflight_init"];
       }
     }
     class $Closure1 extends $stdlib.std.Resource {
@@ -167,7 +167,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {

--- a/tools/hangar/__snapshots__/test_corpus/valid/new_jsii.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/new_jsii.test.w_compile_tf-aws.md
@@ -94,7 +94,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["$inflight_init"];
+        return [...super._supportedOps(), "$inflight_init"];
       }
     }
     let count = 0;

--- a/tools/hangar/__snapshots__/test_corpus/valid/nil.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/nil.test.w_compile_tf-aws.md
@@ -139,7 +139,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["optionalVar", "returnNil", "setOptionalValue", "getOptionalValue", "$inflight_init"];
+        return [...super._supportedOps(), "optionalVar", "returnNil", "setOptionalValue", "getOptionalValue", "$inflight_init"];
       }
     }
     class $Closure1 extends $stdlib.std.Resource {
@@ -167,7 +167,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {
@@ -201,7 +201,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {

--- a/tools/hangar/__snapshots__/test_corpus/valid/optionals.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/optionals.test.w_compile_tf-aws.md
@@ -157,7 +157,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["$inflight_init"];
+        return [...super._supportedOps(), "$inflight_init"];
       }
     }
     class Sub extends Super {
@@ -184,7 +184,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["$inflight_init"];
+        return [...super._supportedOps(), "$inflight_init"];
       }
     }
     class Sub1 extends Super {
@@ -211,7 +211,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["$inflight_init"];
+        return [...super._supportedOps(), "$inflight_init"];
       }
     }
     class Node extends $stdlib.std.Resource {
@@ -239,7 +239,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["$inflight_init"];
+        return [...super._supportedOps(), "$inflight_init"];
       }
     }
     class $Closure1 extends $stdlib.std.Resource {
@@ -269,7 +269,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {

--- a/tools/hangar/__snapshots__/test_corpus/valid/print.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/print.test.w_compile_tf-aws.md
@@ -108,7 +108,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
     }
     class $Closure2 extends $stdlib.std.Resource {
@@ -135,7 +135,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
     }
     {console.log("preflight log")};

--- a/tools/hangar/__snapshots__/test_corpus/valid/reassignment.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/reassignment.test.w_compile_tf-aws.md
@@ -85,7 +85,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["$inflight_init"];
+        return [...super._supportedOps(), "$inflight_init"];
       }
     }
     let x = 5;

--- a/tools/hangar/__snapshots__/test_corpus/valid/redis.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/redis.test.w_compile_tf-aws.md
@@ -582,7 +582,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {
@@ -619,7 +619,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {

--- a/tools/hangar/__snapshots__/test_corpus/valid/resource.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/resource.test.w_compile_tf-aws.md
@@ -731,7 +731,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["inflightField", "fooInc", "fooGet", "fooStatic", "$inflight_init"];
+        return [...super._supportedOps(), "inflightField", "fooInc", "fooGet", "fooStatic", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("$inflight_init")) {
@@ -777,7 +777,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["barStatic", "myMethod", "testTypeAccess", "$inflight_init"];
+        return [...super._supportedOps(), "barStatic", "myMethod", "testTypeAccess", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("$inflight_init")) {
@@ -825,7 +825,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {
@@ -869,7 +869,7 @@ class $Root extends $stdlib.std.Resource {
             `;
           }
           _supportedOps() {
-            return ["handle", "$inflight_init"];
+            return [...super._supportedOps(), "handle", "$inflight_init"];
           }
           _registerOnLift(host, ops) {
             if (ops.includes("handle")) {
@@ -905,7 +905,7 @@ class $Root extends $stdlib.std.Resource {
             `;
           }
           _supportedOps() {
-            return ["handle", "$inflight_init"];
+            return [...super._supportedOps(), "handle", "$inflight_init"];
           }
           _registerOnLift(host, ops) {
             if (ops.includes("handle")) {
@@ -941,7 +941,7 @@ class $Root extends $stdlib.std.Resource {
             `;
           }
           _supportedOps() {
-            return ["handle", "$inflight_init"];
+            return [...super._supportedOps(), "handle", "$inflight_init"];
           }
           _registerOnLift(host, ops) {
             if (ops.includes("handle")) {
@@ -974,7 +974,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["publish", "getObjectCount", "$inflight_init"];
+        return [...super._supportedOps(), "publish", "getObjectCount", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("$inflight_init")) {
@@ -1019,7 +1019,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {
@@ -1053,7 +1053,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["$inflight_init"];
+        return [...super._supportedOps(), "$inflight_init"];
       }
     }
     class ScopeAndIdTestClass extends $stdlib.std.Resource {
@@ -1089,7 +1089,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["$inflight_init"];
+        return [...super._supportedOps(), "$inflight_init"];
       }
     }
     const MyEnum =

--- a/tools/hangar/__snapshots__/test_corpus/valid/resource_as_inflight_literal.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/resource_as_inflight_literal.test.w_compile_tf-aws.md
@@ -211,7 +211,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
     }
     class $Closure1 extends $stdlib.std.Resource {
@@ -239,7 +239,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {

--- a/tools/hangar/__snapshots__/test_corpus/valid/resource_call_static.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/resource_call_static.test.w_compile_tf-aws.md
@@ -123,7 +123,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["myStaticMethod", "$inflight_init"];
+        return [...super._supportedOps(), "myStaticMethod", "$inflight_init"];
       }
       static _registerOnLift(host, ops) {
         if (ops.includes("myStaticMethod")) {
@@ -157,7 +157,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {

--- a/tools/hangar/__snapshots__/test_corpus/valid/resource_captures.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/resource_captures.test.w_compile_tf-aws.md
@@ -280,7 +280,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["$inflight_init"];
+        return [...super._supportedOps(), "$inflight_init"];
       }
     }
     class Another extends $stdlib.std.Resource {
@@ -307,7 +307,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["meaningOfLife", "anotherFunc", "$inflight_init"];
+        return [...super._supportedOps(), "meaningOfLife", "anotherFunc", "$inflight_init"];
       }
     }
     class MyResource extends $stdlib.std.Resource {
@@ -367,7 +367,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["inflightField", "testNoCapture", "testCaptureCollectionsOfData", "testCapturePrimitives", "testCaptureOptional", "testCaptureResource", "testNestedInflightField", "testNestedResource", "testExpressionRecursive", "testExternal", "testUserDefinedResource", "testInflightField", "$inflight_init"];
+        return [...super._supportedOps(), "inflightField", "testNoCapture", "testCaptureCollectionsOfData", "testCapturePrimitives", "testCaptureOptional", "testCaptureResource", "testNestedInflightField", "testNestedResource", "testExpressionRecursive", "testExternal", "testUserDefinedResource", "testInflightField", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("$inflight_init")) {
@@ -458,7 +458,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {

--- a/tools/hangar/__snapshots__/test_corpus/valid/resource_captures_globals.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/resource_captures_globals.test.w_compile_tf-aws.md
@@ -391,7 +391,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["$inflight_init"];
+        return [...super._supportedOps(), "$inflight_init"];
       }
     }
     class Another extends $stdlib.std.Resource {
@@ -419,7 +419,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["myMethod", "myStaticMethod", "$inflight_init"];
+        return [...super._supportedOps(), "myMethod", "myStaticMethod", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("$inflight_init")) {
@@ -468,7 +468,7 @@ class $Root extends $stdlib.std.Resource {
             `;
           }
           _supportedOps() {
-            return ["handle", "$inflight_init"];
+            return [...super._supportedOps(), "handle", "$inflight_init"];
           }
           _registerOnLift(host, ops) {
             if (ops.includes("handle")) {
@@ -510,7 +510,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["myPut", "$inflight_init"];
+        return [...super._supportedOps(), "myPut", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("$inflight_init")) {
@@ -558,7 +558,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {
@@ -592,7 +592,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {

--- a/tools/hangar/__snapshots__/test_corpus/valid/shadowing.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/shadowing.test.w_compile_tf-aws.md
@@ -119,7 +119,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {
@@ -153,7 +153,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {

--- a/tools/hangar/__snapshots__/test_corpus/valid/statements_if.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/statements_if.test.w_compile_tf-aws.md
@@ -106,7 +106,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
     }
     if (true) {

--- a/tools/hangar/__snapshots__/test_corpus/valid/static_members.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/static_members.test.w_compile_tf-aws.md
@@ -115,7 +115,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["get123", "$inflight_init"];
+        return [...super._supportedOps(), "get123", "$inflight_init"];
       }
     }
     class $Closure1 extends $stdlib.std.Resource {
@@ -142,7 +142,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
     }
     const foo = new Foo(this, "Foo");

--- a/tools/hangar/__snapshots__/test_corpus/valid/std_containers.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/std_containers.test.w_compile_tf-aws.md
@@ -106,7 +106,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["$inflight_init"];
+        return [...super._supportedOps(), "$inflight_init"];
       }
     }
     class Cat extends Animal {
@@ -132,7 +132,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["$inflight_init"];
+        return [...super._supportedOps(), "$inflight_init"];
       }
     }
     class Dog extends Animal {
@@ -158,7 +158,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["$inflight_init"];
+        return [...super._supportedOps(), "$inflight_init"];
       }
     }
     const sArray = ["one", "two"];

--- a/tools/hangar/__snapshots__/test_corpus/valid/std_string.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/std_string.test.w_compile_tf-aws.md
@@ -91,7 +91,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {

--- a/tools/hangar/__snapshots__/test_corpus/valid/store.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/store.w_compile_tf-aws.md
@@ -89,7 +89,7 @@ module.exports = function({ $stdlib }) {
       `;
     }
     _supportedOps() {
-      return ["$inflight_init"];
+      return [...super._supportedOps(), "$inflight_init"];
     }
   }
   class Store extends $stdlib.std.Resource {
@@ -122,7 +122,7 @@ module.exports = function({ $stdlib }) {
           `;
         }
         _supportedOps() {
-          return ["handle", "$inflight_init"];
+          return [...super._supportedOps(), "handle", "$inflight_init"];
         }
         _registerOnLift(host, ops) {
           if (ops.includes("handle")) {
@@ -152,7 +152,7 @@ module.exports = function({ $stdlib }) {
       `;
     }
     _supportedOps() {
-      return ["store", "$inflight_init"];
+      return [...super._supportedOps(), "store", "$inflight_init"];
     }
     _registerOnLift(host, ops) {
       if (ops.includes("$inflight_init")) {

--- a/tools/hangar/__snapshots__/test_corpus/valid/struct_from_json.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/struct_from_json.test.w_compile_tf-aws.md
@@ -222,7 +222,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {
@@ -256,7 +256,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
     }
     class $Closure3 extends $stdlib.std.Resource {
@@ -285,7 +285,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {
@@ -323,7 +323,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {
@@ -362,7 +362,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
     }
     const j = ({"public": false});
@@ -550,7 +550,7 @@ module.exports = function({ $stdlib }) {
       `;
     }
     _supportedOps() {
-      return ["$inflight_init"];
+      return [...super._supportedOps(), "$inflight_init"];
     }
   }
   return { UsesStructInImportedFile };

--- a/tools/hangar/__snapshots__/test_corpus/valid/structs.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/structs.test.w_compile_tf-aws.md
@@ -104,7 +104,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["getStuff", "$inflight_init"];
+        return [...super._supportedOps(), "getStuff", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("$inflight_init")) {
@@ -140,7 +140,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
     }
     const x = ({"field0": "Sup"});

--- a/tools/hangar/__snapshots__/test_corpus/valid/super_call.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/super_call.test.w_compile_tf-aws.md
@@ -252,7 +252,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["$inflight_init"];
+        return [...super._supportedOps(), "$inflight_init"];
       }
     }
     class B extends A {
@@ -281,7 +281,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["$inflight_init"];
+        return [...super._supportedOps(), "$inflight_init"];
       }
     }
     class C extends B {
@@ -310,7 +310,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["$inflight_init"];
+        return [...super._supportedOps(), "$inflight_init"];
       }
     }
     class D extends C {
@@ -336,7 +336,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["$inflight_init"];
+        return [...super._supportedOps(), "$inflight_init"];
       }
     }
     class E extends D {
@@ -365,7 +365,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["$inflight_init"];
+        return [...super._supportedOps(), "$inflight_init"];
       }
     }
     class InflightA extends $stdlib.std.Resource {
@@ -390,7 +390,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["description", "$inflight_init"];
+        return [...super._supportedOps(), "description", "$inflight_init"];
       }
     }
     class InflightB extends InflightA {
@@ -416,7 +416,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["description", "$inflight_init"];
+        return [...super._supportedOps(), "description", "$inflight_init"];
       }
     }
     class $Closure1 extends $stdlib.std.Resource {
@@ -445,7 +445,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
     }
     class BaseClass extends $stdlib.std.Resource {
@@ -471,7 +471,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["do", "$inflight_init"];
+        return [...super._supportedOps(), "do", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("do")) {
@@ -504,7 +504,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["do", "$inflight_init"];
+        return [...super._supportedOps(), "do", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("do")) {
@@ -539,7 +539,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {

--- a/tools/hangar/__snapshots__/test_corpus/valid/symbol_shadow.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/symbol_shadow.test.w_compile_tf-aws.md
@@ -165,7 +165,7 @@ class $Root extends $stdlib.std.Resource {
             `;
           }
           _supportedOps() {
-            return ["handle", "$inflight_init"];
+            return [...super._supportedOps(), "handle", "$inflight_init"];
           }
           _registerOnLift(host, ops) {
             if (ops.includes("handle")) {
@@ -194,7 +194,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["$inflight_init"];
+        return [...super._supportedOps(), "$inflight_init"];
       }
     }
     class $Closure3 extends $stdlib.std.Resource {
@@ -222,7 +222,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {
@@ -255,7 +255,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
     }
     const s = "top";
@@ -287,7 +287,7 @@ class $Root extends $stdlib.std.Resource {
           `;
         }
         _supportedOps() {
-          return ["handle", "$inflight_init"];
+          return [...super._supportedOps(), "handle", "$inflight_init"];
         }
         _registerOnLift(host, ops) {
           if (ops.includes("handle")) {

--- a/tools/hangar/__snapshots__/test_corpus/valid/test_bucket.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/test_bucket.test.w_compile_tf-aws.md
@@ -124,7 +124,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {
@@ -158,7 +158,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {

--- a/tools/hangar/__snapshots__/test_corpus/valid/test_without_bring.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/test_without_bring.test.w_compile_tf-aws.md
@@ -86,7 +86,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
     }
     this.node.root.new("@winglang/sdk.std.Test", std.Test, this, "test:hello test", new $Closure1(this, "$Closure1"));

--- a/tools/hangar/__snapshots__/test_corpus/valid/use_inflight_method_inside_init_closure.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/use_inflight_method_inside_init_closure.test.w_compile_tf-aws.md
@@ -213,7 +213,7 @@ class $Root extends $stdlib.std.Resource {
             `;
           }
           _supportedOps() {
-            return ["handle", "$inflight_init"];
+            return [...super._supportedOps(), "handle", "$inflight_init"];
           }
           _registerOnLift(host, ops) {
             if (ops.includes("handle")) {
@@ -242,7 +242,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["bar", "$inflight_init"];
+        return [...super._supportedOps(), "bar", "$inflight_init"];
       }
     }
     new Foo(this, "Foo");

--- a/tools/hangar/__snapshots__/test_corpus/valid/website_with_api.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/website_with_api.test.w_compile_tf-aws.md
@@ -631,7 +631,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {
@@ -666,7 +666,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {
@@ -703,7 +703,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {
@@ -740,7 +740,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
       _registerOnLift(host, ops) {
         if (ops.includes("handle")) {

--- a/tools/hangar/__snapshots__/test_corpus/valid/while_loop_await.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/while_loop_await.test.w_compile_tf-aws.md
@@ -225,7 +225,7 @@ class $Root extends $stdlib.std.Resource {
         `;
       }
       _supportedOps() {
-        return ["handle", "$inflight_init"];
+        return [...super._supportedOps(), "handle", "$inflight_init"];
       }
     }
     const queue = this.node.root.new("@winglang/sdk.cloud.Queue", cloud.Queue, this, "cloud.Queue");


### PR DESCRIPTION
Fixes #5052 by calling `super._supportedOps()` and returning `[]` from the base resource.

Add a bunch of relevant tests.

## Checklist

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [x] Tests added (always)
- [x] Docs updated (only required for features)
- [x] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
