### PR TITLE
feat: use a single `.bak` instead of generating `.tmp` directories every time

### DIFF
--- a/apps/wing/src/commands/compile.test.ts
+++ b/apps/wing/src/commands/compile.test.ts
@@ -28,9 +28,9 @@ describe(
       expect(files.length).toBeGreaterThan(0);
       expect(files).toMatchInlineSnapshot(`
         [
+          ".manifest",
           ".wing",
           "connections.json",
-          ".manifest",
           "simulator.json",
           "tree.json",
         ]
@@ -63,9 +63,9 @@ describe(
       expect(files.length).toBeGreaterThan(0);
       expect(files).toMatchInlineSnapshot(`
         [
+          ".manifest",
           ".wing",
           "connections.json",
-          ".manifest",
           "simulator.json",
           "tree.json",
         ]
@@ -136,9 +136,9 @@ describe(
         expect(files.length).toBeGreaterThan(0);
         expect(files).toMatchInlineSnapshot(`
           [
+            ".manifest",
             ".wing",
             "connections.json",
-            ".manifest",
             "simulator.json",
             "tree.json",
           ]

--- a/apps/wing/src/commands/compile.test.ts
+++ b/apps/wing/src/commands/compile.test.ts
@@ -1,4 +1,4 @@
-import { readdir, stat, writeFile, mkdtemp } from "fs/promises";
+import { readdir, stat, writeFile, mkdtemp, readFile } from "fs/promises";
 import { tmpdir } from "os";
 import { join, resolve } from "path";
 import { BuiltinPlatform } from "@winglang/compiler";
@@ -26,7 +26,15 @@ describe(
       expect(stats.isDirectory()).toBeTruthy();
       const files = (await readdir(outDir)).sort();
       expect(files.length).toBeGreaterThan(0);
-      expect(files).toEqual([".wing", "connections.json", "simulator.json", "tree.json"]);
+      expect(files).toMatchInlineSnapshot(`
+        [
+          ".wing",
+          "connections.json",
+          "manifest.json",
+          "simulator.json",
+          "tree.json",
+        ]
+      `);
     });
 
     test("should be able to compile the SDK capture test to tf-aws", async () => {
@@ -53,7 +61,15 @@ describe(
       expect(stats.isDirectory()).toBeTruthy();
       const files = (await readdir(outDir)).sort();
       expect(files.length).toBeGreaterThan(0);
-      expect(files).toEqual([".wing", "connections.json", "simulator.json", "tree.json"]);
+      expect(files).toMatchInlineSnapshot(`
+        [
+          ".wing",
+          "connections.json",
+          "manifest.json",
+          "simulator.json",
+          "tree.json",
+        ]
+      `);
     });
 
     test("should be able to compile the only entrypoint file in current directory", async () => {
@@ -118,7 +134,15 @@ describe(
         expect(stats.isDirectory()).toBeTruthy();
         const files = (await readdir(outDir)).sort();
         expect(files.length).toBeGreaterThan(0);
-        expect(files).toEqual([".wing", "connections.json", "simulator.json", "tree.json"]);
+        expect(files).toMatchInlineSnapshot(`
+          [
+            ".wing",
+            "connections.json",
+            "manifest.json",
+            "simulator.json",
+            "tree.json",
+          ]
+        `);
       } finally {
         process.chdir(oldCwd);
       }
@@ -150,6 +174,11 @@ describe(
       const files2 = await readdir(artifactDir2);
       expect(files2.length).toBeGreaterThan(0);
       expectedFiles.forEach((file) => expect(files2).toContain(file));
+
+      // check the manifest file to make sure it does not contain "terraform.tfstate"
+      const manifestFile = join(artifactDir2, "manifest.json");
+      const manifest = JSON.parse(await readFile(manifestFile, "utf-8"));
+      expect(manifest.generatedFiles).not.toContain("terraform.tfstate");
     });
   },
   { timeout: 1000 * 60 * 5 }

--- a/apps/wing/src/commands/compile.test.ts
+++ b/apps/wing/src/commands/compile.test.ts
@@ -30,7 +30,7 @@ describe(
         [
           ".wing",
           "connections.json",
-          "manifest.json",
+          ".manifest",
           "simulator.json",
           "tree.json",
         ]
@@ -65,7 +65,7 @@ describe(
         [
           ".wing",
           "connections.json",
-          "manifest.json",
+          ".manifest",
           "simulator.json",
           "tree.json",
         ]
@@ -138,7 +138,7 @@ describe(
           [
             ".wing",
             "connections.json",
-            "manifest.json",
+            ".manifest",
             "simulator.json",
             "tree.json",
           ]
@@ -176,7 +176,7 @@ describe(
       expectedFiles.forEach((file) => expect(files2).toContain(file));
 
       // check the manifest file to make sure it does not contain "terraform.tfstate"
-      const manifestFile = join(artifactDir2, "manifest.json");
+      const manifestFile = join(artifactDir2, ".manifest");
       const manifest = JSON.parse(await readFile(manifestFile, "utf-8"));
       expect(manifest.generatedFiles).not.toContain("terraform.tfstate");
     });

--- a/apps/wing/src/commands/pack.test.ts
+++ b/apps/wing/src/commands/pack.test.ts
@@ -192,7 +192,6 @@ describe("wing pack", () => {
 
     expect(Object.keys(tarballContents).sort()).toMatchInlineSnapshot(`
       [
-        "$lib/.manifest",
         "$lib/.wing/inflight.Store-2.js",
         "$lib/.wing/inflight.Store-2.js.map",
         "$lib/.wing/inflight.Util-1.js",

--- a/apps/wing/src/commands/pack.test.ts
+++ b/apps/wing/src/commands/pack.test.ts
@@ -207,7 +207,7 @@ describe("wing pack", () => {
         "$lib/.wing/preflight.subdir-4.js.map",
         "$lib/.wing/preflight.util-2.js",
         "$lib/.wing/preflight.util-2.js.map",
-        "$lib/manifest.json",
+        "$lib/.manifest",
         "LICENSE",
         "README.md",
         "enums.w",

--- a/apps/wing/src/commands/pack.test.ts
+++ b/apps/wing/src/commands/pack.test.ts
@@ -192,6 +192,7 @@ describe("wing pack", () => {
 
     expect(Object.keys(tarballContents).sort()).toMatchInlineSnapshot(`
       [
+        "$lib/.manifest",
         "$lib/.wing/inflight.Store-2.js",
         "$lib/.wing/inflight.Store-2.js.map",
         "$lib/.wing/inflight.Util-1.js",
@@ -207,7 +208,6 @@ describe("wing pack", () => {
         "$lib/.wing/preflight.subdir-4.js.map",
         "$lib/.wing/preflight.util-2.js",
         "$lib/.wing/preflight.util-2.js.map",
-        "$lib/.manifest",
         "LICENSE",
         "README.md",
         "enums.w",

--- a/apps/wing/src/commands/pack.test.ts
+++ b/apps/wing/src/commands/pack.test.ts
@@ -207,6 +207,7 @@ describe("wing pack", () => {
         "$lib/.wing/preflight.subdir-4.js.map",
         "$lib/.wing/preflight.util-2.js",
         "$lib/.wing/preflight.util-2.js.map",
+        "$lib/manifest.json",
         "LICENSE",
         "README.md",
         "enums.w",

--- a/apps/wing/src/commands/pack.ts
+++ b/apps/wing/src/commands/pack.ts
@@ -118,7 +118,12 @@ export async function pack(options: PackageOptions = {}): Promise<string> {
     // add default globs to "files" so that Wing files are included in the tarball
     const pkgJsonFiles: Set<string> = new Set(pkgJson.files ?? []);
 
-    const expectedGlobs = [compilerOutputFolder, ...defaultGlobs];
+    const expectedGlobs = [
+      compilerOutputFolder,
+      // exclude the unnecessary .manifest file
+      "!" + path.join(compilerOutputFolder, ".manifest"),
+      ...defaultGlobs,
+    ];
     for (const pat of expectedGlobs) {
       if (!pkgJsonFiles.has(pat)) {
         pkgJsonFiles.add(pat);

--- a/apps/wing/src/util.ts
+++ b/apps/wing/src/util.ts
@@ -1,5 +1,5 @@
 import * as cp from "child_process";
-import { copyFileSync, promises as fsPromise } from "fs";
+import * as fs from "fs/promises";
 import { tmpdir } from "os";
 import { join } from "path";
 import { promisify } from "util";
@@ -41,18 +41,6 @@ export async function withSpinner<T>(message: string, fn: () => Promise<T>): Pro
   }
 }
 
-export async function copyDir(src: string, dest: string) {
-  await fsPromise.mkdir(dest, { recursive: true });
-  let entries = await fsPromise.readdir(src, { withFileTypes: true });
-
-  for (let entry of entries) {
-    let srcPath = join(src, entry.name);
-    let destPath = join(dest, entry.name);
-
-    entry.isDirectory() ? await copyDir(srcPath, destPath) : copyFileSync(srcPath, destPath);
-  }
-}
-
 /**
  * Execute a command and return its stdout.
  */
@@ -65,7 +53,7 @@ export async function exec(command: string): Promise<string> {
  * Creates a clean environment for each test by copying the example file to a temporary directory.
  */
 export async function generateTmpDir() {
-  return fsPromise.mkdtemp(join(tmpdir(), "-wing-compile-test"));
+  return fs.mkdtemp(join(tmpdir(), "-wing-compile-test"));
 }
 
 /**

--- a/libs/wingcompiler/src/compile.ts
+++ b/libs/wingcompiler/src/compile.ts
@@ -17,7 +17,7 @@ Error.stackTraceLimit = 50;
 // const log = debug("wing:compile");
 const WINGC_COMPILE = "wingc_compile";
 const WINGC_PREFLIGHT = "preflight.js";
-const MANIFEST_FILE = "manifest.json";
+const MANIFEST_FILE = ".manifest";
 const BACKUP_SUFFIX = ".bak";
 const DOT_WING = ".wing";
 

--- a/libs/wingcompiler/src/util.ts
+++ b/libs/wingcompiler/src/util.ts
@@ -1,6 +1,3 @@
-import { copyFileSync, promises as fsPromise } from "fs";
-import path from "path";
-
 /**
  * Normalize windows paths to be posix-like.
  */
@@ -13,17 +10,5 @@ export function normalPath(path: string) {
     );
   } else {
     return path;
-  }
-}
-
-export async function copyDir(src: string, dest: string) {
-  await fsPromise.mkdir(dest, { recursive: true });
-  let entries = await fsPromise.readdir(src, { withFileTypes: true });
-
-  for (let entry of entries) {
-    let srcPath = path.join(src, entry.name);
-    let destPath = path.join(dest, entry.name);
-
-    entry.isDirectory() ? await copyDir(srcPath, destPath) : copyFileSync(srcPath, destPath);
   }
 }

--- a/libs/wingsdk/src/shared/bundling.ts
+++ b/libs/wingsdk/src/shared/bundling.ts
@@ -71,11 +71,9 @@ export function createBundle(
   const sourcemapData = JSON.parse(
     new TextDecoder().decode(esbuild.outputFiles[0].contents)
   );
-  // unrandomize the sourceRoot
-  sourcemapData.sourceRoot = normalPath(sourcemapData.sourceRoot).replace(
-    /\.\d+\.tmp\/\.wing\//g,
-    "/.wing/"
-  );
+
+  // ensure sourceRoot has posix path separators
+  sourcemapData.sourceRoot = normalPath(sourcemapData.sourceRoot);
 
   for (const [idx, source] of Object.entries(sourcemapData.sources)) {
     if ((source as any).endsWith(".w")) {


### PR DESCRIPTION
Fixes #4988

When starting compilation, if there is already an existing synth directory, it will be renamed to "{dirname}.bak". Files that are not part of the generated output (e.g. terraform state files) will be copied from that backup before running the rest of the process.

To facilitate this, a new `.manifest` json file is created after compilation that lists all the files generated.

This PR looks like a bigger diff than it really is because I added a `try {} finally {}` block around most of the compilation process.

Couple thoughts:
- The current method will always replace a previous backup with a new one, regardless of whether the compilation failed or not. I went back and forth on whether this is important or not
- The main synth dir will no longer always be valid. I think it would be interesting to move (or just delete) failed compilations, but this causes issues with sourcemaps.
- I think there could be more use cases for other data in the .manifest, which is why it's named a little bit generically. It's definitely still not part of the public contract though, which is why it's a dotfile

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
