### PR TITLE
fix(platforms): tf-aws vpc does not support multiple subnets

### DIFF
--- a/apps/wing/project-templates/typescript/private-api/wing.toml
+++ b/apps/wing/project-templates/typescript/private-api/wing.toml
@@ -7,5 +7,5 @@ vpc_lambda = true
 vpc_api_gateway = true
 # The following parameters will be required if using "existing" vpc
 # vpc_id = "vpc-123xyz"
-# private_subnet_id = "subnet-123xyz"
-# public_subnet_id = "subnet-123xyz"
+# private_subnet_id = ["subnet-123xyz"]
+# public_subnet_id = ["subnet-123xyz"]

--- a/apps/wing/project-templates/wing/private-api/wing.toml
+++ b/apps/wing/project-templates/wing/private-api/wing.toml
@@ -7,5 +7,5 @@ vpc_lambda = true
 vpc_api_gateway = true
 # The following parameters will be required if using "existing" vpc
 # vpc_id = "vpc-123xyz"
-# private_subnet_id = "subnet-123xyz"
-# public_subnet_id = "subnet-123xyz"
+# private_subnet_id = ["subnet-123xyz"]
+# public_subnet_id = ["subnet-123xyz"]

--- a/libs/wingsdk/src/target-tf-aws/api.ts
+++ b/libs/wingsdk/src/target-tf-aws/api.ts
@@ -365,7 +365,7 @@ class WingRestApi extends Construct {
         serviceName: service.serviceName,
         privateDnsEnabled: true,
         vpcEndpointType: "Interface",
-        subnetIds: [app.subnets.private.id],
+        subnetIds: [...app.subnets.private.map((s) => s.id)],
         securityGroupIds: [this.securityGroup.id],
       });
     }

--- a/libs/wingsdk/src/target-tf-aws/app.ts
+++ b/libs/wingsdk/src/target-tf-aws/app.ts
@@ -67,7 +67,10 @@ export class App extends CdktfApp {
     super(props);
     new AwsProvider(this, "aws", {});
 
-    this.subnets = {};
+    this.subnets = {
+      private: [],
+      public: [],
+    };
 
     TestRunner._createTree(this, props.rootConstruct);
   }
@@ -195,15 +198,17 @@ export class App extends CdktfApp {
     for (const subnetId of privateSubnetIds) {
       this.subnets.private.push(new DataAwsSubnet(this, `PrivateSubnet${subnetId.slice(-8)}`, {
         vpcId: vpcId,
-        id: privateSubnetIds,
+        id: subnetId,
       }));
     }
-
-    for (const subnetId of publicSubnetIds) {
-      this.subnets.public.push(new DataAwsSubnet(this, `PublicSubnet${subnetId.slice(-8)}`, {
-        vpcId: vpcId,
-        id: publicSubnetIds,
-      }));
+    
+    if (publicSubnetIds) {
+      for (const subnetId of publicSubnetIds) {
+        this.subnets.public.push(new DataAwsSubnet(this, `PublicSubnet${subnetId.slice(-8)}`, {
+          vpcId: vpcId,
+          id: subnetId,
+        }));
+      }
     }
 
     return this._vpc;

--- a/libs/wingsdk/src/target-tf-aws/app.ts
+++ b/libs/wingsdk/src/target-tf-aws/app.ts
@@ -196,18 +196,22 @@ export class App extends CdktfApp {
     });
 
     for (const subnetId of privateSubnetIds) {
-      this.subnets.private.push(new DataAwsSubnet(this, `PrivateSubnet${subnetId.slice(-8)}`, {
-        vpcId: vpcId,
-        id: subnetId,
-      }));
-    }
-    
-    if (publicSubnetIds) {
-      for (const subnetId of publicSubnetIds) {
-        this.subnets.public.push(new DataAwsSubnet(this, `PublicSubnet${subnetId.slice(-8)}`, {
+      this.subnets.private.push(
+        new DataAwsSubnet(this, `PrivateSubnet${subnetId.slice(-8)}`, {
           vpcId: vpcId,
           id: subnetId,
-        }));
+        })
+      );
+    }
+
+    if (publicSubnetIds) {
+      for (const subnetId of publicSubnetIds) {
+        this.subnets.public.push(
+          new DataAwsSubnet(this, `PublicSubnet${subnetId.slice(-8)}`, {
+            vpcId: vpcId,
+            id: subnetId,
+          })
+        );
       }
     }
 

--- a/libs/wingsdk/src/target-tf-aws/function.ts
+++ b/libs/wingsdk/src/target-tf-aws/function.ts
@@ -244,7 +244,7 @@ export class Function extends cloud.Function implements IAwsFunction {
         ],
       });
       this.addNetworkConfig({
-        subnetIds: [app.subnets.private.id],
+        subnetIds: [...app.subnets.private.map((s) => s.id)],
         securityGroupIds: [sg.id],
       });
     }

--- a/libs/wingsdk/src/target-tf-aws/platform.ts
+++ b/libs/wingsdk/src/target-tf-aws/platform.ts
@@ -25,15 +25,21 @@ export class Platform implements IPlatform {
             description: "If using an existing VPC, provide the VPC ID",
             type: "string",
           },
-          private_subnet_id: {
+          private_subnet_ids: {
             description:
               "If using an existing VPC, provide the private subnet ID",
-            type: "string",
+            type: "array",
+            items: {
+              type: "string",
+            },
           },
-          public_subnet_id: {
+          public_subnet_ids: {
             description:
               "If using an existing VPC, provide the public subnet ID",
-            type: "string",
+            type: "array",
+            items: {
+              type: "string",
+            },
           },
           vpc_api_gateway: {
             description: "Whether Api gateways should be deployed in a VPC",
@@ -47,10 +53,10 @@ export class Platform implements IPlatform {
         allOf: [
           {
             $comment:
-              "if vpc is existing, then we need to require the vpc_id, private_subnet_id, and public_subnet_id",
+              "if vpc is existing, then we need to require the vpc_id, private_subnet_ids",
             if: { properties: { vpc: { const: "existing" } } },
             then: {
-              required: ["vpc_id", "private_subnet_id", "public_subnet_id"],
+              required: ["vpc_id", "private_subnet_ids"],
             },
           },
         ],

--- a/libs/wingsdk/src/target-tf-aws/redis.ts
+++ b/libs/wingsdk/src/target-tf-aws/redis.ts
@@ -52,29 +52,29 @@ export class Redis extends ex.Redis {
     this.securityGroups = [];
     const clusterName = ResourceNames.generateName(this, ELASTICACHE_NAME_OPTS);
     for (const subnet of this.subnets) {
-
-      this.securityGroups.push(new SecurityGroup(this, `${subnet.id.slice(-8)}securityGroup`, {
-        vpcId: vpc.id,
-        name: `${this.node.addr.slice(-8)}-securityGroup`,
-        ingress: [
-          {
-            cidrBlocks: [subnet.cidrBlock],
-            fromPort: REDIS_PORT,
-            toPort: REDIS_PORT,
-            protocol: "tcp",
-            selfAttribute: true,
-          },
-        ],
-        egress: [
-          {
-            cidrBlocks: ["0.0.0.0/0"],
-            fromPort: 0,
-            toPort: 0,
-            protocol: "-1",
-          },
-        ],
-      }))
-  
+      this.securityGroups.push(
+        new SecurityGroup(this, `${subnet.id.slice(-8)}securityGroup`, {
+          vpcId: vpc.id,
+          name: `${this.node.addr.slice(-8)}-securityGroup`,
+          ingress: [
+            {
+              cidrBlocks: [subnet.cidrBlock],
+              fromPort: REDIS_PORT,
+              toPort: REDIS_PORT,
+              protocol: "tcp",
+              selfAttribute: true,
+            },
+          ],
+          egress: [
+            {
+              cidrBlocks: ["0.0.0.0/0"],
+              fromPort: 0,
+              toPort: 0,
+              protocol: "-1",
+            },
+          ],
+        })
+      );
     }
 
     const subnetGroup = new ElasticacheSubnetGroup(this, "RedisSubnetGroup", {

--- a/libs/wingsdk/src/target-tf-aws/redis.ts
+++ b/libs/wingsdk/src/target-tf-aws/redis.ts
@@ -24,8 +24,8 @@ const ELASTICACHE_NAME_OPTS: NameOptions = {
 export class Redis extends ex.Redis {
   private readonly clusterId: string;
   private readonly clusterArn: string;
-  private readonly securityGroup: SecurityGroup;
-  private readonly subnet: Subnet | DataAwsSubnet;
+  private readonly securityGroups: SecurityGroup[];
+  private readonly subnets: (Subnet | DataAwsSubnet)[];
 
   constructor(scope: Construct, id: string) {
     super(scope, id);
@@ -48,34 +48,38 @@ export class Redis extends ex.Redis {
 
     const app = App.of(this) as App;
     const vpc = app.vpc;
-    this.subnet = app.subnets.private;
+    this.subnets = app.subnets.private;
+    this.securityGroups = [];
     const clusterName = ResourceNames.generateName(this, ELASTICACHE_NAME_OPTS);
+    for (const subnet of this.subnets) {
 
-    this.securityGroup = new SecurityGroup(this, "securityGroup", {
-      vpcId: vpc.id,
-      name: `${this.node.addr.slice(-8)}-securityGroup`,
-      ingress: [
-        {
-          cidrBlocks: [this.subnet.cidrBlock],
-          fromPort: REDIS_PORT,
-          toPort: REDIS_PORT,
-          protocol: "tcp",
-          selfAttribute: true,
-        },
-      ],
-      egress: [
-        {
-          cidrBlocks: ["0.0.0.0/0"],
-          fromPort: 0,
-          toPort: 0,
-          protocol: "-1",
-        },
-      ],
-    });
+      this.securityGroups.push(new SecurityGroup(this, `${subnet.id.slice(-8)}securityGroup`, {
+        vpcId: vpc.id,
+        name: `${this.node.addr.slice(-8)}-securityGroup`,
+        ingress: [
+          {
+            cidrBlocks: [subnet.cidrBlock],
+            fromPort: REDIS_PORT,
+            toPort: REDIS_PORT,
+            protocol: "tcp",
+            selfAttribute: true,
+          },
+        ],
+        egress: [
+          {
+            cidrBlocks: ["0.0.0.0/0"],
+            fromPort: 0,
+            toPort: 0,
+            protocol: "-1",
+          },
+        ],
+      }))
+  
+    }
 
     const subnetGroup = new ElasticacheSubnetGroup(this, "RedisSubnetGroup", {
       name: `${clusterName}-subnetGroup`,
-      subnetIds: [this.subnet.id],
+      subnetIds: [...this.subnets.map((s) => s.id)],
     });
 
     const cluster = new ElasticacheCluster(this, "RedisCluster", {
@@ -84,9 +88,9 @@ export class Redis extends ex.Redis {
       engineVersion,
       nodeType,
       parameterGroupName,
-      availabilityZone: this.subnet.availabilityZone,
+      availabilityZone: this.subnets[0].availabilityZone,
       subnetGroupName: subnetGroup.name,
-      securityGroupIds: [this.securityGroup.id],
+      securityGroupIds: [...this.securityGroups.map((s) => s.id)],
       numCacheNodes: 1, // This number will always be 1 for Redis
     });
 
@@ -124,8 +128,8 @@ export class Redis extends ex.Redis {
 
     host.addEnvironment(env, this.clusterId);
     host.addNetworkConfig({
-      securityGroupIds: [this.securityGroup.id],
-      subnetIds: [this.subnet.id],
+      securityGroupIds: [...this.securityGroups.map((s) => s.id)],
+      subnetIds: [...this.subnets.map((s) => s.id)],
     });
 
     super.onLift(host, ops);

--- a/libs/wingsdk/test/target-tf-aws/__snapshots__/redis.test.ts.snap
+++ b/libs/wingsdk/test/target-tf-aws/__snapshots__/redis.test.ts.snap
@@ -21,7 +21,7 @@ exports[`When creating a Redis resource > should create an elasticache cluster a
         "num_cache_nodes": 1,
         "parameter_group_name": "default.redis6.x",
         "security_group_ids": [
-          "\${aws_security_group.Redis_securityGroup_BE4B8855.id}",
+          "\${aws_security_group.Redis_KEN15securityGroup_9FF06889.id}",
         ],
         "subnet_group_name": "\${aws_elasticache_subnet_group.Redis_RedisSubnetGroup_E7D796E2.name}",
       },
@@ -110,7 +110,7 @@ exports[`When creating a Redis resource > should create an elasticache cluster a
       },
     },
     "aws_security_group": {
-      "Redis_securityGroup_BE4B8855": {
+      "Redis_KEN15securityGroup_9FF06889": {
         "egress": [
           {
             "cidr_blocks": [

--- a/libs/wingsdk/test/target-tf-aws/platform.test.ts
+++ b/libs/wingsdk/test/target-tf-aws/platform.test.ts
@@ -1,18 +1,18 @@
-import { test, expect, describe, beforeEach } from "vitest";
 import fs from "fs";
 import path from "path";
-import { mkdtemp } from "../util";
+import { test, expect, describe, beforeEach } from "vitest";
+import { Function } from "../../src/cloud";
 import { PlatformManager } from "../../src/platform";
 import { Testing } from "../../src/simulator";
-import { Function } from "../../src/cloud";
+import { mkdtemp } from "../util";
 
 describe("tf-aws platform parameters", () => {
   let platformManager;
   let tempdir;
   let wingParametersFile;
-  
+
   beforeEach(() => {
-    platformManager = new PlatformManager({platformPaths: ["tf-aws"]});
+    platformManager = new PlatformManager({ platformPaths: ["tf-aws"] });
     tempdir = mkdtemp();
     wingParametersFile = path.join(tempdir, "wing.json");
     process.env.WING_VALUES_FILE = wingParametersFile;
@@ -30,7 +30,10 @@ describe("tf-aws platform parameters", () => {
     fs.writeFileSync(wingParametersFile, JSON.stringify(providedParameters));
 
     // WHEN
-    const app = platformManager.createApp({ outdir: tempdir, entrypointDir: tempdir });
+    const app = platformManager.createApp({
+      outdir: tempdir,
+      entrypointDir: tempdir,
+    });
 
     // THEN
     expect(() => app.synth()).toThrow(/must be array/);
@@ -48,7 +51,10 @@ describe("tf-aws platform parameters", () => {
     fs.writeFileSync(wingParametersFile, JSON.stringify(providedParameters));
 
     // WHEN
-    const app = platformManager.createApp({ outdir: tempdir, entrypointDir: tempdir });
+    const app = platformManager.createApp({
+      outdir: tempdir,
+      entrypointDir: tempdir,
+    });
 
     // THEN
     expect(() => app.synth()).not.toThrow();
@@ -64,13 +70,16 @@ describe("tf-aws platform parameters", () => {
       },
     };
     fs.writeFileSync(wingParametersFile, JSON.stringify(providedParameters));
-    
-    // WHEN
-    const app = platformManager.createApp({ outdir: tempdir, entrypointDir: tempdir });
-    
-    // THEN
-    expect(() => app.synth()).toThrow(/must have required property 'private_subnet_ids'/);
 
+    // WHEN
+    const app = platformManager.createApp({
+      outdir: tempdir,
+      entrypointDir: tempdir,
+    });
+    // THEN
+    expect(() => app.synth()).toThrow(
+      /must have required property 'private_subnet_ids'/
+    );
   });
 
   test("does not require public subnet ids, when vpc = existing", () => {
@@ -83,10 +92,12 @@ describe("tf-aws platform parameters", () => {
       },
     };
     fs.writeFileSync(wingParametersFile, JSON.stringify(providedParameters));
-    
+
     // WHEN
-    const app = platformManager.createApp({ outdir: tempdir, entrypointDir: tempdir });
-    
+    const app = platformManager.createApp({
+      outdir: tempdir,
+      entrypointDir: tempdir,
+    });
     // THEN
     expect(() => app.synth()).not.toThrow();
   });
@@ -102,9 +113,12 @@ describe("tf-aws platform parameters", () => {
       },
     };
     fs.writeFileSync(wingParametersFile, JSON.stringify(providedParameters));
-    
+
     // WHEN
-    const app = platformManager.createApp({ outdir: tempdir, entrypointDir: tempdir });
+    const app = platformManager.createApp({
+      outdir: tempdir,
+      entrypointDir: tempdir,
+    });
     const inflight = Testing.makeHandler("");
     new Function(app, "Function", inflight);
 
@@ -113,4 +127,4 @@ describe("tf-aws platform parameters", () => {
     const tfFunction = JSON.parse(output).resource.aws_lambda_function.Function;
     expect(tfFunction.vpc_config.subnet_ids.length).toEqual(2);
   });
-})
+});

--- a/libs/wingsdk/test/target-tf-aws/platform.test.ts
+++ b/libs/wingsdk/test/target-tf-aws/platform.test.ts
@@ -1,0 +1,91 @@
+import { test, expect, describe, beforeEach } from "vitest";
+import fs from "fs";
+import path from "path";
+import { mkdtemp } from "../util";
+import { PlatformManager } from "../../src/platform";
+
+describe("tf-aws platform parameters", () => {
+  let platformManager;
+  let tempdir;
+  let wingParametersFile;
+  
+  beforeEach(() => {
+    platformManager = new PlatformManager({platformPaths: ["tf-aws"]});
+    tempdir = mkdtemp();
+    wingParametersFile = path.join(tempdir, "wing.json");
+    process.env.WING_VALUES_FILE = wingParametersFile;
+  });
+
+  test("throws if private subnet ids are not an array", () => {
+    // GIVEN
+    const providedParameters = {
+      "tf-aws": {
+        vpc: "existing",
+        vpc_id: "vpc-123",
+        private_subnet_ids: "subnet-123",
+      },
+    };
+    fs.writeFileSync(wingParametersFile, JSON.stringify(providedParameters));
+
+    // WHEN
+    const app = platformManager.createApp({ outdir: tempdir, entrypointDir: tempdir });
+
+    // THEN
+    expect(() => app.synth()).toThrow(/must be array/);
+  });
+
+  test("does not throw if private subnet ids are an array", () => {
+    // GIVEN
+    const providedParameters = {
+      "tf-aws": {
+        vpc: "existing",
+        vpc_id: "vpc-123",
+        private_subnet_ids: ["subnet-123"],
+      },
+    };
+    fs.writeFileSync(wingParametersFile, JSON.stringify(providedParameters));
+
+    // WHEN
+    const app = platformManager.createApp({ outdir: tempdir, entrypointDir: tempdir });
+
+    // THEN
+    expect(() => app.synth()).not.toThrow();
+  });
+
+  test("require private subnet ids, when vpc = existing", () => {
+    // GIVEN
+    const providedParameters = {
+      "tf-aws": {
+        vpc: "existing",
+        vpc_api_gateway: true,
+        vpc_lambda: true,
+      },
+    };
+    fs.writeFileSync(wingParametersFile, JSON.stringify(providedParameters));
+    
+    // WHEN
+    const app = platformManager.createApp({ outdir: tempdir, entrypointDir: tempdir });
+    
+    // THEN
+    expect(() => app.synth()).toThrow(/must have required property 'private_subnet_ids'/);
+
+  });
+
+  test("does not require public subnet ids, when vpc = existing", () => {
+    // GIVEN
+    const providedParameters = {
+      "tf-aws": {
+        vpc: "existing",
+        vpc_id: "vpc-123",
+        private_subnet_ids: ["subnet-123"],
+      },
+    };
+    fs.writeFileSync(wingParametersFile, JSON.stringify(providedParameters));
+    
+    // WHEN
+    const app = platformManager.createApp({ outdir: tempdir, entrypointDir: tempdir });
+    
+    // THEN
+    expect(() => app.synth()).not.toThrow();
+  });
+})

--- a/tools/hangar/__snapshots__/test_corpus/valid/redis.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/redis.test.w_compile_tf-aws.md
@@ -114,7 +114,7 @@ module.exports = function({ $queue, $r, $r2, $util_Util }) {
         "num_cache_nodes": 1,
         "parameter_group_name": "default.redis6.x",
         "security_group_ids": [
-          "${aws_security_group.exRedis_securityGroup_3948C3F2.id}"
+          "${aws_security_group.exRedis_KEN15securityGroup_3840F345.id}"
         ],
         "subnet_group_name": "${aws_elasticache_subnet_group.exRedis_RedisSubnetGroup_EE9BBE48.name}"
       },
@@ -133,7 +133,7 @@ module.exports = function({ $queue, $r, $r2, $util_Util }) {
         "num_cache_nodes": 1,
         "parameter_group_name": "default.redis6.x",
         "security_group_ids": [
-          "${aws_security_group.r2_securityGroup_35A75C2E.id}"
+          "${aws_security_group.r2_KEN24securityGroup_AFC21ADF.id}"
         ],
         "subnet_group_name": "${aws_elasticache_subnet_group.r2_RedisSubnetGroup_C415566B.name}"
       }
@@ -256,7 +256,7 @@ module.exports = function({ $queue, $r, $r2, $util_Util }) {
         "timeout": "${aws_sqs_queue.cloudQueue.visibility_timeout_seconds}",
         "vpc_config": {
           "security_group_ids": [
-            "${aws_security_group.exRedis_securityGroup_3948C3F2.id}"
+            "${aws_security_group.exRedis_KEN15securityGroup_3840F345.id}"
           ],
           "subnet_ids": [
             "${aws_subnet.PrivateSubnet.id}"
@@ -386,11 +386,11 @@ module.exports = function({ $queue, $r, $r2, $util_Util }) {
       }
     },
     "aws_security_group": {
-      "exRedis_securityGroup_3948C3F2": {
+      "exRedis_KEN15securityGroup_3840F345": {
         "//": {
           "metadata": {
-            "path": "root/Default/Default/ex.Redis/securityGroup",
-            "uniqueId": "exRedis_securityGroup_3948C3F2"
+            "path": "root/Default/Default/ex.Redis/KEN.15]}securityGroup",
+            "uniqueId": "exRedis_KEN15securityGroup_3840F345"
           }
         },
         "egress": [
@@ -426,11 +426,11 @@ module.exports = function({ $queue, $r, $r2, $util_Util }) {
         "name": "89baf91f-securityGroup",
         "vpc_id": "${aws_vpc.VPC.id}"
       },
-      "r2_securityGroup_35A75C2E": {
+      "r2_KEN24securityGroup_AFC21ADF": {
         "//": {
           "metadata": {
-            "path": "root/Default/Default/r2/securityGroup",
-            "uniqueId": "r2_securityGroup_35A75C2E"
+            "path": "root/Default/Default/r2/KEN.24]}securityGroup",
+            "uniqueId": "r2_KEN24securityGroup_AFC21ADF"
           }
         },
         "egress": [


### PR DESCRIPTION
These changes support providing multiple subnets (public and private) to the tf-aws vpc that is used for resources that require vpcs.


## Checklist

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [x] Tests added (always)
- [x] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
