### PR TITLE
fix(sdk): no resource found with handle simulator error

### DIFF
--- a/apps/wing/src/commands/test/test.test.ts
+++ b/apps/wing/src/commands/test/test.test.ts
@@ -6,7 +6,7 @@ import { BuiltinPlatform } from "@winglang/compiler";
 import { TestResult, TraceType } from "@winglang/sdk/lib/std";
 import chalk from "chalk";
 import { describe, test, expect, beforeEach, afterEach, vi, SpyInstance } from "vitest";
-import { filterTests, pickOneTestPerEnvironment, renderTestReport, test as wingTest } from ".";
+import { filterTests, renderTestReport, test as wingTest } from ".";
 import * as resultsFn from "./results";
 
 const defaultChalkLevel = chalk.level;
@@ -198,7 +198,7 @@ describe("test-filter option", () => {
   });
 
   test("wing test (no test-filter)", () => {
-    const filteredTests = pickOneTestPerEnvironment(filterTests(EXAMPLE_UNFILTERED_TESTS));
+    const filteredTests = filterTests(EXAMPLE_UNFILTERED_TESTS);
 
     expect(filteredTests.length).toBe(3);
     expect(filteredTests[0]).toBe("root/env0/test:get()");
@@ -207,7 +207,7 @@ describe("test-filter option", () => {
   });
 
   test("wing test --test-filter <regex>", () => {
-    const filteredTests = pickOneTestPerEnvironment(filterTests(EXAMPLE_UNFILTERED_TESTS, "get"));
+    const filteredTests = filterTests(EXAMPLE_UNFILTERED_TESTS, "get");
 
     expect(filteredTests.length).toBe(2);
     expect(filteredTests[0]).toBe("root/env0/test:get()");
@@ -426,12 +426,6 @@ const OUTPUT_FILE = {
 
 const EXAMPLE_UNFILTERED_TESTS: string[] = [
   "root/env0/test:get()",
-  "root/env0/test:get:At()",
-  "root/env0/test:stringify()",
-  "root/env1/test:get()",
   "root/env1/test:get:At()",
-  "root/env1/test:stringify()",
-  "root/env2/test:get()",
-  "root/env2/test:get:At()",
   "root/env2/test:stringify()",
 ];

--- a/apps/wing/src/commands/test/test.ts
+++ b/apps/wing/src/commands/test/test.ts
@@ -283,7 +283,7 @@ async function testSimulator(synthDir: string, options: TestOptions) {
 
   const testRunner = s.getResource("root/cloud.TestRunner") as std.ITestRunnerClient;
   const tests = await testRunner.listTests();
-  const filteredTests = pickOneTestPerEnvironment(filterTests(tests, testFilter));
+  const filteredTests = filterTests(tests, testFilter);
 
   const results = await runTestsWithRetry(testRunner, filteredTests, retry ?? 0);
 
@@ -324,7 +324,7 @@ async function testTf(synthDir: string, options: TestOptions): Promise<std.TestR
       const runner = new TestRunnerClient(testArns);
 
       const allTests = await runner.listTests();
-      const filteredTests = pickOneTestPerEnvironment(filterTests(allTests, testFilter));
+      const filteredTests = filterTests(allTests, testFilter);
       return [runner, filteredTests];
     });
 
@@ -374,7 +374,7 @@ async function testAwsCdk(synthDir: string, options: TestOptions): Promise<std.T
       const runner = new TestRunnerClient(testArns);
 
       const allTests = await runner.listTests();
-      const filteredTests = pickOneTestPerEnvironment(filterTests(allTests, testFilter));
+      const filteredTests = filterTests(allTests, testFilter);
       return [runner, filteredTests];
     });
 
@@ -471,50 +471,6 @@ async function terraformOutput(synthDir: string, name: string) {
     throw new Error(`terraform output ${name} not found`);
   }
   return parsed[name].value;
-}
-
-export function pickOneTestPerEnvironment(testPaths: string[]) {
-  // Given a list of test paths like so:
-  //
-  // root/Default/env0/a/b/test:test1
-  // root/Default/env0/d/e/f/test:test2
-  // root/Default/env0/g/test:test3
-  // root/Default/env1/a/b/test:test1
-  // root/Default/env1/d/e/f/test:test2
-  // root/Default/env1/g/test:test3
-  // root/Default/env2/a/b/test:test1
-  // root/Default/env2/d/e/f/test:test2
-  // root/Default/env2/g/test:test3
-  //
-  // This function returns a list of test paths which uses each test name
-  // exactly once and each "env" exactly once. In this case, the result would
-  // be:
-  //
-  // root/Default/env0/a/b/test:test1
-  // root/Default/env1/d/e/f/test:test2
-  // root/Default/env2/g/test:test3
-
-  const tests = new Map<string, string>();
-  const envs = new Set<string>();
-
-  for (const testPath of testPaths) {
-    const testSuffix = testPath.substring(testPath.indexOf("env") + 1); // "<env #>/<path to test>"
-    const env = testSuffix.substring(0, testSuffix.indexOf("/")); // "<env #>"
-    const testName = testSuffix.substring(testSuffix.indexOf("/") + 1); // "<path to test>"
-
-    if (envs.has(env)) {
-      continue;
-    }
-
-    if (tests.has(testName)) {
-      continue;
-    }
-
-    tests.set(testName, testPath);
-    envs.add(env);
-  }
-
-  return Array.from(tests.values());
 }
 
 function sortTests(a: std.TestResult, b: std.TestResult) {

--- a/libs/wingsdk/src/target-sim/api.inflight.ts
+++ b/libs/wingsdk/src/target-sim/api.inflight.ts
@@ -25,10 +25,14 @@ import { TraceType } from "../std";
 
 const LOCALHOST_ADDRESS = "127.0.0.1";
 
+interface ApiRouteWithFunctionHandle extends ApiRoute {
+  functionHandle: string;
+}
+
 export class Api
   implements IApiClient, ISimulatorResourceInstance, IEventPublisher
 {
-  private readonly routes: ApiRoute[];
+  private readonly routes: ApiRouteWithFunctionHandle[];
   private readonly context: ISimulatorContext;
   private readonly app: express.Application;
   private server: Server | undefined;
@@ -118,6 +122,13 @@ export class Api
       this.routes.push(s);
       this.populateRoute(s, subscriber);
     });
+  }
+
+  public async removeEventSubscription(subscriber: string): Promise<void> {
+    const index = this.routes.findIndex((s) => s.functionHandle === subscriber);
+    if (index >= 0) {
+      this.routes.splice(index, 1);
+    }
   }
 
   private populateRoute(route: ApiRoute, functionHandle: string): void {

--- a/libs/wingsdk/src/target-sim/event-mapping.inflight.ts
+++ b/libs/wingsdk/src/target-sim/event-mapping.inflight.ts
@@ -29,7 +29,10 @@ export class EventMapping implements ISimulatorResourceInstance {
     return {};
   }
 
-  public async cleanup(): Promise<void> {}
+  public async cleanup(): Promise<void> {
+    const client = this.context.findInstance(this.publisher) as IEventPublisher;
+    await client.removeEventSubscription(this.subscriber);
+  }
 
   public async save(): Promise<void> {}
 }

--- a/libs/wingsdk/src/target-sim/event-mapping.ts
+++ b/libs/wingsdk/src/target-sim/event-mapping.ts
@@ -27,6 +27,13 @@ export interface IEventPublisher extends ISimulatorResourceInstance {
     subscriber: FunctionHandle,
     subscriptionProps: EventSubscription
   ) => Promise<void>;
+
+  /**
+   * Removes event subscription from the publisher client.
+   * @param subscriber the subscriber function
+   * @param subscriptionProps additional subscription properties
+   */
+  removeEventSubscription: (subscriber: FunctionHandle) => Promise<void>;
 }
 
 export const EVENT_MAPPING_FQN = fqnForType("sim.EventMapping");

--- a/libs/wingsdk/src/target-sim/queue.inflight.ts
+++ b/libs/wingsdk/src/target-sim/queue.inflight.ts
@@ -51,6 +51,17 @@ export class Queue
     this.subscribers.push(s);
   }
 
+  public async removeEventSubscription(
+    subscriber: FunctionHandle
+  ): Promise<void> {
+    const index = this.subscribers.findIndex(
+      (s) => s.functionHandle === subscriber
+    );
+    if (index >= 0) {
+      this.subscribers.splice(index, 1);
+    }
+  }
+
   // TODO: enforce maximum queue message size?
   public async push(...messages: string[]): Promise<void> {
     return this.context.withTrace({

--- a/libs/wingsdk/src/target-sim/schedule.inflight.ts
+++ b/libs/wingsdk/src/target-sim/schedule.inflight.ts
@@ -58,6 +58,13 @@ export class Schedule
     this.tasks.push(task);
   }
 
+  public async removeEventSubscription(subscriber: string): Promise<void> {
+    const index = this.tasks.findIndex((s) => s.functionHandle === subscriber);
+    if (index >= 0) {
+      this.tasks.splice(index, 1);
+    }
+  }
+
   private runTasks() {
     for (const task of this.tasks) {
       const fnClient = this.context.findInstance(

--- a/libs/wingsdk/src/target-sim/topic.inflight.ts
+++ b/libs/wingsdk/src/target-sim/topic.inflight.ts
@@ -81,6 +81,15 @@ export class Topic
     this.subscribers.push(s);
   }
 
+  public async removeEventSubscription(subscriber: string): Promise<void> {
+    const index = this.subscribers.findIndex(
+      (s) => s.functionHandle === subscriber
+    );
+    if (index >= 0) {
+      this.subscribers.splice(index, 1);
+    }
+  }
+
   public async publish(message: string): Promise<void> {
     this.context.addTrace({
       data: {

--- a/tools/hangar/__snapshots__/test_corpus/valid/resource.test.w_test_sim.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/resource.test.w_test_sim.md
@@ -1,18 +1,5 @@
 # [resource.test.w](../../../../../examples/tests/valid/resource.test.w) | test | sim
 
-## stderr.log
-```log
-Error: No resource found with handle "sim-25".
-    at HandleManager.find (<ABSOLUTE>:LINE:COL)
-    at Object.findInstance (<ABSOLUTE>:LINE:COL)
-    at Queue.processMessages (<ABSOLUTE>:LINE:COL)
-    at <ABSOLUTE>/queue.inflight.js:12:59
-    at loop (<ABSOLUTE>:LINE:COL)
-    at runNextTicks (node:internal/process/task_queues:60:5)
-    at listOnTimeout (node:internal/timers:538:9)
-    at process.processTimers (node:internal/timers:512:7)
-```
-
 ## stdout.log
 ```log
 pass ┌ resource.test.wsim » root/env0/test:test             


### PR DESCRIPTION
Fixes #5228

We discovered an issue where invalid errors were thrown in unit tests where a message is pushed to a queue and the queue had a consumer function. The problem occurred because a queue's simulation periodically processes messages, but this continued even after the queue consumer function is deleted during the simulator's cleanup. (I've shared some verbose test logs from the minimal repro in #5228 here: https://gist.github.com/Chriscbr/23fb248fb65d9e349da6e3347c90c866).

To fix this, I updated the EventMapping resource so it also removes the its function from the queue's subscribers when the EventMapping is cleaned up. By doing this, we guarantee the function is removed from the queue's subscribers before the function is cleaned up, so when the queue tries processing messages, it will send the messages to another consumer or simply retain them in memory.

Misc:
- I also cleaned up some dead code that was previously used by the CLI for picking out distinct tests to run (no longer needed after https://github.com/winglang/wing/pull/5164)

## Checklist

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [x] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
