### PR TITLE
fix: `_toInflight()` fails

### DIFF
--- a/libs/wingc/src/jsify.rs
+++ b/libs/wingc/src/jsify.rs
@@ -1548,7 +1548,7 @@ impl<'a> JSifier<'a> {
 
 		code.open("return `");
 
-		code.open(format!("require(\"./{client_path}\")({{"));
+		code.open(format!("require(\"${{__dirname}}/{client_path}\")({{"));
 
 		if let Some(lifts) = &ctx.lifts {
 			for (token, capture) in lifts.captures.iter().filter(|(_, cap)| !cap.is_field) {

--- a/libs/wingc/src/jsify.rs
+++ b/libs/wingc/src/jsify.rs
@@ -1575,7 +1575,7 @@ impl<'a> JSifier<'a> {
 		code.open("(await (async () => {");
 
 		code.line(format!(
-			"const {}Client = ${{{}._toInflightType(this)}};",
+			"const {}Client = ${{{}._toInflightType()}};",
 			resource_name.name, resource_name.name,
 		));
 

--- a/libs/wingc/src/jsify/snapshots/access_methods_and_properties_on_collections.snap
+++ b/libs/wingc/src/jsify/snapshots/access_methods_and_properties_on_collections.snap
@@ -58,7 +58,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
             $__arr__index_______if__index___0____index____arr_length__throw_new_Error__Index_out_of_bounds____return_arr_index______y__0_: ${$stdlib.core.liftObject(((arr, index) => { if (index < 0 || index >= arr.length) throw new Error("Index out of bounds"); return arr[index]; })(y, 0))},
             $x_length: ${$stdlib.core.liftObject(x.length)},
           })
@@ -67,7 +67,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/libs/wingc/src/jsify/snapshots/access_property_on_primitive.snap
+++ b/libs/wingc/src/jsify/snapshots/access_property_on_primitive.snap
@@ -55,7 +55,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
             $s_length: ${$stdlib.core.liftObject(s.length)},
           })
         `;
@@ -63,7 +63,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/libs/wingc/src/jsify/snapshots/access_property_on_value_returned_from_collection.snap
+++ b/libs/wingc/src/jsify/snapshots/access_property_on_value_returned_from_collection.snap
@@ -55,7 +55,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
             $__obj__key_______if____key_in_obj___throw_new_Error__Map_does_not_contain_key_____key______return_obj_key______s___hello___length: ${$stdlib.core.liftObject(((obj, key) => { if (!(key in obj)) throw new Error(`Map does not contain key: "${key}"`); return obj[key]; })(s, "hello").length)},
           })
         `;
@@ -63,7 +63,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/libs/wingc/src/jsify/snapshots/base_class_captures_inflight.snap
+++ b/libs/wingc/src/jsify/snapshots/base_class_captures_inflight.snap
@@ -77,7 +77,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.Base-1.js")({
+          require("${__dirname}/inflight.Base-1.js")({
             $x: ${$stdlib.core.liftObject(x)},
           })
         `;
@@ -85,7 +85,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const BaseClient = ${Base._toInflightType(this)};
+            const BaseClient = ${Base._toInflightType()};
             const client = new BaseClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -111,7 +111,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.Derived-1.js")({
+          require("${__dirname}/inflight.Derived-1.js")({
             $Base: ${$stdlib.core.liftObject(Base)},
           })
         `;
@@ -119,7 +119,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const DerivedClient = ${Derived._toInflightType(this)};
+            const DerivedClient = ${Derived._toInflightType()};
             const client = new DerivedClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/libs/wingc/src/jsify/snapshots/base_class_captures_preflight.snap
+++ b/libs/wingc/src/jsify/snapshots/base_class_captures_preflight.snap
@@ -74,14 +74,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.Base-1.js")({
+          require("${__dirname}/inflight.Base-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const BaseClient = ${Base._toInflightType(this)};
+            const BaseClient = ${Base._toInflightType()};
             const client = new BaseClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -102,7 +102,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.Derived-1.js")({
+          require("${__dirname}/inflight.Derived-1.js")({
             $Base: ${$stdlib.core.liftObject(Base)},
           })
         `;
@@ -110,7 +110,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const DerivedClient = ${Derived._toInflightType(this)};
+            const DerivedClient = ${Derived._toInflightType()};
             const client = new DerivedClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/libs/wingc/src/jsify/snapshots/base_class_lift_indirect.snap
+++ b/libs/wingc/src/jsify/snapshots/base_class_lift_indirect.snap
@@ -87,14 +87,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.Base-1.js")({
+          require("${__dirname}/inflight.Base-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const BaseClient = ${Base._toInflightType(this)};
+            const BaseClient = ${Base._toInflightType()};
             const client = new BaseClient({
               $this_b: ${$stdlib.core.liftObject(this.b)},
             });
@@ -124,7 +124,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.Derived-1.js")({
+          require("${__dirname}/inflight.Derived-1.js")({
             $Base: ${$stdlib.core.liftObject(Base)},
           })
         `;
@@ -132,7 +132,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const DerivedClient = ${Derived._toInflightType(this)};
+            const DerivedClient = ${Derived._toInflightType()};
             const client = new DerivedClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/libs/wingc/src/jsify/snapshots/base_class_with_fields_inflight.snap
+++ b/libs/wingc/src/jsify/snapshots/base_class_with_fields_inflight.snap
@@ -86,14 +86,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.Base-1.js")({
+          require("${__dirname}/inflight.Base-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const BaseClient = ${Base._toInflightType(this)};
+            const BaseClient = ${Base._toInflightType()};
             const client = new BaseClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -111,7 +111,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.Derived-1.js")({
+          require("${__dirname}/inflight.Derived-1.js")({
             $Base: ${$stdlib.core.liftObject(Base)},
           })
         `;
@@ -119,7 +119,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const DerivedClient = ${Derived._toInflightType(this)};
+            const DerivedClient = ${Derived._toInflightType()};
             const client = new DerivedClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/libs/wingc/src/jsify/snapshots/base_class_with_fields_preflight.snap
+++ b/libs/wingc/src/jsify/snapshots/base_class_with_fields_preflight.snap
@@ -77,14 +77,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.Base-1.js")({
+          require("${__dirname}/inflight.Base-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const BaseClient = ${Base._toInflightType(this)};
+            const BaseClient = ${Base._toInflightType()};
             const client = new BaseClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -107,7 +107,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.Derived-1.js")({
+          require("${__dirname}/inflight.Derived-1.js")({
             $Base: ${$stdlib.core.liftObject(Base)},
           })
         `;
@@ -115,7 +115,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const DerivedClient = ${Derived._toInflightType(this)};
+            const DerivedClient = ${Derived._toInflightType()};
             const client = new DerivedClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/libs/wingc/src/jsify/snapshots/base_class_with_lifted_field_object.snap
+++ b/libs/wingc/src/jsify/snapshots/base_class_with_lifted_field_object.snap
@@ -78,14 +78,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.Base-1.js")({
+          require("${__dirname}/inflight.Base-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const BaseClient = ${Base._toInflightType(this)};
+            const BaseClient = ${Base._toInflightType()};
             const client = new BaseClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -103,7 +103,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.Derived-1.js")({
+          require("${__dirname}/inflight.Derived-1.js")({
             $Base: ${$stdlib.core.liftObject(Base)},
           })
         `;
@@ -111,7 +111,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const DerivedClient = ${Derived._toInflightType(this)};
+            const DerivedClient = ${Derived._toInflightType()};
             const client = new DerivedClient({
               $this_b: ${$stdlib.core.liftObject(this.b)},
             });

--- a/libs/wingc/src/jsify/snapshots/base_class_with_lifted_fields.snap
+++ b/libs/wingc/src/jsify/snapshots/base_class_with_lifted_fields.snap
@@ -77,14 +77,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.Base-1.js")({
+          require("${__dirname}/inflight.Base-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const BaseClient = ${Base._toInflightType(this)};
+            const BaseClient = ${Base._toInflightType()};
             const client = new BaseClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -102,7 +102,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.Derived-1.js")({
+          require("${__dirname}/inflight.Derived-1.js")({
             $Base: ${$stdlib.core.liftObject(Base)},
           })
         `;
@@ -110,7 +110,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const DerivedClient = ${Derived._toInflightType(this)};
+            const DerivedClient = ${Derived._toInflightType()};
             const client = new DerivedClient({
               $this_f: ${$stdlib.core.liftObject(this.f)},
             });

--- a/libs/wingc/src/jsify/snapshots/builtins.snap
+++ b/libs/wingc/src/jsify/snapshots/builtins.snap
@@ -53,14 +53,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/libs/wingc/src/jsify/snapshots/call_static_inflight_from_static_inflight.snap
+++ b/libs/wingc/src/jsify/snapshots/call_static_inflight_from_static_inflight.snap
@@ -70,14 +70,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.A-1.js")({
+          require("${__dirname}/inflight.A-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const AClient = ${A._toInflightType(this)};
+            const AClient = ${A._toInflightType()};
             const client = new AClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -95,7 +95,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.B-1.js")({
+          require("${__dirname}/inflight.B-1.js")({
             $A: ${$stdlib.core.liftObject(A)},
           })
         `;
@@ -103,7 +103,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const BClient = ${B._toInflightType(this)};
+            const BClient = ${B._toInflightType()};
             const client = new BClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/libs/wingc/src/jsify/snapshots/calls_methods_on_preflight_object.snap
+++ b/libs/wingc/src/jsify/snapshots/calls_methods_on_preflight_object.snap
@@ -59,7 +59,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
             $b: ${$stdlib.core.liftObject(b)},
           })
         `;
@@ -67,7 +67,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/libs/wingc/src/jsify/snapshots/capture_from_inside_an_inflight_closure.snap
+++ b/libs/wingc/src/jsify/snapshots/capture_from_inside_an_inflight_closure.snap
@@ -59,7 +59,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
             $foo: ${$stdlib.core.liftObject(foo)},
           })
         `;
@@ -67,7 +67,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/libs/wingc/src/jsify/snapshots/capture_identifier_closure_from_preflight_scope.snap
+++ b/libs/wingc/src/jsify/snapshots/capture_identifier_closure_from_preflight_scope.snap
@@ -74,14 +74,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -101,7 +101,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure2-1.js")({
+          require("${__dirname}/inflight.$Closure2-1.js")({
             $foo: ${$stdlib.core.liftObject(foo)},
           })
         `;
@@ -109,7 +109,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure2Client = ${$Closure2._toInflightType(this)};
+            const $Closure2Client = ${$Closure2._toInflightType()};
             const client = new $Closure2Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/libs/wingc/src/jsify/snapshots/capture_identifier_from_preflight_scope.snap
+++ b/libs/wingc/src/jsify/snapshots/capture_identifier_from_preflight_scope.snap
@@ -54,7 +54,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
             $x: ${$stdlib.core.liftObject(x)},
           })
         `;
@@ -62,7 +62,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/libs/wingc/src/jsify/snapshots/capture_identifier_from_preflight_scope_with_method_call.snap
+++ b/libs/wingc/src/jsify/snapshots/capture_identifier_from_preflight_scope_with_method_call.snap
@@ -73,14 +73,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.Foo-1.js")({
+          require("${__dirname}/inflight.Foo-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const FooClient = ${Foo._toInflightType(this)};
+            const FooClient = ${Foo._toInflightType()};
             const client = new FooClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -100,7 +100,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
             $f: ${$stdlib.core.liftObject(f)},
           })
         `;
@@ -108,7 +108,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/libs/wingc/src/jsify/snapshots/capture_identifier_from_preflight_scope_with_nested_object.snap
+++ b/libs/wingc/src/jsify/snapshots/capture_identifier_from_preflight_scope_with_nested_object.snap
@@ -78,14 +78,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.Foo-1.js")({
+          require("${__dirname}/inflight.Foo-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const FooClient = ${Foo._toInflightType(this)};
+            const FooClient = ${Foo._toInflightType()};
             const client = new FooClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -105,7 +105,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
             $f_b: ${$stdlib.core.liftObject(f.b)},
           })
         `;
@@ -113,7 +113,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/libs/wingc/src/jsify/snapshots/capture_identifier_from_preflight_scope_with_property.snap
+++ b/libs/wingc/src/jsify/snapshots/capture_identifier_from_preflight_scope_with_property.snap
@@ -54,7 +54,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
             $x_length: ${$stdlib.core.liftObject(x.length)},
           })
         `;
@@ -62,7 +62,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/libs/wingc/src/jsify/snapshots/capture_in_keyword_args.snap
+++ b/libs/wingc/src/jsify/snapshots/capture_in_keyword_args.snap
@@ -60,7 +60,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
             $util_Util: ${$stdlib.core.liftObject($stdlib.core.toLiftableModuleType(util.Util, "@winglang/sdk/util", "Util"))},
             $x: ${$stdlib.core.liftObject(x)},
           })
@@ -69,7 +69,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/libs/wingc/src/jsify/snapshots/capture_object_with_this_in_name.snap
+++ b/libs/wingc/src/jsify/snapshots/capture_object_with_this_in_name.snap
@@ -56,7 +56,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
             $bucket_this: ${$stdlib.core.liftObject(bucket_this)},
           })
         `;
@@ -64,7 +64,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/libs/wingc/src/jsify/snapshots/capture_token.snap
+++ b/libs/wingc/src/jsify/snapshots/capture_token.snap
@@ -55,7 +55,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
             $api_url: ${$stdlib.core.liftObject(api.url)},
           })
         `;
@@ -63,7 +63,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/libs/wingc/src/jsify/snapshots/capture_type_inflight_class_sibling_from_init.snap
+++ b/libs/wingc/src/jsify/snapshots/capture_type_inflight_class_sibling_from_init.snap
@@ -78,14 +78,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/libs/wingc/src/jsify/snapshots/capture_type_inflight_class_sibling_from_method.snap
+++ b/libs/wingc/src/jsify/snapshots/capture_type_inflight_class_sibling_from_method.snap
@@ -64,14 +64,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/libs/wingc/src/jsify/snapshots/capture_type_new_inflight_class_inner_no_capture.snap
+++ b/libs/wingc/src/jsify/snapshots/capture_type_new_inflight_class_inner_no_capture.snap
@@ -56,14 +56,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/libs/wingc/src/jsify/snapshots/capture_type_new_inflight_class_outer.snap
+++ b/libs/wingc/src/jsify/snapshots/capture_type_new_inflight_class_outer.snap
@@ -66,14 +66,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.Foo-1.js")({
+          require("${__dirname}/inflight.Foo-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const FooClient = ${Foo._toInflightType(this)};
+            const FooClient = ${Foo._toInflightType()};
             const client = new FooClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -93,7 +93,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
             $Foo: ${$stdlib.core.liftObject(Foo)},
           })
         `;
@@ -101,7 +101,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/libs/wingc/src/jsify/snapshots/capture_type_static_method.snap
+++ b/libs/wingc/src/jsify/snapshots/capture_type_static_method.snap
@@ -73,14 +73,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.Foo-1.js")({
+          require("${__dirname}/inflight.Foo-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const FooClient = ${Foo._toInflightType(this)};
+            const FooClient = ${Foo._toInflightType()};
             const client = new FooClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -100,7 +100,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
             $Foo: ${$stdlib.core.liftObject(Foo)},
           })
         `;
@@ -108,7 +108,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/libs/wingc/src/jsify/snapshots/capture_type_static_method_inflight_class.snap
+++ b/libs/wingc/src/jsify/snapshots/capture_type_static_method_inflight_class.snap
@@ -71,14 +71,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.Foo-1.js")({
+          require("${__dirname}/inflight.Foo-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const FooClient = ${Foo._toInflightType(this)};
+            const FooClient = ${Foo._toInflightType()};
             const client = new FooClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -98,7 +98,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
             $Foo: ${$stdlib.core.liftObject(Foo)},
           })
         `;
@@ -106,7 +106,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/libs/wingc/src/jsify/snapshots/capture_var_from_method_inflight.snap
+++ b/libs/wingc/src/jsify/snapshots/capture_var_from_method_inflight.snap
@@ -61,14 +61,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/libs/wingc/src/jsify/snapshots/closed_inflight_class_extends_outer_inflight_class.snap
+++ b/libs/wingc/src/jsify/snapshots/closed_inflight_class_extends_outer_inflight_class.snap
@@ -69,14 +69,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.Base-1.js")({
+          require("${__dirname}/inflight.Base-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const BaseClient = ${Base._toInflightType(this)};
+            const BaseClient = ${Base._toInflightType()};
             const client = new BaseClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -96,7 +96,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
             $Base: ${$stdlib.core.liftObject(Base)},
           })
         `;
@@ -104,7 +104,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/libs/wingc/src/jsify/snapshots/closure_field.snap
+++ b/libs/wingc/src/jsify/snapshots/closure_field.snap
@@ -121,7 +121,7 @@ class $Root extends $stdlib.std.Resource {
           }
           static _toInflightType() {
             return `
-              require("./inflight.$Closure1-1.js")({
+              require("${__dirname}/inflight.$Closure1-1.js")({
                 $globalBucket: ${$stdlib.core.liftObject(globalBucket)},
               })
             `;
@@ -129,7 +129,7 @@ class $Root extends $stdlib.std.Resource {
           _toInflight() {
             return `
               (await (async () => {
-                const $Closure1Client = ${$Closure1._toInflightType(this)};
+                const $Closure1Client = ${$Closure1._toInflightType()};
                 const client = new $Closure1Client({
                 });
                 if (client.$inflight_init) { await client.$inflight_init(); }
@@ -153,14 +153,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.MyResource-1.js")({
+          require("${__dirname}/inflight.MyResource-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const MyResourceClient = ${MyResource._toInflightType(this)};
+            const MyResourceClient = ${MyResource._toInflightType()};
             const client = new MyResourceClient({
               $this_closure: ${$stdlib.core.liftObject(this.closure)},
             });
@@ -192,7 +192,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure2-1.js")({
+          require("${__dirname}/inflight.$Closure2-1.js")({
             $x: ${$stdlib.core.liftObject(x)},
           })
         `;
@@ -200,7 +200,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure2Client = ${$Closure2._toInflightType(this)};
+            const $Closure2Client = ${$Closure2._toInflightType()};
             const client = new $Closure2Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/libs/wingc/src/jsify/snapshots/enum_value.snap
+++ b/libs/wingc/src/jsify/snapshots/enum_value.snap
@@ -58,7 +58,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
             $MyEnum: ${$stdlib.core.liftObject(MyEnum)},
             $x: ${$stdlib.core.liftObject(x)},
           })
@@ -67,7 +67,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/libs/wingc/src/jsify/snapshots/free_inflight_obj_from_inflight.snap
+++ b/libs/wingc/src/jsify/snapshots/free_inflight_obj_from_inflight.snap
@@ -66,14 +66,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/libs/wingc/src/jsify/snapshots/free_preflight_object_from_preflight.snap
+++ b/libs/wingc/src/jsify/snapshots/free_preflight_object_from_preflight.snap
@@ -50,14 +50,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.A-1.js")({
+          require("${__dirname}/inflight.A-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const AClient = ${A._toInflightType(this)};
+            const AClient = ${A._toInflightType()};
             const client = new AClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/libs/wingc/src/jsify/snapshots/func_returns_func.snap
+++ b/libs/wingc/src/jsify/snapshots/func_returns_func.snap
@@ -63,14 +63,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/libs/wingc/src/jsify/snapshots/identify_field.snap
+++ b/libs/wingc/src/jsify/snapshots/identify_field.snap
@@ -58,14 +58,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.A-1.js")({
+          require("${__dirname}/inflight.A-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const AClient = ${A._toInflightType(this)};
+            const AClient = ${A._toInflightType()};
             const client = new AClient({
               $this_bucket_this: ${$stdlib.core.liftObject(this.bucket_this)},
             });

--- a/libs/wingc/src/jsify/snapshots/implicit_lift_inflight_init.snap
+++ b/libs/wingc/src/jsify/snapshots/implicit_lift_inflight_init.snap
@@ -76,14 +76,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.Foo-1.js")({
+          require("${__dirname}/inflight.Foo-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const FooClient = ${Foo._toInflightType(this)};
+            const FooClient = ${Foo._toInflightType()};
             const client = new FooClient({
               $this_c: ${$stdlib.core.liftObject(this.c)},
             });

--- a/libs/wingc/src/jsify/snapshots/indirect_capture.snap
+++ b/libs/wingc/src/jsify/snapshots/indirect_capture.snap
@@ -91,7 +91,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.Capture-1.js")({
+          require("${__dirname}/inflight.Capture-1.js")({
             $b: ${$stdlib.core.liftObject(b)},
           })
         `;
@@ -99,7 +99,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const CaptureClient = ${Capture._toInflightType(this)};
+            const CaptureClient = ${Capture._toInflightType()};
             const client = new CaptureClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -129,7 +129,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
             $f: ${$stdlib.core.liftObject(f)},
           })
         `;
@@ -137,7 +137,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/libs/wingc/src/jsify/snapshots/inflight_class_extends_both_inside_inflight_closure.snap
+++ b/libs/wingc/src/jsify/snapshots/inflight_class_extends_both_inside_inflight_closure.snap
@@ -57,14 +57,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/libs/wingc/src/jsify/snapshots/inflight_class_extends_inflight_class.snap
+++ b/libs/wingc/src/jsify/snapshots/inflight_class_extends_inflight_class.snap
@@ -55,14 +55,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.A-1.js")({
+          require("${__dirname}/inflight.A-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const AClient = ${A._toInflightType(this)};
+            const AClient = ${A._toInflightType()};
             const client = new AClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -80,7 +80,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.B-1.js")({
+          require("${__dirname}/inflight.B-1.js")({
             $A: ${$stdlib.core.liftObject(A)},
           })
         `;
@@ -88,7 +88,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const BClient = ${B._toInflightType(this)};
+            const BClient = ${B._toInflightType()};
             const client = new BClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/libs/wingc/src/jsify/snapshots/inflight_constructor.snap
+++ b/libs/wingc/src/jsify/snapshots/inflight_constructor.snap
@@ -59,14 +59,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.Foo-1.js")({
+          require("${__dirname}/inflight.Foo-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const FooClient = ${Foo._toInflightType(this)};
+            const FooClient = ${Foo._toInflightType()};
             const client = new FooClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/libs/wingc/src/jsify/snapshots/inflight_field.snap
+++ b/libs/wingc/src/jsify/snapshots/inflight_field.snap
@@ -58,14 +58,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.A-1.js")({
+          require("${__dirname}/inflight.A-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const AClient = ${A._toInflightType(this)};
+            const AClient = ${A._toInflightType()};
             const client = new AClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/libs/wingc/src/jsify/snapshots/inflight_field_from_inflight.snap
+++ b/libs/wingc/src/jsify/snapshots/inflight_field_from_inflight.snap
@@ -57,14 +57,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.MyType-1.js")({
+          require("${__dirname}/inflight.MyType-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const MyTypeClient = ${MyType._toInflightType(this)};
+            const MyTypeClient = ${MyType._toInflightType()};
             const client = new MyTypeClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/libs/wingc/src/jsify/snapshots/inflight_field_from_inflight_class.snap
+++ b/libs/wingc/src/jsify/snapshots/inflight_field_from_inflight_class.snap
@@ -56,14 +56,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.MyType-1.js")({
+          require("${__dirname}/inflight.MyType-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const MyTypeClient = ${MyType._toInflightType(this)};
+            const MyTypeClient = ${MyType._toInflightType()};
             const client = new MyTypeClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/libs/wingc/src/jsify/snapshots/inline_inflight_class.snap
+++ b/libs/wingc/src/jsify/snapshots/inline_inflight_class.snap
@@ -86,7 +86,7 @@ class $Root extends $stdlib.std.Resource {
           }
           static _toInflightType() {
             return `
-              require("./inflight.$Closure1-1.js")({
+              require("${__dirname}/inflight.$Closure1-1.js")({
                 $__parent_this_1_b: ${$stdlib.core.liftObject(__parent_this_1.b)},
               })
             `;
@@ -94,7 +94,7 @@ class $Root extends $stdlib.std.Resource {
           _toInflight() {
             return `
               (await (async () => {
-                const $Closure1Client = ${$Closure1._toInflightType(this)};
+                const $Closure1Client = ${$Closure1._toInflightType()};
                 const client = new $Closure1Client({
                 });
                 if (client.$inflight_init) { await client.$inflight_init(); }
@@ -118,14 +118,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.Foo-1.js")({
+          require("${__dirname}/inflight.Foo-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const FooClient = ${Foo._toInflightType(this)};
+            const FooClient = ${Foo._toInflightType()};
             const client = new FooClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/libs/wingc/src/jsify/snapshots/json_object.snap
+++ b/libs/wingc/src/jsify/snapshots/json_object.snap
@@ -55,7 +55,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
             $jsonObj1: ${$stdlib.core.liftObject(jsonObj1)},
             $std_Json: ${$stdlib.core.liftObject($stdlib.core.toLiftableModuleType(std.Json, "@winglang/sdk/std", "Json"))},
           })
@@ -64,7 +64,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/libs/wingc/src/jsify/snapshots/lift_binary_preflight_and_inflight_expression.snap
+++ b/libs/wingc/src/jsify/snapshots/lift_binary_preflight_and_inflight_expression.snap
@@ -56,7 +56,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
             $x: ${$stdlib.core.liftObject(x)},
           })
         `;
@@ -64,7 +64,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/libs/wingc/src/jsify/snapshots/lift_binary_preflight_expression.snap
+++ b/libs/wingc/src/jsify/snapshots/lift_binary_preflight_expression.snap
@@ -55,7 +55,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
             $x: ${$stdlib.core.liftObject(x)},
             $y: ${$stdlib.core.liftObject(y)},
           })
@@ -64,7 +64,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/libs/wingc/src/jsify/snapshots/lift_element_from_collection_as_field.snap
+++ b/libs/wingc/src/jsify/snapshots/lift_element_from_collection_as_field.snap
@@ -59,14 +59,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.Foo-1.js")({
+          require("${__dirname}/inflight.Foo-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const FooClient = ${Foo._toInflightType(this)};
+            const FooClient = ${Foo._toInflightType()};
             const client = new FooClient({
               $__arr__index_______if__index___0____index____arr_length__throw_new_Error__Index_out_of_bounds____return_arr_index______this_arr__0_: ${$stdlib.core.liftObject(((arr, index) => { if (index < 0 || index >= arr.length) throw new Error("Index out of bounds"); return arr[index]; })(this.arr, 0))},
             });

--- a/libs/wingc/src/jsify/snapshots/lift_element_from_collection_of_objects.snap
+++ b/libs/wingc/src/jsify/snapshots/lift_element_from_collection_of_objects.snap
@@ -57,7 +57,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
             $__arr__index_______if__index___0____index____arr_length__throw_new_Error__Index_out_of_bounds____return_arr_index______a__0_: ${$stdlib.core.liftObject(((arr, index) => { if (index < 0 || index >= arr.length) throw new Error("Index out of bounds"); return arr[index]; })(a, 0))},
           })
         `;
@@ -65,7 +65,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/libs/wingc/src/jsify/snapshots/lift_inflight_closure.snap
+++ b/libs/wingc/src/jsify/snapshots/lift_inflight_closure.snap
@@ -75,14 +75,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -102,7 +102,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure2-1.js")({
+          require("${__dirname}/inflight.$Closure2-1.js")({
             $f: ${$stdlib.core.liftObject(f)},
           })
         `;
@@ -110,7 +110,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure2Client = ${$Closure2._toInflightType(this)};
+            const $Closure2Client = ${$Closure2._toInflightType()};
             const client = new $Closure2Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/libs/wingc/src/jsify/snapshots/lift_inside_preflight_method.snap
+++ b/libs/wingc/src/jsify/snapshots/lift_inside_preflight_method.snap
@@ -90,7 +90,7 @@ class $Root extends $stdlib.std.Resource {
           }
           static _toInflightType() {
             return `
-              require("./inflight.$Closure1-1.js")({
+              require("${__dirname}/inflight.$Closure1-1.js")({
                 $b: ${$stdlib.core.liftObject(b)},
               })
             `;
@@ -98,7 +98,7 @@ class $Root extends $stdlib.std.Resource {
           _toInflight() {
             return `
               (await (async () => {
-                const $Closure1Client = ${$Closure1._toInflightType(this)};
+                const $Closure1Client = ${$Closure1._toInflightType()};
                 const client = new $Closure1Client({
                 });
                 if (client.$inflight_init) { await client.$inflight_init(); }
@@ -122,14 +122,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.Foo-1.js")({
+          require("${__dirname}/inflight.Foo-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const FooClient = ${Foo._toInflightType(this)};
+            const FooClient = ${Foo._toInflightType()};
             const client = new FooClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/libs/wingc/src/jsify/snapshots/lift_self_reference.snap
+++ b/libs/wingc/src/jsify/snapshots/lift_self_reference.snap
@@ -54,14 +54,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.Foo-1.js")({
+          require("${__dirname}/inflight.Foo-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const FooClient = ${Foo._toInflightType(this)};
+            const FooClient = ${Foo._toInflightType()};
             const client = new FooClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/libs/wingc/src/jsify/snapshots/lift_string.snap
+++ b/libs/wingc/src/jsify/snapshots/lift_string.snap
@@ -54,7 +54,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
             $b: ${$stdlib.core.liftObject(b)},
           })
         `;
@@ -62,7 +62,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/libs/wingc/src/jsify/snapshots/lift_this.snap
+++ b/libs/wingc/src/jsify/snapshots/lift_this.snap
@@ -90,14 +90,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.Foo-1.js")({
+          require("${__dirname}/inflight.Foo-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const FooClient = ${Foo._toInflightType(this)};
+            const FooClient = ${Foo._toInflightType()};
             const client = new FooClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -124,7 +124,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
             $f: ${$stdlib.core.liftObject(f)},
           })
         `;
@@ -132,7 +132,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/libs/wingc/src/jsify/snapshots/lift_var_with_this.snap
+++ b/libs/wingc/src/jsify/snapshots/lift_var_with_this.snap
@@ -74,14 +74,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.Foo-1.js")({
+          require("${__dirname}/inflight.Foo-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const FooClient = ${Foo._toInflightType(this)};
+            const FooClient = ${Foo._toInflightType()};
             const client = new FooClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -101,14 +101,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
               $foo_this_value: ${$stdlib.core.liftObject(foo_this.value)},
             });

--- a/libs/wingc/src/jsify/snapshots/lift_via_closure.snap
+++ b/libs/wingc/src/jsify/snapshots/lift_via_closure.snap
@@ -83,7 +83,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
             $bucket: ${$stdlib.core.liftObject(bucket)},
           })
         `;
@@ -91,7 +91,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -119,7 +119,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure2-1.js")({
+          require("${__dirname}/inflight.$Closure2-1.js")({
             $fn: ${$stdlib.core.liftObject(fn)},
           })
         `;
@@ -127,7 +127,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure2Client = ${$Closure2._toInflightType(this)};
+            const $Closure2Client = ${$Closure2._toInflightType()};
             const client = new $Closure2Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/libs/wingc/src/jsify/snapshots/lift_via_closure_class_explicit.snap
+++ b/libs/wingc/src/jsify/snapshots/lift_via_closure_class_explicit.snap
@@ -98,14 +98,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.MyClosure-1.js")({
+          require("${__dirname}/inflight.MyClosure-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const MyClosureClient = ${MyClosure._toInflightType(this)};
+            const MyClosureClient = ${MyClosure._toInflightType()};
             const client = new MyClosureClient({
               $this_q: ${$stdlib.core.liftObject(this.q)},
             });
@@ -139,7 +139,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
             $fn: ${$stdlib.core.liftObject(fn)},
           })
         `;
@@ -147,7 +147,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/libs/wingc/src/jsify/snapshots/namespaced_static_from_inflight.snap
+++ b/libs/wingc/src/jsify/snapshots/namespaced_static_from_inflight.snap
@@ -55,7 +55,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
             $util_Util: ${$stdlib.core.liftObject($stdlib.core.toLiftableModuleType(util.Util, "@winglang/sdk/util", "Util"))},
           })
         `;
@@ -63,7 +63,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/libs/wingc/src/jsify/snapshots/nested_inflight_after_preflight_operation.snap
+++ b/libs/wingc/src/jsify/snapshots/nested_inflight_after_preflight_operation.snap
@@ -80,14 +80,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.YourType-1.js")({
+          require("${__dirname}/inflight.YourType-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const YourTypeClient = ${YourType._toInflightType(this)};
+            const YourTypeClient = ${YourType._toInflightType()};
             const client = new YourTypeClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -107,7 +107,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
             $y: ${$stdlib.core.liftObject(y)},
           })
         `;
@@ -115,7 +115,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/libs/wingc/src/jsify/snapshots/nested_preflight_operation.snap
+++ b/libs/wingc/src/jsify/snapshots/nested_preflight_operation.snap
@@ -99,14 +99,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.YourType-1.js")({
+          require("${__dirname}/inflight.YourType-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const YourTypeClient = ${YourType._toInflightType(this)};
+            const YourTypeClient = ${YourType._toInflightType()};
             const client = new YourTypeClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -125,14 +125,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.MyType-1.js")({
+          require("${__dirname}/inflight.MyType-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const MyTypeClient = ${MyType._toInflightType(this)};
+            const MyTypeClient = ${MyType._toInflightType()};
             const client = new MyTypeClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -152,7 +152,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
             $t_y_b: ${$stdlib.core.liftObject(t.y.b)},
           })
         `;
@@ -160,7 +160,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/libs/wingc/src/jsify/snapshots/new_inflight_object.snap
+++ b/libs/wingc/src/jsify/snapshots/new_inflight_object.snap
@@ -66,14 +66,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.Foo-1.js")({
+          require("${__dirname}/inflight.Foo-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const FooClient = ${Foo._toInflightType(this)};
+            const FooClient = ${Foo._toInflightType()};
             const client = new FooClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -93,7 +93,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
             $Foo: ${$stdlib.core.liftObject(Foo)},
           })
         `;
@@ -101,7 +101,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/libs/wingc/src/jsify/snapshots/no_capture_inside_methods.snap
+++ b/libs/wingc/src/jsify/snapshots/no_capture_inside_methods.snap
@@ -59,14 +59,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/libs/wingc/src/jsify/snapshots/no_capture_of_identifier_from_inner_scope.snap
+++ b/libs/wingc/src/jsify/snapshots/no_capture_of_identifier_from_inner_scope.snap
@@ -59,14 +59,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/libs/wingc/src/jsify/snapshots/no_capture_of_identifier_from_same_scope.snap
+++ b/libs/wingc/src/jsify/snapshots/no_capture_of_identifier_from_same_scope.snap
@@ -55,14 +55,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/libs/wingc/src/jsify/snapshots/no_capture_shadow_inside_inner_scopes.snap
+++ b/libs/wingc/src/jsify/snapshots/no_capture_shadow_inside_inner_scopes.snap
@@ -67,14 +67,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/libs/wingc/src/jsify/snapshots/no_lift_shadow_inside_inner_scopes.snap
+++ b/libs/wingc/src/jsify/snapshots/no_lift_shadow_inside_inner_scopes.snap
@@ -65,7 +65,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
             $i: ${$stdlib.core.liftObject(i)},
           })
         `;
@@ -73,7 +73,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/libs/wingc/src/jsify/snapshots/preflight_class_extends_preflight_class.snap
+++ b/libs/wingc/src/jsify/snapshots/preflight_class_extends_preflight_class.snap
@@ -60,14 +60,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.Base-1.js")({
+          require("${__dirname}/inflight.Base-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const BaseClient = ${Base._toInflightType(this)};
+            const BaseClient = ${Base._toInflightType()};
             const client = new BaseClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -85,7 +85,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.Derived-1.js")({
+          require("${__dirname}/inflight.Derived-1.js")({
             $Base: ${$stdlib.core.liftObject(Base)},
           })
         `;
@@ -93,7 +93,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const DerivedClient = ${Derived._toInflightType(this)};
+            const DerivedClient = ${Derived._toInflightType()};
             const client = new DerivedClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/libs/wingc/src/jsify/snapshots/preflight_collection.snap
+++ b/libs/wingc/src/jsify/snapshots/preflight_collection.snap
@@ -56,7 +56,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
             $__arr__index_______if__index___0____index____arr_length__throw_new_Error__Index_out_of_bounds____return_arr_index______a__0_: ${$stdlib.core.liftObject(((arr, index) => { if (index < 0 || index >= arr.length) throw new Error("Index out of bounds"); return arr[index]; })(a, 0))},
             $a_length: ${$stdlib.core.liftObject(a.length)},
           })
@@ -65,7 +65,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/libs/wingc/src/jsify/snapshots/preflight_collection_of_preflight_objects.snap
+++ b/libs/wingc/src/jsify/snapshots/preflight_collection_of_preflight_objects.snap
@@ -61,7 +61,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
             $__arr__index_______if__index___0____index____arr_length__throw_new_Error__Index_out_of_bounds____return_arr_index______arr__0_: ${$stdlib.core.liftObject(((arr, index) => { if (index < 0 || index >= arr.length) throw new Error("Index out of bounds"); return arr[index]; })(arr, 0))},
             $arr_length: ${$stdlib.core.liftObject(arr.length)},
           })
@@ -70,7 +70,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/libs/wingc/src/jsify/snapshots/preflight_nested_object_with_operations.snap
+++ b/libs/wingc/src/jsify/snapshots/preflight_nested_object_with_operations.snap
@@ -78,14 +78,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.A-1.js")({
+          require("${__dirname}/inflight.A-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const AClient = ${A._toInflightType(this)};
+            const AClient = ${A._toInflightType()};
             const client = new AClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -105,7 +105,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
             $a_bucky: ${$stdlib.core.liftObject(a.bucky)},
           })
         `;
@@ -113,7 +113,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/libs/wingc/src/jsify/snapshots/preflight_object.snap
+++ b/libs/wingc/src/jsify/snapshots/preflight_object.snap
@@ -77,14 +77,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.A-1.js")({
+          require("${__dirname}/inflight.A-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const AClient = ${A._toInflightType(this)};
+            const AClient = ${A._toInflightType()};
             const client = new AClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -104,7 +104,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
             $pf_obj: ${$stdlib.core.liftObject(pf_obj)},
           })
         `;
@@ -112,7 +112,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/libs/wingc/src/jsify/snapshots/preflight_object_through_property.snap
+++ b/libs/wingc/src/jsify/snapshots/preflight_object_through_property.snap
@@ -79,14 +79,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.MyType-1.js")({
+          require("${__dirname}/inflight.MyType-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const MyTypeClient = ${MyType._toInflightType(this)};
+            const MyTypeClient = ${MyType._toInflightType()};
             const client = new MyTypeClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -106,7 +106,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
             $t_b: ${$stdlib.core.liftObject(t.b)},
           })
         `;
@@ -114,7 +114,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/libs/wingc/src/jsify/snapshots/preflight_object_with_operations.snap
+++ b/libs/wingc/src/jsify/snapshots/preflight_object_with_operations.snap
@@ -58,7 +58,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
             $b: ${$stdlib.core.liftObject(b)},
           })
         `;
@@ -66,7 +66,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/libs/wingc/src/jsify/snapshots/preflight_object_with_operations_multiple_methods.snap
+++ b/libs/wingc/src/jsify/snapshots/preflight_object_with_operations_multiple_methods.snap
@@ -61,7 +61,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.Foo-1.js")({
+          require("${__dirname}/inflight.Foo-1.js")({
             $b: ${$stdlib.core.liftObject(b)},
           })
         `;
@@ -69,7 +69,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const FooClient = ${Foo._toInflightType(this)};
+            const FooClient = ${Foo._toInflightType()};
             const client = new FooClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/libs/wingc/src/jsify/snapshots/preflight_value_field.snap
+++ b/libs/wingc/src/jsify/snapshots/preflight_value_field.snap
@@ -84,14 +84,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.MyType-1.js")({
+          require("${__dirname}/inflight.MyType-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const MyTypeClient = ${MyType._toInflightType(this)};
+            const MyTypeClient = ${MyType._toInflightType()};
             const client = new MyTypeClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -111,7 +111,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
             $t_last: ${$stdlib.core.liftObject(t.last)},
             $t_name: ${$stdlib.core.liftObject(t.name)},
             $t_name_length: ${$stdlib.core.liftObject(t.name.length)},
@@ -121,7 +121,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/libs/wingc/src/jsify/snapshots/read_primitive_value.snap
+++ b/libs/wingc/src/jsify/snapshots/read_primitive_value.snap
@@ -55,7 +55,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
             $x: ${$stdlib.core.liftObject(x)},
           })
         `;
@@ -63,7 +63,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/libs/wingc/src/jsify/snapshots/reassign_captured_variable.snap
+++ b/libs/wingc/src/jsify/snapshots/reassign_captured_variable.snap
@@ -64,14 +64,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/libs/wingc/src/jsify/snapshots/ref_std_macro.snap
+++ b/libs/wingc/src/jsify/snapshots/ref_std_macro.snap
@@ -55,7 +55,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
             $arr_length: ${$stdlib.core.liftObject(arr.length)},
           })
         `;
@@ -63,7 +63,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/libs/wingc/src/jsify/snapshots/reference_from_static_inflight.snap
+++ b/libs/wingc/src/jsify/snapshots/reference_from_static_inflight.snap
@@ -52,7 +52,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.MyType-1.js")({
+          require("${__dirname}/inflight.MyType-1.js")({
             $s: ${$stdlib.core.liftObject(s)},
           })
         `;
@@ -60,7 +60,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const MyTypeClient = ${MyType._toInflightType(this)};
+            const MyTypeClient = ${MyType._toInflightType()};
             const client = new MyTypeClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/libs/wingc/src/jsify/snapshots/reference_inflight_class.snap
+++ b/libs/wingc/src/jsify/snapshots/reference_inflight_class.snap
@@ -71,14 +71,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.Foo-1.js")({
+          require("${__dirname}/inflight.Foo-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const FooClient = ${Foo._toInflightType(this)};
+            const FooClient = ${Foo._toInflightType()};
             const client = new FooClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -98,7 +98,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
             $Foo: ${$stdlib.core.liftObject(Foo)},
           })
         `;
@@ -106,7 +106,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/libs/wingc/src/jsify/snapshots/reference_inflight_field.snap
+++ b/libs/wingc/src/jsify/snapshots/reference_inflight_field.snap
@@ -59,14 +59,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.Foo-1.js")({
+          require("${__dirname}/inflight.Foo-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const FooClient = ${Foo._toInflightType(this)};
+            const FooClient = ${Foo._toInflightType()};
             const client = new FooClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/libs/wingc/src/jsify/snapshots/reference_inflight_from_inflight.snap
+++ b/libs/wingc/src/jsify/snapshots/reference_inflight_from_inflight.snap
@@ -83,7 +83,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.Foo-1.js")({
+          require("${__dirname}/inflight.Foo-1.js")({
             $s: ${$stdlib.core.liftObject(s)},
           })
         `;
@@ -91,7 +91,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const FooClient = ${Foo._toInflightType(this)};
+            const FooClient = ${Foo._toInflightType()};
             const client = new FooClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -119,7 +119,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
             $Foo: ${$stdlib.core.liftObject(Foo)},
           })
         `;
@@ -127,7 +127,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/libs/wingc/src/jsify/snapshots/reference_lift_of_collection.snap
+++ b/libs/wingc/src/jsify/snapshots/reference_lift_of_collection.snap
@@ -55,7 +55,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
             $a: ${$stdlib.core.liftObject(a)},
           })
         `;
@@ -63,7 +63,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/libs/wingc/src/jsify/snapshots/reference_preflight_field.snap
+++ b/libs/wingc/src/jsify/snapshots/reference_preflight_field.snap
@@ -58,14 +58,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.Foo-1.js")({
+          require("${__dirname}/inflight.Foo-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const FooClient = ${Foo._toInflightType(this)};
+            const FooClient = ${Foo._toInflightType()};
             const client = new FooClient({
               $this_x: ${$stdlib.core.liftObject(this.x)},
             });

--- a/libs/wingc/src/jsify/snapshots/reference_preflight_field_call_independent_method.snap
+++ b/libs/wingc/src/jsify/snapshots/reference_preflight_field_call_independent_method.snap
@@ -58,14 +58,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.Foo-1.js")({
+          require("${__dirname}/inflight.Foo-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const FooClient = ${Foo._toInflightType(this)};
+            const FooClient = ${Foo._toInflightType()};
             const client = new FooClient({
               $__arr__index_______if__index___0____index____arr_length__throw_new_Error__Index_out_of_bounds____return_arr_index______this_arr__1_: ${$stdlib.core.liftObject(((arr, index) => { if (index < 0 || index >= arr.length) throw new Error("Index out of bounds"); return arr[index]; })(this.arr, 1))},
             });

--- a/libs/wingc/src/jsify/snapshots/reference_preflight_fields.snap
+++ b/libs/wingc/src/jsify/snapshots/reference_preflight_fields.snap
@@ -76,14 +76,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.MyType-1.js")({
+          require("${__dirname}/inflight.MyType-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const MyTypeClient = ${MyType._toInflightType(this)};
+            const MyTypeClient = ${MyType._toInflightType()};
             const client = new MyTypeClient({
               $this_b: ${$stdlib.core.liftObject(this.b)},
               $this_s_length: ${$stdlib.core.liftObject(this.s.length)},

--- a/libs/wingc/src/jsify/snapshots/reference_preflight_free_variable_with_this_in_the_expression.snap
+++ b/libs/wingc/src/jsify/snapshots/reference_preflight_free_variable_with_this_in_the_expression.snap
@@ -62,7 +62,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.Foo-1.js")({
+          require("${__dirname}/inflight.Foo-1.js")({
             $b: ${$stdlib.core.liftObject(b)},
           })
         `;
@@ -70,7 +70,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const FooClient = ${Foo._toInflightType(this)};
+            const FooClient = ${Foo._toInflightType()};
             const client = new FooClient({
               $this_name: ${$stdlib.core.liftObject(this.name)},
             });

--- a/libs/wingc/src/jsify/snapshots/reference_preflight_object_from_static_inflight.snap
+++ b/libs/wingc/src/jsify/snapshots/reference_preflight_object_from_static_inflight.snap
@@ -55,7 +55,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.MyType-1.js")({
+          require("${__dirname}/inflight.MyType-1.js")({
             $q: ${$stdlib.core.liftObject(q)},
           })
         `;
@@ -63,7 +63,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const MyTypeClient = ${MyType._toInflightType(this)};
+            const MyTypeClient = ${MyType._toInflightType()};
             const client = new MyTypeClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/libs/wingc/src/jsify/snapshots/reference_static_inflight.snap
+++ b/libs/wingc/src/jsify/snapshots/reference_static_inflight.snap
@@ -73,14 +73,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.MyType-1.js")({
+          require("${__dirname}/inflight.MyType-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const MyTypeClient = ${MyType._toInflightType(this)};
+            const MyTypeClient = ${MyType._toInflightType()};
             const client = new MyTypeClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -100,7 +100,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
             $MyType: ${$stdlib.core.liftObject(MyType)},
           })
         `;
@@ -108,7 +108,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/libs/wingc/src/jsify/snapshots/reference_static_inflight_which_references_preflight_object.snap
+++ b/libs/wingc/src/jsify/snapshots/reference_static_inflight_which_references_preflight_object.snap
@@ -82,7 +82,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.MyType-1.js")({
+          require("${__dirname}/inflight.MyType-1.js")({
             $b: ${$stdlib.core.liftObject(b)},
           })
         `;
@@ -90,7 +90,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const MyTypeClient = ${MyType._toInflightType(this)};
+            const MyTypeClient = ${MyType._toInflightType()};
             const client = new MyTypeClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -118,7 +118,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
             $MyType: ${$stdlib.core.liftObject(MyType)},
           })
         `;
@@ -126,7 +126,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/libs/wingc/src/jsify/snapshots/static_external_inflight_class.snap
+++ b/libs/wingc/src/jsify/snapshots/static_external_inflight_class.snap
@@ -82,14 +82,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.A-1.js")({
+          require("${__dirname}/inflight.A-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const AClient = ${A._toInflightType(this)};
+            const AClient = ${A._toInflightType()};
             const client = new AClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -109,7 +109,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
             $A: ${$stdlib.core.liftObject(A)},
           })
         `;
@@ -117,7 +117,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/libs/wingc/src/jsify/snapshots/static_external_preflight_class.snap
+++ b/libs/wingc/src/jsify/snapshots/static_external_preflight_class.snap
@@ -81,14 +81,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.A-1.js")({
+          require("${__dirname}/inflight.A-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const AClient = ${A._toInflightType(this)};
+            const AClient = ${A._toInflightType()};
             const client = new AClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -108,7 +108,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
             $A: ${$stdlib.core.liftObject(A)},
           })
         `;
@@ -116,7 +116,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/libs/wingc/src/jsify/snapshots/static_inflight_operation.snap
+++ b/libs/wingc/src/jsify/snapshots/static_inflight_operation.snap
@@ -79,7 +79,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.A-1.js")({
+          require("${__dirname}/inflight.A-1.js")({
             $b: ${$stdlib.core.liftObject(b)},
           })
         `;
@@ -87,7 +87,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const AClient = ${A._toInflightType(this)};
+            const AClient = ${A._toInflightType()};
             const client = new AClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -115,7 +115,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
             $A: ${$stdlib.core.liftObject(A)},
           })
         `;
@@ -123,7 +123,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/libs/wingc/src/jsify/snapshots/static_local_inflight_class.snap
+++ b/libs/wingc/src/jsify/snapshots/static_local_inflight_class.snap
@@ -75,14 +75,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/libs/wingc/src/jsify/snapshots/static_on_std_type.snap
+++ b/libs/wingc/src/jsify/snapshots/static_on_std_type.snap
@@ -55,7 +55,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
             $std_Json: ${$stdlib.core.liftObject($stdlib.core.toLiftableModuleType(std.Json, "@winglang/sdk/std", "Json"))},
             $std_String: ${$stdlib.core.liftObject($stdlib.core.toLiftableModuleType(std.String, "@winglang/sdk/std", "String"))},
           })
@@ -64,7 +64,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/libs/wingc/src/jsify/snapshots/transitive_reference.snap
+++ b/libs/wingc/src/jsify/snapshots/transitive_reference.snap
@@ -98,14 +98,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.MyType-1.js")({
+          require("${__dirname}/inflight.MyType-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const MyTypeClient = ${MyType._toInflightType(this)};
+            const MyTypeClient = ${MyType._toInflightType()};
             const client = new MyTypeClient({
               $this_b: ${$stdlib.core.liftObject(this.b)},
             });
@@ -139,7 +139,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
             $t: ${$stdlib.core.liftObject(t)},
           })
         `;
@@ -147,7 +147,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/libs/wingc/src/jsify/snapshots/transitive_reference_via_inflight_class.snap
+++ b/libs/wingc/src/jsify/snapshots/transitive_reference_via_inflight_class.snap
@@ -80,7 +80,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.MyInflightClass-1.js")({
+          require("${__dirname}/inflight.MyInflightClass-1.js")({
             $b: ${$stdlib.core.liftObject(b)},
           })
         `;
@@ -88,7 +88,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const MyInflightClassClient = ${MyInflightClass._toInflightType(this)};
+            const MyInflightClassClient = ${MyInflightClass._toInflightType()};
             const client = new MyInflightClassClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -116,7 +116,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
             $MyInflightClass: ${$stdlib.core.liftObject(MyInflightClass)},
           })
         `;
@@ -124,7 +124,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/libs/wingc/src/jsify/snapshots/transitive_reference_via_static.snap
+++ b/libs/wingc/src/jsify/snapshots/transitive_reference_via_static.snap
@@ -105,7 +105,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.MyType-1.js")({
+          require("${__dirname}/inflight.MyType-1.js")({
             $b: ${$stdlib.core.liftObject(b)},
           })
         `;
@@ -113,7 +113,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const MyTypeClient = ${MyType._toInflightType(this)};
+            const MyTypeClient = ${MyType._toInflightType()};
             const client = new MyTypeClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -139,7 +139,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.YourType-1.js")({
+          require("${__dirname}/inflight.YourType-1.js")({
             $MyType: ${$stdlib.core.liftObject(MyType)},
           })
         `;
@@ -147,7 +147,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const YourTypeClient = ${YourType._toInflightType(this)};
+            const YourTypeClient = ${YourType._toInflightType()};
             const client = new YourTypeClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -175,7 +175,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
             $t: ${$stdlib.core.liftObject(t)},
           })
         `;
@@ -183,7 +183,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/libs/wingc/src/jsify/snapshots/two_identical_lifts.snap
+++ b/libs/wingc/src/jsify/snapshots/two_identical_lifts.snap
@@ -64,7 +64,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
             $b: ${$stdlib.core.liftObject(b)},
           })
         `;
@@ -72,7 +72,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/libs/wingc/src/jsify/snapshots/use_util_functions.snap
+++ b/libs/wingc/src/jsify/snapshots/use_util_functions.snap
@@ -54,7 +54,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
             $util_Util: ${$stdlib.core.liftObject($stdlib.core.toLiftableModuleType(util.Util, "@winglang/sdk/util", "Util"))},
           })
         `;
@@ -62,7 +62,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/libs/wingc/src/jsify/snapshots/var_inflight_field_from_inflight.snap
+++ b/libs/wingc/src/jsify/snapshots/var_inflight_field_from_inflight.snap
@@ -59,14 +59,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.MyType-1.js")({
+          require("${__dirname}/inflight.MyType-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const MyTypeClient = ${MyType._toInflightType(this)};
+            const MyTypeClient = ${MyType._toInflightType()};
             const client = new MyTypeClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/libs/wingc/src/jsify/snapshots/wait_util.snap
+++ b/libs/wingc/src/jsify/snapshots/wait_util.snap
@@ -61,7 +61,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
             $util_Util: ${$stdlib.core.liftObject($stdlib.core.toLiftableModuleType(util.Util, "@winglang/sdk/util", "Util"))},
           })
         `;
@@ -69,7 +69,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/tools/hangar/__snapshots__/test_corpus/valid/api.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/api.test.w_compile_tf-aws.md
@@ -478,7 +478,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
             $counter: ${$stdlib.core.liftObject(counter)},
             $std_Json: ${$stdlib.core.liftObject($stdlib.core.toLiftableModuleType(std.Json, "@winglang/sdk/std", "Json"))},
           })
@@ -487,7 +487,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -515,7 +515,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure2-1.js")({
+          require("${__dirname}/inflight.$Closure2-1.js")({
             $api_url: ${$stdlib.core.liftObject(api.url)},
           })
         `;
@@ -523,7 +523,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure2Client = ${$Closure2._toInflightType(this)};
+            const $Closure2Client = ${$Closure2._toInflightType()};
             const client = new $Closure2Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -556,7 +556,7 @@ class $Root extends $stdlib.std.Resource {
           }
           static _toInflightType() {
             return `
-              require("./inflight.$Closure3-1.js")({
+              require("${__dirname}/inflight.$Closure3-1.js")({
                 $__parent_this_3_api_url: ${$stdlib.core.liftObject(__parent_this_3.api.url)},
               })
             `;
@@ -564,7 +564,7 @@ class $Root extends $stdlib.std.Resource {
           _toInflight() {
             return `
               (await (async () => {
-                const $Closure3Client = ${$Closure3._toInflightType(this)};
+                const $Closure3Client = ${$Closure3._toInflightType()};
                 const client = new $Closure3Client({
                 });
                 if (client.$inflight_init) { await client.$inflight_init(); }
@@ -588,14 +588,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.A-1.js")({
+          require("${__dirname}/inflight.A-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const AClient = ${A._toInflightType(this)};
+            const AClient = ${A._toInflightType()};
             const client = new AClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/tools/hangar/__snapshots__/test_corpus/valid/api_cors_custom.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/api_cors_custom.test.w_compile_tf-aws.md
@@ -337,14 +337,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -364,7 +364,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure2-1.js")({
+          require("${__dirname}/inflight.$Closure2-1.js")({
             $api_url: ${$stdlib.core.liftObject(api.url)},
             $expect_Util: ${$stdlib.core.liftObject($stdlib.core.toLiftableModuleType(expect.Util, "@winglang/sdk/expect", "Util"))},
             $http_Util: ${$stdlib.core.liftObject($stdlib.core.toLiftableModuleType(http.Util, "@winglang/sdk/http", "Util"))},
@@ -374,7 +374,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure2Client = ${$Closure2._toInflightType(this)};
+            const $Closure2Client = ${$Closure2._toInflightType()};
             const client = new $Closure2Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -402,7 +402,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure3-1.js")({
+          require("${__dirname}/inflight.$Closure3-1.js")({
             $api_url: ${$stdlib.core.liftObject(api.url)},
             $expect_Util: ${$stdlib.core.liftObject($stdlib.core.toLiftableModuleType(expect.Util, "@winglang/sdk/expect", "Util"))},
             $http_HttpMethod: ${$stdlib.core.liftObject($stdlib.core.toLiftableModuleType(http.HttpMethod, "@winglang/sdk/http", "HttpMethod"))},
@@ -413,7 +413,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure3Client = ${$Closure3._toInflightType(this)};
+            const $Closure3Client = ${$Closure3._toInflightType()};
             const client = new $Closure3Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -441,7 +441,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure4-1.js")({
+          require("${__dirname}/inflight.$Closure4-1.js")({
             $api_url: ${$stdlib.core.liftObject(api.url)},
             $expect_Util: ${$stdlib.core.liftObject($stdlib.core.toLiftableModuleType(expect.Util, "@winglang/sdk/expect", "Util"))},
             $http_HttpMethod: ${$stdlib.core.liftObject($stdlib.core.toLiftableModuleType(http.HttpMethod, "@winglang/sdk/http", "HttpMethod"))},
@@ -452,7 +452,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure4Client = ${$Closure4._toInflightType(this)};
+            const $Closure4Client = ${$Closure4._toInflightType()};
             const client = new $Closure4Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/tools/hangar/__snapshots__/test_corpus/valid/api_cors_default.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/api_cors_default.test.w_compile_tf-aws.md
@@ -312,14 +312,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -339,7 +339,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure2-1.js")({
+          require("${__dirname}/inflight.$Closure2-1.js")({
             $apiDefaultCors_url: ${$stdlib.core.liftObject(apiDefaultCors.url)},
             $expect_Util: ${$stdlib.core.liftObject($stdlib.core.toLiftableModuleType(expect.Util, "@winglang/sdk/expect", "Util"))},
             $http_Util: ${$stdlib.core.liftObject($stdlib.core.toLiftableModuleType(http.Util, "@winglang/sdk/http", "Util"))},
@@ -349,7 +349,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure2Client = ${$Closure2._toInflightType(this)};
+            const $Closure2Client = ${$Closure2._toInflightType()};
             const client = new $Closure2Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -377,7 +377,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure3-1.js")({
+          require("${__dirname}/inflight.$Closure3-1.js")({
             $apiDefaultCors_url: ${$stdlib.core.liftObject(apiDefaultCors.url)},
             $expect_Util: ${$stdlib.core.liftObject($stdlib.core.toLiftableModuleType(expect.Util, "@winglang/sdk/expect", "Util"))},
             $http_HttpMethod: ${$stdlib.core.liftObject($stdlib.core.toLiftableModuleType(http.HttpMethod, "@winglang/sdk/http", "HttpMethod"))},
@@ -388,7 +388,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure3Client = ${$Closure3._toInflightType(this)};
+            const $Closure3Client = ${$Closure3._toInflightType()};
             const client = new $Closure3Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/tools/hangar/__snapshots__/test_corpus/valid/api_valid_path.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/api_valid_path.test.w_compile_tf-aws.md
@@ -411,14 +411,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/tools/hangar/__snapshots__/test_corpus/valid/assert.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/assert.test.w_compile_tf-aws.md
@@ -73,7 +73,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
             $s1: ${$stdlib.core.liftObject(s1)},
             $s2: ${$stdlib.core.liftObject(s2)},
           })
@@ -82,7 +82,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/tools/hangar/__snapshots__/test_corpus/valid/asynchronous_model_implicit_await_in_functions.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/asynchronous_model_implicit_await_in_functions.test.w_compile_tf-aws.md
@@ -281,14 +281,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -308,7 +308,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure2-1.js")({
+          require("${__dirname}/inflight.$Closure2-1.js")({
             $strToStr: ${$stdlib.core.liftObject(strToStr)},
           })
         `;
@@ -316,7 +316,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure2Client = ${$Closure2._toInflightType(this)};
+            const $Closure2Client = ${$Closure2._toInflightType()};
             const client = new $Closure2Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/tools/hangar/__snapshots__/test_corpus/valid/baz.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/baz.w_compile_tf-aws.md
@@ -29,14 +29,14 @@ class Baz extends $stdlib.std.Resource {
   }
   static _toInflightType() {
     return `
-      require("./inflight.Baz-1.js")({
+      require("${__dirname}/inflight.Baz-1.js")({
       })
     `;
   }
   _toInflight() {
     return `
       (await (async () => {
-        const BazClient = ${Baz._toInflightType(this)};
+        const BazClient = ${Baz._toInflightType()};
         const client = new BazClient({
         });
         if (client.$inflight_init) { await client.$inflight_init(); }

--- a/tools/hangar/__snapshots__/test_corpus/valid/bring_awscdk.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/bring_awscdk.test.w_compile_tf-aws.md
@@ -53,14 +53,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.CdkDockerImageFunction-1.js")({
+          require("${__dirname}/inflight.CdkDockerImageFunction-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const CdkDockerImageFunctionClient = ${CdkDockerImageFunction._toInflightType(this)};
+            const CdkDockerImageFunctionClient = ${CdkDockerImageFunction._toInflightType()};
             const client = new CdkDockerImageFunctionClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/tools/hangar/__snapshots__/test_corpus/valid/bring_cdktf.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/bring_cdktf.test.w_compile_tf-aws.md
@@ -71,14 +71,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.Foo-1.js")({
+          require("${__dirname}/inflight.Foo-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const FooClient = ${Foo._toInflightType(this)};
+            const FooClient = ${Foo._toInflightType()};
             const client = new FooClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/tools/hangar/__snapshots__/test_corpus/valid/bring_jsii.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/bring_jsii.test.w_compile_tf-aws.md
@@ -63,7 +63,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
             $greeting: ${$stdlib.core.liftObject(greeting)},
             $stuff_HelloWorld: ${$stdlib.core.liftObject($stdlib.core.toLiftableModuleType(stuff.HelloWorld, "jsii-code-samples", "HelloWorld"))},
           })
@@ -72,7 +72,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/tools/hangar/__snapshots__/test_corpus/valid/bring_local.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/bring_local.test.w_compile_tf-aws.md
@@ -302,7 +302,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-3.js")({
+          require("${__dirname}/inflight.$Closure1-3.js")({
             $store: ${$stdlib.core.liftObject(store)},
           })
         `;
@@ -310,7 +310,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -339,14 +339,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.Triangle-3.js")({
+          require("${__dirname}/inflight.Triangle-3.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const TriangleClient = ${Triangle._toInflightType(this)};
+            const TriangleClient = ${Triangle._toInflightType()};
             const client = new TriangleClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -364,14 +364,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.Util-3.js")({
+          require("${__dirname}/inflight.Util-3.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const UtilClient = ${Util._toInflightType(this)};
+            const UtilClient = ${Util._toInflightType()};
             const client = new UtilClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -413,14 +413,14 @@ class Util extends $stdlib.std.Resource {
   }
   static _toInflightType() {
     return `
-      require("./inflight.Util-1.js")({
+      require("${__dirname}/inflight.Util-1.js")({
       })
     `;
   }
   _toInflight() {
     return `
       (await (async () => {
-        const UtilClient = ${Util._toInflightType(this)};
+        const UtilClient = ${Util._toInflightType()};
         const client = new UtilClient({
         });
         if (client.$inflight_init) { await client.$inflight_init(); }
@@ -445,7 +445,7 @@ class Store extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
             $__parent_this_1_b: ${$stdlib.core.liftObject(__parent_this_1.b)},
           })
         `;
@@ -453,7 +453,7 @@ class Store extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -477,14 +477,14 @@ class Store extends $stdlib.std.Resource {
   }
   static _toInflightType() {
     return `
-      require("./inflight.Store-1.js")({
+      require("${__dirname}/inflight.Store-1.js")({
       })
     `;
   }
   _toInflight() {
     return `
       (await (async () => {
-        const StoreClient = ${Store._toInflightType(this)};
+        const StoreClient = ${Store._toInflightType()};
         const client = new StoreClient({
           $this_b: ${$stdlib.core.liftObject(this.b)},
         });
@@ -533,14 +533,14 @@ class Q extends $stdlib.std.Resource {
   }
   static _toInflightType() {
     return `
-      require("./inflight.Q-2.js")({
+      require("${__dirname}/inflight.Q-2.js")({
       })
     `;
   }
   _toInflight() {
     return `
       (await (async () => {
-        const QClient = ${Q._toInflightType(this)};
+        const QClient = ${Q._toInflightType()};
         const client = new QClient({
         });
         if (client.$inflight_init) { await client.$inflight_init(); }

--- a/tools/hangar/__snapshots__/test_corpus/valid/bring_local_dir.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/bring_local_dir.test.w_compile_tf-aws.md
@@ -96,14 +96,14 @@ class Foo extends $stdlib.std.Resource {
   }
   static _toInflightType() {
     return `
-      require("./inflight.Foo-2.js")({
+      require("${__dirname}/inflight.Foo-2.js")({
       })
     `;
   }
   _toInflight() {
     return `
       (await (async () => {
-        const FooClient = ${Foo._toInflightType(this)};
+        const FooClient = ${Foo._toInflightType()};
         const client = new FooClient({
         });
         if (client.$inflight_init) { await client.$inflight_init(); }
@@ -136,14 +136,14 @@ class Bar extends $stdlib.std.Resource {
   }
   static _toInflightType() {
     return `
-      require("./inflight.Bar-3.js")({
+      require("${__dirname}/inflight.Bar-3.js")({
       })
     `;
   }
   _toInflight() {
     return `
       (await (async () => {
-        const BarClient = ${Bar._toInflightType(this)};
+        const BarClient = ${Bar._toInflightType()};
         const client = new BarClient({
         });
         if (client.$inflight_init) { await client.$inflight_init(); }
@@ -161,14 +161,14 @@ class Foo extends $stdlib.std.Resource {
   }
   static _toInflightType() {
     return `
-      require("./inflight.Foo-3.js")({
+      require("${__dirname}/inflight.Foo-3.js")({
       })
     `;
   }
   _toInflight() {
     return `
       (await (async () => {
-        const FooClient = ${Foo._toInflightType(this)};
+        const FooClient = ${Foo._toInflightType()};
         const client = new FooClient({
         });
         if (client.$inflight_init) { await client.$inflight_init(); }
@@ -259,14 +259,14 @@ class Widget extends $stdlib.std.Resource {
   }
   static _toInflightType() {
     return `
-      require("./inflight.Widget-1.js")({
+      require("${__dirname}/inflight.Widget-1.js")({
       })
     `;
   }
   _toInflight() {
     return `
       (await (async () => {
-        const WidgetClient = ${Widget._toInflightType(this)};
+        const WidgetClient = ${Widget._toInflightType()};
         const client = new WidgetClient({
         });
         if (client.$inflight_init) { await client.$inflight_init(); }

--- a/tools/hangar/__snapshots__/test_corpus/valid/bring_local_normalization.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/bring_local_normalization.test.w_compile_tf-aws.md
@@ -76,14 +76,14 @@ class Bar extends $stdlib.std.Resource {
   }
   static _toInflightType() {
     return `
-      require("./inflight.Bar-1.js")({
+      require("${__dirname}/inflight.Bar-1.js")({
       })
     `;
   }
   _toInflight() {
     return `
       (await (async () => {
-        const BarClient = ${Bar._toInflightType(this)};
+        const BarClient = ${Bar._toInflightType()};
         const client = new BarClient({
         });
         if (client.$inflight_init) { await client.$inflight_init(); }
@@ -114,14 +114,14 @@ class Baz extends $stdlib.std.Resource {
   }
   static _toInflightType() {
     return `
-      require("./inflight.Baz-2.js")({
+      require("${__dirname}/inflight.Baz-2.js")({
       })
     `;
   }
   _toInflight() {
     return `
       (await (async () => {
-        const BazClient = ${Baz._toInflightType(this)};
+        const BazClient = ${Baz._toInflightType()};
         const client = new BazClient({
         });
         if (client.$inflight_init) { await client.$inflight_init(); }
@@ -160,14 +160,14 @@ class Foo extends $stdlib.std.Resource {
   }
   static _toInflightType() {
     return `
-      require("./inflight.Foo-3.js")({
+      require("${__dirname}/inflight.Foo-3.js")({
       })
     `;
   }
   _toInflight() {
     return `
       (await (async () => {
-        const FooClient = ${Foo._toInflightType(this)};
+        const FooClient = ${Foo._toInflightType()};
         const client = new FooClient({
         });
         if (client.$inflight_init) { await client.$inflight_init(); }

--- a/tools/hangar/__snapshots__/test_corpus/valid/bring_wing_library.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/bring_wing_library.test.w_compile_tf-aws.md
@@ -131,7 +131,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-3.js")({
+          require("${__dirname}/inflight.$Closure1-3.js")({
             $fixture_Store: ${$stdlib.core.liftObject($stdlib.core.toLiftableModuleType(fixture.Store, "", "Store"))},
           })
         `;
@@ -139,7 +139,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -191,7 +191,7 @@ class Store extends $stdlib.std.Resource {
   }
   static _toInflightType() {
     return `
-      require("./inflight.Store-2.js")({
+      require("${__dirname}/inflight.Store-2.js")({
         $myutil_Util: ${$stdlib.core.liftObject($stdlib.core.toLiftableModuleType(myutil.Util, "", "Util"))},
       })
     `;
@@ -199,7 +199,7 @@ class Store extends $stdlib.std.Resource {
   _toInflight() {
     return `
       (await (async () => {
-        const StoreClient = ${Store._toInflightType(this)};
+        const StoreClient = ${Store._toInflightType()};
         const client = new StoreClient({
           $this_data: ${$stdlib.core.liftObject(this.data)},
         });
@@ -266,14 +266,14 @@ class Util extends $stdlib.std.Resource {
   }
   static _toInflightType() {
     return `
-      require("./inflight.Util-1.js")({
+      require("${__dirname}/inflight.Util-1.js")({
       })
     `;
   }
   _toInflight() {
     return `
       (await (async () => {
-        const UtilClient = ${Util._toInflightType(this)};
+        const UtilClient = ${Util._toInflightType()};
         const client = new UtilClient({
         });
         if (client.$inflight_init) { await client.$inflight_init(); }

--- a/tools/hangar/__snapshots__/test_corpus/valid/bucket_keys.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/bucket_keys.test.w_compile_tf-aws.md
@@ -84,7 +84,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
             $b: ${$stdlib.core.liftObject(b)},
           })
         `;
@@ -92,7 +92,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/tools/hangar/__snapshots__/test_corpus/valid/call_static_of_myself.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/call_static_of_myself.test.w_compile_tf-aws.md
@@ -108,14 +108,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.Foo-1.js")({
+          require("${__dirname}/inflight.Foo-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const FooClient = ${Foo._toInflightType(this)};
+            const FooClient = ${Foo._toInflightType()};
             const client = new FooClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -149,14 +149,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.Bar-1.js")({
+          require("${__dirname}/inflight.Bar-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const BarClient = ${Bar._toInflightType(this)};
+            const BarClient = ${Bar._toInflightType()};
             const client = new BarClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -176,7 +176,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
             $Bar: ${$stdlib.core.liftObject(Bar)},
             $Foo: ${$stdlib.core.liftObject(Foo)},
             $foo: ${$stdlib.core.liftObject(foo)},
@@ -186,7 +186,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/tools/hangar/__snapshots__/test_corpus/valid/calling_inflight_variants.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/calling_inflight_variants.test.w_compile_tf-aws.md
@@ -125,14 +125,14 @@ class $Root extends $stdlib.std.Resource {
           }
           static _toInflightType() {
             return `
-              require("./inflight.$Closure1-1.js")({
+              require("${__dirname}/inflight.$Closure1-1.js")({
               })
             `;
           }
           _toInflight() {
             return `
               (await (async () => {
-                const $Closure1Client = ${$Closure1._toInflightType(this)};
+                const $Closure1Client = ${$Closure1._toInflightType()};
                 const client = new $Closure1Client({
                 });
                 if (client.$inflight_init) { await client.$inflight_init(); }
@@ -148,14 +148,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.Foo-1.js")({
+          require("${__dirname}/inflight.Foo-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const FooClient = ${Foo._toInflightType(this)};
+            const FooClient = ${Foo._toInflightType()};
             const client = new FooClient({
               $this_inflight1: ${$stdlib.core.liftObject(this.inflight1)},
             });
@@ -192,7 +192,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure2-1.js")({
+          require("${__dirname}/inflight.$Closure2-1.js")({
             $foo: ${$stdlib.core.liftObject(foo)},
           })
         `;
@@ -200,7 +200,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure2Client = ${$Closure2._toInflightType(this)};
+            const $Closure2Client = ${$Closure2._toInflightType()};
             const client = new $Closure2Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/tools/hangar/__snapshots__/test_corpus/valid/capture_containers.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/capture_containers.test.w_compile_tf-aws.md
@@ -68,7 +68,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
             $Object_keys_myMap__length: ${$stdlib.core.liftObject(Object.keys(myMap).length)},
             $__arr__index_______if__index___0____index____arr_length__throw_new_Error__Index_out_of_bounds____return_arr_index______arr__0_: ${$stdlib.core.liftObject(((arr, index) => { if (index < 0 || index >= arr.length) throw new Error("Index out of bounds"); return arr[index]; })(arr, 0))},
             $__arr__index_______if__index___0____index____arr_length__throw_new_Error__Index_out_of_bounds____return_arr_index______arr__1_: ${$stdlib.core.liftObject(((arr, index) => { if (index < 0 || index >= arr.length) throw new Error("Index out of bounds"); return arr[index]; })(arr, 1))},
@@ -84,7 +84,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/tools/hangar/__snapshots__/test_corpus/valid/capture_in_binary.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/capture_in_binary.test.w_compile_tf-aws.md
@@ -76,7 +76,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
             $b: ${$stdlib.core.liftObject(b)},
             $x: ${$stdlib.core.liftObject(x)},
           })
@@ -85,7 +85,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/tools/hangar/__snapshots__/test_corpus/valid/capture_mutables.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/capture_mutables.test.w_compile_tf-aws.md
@@ -82,7 +82,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
             $Object_keys_m__length: ${$stdlib.core.liftObject(Object.keys(m).length)},
             $aCloned_length: ${$stdlib.core.liftObject(aCloned.length)},
             $a_length: ${$stdlib.core.liftObject(a.length)},
@@ -93,7 +93,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -124,7 +124,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure2-1.js")({
+          require("${__dirname}/inflight.$Closure2-1.js")({
             $handler: ${$stdlib.core.liftObject(handler)},
           })
         `;
@@ -132,7 +132,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure2Client = ${$Closure2._toInflightType(this)};
+            const $Closure2Client = ${$Closure2._toInflightType()};
             const client = new $Closure2Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/tools/hangar/__snapshots__/test_corpus/valid/capture_primitives.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/capture_primitives.test.w_compile_tf-aws.md
@@ -180,7 +180,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
             $myBool: ${$stdlib.core.liftObject(myBool)},
             $myDur_hours: ${$stdlib.core.liftObject(myDur.hours)},
             $myDur_minutes: ${$stdlib.core.liftObject(myDur.minutes)},
@@ -194,7 +194,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/tools/hangar/__snapshots__/test_corpus/valid/capture_reassigable_class_field.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/capture_reassigable_class_field.test.w_compile_tf-aws.md
@@ -171,14 +171,14 @@ class $Root extends $stdlib.std.Resource {
           }
           static _toInflightType() {
             return `
-              require("./inflight.$Closure1-1.js")({
+              require("${__dirname}/inflight.$Closure1-1.js")({
               })
             `;
           }
           _toInflight() {
             return `
               (await (async () => {
-                const $Closure1Client = ${$Closure1._toInflightType(this)};
+                const $Closure1Client = ${$Closure1._toInflightType()};
                 const client = new $Closure1Client({
                 });
                 if (client.$inflight_init) { await client.$inflight_init(); }
@@ -197,14 +197,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.KeyValueStore-1.js")({
+          require("${__dirname}/inflight.KeyValueStore-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const KeyValueStoreClient = ${KeyValueStore._toInflightType(this)};
+            const KeyValueStoreClient = ${KeyValueStore._toInflightType()};
             const client = new KeyValueStoreClient({
               $this_bucket: ${$stdlib.core.liftObject(this.bucket)},
               $this_onUpdateCallback: ${$stdlib.core.liftObject(this.onUpdateCallback)},
@@ -242,7 +242,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure2-1.js")({
+          require("${__dirname}/inflight.$Closure2-1.js")({
             $counter: ${$stdlib.core.liftObject(counter)},
           })
         `;
@@ -250,7 +250,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure2Client = ${$Closure2._toInflightType(this)};
+            const $Closure2Client = ${$Closure2._toInflightType()};
             const client = new $Closure2Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -278,7 +278,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure3-1.js")({
+          require("${__dirname}/inflight.$Closure3-1.js")({
             $counter: ${$stdlib.core.liftObject(counter)},
             $kv: ${$stdlib.core.liftObject(kv)},
             $util_Util: ${$stdlib.core.liftObject($stdlib.core.toLiftableModuleType(util.Util, "@winglang/sdk/util", "Util"))},
@@ -288,7 +288,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure3Client = ${$Closure3._toInflightType(this)};
+            const $Closure3Client = ${$Closure3._toInflightType()};
             const client = new $Closure3Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/tools/hangar/__snapshots__/test_corpus/valid/capture_reassignable.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/capture_reassignable.test.w_compile_tf-aws.md
@@ -80,7 +80,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
             $x: ${$stdlib.core.liftObject(x)},
           })
         `;
@@ -88,7 +88,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -116,7 +116,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure2-1.js")({
+          require("${__dirname}/inflight.$Closure2-1.js")({
             $handler: ${$stdlib.core.liftObject(handler)},
           })
         `;
@@ -124,7 +124,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure2Client = ${$Closure2._toInflightType(this)};
+            const $Closure2Client = ${$Closure2._toInflightType()};
             const client = new $Closure2Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/tools/hangar/__snapshots__/test_corpus/valid/capture_resource_and_data.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/capture_resource_and_data.test.w_compile_tf-aws.md
@@ -90,7 +90,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
             $data_size: ${$stdlib.core.liftObject(data.size)},
             $queue: ${$stdlib.core.liftObject(queue)},
             $res: ${$stdlib.core.liftObject(res)},
@@ -100,7 +100,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/tools/hangar/__snapshots__/test_corpus/valid/capture_resource_with_no_inflight.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/capture_resource_with_no_inflight.test.w_compile_tf-aws.md
@@ -102,14 +102,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.A-1.js")({
+          require("${__dirname}/inflight.A-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const AClient = ${A._toInflightType(this)};
+            const AClient = ${A._toInflightType()};
             const client = new AClient({
               $this_counter: ${$stdlib.core.liftObject(this.counter)},
             });
@@ -141,7 +141,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
             $a: ${$stdlib.core.liftObject(a)},
             $a_field: ${$stdlib.core.liftObject(a.field)},
           })
@@ -150,7 +150,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/tools/hangar/__snapshots__/test_corpus/valid/capture_tokens.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/capture_tokens.test.w_compile_tf-aws.md
@@ -229,14 +229,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.MyResource-1.js")({
+          require("${__dirname}/inflight.MyResource-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const MyResourceClient = ${MyResource._toInflightType(this)};
+            const MyResourceClient = ${MyResource._toInflightType()};
             const client = new MyResourceClient({
               $this_api_url: ${$stdlib.core.liftObject(this.api.url)},
               $this_url: ${$stdlib.core.liftObject(this.url)},
@@ -272,7 +272,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
             $r: ${$stdlib.core.liftObject(r)},
           })
         `;
@@ -280,7 +280,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -308,7 +308,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure2-1.js")({
+          require("${__dirname}/inflight.$Closure2-1.js")({
             $MyResource: ${$stdlib.core.liftObject(MyResource)},
             $api_url: ${$stdlib.core.liftObject(api.url)},
             $url: ${$stdlib.core.liftObject(url)},
@@ -318,7 +318,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure2Client = ${$Closure2._toInflightType(this)};
+            const $Closure2Client = ${$Closure2._toInflightType()};
             const client = new $Closure2Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/tools/hangar/__snapshots__/test_corpus/valid/captures.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/captures.test.w_compile_tf-aws.md
@@ -647,7 +647,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
             $bucket1: ${$stdlib.core.liftObject(bucket1)},
             $bucket2: ${$stdlib.core.liftObject(bucket2)},
             $bucket3: ${$stdlib.core.liftObject(bucket3)},
@@ -657,7 +657,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -687,7 +687,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure2-1.js")({
+          require("${__dirname}/inflight.$Closure2-1.js")({
             $handler: ${$stdlib.core.liftObject(handler)},
           })
         `;
@@ -695,7 +695,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure2Client = ${$Closure2._toInflightType(this)};
+            const $Closure2Client = ${$Closure2._toInflightType()};
             const client = new $Closure2Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -723,7 +723,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure3-1.js")({
+          require("${__dirname}/inflight.$Closure3-1.js")({
             $headers: ${$stdlib.core.liftObject(headers)},
           })
         `;
@@ -731,7 +731,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure3Client = ${$Closure3._toInflightType(this)};
+            const $Closure3Client = ${$Closure3._toInflightType()};
             const client = new $Closure3Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/tools/hangar/__snapshots__/test_corpus/valid/class.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/class.test.w_compile_tf-aws.md
@@ -371,14 +371,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.C1-1.js")({
+          require("${__dirname}/inflight.C1-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const C1Client = ${C1._toInflightType(this)};
+            const C1Client = ${C1._toInflightType()};
             const client = new C1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -397,14 +397,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.C2-1.js")({
+          require("${__dirname}/inflight.C2-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const C2Client = ${C2._toInflightType(this)};
+            const C2Client = ${C2._toInflightType()};
             const client = new C2Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -426,14 +426,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.C3-1.js")({
+          require("${__dirname}/inflight.C3-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const C3Client = ${C3._toInflightType(this)};
+            const C3Client = ${C3._toInflightType()};
             const client = new C3Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -454,14 +454,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.C4-1.js")({
+          require("${__dirname}/inflight.C4-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const C4Client = ${C4._toInflightType(this)};
+            const C4Client = ${C4._toInflightType()};
             const client = new C4Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -479,14 +479,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.C5-1.js")({
+          require("${__dirname}/inflight.C5-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const C5Client = ${C5._toInflightType(this)};
+            const C5Client = ${C5._toInflightType()};
             const client = new C5Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -506,7 +506,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
             $c5: ${$stdlib.core.liftObject(c5)},
           })
         `;
@@ -514,7 +514,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -541,14 +541,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.Person-1.js")({
+          require("${__dirname}/inflight.Person-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const PersonClient = ${Person._toInflightType(this)};
+            const PersonClient = ${Person._toInflightType()};
             const client = new PersonClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -567,7 +567,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.Student-1.js")({
+          require("${__dirname}/inflight.Student-1.js")({
             $Person: ${$stdlib.core.liftObject(Person)},
           })
         `;
@@ -575,7 +575,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const StudentClient = ${Student._toInflightType(this)};
+            const StudentClient = ${Student._toInflightType()};
             const client = new StudentClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -594,7 +594,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.PaidStudent-1.js")({
+          require("${__dirname}/inflight.PaidStudent-1.js")({
             $Student: ${$stdlib.core.liftObject(Student)},
           })
         `;
@@ -602,7 +602,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const PaidStudentClient = ${PaidStudent._toInflightType(this)};
+            const PaidStudentClient = ${PaidStudent._toInflightType()};
             const client = new PaidStudentClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -622,7 +622,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure2-1.js")({
+          require("${__dirname}/inflight.$Closure2-1.js")({
             $student_hrlyWage: ${$stdlib.core.liftObject(student.hrlyWage)},
             $student_major: ${$stdlib.core.liftObject(student.major)},
             $student_name: ${$stdlib.core.liftObject(student.name)},
@@ -632,7 +632,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure2Client = ${$Closure2._toInflightType(this)};
+            const $Closure2Client = ${$Closure2._toInflightType()};
             const client = new $Closure2Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -661,7 +661,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.TeacherAid-1.js")({
+          require("${__dirname}/inflight.TeacherAid-1.js")({
             $PaidStudent: ${$stdlib.core.liftObject(PaidStudent)},
           })
         `;
@@ -669,7 +669,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const TeacherAidClient = ${TeacherAid._toInflightType(this)};
+            const TeacherAidClient = ${TeacherAid._toInflightType()};
             const client = new TeacherAidClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -689,7 +689,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure3-1.js")({
+          require("${__dirname}/inflight.$Closure3-1.js")({
             $ta_hrlyWage: ${$stdlib.core.liftObject(ta.hrlyWage)},
           })
         `;
@@ -697,7 +697,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure3Client = ${$Closure3._toInflightType(this)};
+            const $Closure3Client = ${$Closure3._toInflightType()};
             const client = new $Closure3Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -723,14 +723,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.A-1.js")({
+          require("${__dirname}/inflight.A-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const AClient = ${A._toInflightType(this)};
+            const AClient = ${A._toInflightType()};
             const client = new AClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -755,7 +755,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.B-1.js")({
+          require("${__dirname}/inflight.B-1.js")({
             $A: ${$stdlib.core.liftObject(A)},
           })
         `;
@@ -763,7 +763,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const BClient = ${B._toInflightType(this)};
+            const BClient = ${B._toInflightType()};
             const client = new BClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -783,7 +783,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure4-1.js")({
+          require("${__dirname}/inflight.$Closure4-1.js")({
             $B: ${$stdlib.core.liftObject(B)},
           })
         `;
@@ -791,7 +791,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure4Client = ${$Closure4._toInflightType(this)};
+            const $Closure4Client = ${$Closure4._toInflightType()};
             const client = new $Closure4Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -809,14 +809,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.Bar-1.js")({
+          require("${__dirname}/inflight.Bar-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const BarClient = ${Bar._toInflightType(this)};
+            const BarClient = ${Bar._toInflightType()};
             const client = new BarClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -834,7 +834,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.Foo-1.js")({
+          require("${__dirname}/inflight.Foo-1.js")({
             $Bar: ${$stdlib.core.liftObject(Bar)},
           })
         `;
@@ -842,7 +842,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const FooClient = ${Foo._toInflightType(this)};
+            const FooClient = ${Foo._toInflightType()};
             const client = new FooClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -860,7 +860,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.Baz-1.js")({
+          require("${__dirname}/inflight.Baz-1.js")({
             $Bar: ${$stdlib.core.liftObject(Bar)},
           })
         `;
@@ -868,7 +868,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const BazClient = ${Baz._toInflightType(this)};
+            const BazClient = ${Baz._toInflightType()};
             const client = new BazClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -886,14 +886,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.Boom-1.js")({
+          require("${__dirname}/inflight.Boom-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const BoomClient = ${Boom._toInflightType(this)};
+            const BoomClient = ${Boom._toInflightType()};
             const client = new BoomClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -911,7 +911,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.Bam-1.js")({
+          require("${__dirname}/inflight.Bam-1.js")({
             $Boom: ${$stdlib.core.liftObject(Boom)},
           })
         `;
@@ -919,7 +919,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const BamClient = ${Bam._toInflightType(this)};
+            const BamClient = ${Bam._toInflightType()};
             const client = new BamClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/tools/hangar/__snapshots__/test_corpus/valid/closure_class.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/closure_class.test.w_compile_tf-aws.md
@@ -82,14 +82,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.MyClosure-1.js")({
+          require("${__dirname}/inflight.MyClosure-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const MyClosureClient = ${MyClosure._toInflightType(this)};
+            const MyClosureClient = ${MyClosure._toInflightType()};
             const client = new MyClosureClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -109,7 +109,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
             $fn: ${$stdlib.core.liftObject(fn)},
           })
         `;
@@ -117,7 +117,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/tools/hangar/__snapshots__/test_corpus/valid/construct-base.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/construct-base.test.w_compile_tf-aws.md
@@ -67,14 +67,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.WingResource-1.js")({
+          require("${__dirname}/inflight.WingResource-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const WingResourceClient = ${WingResource._toInflightType(this)};
+            const WingResourceClient = ${WingResource._toInflightType()};
             const client = new WingResourceClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/tools/hangar/__snapshots__/test_corpus/valid/custom_obj_id.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/custom_obj_id.test.w_compile_tf-aws.md
@@ -51,14 +51,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.Foo-1.js")({
+          require("${__dirname}/inflight.Foo-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const FooClient = ${Foo._toInflightType(this)};
+            const FooClient = ${Foo._toInflightType()};
             const client = new FooClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/tools/hangar/__snapshots__/test_corpus/valid/debug_env.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/debug_env.test.w_compile_tf-aws.md
@@ -53,14 +53,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.A-1.js")({
+          require("${__dirname}/inflight.A-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const AClient = ${A._toInflightType(this)};
+            const AClient = ${A._toInflightType()};
             const client = new AClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/tools/hangar/__snapshots__/test_corpus/valid/deep_equality.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/deep_equality.test.w_compile_tf-aws.md
@@ -293,7 +293,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
             $numA: ${$stdlib.core.liftObject(numA)},
             $numB: ${$stdlib.core.liftObject(numB)},
             $strA: ${$stdlib.core.liftObject(strA)},
@@ -304,7 +304,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -335,7 +335,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure2-1.js")({
+          require("${__dirname}/inflight.$Closure2-1.js")({
             $numA: ${$stdlib.core.liftObject(numA)},
             $numC: ${$stdlib.core.liftObject(numC)},
             $strA: ${$stdlib.core.liftObject(strA)},
@@ -346,7 +346,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure2Client = ${$Closure2._toInflightType(this)};
+            const $Closure2Client = ${$Closure2._toInflightType()};
             const client = new $Closure2Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -377,7 +377,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure3-1.js")({
+          require("${__dirname}/inflight.$Closure3-1.js")({
             $jsonA: ${$stdlib.core.liftObject(jsonA)},
             $jsonB: ${$stdlib.core.liftObject(jsonB)},
           })
@@ -386,7 +386,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure3Client = ${$Closure3._toInflightType(this)};
+            const $Closure3Client = ${$Closure3._toInflightType()};
             const client = new $Closure3Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -415,7 +415,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure4-1.js")({
+          require("${__dirname}/inflight.$Closure4-1.js")({
             $jsonA: ${$stdlib.core.liftObject(jsonA)},
             $jsonB: ${$stdlib.core.liftObject(jsonB)},
             $jsonC: ${$stdlib.core.liftObject(jsonC)},
@@ -425,7 +425,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure4Client = ${$Closure4._toInflightType(this)};
+            const $Closure4Client = ${$Closure4._toInflightType()};
             const client = new $Closure4Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -455,7 +455,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure5-1.js")({
+          require("${__dirname}/inflight.$Closure5-1.js")({
             $setA: ${$stdlib.core.liftObject(setA)},
             $setB: ${$stdlib.core.liftObject(setB)},
           })
@@ -464,7 +464,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure5Client = ${$Closure5._toInflightType(this)};
+            const $Closure5Client = ${$Closure5._toInflightType()};
             const client = new $Closure5Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -493,7 +493,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure6-1.js")({
+          require("${__dirname}/inflight.$Closure6-1.js")({
             $setA: ${$stdlib.core.liftObject(setA)},
             $setB: ${$stdlib.core.liftObject(setB)},
             $setC: ${$stdlib.core.liftObject(setC)},
@@ -503,7 +503,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure6Client = ${$Closure6._toInflightType(this)};
+            const $Closure6Client = ${$Closure6._toInflightType()};
             const client = new $Closure6Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -533,7 +533,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure7-1.js")({
+          require("${__dirname}/inflight.$Closure7-1.js")({
             $mapA: ${$stdlib.core.liftObject(mapA)},
             $mapB: ${$stdlib.core.liftObject(mapB)},
           })
@@ -542,7 +542,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure7Client = ${$Closure7._toInflightType(this)};
+            const $Closure7Client = ${$Closure7._toInflightType()};
             const client = new $Closure7Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -571,7 +571,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure8-1.js")({
+          require("${__dirname}/inflight.$Closure8-1.js")({
             $mapA: ${$stdlib.core.liftObject(mapA)},
             $mapB: ${$stdlib.core.liftObject(mapB)},
             $mapC: ${$stdlib.core.liftObject(mapC)},
@@ -581,7 +581,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure8Client = ${$Closure8._toInflightType(this)};
+            const $Closure8Client = ${$Closure8._toInflightType()};
             const client = new $Closure8Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -611,7 +611,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure9-1.js")({
+          require("${__dirname}/inflight.$Closure9-1.js")({
             $arrayA: ${$stdlib.core.liftObject(arrayA)},
             $arrayB: ${$stdlib.core.liftObject(arrayB)},
           })
@@ -620,7 +620,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure9Client = ${$Closure9._toInflightType(this)};
+            const $Closure9Client = ${$Closure9._toInflightType()};
             const client = new $Closure9Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -649,7 +649,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure10-1.js")({
+          require("${__dirname}/inflight.$Closure10-1.js")({
             $arrayA: ${$stdlib.core.liftObject(arrayA)},
             $arrayB: ${$stdlib.core.liftObject(arrayB)},
             $arrayC: ${$stdlib.core.liftObject(arrayC)},
@@ -659,7 +659,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure10Client = ${$Closure10._toInflightType(this)};
+            const $Closure10Client = ${$Closure10._toInflightType()};
             const client = new $Closure10Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -689,7 +689,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure11-1.js")({
+          require("${__dirname}/inflight.$Closure11-1.js")({
             $cat1: ${$stdlib.core.liftObject(cat1)},
             $cat2: ${$stdlib.core.liftObject(cat2)},
           })
@@ -698,7 +698,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure11Client = ${$Closure11._toInflightType(this)};
+            const $Closure11Client = ${$Closure11._toInflightType()};
             const client = new $Closure11Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -727,7 +727,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure12-1.js")({
+          require("${__dirname}/inflight.$Closure12-1.js")({
             $cat1: ${$stdlib.core.liftObject(cat1)},
             $cat2: ${$stdlib.core.liftObject(cat2)},
             $cat3: ${$stdlib.core.liftObject(cat3)},
@@ -737,7 +737,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure12Client = ${$Closure12._toInflightType(this)};
+            const $Closure12Client = ${$Closure12._toInflightType()};
             const client = new $Closure12Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/tools/hangar/__snapshots__/test_corpus/valid/double_reference.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/double_reference.test.w_compile_tf-aws.md
@@ -118,7 +118,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.Foo-1.js")({
+          require("${__dirname}/inflight.Foo-1.js")({
             $initCount: ${$stdlib.core.liftObject(initCount)},
           })
         `;
@@ -126,7 +126,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const FooClient = ${Foo._toInflightType(this)};
+            const FooClient = ${Foo._toInflightType()};
             const client = new FooClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -153,14 +153,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.Bar-1.js")({
+          require("${__dirname}/inflight.Bar-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const BarClient = ${Bar._toInflightType(this)};
+            const BarClient = ${Bar._toInflightType()};
             const client = new BarClient({
               $this_foo: ${$stdlib.core.liftObject(this.foo)},
             });
@@ -192,7 +192,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
             $bar: ${$stdlib.core.liftObject(bar)},
             $bar_foo: ${$stdlib.core.liftObject(bar.foo)},
             $initCount: ${$stdlib.core.liftObject(initCount)},
@@ -202,7 +202,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/tools/hangar/__snapshots__/test_corpus/valid/doubler.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/doubler.test.w_compile_tf-aws.md
@@ -263,14 +263,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.Doubler-1.js")({
+          require("${__dirname}/inflight.Doubler-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const DoublerClient = ${Doubler._toInflightType(this)};
+            const DoublerClient = ${Doubler._toInflightType()};
             const client = new DoublerClient({
               $this_func: ${$stdlib.core.liftObject(this.func)},
             });
@@ -302,14 +302,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -335,7 +335,7 @@ class $Root extends $stdlib.std.Resource {
           }
           static _toInflightType() {
             return `
-              require("./inflight.$Closure2-1.js")({
+              require("${__dirname}/inflight.$Closure2-1.js")({
                 $handler: ${$stdlib.core.liftObject(handler)},
                 $std_Json: ${$stdlib.core.liftObject($stdlib.core.toLiftableModuleType(std.Json, "@winglang/sdk/std", "Json"))},
                 $std_Number: ${$stdlib.core.liftObject($stdlib.core.toLiftableModuleType(std.Number, "@winglang/sdk/std", "Number"))},
@@ -345,7 +345,7 @@ class $Root extends $stdlib.std.Resource {
           _toInflight() {
             return `
               (await (async () => {
-                const $Closure2Client = ${$Closure2._toInflightType(this)};
+                const $Closure2Client = ${$Closure2._toInflightType()};
                 const client = new $Closure2Client({
                 });
                 if (client.$inflight_init) { await client.$inflight_init(); }
@@ -369,14 +369,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.Doubler2-1.js")({
+          require("${__dirname}/inflight.Doubler2-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const Doubler2Client = ${Doubler2._toInflightType(this)};
+            const Doubler2Client = ${Doubler2._toInflightType()};
             const client = new Doubler2Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -396,14 +396,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure3-1.js")({
+          require("${__dirname}/inflight.$Closure3-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure3Client = ${$Closure3._toInflightType(this)};
+            const $Closure3Client = ${$Closure3._toInflightType()};
             const client = new $Closure3Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -423,7 +423,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure4-1.js")({
+          require("${__dirname}/inflight.$Closure4-1.js")({
             $f: ${$stdlib.core.liftObject(f)},
           })
         `;
@@ -431,7 +431,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure4Client = ${$Closure4._toInflightType(this)};
+            const $Closure4Client = ${$Closure4._toInflightType()};
             const client = new $Closure4Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/tools/hangar/__snapshots__/test_corpus/valid/enums.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/enums.test.w_compile_tf-aws.md
@@ -60,7 +60,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
             $SomeEnum: ${$stdlib.core.liftObject(SomeEnum)},
             $one: ${$stdlib.core.liftObject(one)},
             $two: ${$stdlib.core.liftObject(two)},
@@ -70,7 +70,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/tools/hangar/__snapshots__/test_corpus/valid/expressions_string_interpolation.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/expressions_string_interpolation.test.w_compile_tf-aws.md
@@ -61,7 +61,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
             $number: ${$stdlib.core.liftObject(number)},
           })
         `;
@@ -69,7 +69,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/tools/hangar/__snapshots__/test_corpus/valid/extern_implementation.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/extern_implementation.test.w_compile_tf-aws.md
@@ -113,14 +113,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.Foo-1.js")({
+          require("${__dirname}/inflight.Foo-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const FooClient = ${Foo._toInflightType(this)};
+            const FooClient = ${Foo._toInflightType()};
             const client = new FooClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -148,7 +148,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
             $f: ${$stdlib.core.liftObject(f)},
           })
         `;
@@ -156,7 +156,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -184,7 +184,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure2-1.js")({
+          require("${__dirname}/inflight.$Closure2-1.js")({
             $Foo: ${$stdlib.core.liftObject(Foo)},
           })
         `;
@@ -192,7 +192,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure2Client = ${$Closure2._toInflightType(this)};
+            const $Closure2Client = ${$Closure2._toInflightType()};
             const client = new $Closure2Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/tools/hangar/__snapshots__/test_corpus/valid/file_counter.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/file_counter.test.w_compile_tf-aws.md
@@ -225,7 +225,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
             $bucket: ${$stdlib.core.liftObject(bucket)},
             $counter: ${$stdlib.core.liftObject(counter)},
           })
@@ -234,7 +234,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/tools/hangar/__snapshots__/test_corpus/valid/for_loop.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/for_loop.test.w_compile_tf-aws.md
@@ -189,14 +189,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -214,14 +214,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.Foo-1.js")({
+          require("${__dirname}/inflight.Foo-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const FooClient = ${Foo._toInflightType(this)};
+            const FooClient = ${Foo._toInflightType()};
             const client = new FooClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/tools/hangar/__snapshots__/test_corpus/valid/forward_decl.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/forward_decl.test.w_compile_tf-aws.md
@@ -59,14 +59,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.R-1.js")({
+          require("${__dirname}/inflight.R-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const RClient = ${R._toInflightType(this)};
+            const RClient = ${R._toInflightType()};
             const client = new RClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/tools/hangar/__snapshots__/test_corpus/valid/function_returns_function.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/function_returns_function.test.w_compile_tf-aws.md
@@ -68,14 +68,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/tools/hangar/__snapshots__/test_corpus/valid/function_type.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/function_type.test.w_compile_tf-aws.md
@@ -114,14 +114,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -141,14 +141,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure2-1.js")({
+          require("${__dirname}/inflight.$Closure2-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure2Client = ${$Closure2._toInflightType(this)};
+            const $Closure2Client = ${$Closure2._toInflightType()};
             const client = new $Closure2Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -168,14 +168,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure3-1.js")({
+          require("${__dirname}/inflight.$Closure3-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure3Client = ${$Closure3._toInflightType(this)};
+            const $Closure3Client = ${$Closure3._toInflightType()};
             const client = new $Closure3Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -197,14 +197,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.C-1.js")({
+          require("${__dirname}/inflight.C-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const CClient = ${C._toInflightType(this)};
+            const CClient = ${C._toInflightType()};
             const client = new CClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/tools/hangar/__snapshots__/test_corpus/valid/function_variadic_arguments.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/function_variadic_arguments.test.w_compile_tf-aws.md
@@ -102,14 +102,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.A-1.js")({
+          require("${__dirname}/inflight.A-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const AClient = ${A._toInflightType(this)};
+            const AClient = ${A._toInflightType()};
             const client = new AClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -128,7 +128,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.B-1.js")({
+          require("${__dirname}/inflight.B-1.js")({
             $A: ${$stdlib.core.liftObject(A)},
           })
         `;
@@ -136,7 +136,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const BClient = ${B._toInflightType(this)};
+            const BClient = ${B._toInflightType()};
             const client = new BClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/tools/hangar/__snapshots__/test_corpus/valid/hello.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/hello.test.w_compile_tf-aws.md
@@ -203,7 +203,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
             $bucket: ${$stdlib.core.liftObject(bucket)},
           })
         `;
@@ -211,7 +211,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/tools/hangar/__snapshots__/test_corpus/valid/identical_inflights.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/identical_inflights.test.w_compile_tf-aws.md
@@ -77,14 +77,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -104,14 +104,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure2-1.js")({
+          require("${__dirname}/inflight.$Closure2-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure2Client = ${$Closure2._toInflightType(this)};
+            const $Closure2Client = ${$Closure2._toInflightType()};
             const client = new $Closure2Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/tools/hangar/__snapshots__/test_corpus/valid/impl_interface.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/impl_interface.test.w_compile_tf-aws.md
@@ -151,14 +151,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.A-1.js")({
+          require("${__dirname}/inflight.A-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const AClient = ${A._toInflightType(this)};
+            const AClient = ${A._toInflightType()};
             const client = new AClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -178,7 +178,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
             $x: ${$stdlib.core.liftObject(x)},
           })
         `;
@@ -186,7 +186,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -218,14 +218,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.r-1.js")({
+          require("${__dirname}/inflight.r-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const rClient = ${r._toInflightType(this)};
+            const rClient = ${r._toInflightType()};
             const client = new rClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -245,7 +245,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure2-1.js")({
+          require("${__dirname}/inflight.$Closure2-1.js")({
             $i3: ${$stdlib.core.liftObject(i3)},
           })
         `;
@@ -253,7 +253,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure2Client = ${$Closure2._toInflightType(this)};
+            const $Closure2Client = ${$Closure2._toInflightType()};
             const client = new $Closure2Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -279,14 +279,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.Dog-1.js")({
+          require("${__dirname}/inflight.Dog-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const DogClient = ${Dog._toInflightType(this)};
+            const DogClient = ${Dog._toInflightType()};
             const client = new DogClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -304,7 +304,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.Terrier-1.js")({
+          require("${__dirname}/inflight.Terrier-1.js")({
             $Dog: ${$stdlib.core.liftObject(Dog)},
           })
         `;
@@ -312,7 +312,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const TerrierClient = ${Terrier._toInflightType(this)};
+            const TerrierClient = ${Terrier._toInflightType()};
             const client = new TerrierClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/tools/hangar/__snapshots__/test_corpus/valid/in_scope_construct.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/in_scope_construct.test.w_compile_tf-aws.md
@@ -52,14 +52,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.MyClass-1.js")({
+          require("${__dirname}/inflight.MyClass-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const MyClassClient = ${MyClass._toInflightType(this)};
+            const MyClassClient = ${MyClass._toInflightType()};
             const client = new MyClassClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/tools/hangar/__snapshots__/test_corpus/valid/inference.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/inference.test.w_compile_tf-aws.md
@@ -255,14 +255,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/tools/hangar/__snapshots__/test_corpus/valid/inflight-subscribers.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/inflight-subscribers.test.w_compile_tf-aws.md
@@ -331,14 +331,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -358,14 +358,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure2-1.js")({
+          require("${__dirname}/inflight.$Closure2-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure2Client = ${$Closure2._toInflightType(this)};
+            const $Closure2Client = ${$Closure2._toInflightType()};
             const client = new $Closure2Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/tools/hangar/__snapshots__/test_corpus/valid/inflight_capture_static.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/inflight_capture_static.test.w_compile_tf-aws.md
@@ -164,14 +164,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.Preflight-1.js")({
+          require("${__dirname}/inflight.Preflight-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const PreflightClient = ${Preflight._toInflightType(this)};
+            const PreflightClient = ${Preflight._toInflightType()};
             const client = new PreflightClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -189,14 +189,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.OuterInflight-1.js")({
+          require("${__dirname}/inflight.OuterInflight-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const OuterInflightClient = ${OuterInflight._toInflightType(this)};
+            const OuterInflightClient = ${OuterInflight._toInflightType()};
             const client = new OuterInflightClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -216,7 +216,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
             $Preflight: ${$stdlib.core.liftObject(Preflight)},
           })
         `;
@@ -224,7 +224,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -252,7 +252,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure2-1.js")({
+          require("${__dirname}/inflight.$Closure2-1.js")({
             $OuterInflight: ${$stdlib.core.liftObject(OuterInflight)},
           })
         `;
@@ -260,7 +260,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure2Client = ${$Closure2._toInflightType(this)};
+            const $Closure2Client = ${$Closure2._toInflightType()};
             const client = new $Closure2Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -280,14 +280,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure3-1.js")({
+          require("${__dirname}/inflight.$Closure3-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure3Client = ${$Closure3._toInflightType(this)};
+            const $Closure3Client = ${$Closure3._toInflightType()};
             const client = new $Closure3Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -307,7 +307,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure4-1.js")({
+          require("${__dirname}/inflight.$Closure4-1.js")({
             $util_Util: ${$stdlib.core.liftObject($stdlib.core.toLiftableModuleType(util.Util, "@winglang/sdk/util", "Util"))},
           })
         `;
@@ -315,7 +315,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure4Client = ${$Closure4._toInflightType(this)};
+            const $Closure4Client = ${$Closure4._toInflightType()};
             const client = new $Closure4Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/tools/hangar/__snapshots__/test_corpus/valid/inflight_class_as_struct_members.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/inflight_class_as_struct_members.test.w_compile_tf-aws.md
@@ -93,14 +93,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.Foo-1.js")({
+          require("${__dirname}/inflight.Foo-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const FooClient = ${Foo._toInflightType(this)};
+            const FooClient = ${Foo._toInflightType()};
             const client = new FooClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -120,7 +120,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
             $Foo: ${$stdlib.core.liftObject(Foo)},
           })
         `;
@@ -128,7 +128,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -148,7 +148,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure2-1.js")({
+          require("${__dirname}/inflight.$Closure2-1.js")({
             $getBar: ${$stdlib.core.liftObject(getBar)},
           })
         `;
@@ -156,7 +156,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure2Client = ${$Closure2._toInflightType(this)};
+            const $Closure2Client = ${$Closure2._toInflightType()};
             const client = new $Closure2Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/tools/hangar/__snapshots__/test_corpus/valid/inflight_class_capture_const.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/inflight_class_capture_const.test.w_compile_tf-aws.md
@@ -74,7 +74,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.Foo-1.js")({
+          require("${__dirname}/inflight.Foo-1.js")({
             $myConst: ${$stdlib.core.liftObject(myConst)},
           })
         `;
@@ -82,7 +82,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const FooClient = ${Foo._toInflightType(this)};
+            const FooClient = ${Foo._toInflightType()};
             const client = new FooClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -110,7 +110,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
             $Foo: ${$stdlib.core.liftObject(Foo)},
             $myConst: ${$stdlib.core.liftObject(myConst)},
           })
@@ -119,7 +119,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/tools/hangar/__snapshots__/test_corpus/valid/inflight_class_definitions.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/inflight_class_definitions.test.w_compile_tf-aws.md
@@ -190,14 +190,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.A-1.js")({
+          require("${__dirname}/inflight.A-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const AClient = ${A._toInflightType(this)};
+            const AClient = ${A._toInflightType()};
             const client = new AClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -215,14 +215,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.B-1.js")({
+          require("${__dirname}/inflight.B-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const BClient = ${B._toInflightType(this)};
+            const BClient = ${B._toInflightType()};
             const client = new BClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -242,14 +242,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -273,14 +273,14 @@ class $Root extends $stdlib.std.Resource {
           }
           static _toInflightType() {
             return `
-              require("./inflight.E-1.js")({
+              require("${__dirname}/inflight.E-1.js")({
               })
             `;
           }
           _toInflight() {
             return `
               (await (async () => {
-                const EClient = ${E._toInflightType(this)};
+                const EClient = ${E._toInflightType()};
                 const client = new EClient({
                 });
                 if (client.$inflight_init) { await client.$inflight_init(); }
@@ -300,14 +300,14 @@ class $Root extends $stdlib.std.Resource {
           }
           static _toInflightType() {
             return `
-              require("./inflight.F-1.js")({
+              require("${__dirname}/inflight.F-1.js")({
               })
             `;
           }
           _toInflight() {
             return `
               (await (async () => {
-                const FClient = ${F._toInflightType(this)};
+                const FClient = ${F._toInflightType()};
                 const client = new FClient({
                 });
                 if (client.$inflight_init) { await client.$inflight_init(); }
@@ -328,7 +328,7 @@ class $Root extends $stdlib.std.Resource {
           }
           static _toInflightType() {
             return `
-              require("./inflight.$Closure2-1.js")({
+              require("${__dirname}/inflight.$Closure2-1.js")({
                 $F: ${$stdlib.core.liftObject(F)},
               })
             `;
@@ -336,7 +336,7 @@ class $Root extends $stdlib.std.Resource {
           _toInflight() {
             return `
               (await (async () => {
-                const $Closure2Client = ${$Closure2._toInflightType(this)};
+                const $Closure2Client = ${$Closure2._toInflightType()};
                 const client = new $Closure2Client({
                 });
                 if (client.$inflight_init) { await client.$inflight_init(); }
@@ -355,14 +355,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.D-1.js")({
+          require("${__dirname}/inflight.D-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const DClient = ${D._toInflightType(this)};
+            const DClient = ${D._toInflightType()};
             const client = new DClient({
               $this_inner: ${$stdlib.core.liftObject(this.inner)},
             });
@@ -394,7 +394,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure3-1.js")({
+          require("${__dirname}/inflight.$Closure3-1.js")({
             $B: ${$stdlib.core.liftObject(B)},
             $a: ${$stdlib.core.liftObject(a)},
             $d: ${$stdlib.core.liftObject(d)},
@@ -406,7 +406,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure3Client = ${$Closure3._toInflightType(this)};
+            const $Closure3Client = ${$Closure3._toInflightType()};
             const client = new $Closure3Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/tools/hangar/__snapshots__/test_corpus/valid/inflight_class_inner_capture_mutable.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/inflight_class_inner_capture_mutable.test.w_compile_tf-aws.md
@@ -71,14 +71,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/tools/hangar/__snapshots__/test_corpus/valid/inflight_class_inside_inflight_closure.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/inflight_class_inside_inflight_closure.test.w_compile_tf-aws.md
@@ -258,7 +258,7 @@ class $Root extends $stdlib.std.Resource {
           }
           static _toInflightType() {
             return `
-              require("./inflight.$Closure1-1.js")({
+              require("${__dirname}/inflight.$Closure1-1.js")({
                 $__parent_this_1_b: ${$stdlib.core.liftObject(__parent_this_1.b)},
               })
             `;
@@ -266,7 +266,7 @@ class $Root extends $stdlib.std.Resource {
           _toInflight() {
             return `
               (await (async () => {
-                const $Closure1Client = ${$Closure1._toInflightType(this)};
+                const $Closure1Client = ${$Closure1._toInflightType()};
                 const client = new $Closure1Client({
                 });
                 if (client.$inflight_init) { await client.$inflight_init(); }
@@ -291,14 +291,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.PreflightClass-1.js")({
+          require("${__dirname}/inflight.PreflightClass-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const PreflightClassClient = ${PreflightClass._toInflightType(this)};
+            const PreflightClassClient = ${PreflightClass._toInflightType()};
             const client = new PreflightClassClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -318,7 +318,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure2-1.js")({
+          require("${__dirname}/inflight.$Closure2-1.js")({
             $f: ${$stdlib.core.liftObject(f)},
           })
         `;
@@ -326,7 +326,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure2Client = ${$Closure2._toInflightType(this)};
+            const $Closure2Client = ${$Closure2._toInflightType()};
             const client = new $Closure2Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -354,14 +354,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure3-1.js")({
+          require("${__dirname}/inflight.$Closure3-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure3Client = ${$Closure3._toInflightType(this)};
+            const $Closure3Client = ${$Closure3._toInflightType()};
             const client = new $Closure3Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/tools/hangar/__snapshots__/test_corpus/valid/inflight_class_modifiers.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/inflight_class_modifiers.test.w_compile_tf-aws.md
@@ -56,14 +56,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.C-1.js")({
+          require("${__dirname}/inflight.C-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const CClient = ${C._toInflightType(this)};
+            const CClient = ${C._toInflightType()};
             const client = new CClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/tools/hangar/__snapshots__/test_corpus/valid/inflight_class_outside_inflight_closure.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/inflight_class_outside_inflight_closure.test.w_compile_tf-aws.md
@@ -80,14 +80,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.BinaryOperation-1.js")({
+          require("${__dirname}/inflight.BinaryOperation-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const BinaryOperationClient = ${BinaryOperation._toInflightType(this)};
+            const BinaryOperationClient = ${BinaryOperation._toInflightType()};
             const client = new BinaryOperationClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -116,7 +116,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
             $BinaryOperation: ${$stdlib.core.liftObject(BinaryOperation)},
           })
         `;
@@ -124,7 +124,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/tools/hangar/__snapshots__/test_corpus/valid/inflight_class_structural_interace_handler.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/inflight_class_structural_interace_handler.test.w_compile_tf-aws.md
@@ -84,14 +84,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.NotGoo-1.js")({
+          require("${__dirname}/inflight.NotGoo-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const NotGooClient = ${NotGoo._toInflightType(this)};
+            const NotGooClient = ${NotGoo._toInflightType()};
             const client = new NotGooClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -111,7 +111,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
             $NotGoo: ${$stdlib.core.liftObject(NotGoo)},
           })
         `;
@@ -119,7 +119,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/tools/hangar/__snapshots__/test_corpus/valid/inflight_class_without_init.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/inflight_class_without_init.test.w_compile_tf-aws.md
@@ -70,14 +70,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.Foo-1.js")({
+          require("${__dirname}/inflight.Foo-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const FooClient = ${Foo._toInflightType(this)};
+            const FooClient = ${Foo._toInflightType()};
             const client = new FooClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -97,7 +97,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
             $Foo: ${$stdlib.core.liftObject(Foo)},
           })
         `;
@@ -105,7 +105,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/tools/hangar/__snapshots__/test_corpus/valid/inflight_closure_inside_preflight_closure.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/inflight_closure_inside_preflight_closure.test.w_compile_tf-aws.md
@@ -77,14 +77,14 @@ class $Root extends $stdlib.std.Resource {
             }
             static _toInflightType() {
               return `
-                require("./inflight.$Closure1-1.js")({
+                require("${__dirname}/inflight.$Closure1-1.js")({
                 })
               `;
             }
             _toInflight() {
               return `
                 (await (async () => {
-                  const $Closure1Client = ${$Closure1._toInflightType(this)};
+                  const $Closure1Client = ${$Closure1._toInflightType()};
                   const client = new $Closure1Client({
                   });
                   if (client.$inflight_init) { await client.$inflight_init(); }
@@ -101,14 +101,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.Foo-1.js")({
+          require("${__dirname}/inflight.Foo-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const FooClient = ${Foo._toInflightType(this)};
+            const FooClient = ${Foo._toInflightType()};
             const client = new FooClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/tools/hangar/__snapshots__/test_corpus/valid/inflight_concat.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/inflight_concat.test.w_compile_tf-aws.md
@@ -57,14 +57,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.R-1.js")({
+          require("${__dirname}/inflight.R-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const RClient = ${R._toInflightType(this)};
+            const RClient = ${R._toInflightType()};
             const client = new RClient({
               $_this_s1_concat___world___: ${$stdlib.core.liftObject((this.s1.concat(" world")))},
             });

--- a/tools/hangar/__snapshots__/test_corpus/valid/inflight_init.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/inflight_init.test.w_compile_tf-aws.md
@@ -202,14 +202,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.Foo-1.js")({
+          require("${__dirname}/inflight.Foo-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const FooClient = ${Foo._toInflightType(this)};
+            const FooClient = ${Foo._toInflightType()};
             const client = new FooClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -234,7 +234,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.FooChild-1.js")({
+          require("${__dirname}/inflight.FooChild-1.js")({
             $Foo: ${$stdlib.core.liftObject(Foo)},
           })
         `;
@@ -242,7 +242,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const FooChildClient = ${FooChild._toInflightType(this)};
+            const FooChildClient = ${FooChild._toInflightType()};
             const client = new FooChildClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -269,7 +269,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
             $Foo: ${$stdlib.core.liftObject(Foo)},
           })
         `;
@@ -277,7 +277,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -297,7 +297,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure2-1.js")({
+          require("${__dirname}/inflight.$Closure2-1.js")({
             $FooChild: ${$stdlib.core.liftObject(FooChild)},
           })
         `;
@@ -305,7 +305,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure2Client = ${$Closure2._toInflightType(this)};
+            const $Closure2Client = ${$Closure2._toInflightType()};
             const client = new $Closure2Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -325,14 +325,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure3-1.js")({
+          require("${__dirname}/inflight.$Closure3-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure3Client = ${$Closure3._toInflightType(this)};
+            const $Closure3Client = ${$Closure3._toInflightType()};
             const client = new $Closure3Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -352,7 +352,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure4-1.js")({
+          require("${__dirname}/inflight.$Closure4-1.js")({
             $jsii_fixture_JsiiClass: ${$stdlib.core.liftObject($stdlib.core.toLiftableModuleType(jsii_fixture.JsiiClass, "jsii-fixture", "JsiiClass"))},
           })
         `;
@@ -360,7 +360,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure4Client = ${$Closure4._toInflightType(this)};
+            const $Closure4Client = ${$Closure4._toInflightType()};
             const client = new $Closure4Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/tools/hangar/__snapshots__/test_corpus/valid/inflights_calling_inflights.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/inflights_calling_inflights.test.w_compile_tf-aws.md
@@ -278,7 +278,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
             $globalBucket: ${$stdlib.core.liftObject(globalBucket)},
           })
         `;
@@ -286,7 +286,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -314,7 +314,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure2-1.js")({
+          require("${__dirname}/inflight.$Closure2-1.js")({
             $storeInBucket: ${$stdlib.core.liftObject(storeInBucket)},
           })
         `;
@@ -322,7 +322,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure2Client = ${$Closure2._toInflightType(this)};
+            const $Closure2Client = ${$Closure2._toInflightType()};
             const client = new $Closure2Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -350,7 +350,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure3-1.js")({
+          require("${__dirname}/inflight.$Closure3-1.js")({
             $func1: ${$stdlib.core.liftObject(func1)},
             $globalBucket: ${$stdlib.core.liftObject(globalBucket)},
           })
@@ -359,7 +359,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure3Client = ${$Closure3._toInflightType(this)};
+            const $Closure3Client = ${$Closure3._toInflightType()};
             const client = new $Closure3Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -392,7 +392,7 @@ class $Root extends $stdlib.std.Resource {
           }
           static _toInflightType() {
             return `
-              require("./inflight.$Closure4-1.js")({
+              require("${__dirname}/inflight.$Closure4-1.js")({
                 $globalBucket: ${$stdlib.core.liftObject(globalBucket)},
               })
             `;
@@ -400,7 +400,7 @@ class $Root extends $stdlib.std.Resource {
           _toInflight() {
             return `
               (await (async () => {
-                const $Closure4Client = ${$Closure4._toInflightType(this)};
+                const $Closure4Client = ${$Closure4._toInflightType()};
                 const client = new $Closure4Client({
                 });
                 if (client.$inflight_init) { await client.$inflight_init(); }
@@ -424,14 +424,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.MyResource-1.js")({
+          require("${__dirname}/inflight.MyResource-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const MyResourceClient = ${MyResource._toInflightType(this)};
+            const MyResourceClient = ${MyResource._toInflightType()};
             const client = new MyResourceClient({
               $this_closure: ${$stdlib.core.liftObject(this.closure)},
             });
@@ -463,7 +463,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure5-1.js")({
+          require("${__dirname}/inflight.$Closure5-1.js")({
             $x: ${$stdlib.core.liftObject(x)},
           })
         `;
@@ -471,7 +471,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure5Client = ${$Closure5._toInflightType(this)};
+            const $Closure5Client = ${$Closure5._toInflightType()};
             const client = new $Closure5Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/tools/hangar/__snapshots__/test_corpus/valid/inherit_stdlib_class.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/inherit_stdlib_class.test.w_compile_tf-aws.md
@@ -290,7 +290,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.AnApi-1.js")({
+          require("${__dirname}/inflight.AnApi-1.js")({
             $cloud_Api: ${$stdlib.core.liftObject($stdlib.core.toLiftableModuleType(cloud.Api, "@winglang/sdk/cloud", "Api"))},
           })
         `;
@@ -298,7 +298,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const AnApiClient = ${AnApi._toInflightType(this)};
+            const AnApiClient = ${AnApi._toInflightType()};
             const client = new AnApiClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -318,14 +318,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -345,7 +345,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure2-1.js")({
+          require("${__dirname}/inflight.$Closure2-1.js")({
             $api_url: ${$stdlib.core.liftObject(api.url)},
             $http_Util: ${$stdlib.core.liftObject($stdlib.core.toLiftableModuleType(http.Util, "@winglang/sdk/http", "Util"))},
           })
@@ -354,7 +354,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure2Client = ${$Closure2._toInflightType(this)};
+            const $Closure2Client = ${$Closure2._toInflightType()};
             const client = new $Closure2Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/tools/hangar/__snapshots__/test_corpus/valid/inheritance_class_inflight.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/inheritance_class_inflight.test.w_compile_tf-aws.md
@@ -101,14 +101,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.FooBase-1.js")({
+          require("${__dirname}/inflight.FooBase-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const FooBaseClient = ${FooBase._toInflightType(this)};
+            const FooBaseClient = ${FooBase._toInflightType()};
             const client = new FooBaseClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -126,7 +126,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.Foo-1.js")({
+          require("${__dirname}/inflight.Foo-1.js")({
             $FooBase: ${$stdlib.core.liftObject(FooBase)},
           })
         `;
@@ -134,7 +134,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const FooClient = ${Foo._toInflightType(this)};
+            const FooClient = ${Foo._toInflightType()};
             const client = new FooClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -154,7 +154,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
             $expect_Util: ${$stdlib.core.liftObject($stdlib.core.toLiftableModuleType(expect.Util, "@winglang/sdk/expect", "Util"))},
             $foo: ${$stdlib.core.liftObject(foo)},
           })
@@ -163,7 +163,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/tools/hangar/__snapshots__/test_corpus/valid/inheritance_class_preflight.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/inheritance_class_preflight.test.w_compile_tf-aws.md
@@ -73,14 +73,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.FooBase-1.js")({
+          require("${__dirname}/inflight.FooBase-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const FooBaseClient = ${FooBase._toInflightType(this)};
+            const FooBaseClient = ${FooBase._toInflightType()};
             const client = new FooBaseClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -104,7 +104,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.Foo-1.js")({
+          require("${__dirname}/inflight.Foo-1.js")({
             $FooBase: ${$stdlib.core.liftObject(FooBase)},
           })
         `;
@@ -112,7 +112,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const FooClient = ${Foo._toInflightType(this)};
+            const FooClient = ${Foo._toInflightType()};
             const client = new FooClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/tools/hangar/__snapshots__/test_corpus/valid/inheritance_interface.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/inheritance_interface.test.w_compile_tf-aws.md
@@ -58,14 +58,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.Baz-1.js")({
+          require("${__dirname}/inflight.Baz-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const BazClient = ${Baz._toInflightType(this)};
+            const BazClient = ${Baz._toInflightType()};
             const client = new BazClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/tools/hangar/__snapshots__/test_corpus/valid/issue_2889.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/issue_2889.test.w_compile_tf-aws.md
@@ -280,7 +280,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
             $std_Json: ${$stdlib.core.liftObject($stdlib.core.toLiftableModuleType(std.Json, "@winglang/sdk/std", "Json"))},
           })
         `;
@@ -288,7 +288,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -308,7 +308,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure2-1.js")({
+          require("${__dirname}/inflight.$Closure2-1.js")({
             $api_url: ${$stdlib.core.liftObject(api.url)},
             $http_Util: ${$stdlib.core.liftObject($stdlib.core.toLiftableModuleType(http.Util, "@winglang/sdk/http", "Util"))},
             $std_Json: ${$stdlib.core.liftObject($stdlib.core.toLiftableModuleType(std.Json, "@winglang/sdk/std", "Json"))},
@@ -318,7 +318,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure2Client = ${$Closure2._toInflightType(this)};
+            const $Closure2Client = ${$Closure2._toInflightType()};
             const client = new $Closure2Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/tools/hangar/__snapshots__/test_corpus/valid/json.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/json.test.w_compile_tf-aws.md
@@ -67,14 +67,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.Foo-1.js")({
+          require("${__dirname}/inflight.Foo-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const FooClient = ${Foo._toInflightType(this)};
+            const FooClient = ${Foo._toInflightType()};
             const client = new FooClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/tools/hangar/__snapshots__/test_corpus/valid/json_bucket.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/json_bucket.test.w_compile_tf-aws.md
@@ -199,7 +199,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
             $b: ${$stdlib.core.liftObject(b)},
             $fileName: ${$stdlib.core.liftObject(fileName)},
           })
@@ -208,7 +208,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -237,7 +237,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure2-1.js")({
+          require("${__dirname}/inflight.$Closure2-1.js")({
             $b: ${$stdlib.core.liftObject(b)},
             $fileName: ${$stdlib.core.liftObject(fileName)},
             $getJson: ${$stdlib.core.liftObject(getJson)},
@@ -248,7 +248,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure2Client = ${$Closure2._toInflightType(this)};
+            const $Closure2Client = ${$Closure2._toInflightType()};
             const client = new $Closure2Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/tools/hangar/__snapshots__/test_corpus/valid/json_static.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/json_static.test.w_compile_tf-aws.md
@@ -83,7 +83,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
             $jj: ${$stdlib.core.liftObject(jj)},
             $std_Json: ${$stdlib.core.liftObject($stdlib.core.toLiftableModuleType(std.Json, "@winglang/sdk/std", "Json"))},
           })
@@ -92,7 +92,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -120,7 +120,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure2-1.js")({
+          require("${__dirname}/inflight.$Closure2-1.js")({
             $std_Json: ${$stdlib.core.liftObject($stdlib.core.toLiftableModuleType(std.Json, "@winglang/sdk/std", "Json"))},
           })
         `;
@@ -128,7 +128,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure2Client = ${$Closure2._toInflightType(this)};
+            const $Closure2Client = ${$Closure2._toInflightType()};
             const client = new $Closure2Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/tools/hangar/__snapshots__/test_corpus/valid/lift_expr_with_this.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/lift_expr_with_this.test.w_compile_tf-aws.md
@@ -73,14 +73,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.Foo-1.js")({
+          require("${__dirname}/inflight.Foo-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const FooClient = ${Foo._toInflightType(this)};
+            const FooClient = ${Foo._toInflightType()};
             const client = new FooClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -100,14 +100,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
               $foo_this_value: ${$stdlib.core.liftObject(foo_this.value)},
             });

--- a/tools/hangar/__snapshots__/test_corpus/valid/lift_redefinition.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/lift_redefinition.test.w_compile_tf-aws.md
@@ -61,7 +61,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
             $y: ${$stdlib.core.liftObject(y)},
           })
         `;
@@ -69,7 +69,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/tools/hangar/__snapshots__/test_corpus/valid/lift_this.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/lift_this.test.w_compile_tf-aws.md
@@ -80,14 +80,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.Foo-1.js")({
+          require("${__dirname}/inflight.Foo-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const FooClient = ${Foo._toInflightType(this)};
+            const FooClient = ${Foo._toInflightType()};
             const client = new FooClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -114,7 +114,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
             $f: ${$stdlib.core.liftObject(f)},
           })
         `;
@@ -122,7 +122,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/tools/hangar/__snapshots__/test_corpus/valid/lift_via_closure.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/lift_via_closure.test.w_compile_tf-aws.md
@@ -157,7 +157,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
             $bucket2: ${$stdlib.core.liftObject(bucket2)},
           })
         `;
@@ -165,7 +165,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -193,7 +193,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.MyClosure-1.js")({
+          require("${__dirname}/inflight.MyClosure-1.js")({
             $bucket2: ${$stdlib.core.liftObject(bucket2)},
           })
         `;
@@ -201,7 +201,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const MyClosureClient = ${MyClosure._toInflightType(this)};
+            const MyClosureClient = ${MyClosure._toInflightType()};
             const client = new MyClosureClient({
               $this_bucket: ${$stdlib.core.liftObject(this.bucket)},
             });
@@ -239,7 +239,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure2-1.js")({
+          require("${__dirname}/inflight.$Closure2-1.js")({
             $fn: ${$stdlib.core.liftObject(fn)},
           })
         `;
@@ -247,7 +247,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure2Client = ${$Closure2._toInflightType(this)};
+            const $Closure2Client = ${$Closure2._toInflightType()};
             const client = new $Closure2Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -275,7 +275,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure3-1.js")({
+          require("${__dirname}/inflight.$Closure3-1.js")({
             $bucket2: ${$stdlib.core.liftObject(bucket2)},
             $fn2: ${$stdlib.core.liftObject(fn2)},
             $fn2_bucket: ${$stdlib.core.liftObject(fn2.bucket)},
@@ -285,7 +285,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure3Client = ${$Closure3._toInflightType(this)};
+            const $Closure3Client = ${$Closure3._toInflightType()};
             const client = new $Closure3Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/tools/hangar/__snapshots__/test_corpus/valid/lift_via_closure_explicit.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/lift_via_closure_explicit.test.w_compile_tf-aws.md
@@ -96,14 +96,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.MyClosure-1.js")({
+          require("${__dirname}/inflight.MyClosure-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const MyClosureClient = ${MyClosure._toInflightType(this)};
+            const MyClosureClient = ${MyClosure._toInflightType()};
             const client = new MyClosureClient({
               $this_q: ${$stdlib.core.liftObject(this.q)},
             });
@@ -135,7 +135,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
             $fn: ${$stdlib.core.liftObject(fn)},
           })
         `;
@@ -143,7 +143,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/tools/hangar/__snapshots__/test_corpus/valid/lift_with_phase_ind.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/lift_with_phase_ind.test.w_compile_tf-aws.md
@@ -65,7 +65,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
             $__arr__index_______if__index___0____index____arr_length__throw_new_Error__Index_out_of_bounds____return_arr_index______ar__0_: ${$stdlib.core.liftObject(((arr, index) => { if (index < 0 || index >= arr.length) throw new Error("Index out of bounds"); return arr[index]; })(ar, 0))},
             $ar: ${$stdlib.core.liftObject(ar)},
             $ar_length: ${$stdlib.core.liftObject(ar.length)},
@@ -76,7 +76,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/tools/hangar/__snapshots__/test_corpus/valid/new_in_static.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/new_in_static.test.w_compile_tf-aws.md
@@ -113,14 +113,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.MyClass-1.js")({
+          require("${__dirname}/inflight.MyClass-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const MyClassClient = ${MyClass._toInflightType(this)};
+            const MyClassClient = ${MyClass._toInflightType()};
             const client = new MyClassClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -140,7 +140,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
             $bucket: ${$stdlib.core.liftObject(bucket)},
           })
         `;
@@ -148,7 +148,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/tools/hangar/__snapshots__/test_corpus/valid/new_jsii.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/new_jsii.test.w_compile_tf-aws.md
@@ -67,14 +67,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.CustomScope-1.js")({
+          require("${__dirname}/inflight.CustomScope-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const CustomScopeClient = ${CustomScope._toInflightType(this)};
+            const CustomScopeClient = ${CustomScope._toInflightType()};
             const client = new CustomScopeClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/tools/hangar/__snapshots__/test_corpus/valid/nil.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/nil.test.w_compile_tf-aws.md
@@ -114,14 +114,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.Foo-1.js")({
+          require("${__dirname}/inflight.Foo-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const FooClient = ${Foo._toInflightType(this)};
+            const FooClient = ${Foo._toInflightType()};
             const client = new FooClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -141,7 +141,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
             $foo: ${$stdlib.core.liftObject(foo)},
           })
         `;
@@ -149,7 +149,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -177,7 +177,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure2-1.js")({
+          require("${__dirname}/inflight.$Closure2-1.js")({
             $foo: ${$stdlib.core.liftObject(foo)},
           })
         `;
@@ -185,7 +185,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure2Client = ${$Closure2._toInflightType(this)};
+            const $Closure2Client = ${$Closure2._toInflightType()};
             const client = new $Closure2Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/tools/hangar/__snapshots__/test_corpus/valid/optionals.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/optionals.test.w_compile_tf-aws.md
@@ -134,14 +134,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.Super-1.js")({
+          require("${__dirname}/inflight.Super-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const SuperClient = ${Super._toInflightType(this)};
+            const SuperClient = ${Super._toInflightType()};
             const client = new SuperClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -160,7 +160,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.Sub-1.js")({
+          require("${__dirname}/inflight.Sub-1.js")({
             $Super: ${$stdlib.core.liftObject(Super)},
           })
         `;
@@ -168,7 +168,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const SubClient = ${Sub._toInflightType(this)};
+            const SubClient = ${Sub._toInflightType()};
             const client = new SubClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -187,7 +187,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.Sub1-1.js")({
+          require("${__dirname}/inflight.Sub1-1.js")({
             $Super: ${$stdlib.core.liftObject(Super)},
           })
         `;
@@ -195,7 +195,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const Sub1Client = ${Sub1._toInflightType(this)};
+            const Sub1Client = ${Sub1._toInflightType()};
             const client = new Sub1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -216,14 +216,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.Node-1.js")({
+          require("${__dirname}/inflight.Node-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const NodeClient = ${Node._toInflightType(this)};
+            const NodeClient = ${Node._toInflightType()};
             const client = new NodeClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -243,7 +243,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
             $__payloadWithBucket_c_____null_: ${$stdlib.core.liftObject(((payloadWithBucket.c) != null))},
             $__payloadWithoutOptions_b_____null_: ${$stdlib.core.liftObject(((payloadWithoutOptions.b) != null))},
             $payloadWithBucket_c: ${$stdlib.core.liftObject(payloadWithBucket.c)},
@@ -253,7 +253,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/tools/hangar/__snapshots__/test_corpus/valid/print.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/print.test.w_compile_tf-aws.md
@@ -82,14 +82,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -109,14 +109,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure2-1.js")({
+          require("${__dirname}/inflight.$Closure2-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure2Client = ${$Closure2._toInflightType(this)};
+            const $Closure2Client = ${$Closure2._toInflightType()};
             const client = new $Closure2Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/tools/hangar/__snapshots__/test_corpus/valid/reassignment.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/reassignment.test.w_compile_tf-aws.md
@@ -58,14 +58,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.R-1.js")({
+          require("${__dirname}/inflight.R-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const RClient = ${R._toInflightType(this)};
+            const RClient = ${R._toInflightType()};
             const client = new RClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/tools/hangar/__snapshots__/test_corpus/valid/redis.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/redis.test.w_compile_tf-aws.md
@@ -553,7 +553,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
             $r: ${$stdlib.core.liftObject(r)},
           })
         `;
@@ -561,7 +561,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -589,7 +589,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure2-1.js")({
+          require("${__dirname}/inflight.$Closure2-1.js")({
             $queue: ${$stdlib.core.liftObject(queue)},
             $r: ${$stdlib.core.liftObject(r)},
             $r2: ${$stdlib.core.liftObject(r2)},
@@ -600,7 +600,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure2Client = ${$Closure2._toInflightType(this)};
+            const $Closure2Client = ${$Closure2._toInflightType()};
             const client = new $Closure2Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/tools/hangar/__snapshots__/test_corpus/valid/resource.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/resource.test.w_compile_tf-aws.md
@@ -712,14 +712,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.Foo-1.js")({
+          require("${__dirname}/inflight.Foo-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const FooClient = ${Foo._toInflightType(this)};
+            const FooClient = ${Foo._toInflightType()};
             const client = new FooClient({
               $this_c: ${$stdlib.core.liftObject(this.c)},
             });
@@ -756,7 +756,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.Bar-1.js")({
+          require("${__dirname}/inflight.Bar-1.js")({
             $Foo: ${$stdlib.core.liftObject(Foo)},
             $MyEnum: ${$stdlib.core.liftObject(MyEnum)},
           })
@@ -765,7 +765,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const BarClient = ${Bar._toInflightType(this)};
+            const BarClient = ${Bar._toInflightType()};
             const client = new BarClient({
               $this_b: ${$stdlib.core.liftObject(this.b)},
               $this_e: ${$stdlib.core.liftObject(this.e)},
@@ -808,7 +808,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
             $bucket: ${$stdlib.core.liftObject(bucket)},
             $res: ${$stdlib.core.liftObject(res)},
             $res_foo: ${$stdlib.core.liftObject(res.foo)},
@@ -818,7 +818,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -856,7 +856,7 @@ class $Root extends $stdlib.std.Resource {
           }
           static _toInflightType() {
             return `
-              require("./inflight.$Closure2-1.js")({
+              require("${__dirname}/inflight.$Closure2-1.js")({
                 $__parent_this_2_b: ${$stdlib.core.liftObject(__parent_this_2.b)},
               })
             `;
@@ -864,7 +864,7 @@ class $Root extends $stdlib.std.Resource {
           _toInflight() {
             return `
               (await (async () => {
-                const $Closure2Client = ${$Closure2._toInflightType(this)};
+                const $Closure2Client = ${$Closure2._toInflightType()};
                 const client = new $Closure2Client({
                 });
                 if (client.$inflight_init) { await client.$inflight_init(); }
@@ -894,7 +894,7 @@ class $Root extends $stdlib.std.Resource {
           }
           static _toInflightType() {
             return `
-              require("./inflight.$Closure3-1.js")({
+              require("${__dirname}/inflight.$Closure3-1.js")({
                 $__parent_this_3_b: ${$stdlib.core.liftObject(__parent_this_3.b)},
               })
             `;
@@ -902,7 +902,7 @@ class $Root extends $stdlib.std.Resource {
           _toInflight() {
             return `
               (await (async () => {
-                const $Closure3Client = ${$Closure3._toInflightType(this)};
+                const $Closure3Client = ${$Closure3._toInflightType()};
                 const client = new $Closure3Client({
                 });
                 if (client.$inflight_init) { await client.$inflight_init(); }
@@ -932,7 +932,7 @@ class $Root extends $stdlib.std.Resource {
           }
           static _toInflightType() {
             return `
-              require("./inflight.$Closure4-1.js")({
+              require("${__dirname}/inflight.$Closure4-1.js")({
                 $__parent_this_4_q: ${$stdlib.core.liftObject(__parent_this_4.q)},
               })
             `;
@@ -940,7 +940,7 @@ class $Root extends $stdlib.std.Resource {
           _toInflight() {
             return `
               (await (async () => {
-                const $Closure4Client = ${$Closure4._toInflightType(this)};
+                const $Closure4Client = ${$Closure4._toInflightType()};
                 const client = new $Closure4Client({
                 });
                 if (client.$inflight_init) { await client.$inflight_init(); }
@@ -964,14 +964,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.BigPublisher-1.js")({
+          require("${__dirname}/inflight.BigPublisher-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const BigPublisherClient = ${BigPublisher._toInflightType(this)};
+            const BigPublisherClient = ${BigPublisher._toInflightType()};
             const client = new BigPublisherClient({
               $this_b: ${$stdlib.core.liftObject(this.b)},
               $this_b2: ${$stdlib.core.liftObject(this.b2)},
@@ -1014,7 +1014,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure5-1.js")({
+          require("${__dirname}/inflight.$Closure5-1.js")({
             $bigOlPublisher: ${$stdlib.core.liftObject(bigOlPublisher)},
           })
         `;
@@ -1022,7 +1022,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure5Client = ${$Closure5._toInflightType(this)};
+            const $Closure5Client = ${$Closure5._toInflightType()};
             const client = new $Closure5Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -1051,14 +1051,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.Dummy-1.js")({
+          require("${__dirname}/inflight.Dummy-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const DummyClient = ${Dummy._toInflightType(this)};
+            const DummyClient = ${Dummy._toInflightType()};
             const client = new DummyClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -1087,14 +1087,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.ScopeAndIdTestClass-1.js")({
+          require("${__dirname}/inflight.ScopeAndIdTestClass-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const ScopeAndIdTestClassClient = ${ScopeAndIdTestClass._toInflightType(this)};
+            const ScopeAndIdTestClassClient = ${ScopeAndIdTestClass._toInflightType()};
             const client = new ScopeAndIdTestClassClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/tools/hangar/__snapshots__/test_corpus/valid/resource_as_inflight_literal.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/resource_as_inflight_literal.test.w_compile_tf-aws.md
@@ -185,14 +185,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.Foo-1.js")({
+          require("${__dirname}/inflight.Foo-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const FooClient = ${Foo._toInflightType(this)};
+            const FooClient = ${Foo._toInflightType()};
             const client = new FooClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -212,7 +212,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
             $fn: ${$stdlib.core.liftObject(fn)},
           })
         `;
@@ -220,7 +220,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/tools/hangar/__snapshots__/test_corpus/valid/resource_call_static.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/resource_call_static.test.w_compile_tf-aws.md
@@ -96,7 +96,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.Another-1.js")({
+          require("${__dirname}/inflight.Another-1.js")({
             $globalCounter: ${$stdlib.core.liftObject(globalCounter)},
           })
         `;
@@ -104,7 +104,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const AnotherClient = ${Another._toInflightType(this)};
+            const AnotherClient = ${Another._toInflightType()};
             const client = new AnotherClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -132,7 +132,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
             $Another: ${$stdlib.core.liftObject(Another)},
           })
         `;
@@ -140,7 +140,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/tools/hangar/__snapshots__/test_corpus/valid/resource_captures.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/resource_captures.test.w_compile_tf-aws.md
@@ -256,14 +256,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.First-1.js")({
+          require("${__dirname}/inflight.First-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const FirstClient = ${First._toInflightType(this)};
+            const FirstClient = ${First._toInflightType()};
             const client = new FirstClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -283,14 +283,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.Another-1.js")({
+          require("${__dirname}/inflight.Another-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const AnotherClient = ${Another._toInflightType(this)};
+            const AnotherClient = ${Another._toInflightType()};
             const client = new AnotherClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -324,14 +324,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.MyResource-1.js")({
+          require("${__dirname}/inflight.MyResource-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const MyResourceClient = ${MyResource._toInflightType(this)};
+            const MyResourceClient = ${MyResource._toInflightType()};
             const client = new MyResourceClient({
               $___this_setOfStr_has__s3____: ${$stdlib.core.liftObject((!(this.setOfStr.has("s3"))))},
               $__arr__index_______if__index___0____index____arr_length__throw_new_Error__Index_out_of_bounds____return_arr_index______this_arrayOfStr__0_: ${$stdlib.core.liftObject(((arr, index) => { if (index < 0 || index >= arr.length) throw new Error("Index out of bounds"); return arr[index]; })(this.arrayOfStr, 0))},
@@ -435,7 +435,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
             $r: ${$stdlib.core.liftObject(r)},
           })
         `;
@@ -443,7 +443,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/tools/hangar/__snapshots__/test_corpus/valid/resource_captures_globals.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/resource_captures_globals.test.w_compile_tf-aws.md
@@ -369,14 +369,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.First-1.js")({
+          require("${__dirname}/inflight.First-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const FirstClient = ${First._toInflightType(this)};
+            const FirstClient = ${First._toInflightType()};
             const client = new FirstClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -396,7 +396,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.Another-1.js")({
+          require("${__dirname}/inflight.Another-1.js")({
             $globalCounter: ${$stdlib.core.liftObject(globalCounter)},
           })
         `;
@@ -404,7 +404,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const AnotherClient = ${Another._toInflightType(this)};
+            const AnotherClient = ${Another._toInflightType()};
             const client = new AnotherClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -448,7 +448,7 @@ class $Root extends $stdlib.std.Resource {
           }
           static _toInflightType() {
             return `
-              require("./inflight.R-1.js")({
+              require("${__dirname}/inflight.R-1.js")({
                 $_parentThis_localCounter: ${$stdlib.core.liftObject($parentThis.localCounter)},
                 $globalCounter: ${$stdlib.core.liftObject(globalCounter)},
               })
@@ -457,7 +457,7 @@ class $Root extends $stdlib.std.Resource {
           _toInflight() {
             return `
               (await (async () => {
-                const RClient = ${R._toInflightType(this)};
+                const RClient = ${R._toInflightType()};
                 const client = new RClient({
                 });
                 if (client.$inflight_init) { await client.$inflight_init(); }
@@ -482,7 +482,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.MyResource-1.js")({
+          require("${__dirname}/inflight.MyResource-1.js")({
             $Another: ${$stdlib.core.liftObject(Another)},
             $__arr__index_______if__index___0____index____arr_length__throw_new_Error__Index_out_of_bounds____return_arr_index______globalArrayOfStr__0_: ${$stdlib.core.liftObject(((arr, index) => { if (index < 0 || index >= arr.length) throw new Error("Index out of bounds"); return arr[index]; })(globalArrayOfStr, 0))},
             $__obj__key_______if____key_in_obj___throw_new_Error__Map_does_not_contain_key_____key______return_obj_key______globalMapOfNum___a__: ${$stdlib.core.liftObject(((obj, key) => { if (!(key in obj)) throw new Error(`Map does not contain key: "${key}"`); return obj[key]; })(globalMapOfNum, "a"))},
@@ -500,7 +500,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const MyResourceClient = ${MyResource._toInflightType(this)};
+            const MyResourceClient = ${MyResource._toInflightType()};
             const client = new MyResourceClient({
               $this_localTopic: ${$stdlib.core.liftObject(this.localTopic)},
             });
@@ -543,7 +543,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
             $res: ${$stdlib.core.liftObject(res)},
           })
         `;
@@ -551,7 +551,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -579,7 +579,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure2-1.js")({
+          require("${__dirname}/inflight.$Closure2-1.js")({
             $Another: ${$stdlib.core.liftObject(Another)},
           })
         `;
@@ -587,7 +587,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure2Client = ${$Closure2._toInflightType(this)};
+            const $Closure2Client = ${$Closure2._toInflightType()};
             const client = new $Closure2Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/tools/hangar/__snapshots__/test_corpus/valid/shadowing.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/shadowing.test.w_compile_tf-aws.md
@@ -92,7 +92,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
             $bar: ${$stdlib.core.liftObject(bar)},
           })
         `;
@@ -100,7 +100,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -128,7 +128,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure2-1.js")({
+          require("${__dirname}/inflight.$Closure2-1.js")({
             $fn: ${$stdlib.core.liftObject(fn)},
           })
         `;
@@ -136,7 +136,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure2Client = ${$Closure2._toInflightType(this)};
+            const $Closure2Client = ${$Closure2._toInflightType()};
             const client = new $Closure2Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/tools/hangar/__snapshots__/test_corpus/valid/statements_if.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/statements_if.test.w_compile_tf-aws.md
@@ -79,14 +79,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/tools/hangar/__snapshots__/test_corpus/valid/static_members.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/static_members.test.w_compile_tf-aws.md
@@ -89,14 +89,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.Foo-1.js")({
+          require("${__dirname}/inflight.Foo-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const FooClient = ${Foo._toInflightType(this)};
+            const FooClient = ${Foo._toInflightType()};
             const client = new FooClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -116,14 +116,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/tools/hangar/__snapshots__/test_corpus/valid/std_containers.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/std_containers.test.w_compile_tf-aws.md
@@ -81,14 +81,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.Animal-1.js")({
+          require("${__dirname}/inflight.Animal-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const AnimalClient = ${Animal._toInflightType(this)};
+            const AnimalClient = ${Animal._toInflightType()};
             const client = new AnimalClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -106,7 +106,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.Cat-1.js")({
+          require("${__dirname}/inflight.Cat-1.js")({
             $Animal: ${$stdlib.core.liftObject(Animal)},
           })
         `;
@@ -114,7 +114,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const CatClient = ${Cat._toInflightType(this)};
+            const CatClient = ${Cat._toInflightType()};
             const client = new CatClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -132,7 +132,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.Dog-1.js")({
+          require("${__dirname}/inflight.Dog-1.js")({
             $Animal: ${$stdlib.core.liftObject(Animal)},
           })
         `;
@@ -140,7 +140,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const DogClient = ${Dog._toInflightType(this)};
+            const DogClient = ${Dog._toInflightType()};
             const client = new DogClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/tools/hangar/__snapshots__/test_corpus/valid/std_string.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/std_string.test.w_compile_tf-aws.md
@@ -61,7 +61,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
             $__arr__index_______if__index___0____index____arr_length__throw_new_Error__Index_out_of_bounds____return_arr_index_______s1_split________1_: ${$stdlib.core.liftObject(((arr, index) => { if (index < 0 || index >= arr.length) throw new Error("Index out of bounds"); return arr[index]; })((s1.split(" ")), 1))},
             $_s1_concat_s2__: ${$stdlib.core.liftObject((s1.concat(s2)))},
             $s1_indexOf__s__: ${$stdlib.core.liftObject(s1.indexOf("s"))},
@@ -71,7 +71,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/tools/hangar/__snapshots__/test_corpus/valid/store.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/store.w_compile_tf-aws.md
@@ -77,14 +77,14 @@ class Util extends $stdlib.std.Resource {
   }
   static _toInflightType() {
     return `
-      require("./inflight.Util-1.js")({
+      require("${__dirname}/inflight.Util-1.js")({
       })
     `;
   }
   _toInflight() {
     return `
       (await (async () => {
-        const UtilClient = ${Util._toInflightType(this)};
+        const UtilClient = ${Util._toInflightType()};
         const client = new UtilClient({
         });
         if (client.$inflight_init) { await client.$inflight_init(); }
@@ -109,7 +109,7 @@ class Store extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
             $__parent_this_1_b: ${$stdlib.core.liftObject(__parent_this_1.b)},
           })
         `;
@@ -117,7 +117,7 @@ class Store extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -141,14 +141,14 @@ class Store extends $stdlib.std.Resource {
   }
   static _toInflightType() {
     return `
-      require("./inflight.Store-1.js")({
+      require("${__dirname}/inflight.Store-1.js")({
       })
     `;
   }
   _toInflight() {
     return `
       (await (async () => {
-        const StoreClient = ${Store._toInflightType(this)};
+        const StoreClient = ${Store._toInflightType()};
         const client = new StoreClient({
           $this_b: ${$stdlib.core.liftObject(this.b)},
         });

--- a/tools/hangar/__snapshots__/test_corpus/valid/struct_from_json.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/struct_from_json.test.w_compile_tf-aws.md
@@ -198,7 +198,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-2.js")({
+          require("${__dirname}/inflight.$Closure1-2.js")({
             $cloud_BucketProps: ${$stdlib.core.liftObject($stdlib.core.toLiftableModuleType(cloud_BucketProps, "@winglang/sdk/cloud", "BucketProps"))},
             $j: ${$stdlib.core.liftObject(j)},
           })
@@ -207,7 +207,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -235,7 +235,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure2-2.js")({
+          require("${__dirname}/inflight.$Closure2-2.js")({
             $Student: ${$stdlib.core.liftObject(Student)},
           })
         `;
@@ -243,7 +243,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure2Client = ${$Closure2._toInflightType(this)};
+            const $Closure2Client = ${$Closure2._toInflightType()};
             const client = new $Closure2Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -263,7 +263,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure3-2.js")({
+          require("${__dirname}/inflight.$Closure3-2.js")({
             $Student: ${$stdlib.core.liftObject(Student)},
             $jStudent1: ${$stdlib.core.liftObject(jStudent1)},
           })
@@ -272,7 +272,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure3Client = ${$Closure3._toInflightType(this)};
+            const $Closure3Client = ${$Closure3._toInflightType()};
             const client = new $Closure3Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -300,7 +300,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure4-2.js")({
+          require("${__dirname}/inflight.$Closure4-2.js")({
             $MyStruct: ${$stdlib.core.liftObject(MyStruct)},
             $_schema_asStr___: ${$stdlib.core.liftObject((schema.asStr()))},
             $expectedSchema: ${$stdlib.core.liftObject(expectedSchema)},
@@ -312,7 +312,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure4Client = ${$Closure4._toInflightType(this)};
+            const $Closure4Client = ${$Closure4._toInflightType()};
             const client = new $Closure4Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -342,7 +342,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure5-2.js")({
+          require("${__dirname}/inflight.$Closure5-2.js")({
             $Student: ${$stdlib.core.liftObject(Student)},
             $std_Boolean: ${$stdlib.core.liftObject($stdlib.core.toLiftableModuleType(std.Boolean, "@winglang/sdk/std", "Boolean"))},
             $std_Number: ${$stdlib.core.liftObject($stdlib.core.toLiftableModuleType(std.Number, "@winglang/sdk/std", "Number"))},
@@ -353,7 +353,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure5Client = ${$Closure5._toInflightType(this)};
+            const $Closure5Client = ${$Closure5._toInflightType()};
             const client = new $Closure5Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -535,14 +535,14 @@ class UsesStructInImportedFile extends $stdlib.std.Resource {
   }
   static _toInflightType() {
     return `
-      require("./inflight.UsesStructInImportedFile-1.js")({
+      require("${__dirname}/inflight.UsesStructInImportedFile-1.js")({
       })
     `;
   }
   _toInflight() {
     return `
       (await (async () => {
-        const UsesStructInImportedFileClient = ${UsesStructInImportedFile._toInflightType(this)};
+        const UsesStructInImportedFileClient = ${UsesStructInImportedFile._toInflightType()};
         const client = new UsesStructInImportedFileClient({
         });
         if (client.$inflight_init) { await client.$inflight_init(); }

--- a/tools/hangar/__snapshots__/test_corpus/valid/structs.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/structs.test.w_compile_tf-aws.md
@@ -77,14 +77,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.Foo-1.js")({
+          require("${__dirname}/inflight.Foo-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const FooClient = ${Foo._toInflightType(this)};
+            const FooClient = ${Foo._toInflightType()};
             const client = new FooClient({
               $this_data_field0: ${$stdlib.core.liftObject(this.data.field0)},
             });
@@ -116,14 +116,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/tools/hangar/__snapshots__/test_corpus/valid/super_call.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/super_call.test.w_compile_tf-aws.md
@@ -235,14 +235,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.A-1.js")({
+          require("${__dirname}/inflight.A-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const AClient = ${A._toInflightType(this)};
+            const AClient = ${A._toInflightType()};
             const client = new AClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -263,7 +263,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.B-1.js")({
+          require("${__dirname}/inflight.B-1.js")({
             $A: ${$stdlib.core.liftObject(A)},
           })
         `;
@@ -271,7 +271,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const BClient = ${B._toInflightType(this)};
+            const BClient = ${B._toInflightType()};
             const client = new BClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -292,7 +292,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.C-1.js")({
+          require("${__dirname}/inflight.C-1.js")({
             $B: ${$stdlib.core.liftObject(B)},
           })
         `;
@@ -300,7 +300,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const CClient = ${C._toInflightType(this)};
+            const CClient = ${C._toInflightType()};
             const client = new CClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -318,7 +318,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.D-1.js")({
+          require("${__dirname}/inflight.D-1.js")({
             $C: ${$stdlib.core.liftObject(C)},
           })
         `;
@@ -326,7 +326,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const DClient = ${D._toInflightType(this)};
+            const DClient = ${D._toInflightType()};
             const client = new DClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -347,7 +347,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.E-1.js")({
+          require("${__dirname}/inflight.E-1.js")({
             $D: ${$stdlib.core.liftObject(D)},
           })
         `;
@@ -355,7 +355,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const EClient = ${E._toInflightType(this)};
+            const EClient = ${E._toInflightType()};
             const client = new EClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -373,14 +373,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.InflightA-1.js")({
+          require("${__dirname}/inflight.InflightA-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const InflightAClient = ${InflightA._toInflightType(this)};
+            const InflightAClient = ${InflightA._toInflightType()};
             const client = new InflightAClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -398,7 +398,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.InflightB-1.js")({
+          require("${__dirname}/inflight.InflightB-1.js")({
             $InflightA: ${$stdlib.core.liftObject(InflightA)},
           })
         `;
@@ -406,7 +406,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const InflightBClient = ${InflightB._toInflightType(this)};
+            const InflightBClient = ${InflightB._toInflightType()};
             const client = new InflightBClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -426,7 +426,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
             $InflightB: ${$stdlib.core.liftObject(InflightB)},
             $expect_Util: ${$stdlib.core.liftObject($stdlib.core.toLiftableModuleType(expect.Util, "@winglang/sdk/expect", "Util"))},
           })
@@ -435,7 +435,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -453,7 +453,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.BaseClass-1.js")({
+          require("${__dirname}/inflight.BaseClass-1.js")({
             $b: ${$stdlib.core.liftObject(b)},
           })
         `;
@@ -461,7 +461,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const BaseClassClient = ${BaseClass._toInflightType(this)};
+            const BaseClassClient = ${BaseClass._toInflightType()};
             const client = new BaseClassClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -487,7 +487,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.ExtendedClass-1.js")({
+          require("${__dirname}/inflight.ExtendedClass-1.js")({
             $BaseClass: ${$stdlib.core.liftObject(BaseClass)},
             $b: ${$stdlib.core.liftObject(b)},
           })
@@ -496,7 +496,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const ExtendedClassClient = ${ExtendedClass._toInflightType(this)};
+            const ExtendedClassClient = ${ExtendedClass._toInflightType()};
             const client = new ExtendedClassClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -524,7 +524,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure2-1.js")({
+          require("${__dirname}/inflight.$Closure2-1.js")({
             $expect_Util: ${$stdlib.core.liftObject($stdlib.core.toLiftableModuleType(expect.Util, "@winglang/sdk/expect", "Util"))},
             $extended: ${$stdlib.core.liftObject(extended)},
           })
@@ -533,7 +533,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure2Client = ${$Closure2._toInflightType(this)};
+            const $Closure2Client = ${$Closure2._toInflightType()};
             const client = new $Closure2Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/tools/hangar/__snapshots__/test_corpus/valid/symbol_shadow.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/symbol_shadow.test.w_compile_tf-aws.md
@@ -141,7 +141,7 @@ class $Root extends $stdlib.std.Resource {
           }
           static _toInflightType() {
             return `
-              require("./inflight.$Closure2-1.js")({
+              require("${__dirname}/inflight.$Closure2-1.js")({
                 $s: ${$stdlib.core.liftObject(s)},
               })
             `;
@@ -149,7 +149,7 @@ class $Root extends $stdlib.std.Resource {
           _toInflight() {
             return `
               (await (async () => {
-                const $Closure2Client = ${$Closure2._toInflightType(this)};
+                const $Closure2Client = ${$Closure2._toInflightType()};
                 const client = new $Closure2Client({
                 });
                 if (client.$inflight_init) { await client.$inflight_init(); }
@@ -173,14 +173,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.A-1.js")({
+          require("${__dirname}/inflight.A-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const AClient = ${A._toInflightType(this)};
+            const AClient = ${A._toInflightType()};
             const client = new AClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -200,7 +200,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure3-1.js")({
+          require("${__dirname}/inflight.$Closure3-1.js")({
             $s: ${$stdlib.core.liftObject(s)},
           })
         `;
@@ -208,7 +208,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure3Client = ${$Closure3._toInflightType(this)};
+            const $Closure3Client = ${$Closure3._toInflightType()};
             const client = new $Closure3Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -236,14 +236,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure4-1.js")({
+          require("${__dirname}/inflight.$Closure4-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure4Client = ${$Closure4._toInflightType(this)};
+            const $Closure4Client = ${$Closure4._toInflightType()};
             const client = new $Closure4Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -267,7 +267,7 @@ class $Root extends $stdlib.std.Resource {
         }
         static _toInflightType() {
           return `
-            require("./inflight.$Closure1-1.js")({
+            require("${__dirname}/inflight.$Closure1-1.js")({
               $s: ${$stdlib.core.liftObject(s)},
             })
           `;
@@ -275,7 +275,7 @@ class $Root extends $stdlib.std.Resource {
         _toInflight() {
           return `
             (await (async () => {
-              const $Closure1Client = ${$Closure1._toInflightType(this)};
+              const $Closure1Client = ${$Closure1._toInflightType()};
               const client = new $Closure1Client({
               });
               if (client.$inflight_init) { await client.$inflight_init(); }

--- a/tools/hangar/__snapshots__/test_corpus/valid/test_bucket.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/test_bucket.test.w_compile_tf-aws.md
@@ -97,7 +97,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
             $b: ${$stdlib.core.liftObject(b)},
           })
         `;
@@ -105,7 +105,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -133,7 +133,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure2-1.js")({
+          require("${__dirname}/inflight.$Closure2-1.js")({
             $b: ${$stdlib.core.liftObject(b)},
           })
         `;
@@ -141,7 +141,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure2Client = ${$Closure2._toInflightType(this)};
+            const $Closure2Client = ${$Closure2._toInflightType()};
             const client = new $Closure2Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/tools/hangar/__snapshots__/test_corpus/valid/test_without_bring.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/test_without_bring.test.w_compile_tf-aws.md
@@ -59,14 +59,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/tools/hangar/__snapshots__/test_corpus/valid/use_inflight_method_inside_init_closure.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/use_inflight_method_inside_init_closure.test.w_compile_tf-aws.md
@@ -186,7 +186,7 @@ class $Root extends $stdlib.std.Resource {
           }
           static _toInflightType() {
             return `
-              require("./inflight.$Closure1-1.js")({
+              require("${__dirname}/inflight.$Closure1-1.js")({
                 $__parent_this_1: ${$stdlib.core.liftObject(__parent_this_1)},
               })
             `;
@@ -194,7 +194,7 @@ class $Root extends $stdlib.std.Resource {
           _toInflight() {
             return `
               (await (async () => {
-                const $Closure1Client = ${$Closure1._toInflightType(this)};
+                const $Closure1Client = ${$Closure1._toInflightType()};
                 const client = new $Closure1Client({
                 });
                 if (client.$inflight_init) { await client.$inflight_init(); }
@@ -218,14 +218,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.Foo-1.js")({
+          require("${__dirname}/inflight.Foo-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const FooClient = ${Foo._toInflightType(this)};
+            const FooClient = ${Foo._toInflightType()};
             const client = new FooClient({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/tools/hangar/__snapshots__/test_corpus/valid/website_with_api.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/website_with_api.test.w_compile_tf-aws.md
@@ -630,7 +630,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
             $std_Json: ${$stdlib.core.liftObject($stdlib.core.toLiftableModuleType(std.Json, "@winglang/sdk/std", "Json"))},
             $usersTable: ${$stdlib.core.liftObject(usersTable)},
           })
@@ -639,7 +639,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -667,7 +667,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure2-1.js")({
+          require("${__dirname}/inflight.$Closure2-1.js")({
             $std_Json: ${$stdlib.core.liftObject($stdlib.core.toLiftableModuleType(std.Json, "@winglang/sdk/std", "Json"))},
             $usersTable: ${$stdlib.core.liftObject(usersTable)},
           })
@@ -676,7 +676,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure2Client = ${$Closure2._toInflightType(this)};
+            const $Closure2Client = ${$Closure2._toInflightType()};
             const client = new $Closure2Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -704,7 +704,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure3-1.js")({
+          require("${__dirname}/inflight.$Closure3-1.js")({
             $api_url: ${$stdlib.core.liftObject(api.url)},
             $expect_Util: ${$stdlib.core.liftObject($stdlib.core.toLiftableModuleType(expect.Util, "@winglang/sdk/expect", "Util"))},
             $http_HttpMethod: ${$stdlib.core.liftObject($stdlib.core.toLiftableModuleType(http.HttpMethod, "@winglang/sdk/http", "HttpMethod"))},
@@ -715,7 +715,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure3Client = ${$Closure3._toInflightType(this)};
+            const $Closure3Client = ${$Closure3._toInflightType()};
             const client = new $Closure3Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }
@@ -743,7 +743,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure4-1.js")({
+          require("${__dirname}/inflight.$Closure4-1.js")({
             $api_url: ${$stdlib.core.liftObject(api.url)},
             $expect_Util: ${$stdlib.core.liftObject($stdlib.core.toLiftableModuleType(expect.Util, "@winglang/sdk/expect", "Util"))},
             $http_HttpMethod: ${$stdlib.core.liftObject($stdlib.core.toLiftableModuleType(http.HttpMethod, "@winglang/sdk/http", "HttpMethod"))},
@@ -754,7 +754,7 @@ class $Root extends $stdlib.std.Resource {
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure4Client = ${$Closure4._toInflightType(this)};
+            const $Closure4Client = ${$Closure4._toInflightType()};
             const client = new $Closure4Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }

--- a/tools/hangar/__snapshots__/test_corpus/valid/while_loop_await.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/while_loop_await.test.w_compile_tf-aws.md
@@ -198,14 +198,14 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("./inflight.$Closure1-1.js")({
+          require("${__dirname}/inflight.$Closure1-1.js")({
           })
         `;
       }
       _toInflight() {
         return `
           (await (async () => {
-            const $Closure1Client = ${$Closure1._toInflightType(this)};
+            const $Closure1Client = ${$Closure1._toInflightType()};
             const client = new $Closure1Client({
             });
             if (client.$inflight_init) { await client.$inflight_init(); }


### PR DESCRIPTION
**Note**: This PR is a setup for the upcoming typescript PR. This change required many snapshot updates so it made sense to keep it contained in a separate PR.

Normally in wing, all preflight code is executed in the same folder. This typically also works fine typescript, except when calling `_toInflight()` on a inflight closure class. The function returns a string with a relative require. This works fine in winglang but not typescript because we execute that string elsewhere. Adding ensures that the require will always resolve correctly.

This usecase currently doesn't exist in wing, thus the lack of a test. A followup PR will make use of this.

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
