### PR TITLE
fix: broken canary on windows

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -34,6 +34,7 @@ jobs:
         run: |
           ${{ matrix.install_command }}
       - name: Create and test each quickstart app
+        shell: bash
         run: |
           templates=$(wing new --list-templates)
           for template in $templates; do


### PR DESCRIPTION
GitHub actions claims to support bash on Windows so let's try this

## Checklist

- [ ] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [ ] Description explains motivation and solution
- [ ] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
