### PR TITLE
docs(docs): update 02-installation.md with correct local href link

### DIFF
--- a/docs/docs/01-start-here/02-installation.md
+++ b/docs/docs/01-start-here/02-installation.md
@@ -27,7 +27,7 @@ In this section you will install Wing on your system. This includes:
 To install Wing, you will need the following setup:
 
 * [Node.js](https://nodejs.org/en/) (>= 18.13.0)
-* [VSCode] (not required, but currently supported with an [extension](#wing-ide-extension))
+* [VSCode] (not required, but currently supported with an [extension](#wing-vscode-extension))
 
 ## Wing Toolchain
 


### PR DESCRIPTION
On the installation page it had a link for the VSCode extension which was suppposed to link to the below title, but the href was incorrect, so this fixes it. 

## Checklist

- [X] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [X] Description explains motivation and solution
- [ ] Tests added (always)
- [X] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
