### PR TITLE
fix(sdk): killing more redis zombies - but not all of them

### DIFF
--- a/libs/wingsdk/src/target-sim/redis.inflight.ts
+++ b/libs/wingsdk/src/target-sim/redis.inflight.ts
@@ -1,8 +1,9 @@
+import { execSync } from "node:child_process";
 import IoRedis from "ioredis";
 import { v4 as uuidv4 } from "uuid";
 import { RedisAttributes, RedisSchema } from "./schema-resources";
 import { RedisClientBase } from "../ex";
-import { runCommand, runDockerImage } from "../shared/misc";
+import { runDockerImage } from "../shared/misc";
 import {
   ISimulatorContext,
   ISimulatorResourceInstance,
@@ -20,7 +21,8 @@ export class Redis
   private readonly context: ISimulatorContext;
 
   private connection_url?: string = undefined;
-  private connection?: any;
+  private connection?: IoRedis;
+  private isCleanedUp = false;
 
   public constructor(_props: RedisSchema["props"], context: ISimulatorContext) {
     super();
@@ -33,14 +35,18 @@ export class Redis
 
   public async init(): Promise<RedisAttributes> {
     try {
+      if (this.isCleanedUp) {
+        return {};
+      }
+
       const { hostPort } = await runDockerImage({
         imageName: this.WING_REDIS_IMAGE,
         containerName: this.containerName,
         containerPort: "6379",
       });
-
       // redis url based on host port
       this.connection_url = `redis://0.0.0.0:${hostPort}`;
+
       return {};
     } catch (e) {
       throw Error(`Error setting up Redis resource simulation (${e})
@@ -49,10 +55,11 @@ export class Redis
   }
 
   public async cleanup(): Promise<void> {
+    this.isCleanedUp = true;
     // disconnect from the redis server
-    await this.connection?.disconnect();
+    this.connection?.disconnect();
     // stop the redis container
-    await runCommand("docker", ["rm", "-f", `${this.containerName}`]);
+    execSync(`docker rm -f ${this.containerName}`);
   }
 
   public async rawClient(): Promise<any> {


### PR DESCRIPTION
## Description
helping a bit with #4901 
In most cases, the zombies will be killed.
- They won't be killed when there are two or more ctrl+C s in a row (since it exiting the cleanup process)
- They won't be killed when ctrl+C ing `wing test filename.w` - since the killing logic is under the `run` command (and not the test command, where it's a bit more complex - will open a separate issue)
- In general, there are many async operations during cleanup- it could be easier to perform a cleaner cleanup if it was sync
- We cannot perform a cleanup while starting the simulator (another async method...).

## Checklist

- [ ] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [ ] Description explains motivation and solution
- [ ] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
