### PR TITLE
feat(sdk): support variadic arguments in MutArray.push (cont.)

### DIFF
--- a/docs/docs/04-standard-library/03-std/array.md
+++ b/docs/docs/04-standard-library/03-std/array.md
@@ -189,7 +189,7 @@ Mutable Array.
 | <code><a href="#@winglang/sdk.std.MutArray.lastIndexOf">lastIndexOf</a></code> | Returns the index of the last occurrence of searchElement found. |
 | <code><a href="#@winglang/sdk.std.MutArray.pop">pop</a></code> | Remove value from end of array. |
 | <code><a href="#@winglang/sdk.std.MutArray.popAt">popAt</a></code> | Removes value from the given index of an array. |
-| <code><a href="#@winglang/sdk.std.MutArray.push">push</a></code> | Add value to end of array. |
+| <code><a href="#@winglang/sdk.std.MutArray.push">push</a></code> | Add values to end of array. |
 | <code><a href="#@winglang/sdk.std.MutArray.removeFirst">removeFirst</a></code> | Removes first occurrence of a given value in an array. |
 | <code><a href="#@winglang/sdk.std.MutArray.set">set</a></code> | Sets a new value at the given index of an array. |
 
@@ -351,16 +351,16 @@ the index to remove the value at.
 ##### `push` <a name="push" id="@winglang/sdk.std.MutArray.push"></a>
 
 ```wing
-push(value: <T>): void
+push(...values: Array<<T>>): void
 ```
 
-Add value to end of array.
+Add values to end of array.
 
-###### `value`<sup>Required</sup> <a name="value" id="@winglang/sdk.std.MutArray.push.parameter.value"></a>
+###### `values`<sup>Required</sup> <a name="values" id="@winglang/sdk.std.MutArray.push.parameter.values"></a>
 
 - *Type:* <a href="#@winglang/sdk.std.T1">&lt;T&gt;</a>
 
-value to add.
+values to add.
 
 ---
 

--- a/examples/tests/sdk_tests/std/array.test.w
+++ b/examples/tests/sdk_tests/std/array.test.w
@@ -73,6 +73,8 @@ let item = a.pop();
 assert(item == "world");
 assert(a.length == 1);
 assert(a.at(0) == "hello");
+let pushMultipleItems: MutArray<str> = MutArray<str> ["element1"];
+pushMultipleItems.push("element2", "element3");
 
 test "pushAndPop()" {
   let a = MutArray<str>["hello"];

--- a/examples/tests/sdk_tests/std/array.test.w
+++ b/examples/tests/sdk_tests/std/array.test.w
@@ -75,6 +75,10 @@ assert(a.length == 1);
 assert(a.at(0) == "hello");
 let pushMultipleItems: MutArray<str> = MutArray<str> ["element1"];
 pushMultipleItems.push("element2", "element3");
+assert(pushMultipleItems.length == 3);
+assert(pushMultipleItems.at(0) == "element1");
+assert(pushMultipleItems.at(1) == "element2");
+assert(pushMultipleItems.at(2) == "element3");
 
 test "pushAndPop()" {
   let a = MutArray<str>["hello"];
@@ -87,6 +91,12 @@ test "pushAndPop()" {
   assert(item == "world");
   assert(a.length == 1);
   assert(a.at(0) == "hello");
+  let pushMultipleItems: MutArray<str> = MutArray<str> ["element1"];
+  pushMultipleItems.push("element2", "element3");
+  assert(pushMultipleItems.length == 3);
+  assert(pushMultipleItems.at(0) == "element1");
+  assert(pushMultipleItems.at(1) == "element2");
+  assert(pushMultipleItems.at(2) == "element3");
 }
 
 //-----------------------------------------------------------------------------

--- a/libs/wingc/src/jsify/snapshots/no_capture_shadow_inside_inner_scopes.snap
+++ b/libs/wingc/src/jsify/snapshots/no_capture_shadow_inside_inner_scopes.snap
@@ -33,10 +33,10 @@ module.exports = function({  }) {
     async handle() {
       const arr = [0];
       const i = 1;
-      (await arr.push(i));
+      ((obj, args) => { obj.push(...args); })(arr, [i]);
       if (true) {
         const i = 2;
-        (await arr.push(i));
+        ((obj, args) => { obj.push(...args); })(arr, [i]);
       }
     }
   }

--- a/libs/wingc/src/jsify/snapshots/no_lift_shadow_inside_inner_scopes.snap
+++ b/libs/wingc/src/jsify/snapshots/no_lift_shadow_inside_inner_scopes.snap
@@ -31,10 +31,10 @@ module.exports = function({ $i }) {
     }
     async handle() {
       const arr = [0];
-      (await arr.push($i));
+      ((obj, args) => { obj.push(...args); })(arr, [$i]);
       if (true) {
         const i = 2;
-        (await arr.push(i));
+        ((obj, args) => { obj.push(...args); })(arr, [i]);
       }
     }
   }

--- a/libs/wingsdk/src/std/array.ts
+++ b/libs/wingsdk/src/std/array.ts
@@ -236,12 +236,15 @@ export class MutArray {
   }
 
   /**
-   * Add value to end of array
-   * @param value value to add
+   * Add values to end of array
+   *
+   * @macro ((obj, args) => { obj.push(...args); })($self$, [$args$])
+   *
+   * @param values values to add
    */
-  public push(value: T1): void {
-    value;
-    throw new Error("Abstract");
+  public push(...values: T1[]): void {
+    values;
+    throw new Error("Macro");
   }
 
   /**

--- a/tools/hangar/__snapshots__/test_corpus/valid/function_variadic_arguments.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/function_variadic_arguments.test.w_compile_tf-aws.md
@@ -173,7 +173,7 @@ class $Root extends $stdlib.std.Resource {
       for (const i of args) {
         {((cond) => {if (!cond) throw new Error("assertion failed: i > 0 && i < 5")})(((i > 0) && (i < 5)))};
       }
-      (args.push(10));
+      ((obj, args) => { obj.push(...args); })(args, [10]);
       {((cond) => {if (!cond) throw new Error("assertion failed: args.at(4) == 10")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(((arr, index) => { if (index < 0 || index >= arr.length) throw new Error("Index out of bounds"); return arr[index]; })(args, 4),10)))};
     });
     (func1(1, "something", 1, 2, 3, 4));

--- a/tools/hangar/__snapshots__/test_corpus/valid/inference.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/inference.test.w_compile_tf-aws.md
@@ -282,9 +282,9 @@ class $Root extends $stdlib.std.Resource {
     const num_array = emptyArray;
     const emptyArray2 = [];
     const clonedArray2 = [...(emptyArray2)];
-    (clonedArray2.push(1));
-    (clonedArray2.push(2));
-    (clonedArray2.push((((arr, index) => { if (index < 0 || index >= arr.length) throw new Error("Index out of bounds"); return arr[index]; })(clonedArray2, 0) + ((arr, index) => { if (index < 0 || index >= arr.length) throw new Error("Index out of bounds"); return arr[index]; })(clonedArray2, 1))));
+    ((obj, args) => { obj.push(...args); })(clonedArray2, [1]);
+    ((obj, args) => { obj.push(...args); })(clonedArray2, [2]);
+    ((obj, args) => { obj.push(...args); })(clonedArray2, [(((arr, index) => { if (index < 0 || index >= arr.length) throw new Error("Index out of bounds"); return arr[index]; })(clonedArray2, 0) + ((arr, index) => { if (index < 0 || index >= arr.length) throw new Error("Index out of bounds"); return arr[index]; })(clonedArray2, 1))]);
     {((cond) => {if (!cond) throw new Error("assertion failed: clonedArray2.at(2) == 3")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(((arr, index) => { if (index < 0 || index >= arr.length) throw new Error("Index out of bounds"); return arr[index]; })(clonedArray2, 2),3)))};
     const emptySet = new Set([((arr, index) => { if (index < 0 || index >= arr.length) throw new Error("Index out of bounds"); return arr[index]; })(clonedArray2, 2)]);
     const clonedSet = new Set(emptySet);

--- a/tools/hangar/__snapshots__/test_corpus/valid/inflight_class_inner_capture_mutable.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/inflight_class_inner_capture_mutable.test.w_compile_tf-aws.md
@@ -15,7 +15,7 @@ module.exports = function({  }) {
       let i = 10;
       class Inner {
         async dang() {
-          (await y.push(2));
+          ((obj, args) => { obj.push(...args); })(y, [2]);
           i = (i + 1);
           return (((arr, index) => { if (index < 0 || index >= arr.length) throw new Error("Index out of bounds"); return arr[index]; })(y, 0) + 10);
         }

--- a/tools/hangar/__snapshots__/test_corpus/valid/mut_container_types.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/mut_container_types.test.w_compile_tf-aws.md
@@ -85,9 +85,9 @@ class $Root extends $stdlib.std.Resource {
     const arr2 = [1, 2, 3];
     const arr3 = [bucket1, bucket2];
     const arr4 = arr1;
-    (arr1.push("a"));
-    (arr2.push(4));
-    (arr3.push(bucket3));
+    ((obj, args) => { obj.push(...args); })(arr1, ["a"]);
+    ((obj, args) => { obj.push(...args); })(arr2, [4]);
+    ((obj, args) => { obj.push(...args); })(arr3, [bucket3]);
     {((cond) => {if (!cond) throw new Error("assertion failed: arr2.pop() == 4")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })((arr2.pop()),4)))};
     {((cond) => {if (!cond) throw new Error("assertion failed: arr1.length == 4")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(arr1.length,4)))};
     {((cond) => {if (!cond) throw new Error("assertion failed: arr4.at(0) == \"a\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(((arr, index) => { if (index < 0 || index >= arr.length) throw new Error("Index out of bounds"); return arr[index]; })(arr4, 0),"a")))};

--- a/tools/hangar/__snapshots__/test_corpus/valid/shadowing.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/shadowing.test.w_compile_tf-aws.md
@@ -12,13 +12,13 @@ module.exports = function({ $bar }) {
     }
     async handle() {
       const result = [];
-      (await result.push($bar));
+      ((obj, args) => { obj.push(...args); })(result, [$bar]);
       if (true) {
         const bar = "world";
-        (await result.push(bar));
+        ((obj, args) => { obj.push(...args); })(result, [bar]);
       }
       const foo = "bang";
-      (await result.push(foo));
+      ((obj, args) => { obj.push(...args); })(result, [foo]);
       return [...(result)];
     }
   }

--- a/tools/hangar/__snapshots__/test_corpus/valid/std_containers.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/std_containers.test.w_compile_tf-aws.md
@@ -163,7 +163,7 @@ class $Root extends $stdlib.std.Resource {
     }
     const sArray = ["one", "two"];
     const mutArray = [...(sArray)];
-    (mutArray.push("three"));
+    ((obj, args) => { obj.push(...args); })(mutArray, ["three"]);
     const immutArray = [...(mutArray)];
     const s = ((arr, index) => { if (index < 0 || index >= arr.length) throw new Error("Index out of bounds"); return arr[index]; })(sArray, 1);
     {((cond) => {if (!cond) throw new Error("assertion failed: s == \"two\"")})((((a,b) => { try { return require('assert').deepStrictEqual(a,b) === undefined; } catch { return false; } })(s,"two")))};


### PR DESCRIPTION
Fixes issue in #5114 and closes #4836 

Attach updated array.ts file (has updated definition for .push() on MutArray to support variadic arguments) and update snapshots

Example Input:
let myList: MutArray<str> = MutArray<str> ["element1"];
myList.push("element2", "element3");

Example Output:
const myList = ["element1"];
((obj, args) => { obj.push(...args); })(myList, ["element2", "element3"]);

## Checklist

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [x] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
