### PR TITLE
feat: state dir prop for the console server

### DIFF
--- a/apps/wing-console/console/app/src/index.ts
+++ b/apps/wing-console/console/app/src/index.ts
@@ -38,6 +38,7 @@ export interface CreateConsoleAppOptions {
   requireAcceptTerms?: boolean;
   layoutConfig?: LayoutConfig;
   platform?: string[];
+  stateDir?: string;
 }
 
 const staticDir = `${__dirname}/vite`;

--- a/apps/wing-console/console/server/src/index.ts
+++ b/apps/wing-console/console/server/src/index.ts
@@ -69,6 +69,7 @@ export interface CreateConsoleServerOptions {
   requireAcceptTerms?: boolean;
   layoutConfig?: LayoutConfig;
   platform?: string[];
+  stateDir?: string;
 }
 
 export const createConsoleServer = async ({
@@ -84,6 +85,7 @@ export const createConsoleServer = async ({
   requireAcceptTerms,
   layoutConfig,
   platform,
+  stateDir,
 }: CreateConsoleServerOptions) => {
   const emitter = new Emittery<{
     invalidateQuery: RouteNames;
@@ -111,11 +113,16 @@ export const createConsoleServer = async ({
     log,
   });
 
-  const compiler = createCompiler({ wingfile, platform, testing: false });
+  const compiler = createCompiler({
+    wingfile,
+    platform,
+    testing: false,
+    stateDir,
+  });
   let isStarting = false;
   let isStopping = false;
 
-  const simulator = createSimulator();
+  const simulator = createSimulator({ stateDir });
   if (onTrace) {
     simulator.on("trace", onTrace);
   }

--- a/apps/wing-console/console/server/src/utils/compiler.ts
+++ b/apps/wing-console/console/server/src/utils/compiler.ts
@@ -25,12 +25,14 @@ export interface CreateCompilerProps {
   wingfile: string;
   platform?: string[];
   testing?: boolean;
+  stateDir?: string;
 }
 
 export const createCompiler = ({
   wingfile,
   platform = [wing.BuiltinPlatform.SIM],
   testing = false,
+  stateDir,
 }: CreateCompilerProps): Compiler => {
   const events = new Emittery<CompilerEvents>();
   let isCompiling = false;
@@ -81,6 +83,11 @@ export const createCompiler = ({
     "**/node_modules/**",
     "**/.git/**",
   ];
+
+  if (stateDir) {
+    ignoreList.push(stateDir);
+  }
+
   const watcher = chokidar.watch(dirname, {
     ignored: ignoreList,
     ignoreInitial: true,

--- a/apps/wing-console/console/server/src/utils/simulator.ts
+++ b/apps/wing-console/console/server/src/utils/simulator.ts
@@ -23,6 +23,10 @@ export interface Simulator {
   ): void;
 }
 
+export interface CreateSimulatorProps {
+  stateDir?: string;
+}
+
 const stopSilently = async (simulator: simulator.Simulator) => {
   try {
     await simulator.stop();
@@ -38,7 +42,7 @@ const stopSilently = async (simulator: simulator.Simulator) => {
   }
 };
 
-export const createSimulator = (): Simulator => {
+export const createSimulator = (props?: CreateSimulatorProps): Simulator => {
   const events = new Emittery<SimulatorEvents>();
   let instance: simulator.Simulator | undefined;
   const start = async (simfile: string) => {
@@ -48,7 +52,10 @@ export const createSimulator = (): Simulator => {
         await stopSilently(instance);
       }
 
-      instance = new simulator.Simulator({ simfile });
+      instance = new simulator.Simulator({
+        simfile,
+        stateDir: props?.stateDir,
+      });
       instance.onTrace({
         callback(trace) {
           events.emit("trace", trace);


### PR DESCRIPTION
it's now possible to start the console server with a specific state directory

## Checklist

- [X] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [X] Description explains motivation and solution
- [ ] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
