### PR TITLE
fix(compiler): interface method param types are required

### DIFF
--- a/examples/tests/invalid/interface.test.w
+++ b/examples/tests/invalid/interface.test.w
@@ -36,3 +36,9 @@ interface IPointy {
   pub method2(): str;  
 //^^^ Access modifiers are not allowed in interfaces
 }
+
+// interface parameters must have types
+interface IMissingParamTypes {
+  method1(a, b): void;
+  //^ Expected type annotation
+}

--- a/libs/wingc/src/parser.rs
+++ b/libs/wingc/src/parser.rs
@@ -1201,7 +1201,8 @@ impl<'s> Parser<'s> {
 						continue;
 					};
 
-					let Ok(func_def) = self.build_function_definition(Some(method_name.clone()), &class_element, class_phase)
+					let Ok(func_def) =
+						self.build_function_definition(Some(method_name.clone()), &class_element, class_phase, false)
 					else {
 						continue;
 					};
@@ -1243,7 +1244,7 @@ impl<'s> Parser<'s> {
 							.err();
 					}
 					let parameters_node = class_element.child_by_field_name("parameter_list").unwrap();
-					let parameters = self.build_parameter_list(&parameters_node, class_phase)?;
+					let parameters = self.build_parameter_list(&parameters_node, class_phase, false)?;
 					if !parameters.is_empty() && is_inflight && class_phase == Phase::Preflight {
 						self
 							.with_error::<Node>("Inflight initializers cannot have parameters", &parameters_node)
@@ -1541,10 +1542,7 @@ impl<'s> Parser<'s> {
 	) -> DiagnosticResult<(Symbol, FunctionSignature)> {
 		let name = interface_element.child_by_field_name("name").unwrap();
 		let method_name = self.node_symbol(&name)?;
-		let (func_sig, ret_type_inferred) = self.build_function_signature(&interface_element, phase)?;
-		if ret_type_inferred {
-			self.add_error("Expected function return type", &interface_element);
-		}
+		let func_sig = self.build_function_signature(&interface_element, phase, true)?;
 		Ok((method_name, func_sig))
 	}
 
@@ -1552,13 +1550,19 @@ impl<'s> Parser<'s> {
 		&self,
 		func_sig_node: &Node,
 		phase: Phase,
-	) -> DiagnosticResult<(FunctionSignature, bool)> {
-		let parameters = self.build_parameter_list(&func_sig_node.child_by_field_name("parameter_list").unwrap(), phase)?;
-		let mut ret_typed_inferred = false;
+		require_annotations: bool,
+	) -> DiagnosticResult<FunctionSignature> {
+		let parameters = self.build_parameter_list(
+			&func_sig_node.child_by_field_name("parameter_list").unwrap(),
+			phase,
+			require_annotations,
+		)?;
 		let return_type = if let Some(rt) = get_actual_child_by_field_name(*func_sig_node, "type") {
 			self.build_type_annotation(Some(rt), phase)?
 		} else {
-			ret_typed_inferred = true;
+			if require_annotations {
+				self.add_error("Expected function return type", &func_sig_node);
+			}
 			let func_sig_kind = func_sig_node.kind();
 			if func_sig_kind == "closure" {
 				TypeAnnotation {
@@ -1573,18 +1577,15 @@ impl<'s> Parser<'s> {
 			}
 		};
 
-		Ok((
-			FunctionSignature {
-				parameters,
-				return_type: Box::new(return_type),
-				phase,
-			},
-			ret_typed_inferred,
-		))
+		Ok(FunctionSignature {
+			parameters,
+			return_type: Box::new(return_type),
+			phase,
+		})
 	}
 
 	fn build_anonymous_closure(&self, anon_closure_node: &Node, phase: Phase) -> DiagnosticResult<FunctionDefinition> {
-		self.build_function_definition(None, anon_closure_node, phase)
+		self.build_function_definition(None, anon_closure_node, phase, false)
 	}
 
 	fn build_function_definition(
@@ -1592,6 +1593,7 @@ impl<'s> Parser<'s> {
 		name: Option<Symbol>,
 		func_def_node: &Node,
 		phase: Phase,
+		require_annotations: bool,
 	) -> DiagnosticResult<FunctionDefinition> {
 		let modifiers = func_def_node.child_by_field_name("modifiers");
 
@@ -1602,7 +1604,7 @@ impl<'s> Parser<'s> {
 
 		let is_static = self.get_modifier("static", &modifiers)?.is_some();
 
-		let (signature, ret_type_inferred) = self.build_function_signature(func_def_node, phase)?;
+		let signature = self.build_function_signature(func_def_node, phase, require_annotations)?;
 		let statements = if let Some(external) = self.get_modifier("extern_modifier", &modifiers)? {
 			let node_text = self.node_text(&external.named_child(0).unwrap());
 			let file_path = Utf8Path::new(&node_text[1..node_text.len() - 1]);
@@ -1617,10 +1619,6 @@ impl<'s> Parser<'s> {
 					.build_error("Extern functions cannot have a body", &external)
 					.with_annotation("Body defined here", self.node_span(body))
 					.report();
-			}
-
-			if ret_type_inferred {
-				self.add_error("Expected function return type", &func_def_node);
 			}
 
 			FunctionBody::External(file_path.to_string())
@@ -1643,7 +1641,12 @@ impl<'s> Parser<'s> {
 	/// # Returns
 	/// A vector of tuples for each parameter in the list. The tuples are the name, type and a bool letting
 	/// us know whether the parameter is reassignable or not respectively.
-	fn build_parameter_list(&self, parameter_list_node: &Node, phase: Phase) -> DiagnosticResult<Vec<FunctionParameter>> {
+	fn build_parameter_list(
+		&self,
+		parameter_list_node: &Node,
+		phase: Phase,
+		require_annotations: bool,
+	) -> DiagnosticResult<Vec<FunctionParameter>> {
 		let mut res = vec![];
 		let mut cursor = parameter_list_node.walk();
 		for definition_node in parameter_list_node.named_children(&mut cursor) {
@@ -1651,12 +1654,18 @@ impl<'s> Parser<'s> {
 				continue;
 			}
 
-			res.push(FunctionParameter {
+			let param = FunctionParameter {
 				name: self.check_reserved_symbol(&definition_node.child_by_field_name("name").unwrap())?,
 				type_annotation: self.build_type_annotation(get_actual_child_by_field_name(definition_node, "type"), phase)?,
 				reassignable: definition_node.child_by_field_name("reassignable").is_some(),
 				variadic: definition_node.child_by_field_name("variadic").is_some(),
-			});
+			};
+
+			if require_annotations && matches!(param.type_annotation.kind, TypeAnnotationKind::Inferred) {
+				self.add_error("Expected type annotation", &definition_node);
+			}
+
+			res.push(param);
 		}
 
 		Ok(res)

--- a/tools/hangar/__snapshots__/invalid.ts.snap
+++ b/tools/hangar/__snapshots__/invalid.ts.snap
@@ -2168,6 +2168,20 @@ error: Access modifiers are not allowed in interfaces
    |   ^^^^^^^^^^^^^^^^^^^ Access modifiers are not allowed in interfaces
 
 
+error: Expected type annotation
+   --> ../../../examples/tests/invalid/interface.test.w:42:11
+   |
+42 |   method1(a, b): void;
+   |           ^ Expected type annotation
+
+
+error: Expected type annotation
+   --> ../../../examples/tests/invalid/interface.test.w:42:14
+   |
+42 |   method1(a, b): void;
+   |              ^ Expected type annotation
+
+
 error: Unknown parser error
    --> ../../../examples/tests/invalid/interface.test.w:36:14
    |


### PR DESCRIPTION
Fixes https://github.com/winglang/wing/issues/5663 by adding a compiler diagnostic when interface methods are defined without type annotations.

## Checklist

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [x] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
