### PR TITLE
chore: compatibility-spy build fails on PRs from forks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -243,8 +243,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pnpm install --frozen-lockfile --ignore-scripts --filter hangar --filter examples-valid --filter examples-invalid --filter @winglang/compatibility-spy
-          pnpm run compile --filter jsii-fixture --filter @winglang/compatibility-spy
+          pnpm install --frozen-lockfile --ignore-scripts --filter hangar --filter examples-valid --filter examples-invalid
+          pnpm run compile --filter jsii-fixture
 
       - name: Run Hangar Tests
         working-directory: tools/hangar

--- a/libs/compatibility-spy/package.json
+++ b/libs/compatibility-spy/package.json
@@ -30,9 +30,9 @@
     "vitest": "^0.34.6"
   },
   "scripts": {
-    "compile": "tsc",
+    "compile": "tsup",
     "package": "bump-pack -b",
-    "test": "vitest run --passWithNoTests --update"
+    "test": "vitest run --update"
   },
   "files": [
     "lib"

--- a/libs/compatibility-spy/package.json
+++ b/libs/compatibility-spy/package.json
@@ -17,7 +17,7 @@
     "registry": "https://registry.npmjs.org",
     "tag": "latest"
   },
-  "main": "index.js",
+  "main": "lib/index.js",
   "license": "MIT",
   "dependencies": {
     "constructs": "~10.2.69",

--- a/libs/compatibility-spy/test/spy.test.ts
+++ b/libs/compatibility-spy/test/spy.test.ts
@@ -1,6 +1,6 @@
 import { test, describe, expect, vi } from "vitest";
 import { join } from "node:path";
-import { Platform } from "../src/index.js";
+import { Platform } from "../src";
 import { cloud, platform } from "@winglang/sdk";
 import { App as SimApp } from "@winglang/sdk/lib/target-sim/app";
 
@@ -12,7 +12,7 @@ describe("compatibility spy", async () => {
   vi.spyOn(spyPlatform, "newInstance");
 
   const manager = new platform.PlatformManager({
-    platformPaths: ["sim", join(__dirname, "../src")],
+    platformPaths: ["sim", join(__dirname, "../lib")],
   });
 
   //@ts-expect-error- accessing private method

--- a/libs/compatibility-spy/test/spy.test.ts
+++ b/libs/compatibility-spy/test/spy.test.ts
@@ -1,13 +1,8 @@
 import { test, describe, expect, vi } from "vitest";
-import { join } from "path";
-import {
-  PlatformManager,
-  _loadCustomPlatform,
-} from "@winglang/sdk/lib/platform";
-import { Platform } from "../src";
-import { BUCKET_FQN } from "@winglang/sdk/lib/cloud";
+import { join } from "node:path";
+import { Platform } from "../src/index.js";
+import { cloud, platform } from "@winglang/sdk";
 import { App as SimApp } from "@winglang/sdk/lib/target-sim/app";
-import { Bucket } from "@winglang/sdk/lib/target-sim/bucket";
 
 import { Platform as SimPlatform } from "@winglang/sdk/lib/target-sim/platform";
 
@@ -16,8 +11,8 @@ describe("compatibility spy", async () => {
 
   vi.spyOn(spyPlatform, "newInstance");
 
-  const manager = new PlatformManager({
-    platformPaths: ["sim", join(__dirname, "../lib")],
+  const manager = new platform.PlatformManager({
+    platformPaths: ["sim", join(__dirname, "../src")],
   });
 
   //@ts-expect-error- accessing private method
@@ -41,7 +36,11 @@ describe("compatibility spy", async () => {
     expect(app._synthHooks?.preSynthesize.length).toBe(1);
   });
 
-  const bucket = app.newAbstract(BUCKET_FQN, app, "bucket") as Bucket;
+  const bucket = app.newAbstract(
+    cloud.BUCKET_FQN,
+    app,
+    "bucket"
+  ) as cloud.Bucket;
 
   bucket.addObject("a", "b");
   // @ts-expect-error- accessing private property

--- a/libs/compatibility-spy/tsconfig.json
+++ b/libs/compatibility-spy/tsconfig.json
@@ -1,41 +1,12 @@
 {
   "compilerOptions": {
-    "target": "ES2020",                                
-    "module": "commonjs",                                
-    "rootDir": "./src",                                  
-    "outDir": "./lib",                                   
-    "declarationMap": false,
-    "inlineSourceMap": true,
-    "inlineSources": true,
-    "alwaysStrict": true,
-    "declaration": true,
-    "experimentalDecorators": true,
-    "incremental": true,
-    "lib": [
-      "es2020",
-      "dom"
-    ],
-    "esModuleInterop": true,
-    "noEmitOnError": true,
-    "noFallthroughCasesInSwitch": true,
-    "noImplicitAny": true,
-    "noImplicitReturns": true,
-    "noImplicitThis": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "resolveJsonModule": true,
-    "skipLibCheck": true,
+    "target": "ES2020",
+    "module": "commonjs",
     "strict": true,
-    "strictNullChecks": true,
-    "strictPropertyInitialization": true,
-    "stripInternal": false,
-    "composite": false,
-    "tsBuildInfoFile": "lib/tsconfig.tsbuildinfo"
   },
   "include": [
-    "./src/**/*"
+    "src/**/*.ts",
+    "test/**/*.ts",
   ],
-  "exclude": [
-    "./node_modules"
-  ]
+  "exclude": []
 }

--- a/libs/compatibility-spy/tsup.config.ts
+++ b/libs/compatibility-spy/tsup.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from "tsup";
 
 export default defineConfig({
   entry: ["src/index.ts"],
-  dts: true,
-  clean: true,
+  bundle: false,
+  format: "cjs",
+  outDir: "lib",
 });

--- a/libs/compatibility-spy/turbo.json
+++ b/libs/compatibility-spy/turbo.json
@@ -3,7 +3,7 @@
   "extends": ["//"],
   "pipeline": {
     "compile": {
-      "outputs": ["dist/**", "lib/**"]
+      "outputs": ["lib/**"]
     },
     "test": {
       "dependsOn": ["compile"]

--- a/libs/wingsdk/.projen/tasks.json
+++ b/libs/wingsdk/.projen/tasks.json
@@ -554,7 +554,7 @@
       "description": "Prepare the project for compilation",
       "steps": [
         {
-          "exec": "cdktf get --force"
+          "exec": "cdktf get"
         }
       ]
     },

--- a/libs/wingsdk/.projenrc.ts
+++ b/libs/wingsdk/.projenrc.ts
@@ -413,7 +413,7 @@ new JsonFile(project, "cdktf.json", {
 });
 project.gitignore.addPatterns("src/.gen");
 
-project.preCompileTask.exec("cdktf get --force");
+project.preCompileTask.exec("cdktf get");
 
 project.package.file.addDeletionOverride("pnpm");
 

--- a/tools/hangar/__snapshots__/compatibility-spy.ts.snap
+++ b/tools/hangar/__snapshots__/compatibility-spy.ts.snap
@@ -5,7 +5,7 @@ exports[`aws-counter.test.w 1`] = `
   "duration": "<DURATION>",
   "platforms": [
     "sim",
-    "../../../libs/compatibility-spy/lib",
+    "../../../libs/compatibility-spy/lib/index.js",
   ],
   "results": {
     "counter/aws-counter.test.w": {
@@ -45,7 +45,7 @@ exports[`dec.test.w 1`] = `
   "duration": "<DURATION>",
   "platforms": [
     "sim",
-    "../../../libs/compatibility-spy/lib",
+    "../../../libs/compatibility-spy/lib/index.js",
   ],
   "results": {
     "counter/dec.test.w": {
@@ -267,7 +267,7 @@ exports[`inc.test.w 1`] = `
   "duration": "<DURATION>",
   "platforms": [
     "sim",
-    "../../../libs/compatibility-spy/lib",
+    "../../../libs/compatibility-spy/lib/index.js",
   ],
   "results": {
     "counter/inc.test.w": {
@@ -489,7 +489,7 @@ exports[`initial.test.w 1`] = `
   "duration": "<DURATION>",
   "platforms": [
     "sim",
-    "../../../libs/compatibility-spy/lib",
+    "../../../libs/compatibility-spy/lib/index.js",
   ],
   "results": {
     "counter/initial.test.w": {
@@ -614,7 +614,7 @@ exports[`peek.test.w 1`] = `
   "duration": "<DURATION>",
   "platforms": [
     "sim",
-    "../../../libs/compatibility-spy/lib",
+    "../../../libs/compatibility-spy/lib/index.js",
   ],
   "results": {
     "counter/peek.test.w": {
@@ -770,7 +770,7 @@ exports[`set.test.w 1`] = `
   "duration": "<DURATION>",
   "platforms": [
     "sim",
-    "../../../libs/compatibility-spy/lib",
+    "../../../libs/compatibility-spy/lib/index.js",
   ],
   "results": {
     "counter/set.test.w": {

--- a/tools/hangar/__snapshots__/compatibility-spy.ts.snap
+++ b/tools/hangar/__snapshots__/compatibility-spy.ts.snap
@@ -5,7 +5,7 @@ exports[`aws-counter.test.w 1`] = `
   "duration": "<DURATION>",
   "platforms": [
     "sim",
-    "../../../libs/compatibility-spy/lib/index.js",
+    "node_modules/@winglang/compatibility-spy/lib",
   ],
   "results": {
     "counter/aws-counter.test.w": {
@@ -45,7 +45,7 @@ exports[`dec.test.w 1`] = `
   "duration": "<DURATION>",
   "platforms": [
     "sim",
-    "../../../libs/compatibility-spy/lib/index.js",
+    "node_modules/@winglang/compatibility-spy/lib",
   ],
   "results": {
     "counter/dec.test.w": {
@@ -267,7 +267,7 @@ exports[`inc.test.w 1`] = `
   "duration": "<DURATION>",
   "platforms": [
     "sim",
-    "../../../libs/compatibility-spy/lib/index.js",
+    "node_modules/@winglang/compatibility-spy/lib",
   ],
   "results": {
     "counter/inc.test.w": {
@@ -489,7 +489,7 @@ exports[`initial.test.w 1`] = `
   "duration": "<DURATION>",
   "platforms": [
     "sim",
-    "../../../libs/compatibility-spy/lib/index.js",
+    "node_modules/@winglang/compatibility-spy/lib",
   ],
   "results": {
     "counter/initial.test.w": {
@@ -614,7 +614,7 @@ exports[`peek.test.w 1`] = `
   "duration": "<DURATION>",
   "platforms": [
     "sim",
-    "../../../libs/compatibility-spy/lib/index.js",
+    "node_modules/@winglang/compatibility-spy/lib",
   ],
   "results": {
     "counter/peek.test.w": {
@@ -770,7 +770,7 @@ exports[`set.test.w 1`] = `
   "duration": "<DURATION>",
   "platforms": [
     "sim",
-    "../../../libs/compatibility-spy/lib/index.js",
+    "node_modules/@winglang/compatibility-spy/lib",
   ],
   "results": {
     "counter/set.test.w": {

--- a/tools/hangar/src/compatibility-spy.test.ts
+++ b/tools/hangar/src/compatibility-spy.test.ts
@@ -6,7 +6,7 @@ import { rmSync, readFileSync } from "fs";
 
 compatibilityTestFiles.forEach((wingFile) => {
   test(wingFile, async ({ expect }) => {
-    const platforms = ["sim", relative(tmpDir, require.resolve("@winglang/compatibility-spy"))];
+    const platforms = ["sim", relative(tmpDir, require.resolve("@winglang/compatibility-spy").replaceAll("\\", "/"))];
     const args = ["test", "-o", "out.json"];
 
     const absoluteWingFile = join(compatibilityTestsDir, wingFile);

--- a/tools/hangar/src/compatibility-spy.test.ts
+++ b/tools/hangar/src/compatibility-spy.test.ts
@@ -6,13 +6,8 @@ import { rmSync, readFileSync } from "fs";
 
 compatibilityTestFiles.forEach((wingFile) => {
   test(wingFile, async ({ expect }) => {
-    const platforms = [
-      "sim",
-      relative(
-        tmpDir,
-        require.resolve("@winglang/compatibility-spy").replaceAll("\\", "/")
-      ),
-    ];
+    // "@winglang/compatibility-spy" will be installed in the tmpDir
+    const platforms = ["sim", "node_modules/@winglang/compatibility-spy/lib"];
     const args = ["test", "-o", "out.json"];
 
     const absoluteWingFile = join(compatibilityTestsDir, wingFile);

--- a/tools/hangar/src/compatibility-spy.test.ts
+++ b/tools/hangar/src/compatibility-spy.test.ts
@@ -6,7 +6,7 @@ import { rmSync, readFileSync } from "fs";
 
 compatibilityTestFiles.forEach((wingFile) => {
   test(wingFile, async ({ expect }) => {
-    const platforms = ["sim", "../../../libs/compatibility-spy/lib"];
+    const platforms = ["sim", require.resolve("@winglang/compatibility-spy/lib")];
     const args = ["test", "-o", "out.json"];
 
     const absoluteWingFile = join(compatibilityTestsDir, wingFile);

--- a/tools/hangar/src/compatibility-spy.test.ts
+++ b/tools/hangar/src/compatibility-spy.test.ts
@@ -6,7 +6,13 @@ import { rmSync, readFileSync } from "fs";
 
 compatibilityTestFiles.forEach((wingFile) => {
   test(wingFile, async ({ expect }) => {
-    const platforms = ["sim", relative(tmpDir, require.resolve("@winglang/compatibility-spy").replaceAll("\\", "/"))];
+    const platforms = [
+      "sim",
+      relative(
+        tmpDir,
+        require.resolve("@winglang/compatibility-spy").replaceAll("\\", "/")
+      ),
+    ];
     const args = ["test", "-o", "out.json"];
 
     const absoluteWingFile = join(compatibilityTestsDir, wingFile);

--- a/tools/hangar/src/compatibility-spy.test.ts
+++ b/tools/hangar/src/compatibility-spy.test.ts
@@ -6,7 +6,7 @@ import { rmSync, readFileSync } from "fs";
 
 compatibilityTestFiles.forEach((wingFile) => {
   test(wingFile, async ({ expect }) => {
-    const platforms = ["sim", require.resolve("@winglang/compatibility-spy/lib")];
+    const platforms = ["sim", relative(tmpDir, require.resolve("@winglang/compatibility-spy"))];
     const args = ["test", "-o", "out.json"];
 
     const absoluteWingFile = join(compatibilityTestsDir, wingFile);


### PR DESCRIPTION
The recent addition of the compatibility-spy lib broke fork workflows. This is because it was attempting to compile during the e2e matrix, but it fails because the e2e matrix is not actually meant to rebuild things. This accidentally works on PRs from winglang/wing because we use turbo remote caching, so the `turbo compile` command pulled from the remote cache.

This PR instead utilizes @winglang/compatibility-spy as a package in hangar, avoiding any re-compilation. While there I also cleaned up the tsconfig and changed it to use tsup (since it was installed anyways).

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
