### PR TITLE
chore: run e2e cloud tests from test dir

### DIFF
--- a/.github/workflows/tf-aws-test.yml
+++ b/.github/workflows/tf-aws-test.yml
@@ -165,8 +165,9 @@ jobs:
             if  ${{ env.MANUAL == 'true' }}
             then
                pnpm install
+               WING_CLI=$(realpath node_modules/.bin/wing)
                cd ${{ matrix.test.directory }}
-               pnpm wing test -t ${{ matrix.target }} *.test.w
+               $WING_CLI test -t ${{ matrix.target }} *.test.w
             elif ${{ env.LOCAL_BUILD == 'false'}}
             then 
                cd ${{ matrix.test.directory }}

--- a/.github/workflows/tf-aws-test.yml
+++ b/.github/workflows/tf-aws-test.yml
@@ -165,9 +165,8 @@ jobs:
             if  ${{ env.MANUAL == 'true' }}
             then
                pnpm install
-               WING_CLI=$(realpath node_modules/.bin/wing)
                cd ${{ matrix.test.directory }}
-               $WING_CLI test -t ${{ matrix.target }} *.test.w
+               pnpm --workspace-root wing test -t ${{ matrix.target }} *.test.w
             elif ${{ env.LOCAL_BUILD == 'false'}}
             then 
                cd ${{ matrix.test.directory }}

--- a/.github/workflows/tf-aws-test.yml
+++ b/.github/workflows/tf-aws-test.yml
@@ -164,18 +164,17 @@ jobs:
           command: |
             if  ${{ env.MANUAL == 'true' }}
             then
-               pnpm install
-               cd ${{ matrix.test.directory }}
-               pnpm --workspace-root wing test -t ${{ matrix.target }} *.test.w
+              pnpm install
+              pnpm turbo compile -F=winglang
+              WING_CLI=$(realpath apps/wing/bin/wing)
             elif ${{ env.LOCAL_BUILD == 'false'}}
             then 
-               cd ${{ matrix.test.directory }}
-               wing test -t ${{ matrix.target }} *.test.w
+              WING_CLI=$(which wing)
             else
               WING_CLI=$(realpath localwing/node_modules/.bin/wing)
-              cd ${{ matrix.test.directory }}
-              $WING_CLI test -t ${{ matrix.target }} *.test.w
             fi
+            cd ${{ matrix.test.directory }}
+            $WING_CLI test -t ${{ matrix.target }} *.test.w
 
       - name: Output Terraform log
         if: failure()

--- a/.github/workflows/tf-aws-test.yml
+++ b/.github/workflows/tf-aws-test.yml
@@ -162,16 +162,19 @@ jobs:
           retry_on: error
           timeout_minutes: 60
           command: |
-            cd ${{ matrix.test.directory }}
             if  ${{ env.MANUAL == 'true' }}
             then
                pnpm install
+               cd ${{ matrix.test.directory }}
                pnpm wing test -t ${{ matrix.target }} *.test.w
             elif ${{ env.LOCAL_BUILD == 'false'}}
             then 
+               cd ${{ matrix.test.directory }}
                wing test -t ${{ matrix.target }} *.test.w
             else
-              ./localwing/node_modules/.bin/wing test -t ${{ matrix.target }} *.test.w
+              WING_CLI=$(realpath localwing/node_modules/.bin/wing)
+              cd ${{ matrix.test.directory }}
+              $WING_CLI test -t ${{ matrix.target }} *.test.w
             fi
 
       - name: Output Terraform log

--- a/.github/workflows/tf-aws-test.yml
+++ b/.github/workflows/tf-aws-test.yml
@@ -162,15 +162,16 @@ jobs:
           retry_on: error
           timeout_minutes: 60
           command: |
+            cd ${{ matrix.test.directory }}
             if  ${{ env.MANUAL == 'true' }}
             then
                pnpm install
-               pnpm wing test -t ${{ matrix.target }} ${{ matrix.test.directory }}/*.test.w
+               pnpm wing test -t ${{ matrix.target }} *.test.w
             elif ${{ env.LOCAL_BUILD == 'false'}}
             then 
-               wing test -t ${{ matrix.target }} ${{ matrix.test.directory }}/*.test.w
+               wing test -t ${{ matrix.target }} *.test.w
             else
-              ./localwing/node_modules/.bin/wing test -t ${{ matrix.target }} ${{ matrix.test.directory }}/*.test.w
+              ./localwing/node_modules/.bin/wing test -t ${{ matrix.target }} *.test.w
             fi
 
       - name: Output Terraform log


### PR DESCRIPTION
Follow-up to https://github.com/winglang/wing/pull/4608

Tests now need to run from the test directory in case a .env file is used

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
