### PR TITLE
fix(repo): unstable targets won't break build

### DIFF
--- a/.github/workflows/tf-aws-test.yml
+++ b/.github/workflows/tf-aws-test.yml
@@ -173,16 +173,16 @@ jobs:
           retry_on: error
           timeout_minutes: 60
           command: |
-            # if  ${{ env.MANUAL == 'true' }}
-            # then
-            #    pnpm install
-            #    pnpm wing test -t ${{ matrix.target }} ${{ matrix.test.directory }}/*.test.w
-            # elif ${{ env.LOCAL_BUILD == 'false'}}
-            # then 
-            #    wing test -t ${{ matrix.target }} ${{ matrix.test.directory }}/*.test.w
-            # else
-            #   ./localwing/node_modules/.bin/wing test -t ${{ matrix.target }} ${{ matrix.test.directory }}/*.test.w
-            # fi
+            if  ${{ env.MANUAL == 'true' }}
+            then
+               pnpm install
+               pnpm wing test -t ${{ matrix.target }} ${{ matrix.test.directory }}/*.test.w
+            elif ${{ env.LOCAL_BUILD == 'false'}}
+            then 
+               wing test -t ${{ matrix.target }} ${{ matrix.test.directory }}/*.test.w
+            else
+              ./localwing/node_modules/.bin/wing test -t ${{ matrix.target }} ${{ matrix.test.directory }}/*.test.w
+            fi
 
       - name: Output Terraform log
         if: failure()

--- a/.github/workflows/tf-aws-test.yml
+++ b/.github/workflows/tf-aws-test.yml
@@ -1,6 +1,9 @@
 name: SDK Spec Tests
 run-name: SDK Spec Tests (${{ inputs.repo || github.repository }}/${{inputs.ref || github.ref}})
 on:
+  release:
+    types:
+      - published # runs only unstable targets
   workflow_call: {}
   workflow_dispatch:
     inputs:
@@ -17,6 +20,8 @@ on:
         default: all
         description: "target to run at, can be one or all of them"
         options:
+          - all-stable # tf-aws
+          - all-unstable # tf-azure and soon tf-gcp
           - all
           - tf-aws
           - tf-azure
@@ -30,7 +35,7 @@ env:
   MANUAL: ${{ github.event_name == 'workflow_dispatch' }}
   REPO: ${{ inputs.repo || github.repository }}
   REF: ${{ inputs.ref || github.ref }}
-  TARGET: ${{ inputs.target || 'all' }}
+  TARGET: ${{ inputs.target || (github.workflow == 'build' && 'all-stable') || (github.event_name == 'release' && 'all-unstable')  || 'all' }} #the build runs only stable targets, realease only unstable
   PNPM_VERSION: "8.6.3"
   AZURE_LOCATION: "East US"
   GOOGLE_PROJECT_ID: "sdk-spec-tests" # for the future
@@ -72,6 +77,12 @@ jobs:
         run: |
           if [ "${{env.TARGET}}" = "all" ]; then
             target='["tf-aws", "tf-azure"]'
+          else
+          if [ "${{env.TARGET}}" = "all-stable" ]; then
+            target='["tf-aws"]'
+          else
+          if [ "${{env.TARGET}}" = "all-unstable" ]; then
+            target='["tf-azure"]'
           else
            target='["${{env.TARGET}}"]'
           fi
@@ -162,16 +173,16 @@ jobs:
           retry_on: error
           timeout_minutes: 60
           command: |
-            if  ${{ env.MANUAL == 'true' }}
-            then
-               pnpm install
-               pnpm wing test -t ${{ matrix.target }} ${{ matrix.test.directory }}/*.test.w
-            elif ${{ env.LOCAL_BUILD == 'false'}}
-            then 
-               wing test -t ${{ matrix.target }} ${{ matrix.test.directory }}/*.test.w
-            else
-              ./localwing/node_modules/.bin/wing test -t ${{ matrix.target }} ${{ matrix.test.directory }}/*.test.w
-            fi
+            # if  ${{ env.MANUAL == 'true' }}
+            # then
+            #    pnpm install
+            #    pnpm wing test -t ${{ matrix.target }} ${{ matrix.test.directory }}/*.test.w
+            # elif ${{ env.LOCAL_BUILD == 'false'}}
+            # then 
+            #    wing test -t ${{ matrix.target }} ${{ matrix.test.directory }}/*.test.w
+            # else
+            #   ./localwing/node_modules/.bin/wing test -t ${{ matrix.target }} ${{ matrix.test.directory }}/*.test.w
+            # fi
 
       - name: Output Terraform log
         if: failure()


### PR DESCRIPTION
## Description
I split the SDK spec tests to run this way- 
stable targets (currently tf-aws) tests will run during build- and fail release if there's an error, 
un-stable targets (currently tf-azure) tests will run after release- and won't fail the build if there's an error

## Checklist

- [ ] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [ ] Description explains motivation and solution
- [ ] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
