### PR TITLE
chore(docs): fix malformed markdown link on development page

### DIFF
--- a/docs/contributing/01-start-here/05-development.md
+++ b/docs/contributing/01-start-here/05-development.md
@@ -285,7 +285,7 @@ Lastly you can show linting errors in your IDE by enabling the following setting
 
 Adding a new template is straightforward!
 
-Each template is represented by a folder located at [https://github.com/winglang/wing/tree/main/apps/wing/project-templates], containing all of the files that template should be initialized with.
+Each template is represented by a folder located at [project-templates](https://github.com/winglang/wing/tree/main/apps/wing/project-templates), containing all of the files that template should be initialized with.
 
 Create a new folder with the template name, and insert any code files that are needed to run it.
 Unit tests ran with `pnpm turbo test` (or in GitHub Actions once you make a pull request) will automatically validate that the template is valid.


### PR DESCRIPTION
The Markdown link to the project templates directory is malformed and does not render properly on https://www.winglang.io/contributing/start-here/development#-how-do-i-add-a-quickstart-template-to-the-wing-cli. This change fixes the link.

## Checklist

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [ ] Tests added (always)
- [x] Docs updated (only required for features)
- [x] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
