### PR TITLE
chore(repo): unmention maintainers on new pr comment

### DIFF
--- a/.github/workflows/new-pull-request-comment.yml
+++ b/.github/workflows/new-pull-request-comment.yml
@@ -16,25 +16,25 @@ jobs:
             Thanks for opening this pull request! :tada:
             Please consult the [contributing guidelines](https://www.winglang.io/contributing) for details on how to contribute to this project.
             If you need any assistence, don't hesitate to ping the relevant owner over [Slack](https://t.winglang.io/slack).
-            
+
             | Topic                                               | Owner                                                         |
             |-----------------------------------------------------|---------------------------------------------------------------|
-            | Wing SDK and utility APIs                           | @chriscbr
-            | Wing Console                                        | @ainvoner, @skyrpex, @polamoros
-            | JSON, structs, primitives and collections           | @hasanaburayyan
-            | Platforms and plugins                               | @hasanaburayyan
-            | Frontend resources (website, react, etc)            | @tsuf239
-            | Language design                                     | @eladb
-            | VSCode extension and language server                | @markmcculloh
-            | Compiler architecture, inflights, lifting           | @yoav-steinberg
-            | Wing Testing Framework                              | @tsuf239
-            | Wing CLI                                            | @markmcculloh
-            | Build system, dev environment, releases             | @markmcculloh
-            | Library Ecosystem                                   | @chriscbr
-            | Documentation                                       | @hasanaburayyan
-            | SDK test suite                                      | @tsuf239 
-            | Examples                                            | @skorfmann
-            | Wing Playground                                     | @eladcon
+            | Wing SDK and utility APIs                           | `@chriscbr`
+            | Wing Console                                        | `@ainvoner`, `@skyrpex`, `@polamoros`
+            | JSON, structs, primitives and collections           | `@hasanaburayyan`
+            | Platforms and plugins                               | `@hasanaburayyan`
+            | Frontend resources (website, react, etc)            | `@tsuf239`
+            | Language design                                     | `@eladb`
+            | VSCode extension and language server                | `@markmcculloh`
+            | Compiler architecture, inflights, lifting           | `@yoav-steinberg`
+            | Wing Testing Framework                              | `@tsuf239`
+            | Wing CLI                                            | `@markmcculloh`
+            | Build system, dev environment, releases             | `@markmcculloh`
+            | Library Ecosystem                                   | `@chriscbr`
+            | Documentation                                       | `@hasanaburayyan`
+            | SDK test suite                                      | `@tsuf239` 
+            | Examples                                            | `@skorfmann`
+            | Wing Playground                                     | `@eladcon`
 
           comment_tag: New PR
           GITHUB_TOKEN: ${{secrets.PROJEN_GITHUB_TOKEN}}


### PR DESCRIPTION
The new PR comment introduced an ownership table. Owners are mentioned (using `@`) which is annoying when all of them get mentioned on every new PR whether it's relevant for them or not. Escaped `@` (that's the github markdown way).

## Checklist

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [ ] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
