### PR TITLE
chore: ignore bash profile in sdk tests

### DIFF
--- a/examples/tests/sdk_tests/util/exec.test.w
+++ b/examples/tests/sdk_tests/util/exec.test.w
@@ -38,7 +38,7 @@ test "exec() with invalid program" {
 
 test "exec() with explicit non-zero exit status" {
   let program = "bash";
-  let args = ["-c", "exit 1"];
+  let args = ["--norc", "-c", "exit 1"];
 
   let output = util.exec(program, args);
 
@@ -49,7 +49,7 @@ test "exec() with explicit non-zero exit status" {
 
 test "exec() with env option" {
   let program = "bash";
-  let args = ["-c", "echo $WING_TARGET $ENV_VAR"];
+  let args = ["--norc", "-c", "echo $WING_TARGET $ENV_VAR"];
   let opts = {
     env: { ENV_VAR: "Wing" },
   };
@@ -63,7 +63,7 @@ test "exec() with env option" {
 
 test "exec() with inheritEnv option" {
   let program = "bash";
-  let args = ["-c", "echo $WING_TARGET"];
+  let args = ["--norc", "-c", "echo $WING_TARGET"];
   let opts = {
     inheritEnv: true,
   };

--- a/examples/tests/sdk_tests/util/exec.test.w
+++ b/examples/tests/sdk_tests/util/exec.test.w
@@ -38,7 +38,7 @@ test "exec() with invalid program" {
 
 test "exec() with explicit non-zero exit status" {
   let program = "bash";
-  let args = ["--norc", "-c", "exit 1"];
+  let args = ["--norc", "--noprofile", "-c", "exit 1"];
 
   let output = util.exec(program, args);
 
@@ -49,7 +49,7 @@ test "exec() with explicit non-zero exit status" {
 
 test "exec() with env option" {
   let program = "bash";
-  let args = ["--norc", "-c", "echo $WING_TARGET $ENV_VAR"];
+  let args = ["--norc", "--noprofile", "-c", "echo $WING_TARGET $ENV_VAR"];
   let opts = {
     env: { ENV_VAR: "Wing" },
   };
@@ -63,7 +63,7 @@ test "exec() with env option" {
 
 test "exec() with inheritEnv option" {
   let program = "bash";
-  let args = ["--norc", "-c", "echo $WING_TARGET"];
+  let args = ["--norc", "--noprofile", "-c", "echo $WING_TARGET"];
   let opts = {
     inheritEnv: true,
   };

--- a/libs/wingsdk/src/util/util.ts
+++ b/libs/wingsdk/src/util/util.ts
@@ -184,6 +184,8 @@ export class Util {
   ): Promise<Output> {
     const execOpts = {
       cwd: opts?.cwd,
+      windowsHide: true,
+      shell: false,
       env:
         opts?.inheritEnv === true
           ? { ...process.env, ...opts?.env }


### PR DESCRIPTION
My bash profile had an issue when running `wing test` for this file.

Ignoring the bash profile is probably better to reduce some variability for this test across machines anyway.

Also added usual `windowsHide` and `shell` options when using exec as I think that's the expected behavior.

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
