### PR TITLE
chore(vscode): highlight string interpolation

### DIFF
--- a/apps/vscode-wing/syntaxes/wing.tmLanguage.json
+++ b/apps/vscode-wing/syntaxes/wing.tmLanguage.json
@@ -50,7 +50,7 @@
       "patterns": [
         {
           "name": "meta.template.expression.wing",
-          "begin": "\\$\\{",
+          "begin": "\\{",
           "beginCaptures": {
             "0": {
               "name": "punctuation.definition.template-expression.begin.wing"


### PR DESCRIPTION
Fixes #5058 

Following #4326, this PR fixes the vscode highlighting of interpolated strings.

Before this PR:
![image](https://github.com/winglang/wing/assets/106860404/944ef5b7-5b6b-4160-ae14-fbc12b2c995f)

After:
![image](https://github.com/winglang/wing/assets/106860404/582e75f1-2ab8-4fad-af20-dc3a1d64076d)


## Checklist

- [ ] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [ ] Description explains motivation and solution
- [ ] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
