### PR TITLE
fix: cannot call methods from base interfaces

### DIFF
--- a/examples/tests/valid/inheritance_interface.test.w
+++ b/examples/tests/valid/inheritance_interface.test.w
@@ -1,0 +1,18 @@
+bring expect;
+
+interface IFoo {
+  foo(): str;
+}
+
+interface IBar extends IFoo {
+  bar(): str;
+}
+
+class Baz impl IBar {
+  pub foo(): str { return "foo"; }
+  pub bar(): str { return "bar"; }
+}
+
+let baz: IBar = new Baz();
+expect.equal(baz.foo(), "foo");
+expect.equal(baz.bar(), "bar");

--- a/libs/wingc/src/type_check.rs
+++ b/libs/wingc/src/type_check.rs
@@ -5587,7 +5587,7 @@ fn add_parent_members_to_iface_env(
 						sym.clone(),
 						member_type,
 						false,
-						true,
+						false,
 						iface_env.phase,
 						AccessModifier::Public,
 						None,

--- a/tools/hangar/__snapshots__/test_corpus/valid/inheritance_interface.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/inheritance_interface.test.w_compile_tf-aws.md
@@ -1,0 +1,101 @@
+# [inheritance_interface.test.w](../../../../../examples/tests/valid/inheritance_interface.test.w) | compile | tf-aws
+
+## inflight.Baz-1.js
+```js
+"use strict";
+module.exports = function({  }) {
+  class Baz {
+    constructor({  }) {
+    }
+  }
+  return Baz;
+}
+//# sourceMappingURL=inflight.Baz-1.js.map
+```
+
+## main.tf.json
+```json
+{
+  "//": {
+    "metadata": {
+      "backend": "local",
+      "stackName": "root",
+      "version": "0.17.0"
+    },
+    "outputs": {
+      "root": {
+        "Default": {
+          "cloud.TestRunner": {
+            "TestFunctionArns": "WING_TEST_RUNNER_FUNCTION_IDENTIFIERS"
+          }
+        }
+      }
+    }
+  },
+  "output": {
+    "WING_TEST_RUNNER_FUNCTION_IDENTIFIERS": {
+      "value": "[]"
+    }
+  },
+  "provider": {
+    "aws": [
+      {}
+    ]
+  }
+}
+```
+
+## preflight.js
+```js
+"use strict";
+const $stdlib = require('@winglang/sdk');
+const $platforms = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLATFORMS);
+const $outdir = process.env.WING_SYNTH_DIR ?? ".";
+const $wing_is_test = process.env.WING_IS_TEST === "true";
+const std = $stdlib.std;
+const expect = $stdlib.expect;
+class $Root extends $stdlib.std.Resource {
+  constructor($scope, $id) {
+    super($scope, $id);
+    class Baz extends $stdlib.std.Resource {
+      constructor($scope, $id, ) {
+        super($scope, $id);
+      }
+      foo() {
+        return "foo";
+      }
+      bar() {
+        return "bar";
+      }
+      static _toInflightType() {
+        return `
+          require("./inflight.Baz-1.js")({
+          })
+        `;
+      }
+      _toInflight() {
+        return `
+          (await (async () => {
+            const BazClient = ${Baz._toInflightType(this)};
+            const client = new BazClient({
+            });
+            if (client.$inflight_init) { await client.$inflight_init(); }
+            return client;
+          })())
+        `;
+      }
+      _supportedOps() {
+        return ["$inflight_init"];
+      }
+    }
+    const baz = new Baz(this, "Baz");
+    (expect.Util.equal((baz.foo()), "foo"));
+    (expect.Util.equal((baz.bar()), "bar"));
+  }
+}
+const $PlatformManager = new $stdlib.platform.PlatformManager({platformPaths: $platforms});
+const $APP = $PlatformManager.createApp({ outdir: $outdir, name: "inheritance_interface.test", rootConstruct: $Root, isTestEnvironment: $wing_is_test, entrypointDir: process.env['WING_SOURCE_DIR'], rootId: process.env['WING_ROOT_ID'] });
+$APP.synth();
+//# sourceMappingURL=preflight.js.map
+```
+

--- a/tools/hangar/__snapshots__/test_corpus/valid/inheritance_interface.test.w_test_sim.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/inheritance_interface.test.w_test_sim.md
@@ -1,0 +1,12 @@
+# [inheritance_interface.test.w](../../../../../examples/tests/valid/inheritance_interface.test.w) | test | sim
+
+## stdout.log
+```log
+pass ─ inheritance_interface.test.wsim (no tests)
+ 
+ 
+Tests 1 passed (1)
+Test Files 1 passed (1)
+Duration <DURATION>
+```
+


### PR DESCRIPTION
Fixes #5073 by setting inherited members to non static (it was a mistake I am assuming).

## Checklist

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [x] Tests added (always)
- [x] Docs updated (only required for features)
- [x] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
