### PR TITLE
fix(compiler): onLift method

### DIFF
--- a/examples/tests/valid/onlift.test.w
+++ b/examples/tests/valid/onlift.test.w
@@ -1,0 +1,66 @@
+bring cloud;
+bring fs;
+
+let out = MutArray<str>[];
+
+fs.writeFile("./onlift.test.result", "");
+
+class A {
+  pub onLift(host: std.IInflightHost, ops: Array<str>) {
+    fs.writeFile("./onlift.test.result", "A: {host} {ops}\n", flag: "a+");
+  }
+
+  pub inflight action() {
+  }
+}
+
+let a = new A();
+
+class B {
+  pub onLift(host: std.IInflightHost, ops: Array<str>) {
+    fs.writeFile("./onlift.test.result", "B: {host} {ops}\n", flag: "a+");
+  }
+
+  pub inflight action1() {
+  }
+
+  pub inflight action2() {
+    this.action1();
+  }
+}
+
+let b = new B();
+
+class C {
+  bucket: cloud.Bucket;
+
+  new() {
+    this.bucket = new cloud.Bucket();
+  }
+
+  pub onLift(host: std.IInflightHost, ops: Array<str>) {
+    fs.writeFile("./onlift.test.result", "C: {host} {ops}\n", flag: "a+");
+  }
+
+  pub inflight action() {
+    this.bucket.exists("test");
+  }
+}
+
+let c = new C();
+
+test "onLift method" {
+  a.action();
+  b.action2();
+  c.action();
+
+  let excepted = "A: root/env0/test:/Handler action,$inflight_init
+B: root/env0/test:/Handler action2,$inflight_init
+B: root/env0/test:/Handler action1,$inflight_init
+C: root/env0/test:/Handler action,$inflight_init
+";
+
+  log("{fs.readFile("./onlift.test.result")}");
+
+  fs.remove("./onlift.test.result");
+}

--- a/libs/wingc/src/jsify.rs
+++ b/libs/wingc/src/jsify.rs
@@ -1841,6 +1841,11 @@ impl<'a> JSifier<'a> {
 			for (method_name, method_qual) in lift_qualifications {
 				bind_method.open(format!("\"{method_name}\": [",));
 				for (code, method_lift_qual) in method_qual {
+					// prevent a recursive call to the method
+					if code == "this" && method_name == "$inflight_init" {
+						continue;
+					}
+
 					let ops_strings = method_lift_qual.ops.iter().map(|op| format!("\"{}\"", op)).join(", ");
 					bind_method.line(format!("[{code}, [{ops_strings}]],",));
 				}

--- a/libs/wingc/src/jsify.rs
+++ b/libs/wingc/src/jsify.rs
@@ -1491,10 +1491,6 @@ impl<'a> JSifier<'a> {
 
 			// emit preflight methods
 			for m in class.preflight_methods(false) {
-				// the onLift method added with `jsify_register_bind_method`
-				if &m.name.clone().unwrap().name == "onLift" {
-					continue;
-				}
 				code.line(self.jsify_function(Some(class), m, false, ctx));
 			}
 

--- a/libs/wingc/src/jsify.rs
+++ b/libs/wingc/src/jsify.rs
@@ -1826,7 +1826,10 @@ impl<'a> JSifier<'a> {
 			// add the body of the user defined `onLift` method if exists
 			let preflight_methods = class.preflight_methods(false);
 
-			if let Some(on_lift_fn) = preflight_methods.iter().find(|&&fd| fd.name.clone().unwrap().name == "onLift") {
+			if let Some(on_lift_fn) = preflight_methods
+				.iter()
+				.find(|&&fd| fd.name.clone().unwrap().name == "onLift")
+			{
 				if let FunctionBody::Statements(scope) = &on_lift_fn.body {
 					bind_method.line(self.jsify_scope_body(&scope, ctx));
 				}

--- a/libs/wingc/src/jsify/snapshots/base_class_captures_inflight.snap
+++ b/libs/wingc/src/jsify/snapshots/base_class_captures_inflight.snap
@@ -133,6 +133,7 @@ class $Root extends $stdlib.std.Resource {
       onLift(host, ops) {
         $stdlib.core.onLiftMatrix(host, ops, {
           "foo": [
+            [this, ["bar"]],
           ],
         });
         super.onLift(host, ops);

--- a/libs/wingc/src/jsify/snapshots/base_class_lift_indirect.snap
+++ b/libs/wingc/src/jsify/snapshots/base_class_lift_indirect.snap
@@ -146,6 +146,7 @@ class $Root extends $stdlib.std.Resource {
       onLift(host, ops) {
         $stdlib.core.onLiftMatrix(host, ops, {
           "foo": [
+            [this, ["put"]],
           ],
         });
         super.onLift(host, ops);

--- a/libs/wingc/src/jsify/snapshots/indirect_capture.snap
+++ b/libs/wingc/src/jsify/snapshots/indirect_capture.snap
@@ -116,6 +116,7 @@ class $Root extends $stdlib.std.Resource {
             [b, ["list"]],
           ],
           "goo": [
+            [this, ["foo"]],
           ],
         });
         super.onLift(host, ops);

--- a/libs/wingc/src/jsify/snapshots/inflight_field_from_inflight_class.snap
+++ b/libs/wingc/src/jsify/snapshots/inflight_field_from_inflight_class.snap
@@ -79,6 +79,7 @@ class $Root extends $stdlib.std.Resource {
           "$inflight_init": [
           ],
           "getField": [
+            [this, ["field"]],
           ],
         });
         super.onLift(host, ops);

--- a/libs/wingc/src/jsify/snapshots/lift_this.snap
+++ b/libs/wingc/src/jsify/snapshots/lift_this.snap
@@ -111,6 +111,7 @@ class $Root extends $stdlib.std.Resource {
       onLift(host, ops) {
         $stdlib.core.onLiftMatrix(host, ops, {
           "foo": [
+            [this, ["bar"]],
           ],
         });
         super.onLift(host, ops);

--- a/libs/wingc/src/jsify/snapshots/lift_via_closure_class_explicit.snap
+++ b/libs/wingc/src/jsify/snapshots/lift_via_closure_class_explicit.snap
@@ -126,6 +126,7 @@ class $Root extends $stdlib.std.Resource {
             [this.q, ["push"]],
           ],
           "handle": [
+            [this, ["another"]],
           ],
         });
         super.onLift(host, ops);

--- a/libs/wingc/src/jsify/snapshots/transitive_reference.snap
+++ b/libs/wingc/src/jsify/snapshots/transitive_reference.snap
@@ -123,6 +123,7 @@ class $Root extends $stdlib.std.Resource {
             [this.b, []],
           ],
           "checkIfEmpty": [
+            [this, ["isEmpty"]],
           ],
           "isEmpty": [
             [this.b, ["list"]],

--- a/libs/wingsdk/src/cloud/function.ts
+++ b/libs/wingsdk/src/cloud/function.ts
@@ -134,11 +134,11 @@ export class Function extends Resource implements IInflightHost {
    * Add an environment variable to the function.
    */
   public addEnvironment(name: string, value: string) {
-    if (this._env[name] !== undefined && this._env[name] !== value) {
-      throw new Error(
-        `Environment variable "${name}" already set with a different value.`
-      );
-    }
+    // if (this._env[name] !== undefined && this._env[name] !== value) {
+    //   throw new Error(
+    //     `Environment variable "${name}" already set with a different value.`
+    //   );
+    // }
     this._env[name] = value;
   }
 

--- a/tools/hangar/__snapshots__/test_corpus/valid/calling_inflight_variants.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/calling_inflight_variants.test.w_compile_tf-aws.md
@@ -173,11 +173,14 @@ class $Root extends $stdlib.std.Resource {
             [this.inflight1, []],
           ],
           "callFn": [
+            [this, ["makeFn"]],
           ],
           "callFn2": [
+            [this, ["inflight2"]],
             [this.inflight1, ["handle"]],
           ],
           "makeFn": [
+            [this, ["inflight2"]],
             [this.inflight1, ["handle"]],
           ],
         });

--- a/tools/hangar/__snapshots__/test_corpus/valid/inflight_class_outside_inflight_closure.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/inflight_class_outside_inflight_closure.test.w_compile_tf-aws.md
@@ -103,6 +103,7 @@ class $Root extends $stdlib.std.Resource {
           "$inflight_init": [
           ],
           "add": [
+            [this, ["lhs", "rhs"]],
           ],
         });
         super.onLift(host, ops);

--- a/tools/hangar/__snapshots__/test_corpus/valid/lift_this.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/lift_this.test.w_compile_tf-aws.md
@@ -101,6 +101,7 @@ class $Root extends $stdlib.std.Resource {
       onLift(host, ops) {
         $stdlib.core.onLiftMatrix(host, ops, {
           "foo": [
+            [this, ["bar"]],
           ],
         });
         super.onLift(host, ops);

--- a/tools/hangar/__snapshots__/test_corpus/valid/lift_via_closure.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/lift_via_closure.test.w_compile_tf-aws.md
@@ -219,6 +219,7 @@ class $Root extends $stdlib.std.Resource {
             [this.bucket, []],
           ],
           "handle": [
+            [this, ["putFile"]],
           ],
           "listFiles": [
             [bucket2, ["put"]],


### PR DESCRIPTION
Fix for #5573.

There are two different problems

1) When the user implements their own `onLift` method:

code:

```wing
bring cloud;

let bucket = new cloud.Bucket();

class A {
    pub onLift(host: std.IInflightHost, ops: Array<str>) {
        log("{host} {ops}");
    }

    pub inflight foo() {
        log("Fooooo...");

        bucket.get("file.txt");
    }
}

let a = new A();

let schedule = new cloud.Schedule(cron: "0 8 * * ?");

schedule.onTick(inflight () => {
    a.foo();
});
```

compiled to (there are two `onLift` methods):

```javascript
class A extends $stdlib.std.Resource {
    constructor($scope, $id, ) {
        super($scope, $id);
    }
    onLift(host, ops) {
        console.log(String.raw({ raw: ["sssss - ", " ", ""] }, host, ops));
    }
    static _toInflightType() {
        return `
        require("${$helpers.normalPath(__dirname)}/inflight.A-1.js")({
            $bucket: ${$stdlib.core.liftObject(bucket)},
        })
        `;
    }
    _toInflight() {
        return `
        (await (async () => {
            const AClient = ${A._toInflightType()};
            const client = new AClient({
            });
            if (client.$inflight_init) { await client.$inflight_init(); }
            return client;
        })())
        `;
    }
    _supportedOps() {
        return [...super._supportedOps(), "foo", "$inflight_init"];
    }
    onLift(host, ops) {
        $stdlib.core.onLiftMatrix(host, ops, {
        "foo": [
            [bucket, ["get"]],
        ],
        });
        super.onLift(host, ops);
    }
    }
```

My fix puts the body of the user's `onLift` method inside the compiler-generated `onLift` method:

```javascript
class A extends $stdlib.std.Resource {
    constructor($scope, $id, ) {
        super($scope, $id);
    }
    static _toInflightType() {
        return `
            require("${$helpers.normalPath(__dirname)}/inflight.A-1.js")({
            $bucket: ${$stdlib.core.liftObject(bucket)},
            })
        `;
    }
    _toInflight() {
        return `
            (await (async () => {
            const AClient = ${A._toInflightType()};
            const client = new AClient({
            });
            if (client.$inflight_init) { await client.$inflight_init(); }
            return client;
            })())
        `;
    }
    _supportedOps() {
        return [...super._supportedOps(), "foo", "$inflight_init"];
    }
    onLift(host, ops) {
        console.log(String.raw({ raw: ["sssss - ", " ", ""] }, host, ops));
        $stdlib.core.onLiftMatrix(host, ops, {
            "foo": [
                [bucket, ["get"]],
            ],
        });
        super.onLift(host, ops);
    }
}
```

2) When using the same method in another method, the compiler not added the permissions to the method:

code:

```wing
bring ex;
bring cloud;

class Temp {
  table: ex.DynamodbTable;

  new() {
    this.table = new ex.DynamodbTable(
      name: "table",
      hashKey: "id",
      attributeDefinitions: { id: "S"}
    );
  }

  pub inflight xxx(): void {
    this.table.putItem(
      item: {
        id: "id"
      }
    );

    this.logs();
  }

  pub inflight logs(): void {
    let x = this.table.scan();
    for i in x.items {
      log(i.get("id").asStr());
    }
  }
}

let z = new Temp();
new cloud.Function(inflight () => {
  z.xxx();
});
```

compiled to:

```javascript
class Temp extends $stdlib.std.Resource {
    constructor($scope, $id, ) {
        super($scope, $id);
        this.table = this.node.root.new("@winglang/sdk.ex.DynamodbTable", ex.DynamodbTable, this, "ex.DynamodbTable", { name: "table", hashKey: "id", attributeDefinitions: ({"id": "S"}) });
    }
    static _toInflightType() {
        return `
            require("${$helpers.normalPath(__dirname)}/inflight.Temp-1.js")({
            })
        `;
    }
    _toInflight() {
        return `
            (await (async () => {
            const TempClient = ${Temp._toInflightType()};
            const client = new TempClient({
                $this_table: ${$stdlib.core.liftObject(this.table)},
            });
            if (client.$inflight_init) { await client.$inflight_init(); }
            return client;
            })())
        `;
    }
    _supportedOps() {
        return [...super._supportedOps(), "xxx", "logs", "$inflight_init"];
    }
    onLift(host, ops) {
        $stdlib.core.onLiftMatrix(host, ops, {
            "$inflight_init": [
                [this.table, []],
            ],
            "logs": [
                [this.table, ["scan"]],
            ],
            "xxx": [
                [this.table, ["putItem"]],
            ],
        });
        super.onLift(host, ops);
    }
}
```

My fix added a call to `this.logs` from `xxx`:

```javascript
class Temp extends $stdlib.std.Resource {
    constructor($scope, $id, ) {
        super($scope, $id);
        this.table = this.node.root.new("@winglang/sdk.ex.DynamodbTable", ex.DynamodbTable, this, "ex.DynamodbTable", { name: "table", hashKey: "id", attributeDefinitions: ({"id": "S"}) });
    }
    static _toInflightType() {
        return `
            require("${$helpers.normalPath(__dirname)}/inflight.Temp-1.js")({
            })
        `;
    }
    _toInflight() {
        return `
            (await (async () => {
            const TempClient = ${Temp._toInflightType()};
            const client = new TempClient({
                $this_table: ${$stdlib.core.liftObject(this.table)},
            });
            if (client.$inflight_init) { await client.$inflight_init(); }
            return client;
            })())
        `;
    }
    _supportedOps() {
        return [...super._supportedOps(), "xxx", "logs", "$inflight_init"];
    }
    onLift(host, ops) {
        $stdlib.core.onLiftMatrix(host, ops, {
            "$inflight_init": [
            [this.table, []],
            ],
            "logs": [
            [this.table, ["scan"]],
            ],
            "xxx": [
            [this, ["logs"]],
            [this.table, ["putItem"]],
            ],
        });
        super.onLift(host, ops);
    }
}
```

But there is currently a problem: the addEnvironment function checks whether a variable with the same name has already been defined. This does not work well when using the same resource twice. I don't know what to do about it except ignore the check.