### PR TITLE
chore(sdk): failing test case for preflight util.shell

### DIFF
--- a/examples/tests/sdk_tests/util/shell.test.w
+++ b/examples/tests/sdk_tests/util/shell.test.w
@@ -17,11 +17,25 @@ let assertThrows = inflight (expected: str, block: (): void) => {
   assert(error);
 };
 
+class PreflightTest {
+  pub output: str;
+
+  new() {
+    this.output = util.shell("echo Hello, Wing!");
+  }
+}
+
+let preflightTest = new PreflightTest();
+
+test "preflight" {
+  expect.equal(preflightTest.output, "Hello, Wing!\n");
+}
+
 test "shell() with valid command" {
   let command = "echo Hello, Wing!";
 
   let output = util.shell(command);
-  
+
   if Util.platform() != "win32" {
     expect.equal(output, "Hello, Wing!\n");
   } else {


### PR DESCRIPTION
```
runtime error: Unable to lift object of type Promise
  --> examples/tests/sdk_tests/util/shell.test.w:1:1
1 | bring util;
  | ^
```

## Checklist

- [ ] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [ ] Description explains motivation and solution
- [ ] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
