### PR TITLE
feat: endpoints panel in the console

### DIFF
--- a/apps/vscode-wing/.projenrc.ts
+++ b/apps/vscode-wing/.projenrc.ts
@@ -208,6 +208,10 @@ const contributes: VSCodeExtensionContributions = {
         id: "consoleTestsExplorer",
         name: "Wing Tests",
       },
+      {
+        id: "consoleEndpointsExplorer",
+        name: "Wing Endpoints",
+      },
     ],
   },
 };

--- a/apps/vscode-wing/package.json
+++ b/apps/vscode-wing/package.json
@@ -213,6 +213,10 @@
         {
           "id": "consoleTestsExplorer",
           "name": "Wing Tests"
+        },
+        {
+          "id": "consoleEndpointsExplorer",
+          "name": "Wing Endpoints"
         }
       ]
     }

--- a/apps/vscode-wing/src/console/console-manager.ts
+++ b/apps/vscode-wing/src/console/console-manager.ts
@@ -11,6 +11,10 @@ import {
 } from "vscode";
 
 import {
+  EndpointItem,
+  EndpointsExplorerProvider,
+} from "./explorer-providers/EndpointsExplorerProvider";
+import {
   ResourceItem,
   ResourcesExplorerProvider,
 } from "./explorer-providers/ResourcesExplorerProvider";
@@ -46,11 +50,13 @@ export const createConsoleManager = (
   const instances: Record<string, ConsoleInstance> = {};
   const resourcesExplorer = new ResourcesExplorerProvider();
   const testsExplorer = new TestsExplorerProvider();
+  const endpointsExplorer = new EndpointsExplorerProvider();
 
   let activeInstanceId: string | undefined;
   let webviewPanel: WebviewPanel | undefined;
   let explorerView: TreeView<ResourceItem> | undefined;
   let testsExplorerView: TreeView<TestItem> | undefined;
+  let endpointsExplorerView: TreeView<EndpointItem> | undefined;
 
   let timeout: NodeJS.Timeout | undefined;
   let logsTimestamp: number = 0;
@@ -154,6 +160,7 @@ export const createConsoleManager = (
           }
           resourcesExplorer.update(await instance.client.listResources());
           testsExplorer.update(await instance.client.listTests());
+          endpointsExplorer.update(await instance.client.listEndpoints());
         }, 300);
       },
       onError: (err) => {
@@ -230,6 +237,7 @@ export const createConsoleManager = (
       webviewPanel.onDidDispose(async () => {
         resourcesExplorer.clear();
         testsExplorer.clear();
+        endpointsExplorer.clear();
         webviewPanel = undefined;
         activeInstanceId = undefined;
 
@@ -273,6 +281,7 @@ export const createConsoleManager = (
 
     resourcesExplorer.update(await instance.client.listResources());
     testsExplorer.update(await instance.client.listTests());
+    endpointsExplorer.update(await instance.client.listEndpoints());
     await updateLogs(instance);
 
     explorerView = window.createTreeView("consoleExplorer", {
@@ -283,7 +292,16 @@ export const createConsoleManager = (
       treeDataProvider: testsExplorer,
     });
 
-    context.subscriptions.push(webviewPanel, explorerView, testsExplorerView);
+    endpointsExplorerView = window.createTreeView("consoleEndpointsExplorer", {
+      treeDataProvider: endpointsExplorer,
+    });
+
+    context.subscriptions.push(
+      webviewPanel,
+      explorerView,
+      testsExplorerView,
+      endpointsExplorerView
+    );
     activeInstanceId = instanceId;
   };
 

--- a/apps/vscode-wing/src/console/explorer-providers/EndpointsExplorerProvider.ts
+++ b/apps/vscode-wing/src/console/explorer-providers/EndpointsExplorerProvider.ts
@@ -1,0 +1,77 @@
+import {
+  TreeDataProvider,
+  TreeItem,
+  TreeItemCollapsibleState,
+  Event,
+  EventEmitter,
+  ThemeIcon,
+  Uri,
+} from "vscode";
+
+export class EndpointsExplorerProvider
+  implements TreeDataProvider<EndpointItem>
+{
+  private endpoints: EndpointItem[] = [];
+
+  private _onDidChangeTreeData: EventEmitter<
+    EndpointItem | undefined | null | void
+  > = new EventEmitter<EndpointItem | undefined | null | void>();
+
+  readonly onDidChangeTreeData: Event<EndpointItem | undefined | null | void> =
+    this._onDidChangeTreeData.event;
+
+  constructor(endpoints?: EndpointItem[]) {
+    this.endpoints = endpoints || [];
+  }
+
+  public refresh(): void {
+    this._onDidChangeTreeData.fire();
+  }
+
+  public update(endpoints: EndpointItem[]): void {
+    this.endpoints = endpoints;
+    this.refresh();
+  }
+
+  public clear(): void {
+    this.update([]);
+  }
+
+  public getEndpoints(): EndpointItem[] {
+    return this.endpoints;
+  }
+
+  public getTreeItem(element: EndpointItem): TreeItem {
+    element.command = {
+      command: "vscode.open",
+      title: "Open Call",
+      arguments: [Uri.parse(element.url)],
+    };
+    return element;
+  }
+
+  public getChildren(element?: EndpointItem): Thenable<EndpointItem[]> {
+    if (!element) {
+      return Promise.resolve(
+        this.endpoints.map((endpoint) => {
+          return new EndpointItem(endpoint.id, endpoint.label, endpoint.url);
+        })
+      );
+    }
+    return Promise.resolve([]);
+  }
+}
+
+export class EndpointItem extends TreeItem {
+  constructor(
+    public readonly id: string,
+    public readonly label: string,
+    public readonly url: string
+  ) {
+    super(label || "", TreeItemCollapsibleState.None);
+    this.tooltip = this.url;
+    this.id = id;
+    this.url = url;
+    this.iconPath = new ThemeIcon("link");
+  }
+}

--- a/apps/vscode-wing/src/console/services/client.ts
+++ b/apps/vscode-wing/src/console/services/client.ts
@@ -8,6 +8,7 @@ import {
 
 import type { ExplorerItem, Router, LogEntry } from "@wingconsole/server";
 
+import { EndpointItem } from "../explorer-providers/EndpointsExplorerProvider";
 import { TestItem } from "../explorer-providers/TestsExplorerProvider";
 
 export interface SubscriptionOptions {
@@ -24,6 +25,7 @@ export interface Client {
   runTest: (resourcePath: string) => Promise<any>;
   runAllTests: () => Promise<any>;
   listResources: () => Promise<ExplorerItem>;
+  listEndpoints: () => Promise<EndpointItem[]>;
   onInvalidateQuery: (options: SubscriptionOptions) => void;
   onOpenFileInEditor: (options: SubscriptionOptions) => void;
   close: () => void;
@@ -95,6 +97,10 @@ export const createClient = (host: string): Client => {
     return client["app.explorerTree"].query();
   };
 
+  const listEndpoints = (): Promise<EndpointItem[]> => {
+    return client["endpoint.list"].query();
+  };
+
   const onInvalidateQuery = (options: SubscriptionOptions) => {
     return client["app.invalidateQuery"].subscribe(undefined, options);
   };
@@ -119,6 +125,7 @@ export const createClient = (host: string): Client => {
     runTest,
     runAllTests,
     listResources,
+    listEndpoints,
     onInvalidateQuery,
     onOpenFileInEditor,
     close,

--- a/apps/wing-console/console/design-system/src/tree-item.tsx
+++ b/apps/wing-console/console/design-system/src/tree-item.tsx
@@ -11,6 +11,7 @@ export interface TreeItemProps {
   secondaryLabel?: ReactNode | (() => JSX.Element);
   icon?: ReactNode;
   title?: string;
+  selectable?: boolean;
   onKeyDown?: (event: KeyboardEvent<HTMLElement>) => void;
 }
 
@@ -20,6 +21,7 @@ export const TreeItem = memo(
     secondaryLabel,
     title,
     icon,
+    selectable = true,
     children,
     ...props
   }: PropsWithChildren<TreeItemProps>) => {
@@ -35,11 +37,13 @@ export const TreeItem = memo(
               "flex items-center gap-1.5",
               "px-2 py-0.5",
               "select-none",
-              "cursor-pointer",
               "border border-transparent",
-              item.focused && "group-focus:border-sky-500",
-              item.selected && theme.bg2,
-              !item.selected && theme.bg2Hover,
+              selectable && [
+                "cursor-pointer",
+                item.focused && "group-focus:border-sky-500",
+                item.selected && theme.bg2,
+                !item.selected && theme.bg2Hover,
+              ],
             )}
             title={title}
           >

--- a/apps/wing-console/console/server/src/router/endpoint.ts
+++ b/apps/wing-console/console/server/src/router/endpoint.ts
@@ -22,7 +22,7 @@ export const createEndpointRouter = () => {
       return endpoints.map((endpoint) => {
         return {
           id: endpoint.path,
-          label: endpoint.attrs.label || `Endpoint for ${endpoint.path}`,
+          label: endpoint.attrs.label || `${endpoint.path}`,
           url: endpoint.attrs.url,
         };
       });

--- a/apps/wing-console/console/server/src/router/endpoint.ts
+++ b/apps/wing-console/console/server/src/router/endpoint.ts
@@ -9,7 +9,6 @@ const listEndpoints = (simulator: Simulator) => {
     .listResources()
     .map((r) => simulator.getResourceConfig(r))
     .filter((r) => {
-      console.log(11, r.type);
       return r.type === ENDPOINT_FQN;
     })
     .map((r) => r as EndpointSchema);

--- a/apps/wing-console/console/server/src/router/endpoint.ts
+++ b/apps/wing-console/console/server/src/router/endpoint.ts
@@ -1,0 +1,32 @@
+import { ENDPOINT_FQN } from "@winglang/sdk/lib/cloud/endpoint.js";
+import { EndpointSchema } from "@winglang/sdk/lib/target-sim/schema-resources.js";
+
+import { createProcedure, createRouter } from "../utils/createRouter.js";
+import { Simulator } from "../wingsdk.js";
+
+const listEndpoints = (simulator: Simulator) => {
+  const endpoints = simulator
+    .listResources()
+    .map((r) => simulator.getResourceConfig(r))
+    .filter((r) => {
+      console.log(11, r.type);
+      return r.type === ENDPOINT_FQN;
+    })
+    .map((r) => r as EndpointSchema);
+  return endpoints;
+};
+
+export const createEndpointRouter = () => {
+  return createRouter({
+    "endpoint.list": createProcedure.query(async ({ input, ctx }) => {
+      const endpoints = listEndpoints(await ctx.simulator());
+      return endpoints.map((endpoint) => {
+        return {
+          id: endpoint.path,
+          label: endpoint.attrs.label || `Endpoint for ${endpoint.path}`,
+          url: endpoint.attrs.url,
+        };
+      });
+    }),
+  });
+};

--- a/apps/wing-console/console/server/src/router/index.ts
+++ b/apps/wing-console/console/server/src/router/index.ts
@@ -6,6 +6,7 @@ import { createBucketRouter } from "./bucket.js";
 import { createConfigRouter } from "./config.js";
 import { createCounterRouter } from "./counter.js";
 import { createDynamodbTableRouter } from "./dynamodb-table.js";
+import { createEndpointRouter } from "./endpoint.js";
 import { createFunctionRouter } from "./function.js";
 import { createQueueRouter } from "./queue.js";
 import { createReactAppRouter } from "./react-app.js";
@@ -35,6 +36,7 @@ export const mergeAllRouters = () => {
     createReactAppRouter(),
     createConfigRouter(),
     createDynamodbTableRouter(),
+    createEndpointRouter(),
   );
 
   return { router };

--- a/apps/wing-console/console/server/src/utils/createRouter.ts
+++ b/apps/wing-console/console/server/src/utils/createRouter.ts
@@ -24,7 +24,7 @@ export type RouterEvents = {
   invalidateQuery: QueryNames;
 };
 
-export type LayoutComponentType = "explorer" | "tests" | "logs";
+export type LayoutComponentType = "explorer" | "tests" | "logs" | "endpoints";
 
 export interface LayoutComponent {
   type: LayoutComponentType;

--- a/apps/wing-console/console/ui/src/features/endpoints-tree-view.tsx
+++ b/apps/wing-console/console/ui/src/features/endpoints-tree-view.tsx
@@ -1,0 +1,10 @@
+import { memo } from "react";
+
+import { useEndpoints } from "../services/use-endpoints.js";
+import { EndpointTree } from "../ui/endpoint-tree.js";
+
+export const EndpointsTreeView = memo(() => {
+  const { endpointList } = useEndpoints();
+
+  return <EndpointTree endpointList={endpointList} />;
+});

--- a/apps/wing-console/console/ui/src/layout/default-layout.tsx
+++ b/apps/wing-console/console/ui/src/layout/default-layout.tsx
@@ -12,6 +12,7 @@ import { PersistentStateProvider } from "@wingconsole/use-persistent-state";
 import classNames from "classnames";
 import { useCallback, useEffect, useMemo, useState } from "react";
 
+import { EndpointsTreeView } from "../features/endpoints-tree-view.js";
 import { MapView } from "../features/map-view.js";
 import { TestsTreeView } from "../features/tests-tree-view.js";
 import { BlueScreenOfDeath } from "../ui/blue-screen-of-death.js";
@@ -43,6 +44,9 @@ const defaultLayoutConfig: LayoutConfig = {
   },
   bottomPanel: {
     components: [
+      {
+        type: "endpoints",
+      },
       {
         type: "logs",
       },
@@ -172,6 +176,9 @@ export const DefaultLayout = ({
               <LogsWidget onResourceClick={onResourceClick} />
             </div>
           );
+        }
+        case "endpoints": {
+          return <EndpointsTreeView key={component.type} />;
         }
       }
     },

--- a/apps/wing-console/console/ui/src/layout/default-layout.tsx
+++ b/apps/wing-console/console/ui/src/layout/default-layout.tsx
@@ -38,15 +38,15 @@ const defaultLayoutConfig: LayoutConfig = {
         type: "explorer",
       },
       {
+        type: "endpoints",
+      },
+      {
         type: "tests",
       },
     ],
   },
   bottomPanel: {
     components: [
-      {
-        type: "endpoints",
-      },
       {
         type: "logs",
       },

--- a/apps/wing-console/console/ui/src/layout/layout-provider.tsx
+++ b/apps/wing-console/console/ui/src/layout/layout-provider.tsx
@@ -77,12 +77,7 @@ export function LayoutProvider({
           hide: true,
         },
         bottomPanel: {
-          size: "small",
-          components: [
-            {
-              type: "endpoints",
-            },
-          ],
+          hide: true,
         },
         statusBar: {
           hide: true,

--- a/apps/wing-console/console/ui/src/layout/layout-provider.tsx
+++ b/apps/wing-console/console/ui/src/layout/layout-provider.tsx
@@ -77,7 +77,12 @@ export function LayoutProvider({
           hide: true,
         },
         bottomPanel: {
-          hide: true,
+          size: "small",
+          components: [
+            {
+              type: "endpoints",
+            },
+          ],
         },
         statusBar: {
           hide: true,

--- a/apps/wing-console/console/ui/src/services/use-endpoints.ts
+++ b/apps/wing-console/console/ui/src/services/use-endpoints.ts
@@ -7,9 +7,11 @@ import { trpc } from "./trpc.js";
 export const useEndpoints = () => {
   const [endpointList, setEndpointList] = useState<EndpointItem[]>([]);
 
+  const endpointListQuery = trpc["endpoint.list"].useQuery();
+
   useEffect(() => {
-    return setEndpointList(trpc["endpoint.list"].useQuery().data || []);
-  }, [trpc["endpoint.list"].useQuery().data]);
+    return setEndpointList(endpointListQuery.data || []);
+  }, [endpointListQuery.data]);
 
   return {
     endpointList,

--- a/apps/wing-console/console/ui/src/services/use-endpoints.ts
+++ b/apps/wing-console/console/ui/src/services/use-endpoints.ts
@@ -1,0 +1,17 @@
+import { useEffect, useState } from "react";
+
+import { EndpointItem } from "../shared/endpoint-item.js";
+
+import { trpc } from "./trpc.js";
+
+export const useEndpoints = () => {
+  const [endpointList, setEndpointList] = useState<EndpointItem[]>([]);
+
+  useEffect(() => {
+    return setEndpointList(trpc["endpoint.list"].useQuery().data || []);
+  }, [trpc["endpoint.list"].useQuery().data]);
+
+  return {
+    endpointList,
+  };
+};

--- a/apps/wing-console/console/ui/src/shared/endpoint-item.ts
+++ b/apps/wing-console/console/ui/src/shared/endpoint-item.ts
@@ -1,0 +1,5 @@
+export interface EndpointItem {
+  id: string;
+  label: string;
+  url: string;
+}

--- a/apps/wing-console/console/ui/src/ui/endpoint-tree.tsx
+++ b/apps/wing-console/console/ui/src/ui/endpoint-tree.tsx
@@ -45,24 +45,18 @@ export const EndpointTree = ({ endpointList }: EndpointTreeProps) => {
                     itemId={endpoint.id}
                     selectable={false}
                     label={
-                      <div className="flex items-center gap-1">
-                        <span className="truncate">{endpoint.label}</span>
-                      </div>
-                    }
-                    secondaryLabel={
-                      <div
-                        className={classNames("items-center hover:underline ")}
-                      >
+                      <div className="flex items-center gap-1 hover:underline">
                         <a href={endpoint.url} target="_blank" rel="noreferrer">
-                          {endpoint.url}
+                          {endpoint.label}
                         </a>
-                        {/* <PlayIcon className="w-4 h-4" /> */}
                       </div>
                     }
-                    title={endpoint.label}
+                    title={endpoint.url}
                     icon={
                       <>
-                        <LinkIcon className="w-4 h-4" />
+                        <LinkIcon
+                          className={classNames("w-4 h-4", theme.text1)}
+                        />
                       </>
                     }
                   />

--- a/apps/wing-console/console/ui/src/ui/endpoint-tree.tsx
+++ b/apps/wing-console/console/ui/src/ui/endpoint-tree.tsx
@@ -1,0 +1,77 @@
+import { LinkIcon } from "@heroicons/react/24/outline";
+import {
+  ScrollableArea,
+  Toolbar,
+  TreeItem,
+  TreeView,
+  useTheme,
+} from "@wingconsole/design-system";
+import classNames from "classnames";
+
+import { EndpointItem } from "../shared/endpoint-item.js";
+
+import { NoEndpoints } from "./no-endpoints.js";
+
+export interface EndpointTreeProps {
+  endpointList: EndpointItem[];
+}
+
+export const EndpointTree = ({ endpointList }: EndpointTreeProps) => {
+  const { theme } = useTheme();
+
+  return (
+    <div
+      className={classNames("w-full h-full flex flex-col", theme.bg3)}
+      data-testid="endpoint-tree-menu"
+    >
+      <Toolbar title="Endpoints"></Toolbar>
+
+      <div className="relative grow">
+        <div className="absolute inset-0">
+          <ScrollableArea
+            overflowY
+            className={classNames(
+              "h-full w-full text-sm flex flex-col gap-1",
+              theme.bg3,
+              theme.text2,
+            )}
+          >
+            <div className="flex flex-col">
+              {endpointList.length === 0 && <NoEndpoints />}
+              <TreeView>
+                {endpointList.map((endpoint) => (
+                  <TreeItem
+                    key={endpoint.id}
+                    itemId={endpoint.id}
+                    selectable={false}
+                    label={
+                      <div className="flex items-center gap-1">
+                        <span className="truncate">{endpoint.label}</span>
+                      </div>
+                    }
+                    secondaryLabel={
+                      <div
+                        className={classNames("items-center hover:underline ")}
+                      >
+                        <a href={endpoint.url} target="_blank" rel="noreferrer">
+                          {endpoint.url}
+                        </a>
+                        {/* <PlayIcon className="w-4 h-4" /> */}
+                      </div>
+                    }
+                    title={endpoint.label}
+                    icon={
+                      <>
+                        <LinkIcon className="w-4 h-4" />
+                      </>
+                    }
+                  />
+                ))}
+              </TreeView>
+            </div>
+          </ScrollableArea>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/apps/wing-console/console/ui/src/ui/endpoint-tree.tsx
+++ b/apps/wing-console/console/ui/src/ui/endpoint-tree.tsx
@@ -45,7 +45,7 @@ export const EndpointTree = ({ endpointList }: EndpointTreeProps) => {
                     itemId={endpoint.id}
                     selectable={false}
                     label={
-                      <div className="flex items-center gap-1 hover:underline">
+                      <div className="flex items-center gap-1 hover:underline text-sky-500 hover:text-sky-600">
                         <a href={endpoint.url} target="_blank" rel="noreferrer">
                           {endpoint.label}
                         </a>

--- a/apps/wing-console/console/ui/src/ui/no-endpoints.tsx
+++ b/apps/wing-console/console/ui/src/ui/no-endpoints.tsx
@@ -1,0 +1,27 @@
+import { useTheme } from "@wingconsole/design-system";
+import classNames from "classnames";
+
+export const NoEndpoints = () => {
+  const { theme } = useTheme();
+  return (
+    <div
+      className={classNames(
+        theme.text2,
+        "flex flex-col text-xs px-3 py-2 items-center",
+      )}
+    >
+      <div>There are no endpoints.</div>
+      <div>
+        <span>Learn how to add endpoints </span>
+        <a
+          className="text-sky-500 hover:text-sky-600"
+          href="https://www.winglang.io/docs/concepts/endpoints"
+          target="_blank"
+          rel="noreferrer"
+        >
+          here.
+        </a>
+      </div>
+    </div>
+  );
+};

--- a/apps/wing-console/console/ui/src/ui/no-endpoints.tsx
+++ b/apps/wing-console/console/ui/src/ui/no-endpoints.tsx
@@ -15,7 +15,7 @@ export const NoEndpoints = () => {
         <span>Learn how to add endpoints </span>
         <a
           className="text-sky-500 hover:text-sky-600"
-          href="https://www.winglang.io/docs/concepts/endpoints"
+          href="https://www.winglang.io/docs/standard-library/cloud/endpoint"
           target="_blank"
           rel="noreferrer"
         >

--- a/libs/awscdk/src/website.ts
+++ b/libs/awscdk/src/website.ts
@@ -58,7 +58,7 @@ export class Website extends cloud.Website implements IAwsWebsite {
 
     this._url = `https://${distribution.domainName}`;
 
-    this.endpoint = new cloud.Endpoint(this, "Endpoint", this._url, { label: `Endpoint for Website ${this.node.path}`, browserSupport: true })
+    this.endpoint = new cloud.Endpoint(this, "Endpoint", this._url, { label: `Website ${this.node.path}`, browserSupport: true })
   }
 
   protected get _endpoint(): cloud.Endpoint {

--- a/libs/wingsdk/src/cloud/endpoint.ts
+++ b/libs/wingsdk/src/cloud/endpoint.ts
@@ -55,6 +55,7 @@ export class Endpoint extends Resource {
 
     super(scope, id);
 
+    Node.of(this).hidden = true;
     Node.of(this).title = "Endpoint";
     Node.of(this).description = props?.label ?? "A cloud endpoint";
 

--- a/libs/wingsdk/src/target-sim/api.ts
+++ b/libs/wingsdk/src/target-sim/api.ts
@@ -30,7 +30,7 @@ export class Api extends cloud.Api implements ISimulatorResource {
       this,
       "Endpoint",
       simulatorAttrToken(this, "url"),
-      { label: `Endpoint for Api ${this.node.path}` }
+      { label: `Api ${this.node.path}` }
     );
   }
 

--- a/libs/wingsdk/src/target-sim/endpoint.ts
+++ b/libs/wingsdk/src/target-sim/endpoint.ts
@@ -36,7 +36,7 @@ export class Endpoint extends cloud.Endpoint {
         label: this.label,
         browserSupport: this.browserSupport,
       },
-      attrs: {},
+      attrs: {} as any,
     };
   }
 }

--- a/libs/wingsdk/src/target-sim/schema-resources.ts
+++ b/libs/wingsdk/src/target-sim/schema-resources.ts
@@ -352,4 +352,5 @@ export interface EndpointSchema extends BaseResourceSchema {
     /** Browser support of the Endpoint. */
     readonly browserSupport: boolean | undefined;
   };
+  readonly attrs: EndpointAttributes & BaseResourceAttributes;
 }

--- a/libs/wingsdk/src/target-sim/website.ts
+++ b/libs/wingsdk/src/target-sim/website.ts
@@ -21,7 +21,7 @@ export class Website extends cloud.Website implements ISimulatorResource {
       this,
       "Endpoint",
       simulatorAttrToken(this, "url"),
-      { label: `Endpoint for Website ${this.node.path}`, browserSupport: true }
+      { label: `Website ${this.node.path}`, browserSupport: true }
     );
   }
 

--- a/libs/wingsdk/src/target-tf-aws/api.ts
+++ b/libs/wingsdk/src/target-tf-aws/api.ts
@@ -50,7 +50,7 @@ export class Api extends cloud.Api implements IAwsApi {
       cors: this.corsOptions,
     });
     this.endpoint = new cloud.Endpoint(this, "Endpoint", this.api.url, {
-      label: `Endpoint for Api ${this.node.path}`,
+      label: `Api ${this.node.path}`,
     });
   }
 

--- a/libs/wingsdk/src/target-tf-aws/website.ts
+++ b/libs/wingsdk/src/target-tf-aws/website.ts
@@ -156,7 +156,7 @@ export class Website extends cloud.Website implements aws.IAwsWebsite {
     this._url = `https://${distribution.domainName}`;
 
     this.endpoint = new cloud.Endpoint(this, "Endpoint", this._url, {
-      label: `Endpoint for Website ${this.node.path}`,
+      label: `Website ${this.node.path}`,
       browserSupport: true,
     });
   }

--- a/libs/wingsdk/test/target-sim/__snapshots__/api.test.ts.snap
+++ b/libs/wingsdk/test/target-sim/__snapshots__/api.test.ts.snap
@@ -222,6 +222,7 @@ return class Handler {
               },
               "display": {
                 "description": "Endpoint for Api root/my_api",
+                "hidden": true,
                 "title": "Endpoint",
               },
               "id": "Endpoint",
@@ -487,6 +488,7 @@ return class Handler {
               },
               "display": {
                 "description": "Endpoint for Api root/my_api",
+                "hidden": true,
                 "title": "Endpoint",
               },
               "id": "Endpoint",
@@ -752,6 +754,7 @@ return class Handler {
               },
               "display": {
                 "description": "Endpoint for Api root/my_api",
+                "hidden": true,
                 "title": "Endpoint",
               },
               "id": "Endpoint",
@@ -1017,6 +1020,7 @@ return class Handler {
               },
               "display": {
                 "description": "Endpoint for Api root/my_api",
+                "hidden": true,
                 "title": "Endpoint",
               },
               "id": "Endpoint",
@@ -1282,6 +1286,7 @@ return class Handler {
               },
               "display": {
                 "description": "Endpoint for Api root/my_api",
+                "hidden": true,
                 "title": "Endpoint",
               },
               "id": "Endpoint",
@@ -1547,6 +1552,7 @@ return class Handler {
               },
               "display": {
                 "description": "Endpoint for Api root/my_api",
+                "hidden": true,
                 "title": "Endpoint",
               },
               "id": "Endpoint",
@@ -1944,6 +1950,7 @@ return class Handler {
               },
               "display": {
                 "description": "Endpoint for Api root/my_api",
+                "hidden": true,
                 "title": "Endpoint",
               },
               "id": "Endpoint",
@@ -2226,6 +2233,7 @@ return class Handler {
               },
               "display": {
                 "description": "Endpoint for Api root/my_api",
+                "hidden": true,
                 "title": "Endpoint",
               },
               "id": "Endpoint",
@@ -2500,6 +2508,7 @@ return class Handler {
               },
               "display": {
                 "description": "Endpoint for Api root/my_api",
+                "hidden": true,
                 "title": "Endpoint",
               },
               "id": "Endpoint",
@@ -2762,6 +2771,7 @@ return class Handler {
               },
               "display": {
                 "description": "Endpoint for Api root/my_api",
+                "hidden": true,
                 "title": "Endpoint",
               },
               "id": "Endpoint",
@@ -3105,6 +3115,7 @@ return class Handler {
               },
               "display": {
                 "description": "Endpoint for Api root/my_api",
+                "hidden": true,
                 "title": "Endpoint",
               },
               "id": "Endpoint",
@@ -3463,6 +3474,7 @@ return class Handler {
               },
               "display": {
                 "description": "Endpoint for Api root/my_api",
+                "hidden": true,
                 "title": "Endpoint",
               },
               "id": "Endpoint",
@@ -3741,6 +3753,7 @@ return class Handler {
               },
               "display": {
                 "description": "Endpoint for Api root/my_api",
+                "hidden": true,
                 "title": "Endpoint",
               },
               "id": "Endpoint",
@@ -4015,6 +4028,7 @@ return class Handler {
               },
               "display": {
                 "description": "Endpoint for Api root/my_api",
+                "hidden": true,
                 "title": "Endpoint",
               },
               "id": "Endpoint",
@@ -4280,6 +4294,7 @@ return class Handler {
               },
               "display": {
                 "description": "Endpoint for Api root/my_api",
+                "hidden": true,
                 "title": "Endpoint",
               },
               "id": "Endpoint",
@@ -4451,6 +4466,7 @@ exports[`create an api 1`] = `
               },
               "display": {
                 "description": "Endpoint for Api root/my_api",
+                "hidden": true,
                 "title": "Endpoint",
               },
               "id": "Endpoint",

--- a/libs/wingsdk/test/target-sim/__snapshots__/api.test.ts.snap
+++ b/libs/wingsdk/test/target-sim/__snapshots__/api.test.ts.snap
@@ -40,7 +40,7 @@ return class Handler {
         "path": "root/my_api/Endpoint",
         "props": {
           "inputUrl": "\${wsim#root/my_api#attrs.url}",
-          "label": "Endpoint for Api root/my_api",
+          "label": "Api root/my_api",
           "url": "\${wsim#root/my_api#attrs.url}",
         },
         "type": "@winglang/sdk.cloud.Endpoint",
@@ -221,7 +221,7 @@ return class Handler {
                 "version": "10.2.70",
               },
               "display": {
-                "description": "Endpoint for Api root/my_api",
+                "description": "Api root/my_api",
                 "hidden": true,
                 "title": "Endpoint",
               },
@@ -320,7 +320,7 @@ return class Handler {
         "path": "root/my_api/Endpoint",
         "props": {
           "inputUrl": "\${wsim#root/my_api#attrs.url}",
-          "label": "Endpoint for Api root/my_api",
+          "label": "Api root/my_api",
           "url": "\${wsim#root/my_api#attrs.url}",
         },
         "type": "@winglang/sdk.cloud.Endpoint",
@@ -487,7 +487,7 @@ return class Handler {
                 "version": "10.2.70",
               },
               "display": {
-                "description": "Endpoint for Api root/my_api",
+                "description": "Api root/my_api",
                 "hidden": true,
                 "title": "Endpoint",
               },
@@ -586,7 +586,7 @@ return class Handler {
         "path": "root/my_api/Endpoint",
         "props": {
           "inputUrl": "\${wsim#root/my_api#attrs.url}",
-          "label": "Endpoint for Api root/my_api",
+          "label": "Api root/my_api",
           "url": "\${wsim#root/my_api#attrs.url}",
         },
         "type": "@winglang/sdk.cloud.Endpoint",
@@ -753,7 +753,7 @@ return class Handler {
                 "version": "10.2.70",
               },
               "display": {
-                "description": "Endpoint for Api root/my_api",
+                "description": "Api root/my_api",
                 "hidden": true,
                 "title": "Endpoint",
               },
@@ -852,7 +852,7 @@ return class Handler {
         "path": "root/my_api/Endpoint",
         "props": {
           "inputUrl": "\${wsim#root/my_api#attrs.url}",
-          "label": "Endpoint for Api root/my_api",
+          "label": "Api root/my_api",
           "url": "\${wsim#root/my_api#attrs.url}",
         },
         "type": "@winglang/sdk.cloud.Endpoint",
@@ -1019,7 +1019,7 @@ return class Handler {
                 "version": "10.2.70",
               },
               "display": {
-                "description": "Endpoint for Api root/my_api",
+                "description": "Api root/my_api",
                 "hidden": true,
                 "title": "Endpoint",
               },
@@ -1118,7 +1118,7 @@ return class Handler {
         "path": "root/my_api/Endpoint",
         "props": {
           "inputUrl": "\${wsim#root/my_api#attrs.url}",
-          "label": "Endpoint for Api root/my_api",
+          "label": "Api root/my_api",
           "url": "\${wsim#root/my_api#attrs.url}",
         },
         "type": "@winglang/sdk.cloud.Endpoint",
@@ -1285,7 +1285,7 @@ return class Handler {
                 "version": "10.2.70",
               },
               "display": {
-                "description": "Endpoint for Api root/my_api",
+                "description": "Api root/my_api",
                 "hidden": true,
                 "title": "Endpoint",
               },
@@ -1384,7 +1384,7 @@ return class Handler {
         "path": "root/my_api/Endpoint",
         "props": {
           "inputUrl": "\${wsim#root/my_api#attrs.url}",
-          "label": "Endpoint for Api root/my_api",
+          "label": "Api root/my_api",
           "url": "\${wsim#root/my_api#attrs.url}",
         },
         "type": "@winglang/sdk.cloud.Endpoint",
@@ -1551,7 +1551,7 @@ return class Handler {
                 "version": "10.2.70",
               },
               "display": {
-                "description": "Endpoint for Api root/my_api",
+                "description": "Api root/my_api",
                 "hidden": true,
                 "title": "Endpoint",
               },
@@ -1698,7 +1698,7 @@ return class Handler {
         "path": "root/my_api/Endpoint",
         "props": {
           "inputUrl": "\${wsim#root/my_api#attrs.url}",
-          "label": "Endpoint for Api root/my_api",
+          "label": "Api root/my_api",
           "url": "\${wsim#root/my_api#attrs.url}",
         },
         "type": "@winglang/sdk.cloud.Endpoint",
@@ -1949,7 +1949,7 @@ return class Handler {
                 "version": "10.2.70",
               },
               "display": {
-                "description": "Endpoint for Api root/my_api",
+                "description": "Api root/my_api",
                 "hidden": true,
                 "title": "Endpoint",
               },
@@ -2048,7 +2048,7 @@ return class Handler {
         "path": "root/my_api/Endpoint",
         "props": {
           "inputUrl": "\${wsim#root/my_api#attrs.url}",
-          "label": "Endpoint for Api root/my_api",
+          "label": "Api root/my_api",
           "url": "\${wsim#root/my_api#attrs.url}",
         },
         "type": "@winglang/sdk.cloud.Endpoint",
@@ -2232,7 +2232,7 @@ return class Handler {
                 "version": "10.2.70",
               },
               "display": {
-                "description": "Endpoint for Api root/my_api",
+                "description": "Api root/my_api",
                 "hidden": true,
                 "title": "Endpoint",
               },
@@ -2331,7 +2331,7 @@ return class Handler {
         "path": "root/my_api/Endpoint",
         "props": {
           "inputUrl": "\${wsim#root/my_api#attrs.url}",
-          "label": "Endpoint for Api root/my_api",
+          "label": "Api root/my_api",
           "url": "\${wsim#root/my_api#attrs.url}",
         },
         "type": "@winglang/sdk.cloud.Endpoint",
@@ -2507,7 +2507,7 @@ return class Handler {
                 "version": "10.2.70",
               },
               "display": {
-                "description": "Endpoint for Api root/my_api",
+                "description": "Api root/my_api",
                 "hidden": true,
                 "title": "Endpoint",
               },
@@ -2587,7 +2587,7 @@ return class Handler {
         "path": "root/my_api/Endpoint",
         "props": {
           "inputUrl": "\${wsim#root/my_api#attrs.url}",
-          "label": "Endpoint for Api root/my_api",
+          "label": "Api root/my_api",
           "url": "\${wsim#root/my_api#attrs.url}",
         },
         "type": "@winglang/sdk.cloud.Endpoint",
@@ -2770,7 +2770,7 @@ return class Handler {
                 "version": "10.2.70",
               },
               "display": {
-                "description": "Endpoint for Api root/my_api",
+                "description": "Api root/my_api",
                 "hidden": true,
                 "title": "Endpoint",
               },
@@ -2896,7 +2896,7 @@ return class Handler {
         "path": "root/my_api/Endpoint",
         "props": {
           "inputUrl": "\${wsim#root/my_api#attrs.url}",
-          "label": "Endpoint for Api root/my_api",
+          "label": "Api root/my_api",
           "url": "\${wsim#root/my_api#attrs.url}",
         },
         "type": "@winglang/sdk.cloud.Endpoint",
@@ -3114,7 +3114,7 @@ return class Handler {
                 "version": "10.2.70",
               },
               "display": {
-                "description": "Endpoint for Api root/my_api",
+                "description": "Api root/my_api",
                 "hidden": true,
                 "title": "Endpoint",
               },
@@ -3253,7 +3253,7 @@ return class Handler {
         "path": "root/my_api/Endpoint",
         "props": {
           "inputUrl": "\${wsim#root/my_api#attrs.url}",
-          "label": "Endpoint for Api root/my_api",
+          "label": "Api root/my_api",
           "url": "\${wsim#root/my_api#attrs.url}",
         },
         "type": "@winglang/sdk.cloud.Endpoint",
@@ -3473,7 +3473,7 @@ return class Handler {
                 "version": "10.2.70",
               },
               "display": {
-                "description": "Endpoint for Api root/my_api",
+                "description": "Api root/my_api",
                 "hidden": true,
                 "title": "Endpoint",
               },
@@ -3585,7 +3585,7 @@ return class Handler {
         "path": "root/my_api/Endpoint",
         "props": {
           "inputUrl": "\${wsim#root/my_api#attrs.url}",
-          "label": "Endpoint for Api root/my_api",
+          "label": "Api root/my_api",
           "url": "\${wsim#root/my_api#attrs.url}",
         },
         "type": "@winglang/sdk.cloud.Endpoint",
@@ -3752,7 +3752,7 @@ return class Handler {
                 "version": "10.2.70",
               },
               "display": {
-                "description": "Endpoint for Api root/my_api",
+                "description": "Api root/my_api",
                 "hidden": true,
                 "title": "Endpoint",
               },
@@ -3851,7 +3851,7 @@ return class Handler {
         "path": "root/my_api/Endpoint",
         "props": {
           "inputUrl": "\${wsim#root/my_api#attrs.url}",
-          "label": "Endpoint for Api root/my_api",
+          "label": "Api root/my_api",
           "url": "\${wsim#root/my_api#attrs.url}",
         },
         "type": "@winglang/sdk.cloud.Endpoint",
@@ -4027,7 +4027,7 @@ return class Handler {
                 "version": "10.2.70",
               },
               "display": {
-                "description": "Endpoint for Api root/my_api",
+                "description": "Api root/my_api",
                 "hidden": true,
                 "title": "Endpoint",
               },
@@ -4126,7 +4126,7 @@ return class Handler {
         "path": "root/my_api/Endpoint",
         "props": {
           "inputUrl": "\${wsim#root/my_api#attrs.url}",
-          "label": "Endpoint for Api root/my_api",
+          "label": "Api root/my_api",
           "url": "\${wsim#root/my_api#attrs.url}",
         },
         "type": "@winglang/sdk.cloud.Endpoint",
@@ -4293,7 +4293,7 @@ return class Handler {
                 "version": "10.2.70",
               },
               "display": {
-                "description": "Endpoint for Api root/my_api",
+                "description": "Api root/my_api",
                 "hidden": true,
                 "title": "Endpoint",
               },
@@ -4364,7 +4364,7 @@ exports[`create an api 1`] = `
         "path": "root/my_api/Endpoint",
         "props": {
           "inputUrl": "\${wsim#root/my_api#attrs.url}",
-          "label": "Endpoint for Api root/my_api",
+          "label": "Api root/my_api",
           "url": "\${wsim#root/my_api#attrs.url}",
         },
         "type": "@winglang/sdk.cloud.Endpoint",
@@ -4465,7 +4465,7 @@ exports[`create an api 1`] = `
                 "version": "10.2.70",
               },
               "display": {
-                "description": "Endpoint for Api root/my_api",
+                "description": "Api root/my_api",
                 "hidden": true,
                 "title": "Endpoint",
               },

--- a/libs/wingsdk/test/target-tf-aws/__snapshots__/domain.test.ts.snap
+++ b/libs/wingsdk/test/target-tf-aws/__snapshots__/domain.test.ts.snap
@@ -238,6 +238,7 @@ exports[`cloud.Domain for tf-aws > react website with a domain when passing valu
                         },
                         "display": {
                           "description": "Endpoint for Website root/Default/Website/Website-host",
+                          "hidden": true,
                           "title": "Endpoint",
                         },
                         "id": "Endpoint",
@@ -581,6 +582,7 @@ exports[`cloud.Domain for tf-aws > react website with a domain when passing valu
                         },
                         "display": {
                           "description": "Endpoint for Website root/Default/Website/Website-host",
+                          "hidden": true,
                           "title": "Endpoint",
                         },
                         "id": "Endpoint",
@@ -932,6 +934,7 @@ exports[`cloud.Domain for tf-aws > website with a domain when passing values fro
                     },
                     "display": {
                       "description": "Endpoint for Website root/Default/Website",
+                      "hidden": true,
                       "title": "Endpoint",
                     },
                     "id": "Endpoint",
@@ -1279,6 +1282,7 @@ exports[`cloud.Domain for tf-aws > website with a domain when passing values on 
                     },
                     "display": {
                       "description": "Endpoint for Website root/Default/Website",
+                      "hidden": true,
                       "title": "Endpoint",
                     },
                     "id": "Endpoint",

--- a/libs/wingsdk/test/target-tf-aws/__snapshots__/domain.test.ts.snap
+++ b/libs/wingsdk/test/target-tf-aws/__snapshots__/domain.test.ts.snap
@@ -237,7 +237,7 @@ exports[`cloud.Domain for tf-aws > react website with a domain when passing valu
                           "version": "10.2.70",
                         },
                         "display": {
-                          "description": "Endpoint for Website root/Default/Website/Website-host",
+                          "description": "Website root/Default/Website/Website-host",
                           "hidden": true,
                           "title": "Endpoint",
                         },
@@ -581,7 +581,7 @@ exports[`cloud.Domain for tf-aws > react website with a domain when passing valu
                           "version": "10.2.70",
                         },
                         "display": {
-                          "description": "Endpoint for Website root/Default/Website/Website-host",
+                          "description": "Website root/Default/Website/Website-host",
                           "hidden": true,
                           "title": "Endpoint",
                         },
@@ -933,7 +933,7 @@ exports[`cloud.Domain for tf-aws > website with a domain when passing values fro
                       "version": "10.2.70",
                     },
                     "display": {
-                      "description": "Endpoint for Website root/Default/Website",
+                      "description": "Website root/Default/Website",
                       "hidden": true,
                       "title": "Endpoint",
                     },
@@ -1281,7 +1281,7 @@ exports[`cloud.Domain for tf-aws > website with a domain when passing values on 
                       "version": "10.2.70",
                     },
                     "display": {
-                      "description": "Endpoint for Website root/Default/Website",
+                      "description": "Website root/Default/Website",
                       "hidden": true,
                       "title": "Endpoint",
                     },

--- a/libs/wingsdk/test/target-tf-aws/__snapshots__/react-app.test.ts.snap
+++ b/libs/wingsdk/test/target-tf-aws/__snapshots__/react-app.test.ts.snap
@@ -208,7 +208,7 @@ exports[`Testing ReactApp > default React App behavior 2`] = `
                           "version": "10.2.70",
                         },
                         "display": {
-                          "description": "Endpoint for Website root/Default/Website/Website-host",
+                          "description": "Website root/Default/Website/Website-host",
                           "hidden": true,
                           "title": "Endpoint",
                         },
@@ -517,7 +517,7 @@ exports[`Testing ReactApp > website with addEnvironment 2`] = `
                           "version": "10.2.70",
                         },
                         "display": {
-                          "description": "Endpoint for Website root/Default/Website/Website-host",
+                          "description": "Website root/Default/Website/Website-host",
                           "hidden": true,
                           "title": "Endpoint",
                         },

--- a/libs/wingsdk/test/target-tf-aws/__snapshots__/react-app.test.ts.snap
+++ b/libs/wingsdk/test/target-tf-aws/__snapshots__/react-app.test.ts.snap
@@ -209,6 +209,7 @@ exports[`Testing ReactApp > default React App behavior 2`] = `
                         },
                         "display": {
                           "description": "Endpoint for Website root/Default/Website/Website-host",
+                          "hidden": true,
                           "title": "Endpoint",
                         },
                         "id": "Endpoint",
@@ -517,6 +518,7 @@ exports[`Testing ReactApp > website with addEnvironment 2`] = `
                         },
                         "display": {
                           "description": "Endpoint for Website root/Default/Website/Website-host",
+                          "hidden": true,
                           "title": "Endpoint",
                         },
                         "id": "Endpoint",

--- a/libs/wingsdk/test/target-tf-aws/__snapshots__/website.test.ts.snap
+++ b/libs/wingsdk/test/target-tf-aws/__snapshots__/website.test.ts.snap
@@ -217,6 +217,7 @@ exports[`default website behavior 2`] = `
                     },
                     "display": {
                       "description": "Endpoint for Website root/Default/Website",
+                      "hidden": true,
                       "title": "Endpoint",
                     },
                     "id": "Endpoint",
@@ -536,6 +537,7 @@ exports[`website with addFile 2`] = `
                     },
                     "display": {
                       "description": "Endpoint for Website root/Default/Website",
+                      "hidden": true,
                       "title": "Endpoint",
                     },
                     "id": "Endpoint",
@@ -863,6 +865,7 @@ exports[`website with addJson 2`] = `
                     },
                     "display": {
                       "description": "Endpoint for Website root/Default/Website",
+                      "hidden": true,
                       "title": "Endpoint",
                     },
                     "id": "Endpoint",

--- a/libs/wingsdk/test/target-tf-aws/__snapshots__/website.test.ts.snap
+++ b/libs/wingsdk/test/target-tf-aws/__snapshots__/website.test.ts.snap
@@ -216,7 +216,7 @@ exports[`default website behavior 2`] = `
                       "version": "10.2.70",
                     },
                     "display": {
-                      "description": "Endpoint for Website root/Default/Website",
+                      "description": "Website root/Default/Website",
                       "hidden": true,
                       "title": "Endpoint",
                     },
@@ -536,7 +536,7 @@ exports[`website with addFile 2`] = `
                       "version": "10.2.70",
                     },
                     "display": {
-                      "description": "Endpoint for Website root/Default/Website",
+                      "description": "Website root/Default/Website",
                       "hidden": true,
                       "title": "Endpoint",
                     },
@@ -864,7 +864,7 @@ exports[`website with addJson 2`] = `
                       "version": "10.2.70",
                     },
                     "display": {
-                      "description": "Endpoint for Website root/Default/Website",
+                      "description": "Website root/Default/Website",
                       "hidden": true,
                       "title": "Endpoint",
                     },


### PR DESCRIPTION
Adding a panel to list all `cloud.Endpoint` in the app

<img width="1688" alt="Screenshot 2023-12-24 at 13 57 01" src="https://github.com/winglang/wing/assets/16601535/7c7899d0-ed2b-4438-8684-9f36be672a9a">



## Checklist

- [X] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [X] Description explains motivation and solution
- [ ] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
