### PR TITLE
fix(compiler): optional functions missing a return type caused a crash

### DIFF
--- a/examples/tests/invalid/optionals.test.w
+++ b/examples/tests/invalid/optionals.test.w
@@ -94,3 +94,6 @@ let val: str = baz?.bar?.foo?.val;
 let optionalFunction = Json.tryParse("")?.asStr;
 optionalFunction();
 //^ Cannot call optional function (unless it's part of a reference)
+
+let optionalFunctionWithNoRetType: ()? = () => {};
+//                                 ^^ Expected function return type

--- a/libs/wingc/src/parser.rs
+++ b/libs/wingc/src/parser.rs
@@ -1758,7 +1758,7 @@ impl<'s> Parser<'s> {
 				other => return self.report_unimplemented_grammar(other, "builtin", type_node),
 			},
 			"optional" => {
-				let inner_type = self.build_type_annotation(type_node.named_child(0), phase).unwrap();
+				let inner_type = self.build_type_annotation(type_node.named_child(0), phase)?;
 				Ok(TypeAnnotation {
 					kind: TypeAnnotationKind::Optional(Box::new(inner_type)),
 					span,

--- a/tools/hangar/__snapshots__/invalid.ts.snap
+++ b/tools/hangar/__snapshots__/invalid.ts.snap
@@ -2664,7 +2664,14 @@ Duration <DURATION>"
 `;
 
 exports[`optionals.test.w 1`] = `
-"error: Expected type to be \\"num\\", but got \\"num?\\" instead
+"error: Expected function return type
+   --> ../../../examples/tests/invalid/optionals.test.w:98:36
+   |
+98 | let optionalFunctionWithNoRetType: ()? = () => {};
+   |                                    ^^ Expected function return type
+
+
+error: Expected type to be \\"num\\", but got \\"num?\\" instead
    --> ../../../examples/tests/invalid/optionals.test.w:11:3
    |
 11 | f(x);


### PR DESCRIPTION
Optional functions missing a return type caused a crash.
note that optional function types are still not supported, this only adds an appropriate diagnostic instead of crashing the compiler.

see #4296 

## Checklist

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [x] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
