### PR TITLE
chore: test that inflight clients are not reused across functions

### DIFF
--- a/examples/tests/valid/inflight_handler_singleton.test.w
+++ b/examples/tests/valid/inflight_handler_singleton.test.w
@@ -21,17 +21,24 @@ let fn = new cloud.Function(inflight () => {
   return "{n}";
 });
 
+let fn2 = new cloud.Function(inflight () => {
+  let n = foo.inc();
+  return "{n}-fn2";
+}) as "fn2";
+
 let sim = util.env("WING_TARGET") == "sim";
 
 test "single instance of Foo" {
   let x = fn.invoke("");
   let y = fn.invoke("");
+  let z = fn2.invoke("");
 
   // the simulator intentionally reuses the sandbox across invocations
   // but we can't trust that this will always happen on the cloud
   if sim {
     expect.equal(x, "100");
     expect.equal(y, "101");
+    expect.equal(z, "100-fn2"); // fn2 should have a separate instance
     log("client has been reused");
   }
 }


### PR DESCRIPTION
Following up on #5478 and [@Chriscbr's comment](https://github.com/winglang/wing/pull/5478/files#r1462456582), verify that inflight clients are not shared across two separate instances of a cloud function.

## Checklist

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [x] Tests added (always)
- [x] Docs updated (only required for features)
- [x] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
