### PR TITLE
feat(compiler): enhance diagnostics for invalid access errors

### DIFF
--- a/apps/jsii-docgen/src/cli.ts
+++ b/apps/jsii-docgen/src/cli.ts
@@ -58,5 +58,5 @@ export async function main() {
 
 main().catch((e) => {
   console.error(e);
-  process.exit(1);
+  process.exitCode = 1;
 });

--- a/apps/wing-api-checker/src/index.ts
+++ b/apps/wing-api-checker/src/index.ts
@@ -109,12 +109,12 @@ async function main() {
   } else {
     const warnings = await generateWarnings(packageDir);
     if (warnings > 0) {
-      process.exit(1);
+      process.exitCode = 1;
     }
   }
 }
 
 main().catch((e) => {
   console.error(e);
-  process.exit(1);
+  process.exitCode = 1;
 });

--- a/apps/wing-console/console/server/src/utils/format-wing-error.ts
+++ b/apps/wing-console/console/server/src/utils/format-wing-error.ts
@@ -54,6 +54,10 @@ export const formatWingError = async (error: unknown, entryPoint?: string) => {
         }
 
         for (const annotation of annotations) {
+          // file_id might be "" if the span is synthetic (see #2521)
+          if (!annotation.span?.file_id) {
+            continue;
+          }
           const source = await readFile(annotation.span.file_id, "utf8");
           const start = offsetFromLineAndColumn(
             source,

--- a/apps/wing/.eslintrc.json
+++ b/apps/wing/.eslintrc.json
@@ -45,6 +45,7 @@
     "!projenrc/**/*.ts"
   ],
   "rules": {
+    "@typescript-eslint/no-misused-promises": "error",
     "prettier/prettier": [
       "error"
     ],

--- a/apps/wing/src/cli.ts
+++ b/apps/wing/src/cli.ts
@@ -30,11 +30,11 @@ function runSubCommand(subCommand: string, path: string = subCommand) {
       const exitCode = await import(`./commands/${path}`).then((m) => m[subCommand](...args));
       if (exitCode === 1) {
         await exportAnalyticsHook();
-        process.exit(1);
+        process.exitCode = 1;
       }
     } catch (err) {
       console.error((err as any)?.message ?? err);
-      process.exit(1);
+      process.exitCode = 1;
     }
   };
 }
@@ -234,5 +234,5 @@ function checkNodeVersion() {
 
 main().catch((err) => {
   console.error(err);
-  process.exit(1);
+  process.exitCode = 1;
 });

--- a/apps/wing/src/cli.ts
+++ b/apps/wing/src/cli.ts
@@ -17,7 +17,7 @@ if (!SUPPORTED_NODE_VERSION) {
 }
 
 const DEFAULT_PLATFORM = ["sim"];
-let analyticsExportFile: Promise<string | undefined>;
+let analyticsExportFile: Promise<string | undefined> | undefined;
 
 function runSubCommand(subCommand: string, path: string = subCommand) {
   loadEnvVariables({

--- a/apps/wing/src/commands/compile.ts
+++ b/apps/wing/src/commands/compile.ts
@@ -117,6 +117,10 @@ export async function compile(entrypoint?: string, options?: CompileOptions): Pr
         }
 
         for (const annotation of annotations) {
+          // file_id might be "" if the span is synthetic (see #2521)
+          if (!annotation.span?.file_id) {
+            continue;
+          }
           const source = await fsPromise.readFile(annotation.span.file_id, "utf8");
           const start = byteOffsetFromLineAndColumn(
             source,

--- a/apps/wing/src/commands/lsp.ts
+++ b/apps/wing/src/commands/lsp.ts
@@ -178,14 +178,14 @@ export async function lsp() {
     }
   }
 
-  connection.onDidOpenTextDocument(async (params) => {
+  connection.onDidOpenTextDocument((params) => {
     void handle_event_and_update_diagnostics(
       "wingc_on_did_open_text_document",
       params,
       params.textDocument.uri
     );
   });
-  connection.onDidChangeTextDocument(async (params) => {
+  connection.onDidChangeTextDocument((params) => {
     void handle_event_and_update_diagnostics(
       "wingc_on_did_change_text_document",
       params,

--- a/apps/wing/src/commands/run.ts
+++ b/apps/wing/src/commands/run.ts
@@ -79,7 +79,7 @@ export async function run(entrypoint?: string, options?: RunOptions) {
     await close(() => process.exit(exitCode));
   };
 
-  process.once("exit", async (c) => onExit(c));
-  process.once("SIGTERM", async () => onExit(0));
-  process.once("SIGINT", async () => onExit(0));
+  process.once("exit", (c) => void onExit(c));
+  process.once("SIGTERM", () => void onExit(0));
+  process.once("SIGINT", () => void onExit(0));
 }

--- a/apps/wing/src/commands/test/test.ts
+++ b/apps/wing/src/commands/test/test.ts
@@ -305,7 +305,8 @@ async function testTf(synthDir: string, options: TestOptions): Promise<std.TestR
   const { clean, testFilter, retry, platform = [BuiltinPlatform.SIM] } = options;
 
   try {
-    if (!isTerraformInstalled(synthDir)) {
+    const installed = await isTerraformInstalled(synthDir);
+    if (!installed) {
       throw new Error(
         "Terraform is not installed. Please install Terraform to run tests in the cloud."
       );

--- a/libs/wingc/src/diagnostic.rs
+++ b/libs/wingc/src/diagnostic.rs
@@ -293,10 +293,25 @@ pub struct DiagnosticAnnotation {
 impl std::fmt::Display for Diagnostic {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		if let Some(span) = &self.span {
-			write!(f, "Error at {} | {}", span, self.message.bold().white())
+			write!(f, "Error at {} | {}", span, self.message.bold().white())?;
 		} else {
-			write!(f, "Error | {}", self.message.bold().white())
+			write!(f, "Error | {}", self.message.bold().white())?;
 		}
+		if !self.annotations.is_empty() {
+			if self.annotations.len() == 1 {
+				write!(f, " ({} annotation)", self.annotations.len())?;
+			} else {
+				write!(f, " ({} annotations)", self.annotations.len())?;
+			}
+		}
+		if !self.hints.is_empty() {
+			if self.hints.len() == 1 {
+				write!(f, " ({} hint)", self.hints.len())?;
+			} else {
+				write!(f, " ({} hints)", self.hints.len())?;
+			}
+		}
+		Ok(())
 	}
 }
 

--- a/libs/wingc/src/type_check.rs
+++ b/libs/wingc/src/type_check.rs
@@ -5365,18 +5365,32 @@ impl<'a> TypeChecker<'a> {
 			match var.access {
 				AccessModifier::Private => {
 					if !private_access {
-						self.spanned_error(
-							property,
-							format!("Cannot access private member \"{property}\" of \"{class}\""),
-						);
+						report_diagnostic(Diagnostic {
+							message: format!("Cannot access private member \"{property}\" of \"{class}\""),
+							span: Some(property.span()),
+							annotations: vec![DiagnosticAnnotation {
+								message: "defined here".to_string(),
+								span: lookup_info.span,
+							}],
+							hints: vec![format!(
+								"the definition of \"{property}\" needs a broader access modifier like \"pub\" or \"protected\" to be used outside of \"{class}\"",
+							)],
+						});
 					}
 				}
 				AccessModifier::Protected => {
 					if !protected_access {
-						self.spanned_error(
-							property,
-							format!("Cannot access protected member \"{property}\" of \"{class}\""),
-						);
+						report_diagnostic(Diagnostic {
+							message: format!("Cannot access protected member \"{property}\" of \"{class}\""),
+							span: Some(property.span()),
+							annotations: vec![DiagnosticAnnotation {
+								message: "defined here".to_string(),
+								span: lookup_info.span,
+							}],
+							hints: vec![format!(
+								"the definition of \"{property}\" needs a broader access modifier like \"pub\" to be used outside of \"{class}\"",
+							)],
+						});
 					}
 				}
 				AccessModifier::Public => {} // keep this here to make sure we don't add a new access modifier without handling it here

--- a/libs/wingc/src/type_check/jsii_importer.rs
+++ b/libs/wingc/src/type_check/jsii_importer.rs
@@ -3,7 +3,6 @@ use std::collections::BTreeMap;
 use crate::{
 	ast::{AccessModifier, Phase, Symbol},
 	debug,
-	diagnostic::{WingLocation, WingSpan},
 	docs::Docs,
 	type_check::{
 		self,
@@ -591,25 +590,14 @@ impl<'a> JsiiImporter<'a> {
 		}
 	}
 
-	fn jsii_name_to_symbol(name: &str, jsii_source_location: &Option<jsii::SourceLocation>) -> Symbol {
-		let span = if let Some(jsii_source_location) = jsii_source_location {
-			WingSpan {
-				start: WingLocation {
-					line: (jsii_source_location.line - 1.0) as u32,
-					col: 0,
-				},
-				end: WingLocation {
-					line: (jsii_source_location.line - 1.0) as u32,
-					col: 0,
-				},
-				file_id: jsii_source_location.filename.clone(),
-			}
-		} else {
-			Default::default()
-		};
+	fn jsii_name_to_symbol(name: &str, _jsii_source_location: &Option<jsii::SourceLocation>) -> Symbol {
+		// JSII source location is not used right now since it doesn't necessarily map to a file on the user's disk
+		// (the JSII library might include .js files but not the original .ts files)
+		// if this information is useful, we could consider changing `Span` or `Symbol` to
+		// model whether or not the span represents a file on disk that we can read.
 		Symbol {
 			name: name.to_string(),
-			span,
+			span: Default::default(),
 		}
 	}
 

--- a/libs/wingsdk/src/simulator/simulator.ts
+++ b/libs/wingsdk/src/simulator/simulator.ts
@@ -257,32 +257,38 @@ export class Simulator {
 
     await this.startServer();
 
-    while (true) {
-      const next = initQueue.shift();
-      if (!next) {
-        break;
-      }
-
-      // we couldn't start this resource yet, so decrement the retry counter and put it back in
-      // the init queue.
-      if (!(await this.tryStartResource(next))) {
-        // we couldn't start this resource yet, so decrement the attempt counter
-        next._attempts = next._attempts ?? START_ATTEMPT_COUNT;
-        next._attempts--;
-
-        // if we've tried too many times, give up (might be a dependency cycle or a bad reference)
-        if (next._attempts === 0) {
-          throw new Error(
-            `Could not start resource ${next.path} after ${START_ATTEMPT_COUNT} attempts. This could be due to a dependency cycle or an invalid attribute reference.`
-          );
+    try {
+      while (true) {
+        const next = initQueue.shift();
+        if (!next) {
+          break;
         }
 
-        // put back in the queue for another round
-        initQueue.push(next);
-      }
-    }
+        // we couldn't start this resource yet, so decrement the retry counter and put it back in
+        // the init queue.
+        if (!(await this.tryStartResource(next))) {
+          // we couldn't start this resource yet, so decrement the attempt counter
+          next._attempts = next._attempts ?? START_ATTEMPT_COUNT;
+          next._attempts--;
 
-    this._running = "running";
+          // if we've tried too many times, give up (might be a dependency cycle or a bad reference)
+          if (next._attempts === 0) {
+            throw new Error(
+              `Could not start resource ${next.path} after ${START_ATTEMPT_COUNT} attempts. This could be due to a dependency cycle or an invalid attribute reference.`
+            );
+          }
+
+          // put back in the queue for another round
+          initQueue.push(next);
+        }
+      }
+
+      this._running = "running";
+    } catch (err) {
+      this.stopServer();
+      this._running = "stopped";
+      throw err;
+    }
   }
 
   /**
@@ -329,8 +335,7 @@ export class Simulator {
       this._addTrace(event);
     }
 
-    this._server!.close();
-    this._server!.closeAllConnections();
+    this.stopServer();
 
     this._handles.reset();
     this._running = "stopped";
@@ -569,6 +574,14 @@ export class Simulator {
         resolve();
       });
     });
+  }
+
+  /**
+   * Stop the simulator server.
+   */
+  private stopServer() {
+    this._server!.close();
+    this._server!.closeAllConnections();
   }
 
   /**

--- a/tools/hangar/__snapshots__/invalid.ts.snap
+++ b/tools/hangar/__snapshots__/invalid.ts.snap
@@ -47,29 +47,49 @@ error: Cannot override private method \\"method\\" of \\"Bar\\"
 error: Cannot access protected member \\"protected_field\\" of \\"Foo\\"
     --> ../../../examples/tests/invalid/access_modifiers.test.w:109:9
     |
+  8 |   protected protected_field: str;
+    |             --------------- defined here
+    .
 109 | log(foo.protected_field);
     |         ^^^^^^^^^^^^^^^ Cannot access protected member \\"protected_field\\" of \\"Foo\\"
+    |
+    = hint: the definition of \\"protected_field\\" needs a broader access modifier like \\"pub\\" to be used outside of \\"Foo\\"
 
 
 error: Cannot access private member \\"private_field\\" of \\"Foo\\"
     --> ../../../examples/tests/invalid/access_modifiers.test.w:111:9
     |
+  9 |   private_field: str;
+    |   ------------- defined here
+    .
 111 | log(foo.private_field);
     |         ^^^^^^^^^^^^^ Cannot access private member \\"private_field\\" of \\"Foo\\"
+    |
+    = hint: the definition of \\"private_field\\" needs a broader access modifier like \\"pub\\" or \\"protected\\" to be used outside of \\"Foo\\"
 
 
 error: Cannot access protected member \\"protected_static_method\\" of \\"Foo\\"
     --> ../../../examples/tests/invalid/access_modifiers.test.w:115:5
     |
+ 53 |   protected static protected_static_method() {}
+    |                    ----------------------- defined here
+    .
 115 | Foo.protected_static_method();
     |     ^^^^^^^^^^^^^^^^^^^^^^^ Cannot access protected member \\"protected_static_method\\" of \\"Foo\\"
+    |
+    = hint: the definition of \\"protected_static_method\\" needs a broader access modifier like \\"pub\\" to be used outside of \\"Foo\\"
 
 
 error: Cannot access private member \\"private_static_method\\" of \\"Foo\\"
     --> ../../../examples/tests/invalid/access_modifiers.test.w:117:5
     |
+ 54 |   static private_static_method() {}
+    |          --------------------- defined here
+    .
 117 | Foo.private_static_method();
     |     ^^^^^^^^^^^^^^^^^^^^^ Cannot access private member \\"private_static_method\\" of \\"Foo\\"
+    |
+    = hint: the definition of \\"private_static_method\\" needs a broader access modifier like \\"pub\\" or \\"protected\\" to be used outside of \\"Foo\\"
 
 
 error: Cannot override public method \\"public_method\\" of \\"Foo\\" with a private method
@@ -117,99 +137,85 @@ error: Cannot override private method \\"private_method\\" of \\"Foo\\"
 error: Cannot access private member \\"private_field\\" of \\"Bar\\"
    --> ../../../examples/tests/invalid/access_modifiers.test.w:61:14
    |
+ 9 |   private_field: str;
+   |   ------------- defined here
+   .
 61 |     log(this.private_field);
    |              ^^^^^^^^^^^^^ Cannot access private member \\"private_field\\" of \\"Bar\\"
+   |
+   = hint: the definition of \\"private_field\\" needs a broader access modifier like \\"pub\\" or \\"protected\\" to be used outside of \\"Bar\\"
 
 
 error: Cannot access private member \\"private_method\\" of \\"Bar\\"
    --> ../../../examples/tests/invalid/access_modifiers.test.w:66:10
    |
+49 |   private_method() {}
+   |   -------------- defined here
+   .
 66 |     this.private_method();
    |          ^^^^^^^^^^^^^^ Cannot access private member \\"private_method\\" of \\"Bar\\"
+   |
+   = hint: the definition of \\"private_method\\" needs a broader access modifier like \\"pub\\" or \\"protected\\" to be used outside of \\"Bar\\"
 
 
 error: Cannot access private member \\"private_static_method\\" of \\"Foo\\"
    --> ../../../examples/tests/invalid/access_modifiers.test.w:74:9
    |
+54 |   static private_static_method() {}
+   |          --------------------- defined here
+   .
 74 |     Foo.private_static_method();
    |         ^^^^^^^^^^^^^^^^^^^^^ Cannot access private member \\"private_static_method\\" of \\"Foo\\"
+   |
+   = hint: the definition of \\"private_static_method\\" needs a broader access modifier like \\"pub\\" or \\"protected\\" to be used outside of \\"Foo\\"
 
 
 error: Cannot access private member \\"private_field\\" of \\"Baz\\"
    --> ../../../examples/tests/invalid/access_modifiers.test.w:84:14
    |
+ 9 |   private_field: str;
+   |   ------------- defined here
+   .
 84 |     log(this.private_field);
    |              ^^^^^^^^^^^^^ Cannot access private member \\"private_field\\" of \\"Baz\\"
+   |
+   = hint: the definition of \\"private_field\\" needs a broader access modifier like \\"pub\\" or \\"protected\\" to be used outside of \\"Baz\\"
 
 
 error: Cannot access private member \\"private_method\\" of \\"Baz\\"
    --> ../../../examples/tests/invalid/access_modifiers.test.w:89:10
    |
+49 |   private_method() {}
+   |   -------------- defined here
+   .
 89 |     this.private_method();
    |          ^^^^^^^^^^^^^^ Cannot access private member \\"private_method\\" of \\"Baz\\"
+   |
+   = hint: the definition of \\"private_method\\" needs a broader access modifier like \\"pub\\" or \\"protected\\" to be used outside of \\"Baz\\"
 
 
 error: Cannot access private member \\"private_static_method\\" of \\"Foo\\"
    --> ../../../examples/tests/invalid/access_modifiers.test.w:97:9
    |
+54 |   static private_static_method() {}
+   |          --------------------- defined here
+   .
 97 |     Foo.private_static_method();
    |         ^^^^^^^^^^^^^^^^^^^^^ Cannot access private member \\"private_static_method\\" of \\"Foo\\"
+   |
+   = hint: the definition of \\"private_static_method\\" needs a broader access modifier like \\"pub\\" or \\"protected\\" to be used outside of \\"Foo\\"
 
 
 error: Cannot access private member \\"private_static_method\\" of \\"Bar\\"
     --> ../../../examples/tests/invalid/access_modifiers.test.w:102:9
     |
+ 54 |   static private_static_method() {}
+    |          --------------------- defined here
+    .
 102 |     Bar.private_static_method();
     |         ^^^^^^^^^^^^^^^^^^^^^ Cannot access private member \\"private_static_method\\" of \\"Bar\\"
-
-
-error: Cannot access protected member \\"protected_field\\" of \\"Foo\\"
-    --> ../../../examples/tests/invalid/access_modifiers.test.w:123:13
     |
-123 |     log(foo.protected_field);
-    |             ^^^^^^^^^^^^^^^ Cannot access protected member \\"protected_field\\" of \\"Foo\\"
-
-
-error: Cannot access private member \\"private_field\\" of \\"Foo\\"
-    --> ../../../examples/tests/invalid/access_modifiers.test.w:125:13
-    |
-125 |     log(foo.private_field);
-    |             ^^^^^^^^^^^^^ Cannot access private member \\"private_field\\" of \\"Foo\\"
-
-
-error: Cannot access protected member \\"protected_method\\" of \\"Foo\\"
-    --> ../../../examples/tests/invalid/access_modifiers.test.w:129:9
-    |
-129 |     foo.protected_method();
-    |         ^^^^^^^^^^^^^^^^ Cannot access protected member \\"protected_method\\" of \\"Foo\\"
-
-
-error: Cannot access private member \\"private_method\\" of \\"Foo\\"
-    --> ../../../examples/tests/invalid/access_modifiers.test.w:131:9
-    |
-131 |     foo.private_method();
-    |         ^^^^^^^^^^^^^^ Cannot access private member \\"private_method\\" of \\"Foo\\"
-
-
-error: Cannot access protected member \\"protected_static_method\\" of \\"Foo\\"
-    --> ../../../examples/tests/invalid/access_modifiers.test.w:137:9
-    |
-137 |     Foo.protected_static_method();
-    |         ^^^^^^^^^^^^^^^^^^^^^^^ Cannot access protected member \\"protected_static_method\\" of \\"Foo\\"
-
-
-error: Cannot access private member \\"private_static_method\\" of \\"Foo\\"
-    --> ../../../examples/tests/invalid/access_modifiers.test.w:139:9
-    |
-139 |     Foo.private_static_method();
-    |         ^^^^^^^^^^^^^^^^^^^^^ Cannot access private member \\"private_static_method\\" of \\"Foo\\"
-
-
- 
- 
-Tests 1 failed (1)
-Test Files 1 failed (1)
-Duration <DURATION>"
+    = hint: the definition of"
 `;
 
 exports[`access_private_apis.test.w 1`] = `
@@ -2052,6 +2058,8 @@ exports[`jsii_access_modifiers.test.w 1`] = `
    |
 13 | b.createTopic(cloud.BucketEventType.CREATE);
    |   ^^^^^^^^^^^ Cannot access protected member \\"createTopic\\" of \\"Bucket\\"
+   |
+   = hint: the definition of \\"createTopic\\" needs a broader access modifier like \\"pub\\" to be used outside of \\"Bucket\\"
 
 
  

--- a/tools/hangar/__snapshots__/invalid.ts.snap
+++ b/tools/hangar/__snapshots__/invalid.ts.snap
@@ -215,7 +215,86 @@ error: Cannot access private member \\"private_static_method\\" of \\"Bar\\"
 102 |     Bar.private_static_method();
     |         ^^^^^^^^^^^^^^^^^^^^^ Cannot access private member \\"private_static_method\\" of \\"Bar\\"
     |
-    = hint: the definition of"
+    = hint: the definition of \\"private_static_method\\" needs a broader access modifier like \\"pub\\" or \\"protected\\" to be used outside of \\"Bar\\"
+
+
+error: Cannot access protected member \\"protected_field\\" of \\"Foo\\"
+    --> ../../../examples/tests/invalid/access_modifiers.test.w:123:13
+    |
+  8 |   protected protected_field: str;
+    |             --------------- defined here
+    .
+123 |     log(foo.protected_field);
+    |             ^^^^^^^^^^^^^^^ Cannot access protected member \\"protected_field\\" of \\"Foo\\"
+    |
+    = hint: the definition of \\"protected_field\\" needs a broader access modifier like \\"pub\\" to be used outside of \\"Foo\\"
+
+
+error: Cannot access private member \\"private_field\\" of \\"Foo\\"
+    --> ../../../examples/tests/invalid/access_modifiers.test.w:125:13
+    |
+  9 |   private_field: str;
+    |   ------------- defined here
+    .
+125 |     log(foo.private_field);
+    |             ^^^^^^^^^^^^^ Cannot access private member \\"private_field\\" of \\"Foo\\"
+    |
+    = hint: the definition of \\"private_field\\" needs a broader access modifier like \\"pub\\" or \\"protected\\" to be used outside of \\"Foo\\"
+
+
+error: Cannot access protected member \\"protected_method\\" of \\"Foo\\"
+    --> ../../../examples/tests/invalid/access_modifiers.test.w:129:9
+    |
+ 47 |   protected protected_method() {}
+    |             ---------------- defined here
+    .
+129 |     foo.protected_method();
+    |         ^^^^^^^^^^^^^^^^ Cannot access protected member \\"protected_method\\" of \\"Foo\\"
+    |
+    = hint: the definition of \\"protected_method\\" needs a broader access modifier like \\"pub\\" to be used outside of \\"Foo\\"
+
+
+error: Cannot access private member \\"private_method\\" of \\"Foo\\"
+    --> ../../../examples/tests/invalid/access_modifiers.test.w:131:9
+    |
+ 49 |   private_method() {}
+    |   -------------- defined here
+    .
+131 |     foo.private_method();
+    |         ^^^^^^^^^^^^^^ Cannot access private member \\"private_method\\" of \\"Foo\\"
+    |
+    = hint: the definition of \\"private_method\\" needs a broader access modifier like \\"pub\\" or \\"protected\\" to be used outside of \\"Foo\\"
+
+
+error: Cannot access protected member \\"protected_static_method\\" of \\"Foo\\"
+    --> ../../../examples/tests/invalid/access_modifiers.test.w:137:9
+    |
+ 53 |   protected static protected_static_method() {}
+    |                    ----------------------- defined here
+    .
+137 |     Foo.protected_static_method();
+    |         ^^^^^^^^^^^^^^^^^^^^^^^ Cannot access protected member \\"protected_static_method\\" of \\"Foo\\"
+    |
+    = hint: the definition of \\"protected_static_method\\" needs a broader access modifier like \\"pub\\" to be used outside of \\"Foo\\"
+
+
+error: Cannot access private member \\"private_static_method\\" of \\"Foo\\"
+    --> ../../../examples/tests/invalid/access_modifiers.test.w:139:9
+    |
+ 54 |   static private_static_method() {}
+    |          --------------------- defined here
+    .
+139 |     Foo.private_static_method();
+    |         ^^^^^^^^^^^^^^^^^^^^^ Cannot access private member \\"private_static_method\\" of \\"Foo\\"
+    |
+    = hint: the definition of \\"private_static_method\\" needs a broader access modifier like \\"pub\\" or \\"protected\\" to be used outside of \\"Foo\\"
+
+
+ 
+ 
+Tests 1 failed (1)
+Test Files 1 failed (1)
+Duration <DURATION>"
 `;
 
 exports[`access_private_apis.test.w 1`] = `


### PR DESCRIPTION
Before:

![Screenshot 2023-12-14 at 5 22 59 PM](https://github.com/winglang/wing/assets/5008987/79f0fe0b-fd0e-4fa0-9f03-9e2b38657494)

After:

![Screenshot 2023-12-14 at 5 22 18 PM](https://github.com/winglang/wing/assets/5008987/ef8a3983-d1ba-41a9-b13d-3cc35e592ed7)

Misc:
1. Adding this diagnostic uncovered an issue where if a diagnostic annotation references a span from a JSII library (for example, if you try accessing a protected member of a JSII class), then the CLI crashes since the spans don't point to real files on disk. To fix that, I've removed JSII spans from the compiler AST for now.
2. Adding this diagnostic also uncovered an issue where if too many compiler errors are emitted, then they might not all get printed because the CLI calls `process.exit()`, which forces the process to exit before all I/O operations finish (see https://stackoverflow.com/a/37592669/8605016). To fix this, I've changed several of these places in the code to set the process's exit code with `process.exitCode = 1`.
3. The changes in (2) uncovered an issue where if the simulator is unable to spin up a resource like in https://github.com/winglang/wing/blob/main/examples/tests/invalid/unresolved_state.test.w, then the simulator server wouldn't get cleaned up. I fixed this by adding try/catch handling to this area of the simulator code.
4. In the debugging process I added an eslint rule for catching incorrect promise usage to the `wing` package.

## Checklist

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [x] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
