### PR TITLE
feat(compiler): early return in `cloud.Service()`

### DIFF
--- a/examples/tests/valid/optionals.test.w
+++ b/examples/tests/valid/optionals.test.w
@@ -204,3 +204,13 @@ if let s1 = str1 {
 } elif let s2 = str2 {
   assert(true);
 }
+
+let functionReturningNothing = (): void? => {
+  return;
+}
+
+if let nothing = functionReturningNothing {
+  assert(false);
+} else {
+  assert(true);
+}

--- a/examples/tests/valid/optionals.test.w
+++ b/examples/tests/valid/optionals.test.w
@@ -205,7 +205,7 @@ if let s1 = str1 {
   assert(true);
 }
 
-let functionReturningNothing = (): void? => {
+let functionReturningNothing = (): str? => {
   return;
 }
 

--- a/libs/wingc/src/type_check.rs
+++ b/libs/wingc/src/type_check.rs
@@ -756,9 +756,9 @@ impl Subtype for Type {
 			(Self::Nil, Self::Optional(_)) => {
 				// Nil is a subtype of Optional<T> for any T
 				true
-			},
+			}
 			(Self::Void, Self::Optional(_)) => {
-				// Void (not specifying a type) is a subtype of Optional<T> 
+				// Void (not specifying a type) is a subtype of Optional<T>
 				// (something that can have no value, and therefore no type)
 				true
 			}

--- a/libs/wingc/src/type_check.rs
+++ b/libs/wingc/src/type_check.rs
@@ -756,6 +756,11 @@ impl Subtype for Type {
 			(Self::Nil, Self::Optional(_)) => {
 				// Nil is a subtype of Optional<T> for any T
 				true
+			},
+			(Self::Void, Self::Optional(_)) => {
+				// Void (not specifying a type) is a subtype of Optional<T> 
+				// (something that can have no value, and therefore no type)
+				true
 			}
 			(_, Self::Optional(r0)) => {
 				// A non-Optional type is a subtype of an Optional type if the non-optional's type is a subtype of the value type


### PR DESCRIPTION
Addresses #4972 

Adds early returning in `cloud.Service()` by considering void to be a subtype of the optional<t> type in the typechecker.

The transpiled code functions properly with 'return;' in cloud.Service's handler function:

```js
async handle() {
  return;
}
```

**Not sure how this could be fixed from the WingSDK side, so fixing it from the typechecker side was my solution.**

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [ ] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
