### PR TITLE
chore(console): disable analytics for console preview environments

### DIFF
--- a/apps/wing-console/console/app/preview/Dockerfile
+++ b/apps/wing-console/console/app/preview/Dockerfile
@@ -8,4 +8,6 @@ COPY apps/wing-console/console/app/demo demo
 
 RUN npm init -y && npm install --no-package-lock ./dist/*-[0-9]*.[0-9]*.[0-9]*.tgz
 
+ENV WING_DISABLE_ANALYTICS=true
+
 ENTRYPOINT ["node", "dist/index.mjs"]


### PR DESCRIPTION
For each PR we create a new Console preview environment for internal testing. We forgot to disable analytics for this instance.
Updating our Dockerfile with the relevant env var

## Checklist

- [ ] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [ ] Description explains motivation and solution
- [ ] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
