### PR TITLE
feat: use `this` for lifting in typescript instead of ctx

### DIFF
--- a/examples/ts-fixture/src/main.ts
+++ b/examples/ts-fixture/src/main.ts
@@ -8,8 +8,8 @@ main((app) => {
     "F1",
     lift({ bucket })
       .grant({ bucket: ["put"] })
-      .inflight(async ({ bucket }) => {
-        await bucket.put("hi", "stuff");
+      .inflight(async function () {
+        await this.bucket.put("hi", "stuff");
         console.log("hi from function");
         return "hi";
       })
@@ -17,12 +17,12 @@ main((app) => {
 
   const store = new winglib.Store(app, "Store");
 
-  let inf = inflight<() => Promise<void>>(async ({}) => {
+  let inf = inflight<() => Promise<void>>(async () => {
     console.log("hi from loose inflight");
   });
 
   store.onSet(
-    inflight(async ({}, message) => {
+    inflight(async (message) => {
       console.log(`Set("${message}")`);
     })
   );
@@ -32,11 +32,11 @@ main((app) => {
     "Test",
     lift({ store, inf, f })
       .grant({ store: ["set"] })
-      .inflight(async ({ store, inf, f }) => {
+      .inflight(async function () {
         console.log("hi from test");
-        await inf();
-        await f.invoke("me");
-        await store.set("wing");
+        await this.inf();
+        await this.f.invoke("me");
+        await this.store.set("wing");
       })
   );
 });

--- a/libs/ts4w/README.md
+++ b/libs/ts4w/README.md
@@ -2,12 +2,19 @@
 
 ```ts
 // main.ts
-import { main } from "ts4w";
-import { cloud } from "@winglang/sdk";
+import { main, cloud, std, lift } from "ts4w";
 
 main((app) => {
-  new cloud.Bucket(app, "Bucket");
-})
+  const bucket = new cloud.Bucket(app, "Bucket");
+
+  new std.Test(
+    app,
+    "put stuff into bucket",
+    lift({ bucket }).inflight(async function () {
+      await this.bucket.put("hello.txt", "hello world");
+    })
+  );
+});
 ```
 
 ```shell

--- a/libs/ts4w/src/inflight.ts
+++ b/libs/ts4w/src/inflight.ts
@@ -188,9 +188,7 @@ class Lifter<
     .map(([name, liftable]) => `${name}: ${liftObject(liftable)}`)
     .join(",\n")}
   };
-  let newFunction = async (...args) => {
-    return $func.call($ctx, ...args);
-  };
+  let newFunction = $func.bind($ctx);
   newFunction.handle = newFunction;
   return newFunction;
 }

--- a/libs/ts4w/test/inflight.test.ts
+++ b/libs/ts4w/test/inflight.test.ts
@@ -1,6 +1,5 @@
-import { std } from "@winglang/sdk";
 import { test, expect, expectTypeOf, vi } from "vitest";
-import { lift } from "../src";
+import { lift, std } from "../src";
 import { INFLIGHT_SYMBOL } from "@winglang/sdk/lib/core/types";
 
 interface FakeBucketClient {
@@ -18,10 +17,10 @@ test("can lift bucket", async () => {
   const bucket = new FakeBucket();
   const inflightSpy = vi.spyOn(bucket, "_toInflight");
 
-  let x = lift({ bucket }).inflight(async ({ bucket }) => {
-    expectTypeOf(bucket.hi).toEqualTypeOf<() => Promise<void>>();
-    expectTypeOf(bucket.field).toEqualTypeOf<string>();
-    expectTypeOf(bucket).toEqualTypeOf<FakeBucketClient>();
+  let x = lift({ bucket }).inflight(async function () {
+    expectTypeOf(this.bucket.hi).toEqualTypeOf<() => Promise<void>>();
+    expectTypeOf(this.bucket.field).toEqualTypeOf<string>();
+    expectTypeOf(this.bucket).toEqualTypeOf<FakeBucketClient>();
   });
 
   x._toInflight();
@@ -35,10 +34,10 @@ test("can lift bucket with grant", async () => {
 
   let x = lift({ bucket })
     .grant({ bucket: [] })
-    .inflight(async ({ bucket }) => {
-      expectTypeOf(bucket).not.toEqualTypeOf<FakeBucketClient>();
-      expectTypeOf(bucket.field).toEqualTypeOf<string>();
-      expectTypeOf(bucket).not.toHaveProperty("hi");
+    .inflight(async function () {
+      expectTypeOf(this.bucket).not.toEqualTypeOf<FakeBucketClient>();
+      expectTypeOf(this.bucket.field).toEqualTypeOf<string>();
+      expectTypeOf(this.bucket).not.toHaveProperty("hi");
     });
 
   x._toInflight();


### PR DESCRIPTION
I wanted to experiment with this, and since I got it working pretty quickly, I decided to put up a PR for discussion.

Changes the lifting/inflight from this:

```ts
import { lift, main, cloud } from "ts4w";

main((app) => {
  const bucket = new cloud.Bucket(app, "B1");
  new cloud.Function(
    app,
    "F1",
    lift({ bucket }).inflight(async ({ bucket }, event) => {
      await bucket.put("hi", "stuff");
      return event;
    })
  );
});
```

to this:

```ts
import { lift, main, cloud } from "ts4w";

main((app) => {
  const bucket = new cloud.Bucket(app, "B1");
  new cloud.Function(
    app,
    "F1",
    lift({ bucket }).inflight(async function (event) {
      await this.bucket.put("hi", "stuff");
      return event;
    })
  );
});
```

Full typing remains intact, with `this` now being typed the same way `ctx` previously was.


Pros:
- function arguments are as-is, no longer shifted by the first argument
  - I think users will appreciate the 1to1 match of function signatures
  - This is especially useful for inflights with no bindings, which previously required an empty first arg
- When using `function(){}`, it won't be possible to use `this` thinking the value is something else

Cons:
- inflights with lifts require the use of the more verbose `function(){}` syntax rather than `()=>{}` syntax
  - if you use an arrow function, `this` will not correct typing so it shouldn't be possible to use it incorrectly.
  - The distraction between these two js function syntaxes will be pretty opaque for most users

Note: Not marking this as a breaking change since ts isn't really released yet.

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
