### PR TITLE
docs(sdk): modify documentation to match behaviour of `Map.get()`

### DIFF
--- a/libs/wingsdk/src/std/map.ts
+++ b/libs/wingsdk/src/std/map.ts
@@ -42,7 +42,7 @@ export class Map {
    * @macro ((obj, key) => { if (!(key in obj)) throw new Error(`Map does not contain key: "${key}"`); return obj[key]; })($self$, $args$)
    *
    * @param key The key of the element to return.
-   * @returns The element associated with the specified key, or undefined if the key can't be found
+   * @returns The element associated with the specified key, or throw an error if the key can't be found
    */
   public get(key: string): T1 {
     key;


### PR DESCRIPTION
Based on #5512

## Description
Modified the documentation of the `Map.get` method where it said `undefined` but returned an error when the key was not found.

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.