### PR TITLE
chore: add missing metadata back into docs page

### DIFF
--- a/docs/docs/01-start-here/02-installation.md
+++ b/docs/docs/01-start-here/02-installation.md
@@ -2,6 +2,7 @@
 id: installation
 title: Installation
 keywords: [Wing installation, installation, Wing toolchain]
+slug: /
 ---
 
 ## Prerequisite


### PR DESCRIPTION
I accidentally removed this in my last PR, and it's causing a build error

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
