### PR TITLE
fix(sdk): awaiting client object causes error in sim target

### DIFF
--- a/libs/wingsdk/src/shared/sandbox.ts
+++ b/libs/wingsdk/src/shared/sandbox.ts
@@ -42,6 +42,10 @@ export class Sandbox {
       sandboxConsole[level] = (...args: any[]) => {
         const message = util.format(...args);
         this.options.log?.(false, level, message);
+        // also log to stderr if DEBUG is set
+        if (process.env.DEBUG) {
+          console.error(message);
+        }
       };
     }
 

--- a/libs/wingsdk/src/simulator/client.ts
+++ b/libs/wingsdk/src/simulator/client.ts
@@ -48,7 +48,14 @@ export function deserializeValue(input: string): any {
 }
 
 export function makeSimulatorClient(url: string, handle: string) {
+  let proxy: any;
+  let hasThenMethod = true; // assume that the object has a "then" method until proven otherwise
+
   const get = (_target: any, method: string, _receiver: any) => {
+    if (method === "then" && !hasThenMethod) {
+      return undefined;
+    }
+
     return async function (...args: any[]) {
       const body: SimulatorServerRequest = { handle, method, args };
       let resp;
@@ -75,15 +82,35 @@ export function makeSimulatorClient(url: string, handle: string) {
       let parsed: SimulatorServerResponse = deserializeValue(await resp.text());
 
       if (parsed.error) {
+        // objects with "then" methods are special-cased by the JS runtime
+        // because they are assumed to be promises, and can be awaited.
+        // however, we don't know ahead of time what methods will be on the
+        // object, so we have to assume that it has a "then" method until
+        // we get an error back from the server saying that it doesn't.
+        if (
+          method === "then" &&
+          parsed.error &&
+          parsed.error.message &&
+          parsed.error.message.startsWith("Method then not found on resource")
+        ) {
+          hasThenMethod = false;
+          // args[0] is the onFulfilled callback passed to the then method.
+          // we call it with the proxy object so that that `await client`
+          // returns the proxy object back, as callers might expect.
+          return args[0](proxy);
+        }
+
         let err = new Error();
         err.message = parsed.error?.message;
         err.stack = parsed.error?.stack;
         err.name = parsed.error?.name;
         throw err;
       }
+
       return parsed.result;
     };
   };
 
-  return new Proxy({}, { get });
+  proxy = new Proxy({}, { get });
+  return proxy;
 }

--- a/libs/wingsdk/src/simulator/client.ts
+++ b/libs/wingsdk/src/simulator/client.ts
@@ -91,9 +91,7 @@ export function makeSimulatorClient(url: string, handle: string) {
         // [0]: https://stackoverflow.com/questions/55262996/does-awaiting-a-non-promise-have-any-detectable-effect
         if (
           method === "then" &&
-          parsed.error &&
-          parsed.error.message &&
-          parsed.error.message.startsWith("Method then not found on resource")
+          parsed.error?.message?.startsWith("Method then not found on resource")
         ) {
           hasThenMethod = false;
           // args[0] is the onFulfilled callback passed to the then method.

--- a/libs/wingsdk/src/simulator/client.ts
+++ b/libs/wingsdk/src/simulator/client.ts
@@ -83,10 +83,12 @@ export function makeSimulatorClient(url: string, handle: string) {
 
       if (parsed.error) {
         // objects with "then" methods are special-cased by the JS runtime
-        // because they are assumed to be promises, and can be awaited.
-        // however, we don't know ahead of time what methods will be on the
+        // because they are assumed to be promises, and can be awaited. [0]
+        // however, this client don't know ahead of time what methods are on the
         // object, so we have to assume that it has a "then" method until
         // we get an error back from the server saying that it doesn't.
+        //
+        // [0]: https://stackoverflow.com/questions/55262996/does-awaiting-a-non-promise-have-any-detectable-effect
         if (
           method === "then" &&
           parsed.error &&

--- a/libs/wingsdk/src/simulator/simulator.ts
+++ b/libs/wingsdk/src/simulator/simulator.ts
@@ -469,7 +469,9 @@ export class Simulator {
             res.writeHead(500, { "Content-Type": "application/json" });
             res.end(
               serializeValue({
-                error: `Resource ${handle} not found. It may not have been initialized yet.`,
+                error: {
+                  message: `Resource ${handle} not found. It may not have been initialized yet.`,
+                },
               }),
               "utf-8"
             );
@@ -478,7 +480,9 @@ export class Simulator {
             res.writeHead(500, { "Content-Type": "application/json" });
             res.end(
               serializeValue({
-                error: `Resource ${handle} not found. It may have been cleaned up already.`,
+                error: {
+                  message: `Resource ${handle} not found. It may have been cleaned up already.`,
+                },
               }),
               "utf-8"
             );
@@ -486,6 +490,20 @@ export class Simulator {
           } else {
             throw new Error(`Internal error - resource ${handle} not found.`);
           }
+        }
+
+        const methodExists = (resource as any)[method] !== undefined;
+        if (!methodExists) {
+          res.writeHead(500, { "Content-Type": "application/json" });
+          res.end(
+            serializeValue({
+              error: {
+                message: `Method ${method} not found on resource ${handle}.`,
+              },
+            }),
+            "utf-8"
+          );
+          return;
         }
 
         (resource as any)


### PR DESCRIPTION
I was debugging an error with @yoav-steinberg, and we had an issue while augmenting the lifting system to get the following code to work:

```js
let b = [new cloud.Bucket()];
test "foo" {
  b.at(0);
}
```

We found that the generated JavaScript looked like this:

```js
await b.at(0);
```

Ordinarily this would no-op (since calling "await" on non-promises usually does nothing). But in the Wing simulator, the bucket client is a special proxy object that automatically translates all method calls into HTTP requests. When determining if a value is a promise or not, the JS runtime tries to call "then" on objects (see https://stackoverflow.com/questions/55262996/does-awaiting-a-non-promise-have-any-detectable-effect), and this ended up causing an error instead of the no-op behavior.

The first major bug was that trying to call a non-existent method on the proxy object was crashing the simulator server, so that's fixed.

Beyond that, to accommodate the "no-op await" use case, I've added some special case handling so if the the client contacts the server, trying to call `then()`, and the server responds saying the method does not exist, then the client object will return itself back. Of course, we probably shouldn't generate `await b.at(0)` since `at` is a synchronous method on `Array`, but I don't think this does any harm.

## Checklist

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [x] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
