### PR TITLE
chore(console): include hidden nodes 

### DIFF
--- a/apps/wing-console/console/server/src/router/app.ts
+++ b/apps/wing-console/console/server/src/router/app.ts
@@ -106,6 +106,7 @@ export const createAppRouter = () => {
         z
           .object({
             showTests: z.boolean().optional(),
+            includeHiddens: z.boolean().optional(),
           })
           .optional(),
       )
@@ -116,6 +117,7 @@ export const createAppRouter = () => {
           shakeTree(tree),
           simulator,
           input?.showTests,
+          input?.includeHiddens,
         );
       }),
     "app.nodeIds": createProcedure
@@ -637,6 +639,7 @@ function createExplorerItemFromConstructTreeNode(
   node: ConstructTreeNode,
   simulator: Simulator,
   showTests = false,
+  includeHiddens = false,
 ): ExplorerItem {
   const label =
     node.display?.sourceModule === "@winglang/sdk" && node.display?.title
@@ -652,11 +655,17 @@ function createExplorerItemFromConstructTreeNode(
       ? Object.values(node.children)
           .filter((node) => {
             return (
-              !node.display?.hidden && (showTests || !matchTest(node.path))
+              (includeHiddens || !node.display?.hidden) &&
+              (showTests || !matchTest(node.path))
             );
           })
           .map((node) =>
-            createExplorerItemFromConstructTreeNode(node, simulator),
+            createExplorerItemFromConstructTreeNode(
+              node,
+              simulator,
+              showTests,
+              includeHiddens,
+            ),
           )
       : undefined,
   };


### PR DESCRIPTION
The console server api can now respond with all nodes including those that are hidden in the tree

## Checklist

- [ ] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [ ] Description explains motivation and solution
- [ ] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
