### PR TITLE
fix: returning a struct literal after an incomplete reference breaks lsp completions

### DIFF
--- a/libs/wingc/src/lsp/snapshots/completions/dot_before_returning_struct.snap
+++ b/libs/wingc/src/lsp/snapshots/completions/dot_before_returning_struct.snap
@@ -1,0 +1,11 @@
+---
+source: libs/wingc/src/lsp/completions.rs
+---
+- label: s
+  kind: 5
+  detail: str
+  documentation:
+    kind: markdown
+    value: "```wing\ns: str\n```"
+  sortText: ab|s
+


### PR DESCRIPTION
fixes #5511

See the added comment for the how/why of this change

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
