### PR TITLE
fix(docs): not all categories were using generated-index

### DIFF
--- a/docs/docs/04-standard-library/aws/_category_.yml
+++ b/docs/docs/04-standard-library/aws/_category_.yml
@@ -1,3 +1,5 @@
 label: aws
 collapsible: true
 collapsed: true
+link:
+  type: generated-index

--- a/docs/docs/04-standard-library/ex/_category_.yml
+++ b/docs/docs/04-standard-library/ex/_category_.yml
@@ -1,3 +1,5 @@
 label: ex
 collapsible: true
 collapsed: true
+link:
+  type: generated-index

--- a/docs/docs/04-standard-library/expect/_category_.yml
+++ b/docs/docs/04-standard-library/expect/_category_.yml
@@ -1,3 +1,6 @@
 label: expect
 collapsible: true
 collapsed: true
+link:
+  type: generated-index
+  title: expect

--- a/docs/docs/04-standard-library/fs/_category_.yml
+++ b/docs/docs/04-standard-library/fs/_category_.yml
@@ -1,3 +1,5 @@
 label: fs
 collapsible: true
 collapsed: true
+link:
+  type: generated-index

--- a/docs/docs/04-standard-library/http/_category_.yml
+++ b/docs/docs/04-standard-library/http/_category_.yml
@@ -1,3 +1,5 @@
 label: http
 collapsible: true
 collapsed: true
+link:
+  type: generated-index

--- a/docs/docs/04-standard-library/math/_category_.yml
+++ b/docs/docs/04-standard-library/math/_category_.yml
@@ -1,3 +1,5 @@
 label: math
 collapsible: true
 collapsed: true
+link:
+  type: generated-index

--- a/docs/docs/04-standard-library/regex/_category_.yml
+++ b/docs/docs/04-standard-library/regex/_category_.yml
@@ -1,3 +1,5 @@
 label: regex
 collapsible: true
 collapsed: true
+link:
+  type: generated-index

--- a/docs/docs/04-standard-library/sim/_category_.yml
+++ b/docs/docs/04-standard-library/sim/_category_.yml
@@ -1,3 +1,5 @@
 label: sim
 collapsible: true
 collapsed: true
+link:
+  type: generated-index

--- a/docs/docs/04-standard-library/std/_category_.yml
+++ b/docs/docs/04-standard-library/std/_category_.yml
@@ -1,3 +1,5 @@
 label: std
 collapsible: true
 collapsed: true
+link:
+  type: generated-index

--- a/docs/docs/04-standard-library/ui/_category_.yml
+++ b/docs/docs/04-standard-library/ui/_category_.yml
@@ -1,3 +1,5 @@
 label: ui
 collapsible: true
 collapsed: true
+link:
+  type: generated-index

--- a/docs/docs/04-standard-library/util/_category_.yml
+++ b/docs/docs/04-standard-library/util/_category_.yml
@@ -1,3 +1,5 @@
 label: util
 collapsible: true
 collapsed: true
+link:
+  type: generated-index


### PR DESCRIPTION
Not all the sections in Standard Library were using "genereated-index" which was leading to a non uniform experience across the libraries. 

Also this prevents the docsite from defaulting to using README.md files which was mentioned in this thread: https://winglang.slack.com/archives/C047QFSUL5R/p1704035377312369

## Checklist

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [x] Tests added (always)
- [x] Docs updated (only required for features)
- [x] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
