### PR TITLE
chore: wrong cache location for @wingcloud/framework build output

### DIFF
--- a/libs/@wingcloud/framework/turbo.json
+++ b/libs/@wingcloud/framework/turbo.json
@@ -9,12 +9,9 @@
         "dist/**"
       ]
     },
-    "test": {
-      "dependsOn": ["compile"]
-    },
+    "test": {},
     "package": {
-      "dependsOn": ["compile"],
-      "outputs": ["../../dist/wingcloud-framework-*.tgz"]
+      "outputs": ["../../../dist/wingcloud-framework-*.tgz"]
     }
   }
 }


### PR DESCRIPTION
Resolves the build failure from [wingcloud-framework-](https://github.com/winglang/wing/actions/runs/7738555901/job/21101794210)

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
