### PR TITLE
docs(examples): path parameters

### DIFF
--- a/docs/docs/07-examples/13-api-gateway.md
+++ b/docs/docs/07-examples/13-api-gateway.md
@@ -42,7 +42,7 @@ bring cloud;
 
 let api = new cloud.Api();
 
-api.get("/items/{id}/{value}", inflight (req: cloud.ApiRequest): cloud.ApiResponse => {
+api.get("/items/:id/:value", inflight (req: cloud.ApiRequest): cloud.ApiResponse => {
   let itemId = req.vars.get("id");
   let itemValue = req.vars.get("value");
   log("Received itemId:{itemId}, itemValue:{itemValue}");
@@ -60,7 +60,7 @@ bring cloud;
 
 let api = new cloud.Api();
 
-api.put("/items/{id}", inflight (req: cloud.ApiRequest): cloud.ApiResponse => {
+api.put("/items/:id", inflight (req: cloud.ApiRequest): cloud.ApiResponse => {
   let itemId = req.vars.get("id");
   if let itemBody = Json.tryParse(req.body ?? "") {    
     return cloud.ApiResponse {


### PR DESCRIPTION
The path parameters of the API routes are invalid (`{var}` instead of `:var`).