### PR TITLE
fix(cli): wing new showing duplicate template names

### DIFF
--- a/apps/wing/src/commands/init.test.ts
+++ b/apps/wing/src/commands/init.test.ts
@@ -5,7 +5,6 @@ import { describe, expect, test, vitest, beforeEach, afterEach, vi } from "vites
 import { test as cliTest } from "./test/test";
 import { init } from "../commands/init";
 import { generateTmpDir, projectTemplateNames } from "../util";
-import { ex } from "@winglang/sdk";
 
 vitest.mock("inquirer");
 

--- a/apps/wing/src/commands/init.test.ts
+++ b/apps/wing/src/commands/init.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, test, vitest, beforeEach, afterEach, vi } from "vites
 import { test as cliTest } from "./test/test";
 import { init } from "../commands/init";
 import { generateTmpDir, projectTemplateNames } from "../util";
+import { ex } from "@winglang/sdk";
 
 vitest.mock("inquirer");
 
@@ -31,6 +32,30 @@ describe.each(templates)("new %s --language=wing", (template) => {
       platform: ["sim"],
       clean: false,
     });
+  });
+});
+
+describe("new --list-templates", () => {
+  let log: any;
+  beforeEach(() => {
+    log = console.log;
+    console.log = vi.fn();
+  });
+
+  afterEach(() => {
+    console.log = log;
+  });
+
+  test("wing new --list-templates", async () => {
+    await init("", { listTemplates: true });
+    expect(console.log).toHaveBeenCalledWith(templates.join("\n"));
+
+    const outputLines = ((console.log as any).mock.calls[0][0]).split("\n");
+    const outputLinesAsSet = new Set(outputLines);
+
+    expect(outputLines.length).toBeGreaterThan(0);
+    // Check there are no duplicate lines
+    expect(outputLinesAsSet.size).toBe(outputLines.length);
   });
 });
 

--- a/apps/wing/src/commands/init.test.ts
+++ b/apps/wing/src/commands/init.test.ts
@@ -49,7 +49,7 @@ describe("new --list-templates", () => {
     await init("", { listTemplates: true });
     expect(console.log).toHaveBeenCalledWith(templates.join("\n"));
 
-    const outputLines = ((console.log as any).mock.calls[0][0]).split("\n");
+    const outputLines = (console.log as any).mock.calls[0][0].split("\n");
     const outputLinesAsSet = new Set(outputLines);
 
     expect(outputLines.length).toBeGreaterThan(0);

--- a/apps/wing/src/commands/init.test.ts
+++ b/apps/wing/src/commands/init.test.ts
@@ -45,7 +45,7 @@ describe("new --list-templates", () => {
     console.log = log;
   });
 
-  test("wing new --list-templates", async () => {
+  test("does not contain duplicate template names", async () => {
     await init("", { listTemplates: true });
     expect(console.log).toHaveBeenCalledWith(templates.join("\n"));
 

--- a/apps/wing/src/util.ts
+++ b/apps/wing/src/util.ts
@@ -87,11 +87,11 @@ export const currentPackage: {
 export const PROJECT_TEMPLATES_DIR = join(__dirname, "..", "project-templates");
 
 export function projectTemplateNames(): string[] {
-  const templateNames: string[] = [];
+  const templateNames: Set<string> = new Set();
   readdirSync(join(PROJECT_TEMPLATES_DIR)).forEach((language) => {
     readdirSync(join(PROJECT_TEMPLATES_DIR, language)).forEach((template) => {
-      templateNames.push(template);
+      templateNames.add(template);
     });
   });
-  return templateNames;
+  return [...templateNames];
 }


### PR DESCRIPTION
Duplicate template names were being listed if we supported more than 1 language

## Checklist

- [ ] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [ ] Description explains motivation and solution
- [ ] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
