### PR TITLE
feat(cli): allow all tests in default environment

### DIFF
--- a/apps/wing/src/commands/test/test.test.ts
+++ b/apps/wing/src/commands/test/test.test.ts
@@ -216,6 +216,24 @@ describe("test-filter option", () => {
     expect(filteredTests[0]).toBe("root/env0/test:get()");
     expect(filteredTests[1]).toBe("root/env1/test:get:At()");
   });
+
+  // use-case:
+  // an external platform overrides the test generation logic
+  // in https://github.com/winglang/wing/blob/9573195e753fa0d303e65d8237d3902159708457/libs/wingsdk/src/core/app.ts#L297-L316
+  // to generate all tests in a single Default environment
+  test("wing test with single Default environment", () => {
+    const testNames = [
+      "root/Default/test:get()",
+      "root/Default/test:get:At()",
+      "root/Default/test:stringify()",
+    ];
+    const filteredTests = pickOneTestPerEnvironment(filterTests(testNames));
+
+    expect(filteredTests.length).toBe(3);
+    expect(filteredTests[0]).toBe("root/Default/test:get()");
+    expect(filteredTests[1]).toBe("root/Default/test:get:At()");
+    expect(filteredTests[2]).toBe("root/Default/test:stringify()");
+  });
 });
 
 describe("retry option", () => {

--- a/apps/wing/src/commands/test/test.ts
+++ b/apps/wing/src/commands/test/test.ts
@@ -496,6 +496,12 @@ export function pickOneTestPerEnvironment(testPaths: string[]) {
   const envs = new Set<string>();
 
   for (const testPath of testPaths) {
+    if (testPath.startsWith("root/Default/")) {
+      const testName = testPath.substring(testPath.lastIndexOf("/") + 1);
+      tests.set(testName, testPath);
+      continue;
+    }
+
     const testSuffix = testPath.substring(testPath.indexOf("env") + 1); // "<env #>/<path to test>"
     const env = testSuffix.substring(0, testSuffix.indexOf("/")); // "<env #>"
     const testName = testSuffix.substring(testSuffix.indexOf("/") + 1); // "<path to test>"


### PR DESCRIPTION
use-case:

an external platform overrides the test generation logic in https://github.com/winglang/wing/blob/9573195e753fa0d303e65d8237d3902159708457/libs/wingsdk/src/core/app.ts#L297-L316 to generate all tests in a single Default environment.

Without this, `wing test` would only select one test and ignore the rest.

related to https://github.com/winglang/wing/issues/3168 / https://github.com/winglang/wing/issues/4997

## Checklist

- [ ] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [ ] Description explains motivation and solution
- [ ] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
