### PR TITLE
chore(docs): change "standard-library" to "Standard Library"

### DIFF
--- a/docs/docs/04-standard-library/_category_.yml
+++ b/docs/docs/04-standard-library/_category_.yml
@@ -1,0 +1,6 @@
+label: Standard Library
+collapsible: true
+collapsed: true
+link:
+  type: generated-index
+  title: Wing Standard Library


### PR DESCRIPTION
Restore the `_category_.yml` file.

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
