### PR TITLE
fix(console): tests errors are not shown in the console

### DIFF
--- a/apps/wing-console/console/server/src/index.ts
+++ b/apps/wing-console/console/server/src/index.ts
@@ -21,6 +21,7 @@ import {
   TestItem,
   TestsStateManager,
 } from "./utils/createRouter.js";
+import { formatTraceError } from "./utils/format-wing-error.js";
 import type { LogInterface } from "./utils/LogInterface.js";
 import { createSimulator } from "./utils/simulator.js";
 
@@ -211,14 +212,7 @@ export const createConsoleServer = async ({
       });
     }
     if (trace.data.status === "failure") {
-      let output = await prettyPrintError(trace.data.error);
-
-      // Remove ANSI color codes
-      const regex =
-        /[\u001B\u009B][#();?[]*(?:\d{1,4}(?:;\d{0,4})*)?[\d<=>A-ORZcf-nqry]/g;
-
-      output = output.replaceAll(regex, "");
-
+      let output = await formatTraceError(trace.data.error);
       consoleLogger.error(output, "user", {
         sourceType: trace.sourceType,
         sourcePath: trace.sourcePath,

--- a/apps/wing-console/console/server/src/router/test.ts
+++ b/apps/wing-console/console/server/src/router/test.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 
 import { ConsoleLogger } from "../consoleLogger.js";
 import { createProcedure, createRouter } from "../utils/createRouter.js";
+import { formatTraceError } from "../utils/format-wing-error.js";
 import { ITestRunnerClient, Simulator } from "../wingsdk.js";
 
 const getTestName = (testPath: string) => {
@@ -63,7 +64,8 @@ const runTest = async (
       },
     );
   } catch (error: any) {
-    logger.log(error?.message, "console", {
+    let output = await formatTraceError(error?.message);
+    logger.log(output, "console", {
       messageType: "fail",
     });
     logger.log(

--- a/apps/wing-console/console/server/src/router/test.ts
+++ b/apps/wing-console/console/server/src/router/test.ts
@@ -62,7 +62,10 @@ const runTest = async (
         messageType: "success",
       },
     );
-  } catch {
+  } catch (error: any) {
+    logger.log(error?.message, "console", {
+      messageType: "fail",
+    });
     logger.log(
       `Test "${getTestName(resourcePath)}" failed (${
         Date.now() - startTime

--- a/apps/wing-console/console/server/src/utils/format-wing-error.ts
+++ b/apps/wing-console/console/server/src/utils/format-wing-error.ts
@@ -130,3 +130,13 @@ export const formatWingError = async (error: unknown, entryPoint?: string) => {
     return `Unexpected error: ${error}`;
   }
 };
+
+export const formatTraceError = async (error: string): Promise<string> => {
+  let output = await prettyPrintError(error);
+
+  // Remove ANSI color codes
+  const regex =
+    /[\u001B\u009B][#();?[]*(?:\d{1,4}(?:;\d{0,4})*)?[\d<=>A-ORZcf-nqry]/g;
+
+  return output.replaceAll(regex, "");
+};


### PR DESCRIPTION
extracting TestRunnerClient TestResult error and adding to the console logger.
for example, the following TestResult error:
```
{
  path: 'root/env0/test:hello',
  pass: false,
  error: 'AssertionError [ERR_ASSERTION]: Expected values to be strictly deep-equal:\n' +
    '\n' +
    '1 !== 2\n' +
    '\n' +
    '    at Util.equal (/var/folders/dy/sygfk8k13rlgxfgj6r3zkr1c0000gn/T/wing-bundles-6TowaX/index.js:7070:26)\n' +
    '    at $Closure1.handle (/var/folders/dy/sygfk8k13rlgxfgj6r3zkr1c0000gn/T/wing-bundles-6TowaX/index.js:24:30)\n' +
    '    at exports.handler (/var/folders/dy/sygfk8k13rlgxfgj6r3zkr1c0000gn/T/wing-bundles-6TowaX/index.js:7120:9)',
  traces: [
    {
      data: [Object],
      type: 'resource',
      sourcePath: 'root/env0/test:hello/Handler',
      sourceType: '@winglang/sdk.cloud.Function',
      timestamp: '2023-12-25T17:33:34.191Z'
    }
  ]
}
```
now looks like this in the console logs panel:
![Screenshot 2023-12-25 at 21 47 46](https://github.com/winglang/wing/assets/2538825/5da04544-7e1c-4f74-90a5-2c72182f733c)


resolves: https://github.com/winglang/wing/issues/5331
also resolves: https://github.com/winglang/wing/issues/4803

test output is now:
![Screenshot 2023-12-25 at 21 48 00](https://github.com/winglang/wing/assets/2538825/45de313b-6a2c-4d96-963e-371871b5c385)


## Checklist

- [ ] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [ ] Description explains motivation and solution
- [ ] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
