### PR TITLE
fix(sdk): switch to SDK for JS v3 error class for `bucket.exists()` on AWS targets

### DIFF
--- a/libs/wingsdk/src/shared-aws/bucket.inflight.ts
+++ b/libs/wingsdk/src/shared-aws/bucket.inflight.ts
@@ -49,7 +49,7 @@ export class BucketClient implements IBucketClient {
       await this.s3Client.send(command);
       return true;
     } catch (error) {
-      if ((error as Error).name === "NotFound") {
+      if (error instanceof NotFound) {
         return false;
       }
       throw error;

--- a/libs/wingsdk/test/shared-aws/bucket.inflight.test.ts
+++ b/libs/wingsdk/test/shared-aws/bucket.inflight.test.ts
@@ -212,11 +212,9 @@ test("delete non-existent object from the bucket with mustExist option", async (
   const KEY = "KEY";
 
   s3Mock
-    .on(DeleteObjectCommand, { Bucket: BUCKET_NAME, Key: KEY })
-    .resolves({});
-  s3Mock
     .on(HeadObjectCommand, { Bucket: BUCKET_NAME, Key: KEY })
-    .rejects({ name: "NotFound" });
+    .rejects(new NotFound({ message: "Object not found", $metadata: {} }));
+
   // WHEN
   const client = new BucketClient(BUCKET_NAME);
 
@@ -256,7 +254,7 @@ test("Given a non public bucket when reaching to a key public url it should thro
   );
 });
 
-test("Given a public bucket when reaching to a non existent key, public url it should throw an error", async () => {
+test("Given a public bucket when reaching to a non-existent key, public url it should throw an error", async () => {
   // GIVEN
   let error;
   const BUCKET_NAME = "BUCKET_NAME";
@@ -271,19 +269,17 @@ test("Given a public bucket when reaching to a non existent key, public url it s
     },
   });
   s3Mock
-    .on(GetBucketLocationCommand, { Bucket: BUCKET_NAME })
-    .resolves({ LocationConstraint: "us-east-2" });
-  s3Mock
     .on(HeadObjectCommand, { Bucket: BUCKET_NAME, Key: KEY })
-    .rejects({ name: "NotFound" });
+    .rejects(new NotFound({ message: "Object not found", $metadata: {} }));
 
-  //WHEN
+  // WHEN
   const client = new BucketClient(BUCKET_NAME);
   try {
     await client.publicUrl(KEY);
   } catch (err) {
     error = err;
   }
+
   // THEN
   expect(error?.message).toBe(
     "Cannot provide public url for a non-existent key (key=KEY)"
@@ -357,7 +353,7 @@ test("check that an object doesn't exist in the bucket", async () => {
 
   s3Mock
     .on(HeadObjectCommand, { Bucket: BUCKET_NAME, Key: KEY })
-    .rejects({ name: "NotFound" });
+    .rejects(new NotFound({ message: "Object not found", $metadata: {} }));
 
   // WHEN
   const client = new BucketClient(BUCKET_NAME);
@@ -548,12 +544,10 @@ test("tryDelete a non-existent object from the bucket", async () => {
   // GIVEN
   const BUCKET_NAME = "BUCKET_NAME";
   const KEY = "KEY";
-  s3Mock
-    .on(DeleteObjectCommand, { Bucket: BUCKET_NAME, Key: KEY })
-    .resolves({});
+
   s3Mock
     .on(HeadObjectCommand, { Bucket: BUCKET_NAME, Key: KEY })
-    .rejects({ name: "NotFound" });
+    .rejects(new NotFound({ message: "Object not found", $metadata: {} }));
 
   // WHEN
   const client = new BucketClient(BUCKET_NAME);
@@ -563,7 +557,7 @@ test("tryDelete a non-existent object from the bucket", async () => {
   expect(objectTryDelete).toEqual(false);
 });
 
-test("Given a bucket when reaching to a non existent key, signed url it should throw an error", async () => {
+test("Given a bucket when reaching to a non-existent key, signed url it should throw an error", async () => {
   // GIVEN
   let error;
   const BUCKET_NAME = "BUCKET_NAME";
@@ -571,15 +565,16 @@ test("Given a bucket when reaching to a non existent key, signed url it should t
 
   s3Mock
     .on(HeadObjectCommand, { Bucket: BUCKET_NAME, Key: KEY })
-    .rejects({ name: "NotFound" });
+    .rejects(new NotFound({ message: "Object not found", $metadata: {} }));
 
-  //WHEN
+  // WHEN
   const client = new BucketClient(BUCKET_NAME);
   try {
     await client.signedUrl(KEY);
   } catch (err) {
     error = err;
   }
+
   // THEN
   expect(error?.message).toBe(
     `Cannot provide signed url for a non-existent key (key=${KEY})`


### PR DESCRIPTION
Updating `bucket.exists()` to use `NotFound` error class for AWS targets and also removing some unneeded mock listeners from bucket inflight tests.

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
