### PR TITLE
feat(sdk): bundle functions eagerly in simulator

### DIFF
--- a/libs/wingsdk/src/shared/sandbox.ts
+++ b/libs/wingsdk/src/shared/sandbox.ts
@@ -14,7 +14,9 @@ export interface SandboxOptions {
 
 export class Sandbox {
   private loaded = false; // "true" after first run (module is loaded into context)
+  private createBundlePromise: Promise<void>;
   private entrypoint: string;
+  private code: string | undefined;
   private readonly options: SandboxOptions;
   private readonly context: any = {};
 
@@ -22,6 +24,7 @@ export class Sandbox {
     this.entrypoint = entrypoint;
     this.options = options;
     this.context = this.createContext();
+    this.createBundlePromise = this.createBundle();
   }
 
   private createContext() {
@@ -92,25 +95,31 @@ export class Sandbox {
     return context;
   }
 
-  private async loadBundleOnce() {
+  private async createBundle() {
     // load bundle into context on first run
-    if (this.loaded) {
-      return;
-    }
-
     const workdir = await mkdtemp(path.join(tmpdir(), "wing-bundles-"));
     const bundle = createBundle(this.entrypoint, [], workdir);
     this.entrypoint = bundle.entrypointPath;
 
-    const code = await readFile(this.entrypoint, "utf-8");
+    this.code = await readFile(this.entrypoint, "utf-8");
 
     if (process.env.DEBUG) {
-      const bundleSize = Buffer.byteLength(code, "utf-8");
+      const bundleSize = Buffer.byteLength(this.code, "utf-8");
       this.options.log?.(true, "log", `Bundled code (${bundleSize} bytes).`);
+    }
+  }
+
+  private loadBundleOnce() {
+    if (this.loaded) {
+      return;
+    }
+
+    if (!this.code) {
+      throw new Error("Bundle not created yet - please report this as a bug");
     }
 
     // this will add stuff to the "exports" object within our context
-    vm.runInContext(code, this.context, {
+    vm.runInContext(this.code!, this.context, {
       filename: this.entrypoint,
     });
 
@@ -118,7 +127,13 @@ export class Sandbox {
   }
 
   public async call(fn: string, ...args: any[]): Promise<any> {
-    await this.loadBundleOnce();
+    // wait for the bundle to finish creation
+    await this.createBundlePromise;
+
+    // load the bundle into context on the first run
+    // we don't do this earlier because bundled code may have side effects
+    // and we want to simulate that a function is "cold" on the first run
+    this.loadBundleOnce();
 
     return new Promise(($resolve, $reject) => {
       const cleanup = () => {


### PR DESCRIPTION
Fixes #5031

Sometimes [laziness is a virtue](https://github.com/winglang/wing/pull/5453). Other times (like now), eagerness is a virtue. It just depends on the situation. 🤓 

To improve interactivity in the Wing Console and Wing Playground, this PR updates the local simulator so that it eagerly bundles all functions while starting a simulation, instead of the previous behavior of waiting until the first time a function is invoked. This means that in most cases, by the time you try interacting with any `cloud.Function`, the code will probably have finished bundling in the background, and so clicking "Invoke" will only take as much time as it takes to actually execute the inflight code.

Since bundled code can have side effects at the top-level (for example, any code that runs inside `inflight new() {}` blocks), we still only load the bundled code into the VM upon the first time a function invocation is made, to guarantee that you get FaaS cold-start-like behavior. I've updated one of our tests (inflight_handler_singleton.test.w) to demonstrate this.

If you happen to click on the "invoke" button on a function before it has finished bundling, it's possible you might still have to wait a little bit extra - but even then it should be a speedup. 🏃

## Checklist

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [x] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
