### PR TITLE
fix: tsconfig options in framework are slow

### DIFF
--- a/libs/@wingcloud/framework/src/internal.ts
+++ b/libs/@wingcloud/framework/src/internal.ts
@@ -23,6 +23,10 @@ export async function compile(options: CompileOptions) {
     declaration: false,
     noEmitOnError: true,
     listEmittedFiles: true,
+    allowJs: true,
+    skipLibCheck: true,
+    resolveJsonModule: true,
+    isolatedModules: true,
     baseUrl: dirname(options.entrypoint),
     paths: {
       "@winglang/sdk/*": [dirname(require.resolve("@winglang/sdk")) + "/*"],


### PR DESCRIPTION
Noticed that ts compilation tests were still timing out, wanted to partially address them.

Used https://www.totaltypescript.com/tsconfig-cheat-sheet as a good guide to build some out.
I suspect skipLibCheck will help a lot, and honestly it's probably a good thing to avoid the unnecessary .d.ts checks.

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
