### PR TITLE
fix(compiler)!: interface methods can be declared with no return type

### DIFF
--- a/examples/tests/valid/extern_implementation.test.w
+++ b/examples/tests/valid/extern_implementation.test.w
@@ -5,7 +5,7 @@ class Foo {
   extern "./external_js.js" static inflight regexInflight(pattern: str, text: str): bool;
   extern "./external_js.js" static inflight getUuid(): str;
   extern "./external_js.js" static inflight getData(): str;
-  extern "./external_js.js" pub static inflight print(msg: str);
+  extern "./external_js.js" pub static inflight print(msg: str): void;
 
   pub inflight call() {
     assert(Foo.regexInflight("[a-z]+-\\d+", "abc-123"));

--- a/examples/tests/valid/impl_interface.test.w
+++ b/examples/tests/valid/impl_interface.test.w
@@ -67,3 +67,18 @@ class Terrier extends Dog {
 }
 
 let w: IAnimal = new Terrier();
+
+// interface inheriting the phase from the function it's inside
+// does it make sense to support this?
+let f = inflight () => {
+  interface IDog {
+    bark(): void;
+  } // All methods should be implicitly inflight
+  class MyDog impl IDog {
+    pub bark(): void {
+      log("woof");
+    }
+  } // Because MyIf can only be used inflight
+  let dog = new MyDog();
+  dog.bark();
+};

--- a/libs/wingc/src/dtsify/mod.rs
+++ b/libs/wingc/src/dtsify/mod.rs
@@ -416,8 +416,8 @@ pub interface Interface {
 }
 
 pub interface ClassInterface {
-	addHandler(handler: inflight (str): str);
-	inflight bar();
+	addHandler(handler: inflight (str): str): void;
+	inflight bar(): void;
 }
 
 pub class ParentClass impl ClassInterface {

--- a/libs/wingc/src/dtsify/snapshots/declarations.snap
+++ b/libs/wingc/src/dtsify/snapshots/declarations.snap
@@ -17,8 +17,8 @@ pub interface Interface {
 }
 
 pub interface ClassInterface {
-  addHandler(handler: inflight (str): str);
-  inflight bar();
+  addHandler(handler: inflight (str): str): void;
+  inflight bar(): void;
 }
 
 pub class ParentClass impl ClassInterface {

--- a/libs/wingc/src/parser.rs
+++ b/libs/wingc/src/parser.rs
@@ -612,7 +612,7 @@ impl<'s> Parser<'s> {
 			"return_statement" => self.build_return_statement(statement_node, phase)?,
 			"throw_statement" => self.build_throw_statement(statement_node, phase)?,
 			"class_definition" => self.build_class_statement(statement_node, phase)?,
-			"interface_definition" => self.build_interface_statement(statement_node)?,
+			"interface_definition" => self.build_interface_statement(statement_node, phase)?,
 			"enum_definition" => self.build_enum_statement(statement_node)?,
 			"try_catch_statement" => self.build_try_catch_statement(statement_node, phase)?,
 			"struct_definition" => self.build_struct_definition_statement(statement_node, phase)?,
@@ -1444,7 +1444,7 @@ impl<'s> Parser<'s> {
 		})
 	}
 
-	fn build_interface_statement(&self, statement_node: &Node) -> DiagnosticResult<StmtKind> {
+	fn build_interface_statement(&self, statement_node: &Node, phase: Phase) -> DiagnosticResult<StmtKind> {
 		let mut cursor = statement_node.walk();
 		let mut extends = vec![];
 		let mut methods = vec![];

--- a/libs/wingc/src/parser.rs
+++ b/libs/wingc/src/parser.rs
@@ -1460,7 +1460,7 @@ impl<'s> Parser<'s> {
 			}
 			match interface_element.kind() {
 				"method_signature" => {
-					if let Ok((method_name, func_sig)) = self.build_interface_method(interface_element, Phase::Preflight) {
+					if let Ok((method_name, func_sig)) = self.build_interface_method(interface_element, phase) {
 						methods.push((method_name, func_sig))
 					}
 				}

--- a/tools/hangar/__snapshots__/invalid.ts.snap
+++ b/tools/hangar/__snapshots__/invalid.ts.snap
@@ -1474,7 +1474,21 @@ Duration <DURATION>"
 `;
 
 exports[`function_type.test.w 1`] = `
-"error: Optional parameters must always be after all non-optional parameters.
+"error: Expected function return type
+  --> ../../../examples/tests/invalid/function_type.test.w:3:3
+  |
+3 |   my_method(x: num);
+  |   ^^^^^^^^^^^^^^^^^^ Expected function return type
+
+
+error: Expected function return type
+  --> ../../../examples/tests/invalid/function_type.test.w:5:3
+  |
+5 |   inflight my_method2(x: num);
+  |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Expected function return type
+
+
+error: Optional parameters must always be after all non-optional parameters.
   --> ../../../examples/tests/invalid/function_type.test.w:9:25
   |
 9 | let my_func3 = (a: num, b: str?, c: bool) => {};

--- a/tools/hangar/__snapshots__/test_corpus/valid/impl_interface.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/impl_interface.test.w_compile_tf-aws.md
@@ -40,6 +40,32 @@ module.exports = function({ $i3 }) {
 //# sourceMappingURL=inflight.$Closure2-1.js.map
 ```
 
+## inflight.$Closure3-1.js
+```js
+"use strict";
+const $helpers = require("@winglang/sdk/lib/helpers");
+module.exports = function({  }) {
+  class $Closure3 {
+    constructor({  }) {
+      const $obj = (...args) => this.handle(...args);
+      Object.setPrototypeOf($obj, this);
+      return $obj;
+    }
+    async handle() {
+      class MyDog {
+        async bark() {
+          console.log("woof");
+        }
+      }
+      const dog = (await (async () => {const o = new MyDog(); await o.$inflight_init?.(); return o; })());
+      (await dog.bark());
+    }
+  }
+  return $Closure3;
+}
+//# sourceMappingURL=inflight.$Closure3-1.js.map
+```
+
 ## inflight.A-1.js
 ```js
 "use strict";
@@ -324,6 +350,33 @@ class $Root extends $stdlib.std.Resource {
         return [...super._supportedOps(), "eat", "$inflight_init"];
       }
     }
+    class $Closure3 extends $stdlib.std.AutoIdResource {
+      _id = $stdlib.core.closureId();
+      constructor($scope, $id, ) {
+        super($scope, $id);
+        $helpers.nodeof(this).hidden = true;
+      }
+      static _toInflightType() {
+        return `
+          require("${$helpers.normalPath(__dirname)}/inflight.$Closure3-1.js")({
+          })
+        `;
+      }
+      _toInflight() {
+        return `
+          (await (async () => {
+            const $Closure3Client = ${$Closure3._toInflightType()};
+            const client = new $Closure3Client({
+            });
+            if (client.$inflight_init) { await client.$inflight_init(); }
+            return client;
+          })())
+        `;
+      }
+      _supportedOps() {
+        return [...super._supportedOps(), "handle", "$inflight_init"];
+      }
+    }
     const x = new A(this, "A");
     const y = new $Closure1(this, "$Closure1");
     const i3 = ((() => {
@@ -334,6 +387,7 @@ class $Root extends $stdlib.std.Resource {
     $helpers.assert($helpers.eq((i3.method3([1, 2, 3])), [1, 2, 3]), "i3.method3([1, 2, 3]) == [1, 2, 3]");
     const z = new Dog(this, "Dog");
     const w = new Terrier(this, "Terrier");
+    const f = new $Closure3(this, "$Closure3");
   }
 }
 const $PlatformManager = new $stdlib.platform.PlatformManager({platformPaths: $platforms});


### PR DESCRIPTION
Fixes #5454 by raising an error when interface methods are declared without return types.

In addition to requiring return types on interfaces, I also made them required on extern function statements.

The language reference is a ambiguous and doesn't explicitly say return types are optional on class methods. It's probably a good idea to require return types there as well, but I imagine this is more controversial since some might argue it's okay to omit them and let the compiler infer them from function bodies. To avoid controversy I've left the existing behavior as is.

BREAKING CHANGE: Interface methods now require return types. This was required in earlier versions of Wing (v0.18.x) but due to regressions it was not enforced, so out of caution this change has been labeled as potentially breaking.

## Checklist

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [x] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
