### PR TITLE
fix(sdk): Policy statement must contain actions

### DIFF
--- a/libs/wingsdk/src/shared-aws/permissions.ts
+++ b/libs/wingsdk/src/shared-aws/permissions.ts
@@ -226,7 +226,9 @@ export function calculateBucketPermissions(
   if (ops.includes(cloud.BucketInflightMethods.COPY)) {
     actions.push("s3:CopyObject");
   }
-
+  if (actions.length == 0) {
+    return [];
+  }
   return [{ actions, resources: [arn, `${arn}/*`] }];
 }
 


### PR DESCRIPTION
The following example:
```ts
bring cloud;
class A {
  b: cloud.Bucket;
  new() {
    this.b = new cloud.Bucket();

  }
  pub inflight foo(){
    log(this.b.get("/"));
  }
  pub inflight bar(){
  }
}
let a = new A();
let api = new cloud.Api();
api.get("/foo", inflight () => {
  a.foo();
  return {
    status:200
  };
});

api.get("/bar", inflight () => {
  a.bar();
  return {
    status:200
  };
});

```

The `/bar` handler generates a permission statement with no actions

The result of this (in tf-aws)
> │ Error: putting IAM role policy terraform-20231203231506983600000011: MalformedPolicyDocument: Policy statement must contain actions.
│       status code: 400, request id: 64362a50-bf3d-412b-8e65-d26af68e71bd

## Checklist

- [ ] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [ ] Description explains motivation and solution
- [ ] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
