### PR TITLE
feat(cli): empty template

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -33,12 +33,16 @@ jobs:
       - name: Install Wing
         run: |
           ${{ matrix.install_command }}
-      - name: Create a new Wing project
+      - name: Create and test each quickstart app
         run: |
-          wing new http-api
-      - name: Run Test
-        run: |
-          wing test main.w
+          templates=$(wing new --list-templates)
+          for template in $templates; do
+            mkdir "$template"
+            cd "$_"
+            wing new "$template"
+            wing test main.w
+            cd ..
+          done
       - name: Download examples/tests/valid/hello.test.w
         run: |
           curl -L https://raw.githubusercontent.com/winglang/wing/main/examples/tests/valid/hello.test.w > hello.test.w

--- a/apps/wing/project-templates/wing/empty/main.w
+++ b/apps/wing/project-templates/wing/empty/main.w
@@ -1,0 +1,10 @@
+bring cloud;
+bring expect;
+
+let fn = new cloud.Function(inflight () => {
+  return "hello, world";
+});
+
+test "fn returns hello" {
+  expect.equal(fn.invoke(""), "hello, world");
+}

--- a/apps/wing/project-templates/wing/empty/package.json
+++ b/apps/wing/project-templates/wing/empty/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "my-wing-app",
+  "version": "0.0.0",
+  "description": "A description of my Wing application",
+  "author": "Your Name",
+  "license": "MIT",
+  "wing": true
+}

--- a/apps/wing/src/cli.ts
+++ b/apps/wing/src/cli.ts
@@ -222,6 +222,7 @@ async function main() {
         .choices(["wing", "typescript"])
         .argParser((value) => value ?? "wing")
     )
+    .addOption(new Option("--list-templates", "List available templates"))
     .hook("preAction", collectAnalyticsHook)
     .action(runSubCommand("init"));
 

--- a/apps/wing/src/commands/__snapshots__/init.test.ts.snap
+++ b/apps/wing/src/commands/__snapshots__/init.test.ts.snap
@@ -1,7 +1,0 @@
-// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
-
-exports[`projectTemplateNames > should list project templates 1`] = `
-[
-  "http-api",
-]
-`;

--- a/apps/wing/src/commands/init.ts
+++ b/apps/wing/src/commands/init.ts
@@ -19,6 +19,7 @@ const execPromise = promisify(exec);
 export interface InitOptions {
   readonly template?: string;
   readonly language?: string;
+  readonly listTemplates?: boolean;
 }
 
 /**
@@ -30,6 +31,12 @@ export interface InitOptions {
 export async function init(template: string, options: InitOptions = {}): Promise<void> {
   const templates = projectTemplateNames();
   let language = options.language ?? "wing";
+
+  // If --list-templates is specified, list the available templates and exit
+  if (options.listTemplates) {
+    console.log(templates.join("\n"));
+    return;
+  }
 
   // If no template is specified, let them interactively select one
   if (!template) {

--- a/docs/contributing/01-start-here/05-development.md
+++ b/docs/contributing/01-start-here/05-development.md
@@ -280,3 +280,12 @@ Lastly you can show linting errors in your IDE by enabling the following setting
 // in your VS Code settings
 "rust-analyzer.check.command": "clippy",
 ```
+
+## 🏁 How do I add a quickstart template to the `wing` CLI?
+
+Adding a new template is straightforward!
+
+Each template is represented by a folder located at [https://github.com/winglang/wing/tree/main/apps/wing/project-templates], containing all of the files that template should be initialized with.
+
+Create a new folder with the template name, and insert any code files that are needed to run it.
+Unit tests ran with `pnpm turbo test` (or in GitHub Actions once you make a pull request) will automatically validate that the template is valid.


### PR DESCRIPTION
Adds a new template named `empty` that with a minimal cloud function resource (proposed by @eladb). 

Misc:
- Added canary testing for all templates so we'll get notified if there's an issue with installing dependencies etc.
- Added unit tests that run all templates in CI
- Added contributing guide blurb

## Checklist

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [x] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
