### PR TITLE
fix(compiler): can't define optional function types

### DIFF
--- a/docs/docs/03-language-reference.md
+++ b/docs/docs/03-language-reference.md
@@ -1526,7 +1526,7 @@ class Foo {
 ```
 
 Preflight objects all have a scope and a unique ID. Compiler provides an implicit scope
-and ID ach object.
+and ID for each object.
 
 The default for scope is `this`, which means the scope in which the object was
 defined (instantiated). The implicit ID is the type name of the class iff the type

--- a/docs/docs/03-language-reference.md
+++ b/docs/docs/03-language-reference.md
@@ -813,6 +813,11 @@ Here's a quick summary of how optionality works in Wing:
 * The `x ?? y` notation will return the value in `x` if there is one, `y` otherwise.
 * The keyword `nil` can be used in assignment scenarios to indicate that an optional doesn't have a
   value. It cannot be used to test if an optional has a value or not.
+* A type annotation in Wing can always be enclosed in parentheses: `num` and `(num)` are the same type.
+  This is useful when you want to denote an optional function type. For example `((str):num)?` means
+  an **optional function** receiving a `str` and returning a `num`, while the similarly written 
+  `(str):num?` means a function receiving a `str` and returning an **optional `num`**.
+
 
 #### 1.7.1 Declaration
 
@@ -1521,7 +1526,7 @@ class Foo {
 ```
 
 Preflight objects all have a scope and a unique ID. Compiler provides an implicit scope
-and ID for each object.
+and ID ach object.
 
 The default for scope is `this`, which means the scope in which the object was
 defined (instantiated). The implicit ID is the type name of the class iff the type

--- a/examples/tests/invalid/function_type.test.w
+++ b/examples/tests/invalid/function_type.test.w
@@ -1,10 +1,3 @@
-// function type with no return type
-let my_func = (callback: (num)) => {  };
-//                       ^^^^^ Expected function return type
-let my_func2 = (callback: ((num)): (str)) => {  };
-//                                 ^^^^^ Expected function return type
-//                         ^^^^^ Expected function return type
-
 // interface methods with no return type
 interface IFace {
   my_method(x: num);

--- a/examples/tests/invalid/optionals.test.w
+++ b/examples/tests/invalid/optionals.test.w
@@ -96,4 +96,10 @@ optionalFunction();
 //^ Cannot call optional function (unless it's part of a reference)
 
 let optionalFunctionWithNoRetType: ()? = () => {};
-//                                 ^^ Expected function return type
+//                                 ^^ Unexpected syntax
+
+// Pass incorrect optional function type to a function
+let functionWithOptionalFuncParam1: ((num):void)? = (x: str):void => {};
+//                                                  ^^^^^^^^^^^^^^^^^^^ Expected type to be "(preflight (num): void)?", but got "preflight (x: str): void" instead
+let functionWithOptionalFuncParam2: (():num)? = ():str => { return "s"; };
+//                                              ^^^^^^^^^^^^^^^^^^^^^^^^^ Expected type to be "(preflight (): num)?", but got "preflight (): str" instead

--- a/examples/tests/valid/optionals.test.w
+++ b/examples/tests/valid/optionals.test.w
@@ -204,3 +204,18 @@ if let s1 = str1 {
 } elif let s2 = str2 {
   assert(true);
 }
+
+// Optional function return type
+let var fn: (): ((): num)? = () => { return () => { return 1337; }; };
+if let f = fn() {
+  assert(f() == 1337);
+} else {
+  assert(false);
+}
+fn = () => { return nil; };
+if let f = fn() {
+  assert(false);
+} else {
+  assert(true);
+}
+

--- a/libs/tree-sitter-wing/grammar.js
+++ b/libs/tree-sitter-wing/grammar.js
@@ -91,13 +91,13 @@ module.exports = grammar({
               $.json_container_type
             )
           ),
-          field("accessor_type", $._accessor),
+          field("accessor_type", $.accessor),
           // While the "property" identifier is optional in this grammar, upstream parsing will fail if it is not present
           optional(field("property", $._member_identifier))
         )
       ),
 
-    _accessor: ($) => choice(".", "?."),
+    accessor: ($) => choice(".", "?."),
 
     inflight_specifier: ($) => "inflight",
 

--- a/libs/tree-sitter-wing/grammar.js
+++ b/libs/tree-sitter-wing/grammar.js
@@ -442,15 +442,17 @@ module.exports = grammar({
         )
       ),
 
-    _type: ($) =>
-      choice(
-        $.custom_type,
-        $.builtin_type,
-        $._builtin_container_type,
-        $.json_container_type,
-        $.function_type,
-        $.optional
-      ),
+    _type: ($) => choice(
+      $.custom_type,
+      $.builtin_type,
+      $._builtin_container_type,
+      $.json_container_type,
+      $.function_type,
+      $.optional,
+      $._parenthesized_type,
+    ),
+
+    _parenthesized_type: ($) => seq("(", $._type, ")"),
 
     optional: ($) => seq($._type, "?"),
 
@@ -459,7 +461,7 @@ module.exports = grammar({
         seq(
           optional(field("inflight", $.inflight_specifier)),
           field("parameter_types", $.parameter_type_list),
-          optional(seq(":", field("return_type", $._type)))
+          seq(":", field("return_type", $._type))
         )
       ),
 

--- a/libs/tree-sitter-wing/test/corpus/expressions.txt
+++ b/libs/tree-sitter-wing/test/corpus/expressions.txt
@@ -111,6 +111,7 @@ obj.method();
         (nested_identifier
           object: (reference
             (reference_identifier))
+          accessor_type: (accessor)
           property: (member_identifier)))
       args: (argument_list))))
 
@@ -132,6 +133,7 @@ x == obj.method();
           (nested_identifier
             object: (reference
               (reference_identifier))
+            accessor_type: (accessor)
             property: (member_identifier)))
         args: (argument_list)))))
 
@@ -489,7 +491,9 @@ a?;
               (nested_identifier
                 object: (reference
                   (reference_identifier))
+                accessor_type: (accessor)
                 property: (member_identifier)))
+            accessor_type: (accessor)
             property: (member_identifier)))))))
 
 ================================================================================

--- a/libs/tree-sitter-wing/test/corpus/references.txt
+++ b/libs/tree-sitter-wing/test/corpus/references.txt
@@ -14,7 +14,9 @@ test1.test2.test3;
           (nested_identifier
             object: (reference
               (reference_identifier))
+            accessor_type: (accessor)
             property: (member_identifier)))
+        accessor_type: (accessor)
         property: (member_identifier)))))
 
 ================================================================================
@@ -34,6 +36,8 @@ test1.test2.test3();
             (nested_identifier
               object: (reference
                 (reference_identifier))
+              accessor_type: (accessor)
               property: (member_identifier)))
+          accessor_type: (accessor)
           property: (member_identifier)))
       args: (argument_list))))

--- a/libs/tree-sitter-wing/test/corpus/statements/statements.txt
+++ b/libs/tree-sitter-wing/test/corpus/statements/statements.txt
@@ -78,6 +78,8 @@ z -= 1;
 
 let var y = "hello";
 
+let w: (((num))) = 1;
+
 --------------------------------------------------------------------------------
 
 (source
@@ -107,7 +109,11 @@ let var y = "hello";
   (variable_definition_statement
     reassignable: (reassignable)
     name: (identifier)
-    value: (string)))
+    value: (string))
+  (variable_definition_statement
+    name: (identifier)
+    type: (builtin_type)
+    value: (number)))
 
 ================================================================================
 If
@@ -472,7 +478,7 @@ if let x = y {} elif let x = z {} else {}
 (source
   (if_let_statement
     name: (identifier)
-    value: (reference 
+    value: (reference
       (reference_identifier))
     block: (block)
     elif_let_block: (elif_let_block

--- a/libs/wingc/src/parser.rs
+++ b/libs/wingc/src/parser.rs
@@ -2552,23 +2552,11 @@ impl<'s> Parser<'s> {
 	}
 }
 
-/// Get actual child by field name when multiple childs exist because of extra nodes.
+/// Get actual child by field name when multiple children exist because of extra nodes.
 /// It should be safe to use this instead of `node.get_child_by_field_name`
 /// in cases where there's doubt.
 fn get_actual_child_by_field_name<'a>(node: Node<'a>, field_name: &str) -> Option<Node<'a>> {
-	let mut cursor = node.walk();
-
-	for child_node in node.children_by_field_name(field_name, &mut cursor) {
-		if child_node.is_extra() {
-			continue;
-		}
-		if !child_node.is_named() {
-			continue;
-		}
-
-		return Some(child_node);
-	}
-	None
+	get_actual_children_by_field_name(node, field_name).into_iter().next()
 }
 
 /// Get actual children by field name when the children might contain extra nodes.
@@ -2585,9 +2573,7 @@ fn get_actual_children_by_field_name<'a>(node: Node<'a>, field_name: &str) -> Ve
 		if !child_node.is_named() {
 			continue;
 		}
-		if let Some(child_node) = get_actual_child_by_field_name(child_node, field_name) {
-			children.push(child_node);
-		}
+		children.push(child_node);
 	}
 	children
 }

--- a/libs/wingc/src/parser.rs
+++ b/libs/wingc/src/parser.rs
@@ -494,7 +494,7 @@ impl<'s> Parser<'s> {
 
 	fn get_child_field<'a>(&'a self, node: &'a Node<'a>, field: &str) -> DiagnosticResult<Node> {
 		let checked_node = self.check_error(*node, field)?;
-		let child = checked_node.child_by_field_name(field);
+		let child = get_actual_child_by_field_name(checked_node, field);
 		if let Some(child) = child {
 			self.check_error(child, field)
 		} else {
@@ -842,7 +842,7 @@ impl<'s> Parser<'s> {
 		}
 
 		let mut extends = vec![];
-		for super_node in statement_node.children_by_field_name("extends", &mut cursor) {
+		for super_node in get_actual_children_by_field_name(*statement_node, "extends") {
 			let super_type = self.build_type_annotation(Some(super_node), phase)?;
 			match super_type.kind {
 				TypeAnnotationKind::UserDefined(t) => {
@@ -875,7 +875,7 @@ impl<'s> Parser<'s> {
 	}
 
 	fn build_variable_def_statement(&self, statement_node: &Node, phase: Phase) -> DiagnosticResult<StmtKind> {
-		let type_ = if let Some(type_node) = statement_node.child_by_field_name("type") {
+		let type_ = if let Some(type_node) = get_actual_child_by_field_name(*statement_node, "type") {
 			Some(self.build_type_annotation(Some(type_node), phase)?)
 		} else {
 			None
@@ -1361,7 +1361,7 @@ impl<'s> Parser<'s> {
 			},
 		};
 
-		let parent = if let Some(parent_node) = statement_node.child_by_field_name("parent") {
+		let parent = if let Some(parent_node) = get_actual_child_by_field_name(*statement_node, "parent") {
 			let parent_type = self.build_type_annotation(Some(parent_node), class_phase)?;
 			match parent_type.kind {
 				TypeAnnotationKind::UserDefined(parent_type) => Some(parent_type),
@@ -1378,17 +1378,7 @@ impl<'s> Parser<'s> {
 		};
 
 		let mut implements = vec![];
-		for type_node in statement_node.children_by_field_name("implements", &mut cursor) {
-			// ignore comments
-			if type_node.is_extra() {
-				continue;
-			}
-
-			// ignore commas
-			if !type_node.is_named() {
-				continue;
-			}
-
+		for type_node in get_actual_children_by_field_name(*statement_node, "implements") {
 			let interface_type = self.build_type_annotation(Some(type_node), class_phase)?;
 			match interface_type.kind {
 				TypeAnnotationKind::UserDefined(interface_type) => implements.push(interface_type),
@@ -1445,7 +1435,7 @@ impl<'s> Parser<'s> {
 		};
 		Ok(ClassField {
 			name: self.node_symbol(&class_element.child_by_field_name("name").unwrap())?,
-			member_type: self.build_type_annotation(class_element.child_by_field_name("type"), phase)?,
+			member_type: self.build_type_annotation(get_actual_child_by_field_name(class_element, "type"), phase)?,
 			reassignable: self.get_modifier("reassignable", &modifiers)?.is_some(),
 			is_static,
 			phase,
@@ -1559,7 +1549,7 @@ impl<'s> Parser<'s> {
 
 	fn build_function_signature(&self, func_sig_node: &Node, phase: Phase) -> DiagnosticResult<FunctionSignature> {
 		let parameters = self.build_parameter_list(&func_sig_node.child_by_field_name("parameter_list").unwrap(), phase)?;
-		let return_type = if let Some(rt) = func_sig_node.child_by_field_name("type") {
+		let return_type = if let Some(rt) = get_actual_child_by_field_name(*func_sig_node, "type") {
 			self.build_type_annotation(Some(rt), phase)?
 		} else {
 			let func_sig_kind = func_sig_node.kind();
@@ -1649,7 +1639,7 @@ impl<'s> Parser<'s> {
 
 			res.push(FunctionParameter {
 				name: self.check_reserved_symbol(&definition_node.child_by_field_name("name").unwrap())?,
-				type_annotation: self.build_type_annotation(definition_node.child_by_field_name("type"), phase)?,
+				type_annotation: self.build_type_annotation(get_actual_child_by_field_name(definition_node, "type"), phase)?,
 				reassignable: definition_node.child_by_field_name("reassignable").is_some(),
 				variadic: definition_node.child_by_field_name("variadic").is_some(),
 			});
@@ -1781,21 +1771,21 @@ impl<'s> Parser<'s> {
 					})
 				}
 
-				match type_node.child_by_field_name("return_type") {
-					Some(return_type) => Ok(TypeAnnotation {
-						kind: TypeAnnotationKind::Function(FunctionSignature {
-							parameters,
-							return_type: Box::new(self.build_type_annotation(Some(return_type), phase)?),
-							phase: if type_node.child_by_field_name("inflight").is_some() {
-								Phase::Inflight
-							} else {
-								phase // inherit from scope
-							},
-						}),
-						span,
+				Ok(TypeAnnotation {
+					kind: TypeAnnotationKind::Function(FunctionSignature {
+						parameters,
+						return_type: Box::new(self.build_type_annotation(
+							Some(get_actual_child_by_field_name(*type_node, "return_type").unwrap()),
+							phase,
+						)?),
+						phase: if type_node.child_by_field_name("inflight").is_some() {
+							Phase::Inflight
+						} else {
+							phase // inherit from scope
+						},
 					}),
-					None => self.with_error("Expected function return type".to_string(), &type_node),
-				}
+					span,
+				})
 			}
 			"json_container_type" => {
 				let container_type = self.node_text(&type_node);
@@ -1812,8 +1802,8 @@ impl<'s> Parser<'s> {
 				}
 			}
 			"mutable_container_type" | "immutable_container_type" => {
-				let container_type = self.node_text(&type_node.child_by_field_name("collection_type").unwrap());
-				let element_type = type_node.child_by_field_name("type_parameter");
+				let container_type = self.node_text(&get_actual_child_by_field_name(*type_node, "collection_type").unwrap());
+				let element_type = get_actual_child_by_field_name(*type_node, "type_parameter");
 				match container_type {
 					"Map" => Ok(TypeAnnotation {
 						kind: TypeAnnotationKind::Map(Box::new(self.build_type_annotation(element_type, phase)?)),
@@ -2175,7 +2165,7 @@ impl<'s> Parser<'s> {
 				expression_span,
 			)),
 			"array_literal" => {
-				let array_type = if let Some(type_node) = expression_node.child_by_field_name("type") {
+				let array_type = if let Some(type_node) = get_actual_child_by_field_name(*expression_node, "type") {
 					self.build_type_annotation(Some(type_node), phase).ok()
 				} else {
 					None
@@ -2200,7 +2190,7 @@ impl<'s> Parser<'s> {
 				Ok(Expr::new(ExprKind::JsonMapLiteral { fields }, expression_span))
 			}
 			"map_literal" => {
-				let map_type = if let Some(type_node) = expression_node.child_by_field_name("type") {
+				let map_type = if let Some(type_node) = get_actual_child_by_field_name(*expression_node, "type") {
 					self.build_type_annotation(Some(type_node), phase).ok()
 				} else {
 					None
@@ -2273,7 +2263,7 @@ impl<'s> Parser<'s> {
 			}
 			"set_literal" => self.build_set_literal(expression_node, phase),
 			"struct_literal" => {
-				let type_ = self.build_type_annotation(expression_node.child_by_field_name("type"), phase);
+				let type_ = self.build_type_annotation(get_actual_child_by_field_name(*expression_node, "type"), phase);
 				let mut fields = IndexMap::new();
 				let mut cursor = expression_node.walk();
 				for field in expression_node.children_by_field_name("fields", &mut cursor) {
@@ -2362,7 +2352,7 @@ impl<'s> Parser<'s> {
 
 	fn build_set_literal(&self, expression_node: &Node, phase: Phase) -> Result<Expr, ()> {
 		let expression_span = self.node_span(expression_node);
-		let set_type = if let Some(type_node) = expression_node.child_by_field_name("type") {
+		let set_type = if let Some(type_node) = get_actual_child_by_field_name(*expression_node, "type") {
 			self.build_type_annotation(Some(type_node), phase).ok()
 		} else {
 			None
@@ -2560,6 +2550,46 @@ impl<'s> Parser<'s> {
 			span,
 		)))
 	}
+}
+
+/// Get actual child by field name when multiple childs exist because of extra nodes.
+/// It should be safe to use this instead of `node.get_child_by_field_name`
+/// in cases where there's doubt.
+fn get_actual_child_by_field_name<'a>(node: Node<'a>, field_name: &str) -> Option<Node<'a>> {
+	let mut cursor = node.walk();
+
+	for child_node in node.children_by_field_name(field_name, &mut cursor) {
+		if child_node.is_extra() {
+			continue;
+		}
+		if !child_node.is_named() {
+			continue;
+		}
+
+		return Some(child_node);
+	}
+	None
+}
+
+/// Get actual children by field name when the children might contain extra nodes.
+/// It should be safe to use this instead of `node.get_children_by_field_name`
+/// in cases where there's doubt.
+fn get_actual_children_by_field_name<'a>(node: Node<'a>, field_name: &str) -> Vec<Node<'a>> {
+	let mut cursor = node.walk();
+	let mut children = Vec::new();
+
+	for child_node in node.children_by_field_name(field_name, &mut cursor) {
+		if child_node.is_extra() {
+			continue;
+		}
+		if !child_node.is_named() {
+			continue;
+		}
+		if let Some(child_node) = get_actual_child_by_field_name(child_node, field_name) {
+			children.push(child_node);
+		}
+	}
+	children
 }
 
 /// Check if the package.json in the given directory has a `wing` field

--- a/libs/wingc/src/parser.rs
+++ b/libs/wingc/src/parser.rs
@@ -2698,6 +2698,28 @@ mod tests {
 	use super::*;
 
 	#[test]
+	fn filter_unnamed_nodes() {
+		// Test get_actual_children_by_field_name
+		let language = tree_sitter_wing::language();
+		let mut tree_sitter_parser = tree_sitter::Parser::new();
+		tree_sitter_parser.set_language(language).unwrap();
+
+		let tree_sitter_tree = tree_sitter_parser
+			.parse("let x: ((num)) = 1;".as_bytes(), None)
+			.unwrap();
+		let stmt_node = tree_sitter_tree.root_node().named_child(0).expect("a statement node");
+
+		// We expect 5 sibling nodes because of the parentheses nodes
+		let mut cursor = stmt_node.walk();
+		let unnamed_type_nodes = stmt_node.children_by_field_name("type", &mut cursor);
+		assert!(unnamed_type_nodes.count() == 5);
+
+		// get_actual_children_by_field_name should filter out the unnamed nodes leaving us with the actual type node
+		let type_node = get_actual_children_by_field_name(stmt_node, "type");
+		assert!(type_node.len() == 1);
+	}
+
+	#[test]
 	fn normalize_path_relative_to_nothing() {
 		let file_path = Utf8Path::new("/a/b/c/d/e.f");
 		assert_eq!(normalize_path(file_path, None), file_path);

--- a/libs/wingc/src/parser.rs
+++ b/libs/wingc/src/parser.rs
@@ -1802,7 +1802,7 @@ impl<'s> Parser<'s> {
 				}
 			}
 			"mutable_container_type" | "immutable_container_type" => {
-				let container_type = self.node_text(&get_actual_child_by_field_name(*type_node, "collection_type").unwrap());
+				let container_type = self.node_text(&type_node.child_by_field_name("collection_type").unwrap());
 				let element_type = get_actual_child_by_field_name(*type_node, "type_parameter");
 				match container_type {
 					"Map" => Ok(TypeAnnotation {

--- a/libs/wingc/src/type_check.rs
+++ b/libs/wingc/src/type_check.rs
@@ -873,7 +873,13 @@ impl Display for Type {
 			Type::Nil => write!(f, "nil"),
 			Type::Unresolved => write!(f, "unresolved"),
 			Type::Inferred(_) => write!(f, "unknown"),
-			Type::Optional(v) => write!(f, "{}?", v),
+			Type::Optional(v) => {
+				if v.is_closure() {
+					write!(f, "({})?", v)
+				} else {
+					write!(f, "{}?", v)
+				}
+			}
 			Type::Function(sig) => write!(f, "{}", sig),
 			Type::Class(class) => write!(f, "{}", class),
 

--- a/tools/hangar/__snapshots__/invalid.ts.snap
+++ b/tools/hangar/__snapshots__/invalid.ts.snap
@@ -1474,25 +1474,11 @@ Duration <DURATION>"
 `;
 
 exports[`function_type.test.w 1`] = `
-"error: Expected function return type
-  --> ../../../examples/tests/invalid/function_type.test.w:2:26
+"error: Optional parameters must always be after all non-optional parameters.
+  --> ../../../examples/tests/invalid/function_type.test.w:9:25
   |
-2 | let my_func = (callback: (num)) => {  };
-  |                          ^^^^^ Expected function return type
-
-
-error: Expected function return type
-  --> ../../../examples/tests/invalid/function_type.test.w:4:28
-  |
-4 | let my_func2 = (callback: ((num)): (str)) => {  };
-  |                            ^^^^^ Expected function return type
-
-
-error: Optional parameters must always be after all non-optional parameters.
-   --> ../../../examples/tests/invalid/function_type.test.w:16:25
-   |
-16 | let my_func3 = (a: num, b: str?, c: bool) => {};
-   |                         ^ Optional parameters must always be after all non-optional parameters.
+9 | let my_func3 = (a: num, b: str?, c: bool) => {};
+  |                         ^ Optional parameters must always be after all non-optional parameters.
 
 
  
@@ -2664,11 +2650,11 @@ Duration <DURATION>"
 `;
 
 exports[`optionals.test.w 1`] = `
-"error: Expected function return type
+"error: Unexpected 'parameter_type_list'
    --> ../../../examples/tests/invalid/optionals.test.w:98:36
    |
 98 | let optionalFunctionWithNoRetType: ()? = () => {};
-   |                                    ^^ Expected function return type
+   |                                    ^^ Unexpected 'parameter_type_list'
 
 
 error: Expected type to be \\"num\\", but got \\"num?\\" instead
@@ -2753,6 +2739,20 @@ error: Cannot call an optional function
    |
 95 | optionalFunction();
    | ^^^^^^^^^^^^^^^^ Cannot call an optional function
+
+
+error: Expected type to be \\"(preflight (num): void)?\\", but got \\"preflight (x: str): void\\" instead
+    --> ../../../examples/tests/invalid/optionals.test.w:102:53
+    |
+102 | let functionWithOptionalFuncParam1: ((num):void)? = (x: str):void => {};
+    |                                                     ^^^^^^^^^^^^^^^^^^^ Expected type to be \\"(preflight (num): void)?\\", but got \\"preflight (x: str): void\\" instead
+
+
+error: Expected type to be \\"(preflight (): num)?\\", but got \\"preflight (): str\\" instead
+    --> ../../../examples/tests/invalid/optionals.test.w:104:49
+    |
+104 | let functionWithOptionalFuncParam2: (():num)? = ():str => { return \\"s\\"; };
+    |                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^ Expected type to be \\"(preflight (): num)?\\", but got \\"preflight (): str\\" instead
 
 
 error: Variable is not reassignable

--- a/tools/hangar/__snapshots__/test_corpus/valid/optionals.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/optionals.test.w_compile_tf-aws.md
@@ -455,6 +455,34 @@ class $Root extends $stdlib.std.Resource {
         }
       }
     }
+    let fn = (() => {
+      return (() => {
+        return 1337;
+      });
+    });
+    {
+      const $if_let_value = (fn());
+      if ($if_let_value != undefined) {
+        const f = $if_let_value;
+        $helpers.assert($helpers.eq((f()), 1337), "f() == 1337");
+      }
+      else {
+        $helpers.assert(false, "false");
+      }
+    }
+    fn = (() => {
+      return undefined;
+    });
+    {
+      const $if_let_value = (fn());
+      if ($if_let_value != undefined) {
+        const f = $if_let_value;
+        $helpers.assert(false, "false");
+      }
+      else {
+        $helpers.assert(true, "true");
+      }
+    }
   }
 }
 const $PlatformManager = new $stdlib.platform.PlatformManager({platformPaths: $platforms});


### PR DESCRIPTION
See #4296
We can now define optional function types via support for parenthesis around type annotations:
```wing
// Optional function type
var let fn: (():void)? = () => { };
fn = nil;
// Crazy parenthesis type annotation
let x: (((((((num))))))) = 1;
```

## Checklist

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [x] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
