### PR TITLE
feat(sdk): support apig and lambda behind vpc

### DIFF
--- a/libs/wingsdk/src/target-tf-aws/platform.ts
+++ b/libs/wingsdk/src/target-tf-aws/platform.ts
@@ -35,6 +35,10 @@ export class Platform implements IPlatform {
               "If using an existing VPC, provide the public subnet ID",
             type: "string",
           },
+          vpc_api_gateway: {
+            description: "Whether Api gateways should be deployed in the VPC",
+            type: "boolean",
+          },
         },
         allOf: [
           {

--- a/libs/wingsdk/src/target-tf-aws/platform.ts
+++ b/libs/wingsdk/src/target-tf-aws/platform.ts
@@ -36,7 +36,11 @@ export class Platform implements IPlatform {
             type: "string",
           },
           vpc_api_gateway: {
-            description: "Whether Api gateways should be deployed in the VPC",
+            description: "Whether Api gateways should be deployed in a VPC",
+            type: "boolean",
+          },
+          vpc_lambda: {
+            description: "Whether Lambda functions should be deployed in a VPC",
             type: "boolean",
           },
         },

--- a/libs/wingsdk/test/target-tf-aws/__snapshots__/api.test.ts.snap
+++ b/libs/wingsdk/test/target-tf-aws/__snapshots__/api.test.ts.snap
@@ -133,6 +133,207 @@ exports[`api configured for cors 1`] = `
 }
 `;
 
+exports[`api will be private when vpc_api_gateway is true 1`] = `
+{
+  "data": {
+    "aws_caller_identity": {
+      "account": {},
+    },
+    "aws_region": {
+      "Region": {},
+    },
+    "aws_vpc_endpoint_service": {
+      "Api_api_apiServiceLookup_C62CF75C": {
+        "service": "execute-api",
+      },
+    },
+  },
+  "output": {
+    "Api_Endpoint_Url_473FEE9F": {
+      "value": "https://\${aws_api_gateway_rest_api.Api_api_91C07D84.id}.execute-api.\${data.aws_region.Region.name}.amazonaws.com/\${aws_api_gateway_stage.Api_api_stage_E0FA39D6.stage_name}",
+    },
+  },
+  "resource": {
+    "aws_api_gateway_deployment": {
+      "Api_api_deployment_7FB64CC4": {
+        "lifecycle": {
+          "create_before_destroy": true,
+        },
+        "rest_api_id": "\${aws_api_gateway_rest_api.Api_api_91C07D84.id}",
+        "triggers": {
+          "redeployment": "\${sha256(aws_api_gateway_rest_api.Api_api_91C07D84.body)}",
+        },
+      },
+    },
+    "aws_api_gateway_rest_api": {
+      "Api_api_91C07D84": {
+        "body": "{\\"openapi\\":\\"3.0.3\\",\\"paths\\":{\\"/{proxy+}\\":{\\"x-amazon-apigateway-any-method\\":{\\"produces\\":[\\"application/json\\"],\\"x-amazon-apigateway-integration\\":{\\"type\\":\\"mock\\",\\"requestTemplates\\":{\\"application/json\\":\\"\\\\n                {\\\\\\"statusCode\\\\\\": 404}\\\\n              \\"},\\"passthroughBehavior\\":\\"never\\",\\"responses\\":{\\"404\\":{\\"statusCode\\":\\"404\\",\\"responseParameters\\":{\\"method.response.header.Content-Type\\":\\"'application/json'\\"},\\"responseTemplates\\":{\\"application/json\\":\\"{\\\\\\"statusCode\\\\\\": 404, \\\\\\"message\\\\\\": \\\\\\"Error: Resource not found\\\\\\"}\\"}},\\"default\\":{\\"statusCode\\":\\"404\\",\\"responseParameters\\":{\\"method.response.header.Content-Type\\":\\"'application/json'\\"},\\"responseTemplates\\":{\\"application/json\\":\\"{\\\\\\"statusCode\\\\\\": 404, \\\\\\"message\\\\\\": \\\\\\"Error: Resource not found\\\\\\"}\\"}}}},\\"responses\\":{\\"404\\":{\\"description\\":\\"404 response\\",\\"headers\\":{\\"Content-Type\\":{\\"type\\":\\"string\\"}}}}}}}}",
+        "endpoint_configuration": {
+          "types": [
+            "PRIVATE",
+          ],
+          "vpc_endpoint_ids": [
+            "\${aws_vpc_endpoint.Api_api_api-vpc-endpoint_F7BB1063.id}",
+          ],
+        },
+        "lifecycle": {
+          "create_before_destroy": true,
+        },
+        "name": "api-c8f613f0",
+        "policy": "{\\"Version\\":\\"2012-10-17\\",\\"Statement\\":[{\\"Effect\\":\\"Allow\\",\\"Principal\\":\\"*\\",\\"Action\\":\\"execute-api:Invoke\\",\\"Resource\\":[\\"*\\"]},{\\"Effect\\":\\"Deny\\",\\"Principal\\":\\"*\\",\\"Action\\":\\"execute-api:Invoke\\",\\"Resource\\":[\\"*\\"],\\"Condition\\":{\\"StringNotEquals\\":{\\"aws:sourceVpce\\":\\"\${aws_vpc_endpoint.Api_api_api-vpc-endpoint_F7BB1063.id}\\"}}}]}",
+      },
+    },
+    "aws_api_gateway_stage": {
+      "Api_api_stage_E0FA39D6": {
+        "deployment_id": "\${aws_api_gateway_deployment.Api_api_deployment_7FB64CC4.id}",
+        "rest_api_id": "\${aws_api_gateway_rest_api.Api_api_91C07D84.id}",
+        "stage_name": "prod",
+      },
+    },
+    "aws_eip": {
+      "EIP": {},
+    },
+    "aws_internet_gateway": {
+      "InternetGateway": {
+        "tags": {
+          "Name": "Default-c82bf964-internet-gateway",
+        },
+        "vpc_id": "\${aws_vpc.VPC.id}",
+      },
+    },
+    "aws_nat_gateway": {
+      "NATGateway": {
+        "allocation_id": "\${aws_eip.EIP.id}",
+        "subnet_id": "\${aws_subnet.PublicSubnet.id}",
+        "tags": {
+          "Name": "Default-c82bf964-nat-gateway",
+        },
+      },
+    },
+    "aws_route_table": {
+      "PrivateRouteTable": {
+        "route": [
+          {
+            "carrier_gateway_id": null,
+            "cidr_block": "0.0.0.0/0",
+            "core_network_arn": null,
+            "destination_prefix_list_id": null,
+            "egress_only_gateway_id": null,
+            "gateway_id": null,
+            "ipv6_cidr_block": null,
+            "local_gateway_id": null,
+            "nat_gateway_id": "\${aws_nat_gateway.NATGateway.id}",
+            "network_interface_id": null,
+            "transit_gateway_id": null,
+            "vpc_endpoint_id": null,
+            "vpc_peering_connection_id": null,
+          },
+        ],
+        "tags": {
+          "Name": "Default-c82bf964-private-route-table-1",
+        },
+        "vpc_id": "\${aws_vpc.VPC.id}",
+      },
+      "PublicRouteTable": {
+        "route": [
+          {
+            "carrier_gateway_id": null,
+            "cidr_block": "0.0.0.0/0",
+            "core_network_arn": null,
+            "destination_prefix_list_id": null,
+            "egress_only_gateway_id": null,
+            "gateway_id": "\${aws_internet_gateway.InternetGateway.id}",
+            "ipv6_cidr_block": null,
+            "local_gateway_id": null,
+            "nat_gateway_id": null,
+            "network_interface_id": null,
+            "transit_gateway_id": null,
+            "vpc_endpoint_id": null,
+            "vpc_peering_connection_id": null,
+          },
+        ],
+        "tags": {
+          "Name": "Default-c82bf964-public-route-table-1",
+        },
+        "vpc_id": "\${aws_vpc.VPC.id}",
+      },
+    },
+    "aws_route_table_association": {
+      "PrivateRouteTableAssociation": {
+        "route_table_id": "\${aws_route_table.PrivateRouteTable.id}",
+        "subnet_id": "\${aws_subnet.PrivateSubnet.id}",
+      },
+      "PublicRouteTableAssociation": {
+        "route_table_id": "\${aws_route_table.PublicRouteTable.id}",
+        "subnet_id": "\${aws_subnet.PublicSubnet.id}",
+      },
+    },
+    "aws_security_group": {
+      "Api_api_apiSecurityGroup_CF67DC80": {
+        "ingress": [
+          {
+            "cidr_blocks": [
+              "0.0.0.0/0",
+            ],
+            "description": null,
+            "from_port": 0,
+            "ipv6_cidr_blocks": null,
+            "prefix_list_ids": null,
+            "protocol": "-1",
+            "security_groups": null,
+            "self": null,
+            "to_port": 0,
+          },
+        ],
+        "vpc_id": "\${aws_vpc.VPC.id}",
+      },
+    },
+    "aws_subnet": {
+      "PrivateSubnet": {
+        "availability_zone": "\${data.aws_region.Region.name}a",
+        "cidr_block": "10.0.4.0/22",
+        "tags": {
+          "Name": "Default-c82bf964-private-subnet-1",
+        },
+        "vpc_id": "\${aws_vpc.VPC.id}",
+      },
+      "PublicSubnet": {
+        "availability_zone": "\${data.aws_region.Region.name}a",
+        "cidr_block": "10.0.0.0/24",
+        "tags": {
+          "Name": "Default-c82bf964-public-subnet-1",
+        },
+        "vpc_id": "\${aws_vpc.VPC.id}",
+      },
+    },
+    "aws_vpc": {
+      "VPC": {
+        "cidr_block": "10.0.0.0/16",
+        "enable_dns_hostnames": true,
+        "enable_dns_support": true,
+        "tags": {
+          "Name": "Default-c82bf964-vpc",
+        },
+      },
+    },
+    "aws_vpc_endpoint": {
+      "Api_api_api-vpc-endpoint_F7BB1063": {
+        "private_dns_enabled": true,
+        "security_group_ids": [
+          "\${aws_security_group.Api_api_apiSecurityGroup_CF67DC80.id}",
+        ],
+        "service_name": "\${data.aws_vpc_endpoint_service.Api_api_apiServiceLookup_C62CF75C.service_name}",
+        "subnet_ids": [
+          "\${aws_subnet.PrivateSubnet.id}",
+        ],
+        "vpc_endpoint_type": "Interface",
+        "vpc_id": "\${aws_vpc.VPC.id}",
+      },
+    },
+  },
+}
+`;
+
 exports[`api with 'name' & 'age' parameter 1`] = `
 {
   "openapi": "3.0.3",

--- a/libs/wingsdk/test/target-tf-aws/__snapshots__/bucket.test.ts.snap
+++ b/libs/wingsdk/test/target-tf-aws/__snapshots__/bucket.test.ts.snap
@@ -444,6 +444,14 @@ exports[`bucket with onCreate method 2`] = `
                 "id": "Code",
                 "path": "root/Default/Code",
               },
+              "ParameterRegistrar": {
+                "constructInfo": {
+                  "fqn": "constructs.Construct",
+                  "version": "10.3.0",
+                },
+                "id": "ParameterRegistrar",
+                "path": "root/Default/ParameterRegistrar",
+              },
               "aws": {
                 "constructInfo": {
                   "fqn": "cdktf.TerraformProvider",
@@ -798,6 +806,14 @@ exports[`bucket with onDelete method 2`] = `
                 },
                 "id": "Code",
                 "path": "root/Default/Code",
+              },
+              "ParameterRegistrar": {
+                "constructInfo": {
+                  "fqn": "constructs.Construct",
+                  "version": "10.3.0",
+                },
+                "id": "ParameterRegistrar",
+                "path": "root/Default/ParameterRegistrar",
               },
               "aws": {
                 "constructInfo": {
@@ -1293,6 +1309,14 @@ exports[`bucket with onEvent method 2`] = `
                 },
                 "id": "Code",
                 "path": "root/Default/Code",
+              },
+              "ParameterRegistrar": {
+                "constructInfo": {
+                  "fqn": "constructs.Construct",
+                  "version": "10.3.0",
+                },
+                "id": "ParameterRegistrar",
+                "path": "root/Default/ParameterRegistrar",
               },
               "aws": {
                 "constructInfo": {
@@ -1880,6 +1904,14 @@ exports[`bucket with onUpdate method 2`] = `
                 },
                 "id": "Code",
                 "path": "root/Default/Code",
+              },
+              "ParameterRegistrar": {
+                "constructInfo": {
+                  "fqn": "constructs.Construct",
+                  "version": "10.3.0",
+                },
+                "id": "ParameterRegistrar",
+                "path": "root/Default/ParameterRegistrar",
               },
               "aws": {
                 "constructInfo": {

--- a/libs/wingsdk/test/target-tf-aws/__snapshots__/counter.test.ts.snap
+++ b/libs/wingsdk/test/target-tf-aws/__snapshots__/counter.test.ts.snap
@@ -378,6 +378,14 @@ exports[`dec() policy statement 2`] = `
                 "id": "Function",
                 "path": "root/Default/Function",
               },
+              "ParameterRegistrar": {
+                "constructInfo": {
+                  "fqn": "constructs.Construct",
+                  "version": "10.3.0",
+                },
+                "id": "ParameterRegistrar",
+                "path": "root/Default/ParameterRegistrar",
+              },
               "aws": {
                 "constructInfo": {
                   "fqn": "cdktf.TerraformProvider",
@@ -650,6 +658,14 @@ exports[`function with a counter binding 3`] = `
                 "id": "Function",
                 "path": "root/Default/Function",
               },
+              "ParameterRegistrar": {
+                "constructInfo": {
+                  "fqn": "constructs.Construct",
+                  "version": "10.3.0",
+                },
+                "id": "ParameterRegistrar",
+                "path": "root/Default/ParameterRegistrar",
+              },
               "aws": {
                 "constructInfo": {
                   "fqn": "cdktf.TerraformProvider",
@@ -884,6 +900,14 @@ exports[`inc() policy statement 2`] = `
                 "id": "Function",
                 "path": "root/Default/Function",
               },
+              "ParameterRegistrar": {
+                "constructInfo": {
+                  "fqn": "constructs.Construct",
+                  "version": "10.3.0",
+                },
+                "id": "ParameterRegistrar",
+                "path": "root/Default/ParameterRegistrar",
+              },
               "aws": {
                 "constructInfo": {
                   "fqn": "cdktf.TerraformProvider",
@@ -1117,6 +1141,14 @@ exports[`peek() policy statement 2`] = `
                 },
                 "id": "Function",
                 "path": "root/Default/Function",
+              },
+              "ParameterRegistrar": {
+                "constructInfo": {
+                  "fqn": "constructs.Construct",
+                  "version": "10.3.0",
+                },
+                "id": "ParameterRegistrar",
+                "path": "root/Default/ParameterRegistrar",
               },
               "aws": {
                 "constructInfo": {
@@ -1445,6 +1477,14 @@ exports[`set() policy statement 2`] = `
                 },
                 "id": "Function",
                 "path": "root/Default/Function",
+              },
+              "ParameterRegistrar": {
+                "constructInfo": {
+                  "fqn": "constructs.Construct",
+                  "version": "10.3.0",
+                },
+                "id": "ParameterRegistrar",
+                "path": "root/Default/ParameterRegistrar",
               },
               "aws": {
                 "constructInfo": {

--- a/libs/wingsdk/test/target-tf-aws/__snapshots__/dynamodb-table.test.ts.snap
+++ b/libs/wingsdk/test/target-tf-aws/__snapshots__/dynamodb-table.test.ts.snap
@@ -206,6 +206,14 @@ exports[`function with a table binding 3`] = `
                 "id": "Function",
                 "path": "root/Default/Function",
               },
+              "ParameterRegistrar": {
+                "constructInfo": {
+                  "fqn": "constructs.Construct",
+                  "version": "10.3.0",
+                },
+                "id": "ParameterRegistrar",
+                "path": "root/Default/ParameterRegistrar",
+              },
               "Table": {
                 "children": {
                   "Default": {

--- a/libs/wingsdk/test/target-tf-aws/__snapshots__/function.test.ts.snap
+++ b/libs/wingsdk/test/target-tf-aws/__snapshots__/function.test.ts.snap
@@ -1430,6 +1430,209 @@ exports[`function name valid 2`] = `
 }
 `;
 
+exports[`function will be behind a vpc when vpc_lambda is set to true 1`] = `
+{
+  "data": {
+    "aws_region": {
+      "Region": {},
+    },
+  },
+  "resource": {
+    "aws_cloudwatch_log_group": {
+      "Function_CloudwatchLogGroup_ABDCF4C4": {
+        "name": "/aws/lambda/Function-c852aba6",
+        "retention_in_days": 30,
+      },
+    },
+    "aws_eip": {
+      "EIP": {},
+    },
+    "aws_iam_role": {
+      "Function_IamRole_678BE84C": {
+        "assume_role_policy": "{\\"Version\\":\\"2012-10-17\\",\\"Statement\\":[{\\"Action\\":\\"sts:AssumeRole\\",\\"Principal\\":{\\"Service\\":\\"lambda.amazonaws.com\\"},\\"Effect\\":\\"Allow\\"}]}",
+      },
+    },
+    "aws_iam_role_policy": {
+      "Function_IamRolePolicy_E3B26607": {
+        "policy": "{\\"Version\\":\\"2012-10-17\\",\\"Statement\\":[{\\"Action\\":[\\"ec2:CreateNetworkInterface\\",\\"ec2:DescribeNetworkInterfaces\\",\\"ec2:DeleteNetworkInterface\\",\\"ec2:DescribeSubnets\\",\\"ec2:DescribeSecurityGroups\\"],\\"Resource\\":[\\"*\\"],\\"Effect\\":\\"Allow\\"}]}",
+        "role": "\${aws_iam_role.Function_IamRole_678BE84C.name}",
+      },
+    },
+    "aws_iam_role_policy_attachment": {
+      "Function_IamRolePolicyAttachment_CACE1358": {
+        "policy_arn": "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+        "role": "\${aws_iam_role.Function_IamRole_678BE84C.name}",
+      },
+    },
+    "aws_internet_gateway": {
+      "InternetGateway": {
+        "tags": {
+          "Name": "Default-c82bf964-internet-gateway",
+        },
+        "vpc_id": "\${aws_vpc.VPC.id}",
+      },
+    },
+    "aws_lambda_function": {
+      "Function": {
+        "architectures": [
+          "arm64",
+        ],
+        "environment": {
+          "variables": {
+            "NODE_OPTIONS": "--enable-source-maps",
+            "WING_FUNCTION_NAME": "Function-c852aba6",
+          },
+        },
+        "function_name": "Function-c852aba6",
+        "handler": "index.handler",
+        "memory_size": 1024,
+        "publish": true,
+        "role": "\${aws_iam_role.Function_IamRole_678BE84C.arn}",
+        "runtime": "nodejs20.x",
+        "s3_bucket": "\${aws_s3_bucket.Code.bucket}",
+        "s3_key": "\${aws_s3_object.Function_S3Object_C62A0C2D.key}",
+        "timeout": 60,
+        "vpc_config": {
+          "security_group_ids": [
+            "\${aws_security_group.Function_FunctionSecurityGroup_2DC31536.id}",
+          ],
+          "subnet_ids": [
+            "\${aws_subnet.PrivateSubnet.id}",
+          ],
+        },
+      },
+    },
+    "aws_nat_gateway": {
+      "NATGateway": {
+        "allocation_id": "\${aws_eip.EIP.id}",
+        "subnet_id": "\${aws_subnet.PublicSubnet.id}",
+        "tags": {
+          "Name": "Default-c82bf964-nat-gateway",
+        },
+      },
+    },
+    "aws_route_table": {
+      "PrivateRouteTable": {
+        "route": [
+          {
+            "carrier_gateway_id": null,
+            "cidr_block": "0.0.0.0/0",
+            "core_network_arn": null,
+            "destination_prefix_list_id": null,
+            "egress_only_gateway_id": null,
+            "gateway_id": null,
+            "ipv6_cidr_block": null,
+            "local_gateway_id": null,
+            "nat_gateway_id": "\${aws_nat_gateway.NATGateway.id}",
+            "network_interface_id": null,
+            "transit_gateway_id": null,
+            "vpc_endpoint_id": null,
+            "vpc_peering_connection_id": null,
+          },
+        ],
+        "tags": {
+          "Name": "Default-c82bf964-private-route-table-1",
+        },
+        "vpc_id": "\${aws_vpc.VPC.id}",
+      },
+      "PublicRouteTable": {
+        "route": [
+          {
+            "carrier_gateway_id": null,
+            "cidr_block": "0.0.0.0/0",
+            "core_network_arn": null,
+            "destination_prefix_list_id": null,
+            "egress_only_gateway_id": null,
+            "gateway_id": "\${aws_internet_gateway.InternetGateway.id}",
+            "ipv6_cidr_block": null,
+            "local_gateway_id": null,
+            "nat_gateway_id": null,
+            "network_interface_id": null,
+            "transit_gateway_id": null,
+            "vpc_endpoint_id": null,
+            "vpc_peering_connection_id": null,
+          },
+        ],
+        "tags": {
+          "Name": "Default-c82bf964-public-route-table-1",
+        },
+        "vpc_id": "\${aws_vpc.VPC.id}",
+      },
+    },
+    "aws_route_table_association": {
+      "PrivateRouteTableAssociation": {
+        "route_table_id": "\${aws_route_table.PrivateRouteTable.id}",
+        "subnet_id": "\${aws_subnet.PrivateSubnet.id}",
+      },
+      "PublicRouteTableAssociation": {
+        "route_table_id": "\${aws_route_table.PublicRouteTable.id}",
+        "subnet_id": "\${aws_subnet.PublicSubnet.id}",
+      },
+    },
+    "aws_s3_bucket": {
+      "Code": {
+        "bucket_prefix": "code-c84a50b1-",
+      },
+    },
+    "aws_s3_object": {
+      "Function_S3Object_C62A0C2D": {
+        "bucket": "\${aws_s3_bucket.Code.bucket}",
+        "key": "<key>",
+        "source": "<source>",
+      },
+    },
+    "aws_security_group": {
+      "Function_FunctionSecurityGroup_2DC31536": {
+        "egress": [
+          {
+            "cidr_blocks": [
+              "0.0.0.0/0",
+            ],
+            "description": null,
+            "from_port": 0,
+            "ipv6_cidr_blocks": null,
+            "prefix_list_ids": null,
+            "protocol": "-1",
+            "security_groups": null,
+            "self": null,
+            "to_port": 0,
+          },
+        ],
+        "vpc_id": "\${aws_vpc.VPC.id}",
+      },
+    },
+    "aws_subnet": {
+      "PrivateSubnet": {
+        "availability_zone": "\${data.aws_region.Region.name}a",
+        "cidr_block": "10.0.4.0/22",
+        "tags": {
+          "Name": "Default-c82bf964-private-subnet-1",
+        },
+        "vpc_id": "\${aws_vpc.VPC.id}",
+      },
+      "PublicSubnet": {
+        "availability_zone": "\${data.aws_region.Region.name}a",
+        "cidr_block": "10.0.0.0/24",
+        "tags": {
+          "Name": "Default-c82bf964-public-subnet-1",
+        },
+        "vpc_id": "\${aws_vpc.VPC.id}",
+      },
+    },
+    "aws_vpc": {
+      "VPC": {
+        "cidr_block": "10.0.0.0/16",
+        "enable_dns_hostnames": true,
+        "enable_dns_support": true,
+        "tags": {
+          "Name": "Default-c82bf964-vpc",
+        },
+      },
+    },
+  },
+}
+`;
+
 exports[`replace invalid character from function name 1`] = `
 {
   "resource": {

--- a/libs/wingsdk/test/target-tf-aws/__snapshots__/function.test.ts.snap
+++ b/libs/wingsdk/test/target-tf-aws/__snapshots__/function.test.ts.snap
@@ -154,6 +154,14 @@ exports[`basic function 2`] = `
                 "id": "Function",
                 "path": "root/Default/Function",
               },
+              "ParameterRegistrar": {
+                "constructInfo": {
+                  "fqn": "constructs.Construct",
+                  "version": "10.3.0",
+                },
+                "id": "ParameterRegistrar",
+                "path": "root/Default/ParameterRegistrar",
+              },
               "aws": {
                 "constructInfo": {
                   "fqn": "cdktf.TerraformProvider",
@@ -351,6 +359,14 @@ exports[`basic function with custom log retention 2`] = `
                 },
                 "id": "Function",
                 "path": "root/Default/Function",
+              },
+              "ParameterRegistrar": {
+                "constructInfo": {
+                  "fqn": "constructs.Construct",
+                  "version": "10.3.0",
+                },
+                "id": "ParameterRegistrar",
+                "path": "root/Default/ParameterRegistrar",
               },
               "aws": {
                 "constructInfo": {
@@ -552,6 +568,14 @@ exports[`basic function with environment variables 2`] = `
                 "id": "Function",
                 "path": "root/Default/Function",
               },
+              "ParameterRegistrar": {
+                "constructInfo": {
+                  "fqn": "constructs.Construct",
+                  "version": "10.3.0",
+                },
+                "id": "ParameterRegistrar",
+                "path": "root/Default/ParameterRegistrar",
+              },
               "aws": {
                 "constructInfo": {
                   "fqn": "cdktf.TerraformProvider",
@@ -735,6 +759,14 @@ exports[`basic function with infinite log retention 2`] = `
                 },
                 "id": "Function",
                 "path": "root/Default/Function",
+              },
+              "ParameterRegistrar": {
+                "constructInfo": {
+                  "fqn": "constructs.Construct",
+                  "version": "10.3.0",
+                },
+                "id": "ParameterRegistrar",
+                "path": "root/Default/ParameterRegistrar",
               },
               "aws": {
                 "constructInfo": {
@@ -934,6 +966,14 @@ exports[`basic function with memory size specified 2`] = `
                 "id": "Function",
                 "path": "root/Default/Function",
               },
+              "ParameterRegistrar": {
+                "constructInfo": {
+                  "fqn": "constructs.Construct",
+                  "version": "10.3.0",
+                },
+                "id": "ParameterRegistrar",
+                "path": "root/Default/ParameterRegistrar",
+              },
               "aws": {
                 "constructInfo": {
                   "fqn": "cdktf.TerraformProvider",
@@ -1132,6 +1172,14 @@ exports[`basic function with timeout explicitly set 2`] = `
                 "id": "Function",
                 "path": "root/Default/Function",
               },
+              "ParameterRegistrar": {
+                "constructInfo": {
+                  "fqn": "constructs.Construct",
+                  "version": "10.3.0",
+                },
+                "id": "ParameterRegistrar",
+                "path": "root/Default/ParameterRegistrar",
+              },
               "aws": {
                 "constructInfo": {
                   "fqn": "cdktf.TerraformProvider",
@@ -1259,6 +1307,14 @@ exports[`function name valid 2`] = `
                 },
                 "id": "Code",
                 "path": "root/Default/Code",
+              },
+              "ParameterRegistrar": {
+                "constructInfo": {
+                  "fqn": "constructs.Construct",
+                  "version": "10.3.0",
+                },
+                "id": "ParameterRegistrar",
+                "path": "root/Default/ParameterRegistrar",
               },
               "The-Mighty_Function-01": {
                 "children": {
@@ -1457,6 +1513,14 @@ exports[`replace invalid character from function name 2`] = `
                 },
                 "id": "Code",
                 "path": "root/Default/Code",
+              },
+              "ParameterRegistrar": {
+                "constructInfo": {
+                  "fqn": "constructs.Construct",
+                  "version": "10.3.0",
+                },
+                "id": "ParameterRegistrar",
+                "path": "root/Default/ParameterRegistrar",
               },
               "The%Mighty$Function": {
                 "children": {

--- a/libs/wingsdk/test/target-tf-aws/__snapshots__/on-deploy.test.ts.snap
+++ b/libs/wingsdk/test/target-tf-aws/__snapshots__/on-deploy.test.ts.snap
@@ -93,6 +93,14 @@ exports[`create an OnDeploy 2`] = `
                 "id": "Code",
                 "path": "root/Default/Code",
               },
+              "ParameterRegistrar": {
+                "constructInfo": {
+                  "fqn": "constructs.Construct",
+                  "version": "10.3.0",
+                },
+                "id": "ParameterRegistrar",
+                "path": "root/Default/ParameterRegistrar",
+              },
               "aws": {
                 "constructInfo": {
                   "fqn": "cdktf.TerraformProvider",
@@ -327,6 +335,14 @@ exports[`execute OnDeploy after other resources 2`] = `
                 },
                 "id": "Code",
                 "path": "root/Default/Code",
+              },
+              "ParameterRegistrar": {
+                "constructInfo": {
+                  "fqn": "constructs.Construct",
+                  "version": "10.3.0",
+                },
+                "id": "ParameterRegistrar",
+                "path": "root/Default/ParameterRegistrar",
               },
               "aws": {
                 "constructInfo": {
@@ -585,6 +601,14 @@ exports[`execute OnDeploy before other resources 2`] = `
                 },
                 "id": "Code",
                 "path": "root/Default/Code",
+              },
+              "ParameterRegistrar": {
+                "constructInfo": {
+                  "fqn": "constructs.Construct",
+                  "version": "10.3.0",
+                },
+                "id": "ParameterRegistrar",
+                "path": "root/Default/ParameterRegistrar",
               },
               "aws": {
                 "constructInfo": {

--- a/libs/wingsdk/test/target-tf-aws/__snapshots__/queue.test.ts.snap
+++ b/libs/wingsdk/test/target-tf-aws/__snapshots__/queue.test.ts.snap
@@ -276,6 +276,14 @@ exports[`queue with a consumer function 3`] = `
                 "id": "Code",
                 "path": "root/Default/Code",
               },
+              "ParameterRegistrar": {
+                "constructInfo": {
+                  "fqn": "constructs.Construct",
+                  "version": "10.3.0",
+                },
+                "id": "ParameterRegistrar",
+                "path": "root/Default/ParameterRegistrar",
+              },
               "Queue": {
                 "children": {
                   "Default": {

--- a/libs/wingsdk/test/target-tf-aws/__snapshots__/schedule.test.ts.snap
+++ b/libs/wingsdk/test/target-tf-aws/__snapshots__/schedule.test.ts.snap
@@ -105,6 +105,14 @@ exports[`schedule behavior with cron 2`] = `
                 "id": "Code",
                 "path": "root/Default/Code",
               },
+              "ParameterRegistrar": {
+                "constructInfo": {
+                  "fqn": "constructs.Construct",
+                  "version": "10.3.0",
+                },
+                "id": "ParameterRegistrar",
+                "path": "root/Default/ParameterRegistrar",
+              },
               "Schedule": {
                 "children": {
                   "OnTick0": {
@@ -361,6 +369,14 @@ exports[`schedule behavior with rate 2`] = `
                 },
                 "id": "Code",
                 "path": "root/Default/Code",
+              },
+              "ParameterRegistrar": {
+                "constructInfo": {
+                  "fqn": "constructs.Construct",
+                  "version": "10.3.0",
+                },
+                "id": "ParameterRegistrar",
+                "path": "root/Default/ParameterRegistrar",
               },
               "Schedule": {
                 "children": {
@@ -673,6 +689,14 @@ exports[`schedule with two functions 2`] = `
                 },
                 "id": "Code",
                 "path": "root/Default/Code",
+              },
+              "ParameterRegistrar": {
+                "constructInfo": {
+                  "fqn": "constructs.Construct",
+                  "version": "10.3.0",
+                },
+                "id": "ParameterRegistrar",
+                "path": "root/Default/ParameterRegistrar",
               },
               "Schedule": {
                 "children": {

--- a/libs/wingsdk/test/target-tf-aws/__snapshots__/table.test.ts.snap
+++ b/libs/wingsdk/test/target-tf-aws/__snapshots__/table.test.ts.snap
@@ -207,6 +207,14 @@ exports[`function with a table binding 3`] = `
                 "id": "Function",
                 "path": "root/Default/Function",
               },
+              "ParameterRegistrar": {
+                "constructInfo": {
+                  "fqn": "constructs.Construct",
+                  "version": "10.3.0",
+                },
+                "id": "ParameterRegistrar",
+                "path": "root/Default/ParameterRegistrar",
+              },
               "Table": {
                 "children": {
                   "Default": {

--- a/libs/wingsdk/test/target-tf-aws/__snapshots__/topic.test.ts.snap
+++ b/libs/wingsdk/test/target-tf-aws/__snapshots__/topic.test.ts.snap
@@ -377,6 +377,14 @@ exports[`topic with subscriber function 3`] = `
                 "id": "Code",
                 "path": "root/Default/Code",
               },
+              "ParameterRegistrar": {
+                "constructInfo": {
+                  "fqn": "constructs.Construct",
+                  "version": "10.3.0",
+                },
+                "id": "ParameterRegistrar",
+                "path": "root/Default/ParameterRegistrar",
+              },
               "Topic": {
                 "children": {
                   "Default": {

--- a/libs/wingsdk/test/target-tf-aws/api.test.ts
+++ b/libs/wingsdk/test/target-tf-aws/api.test.ts
@@ -2,7 +2,7 @@ import { test, expect } from "vitest";
 import { Testing } from "../../src/simulator";
 import * as tfaws from "../../src/target-tf-aws";
 import { Api, Function } from "../../src/target-tf-aws";
-import { mkdtemp, tfResourcesOfCount } from "../util";
+import { mkdtemp, tfResourcesOfCount, tfSanitize } from "../util";
 
 const INFLIGHT_CODE = `async handle(name) { return "Hello, World"; }`;
 const extractApiSpec = (output: any) => {
@@ -63,6 +63,7 @@ test("api will be private when vpc_api_gateway is true", () => {
     parsedOutput.resource.aws_api_gateway_rest_api[apiGatewayKey]
       .endpoint_configuration.vpc_endpoint_ids.length
   ).toEqual(1); // uses vpc endpoint
+  expect(tfSanitize(output)).toMatchSnapshot();
 });
 
 test("api with multiple methods on same route", () => {

--- a/libs/wingsdk/test/target-tf-aws/api.test.ts
+++ b/libs/wingsdk/test/target-tf-aws/api.test.ts
@@ -33,6 +33,38 @@ test("api with GET route at root", () => {
   expect(apiSpec).toMatchSnapshot();
 });
 
+test("api will be private when vpc_api_gateway is true", () => {
+  // GIVEN
+  const app = new tfaws.App({ outdir: mkdtemp(), entrypointDir: __dirname });
+  const parameters = app.platformParameters;
+  parameters._rawParameters["tf-aws"] = {
+    vpc: "new",
+    vpc_api_gateway: true,
+  };
+  const api = new Api(app, "Api");
+
+  // WHEN
+  const output = app.synth();
+
+  // THEN
+  const parsedOutput = JSON.parse(output);
+
+  const apiGatewayKey = Object.keys(
+    parsedOutput.resource.aws_api_gateway_rest_api
+  )[0];
+  expect(tfResourcesOfCount(output, "aws_api_gateway_rest_api")).toEqual(1);
+  expect(tfResourcesOfCount(output, "aws_vpc")).toEqual(1);
+  expect(tfResourcesOfCount(output, "aws_vpc_endpoint")).toEqual(1);
+  expect(
+    parsedOutput.resource.aws_api_gateway_rest_api[apiGatewayKey]
+      .endpoint_configuration.types[0]
+  ).toEqual("PRIVATE");
+  expect(
+    parsedOutput.resource.aws_api_gateway_rest_api[apiGatewayKey]
+      .endpoint_configuration.vpc_endpoint_ids.length
+  ).toEqual(1); // uses vpc endpoint
+});
+
 test("api with multiple methods on same route", () => {
   // GIVEN
   const app = new tfaws.App({ outdir: mkdtemp(), entrypointDir: __dirname });

--- a/libs/wingsdk/test/target-tf-aws/function.test.ts
+++ b/libs/wingsdk/test/target-tf-aws/function.test.ts
@@ -4,7 +4,13 @@ import { Function } from "../../src/cloud";
 import { Testing } from "../../src/simulator";
 import { Duration } from "../../src/std";
 import * as tfaws from "../../src/target-tf-aws";
-import { mkdtemp, tfResourcesOf, tfSanitize, treeJsonOf } from "../util";
+import {
+  mkdtemp,
+  tfResourcesOf,
+  tfResourcesOfCount,
+  tfSanitize,
+  treeJsonOf,
+} from "../util";
 
 const INFLIGHT_CODE = `async handle(name) { console.log("Hello, " + name); }`;
 
@@ -34,6 +40,29 @@ test("basic function", () => {
   ).toEqual(true);
   expect(tfSanitize(output)).toMatchSnapshot();
   expect(treeJsonOf(app.outdir)).toMatchSnapshot();
+});
+
+test("function will be behind a vpc when vpc_lambda is set to true", () => {
+  // GIVEN
+  const app = new tfaws.App({ outdir: mkdtemp(), entrypointDir: __dirname });
+  const parameters = app.platformParameters;
+  parameters._rawParameters["tf-aws"] = {
+    vpc: "new",
+    vpc_lambda: true,
+  };
+
+  const inflight = Testing.makeHandler(INFLIGHT_CODE);
+  new Function(app, "Function", inflight);
+
+  // WHEN
+  const output = app.synth();
+
+  // THEN
+  const tfFunction = JSON.parse(output).resource.aws_lambda_function.Function;
+  expect(tfResourcesOfCount(output, "aws_vpc")).toEqual(1);
+  expect(tfFunction.vpc_config).toBeDefined();
+  expect(tfFunction.vpc_config.security_group_ids.length).toEqual(1);
+  expect(tfFunction.vpc_config.subnet_ids.length).toEqual(1);
 });
 
 test("basic function with environment variables", () => {

--- a/libs/wingsdk/test/target-tf-aws/function.test.ts
+++ b/libs/wingsdk/test/target-tf-aws/function.test.ts
@@ -63,6 +63,7 @@ test("function will be behind a vpc when vpc_lambda is set to true", () => {
   expect(tfFunction.vpc_config).toBeDefined();
   expect(tfFunction.vpc_config.security_group_ids.length).toEqual(1);
   expect(tfFunction.vpc_config.subnet_ids.length).toEqual(1);
+  expect(tfSanitize(output)).toMatchSnapshot();
 });
 
 test("basic function with environment variables", () => {


### PR DESCRIPTION
Supports deploying lamdbas and api gateways behind a vpc. also ensures that when API gateways are deployed behind vpcs that they use an VPC endpoint for invocation

to enable parameters `tf-aws/vpc_api_gateway` and `tf-aws/vpc_lambda` must be set

I tested the implementation in my own aws account as well:
Here we cannot hit the endpoint publicly
<img width="1260" alt="image" src="https://github.com/winglang/wing/assets/45375125/a6417e46-a4d4-45c7-b8c1-4b3e1e23f060">



Here the lambda was able to invoke the API gateway
<img width="625" alt="image" src="https://github.com/winglang/wing/assets/45375125/3c46cc31-fca6-40ff-9b73-8bd3f8f49d94">


## Checklist

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [x] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
