### PR TITLE
fix(compiler): panic when method has same name as a field

### DIFF
--- a/examples/tests/invalid/class.test.w
+++ b/examples/tests/invalid/class.test.w
@@ -164,3 +164,32 @@ inflight class Jet extends Plane{
 
 new std.Resource();
 //^^^^^^^^^^^^^^^^ Cannot instantiate abstract class "Resource"
+
+// Class with field and method of the same name (field comes first)
+class C12 {
+  x: num;
+  x() {
+  //^ Symbol "x" is already defined
+    // The method body should still be type checked
+    2 + "2";
+    //^ Expected type to be "num", but got "str" instead
+    x == 5; // OK
+  }
+  new() {
+    this.x = 5;
+  }
+}
+
+// Class with method and field of the same name (method comes first)
+class C13 {
+  x() {
+  //^ Symbol "x" is already defined
+    // The method body should still be type checked
+    2 + "2";
+    //^ Expected type to be "num", but got "str" instead
+  }
+  x: num;
+  new() {
+    this.x = 5;
+  }
+}

--- a/examples/tests/invalid/class.test.w
+++ b/examples/tests/invalid/class.test.w
@@ -168,28 +168,50 @@ new std.Resource();
 // Class with field and method of the same name (field comes first)
 class C12 {
   x: num;
-  x() {
+  x(): num {
   //^ Symbol "x" is already defined
     // The method body should still be type checked
     2 + "2";
     //^ Expected type to be "num", but got "str" instead
     x == 5; // OK
+    return "hello";
+    //^ Expected type to be "num", but got "str" instead
   }
   new() {
     this.x = 5;
+  }
+  x: str;
+  //^ Symbol "x" is already defined
+  x(): str {
+  //^ Symbol "x" is already defined
+    2 + "2";
+    //^ Expected type to be "num", but got "str" instead
+    return 5;
+    //^ Expected type to be "str", but got "num" instead
   }
 }
 
 // Class with method and field of the same name (method comes first)
 class C13 {
-  x() {
+  x(): num {
   //^ Symbol "x" is already defined
     // The method body should still be type checked
     2 + "2";
+    //^ Expected type to be "num", but got "str" instead
+    return "hello";
     //^ Expected type to be "num", but got "str" instead
   }
   x: num;
   new() {
     this.x = 5;
   }
+  x(): str {
+  //^ Symbol "x" is already defined
+    2 + "2";
+    //^ Expected type to be "num", but got "str" instead
+    return 5;
+    //^ Expected type to be "str", but got "num" instead
+  }
+  x: str;
+  //^ Symbol "x" is already defined
 }

--- a/examples/tests/invalid/class.test.w
+++ b/examples/tests/invalid/class.test.w
@@ -167,23 +167,23 @@ new std.Resource();
 
 // Class with field and method of the same name (field comes first)
 class C12 {
-  x: num;
-  x(): num {
-  //^ Symbol "x" is already defined
+  z: num;
+  z(): num {
+  //^ Symbol "z" is already defined
     // The method body should still be type checked
     2 + "2";
     //^ Expected type to be "num", but got "str" instead
-    x == 5; // OK
+    this.z == 5; // OK
     return "hello";
     //^ Expected type to be "num", but got "str" instead
   }
   new() {
-    this.x = 5;
+    this.z = 5;
   }
-  x: str;
-  //^ Symbol "x" is already defined
-  x(): str {
-  //^ Symbol "x" is already defined
+  z: str;
+  //^ Symbol "z" is already defined
+  z(): str {
+  //^ Symbol "z" is already defined
     2 + "2";
     //^ Expected type to be "num", but got "str" instead
     return 5;
@@ -193,25 +193,25 @@ class C12 {
 
 // Class with method and field of the same name (method comes first)
 class C13 {
-  x(): num {
-  //^ Symbol "x" is already defined
+  z(): num {
+  //^ Symbol "z" is already defined
     // The method body should still be type checked
     2 + "2";
     //^ Expected type to be "num", but got "str" instead
     return "hello";
     //^ Expected type to be "num", but got "str" instead
   }
-  x: num;
+  z: num;
   new() {
-    this.x = 5;
+    this.z = 5;
   }
-  x(): str {
-  //^ Symbol "x" is already defined
+  z(): str {
+  //^ Symbol "z" is already defined
     2 + "2";
     //^ Expected type to be "num", but got "str" instead
     return 5;
     //^ Expected type to be "str", but got "num" instead
   }
-  x: str;
-  //^ Symbol "x" is already defined
+  z: str;
+  //^ Symbol "z" is already defined
 }

--- a/libs/wingc/src/type_check.rs
+++ b/libs/wingc/src/type_check.rs
@@ -37,7 +37,7 @@ use itertools::{izip, Itertools};
 use jsii_importer::JsiiImporter;
 
 use std::cmp;
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fmt::{Debug, Display};
 use std::iter::FilterMap;
 use symbol_env::{StatementIdx, SymbolEnv};
@@ -3957,15 +3957,17 @@ impl<'a> TypeChecker<'a> {
 		}
 
 		// Add methods to the class env
+		let mut method_types: BTreeMap<&str, TypeRef> = BTreeMap::new();
 		for (method_name, method_def) in ast_class.methods.iter() {
+			let mut method_type = self.resolve_type_annotation(&method_def.signature.to_type_annotation(), env);
 			self.add_method_to_class_env(
-				&method_def.signature,
-				env,
+				&mut method_type,
 				if method_def.is_static { None } else { Some(class_type) },
 				method_def.access,
 				&mut class_env,
 				method_name,
 			);
+			method_types.insert(method_name.name.as_str(), method_type);
 		}
 
 		// Add the constructor to the class env
@@ -3974,14 +3976,15 @@ impl<'a> TypeChecker<'a> {
 			span: ast_class.initializer.span.clone(),
 		};
 
+		let mut init_func_type = self.resolve_type_annotation(&ast_class.initializer.signature.to_type_annotation(), env);
 		self.add_method_to_class_env(
-			&ast_class.initializer.signature,
-			env,
+			&mut init_func_type,
 			None,
 			ast_class.initializer.access,
 			&mut class_env,
 			&init_symb,
 		);
+		method_types.insert(init_symb.name.as_str(), init_func_type);
 
 		let inflight_init_symb = Symbol {
 			name: CLASS_INFLIGHT_INIT_NAME.into(),
@@ -3989,14 +3992,16 @@ impl<'a> TypeChecker<'a> {
 		};
 
 		// Add the inflight initializer to the class env
+		let mut inflight_init_func_type =
+			self.resolve_type_annotation(&ast_class.inflight_initializer.signature.to_type_annotation(), env);
 		self.add_method_to_class_env(
-			&ast_class.inflight_initializer.signature,
-			env,
+			&mut inflight_init_func_type,
 			Some(class_type),
 			ast_class.inflight_initializer.access,
 			&mut class_env,
 			&inflight_init_symb,
 		);
+		method_types.insert(inflight_init_symb.name.as_str(), inflight_init_func_type);
 
 		// Replace the dummy class environment with the real one before type checking the methods
 		if let Some(mut_class) = class_type.as_class_mut() {
@@ -4010,7 +4015,14 @@ impl<'a> TypeChecker<'a> {
 		};
 
 		// Type check constructor
-		self.type_check_method(class_type, &init_symb, env, stmt.idx, &ast_class.initializer);
+		self.type_check_method(
+			class_type,
+			&init_symb,
+			&mut init_func_type,
+			env,
+			stmt.idx,
+			&ast_class.initializer,
+		);
 
 		// Verify if all fields of a class/resource are initialized in the initializer.
 		let init_statements = match &ast_class.initializer.body {
@@ -4024,6 +4036,7 @@ impl<'a> TypeChecker<'a> {
 		self.type_check_method(
 			class_type,
 			&inflight_init_symb,
+			&mut inflight_init_func_type,
 			env,
 			stmt.idx,
 			&ast_class.inflight_initializer,
@@ -4034,7 +4047,8 @@ impl<'a> TypeChecker<'a> {
 
 		// Type check methods
 		for (method_name, method_def) in ast_class.methods.iter() {
-			self.type_check_method(class_type, method_name, env, stmt.idx, method_def);
+			let mut method_type = *method_types.get(method_name.name.as_str()).unwrap();
+			self.type_check_method(class_type, method_name, &mut method_type, env, stmt.idx, method_def);
 		}
 
 		// Check that the class satisfies all of its interfaces
@@ -4668,6 +4682,7 @@ impl<'a> TypeChecker<'a> {
 		&mut self,
 		class_type: TypeRef,
 		method_name: &Symbol,
+		method_type: &mut TypeRef,
 		parent_env: &SymbolEnv, // the environment in which the class is declared
 		statement_idx: usize,
 		method_def: &FunctionDefinition,
@@ -4675,13 +4690,6 @@ impl<'a> TypeChecker<'a> {
 		let class_env = &class_type.as_class().unwrap().env;
 		// TODO: make sure this function returns on all control paths when there's a return type (can be done by recursively traversing the statements and making sure there's a "return" statements in all control paths)
 		// https://github.com/winglang/wing/issues/457
-		// Lookup the method in the class_env
-		let method_type = class_env
-			.lookup(&method_name, None)
-			.expect(format!("Expected method '{}' to be in class env", method_name.name).as_str())
-			.as_variable()
-			.expect("Expected method to be a variable")
-			.type_;
 
 		let method_sig = method_type
 			.as_function_sig()
@@ -4693,7 +4701,7 @@ impl<'a> TypeChecker<'a> {
 			Some(parent_env.get_ref()),
 			SymbolEnvKind::Function {
 				is_init,
-				sig: method_type,
+				sig: *method_type,
 			},
 			method_sig.phase,
 			statement_idx,
@@ -4739,14 +4747,12 @@ impl<'a> TypeChecker<'a> {
 
 	fn add_method_to_class_env(
 		&mut self,
-		method_sig: &ast::FunctionSignature,
-		env: &mut SymbolEnv,
+		method_type: &mut TypeRef,
 		instance_type: Option<TypeRef>,
 		access: AccessModifier,
 		class_env: &mut SymbolEnv,
 		method_name: &Symbol,
 	) {
-		let mut method_type = self.resolve_type_annotation(&method_sig.to_type_annotation(), env);
 		// use the class type as the function's "this" type (or None if static)
 		method_type
 			.as_mut_function_sig()
@@ -4787,14 +4793,16 @@ impl<'a> TypeChecker<'a> {
 			}
 		}
 
+		let method_phase = method_type.as_function_sig().unwrap().phase;
+
 		match class_env.define(
 			method_name,
 			SymbolKind::make_member_variable(
 				method_name.clone(),
-				method_type,
+				*method_type,
 				false,
 				instance_type.is_none(),
-				method_sig.phase,
+				method_phase,
 				access,
 				None,
 			),

--- a/libs/wingc/src/type_check.rs
+++ b/libs/wingc/src/type_check.rs
@@ -3957,7 +3957,7 @@ impl<'a> TypeChecker<'a> {
 		}
 
 		// Add methods to the class env
-		let mut method_types: BTreeMap<&str, TypeRef> = BTreeMap::new();
+		let mut method_types: BTreeMap<&Symbol, TypeRef> = BTreeMap::new();
 		for (method_name, method_def) in ast_class.methods.iter() {
 			let mut method_type = self.resolve_type_annotation(&method_def.signature.to_type_annotation(), env);
 			self.add_method_to_class_env(
@@ -3967,7 +3967,7 @@ impl<'a> TypeChecker<'a> {
 				&mut class_env,
 				method_name,
 			);
-			method_types.insert(method_name.name.as_str(), method_type);
+			method_types.insert(&method_name, method_type);
 		}
 
 		// Add the constructor to the class env
@@ -3984,7 +3984,7 @@ impl<'a> TypeChecker<'a> {
 			&mut class_env,
 			&init_symb,
 		);
-		method_types.insert(init_symb.name.as_str(), init_func_type);
+		method_types.insert(&init_symb, init_func_type);
 
 		let inflight_init_symb = Symbol {
 			name: CLASS_INFLIGHT_INIT_NAME.into(),
@@ -4001,7 +4001,7 @@ impl<'a> TypeChecker<'a> {
 			&mut class_env,
 			&inflight_init_symb,
 		);
-		method_types.insert(inflight_init_symb.name.as_str(), inflight_init_func_type);
+		method_types.insert(&inflight_init_symb, inflight_init_func_type);
 
 		// Replace the dummy class environment with the real one before type checking the methods
 		if let Some(mut_class) = class_type.as_class_mut() {
@@ -4047,7 +4047,7 @@ impl<'a> TypeChecker<'a> {
 
 		// Type check methods
 		for (method_name, method_def) in ast_class.methods.iter() {
-			let mut method_type = *method_types.get(method_name.name.as_str()).unwrap();
+			let mut method_type = *method_types.get(&method_name).unwrap();
 			self.type_check_method(class_type, method_name, &mut method_type, env, stmt.idx, method_def);
 		}
 

--- a/tools/hangar/__snapshots__/invalid.ts.snap
+++ b/tools/hangar/__snapshots__/invalid.ts.snap
@@ -852,22 +852,62 @@ error: Cannot instantiate abstract class \\"Resource\\"
 
 
 error: Symbol \\"x\\" already defined in this scope
+    --> ../../../examples/tests/invalid/class.test.w:183:3
+    |
+170 |   x: num;
+    |   - previous definition
+    .
+183 |   x: str;
+    |   ^ Symbol \\"x\\" already defined in this scope
+
+
+error: Symbol \\"x\\" already defined in this scope
     --> ../../../examples/tests/invalid/class.test.w:171:3
     |
 170 |   x: num;
     |   - previous definition
-171 |   x() {
+171 |   x(): num {
     |   ^ Symbol \\"x\\" already defined in this scope
 
 
 error: Symbol \\"x\\" already defined in this scope
     --> ../../../examples/tests/invalid/class.test.w:185:3
     |
-185 |   x() {
+170 |   x: num;
+    |   - previous definition
+    .
+185 |   x(): str {
+    |   ^ Symbol \\"x\\" already defined in this scope
+
+
+error: Symbol \\"x\\" already defined in this scope
+    --> ../../../examples/tests/invalid/class.test.w:215:3
+    |
+204 |   x: num;
+    |   - previous definition
+    .
+215 |   x: str;
+    |   ^ Symbol \\"x\\" already defined in this scope
+
+
+error: Symbol \\"x\\" already defined in this scope
+    --> ../../../examples/tests/invalid/class.test.w:196:3
+    |
+196 |   x(): num {
     |   ^ Symbol \\"x\\" already defined in this scope
     .
-191 |   x: num;
+204 |   x: num;
     |   - previous definition
+
+
+error: Symbol \\"x\\" already defined in this scope
+    --> ../../../examples/tests/invalid/class.test.w:208:3
+    |
+204 |   x: num;
+    |   - previous definition
+    .
+208 |   x(): str {
+    |   ^ Symbol \\"x\\" already defined in this scope
 
 
 error: Expected type to be \\"num\\", but got \\"str\\" instead
@@ -919,11 +959,53 @@ error: Binary operator '+' cannot be applied to operands of type 'num' and 'str'
     |     ^^^^^^^ Binary operator '+' cannot be applied to operands of type 'num' and 'str'; only (num, num) and (str, str) are supported
 
 
-error: Binary operator '+' cannot be applied to operands of type 'num' and 'str'; only (num, num) and (str, str) are supported
-    --> ../../../examples/tests/invalid/class.test.w:188:5
+error: Expected type to be \\"num\\", but got \\"str\\" instead
+    --> ../../../examples/tests/invalid/class.test.w:177:12
     |
-188 |     2 + \\"2\\";
+177 |     return \\"hello\\";
+    |            ^^^^^^^ Expected type to be \\"num\\", but got \\"str\\" instead
+
+
+error: Binary operator '+' cannot be applied to operands of type 'num' and 'str'; only (num, num) and (str, str) are supported
+    --> ../../../examples/tests/invalid/class.test.w:187:5
+    |
+187 |     2 + \\"2\\";
     |     ^^^^^^^ Binary operator '+' cannot be applied to operands of type 'num' and 'str'; only (num, num) and (str, str) are supported
+
+
+error: Expected type to be \\"str\\", but got \\"num\\" instead
+    --> ../../../examples/tests/invalid/class.test.w:189:12
+    |
+189 |     return 5;
+    |            ^ Expected type to be \\"str\\", but got \\"num\\" instead
+
+
+error: Binary operator '+' cannot be applied to operands of type 'num' and 'str'; only (num, num) and (str, str) are supported
+    --> ../../../examples/tests/invalid/class.test.w:199:5
+    |
+199 |     2 + \\"2\\";
+    |     ^^^^^^^ Binary operator '+' cannot be applied to operands of type 'num' and 'str'; only (num, num) and (str, str) are supported
+
+
+error: Expected type to be \\"num\\", but got \\"str\\" instead
+    --> ../../../examples/tests/invalid/class.test.w:201:12
+    |
+201 |     return \\"hello\\";
+    |            ^^^^^^^ Expected type to be \\"num\\", but got \\"str\\" instead
+
+
+error: Binary operator '+' cannot be applied to operands of type 'num' and 'str'; only (num, num) and (str, str) are supported
+    --> ../../../examples/tests/invalid/class.test.w:210:5
+    |
+210 |     2 + \\"2\\";
+    |     ^^^^^^^ Binary operator '+' cannot be applied to operands of type 'num' and 'str'; only (num, num) and (str, str) are supported
+
+
+error: Expected type to be \\"str\\", but got \\"num\\" instead
+    --> ../../../examples/tests/invalid/class.test.w:212:12
+    |
+212 |     return 5;
+    |            ^ Expected type to be \\"str\\", but got \\"num\\" instead
 
 
  

--- a/tools/hangar/__snapshots__/invalid.ts.snap
+++ b/tools/hangar/__snapshots__/invalid.ts.snap
@@ -851,6 +851,25 @@ error: Cannot instantiate abstract class \\"Resource\\"
     | ^^^^^^^^^^^^^^^^^^ Cannot instantiate abstract class \\"Resource\\"
 
 
+error: Symbol \\"x\\" already defined in this scope
+    --> ../../../examples/tests/invalid/class.test.w:171:3
+    |
+170 |   x: num;
+    |   - previous definition
+171 |   x() {
+    |   ^ Symbol \\"x\\" already defined in this scope
+
+
+error: Symbol \\"x\\" already defined in this scope
+    --> ../../../examples/tests/invalid/class.test.w:185:3
+    |
+185 |   x() {
+    |   ^ Symbol \\"x\\" already defined in this scope
+    .
+191 |   x: num;
+    |   - previous definition
+
+
 error: Expected type to be \\"num\\", but got \\"str\\" instead
    --> ../../../examples/tests/invalid/class.test.w:31:14
    |
@@ -891,6 +910,20 @@ error: Expected 1 positional argument(s) but got 0
     |
 157 |     super();
     |     ^^^^^^^^ Expected 1 positional argument(s) but got 0
+
+
+error: Binary operator '+' cannot be applied to operands of type 'num' and 'str'; only (num, num) and (str, str) are supported
+    --> ../../../examples/tests/invalid/class.test.w:174:5
+    |
+174 |     2 + \\"2\\";
+    |     ^^^^^^^ Binary operator '+' cannot be applied to operands of type 'num' and 'str'; only (num, num) and (str, str) are supported
+
+
+error: Binary operator '+' cannot be applied to operands of type 'num' and 'str'; only (num, num) and (str, str) are supported
+    --> ../../../examples/tests/invalid/class.test.w:188:5
+    |
+188 |     2 + \\"2\\";
+    |     ^^^^^^^ Binary operator '+' cannot be applied to operands of type 'num' and 'str'; only (num, num) and (str, str) are supported
 
 
  

--- a/tools/hangar/__snapshots__/invalid.ts.snap
+++ b/tools/hangar/__snapshots__/invalid.ts.snap
@@ -851,63 +851,63 @@ error: Cannot instantiate abstract class \\"Resource\\"
     | ^^^^^^^^^^^^^^^^^^ Cannot instantiate abstract class \\"Resource\\"
 
 
-error: Symbol \\"x\\" already defined in this scope
+error: Symbol \\"z\\" already defined in this scope
     --> ../../../examples/tests/invalid/class.test.w:183:3
     |
-170 |   x: num;
+170 |   z: num;
     |   - previous definition
     .
-183 |   x: str;
-    |   ^ Symbol \\"x\\" already defined in this scope
+183 |   z: str;
+    |   ^ Symbol \\"z\\" already defined in this scope
 
 
-error: Symbol \\"x\\" already defined in this scope
+error: Symbol \\"z\\" already defined in this scope
     --> ../../../examples/tests/invalid/class.test.w:171:3
     |
-170 |   x: num;
+170 |   z: num;
     |   - previous definition
-171 |   x(): num {
-    |   ^ Symbol \\"x\\" already defined in this scope
+171 |   z(): num {
+    |   ^ Symbol \\"z\\" already defined in this scope
 
 
-error: Symbol \\"x\\" already defined in this scope
+error: Symbol \\"z\\" already defined in this scope
     --> ../../../examples/tests/invalid/class.test.w:185:3
     |
-170 |   x: num;
+170 |   z: num;
     |   - previous definition
     .
-185 |   x(): str {
-    |   ^ Symbol \\"x\\" already defined in this scope
+185 |   z(): str {
+    |   ^ Symbol \\"z\\" already defined in this scope
 
 
-error: Symbol \\"x\\" already defined in this scope
+error: Symbol \\"z\\" already defined in this scope
     --> ../../../examples/tests/invalid/class.test.w:215:3
     |
-204 |   x: num;
+204 |   z: num;
     |   - previous definition
     .
-215 |   x: str;
-    |   ^ Symbol \\"x\\" already defined in this scope
+215 |   z: str;
+    |   ^ Symbol \\"z\\" already defined in this scope
 
 
-error: Symbol \\"x\\" already defined in this scope
+error: Symbol \\"z\\" already defined in this scope
     --> ../../../examples/tests/invalid/class.test.w:196:3
     |
-196 |   x(): num {
-    |   ^ Symbol \\"x\\" already defined in this scope
+196 |   z(): num {
+    |   ^ Symbol \\"z\\" already defined in this scope
     .
-204 |   x: num;
+204 |   z: num;
     |   - previous definition
 
 
-error: Symbol \\"x\\" already defined in this scope
+error: Symbol \\"z\\" already defined in this scope
     --> ../../../examples/tests/invalid/class.test.w:208:3
     |
-204 |   x: num;
+204 |   z: num;
     |   - previous definition
     .
-208 |   x(): str {
-    |   ^ Symbol \\"x\\" already defined in this scope
+208 |   z(): str {
+    |   ^ Symbol \\"z\\" already defined in this scope
 
 
 error: Expected type to be \\"num\\", but got \\"str\\" instead


### PR DESCRIPTION
Fixes #1635

Fixing this required a bit of refactoring code around because even when there are member name conflicts, we want to make sure all of the code in the method still gets type checked. Type checking the body requires knowing the type signature of the method. But the method's correct type isn't available in the environment because of the name conflicts.

To solve this, I added some logic to keep track of a mapping of method name symbols to the method types within `type_check_class` (where `type_check_method` is called from). Since the keys of the map are symbols, and each symbol has a name and source location, the method types won't overwrite each other.

## Checklist

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [x] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
