### PR TITLE
fix(sdk): sometimes aws function cannot be added to vpc

### DIFF
--- a/libs/wingsdk/src/target-tf-aws/function.ts
+++ b/libs/wingsdk/src/target-tf-aws/function.ts
@@ -127,6 +127,8 @@ export class Function extends cloud.Function implements IAwsFunction {
       role: this.role.name,
       policy: Lazy.stringValue({
         produce: () => {
+          this.policyStatements = this.policyStatements ?? [];
+          
           // If there are subnets to attach then the role needs to be able to
           // create network interfaces
           if ((this.subnets?.size ?? 0) !== 0) {
@@ -142,12 +144,14 @@ export class Function extends cloud.Function implements IAwsFunction {
               Resource: "*",
             });
           }
+          
           if ((this.policyStatements ?? []).length !== 0) {
             return JSON.stringify({
               Version: "2012-10-17",
               Statement: this.policyStatements,
             });
           }
+          
           // policy must contain at least one statement, so include a no-op statement
           return JSON.stringify({
             Version: "2012-10-17",

--- a/libs/wingsdk/src/target-tf-aws/function.ts
+++ b/libs/wingsdk/src/target-tf-aws/function.ts
@@ -14,7 +14,7 @@ import * as core from "../core";
 import { createBundle } from "../shared/bundling";
 import { DEFAULT_MEMORY_SIZE } from "../shared/function";
 import { NameOptions, ResourceNames } from "../shared/resource-names";
-import { IAwsFunction, PolicyStatement } from "../shared-aws";
+import { Effect, IAwsFunction, PolicyStatement } from "../shared-aws";
 import { IInflightHost, Resource } from "../std";
 import { Duration } from "../std/duration";
 
@@ -59,6 +59,7 @@ export class Function extends cloud.Function implements IAwsFunction {
   private readonly role: IamRole;
   private policyStatements?: any[];
   private subnets?: Set<string>;
+  private vpcPermissionsAdded = false;
   private securityGroups?: Set<string>;
 
   /**
@@ -128,30 +129,14 @@ export class Function extends cloud.Function implements IAwsFunction {
       policy: Lazy.stringValue({
         produce: () => {
           this.policyStatements = this.policyStatements ?? [];
-          
-          // If there are subnets to attach then the role needs to be able to
-          // create network interfaces
-          if ((this.subnets?.size ?? 0) !== 0) {
-            this.policyStatements?.push({
-              Effect: "Allow",
-              Action: [
-                "ec2:CreateNetworkInterface",
-                "ec2:DescribeNetworkInterfaces",
-                "ec2:DeleteNetworkInterface",
-                "ec2:DescribeSubnets",
-                "ec2:DescribeSecurityGroups",
-              ],
-              Resource: "*",
-            });
-          }
-          
-          if ((this.policyStatements ?? []).length !== 0) {
+
+          if (this.policyStatements.length !== 0) {
             return JSON.stringify({
               Version: "2012-10-17",
               Statement: this.policyStatements,
             });
           }
-          
+
           // policy must contain at least one statement, so include a no-op statement
           return JSON.stringify({
             Version: "2012-10-17",
@@ -283,6 +268,22 @@ export class Function extends cloud.Function implements IAwsFunction {
     }
     vpcConfig.subnetIds.forEach((subnet) => this.subnets!.add(subnet));
     vpcConfig.securityGroupIds.forEach((sg) => this.securityGroups!.add(sg));
+
+    if (!this.vpcPermissionsAdded) {
+      this.addPolicyStatements({
+        effect: Effect.ALLOW,
+        actions: [
+          "ec2:CreateNetworkInterface",
+          "ec2:DescribeNetworkInterfaces",
+          "ec2:DeleteNetworkInterface",
+          "ec2:DescribeSubnets",
+          "ec2:DescribeSecurityGroups",
+        ],
+        resources: ["*"],
+      });
+
+      this.vpcPermissionsAdded = true;
+    }
   }
 
   /**

--- a/libs/wingsdk/test/target-tf-aws/function.test.ts
+++ b/libs/wingsdk/test/target-tf-aws/function.test.ts
@@ -176,3 +176,14 @@ test("asset path is stripped of spaces", () => {
   // THEN
   expect(f.entrypoint).toContain(expectedReplacement);
 });
+
+test("vpc permissions are added even if there is no policy", () => {
+  const app = new tfaws.App({ outdir: mkdtemp(), entrypointDir: __dirname });
+  const inflight = Testing.makeHandler(INFLIGHT_CODE);
+  const f = new Function(app, some_name, inflight);
+
+
+  const output = app.synth();
+
+  console.log(tfSanitize(output));
+});

--- a/tools/hangar/__snapshots__/test_corpus/valid/redis.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/redis.test.w_compile_tf-aws.md
@@ -181,7 +181,7 @@ module.exports = function({ $queue, $r, $r2, $util_Util }) {
             "uniqueId": "cloudQueue-SetConsumer0_IamRolePolicy_3E29E517"
           }
         },
-        "policy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Action\":[\"sqs:ReceiveMessage\",\"sqs:ChangeMessageVisibility\",\"sqs:GetQueueUrl\",\"sqs:DeleteMessage\",\"sqs:GetQueueAttributes\"],\"Resource\":[\"${aws_sqs_queue.cloudQueue.arn}\"],\"Effect\":\"Allow\"},{\"Action\":[\"elasticache:Describe*\"],\"Resource\":[\"${aws_elasticache_cluster.exRedis_RedisCluster_3C9A5882.arn}\"],\"Effect\":\"Allow\"},{\"Effect\":\"Allow\",\"Action\":[\"ec2:CreateNetworkInterface\",\"ec2:DescribeNetworkInterfaces\",\"ec2:DeleteNetworkInterface\",\"ec2:DescribeSubnets\",\"ec2:DescribeSecurityGroups\"],\"Resource\":\"*\"},{\"Effect\":\"Allow\",\"Action\":[\"ec2:CreateNetworkInterface\",\"ec2:DescribeNetworkInterfaces\",\"ec2:DeleteNetworkInterface\",\"ec2:DescribeSubnets\",\"ec2:DescribeSecurityGroups\"],\"Resource\":\"*\"}]}",
+        "policy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Action\":[\"sqs:ReceiveMessage\",\"sqs:ChangeMessageVisibility\",\"sqs:GetQueueUrl\",\"sqs:DeleteMessage\",\"sqs:GetQueueAttributes\"],\"Resource\":[\"${aws_sqs_queue.cloudQueue.arn}\"],\"Effect\":\"Allow\"},{\"Action\":[\"elasticache:Describe*\"],\"Resource\":[\"${aws_elasticache_cluster.exRedis_RedisCluster_3C9A5882.arn}\"],\"Effect\":\"Allow\"},{\"Action\":[\"ec2:CreateNetworkInterface\",\"ec2:DescribeNetworkInterfaces\",\"ec2:DeleteNetworkInterface\",\"ec2:DescribeSubnets\",\"ec2:DescribeSecurityGroups\"],\"Resource\":[\"*\"],\"Effect\":\"Allow\"}]}",
         "role": "${aws_iam_role.cloudQueue-SetConsumer0_IamRole_968DB138.name}"
       }
     },


### PR DESCRIPTION
If a function didn't have policy statements before, then the IAM statements required so that it can be added to the VPC are not added because `policyStatements` might be undefined.

The fix is to make sure `policyStatements` is either defined or an empty array.

## Checklist

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [x] Tests added (always)
- [x] Docs updated (only required for features)
- [x] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
