### PR TITLE
fix: ts types for optional requires explicit `undefined`

### DIFF
--- a/examples/wing-fixture/store.w
+++ b/examples/wing-fixture/store.w
@@ -1,11 +1,15 @@
 bring cloud;
 bring "./subdir/util.w" as myutil;
 
+pub struct StoreOptions {
+  name: str?;
+}
+
 pub class Store {
   handlers: MutArray<inflight (str): void>;
   data: cloud.Bucket;
 
-  new() {
+  new(options: StoreOptions?) {
     this.data = new cloud.Bucket();
     this.handlers = MutArray<inflight (str): void> [];
   }

--- a/libs/wingc/src/dtsify/snapshots/optionals.snap
+++ b/libs/wingc/src/dtsify/snapshots/optionals.snap
@@ -1,0 +1,132 @@
+---
+source: libs/wingc/src/dtsify/mod.rs
+---
+## Code
+
+```w
+
+pub struct Struct {
+  n: num?;
+}
+
+pub interface Interface {
+  method(s: Struct?): str;
+}
+
+pub interface ClassInterface {
+  addHandler(handler: inflight (str?): str, s: Struct?): void;
+}
+
+pub class ParentClass impl ClassInterface {
+  pub addHandler(handler: inflight (str?): str, s: Struct?) {}
+}
+
+```
+
+## inflight.ParentClass-1.js
+
+```js
+"use strict";
+const $helpers = require("@winglang/sdk/lib/helpers");
+module.exports = function({  }) {
+  class ParentClass {
+    constructor({  }) {
+    }
+  }
+  return ParentClass;
+}
+//# sourceMappingURL=inflight.ParentClass-1.js.map
+```
+
+## preflight.d.ts
+
+```js
+export * from "./preflight.lib-1.js"
+```
+
+## preflight.js
+
+```js
+"use strict";
+const $stdlib = require('@winglang/sdk');
+const std = $stdlib.std;
+const $helpers = $stdlib.helpers;
+module.exports = {
+  ...require("./preflight.lib-1.js"),
+};
+//# sourceMappingURL=preflight.js.map
+```
+
+## preflight.lib-1.d.ts
+
+```js
+import * as $internal from "@winglang/sdk/lib/core/types"
+import { std } from "@winglang/sdk"
+export interface Struct {
+  readonly n?: (number) | undefined;
+}
+export interface Interface
+{
+  readonly method: (s?: (Struct) | undefined) => string;
+}
+export interface Interface$Inflight
+{
+}
+export interface ClassInterface
+{
+  readonly addHandler: (handler: $internal.Inflight<(arg0?: (string) | undefined) => Promise<string>>, s?: (Struct) | undefined) => void;
+}
+export interface ClassInterface$Inflight
+{
+}
+export class ParentClass extends std.Resource implements ClassInterface
+{
+  constructor(scope: $internal.Construct, id: string);
+  [$internal.INFLIGHT_SYMBOL]?: ParentClass$Inflight;
+  _supportedOps(): $internal.OperationsOf<ParentClass$Inflight>;
+  addHandler: (handler: $internal.Inflight<(arg0?: (string) | undefined) => Promise<string>>, s?: (Struct) | undefined) => void;
+}
+export class ParentClass$Inflight implements ClassInterface$Inflight
+{
+  constructor();
+}
+```
+
+## preflight.lib-1.js
+
+```js
+"use strict";
+const $stdlib = require('@winglang/sdk');
+const std = $stdlib.std;
+const $helpers = $stdlib.helpers;
+class ParentClass extends $stdlib.std.Resource {
+  constructor($scope, $id, ) {
+    super($scope, $id);
+  }
+  addHandler(handler, s) {
+  }
+  static _toInflightType() {
+    return `
+      require("${$helpers.normalPath(__dirname)}/inflight.ParentClass-1.js")({
+      })
+    `;
+  }
+  _toInflight() {
+    return `
+      (await (async () => {
+        const ParentClassClient = ${ParentClass._toInflightType()};
+        const client = new ParentClassClient({
+        });
+        if (client.$inflight_init) { await client.$inflight_init(); }
+        return client;
+      })())
+    `;
+  }
+  _supportedOps() {
+    return [...super._supportedOps(), "$inflight_init"];
+  }
+}
+module.exports = { ParentClass };
+//# sourceMappingURL=preflight.lib-1.js.map
+```
+


### PR DESCRIPTION
wingc currently emits an optional type in functions/fields like this:

```ts
interface StructyGuy {
  a: (str) | undefined
}
```

While this is technically correct for the purpose of the runtime, it doesn't allow you to completely omit `a`.
This PR generates it like this:

```ts
interface StructyGuy {
  a?: (str) | undefined
}
```

This may seem verbose, but in wing the `?` on a type technically does mean both of these things. It's possible that in certain contexts we could simplify it to improve how it looks to users, but this behavior is still correct so I think it's fine to continue on this path.

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
