### PR TITLE
chore(build): upgrade github actions to artifacts v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,7 +91,7 @@ jobs:
           SEGMENT_WRITE_KEY: ${{ secrets.SEGMENT_WRITE_KEY }}
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: dist
           path: dist/*
@@ -140,7 +140,7 @@ jobs:
 
       - name: Upload patch
         if: steps.diff.outputs.diff == 'true'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: build.diff
           path: build.diff
@@ -156,7 +156,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Download Dist Artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: dist
           path: dist
@@ -191,7 +191,7 @@ jobs:
         run: pnpm bench
 
       - name: Upload Report JSON
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: benchmarks
           path: tools/hangar/results/report.json
@@ -236,7 +236,7 @@ jobs:
           node-version: ${{ matrix.node }}
 
       - name: Download Dist Artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: dist
           path: dist
@@ -264,7 +264,7 @@ jobs:
 
       - name: Upload mutation
         if: matrix.runner == 'ubuntu' && matrix.node == '18' && steps.diff.outputs.diff == 'true'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.diff.outputs.diff_name }}
           path: ${{ steps.diff.outputs.diff_name }}
@@ -291,7 +291,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Download Dist Artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: dist
           path: dist
@@ -338,7 +338,7 @@ jobs:
         if: needs.build.result == 'failure' || needs.e2e-test.result == 'failure' || needs.benchmark.result == 'failure' || needs.test.result == 'failure' || needs.aws-sdk-spec-test.result == 'failure'
         run: exit 1
       - name: Download patches
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
       - name: Check patches
         run: |
           PATCH_COUNT=0
@@ -362,7 +362,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download Build Artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
 
       - name: Tag commit
         uses: tvdias/github-tagger@v0.0.1

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - name: Download artifacts
         id: download-artifacts
-        uses: dawidd6/action-download-artifact@v2
+        uses: dawidd6/action-download-artifact@v3
         with:
           github_token: ${{secrets.GITHUB_TOKEN}}
           run_id: ${{ github.event.workflow_run.id }}

--- a/.github/workflows/tf-aws-test.yml
+++ b/.github/workflows/tf-aws-test.yml
@@ -120,7 +120,7 @@ jobs:
       ##################### install a local wing version #########################
       - name: Download Dist Artifacts
         if: ${{ env.LOCAL_BUILD ==  'true' }}
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: dist
           path: dist


### PR DESCRIPTION
Upgrading GitHub Actions to [Artifacts v4](https://github.blog/changelog/2023-12-14-github-actions-artifacts-v4-is-now-generally-available/) for performance improvements.

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
