### PR TITLE
fix: main.w files cannot use `this`

### DIFF
--- a/libs/wingc/src/jsify/snapshots/entrypoint_this.snap
+++ b/libs/wingc/src/jsify/snapshots/entrypoint_this.snap
@@ -1,0 +1,33 @@
+---
+source: libs/wingc/src/jsify/tests.rs
+---
+## Code
+
+```w
+
+    this;
+    
+```
+
+## preflight.js
+
+```js
+"use strict";
+const $stdlib = require('@winglang/sdk');
+const $platforms = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLATFORMS);
+const $outdir = process.env.WING_SYNTH_DIR ?? ".";
+const $wing_is_test = process.env.WING_IS_TEST === "true";
+const std = $stdlib.std;
+const $helpers = $stdlib.helpers;
+class $Root extends $stdlib.std.Resource {
+  constructor($scope, $id) {
+    super($scope, $id);
+    this;
+  }
+}
+const $PlatformManager = new $stdlib.platform.PlatformManager({platformPaths: $platforms});
+const $APP = $PlatformManager.createApp({ outdir: $outdir, name: "main", rootConstruct: $Root, isTestEnvironment: $wing_is_test, entrypointDir: process.env['WING_SOURCE_DIR'], rootId: process.env['WING_ROOT_ID'] });
+$APP.synth();
+//# sourceMappingURL=preflight.js.map
+```
+

--- a/libs/wingc/src/jsify/snapshots/fails_when_referencing_this_from_static.snap
+++ b/libs/wingc/src/jsify/snapshots/fails_when_referencing_this_from_static.snap
@@ -2,4 +2,4 @@
 source: libs/wingc/src/jsify/tests.rs
 ---
 ## Errors
-Unknown symbol "this" 3:8
+Unknown symbol "print" 3:13

--- a/libs/wingc/src/jsify/tests.rs
+++ b/libs/wingc/src/jsify/tests.rs
@@ -2031,3 +2031,12 @@ fn lift_self_reference() {
     "#
 	);
 }
+
+#[test]
+fn entrypoint_this() {
+	assert_compile_ok!(
+		r#"
+    this;
+    "#
+	);
+}

--- a/libs/wingc/src/lib.rs
+++ b/libs/wingc/src/lib.rs
@@ -19,7 +19,7 @@ use indexmap::IndexMap;
 use jsify::JSifier;
 
 use lifting::LiftVisitor;
-use parser::parse_wing_project;
+use parser::{is_entrypoint_file, parse_wing_project};
 use struct_schema::StructSchemaVisitor;
 use type_check::jsii_importer::JsiiImportSpec;
 use type_check::symbol_env::SymbolEnvKind;
@@ -229,9 +229,8 @@ pub fn type_check(
 	);
 	tc.add_builtins(scope);
 
-	let file_path_as_str = file_path.to_string();
 	// If the file is an entrypoint file, we add "this" to its symbol environment
-	if file_path_as_str == "main.w" || file_path_as_str.ends_with(".main.w") || file_path_as_str.ends_with(".test.w") {
+	if is_entrypoint_file(file_path) {
 		tc.add_this(&mut env);
 	}
 


### PR DESCRIPTION
Fixes #5649

Added a simple test to the jsifier because it uses `main.w` as the filename.

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
