### PR TITLE
chore(docs): add missing PR scope

### DIFF
--- a/docs/contributing/01-start-here/06-pull-requests.md
+++ b/docs/contributing/01-start-here/06-pull-requests.md
@@ -51,9 +51,9 @@ changelog. To that end, pull request titles must follow this convention:
   * `tutorial`
   * `vscode`
   * `plugins`
+  * `platforms`
   * `build` - change related to development environment, build system, build tools, etc.
-  * `repo` - change related to repository behavior (e.g. pull request templates, issue templates,
-    etc).
+  * `repo` - change related to repository behavior (e.g. pull request templates, issue templates, etc).
 * `<subject>`
   * Prefer lowercase (except for proper nouns) and do not include a period (improves aesthetics of changelog).
   * For `fix` changes, subject should describe the problem, not the solution (e.g. `fix(cli): intermediate.js file not found` instead of ~`fix(cli): make sure output directory exists`~).


### PR DESCRIPTION
The `platforms` scope was added to the workflow but not in the docs.

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
