### PR TITLE
fix(platforms): platforms cannot use "this" in hooks

### DIFF
--- a/libs/wingsdk/src/platform/platform-manager.ts
+++ b/libs/wingsdk/src/platform/platform-manager.ts
@@ -84,19 +84,19 @@ export class PlatformManager {
 
     this.platformInstances.forEach((instance) => {
       if (instance.preSynth) {
-        synthHooks.preSynthesize!.push(instance.preSynth);
+        synthHooks.preSynthesize!.push(instance.preSynth.bind(instance));
       }
 
       if (instance.postSynth) {
-        synthHooks.postSynthesize!.push(instance.postSynth);
+        synthHooks.postSynthesize!.push(instance.postSynth.bind(instance));
       }
 
       if (instance.validate) {
-        synthHooks.validate!.push(instance.validate);
+        synthHooks.validate!.push(instance.validate.bind(instance));
       }
 
       if (instance.newInstance) {
-        newInstanceOverrides.push(instance.newInstance);
+        newInstanceOverrides.push(instance.newInstance.bind(instance));
       }
     });
 


### PR DESCRIPTION
Since I was yanking out the callbacks for synth-hooks I needed to bind their associated instance to the callback's `this`

Closes: https://github.com/winglang/wing/issues/5131

## Checklist

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [x] Tests added (always)
- [x] Docs updated (only required for features)
- [x] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
