### PR TITLE
feat(console): hide connections that go from a node to a parent

### DIFF
--- a/apps/wing-console/console/server/src/router/app.ts
+++ b/apps/wing-console/console/server/src/router/app.ts
@@ -735,6 +735,11 @@ function createMapEdgesFromConnectionData(
           return false;
         }
 
+        // Hide connections that go from a node to a parent.
+        if (sourceNode.path.startsWith(`${targetNode.path}/`)) {
+          return false;
+        }
+
         if (sourceNode.display?.hidden || targetNode.display?.hidden) {
           return false;
         }


### PR DESCRIPTION
Some connections go from a node to a parent node, which isn't visually helpful.