### PR TITLE
fix(sdk): invalid characters in container names for redis and dynamo

### DIFF
--- a/libs/wingsdk/src/shared/misc.ts
+++ b/libs/wingsdk/src/shared/misc.ts
@@ -1,6 +1,7 @@
 import { execFile } from "child_process";
 import { readFileSync } from "fs";
 import { promisify } from "util";
+import { v4 as uuidv4 } from "uuid";
 
 const execFilePromise = promisify(execFile);
 
@@ -29,6 +30,12 @@ export function normalPath(path: string) {
 export async function runCommand(cmd: string, args: string[]): Promise<any> {
   const { stdout } = await execFilePromise(cmd, args);
   return stdout;
+}
+
+export function generateDockerContainerName(prefix: string): string {
+  // Docker checks against [a-zA-Z0-9][a-zA-Z0-9_.-]
+  const name = prefix.replace(/[^a-zA-Z0-9_.-]/g, "-");
+  return `${name}-${uuidv4()}`;
 }
 
 export interface runDockerImageProps {

--- a/libs/wingsdk/src/target-sim/dynamodb-table.inflight.ts
+++ b/libs/wingsdk/src/target-sim/dynamodb-table.inflight.ts
@@ -5,13 +5,12 @@ import {
   KeyType,
   KeySchemaElement,
 } from "@aws-sdk/client-dynamodb";
-import { v4 as uuidv4 } from "uuid";
 import {
   DynamodbTableAttributes,
   DynamodbTableSchema,
 } from "./schema-resources";
 import { DynamodbTableClientBase, GlobalSecondaryIndex } from "../ex";
-import { runDockerImage } from "../shared/misc";
+import { generateDockerContainerName, runDockerImage } from "../shared/misc";
 import {
   ISimulatorContext,
   ISimulatorResourceInstance,
@@ -36,10 +35,9 @@ export class DynamodbTable
     super(props.name);
 
     this.context = context;
-    this.containerName = `wing-sim-dynamodb-${this.context.resourcePath.replace(
-      /\//g,
-      "."
-    )}-${uuidv4()}`;
+    this.containerName = generateDockerContainerName(
+      `wing-sim-dynamodb-${this.context.resourcePath}`
+    );
   }
 
   public async init(): Promise<DynamodbTableAttributes> {

--- a/libs/wingsdk/src/target-sim/redis.inflight.ts
+++ b/libs/wingsdk/src/target-sim/redis.inflight.ts
@@ -1,9 +1,8 @@
 import { execSync } from "node:child_process";
 import IoRedis from "ioredis";
-import { v4 as uuidv4 } from "uuid";
 import { RedisAttributes, RedisSchema } from "./schema-resources";
 import { RedisClientBase } from "../ex";
-import { runDockerImage } from "../shared/misc";
+import { generateDockerContainerName, runDockerImage } from "../shared/misc";
 import {
   ISimulatorContext,
   ISimulatorResourceInstance,
@@ -27,10 +26,9 @@ export class Redis
   public constructor(_props: RedisSchema["props"], context: ISimulatorContext) {
     super();
     this.context = context;
-    this.containerName = `wing-sim-redis-${this.context.resourcePath.replace(
-      /\//g,
-      "."
-    )}-${uuidv4()}`;
+    this.containerName = generateDockerContainerName(
+      `wing-sim-redis-${this.context.resourcePath}`
+    );
   }
 
   public async init(): Promise<RedisAttributes> {

--- a/libs/wingsdk/test/shared/misc.test.ts
+++ b/libs/wingsdk/test/shared/misc.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from "vitest";
+import { generateDockerContainerName } from "../../src/shared/misc";
+
+describe("generateDockerContainerName", () => {
+  test("includes the provided prefix", () => {
+    const prefix = "my-example-name";
+    const actual = generateDockerContainerName(prefix);
+    expect(actual).toContain(prefix);
+  });
+
+  test("removes disallowed characters", () => {
+    const actual = generateDockerContainerName(
+      "wing-container-type-App.Name With Spaces/And/Stuff"
+    );
+    expect(actual).not.contains(/[ \/]/);
+  });
+
+  test("includes a uuid v4 suffix", () => {
+    const uuidRegexp = /[a-f\d]{8}(-[a-f\d]{4}){3}-[a-f\d]{12}$/i;
+    const actual = generateDockerContainerName("wing-container-type-name");
+    expect(actual).toMatch(uuidRegexp);
+  });
+});


### PR DESCRIPTION
Fixes #5674 and Fixes #5070 by ensuring that disallowed characters are removed from Docker container names before they are started.

- I considered leveraging https://github.com/winglang/wing/blob/main/libs/wingsdk/src/shared/resource-names.ts for this but realized the options are a bit overkill for what is required when naming Docker containers. However, I'd be happy to move/rewrite if you'd prefer a different solution!
- This affects both Redis and DynamoDB docker containers started by the simulator, but does not automatically extend to any future containers that the simulator might use. Given that I'm new to the project, I'm not sure how to best achieve that yet.
- Based on my testing, container names can be >1000 characters long, so length should not be a problem.
- I confirmed that with a Wing file containing the below, the simulator is able to start the containers without issue.

```ts
let table = new ex.DynamodbTable(name: "MyTable", attributeDefinitions: { id: "S" }, hashKey: "id") as "My Table";
let redis = new ex.Redis() as "My Redis";
```

## Checklist

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [x] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
