### PR TITLE
fix(sdk): valid api url

### DIFF
--- a/examples/tests/valid/api_valid_path.test.w
+++ b/examples/tests/valid/api_valid_path.test.w
@@ -65,3 +65,4 @@ testValidPath("/test/segment1/:param1/segment2?query1=value1?query2=value2");
 testValidPath("/test/segment1/segment2?query=value1&query2=value2");
 testValidPath("/test/path.withDots");
 testValidPath("/test/path/.withDots/:param/:param-dash/x");
+testValidPath("/:param/test");

--- a/libs/wingsdk/src/cloud/api.ts
+++ b/libs/wingsdk/src/cloud/api.ts
@@ -383,11 +383,7 @@ export class Api extends Resource {
    * @internal
    */
   protected _validatePath(path: string) {
-    if (
-      !/^(\/[a-zA-Z0-9_\-\.]+(\/\:[a-zA-Z0-9_\-]+|\/[a-zA-Z0-9_\-\.]+)*(?:\?[^#]*)?)?$|^(\/\:[a-zA-Z0-9_\-]+)*\/?$/g.test(
-        path
-      )
-    ) {
+    if (!/^((\/:[\w-]+|\/[\w\.-]+)*(\?[^#]*)?)?\/?$/g.test(path)) {
       throw new Error(
         `Invalid path ${path}. Url parts can only contain alpha-numeric chars, "-", "_" and ".". Params can only contain alpha-numeric chars and "_".`
       );


### PR DESCRIPTION
Hi!

There is a problem with the current api validate path, a path like this: `/:param/test` is considered invalid.

I fixed and simplified the Regex.

