### PR TITLE
fix(sdk): `cloud.Service` crashes the simulator if initialization fails

### DIFF
--- a/libs/wingsdk/src/target-sim/service.inflight.ts
+++ b/libs/wingsdk/src/target-sim/service.inflight.ts
@@ -51,7 +51,7 @@ export class Service implements IServiceClient, ISimulatorResourceInstance {
     await this.stop();
   }
 
-  public async save(): Promise<void> {}
+  public async save(): Promise<void> { }
 
   public async start(): Promise<void> {
     // Do nothing if service is already running.
@@ -59,8 +59,18 @@ export class Service implements IServiceClient, ISimulatorResourceInstance {
       return;
     }
 
-    this.onStop = await this.sandbox.call("handle");
-    this.running = true;
+    try {
+      this.onStop = await this.sandbox.call("handle");
+      this.running = true;
+    } catch (e: any) {
+      this.context.addTrace({
+        data: { message: `Failed to start service: ${e.message}` },
+        type: TraceType.RESOURCE,
+        sourcePath: this.context.resourcePath,
+        sourceType: SERVICE_FQN,
+        timestamp: new Date().toISOString(),
+      });
+    }
   }
 
   public async stop(): Promise<void> {

--- a/libs/wingsdk/src/target-sim/service.inflight.ts
+++ b/libs/wingsdk/src/target-sim/service.inflight.ts
@@ -51,7 +51,7 @@ export class Service implements IServiceClient, ISimulatorResourceInstance {
     await this.stop();
   }
 
-  public async save(): Promise<void> { }
+  public async save(): Promise<void> {}
 
   public async start(): Promise<void> {
     // Do nothing if service is already running.

--- a/libs/wingsdk/test/target-sim/service.test.ts
+++ b/libs/wingsdk/test/target-sim/service.test.ts
@@ -199,11 +199,13 @@ test("throws during service start", async () => {
     async handle() {
       throw new Error("ThisIsAnError");
       return () => console.log("stop!");
-    }`),
+    }`)
   );
 
   const s = await app.startSimulator();
-  const msg = s.listTraces().find(t => t.data.message.startsWith("Failed to start service"));
+  const msg = s
+    .listTraces()
+    .find((t) => t.data.message.startsWith("Failed to start service"));
   expect(msg).toBeTruthy();
   expect(msg?.data.message).toEqual("Failed to start service: ThisIsAnError");
 });

--- a/libs/wingsdk/test/target-sim/service.test.ts
+++ b/libs/wingsdk/test/target-sim/service.test.ts
@@ -188,3 +188,22 @@ test("consecutive start and stop service", async () => {
       .map((trace) => trace.data.message)
   ).toEqual(["@winglang/sdk.cloud.Service created.", "start!", "stop!"]);
 });
+
+test("throws during service start", async () => {
+  // GIVEN
+  const app = new SimApp();
+  new cloud.Service(
+    app,
+    "my_service",
+    Testing.makeHandler(`\
+    async handle() {
+      throw new Error("ThisIsAnError");
+      return () => console.log("stop!");
+    }`),
+  );
+
+  const s = await app.startSimulator();
+  const msg = s.listTraces().find(t => t.data.message.startsWith("Failed to start service"));
+  expect(msg).toBeTruthy();
+  expect(msg?.data.message).toEqual("Failed to start service: ThisIsAnError");
+});


### PR DESCRIPTION
Emit an error to log instead of crashing the simulator.

## Checklist

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [x] Tests added (always)
- [x] Docs updated (only required for features)
- [x] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
