### PR TITLE
chore(sdk): use `util.datetime` in more wing tests

### DIFF
--- a/examples/tests/sdk_tests/util/sleep-helper.js
+++ b/examples/tests/sdk_tests/util/sleep-helper.js
@@ -1,3 +1,0 @@
-exports.getTime = function(){
-  return (new Date()).getTime();
-};

--- a/examples/tests/sdk_tests/util/sleep.test.w
+++ b/examples/tests/sdk_tests/util/sleep.test.w
@@ -1,14 +1,10 @@
 bring util;
 
-class JSHelper { 
-  extern "./sleep-helper.js" pub static inflight getTime(): num;
-}
-
 let oneHundredMiliseconds = 0.1s;
 test "sleep 100 mili seconds" {
-  let start = JSHelper.getTime();
+  let start = datetime.systemNow().timestampMs;
   util.sleep(oneHundredMiliseconds);
-  let end = JSHelper.getTime();
+  let end = datetime.systemNow().timestampMs;
   let delta = end - start;
   // Node.js setTimeout isn't precise, so the actual time slept could be less
   assert(delta >= 90);

--- a/examples/tests/sdk_tests/util/wait-until.test.w
+++ b/examples/tests/sdk_tests/util/wait-until.test.w
@@ -1,38 +1,34 @@
 bring cloud;
 bring util;
 
-class JSHelper { 
-  extern "./sleep-helper.js" pub static inflight getTime(): num;
-}
-
 let invokeCounter = new cloud.Counter();
 let oneHundredMiliseconds = 0.1s;
 let oneSecond = 1s;
 let fiveSeconds = 5s;
 
 test "returns true immediately" {
-  let start = JSHelper.getTime();
+  let start = datetime.systemNow().timestampMs;
   if util.waitUntil((): bool => { return true; }) {
-    assert(JSHelper.getTime() - start < 1000);
+    assert(datetime.systemNow().timestampMs - start < 1000);
   } else {
     assert(false);
   }
 }
 
 test "returns false goes to timeout" {
-  let start = JSHelper.getTime();
+  let start = datetime.systemNow().timestampMs;
   if util.waitUntil(inflight (): bool => { return false; }, timeout: oneSecond) {
       assert(false);
     } else {
-      assert(JSHelper.getTime() - start > 1 * 1000);
+      assert(datetime.systemNow().timestampMs - start > 1 * 1000);
   }
 }
 
 test "returns after some time waiting" {
-  let start = JSHelper.getTime();
+  let start = datetime.systemNow().timestampMs;
   let returnTrueAfter3Seconds = (): bool => { 
     invokeCounter.inc();
-    return JSHelper.getTime() - start > 3 * 1000; 
+    return datetime.systemNow().timestampMs - start > 3 * 1000; 
   };
   if util.waitUntil(returnTrueAfter3Seconds, interval: oneSecond) {
     let invocations = invokeCounter.peek();
@@ -43,7 +39,7 @@ test "returns after some time waiting" {
 }
 
 test "setting props" {
-  let start = JSHelper.getTime();
+  let start = datetime.systemNow().timestampMs;
   let returnFalse = (): bool => { 
     invokeCounter.inc();
     return false;


### PR DESCRIPTION
Addressing point 1 of #4405

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
