### PR TITLE
fix: invalid snapshots when removing multiple abs paths in same line

### DIFF
--- a/libs/awscdk/test/util.ts
+++ b/libs/awscdk/test/util.ts
@@ -5,7 +5,7 @@ import { Template } from "aws-cdk-lib/assertions";
  */
 export function sanitizeCode(code: string): string {
   function removeAbsolutePaths(text: string) {
-    const regex = /".+\/libs\/awscdk\/(.+)"/g;
+    const regex = /"[^"]+?\/libs\/awscdk\/(.+?)"/g;
 
     // replace first group with static text
     return text.replace(regex, '"[REDACTED]/awscdk/$1"');

--- a/libs/wingsdk/test/target-sim/__snapshots__/immutable-capture.test.ts.snap
+++ b/libs/wingsdk/test/target-sim/__snapshots__/immutable-capture.test.ts.snap
@@ -408,7 +408,7 @@ if (!(this.my_array[1].minutes === 20)) { throw new Error(\`assertion failed: \\
 }
 };
 })())({
-my_array: [(new (require(\\"[REDACTED]/wingsdk/src/std/duration.js\\").Duration)(1200))]
+my_array: [(new (require(\\"[REDACTED]/wingsdk/src/std/duration.js\\").Duration)(600)),(new (require(\\"[REDACTED]/wingsdk/src/std/duration.js\\").Duration)(1200))]
 })).handle(event);
 };",
   "connections.json": {
@@ -1330,7 +1330,7 @@ if (!(this.my_map.get('bar')[1].seconds === 40 * 60)) { throw new Error(\`assert
 }
 };
 })())({
-my_map: new Map([[\\"[REDACTED]/wingsdk/src/std/duration.js\\").Duration)(2400))]]])
+my_map: new Map([[\\"foo\\",[(new (require(\\"[REDACTED]/wingsdk/src/std/duration.js\\").Duration)(600)),(new (require(\\"[REDACTED]/wingsdk/src/std/duration.js\\").Duration)(1200))]],[\\"bar\\",[(new (require(\\"[REDACTED]/wingsdk/src/std/duration.js\\").Duration)(1800)),(new (require(\\"[REDACTED]/wingsdk/src/std/duration.js\\").Duration)(2400))]]])
 })).handle(event);
 };",
   "connections.json": {
@@ -2021,7 +2021,7 @@ if (!(Array.from(this.my_set)[1].seconds === 1200)) { throw new Error(\`assertio
 }
 };
 })())({
-my_set: new Set([(new (require(\\"[REDACTED]/wingsdk/src/std/duration.js\\").Duration)(1200))])
+my_set: new Set([(new (require(\\"[REDACTED]/wingsdk/src/std/duration.js\\").Duration)(600)),(new (require(\\"[REDACTED]/wingsdk/src/std/duration.js\\").Duration)(1200))])
 })).handle(event);
 };",
   "connections.json": {

--- a/libs/wingsdk/test/util.ts
+++ b/libs/wingsdk/test/util.ts
@@ -180,7 +180,7 @@ export function sanitizePaths(json: DeepWriteable<WingSimulatorSchema>) {
  */
 export function sanitizeCode(code: string): string {
   function removeAbsolutePaths(text: string) {
-    const regex = /".+\/libs\/wingsdk\/(.+)"/g;
+    const regex = /"[^"]+?\/libs\/wingsdk\/(.+?)"/g;
 
     // replace first group with static text
     return text.replace(regex, '"[REDACTED]/wingsdk/$1"');


### PR DESCRIPTION
The code sanitizer had a faulty regex to detect absolute paths which swallowed multiple abs paths and other double quote strings when they were in the same line.
The result are fixed snapshots.

## Checklist

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [ ] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
