### PR TITLE
feat(repo): comment on each new pr with ownership table

### DIFF
--- a/.github/workflows/new-pull-request-comment.yml
+++ b/.github/workflows/new-pull-request-comment.yml
@@ -1,0 +1,48 @@
+name: PR Creation Comment
+
+on:
+  pull_request:
+    types:
+      - opened
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Comment on new PR
+        uses: thollander/actions-comment-pull-request@v2
+        with:
+          message: |
+            Thanks for opening this pull request! :tada:
+            Please consult the [contributing guidelines](https://www.winglang.io/contributing) for information on how to contribute to this project.
+            Below is the list of owners for the different areas of this project:
+            | Owner(s)                                   | Area                                                          |
+            |--------------------------------------------|---------------------------------------------------------------|
+            | @eladb                                     | Language design                                               |
+            | @yoav-steinberg                            | Inflight/lifting                                              |
+            |                                            | Compiler architecture                                         |
+            | @chriscbr                                  | Libraries                                                     |
+            |                                            | Containers                                                    |
+            |                                            | SDK API design + architecture                                 |
+            |                                            | /apps/wing-api-checker                                        |
+            |                                            | Standard utils                                                |
+            | @markmcculloh                              | Build+infra (CI/CD)                                           |
+            |                                            | /tools                                                        |
+            |                                            | /libs/wingii                                                  |
+            |                                            | /libs/wingc/src/lsp                                           |
+            |                                            | /apps/vscode-wing                                             |
+            |                                            | /libs/tree-sitter-wing                                        |
+            |                                            | /apps/wing (CLI)                                              |
+            |                                            | /libs/wingcompiler                                            |
+            | @hasanaburayyan                            | Platforms                                                     |
+            |                                            | Json & Struct                                                 |
+            |                                            | Standard types (Array, Map, etc.)                             |
+            |                                            | /docs                                                         |
+            | @tsuf239                                   | Cloud coverage (/examples)                                    |
+            |                                            | Wing test                                                     |
+            |                                            | On-call                                                       |
+            |                                            | /apps/jsii-docgen                                             |
+            | @ainvoner, @skyrpex, @polamoros, @eladcon  | Wing Console, Wing Cloud, Docsite, Playground, Learn          |
+            | @skorfmann                                 | Examples repo                                                 |
+          comment_tag: New PR
+          GITHUB_TOKEN: ${{secrets.PROJEN_GITHUB_TOKEN}}

--- a/.github/workflows/new-pull-request-comment.yml
+++ b/.github/workflows/new-pull-request-comment.yml
@@ -16,33 +16,33 @@ jobs:
             Thanks for opening this pull request! :tada:
             Please consult the [contributing guidelines](https://www.winglang.io/contributing) for information on how to contribute to this project.
             Below is the list of owners for the different areas of this project:
-            | Owner(s)                                   | Area                                                          |
-            |--------------------------------------------|---------------------------------------------------------------|
-            | @eladb                                     | Language design                                               |
-            | @yoav-steinberg                            | Inflight/lifting                                              |
-            |                                            | Compiler architecture                                         |
-            | @chriscbr                                  | Libraries                                                     |
-            |                                            | Containers                                                    |
-            |                                            | SDK API design + architecture                                 |
-            |                                            | /apps/wing-api-checker                                        |
-            |                                            | Standard utils                                                |
-            | @markmcculloh                              | Build+infra (CI/CD)                                           |
-            |                                            | /tools                                                        |
-            |                                            | /libs/wingii                                                  |
-            |                                            | /libs/wingc/src/lsp                                           |
-            |                                            | /apps/vscode-wing                                             |
-            |                                            | /libs/tree-sitter-wing                                        |
-            |                                            | /apps/wing (CLI)                                              |
-            |                                            | /libs/wingcompiler                                            |
-            | @hasanaburayyan                            | Platforms                                                     |
-            |                                            | Json & Struct                                                 |
-            |                                            | Standard types (Array, Map, etc.)                             |
-            |                                            | /docs                                                         |
-            | @tsuf239                                   | Cloud coverage (/examples)                                    |
-            |                                            | Wing test                                                     |
-            |                                            | On-call                                                       |
-            |                                            | /apps/jsii-docgen                                             |
-            | @ainvoner, @skyrpex, @polamoros, @eladcon  | Wing Console, Wing Cloud, Docsite, Playground, Learn          |
-            | @skorfmann                                 | Examples repo                                                 |
+            | Owner(s)                                            | Area                                                          |
+            |-----------------------------------------------------|---------------------------------------------------------------|
+            | @eladb                                              | Language design                                               |
+            | @yoav-steinberg                                     | Inflight/lifting                                              |
+            |                                                     | Compiler architecture                                         |
+            | @chriscbr                                           | Libraries                                                     |
+            |                                                     | Containers                                                    |
+            |                                                     | SDK API design + architecture                                 |
+            |                                                     | /apps/wing-api-checker                                        |
+            |                                                     | Standard utils                                                |
+            | @markmcculloh                                       | Build+infra (CI/CD)                                           |
+            |                                                     | /tools                                                        |
+            |                                                     | /libs/wingii                                                  |
+            |                                                     | /libs/wingc/src/lsp                                           |
+            |                                                     | /apps/vscode-wing                                             |
+            |                                                     | /libs/tree-sitter-wing                                        |
+            |                                                     | /apps/wing (CLI)                                              |
+            |                                                     | /libs/wingcompiler                                            |
+            | @hasanaburayyan                                     | Platforms                                                     |
+            |                                                     | Json & Struct                                                 |
+            |                                                     | Standard types (Array, Map, etc.)                             |
+            |                                                     | /docs                                                         |
+            | @tsuf239                                            | Cloud coverage (/examples)                                    |
+            |                                                     | Wing test                                                     |
+            |                                                     | On-call                                                       |
+            |                                                     | /apps/jsii-docgen                                             |
+            | @ainvoner, @skyrpex, @polamoros, @eladcon, @skorfmann | Wing Console, Wing Cloud, Docsite, Playground, Learn          |
+            | @skorfmann                                          | Examples repo                                                 |
           comment_tag: New PR
           GITHUB_TOKEN: ${{secrets.PROJEN_GITHUB_TOKEN}}

--- a/.github/workflows/new-pull-request-comment.yml
+++ b/.github/workflows/new-pull-request-comment.yml
@@ -14,35 +14,27 @@ jobs:
         with:
           message: |
             Thanks for opening this pull request! :tada:
-            Please consult the [contributing guidelines](https://www.winglang.io/contributing) for information on how to contribute to this project.
-            Below is the list of owners for the different areas of this project:
-            | Owner(s)                                            | Area                                                          |
+            Please consult the [contributing guidelines](https://www.winglang.io/contributing) for details on how to contribute to this project.
+            If you need any assistence, don't hesitate to ping the relevant owner over [Slack](https://t.winglang.io/slack).
+            
+            | Topic                                               | Owner                                                         |
             |-----------------------------------------------------|---------------------------------------------------------------|
-            | @eladb                                              | Language design                                               |
-            | @yoav-steinberg                                     | Inflight/lifting                                              |
-            |                                                     | Compiler architecture                                         |
-            | @chriscbr                                           | Libraries                                                     |
-            |                                                     | Containers                                                    |
-            |                                                     | SDK API design + architecture                                 |
-            |                                                     | /apps/wing-api-checker                                        |
-            |                                                     | Standard utils                                                |
-            | @markmcculloh                                       | Build+infra (CI/CD)                                           |
-            |                                                     | /tools                                                        |
-            |                                                     | /libs/wingii                                                  |
-            |                                                     | /libs/wingc/src/lsp                                           |
-            |                                                     | /apps/vscode-wing                                             |
-            |                                                     | /libs/tree-sitter-wing                                        |
-            |                                                     | /apps/wing (CLI)                                              |
-            |                                                     | /libs/wingcompiler                                            |
-            | @hasanaburayyan                                     | Platforms                                                     |
-            |                                                     | Json & Struct                                                 |
-            |                                                     | Standard types (Array, Map, etc.)                             |
-            |                                                     | /docs                                                         |
-            | @tsuf239                                            | Cloud coverage (/examples)                                    |
-            |                                                     | Wing test                                                     |
-            |                                                     | On-call                                                       |
-            |                                                     | /apps/jsii-docgen                                             |
-            | @ainvoner, @skyrpex, @polamoros, @eladcon, @skorfmann | Wing Console, Wing Cloud, Docsite, Playground, Learn          |
-            | @skorfmann                                          | Examples repo                                                 |
+            | Wing SDK and utility APIs                           | @chriscbr
+            | Wing Console                                        | @ainvoner, @skyrpex, @polamoros
+            | JSON, structs, primitives and collections           | @hasanaburayyan
+            | Platforms and plugins                               | @hasanaburayyan
+            | Frontend resources (website, react, etc)            | @tsuf239
+            | Language design                                     | @eladb
+            | VSCode extension and language server                | @markmcculloh
+            | Compiler architecture, inflights, lifting           | @yoav-steinberg
+            | Wing Testing Framework                              | @tsuf239
+            | Wing CLI                                            | @markmcculloh
+            | Build system, dev environment, releases             | @markmcculloh
+            | Library Ecosystem                                   | @chriscbr
+            | Documentation                                       | @hasanaburayyan
+            | SDK test suite                                      | @tsuf239 
+            | Examples                                            | @skorfmann
+            | Wing Playground                                     | @eladcon
+
           comment_tag: New PR
           GITHUB_TOKEN: ${{secrets.PROJEN_GITHUB_TOKEN}}


### PR DESCRIPTION
We decided we'd like to add a comment on each new PR opened.

This comment should contain the ownership on the different areas of our project.

See below what the comment looks like.


## Checklist

- [ ] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [ ] Description explains motivation and solution
- [ ] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
