### PR TITLE
fix(sdk): `util.shell` on windows displays the console window

### DIFF
--- a/libs/wingsdk/src/util/util.ts
+++ b/libs/wingsdk/src/util/util.ts
@@ -141,6 +141,7 @@ export class Util {
     opts?: ShellOptions
   ): Promise<String> {
     const shellOpts = {
+      windowsHide: true,
       cwd: opts?.cwd,
       env:
         opts?.inheritEnv === true
@@ -183,9 +184,8 @@ export class Util {
     opts?: ExecOptions
   ): Promise<Output> {
     const execOpts = {
-      cwd: opts?.cwd,
       windowsHide: true,
-      shell: false,
+      cwd: opts?.cwd,
       env:
         opts?.inheritEnv === true
           ? { ...process.env, ...opts?.env }

--- a/libs/wingsdk/src/util/util.ts
+++ b/libs/wingsdk/src/util/util.ts
@@ -185,6 +185,7 @@ export class Util {
   ): Promise<Output> {
     const execOpts = {
       windowsHide: true,
+      shell: false,
       cwd: opts?.cwd,
       env:
         opts?.inheritEnv === true


### PR DESCRIPTION
Aligning `util.shell()` to `util.exec()` and removing `shell: false` since that's the default value anyway.

![image](https://github.com/winglang/wing/assets/10464497/99043462-f386-4441-8e82-faf4b54c597f)

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
