### PR TITLE
fix: verbose preflight stacktrace does not contain anything useful

### DIFF
--- a/apps/wing/src/commands/compile.test.ts
+++ b/apps/wing/src/commands/compile.test.ts
@@ -6,6 +6,7 @@ import { describe, test, expect } from "vitest";
 import { compile } from "./compile";
 
 const exampleDir = resolve("../../examples/tests/valid");
+const exampleErrorDir = resolve("../../examples/tests/error");
 const exampleSmallDir = resolve("../../examples/tests/valid/subdir2");
 const exampleFilePath = join(exampleDir, "captures.test.w");
 
@@ -95,6 +96,23 @@ describe(
       return expect(
         compile("non-existent-file.w", { platform: [BuiltinPlatform.SIM] })
       ).rejects.toThrowError(/Source file cannot be found/);
+    });
+
+    test("should create verbose stacktrace with DEBUG env set", async () => {
+      const exampleErrorFile = join(exampleErrorDir, "bool_from_json.test.w");
+
+      await expect(
+        compile(exampleErrorFile, { platform: [BuiltinPlatform.SIM] })
+      ).rejects.not.toThrowError(/wingsdk/);
+
+      const prevDebug = process.env.DEBUG;
+      process.env.DEBUG = "true";
+
+      await expect(
+        compile(exampleErrorFile, { platform: [BuiltinPlatform.SIM] })
+      ).rejects.toThrowError(/wingsdk/);
+
+      process.env.DEBUG = prevDebug;
     });
 
     test("should be able to compile a directory", async () => {

--- a/apps/wing/src/commands/compile.ts
+++ b/apps/wing/src/commands/compile.ts
@@ -168,7 +168,7 @@ export async function compile(entrypoint?: string, options?: CompileOptions): Pr
       if (process.env.DEBUG) {
         output +=
           "\n--------------------------------- ORIGINAL STACK TRACE ---------------------------------\n" +
-          (error.stack ?? "(no stacktrace available)");
+          (error.causedBy.stack ?? "(no stacktrace available)");
       }
 
       error.causedBy.message = output;


### PR DESCRIPTION
fixes #5032

#### Before
<img width="1286" alt="image" src="https://github.com/winglang/wing/assets/1237390/8b84bdf6-1569-42d7-9494-b73690426030">

#### After
<img width="1229" alt="image" src="https://github.com/winglang/wing/assets/1237390/63a99f0c-9a3a-43c6-95d3-bf6bfd02858f">


*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
