### PR TITLE
feat: `wing test` recursively finds entrypoints by default, and simpler filename filtering

### DIFF
--- a/apps/wing/src/commands/compile.ts
+++ b/apps/wing/src/commands/compile.ts
@@ -63,10 +63,10 @@ export interface CompileOptions {
  */
 export async function compile(entrypoint?: string, options?: CompileOptions): Promise<string> {
   if (!entrypoint) {
-    const wingFiles = (await glob("{main,*.main}.w")).sort();
+    const wingFiles = (await glob("{main,*.main}.{w,ts}")).sort();
     if (wingFiles.length === 0) {
       throw new Error(
-        "Cannot find entrypoint files (main.w or *.main.w) in the current directory."
+        "Cannot find an entrypoint file (main.w, main.ts, *.main.w, *.main.ts) in the current directory."
       );
     }
     if (wingFiles.length > 1) {

--- a/apps/wing/src/commands/run.ts
+++ b/apps/wing/src/commands/run.ts
@@ -36,7 +36,7 @@ export async function run(entrypoint?: string, options?: RunOptions) {
   const openBrowser = options?.open ?? true;
 
   if (!entrypoint) {
-    const wingFiles = (await glob("{main,*.main}.w")).sort();
+    const wingFiles = (await glob("{main,*.main}.{w,ts}")).sort();
     if (wingFiles.length === 0) {
       throw new Error(
         "Cannot find entrypoint files (main.w or *.main.w) in the current directory."

--- a/apps/wing/src/commands/test/test.test.ts
+++ b/apps/wing/src/commands/test/test.test.ts
@@ -6,7 +6,7 @@ import { BuiltinPlatform } from "@winglang/compiler";
 import { TestResult, TraceType } from "@winglang/sdk/lib/std";
 import chalk from "chalk";
 import { describe, test, expect, beforeEach, afterEach, vi, SpyInstance } from "vitest";
-import { filterTests, renderTestReport, test as wingTest } from ".";
+import { filterTests, renderTestReport, collectTestFiles, test as wingTest } from ".";
 import * as resultsFn from "./results";
 
 const defaultChalkLevel = chalk.level;
@@ -90,33 +90,108 @@ describe("wing test (custom platform)", () => {
   });
 });
 
-describe("wing test (no options)", () => {
-  let logSpy: SpyInstance;
-
-  beforeEach(() => {
-    chalk.level = 0;
-    logSpy = vi.spyOn(console, "log");
-  });
-
-  afterEach(() => {
-    chalk.level = defaultChalkLevel;
-    process.chdir(cwd);
-    logSpy.mockRestore();
-  });
-
-  test("default entrypoint behaviour", async () => {
+describe("collectTestFiles", () => {
+  test("default entrypoints", async () => {
     const outDir = await fsPromises.mkdtemp(join(tmpdir(), "-wing-compile-test"));
 
     process.chdir(outDir);
-    fs.writeFileSync("foo.test.w", "bring cloud;");
-    fs.writeFileSync("bar.test.w", "bring cloud;");
-    fs.writeFileSync("baz.test.w", "bring cloud;");
+    fs.writeFileSync("foo.test.w", "");
+    fs.writeFileSync("bar.test.w", "");
+    fs.writeFileSync("baz.test.w", "");
+    fs.writeFileSync("typescript.test.ts", "");
 
-    await wingTest([], { clean: true, platform: [BuiltinPlatform.SIM] });
+    const files = await collectTestFiles([]);
 
-    expect(logSpy).toHaveBeenCalledWith("pass ─ foo.test.wsim (no tests)");
-    expect(logSpy).toHaveBeenCalledWith("pass ─ bar.test.wsim (no tests)");
-    expect(logSpy).toHaveBeenCalledWith("pass ─ baz.test.wsim (no tests)");
+    expect(files).toMatchInlineSnapshot(`
+      [
+        "typescript.test.ts",
+        "foo.test.w",
+        "baz.test.w",
+        "bar.test.w",
+      ]
+    `);
+  });
+
+  test("specific entrypoint", async () => {
+    const outDir = await fsPromises.mkdtemp(join(tmpdir(), "-wing-compile-test"));
+
+    process.chdir(outDir);
+    fs.writeFileSync("foo.test.w", "");
+    fs.writeFileSync("bar.test.w", "");
+    fs.writeFileSync("baz.test.w", "");
+
+    const files = await collectTestFiles(["foo.test.w"]);
+
+    expect(files).toMatchInlineSnapshot(`
+      [
+        "foo.test.w",
+      ]
+    `);
+  });
+
+  test("fuzzy match dir", async () => {
+    const outDir = await fsPromises.mkdtemp(join(tmpdir(), "-wing-compile-test"));
+
+    process.chdir(outDir);
+    fs.mkdirSync("foo");
+    fs.writeFileSync("foo/a.test.w", "");
+    fs.writeFileSync("foo/b.test.w", "");
+    fs.writeFileSync("foo.test.w", "");
+    fs.writeFileSync("baz.test.w", "");
+
+    const files = await collectTestFiles(["foo"]);
+
+    expect(files).toMatchInlineSnapshot(`
+      [
+        "foo.test.w",
+        "foo/b.test.w",
+        "foo/a.test.w",
+      ]
+    `);
+  });
+
+  test("absolute path dedupe", async () => {
+    const outDir = await fsPromises.mkdtemp(join(tmpdir(), "-wing-compile-test"));
+
+    process.chdir(outDir);
+    fs.mkdirSync("foo");
+    fs.writeFileSync("foo/a.test.w", "");
+    fs.writeFileSync("foo/b.test.w", "");
+    fs.writeFileSync("foo.test.w", "");
+    fs.writeFileSync("baz.test.w", "");
+
+    const files = await collectTestFiles(["foo"]);
+
+    expect(files).toMatchInlineSnapshot(`
+    [
+      "foo.test.w",
+      "foo/b.test.w",
+      "foo/a.test.w",
+    ]
+  `);
+  });
+
+  test("testing file outside current dir", async () => {
+    const outDir = await fsPromises.mkdtemp(join(tmpdir(), "-wing-compile-test"));
+    const subDir = join(outDir, "subdir");
+
+    process.chdir(outDir);
+
+    fs.writeFileSync("foo.test.w", "");
+
+    fs.mkdirSync(subDir);
+
+    process.chdir(subDir);
+
+    fs.writeFileSync("main.w", "");
+
+    const files = await collectTestFiles(["../foo.test.w"]);
+
+    expect(files).toMatchInlineSnapshot(`
+      [
+        "../foo.test.w",
+      ]
+    `);
   });
 });
 

--- a/apps/wing/src/commands/test/test.test.ts
+++ b/apps/wing/src/commands/test/test.test.ts
@@ -98,13 +98,13 @@ describe("collectTestFiles", () => {
     fs.writeFileSync("foo.test.w", "");
     fs.writeFileSync("bar.test.w", "");
     fs.writeFileSync("baz.test.w", "");
-    fs.writeFileSync("typescript.test.ts", "");
+    fs.writeFileSync("main.ts", "");
 
     const files = await collectTestFiles([]);
 
     expect(files).toMatchInlineSnapshot(`
       [
-        "typescript.test.ts",
+        "main.ts",
         "foo.test.w",
         "baz.test.w",
         "bar.test.w",

--- a/apps/wing/src/commands/test/test.ts
+++ b/apps/wing/src/commands/test/test.ts
@@ -1,6 +1,6 @@
 import * as cp from "child_process";
-import { existsSync, readFile, readFileSync, rm, rmSync } from "fs";
-import { basename, join, resolve, sep } from "path";
+import { existsSync, readFile, readFileSync, realpathSync, rm, rmSync, statSync } from "fs";
+import { basename, join, relative, resolve, sep } from "path";
 import { promisify } from "util";
 import { BuiltinPlatform, determineTargetFromPlatforms } from "@winglang/compiler";
 import { std, simulator } from "@winglang/sdk";
@@ -11,7 +11,7 @@ import debug from "debug";
 import { glob } from "glob";
 import { nanoid } from "nanoid";
 import { printResults, validateOutputFilePath, writeResultsToFile } from "./results";
-import { withSpinner, normalPath } from "../../util";
+import { withSpinner } from "../../util";
 import { compile, CompileOptions } from "../compile";
 
 const log = debug("wing:test");
@@ -47,22 +47,52 @@ export interface TestOptions extends CompileOptions {
   retry?: number;
 }
 
-export async function test(entrypoints: string[], options: TestOptions): Promise<number> {
-  let patterns;
+const TEST_FILE_PATTERNS = ["**/*.test.{w,ts}", "**/{main,*.main}.{w,ts}"];
+const TEST_FILE_IGNORE = ["**/node_modules/**", "**/target/**"];
 
+/**
+ * Collects all the test files that should be run.
+ * If no entrypoints are specified, all the entrypoint files in the current directory (recursive) are collected.
+ * This excludes node_modules and target directories.
+ *
+ * If entrypoints are specified, only the files that contain the entrypoint string are collected.
+ */
+export async function collectTestFiles(entrypoints: string[] = []): Promise<string[]> {
+  const expandedEntrypoints = await glob(TEST_FILE_PATTERNS, {
+    ignore: TEST_FILE_IGNORE,
+    absolute: false,
+    posix: true,
+  });
+
+  // check if any of the entrypoints are exact files
+  const exactEntrypoints = entrypoints.filter(
+    (e) => statSync(e, { throwIfNoEntry: false })?.isFile() === true
+  );
+  const fuzzyEntrypoints = entrypoints.filter((e) => !exactEntrypoints.includes(e));
+
+  let finalEntrypoints: string[] = exactEntrypoints;
+  if (fuzzyEntrypoints.length > 0) {
+    // if entrypoints are specified, filter the expanded entrypoints to ones that contain them
+    finalEntrypoints = finalEntrypoints.concat(
+      expandedEntrypoints.filter((e) => fuzzyEntrypoints.some((f) => e.includes(f)))
+    );
+  } else if (exactEntrypoints.length === 0) {
+    finalEntrypoints = finalEntrypoints.concat(expandedEntrypoints);
+  }
+
+  // dedupe based on real path, then get all paths as relative to cwd
+  const cwd = process.cwd();
+  return [...new Set(finalEntrypoints.map((e) => realpathSync(e)))].map((e) => relative(cwd, e));
+}
+
+export async function test(entrypoints: string[], options: TestOptions): Promise<number> {
   if (options.outputFile) {
     validateOutputFilePath(options.outputFile);
   }
 
-  if (entrypoints.length === 0) {
-    patterns = ["*.test.w"];
-  } else {
-    patterns = entrypoints.map((entrypoint) => normalPath(entrypoint));
-  }
-
-  const expandedEntrypoints = await glob(patterns);
-  if (expandedEntrypoints.length === 0) {
-    throw new Error(`No matching files found for patterns: [${patterns.join(", ")}]`);
+  const selectedEntrypoints = await collectTestFiles(entrypoints);
+  if (selectedEntrypoints.length === 0) {
+    throw new Error(`No matching test or entrypoint files found: [${entrypoints.join(", ")}]`);
   }
 
   const startTime = Date.now();
@@ -91,7 +121,7 @@ export async function test(entrypoints: string[], options: TestOptions): Promise
       });
     }
   };
-  await Promise.all(expandedEntrypoints.map(testFile));
+  await Promise.all(selectedEntrypoints.map(testFile));
   const testDuration = Date.now() - startTime;
   printResults(results, testDuration);
   if (options.outputFile) {

--- a/apps/wing/src/commands/test/test.ts
+++ b/apps/wing/src/commands/test/test.ts
@@ -47,7 +47,7 @@ export interface TestOptions extends CompileOptions {
   retry?: number;
 }
 
-const TEST_FILE_PATTERNS = ["**/*.test.{w,ts}", "**/{main,*.main}.{w,ts}"];
+const TEST_FILE_PATTERNS = ["**/*.test.w", "**/{main,*.main}.{w,ts}"];
 const TEST_FILE_IGNORE = ["**/node_modules/**", "**/target/**"];
 
 /**

--- a/docs/docs/06-tools/01-cli.md
+++ b/docs/docs/06-tools/01-cli.md
@@ -181,19 +181,17 @@ Usage:
 $ wing test [entrypoint...] [--test-filter <regex>] [--retry [retries]]
 ```
 
-`[entrypoint...]` specifies the entrypoint list of files that will be compiled and tested. A file is considered a valid entrypoint if its name ends with `.w`.
+`[entrypoint...]` is the list of entrypoints that will be compiled and tested. 
+A file is considered an entrypoint if its name is `main` or ends with `.main` or `.test` and the extension is `.w` or `.ts`. 
+Exact paths or partial text can be used. If partial, all entrypoints in the current directory that contain the partial path will be used. For example `wing test bucket` will test `bucket.test.w` and `bucket/get.test.w`.
 
-`[--test-filter <regex>]` option to run only specific tests within the entrypoints based on a provided regex.
+By default, all entrypoints in the current directory will be used.
 
-`[--retry [retries]]` option specifies the number of retries for failed tests. If no number is specified, the default number of retries is `3`.
+`[--test-filter <regex>]` runs only specific tests within the entrypoints based on a provided regex.
+
+`[--retry [retries]]` will retry failed tests based on number provided. By default it will retry `3` times.
 
 For example ([test_bucket.test.w](https://github.com/winglang/wing/tree/main/examples/tests/valid/test_bucket.test.w)):
-
-:::note Default Entrypoint(s)
-
-It's possible to execute `wing test` without specifying any entrypoint, in which case the CLI looks for all files ending with `.test.w` in the current directory. If no files are found, the CLI throws an error.
-
-:::
 
 ```js
 bring cloud;

--- a/libs/wingcompiler/package.json
+++ b/libs/wingcompiler/package.json
@@ -10,8 +10,7 @@
   "engines": {
     "node": ">=v18.0.0"
   },
-  "main": "./dist/index.js",
-  "types": "./dist/index.d.ts",
+  "main": "dist/index.js",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/winglang/wing.git"


### PR DESCRIPTION
fixes #4839, specifically implementing @Chriscbr's suggestion https://github.com/winglang/wing/issues/4839#issuecomment-1804447937

Other changes:
- .ts files are now also matched by default for run, compile, and test
- Fixed the `main` and `types` entry in `@winglang/compiler`, which was not written correctly and has been causing errors in my ide for a long time

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
