### PR TITLE
fix(compiler): unused global lifts cause sim to fail

### DIFF
--- a/examples/tests/valid/unused_lift.test.w
+++ b/examples/tests/valid/unused_lift.test.w
@@ -1,0 +1,31 @@
+bring cloud;
+
+let b = new cloud.Bucket();
+
+class Foo {
+  inflight access_b() {
+    b.list();
+  }
+
+  pub inflight m() {}
+}
+
+let f = new Foo();
+
+test "Use class but not method that access lifted object" {
+  f.m();
+}
+
+class Bar {
+  static inflight access_b() {
+    b.list();
+  }
+
+  pub inflight m() {}
+}
+
+let bar = new Bar();
+
+test "Use class but not static method that access lifted object" {
+  bar.m();
+}

--- a/libs/wingc/src/jsify/snapshots/access_methods_and_properties_on_collections.snap
+++ b/libs/wingc/src/jsify/snapshots/access_methods_and_properties_on_collections.snap
@@ -82,6 +82,8 @@ class $Root extends $stdlib.std.Resource {
             [x.length, []],
           ],
           "$inflight_init": [
+            [((arr, index) => { if (index < 0 || index >= arr.length) throw new Error("Index out of bounds"); return arr[index]; })(y, 0), []],
+            [x.length, []],
           ],
         });
       }

--- a/libs/wingc/src/jsify/snapshots/access_property_on_primitive.snap
+++ b/libs/wingc/src/jsify/snapshots/access_property_on_primitive.snap
@@ -77,6 +77,7 @@ class $Root extends $stdlib.std.Resource {
             [s.length, []],
           ],
           "$inflight_init": [
+            [s.length, []],
           ],
         });
       }

--- a/libs/wingc/src/jsify/snapshots/access_property_on_value_returned_from_collection.snap
+++ b/libs/wingc/src/jsify/snapshots/access_property_on_value_returned_from_collection.snap
@@ -77,6 +77,7 @@ class $Root extends $stdlib.std.Resource {
             [((obj, key) => { if (!(key in obj)) throw new Error(`Map does not contain key: "${key}"`); return obj[key]; })(s, "hello").length, []],
           ],
           "$inflight_init": [
+            [((obj, key) => { if (!(key in obj)) throw new Error(`Map does not contain key: "${key}"`); return obj[key]; })(s, "hello").length, []],
           ],
         });
       }

--- a/libs/wingc/src/jsify/snapshots/base_class_captures_inflight.snap
+++ b/libs/wingc/src/jsify/snapshots/base_class_captures_inflight.snap
@@ -99,6 +99,7 @@ class $Root extends $stdlib.std.Resource {
             [x, []],
           ],
           "$inflight_init": [
+            [x, []],
           ],
         });
       }

--- a/libs/wingc/src/jsify/snapshots/call_static_inflight_from_static_inflight.snap
+++ b/libs/wingc/src/jsify/snapshots/call_static_inflight_from_static_inflight.snap
@@ -123,6 +123,7 @@ class $Root extends $stdlib.std.Resource {
       get _liftMap() {
         return ({
           "$inflight_init": [
+            [A, []],
           ],
         });
       }

--- a/libs/wingc/src/jsify/snapshots/calls_methods_on_preflight_object.snap
+++ b/libs/wingc/src/jsify/snapshots/calls_methods_on_preflight_object.snap
@@ -81,6 +81,7 @@ class $Root extends $stdlib.std.Resource {
             [b, ["list", "put"]],
           ],
           "$inflight_init": [
+            [b, []],
           ],
         });
       }

--- a/libs/wingc/src/jsify/snapshots/capture_from_inside_an_inflight_closure.snap
+++ b/libs/wingc/src/jsify/snapshots/capture_from_inside_an_inflight_closure.snap
@@ -81,6 +81,7 @@ class $Root extends $stdlib.std.Resource {
             [foo, []],
           ],
           "$inflight_init": [
+            [foo, []],
           ],
         });
       }

--- a/libs/wingc/src/jsify/snapshots/capture_identifier_closure_from_preflight_scope.snap
+++ b/libs/wingc/src/jsify/snapshots/capture_identifier_closure_from_preflight_scope.snap
@@ -128,6 +128,7 @@ class $Root extends $stdlib.std.Resource {
             [foo, ["handle"]],
           ],
           "$inflight_init": [
+            [foo, []],
           ],
         });
       }

--- a/libs/wingc/src/jsify/snapshots/capture_identifier_from_preflight_scope.snap
+++ b/libs/wingc/src/jsify/snapshots/capture_identifier_from_preflight_scope.snap
@@ -76,6 +76,7 @@ class $Root extends $stdlib.std.Resource {
             [x, []],
           ],
           "$inflight_init": [
+            [x, []],
           ],
         });
       }

--- a/libs/wingc/src/jsify/snapshots/capture_identifier_from_preflight_scope_with_method_call.snap
+++ b/libs/wingc/src/jsify/snapshots/capture_identifier_from_preflight_scope_with_method_call.snap
@@ -127,6 +127,7 @@ class $Root extends $stdlib.std.Resource {
             [f, ["bar"]],
           ],
           "$inflight_init": [
+            [f, []],
           ],
         });
       }

--- a/libs/wingc/src/jsify/snapshots/capture_identifier_from_preflight_scope_with_nested_object.snap
+++ b/libs/wingc/src/jsify/snapshots/capture_identifier_from_preflight_scope_with_nested_object.snap
@@ -130,6 +130,7 @@ class $Root extends $stdlib.std.Resource {
             [f.b, ["put"]],
           ],
           "$inflight_init": [
+            [f.b, []],
           ],
         });
       }

--- a/libs/wingc/src/jsify/snapshots/capture_identifier_from_preflight_scope_with_property.snap
+++ b/libs/wingc/src/jsify/snapshots/capture_identifier_from_preflight_scope_with_property.snap
@@ -76,6 +76,7 @@ class $Root extends $stdlib.std.Resource {
             [x.length, []],
           ],
           "$inflight_init": [
+            [x.length, []],
           ],
         });
       }

--- a/libs/wingc/src/jsify/snapshots/capture_in_keyword_args.snap
+++ b/libs/wingc/src/jsify/snapshots/capture_in_keyword_args.snap
@@ -83,6 +83,7 @@ class $Root extends $stdlib.std.Resource {
             [x, []],
           ],
           "$inflight_init": [
+            [x, []],
           ],
         });
       }

--- a/libs/wingc/src/jsify/snapshots/capture_object_with_this_in_name.snap
+++ b/libs/wingc/src/jsify/snapshots/capture_object_with_this_in_name.snap
@@ -78,6 +78,7 @@ class $Root extends $stdlib.std.Resource {
             [bucket_this, ["put"]],
           ],
           "$inflight_init": [
+            [bucket_this, []],
           ],
         });
       }

--- a/libs/wingc/src/jsify/snapshots/capture_token.snap
+++ b/libs/wingc/src/jsify/snapshots/capture_token.snap
@@ -77,6 +77,7 @@ class $Root extends $stdlib.std.Resource {
             [api.url, []],
           ],
           "$inflight_init": [
+            [api.url, []],
           ],
         });
       }

--- a/libs/wingc/src/jsify/snapshots/capture_type_static_method.snap
+++ b/libs/wingc/src/jsify/snapshots/capture_type_static_method.snap
@@ -131,6 +131,7 @@ class $Root extends $stdlib.std.Resource {
             [Foo, ["bars"]],
           ],
           "$inflight_init": [
+            [Foo, []],
           ],
         });
       }

--- a/libs/wingc/src/jsify/snapshots/closure_field.snap
+++ b/libs/wingc/src/jsify/snapshots/closure_field.snap
@@ -143,6 +143,7 @@ class $Root extends $stdlib.std.Resource {
                 [globalBucket, ["list"]],
               ],
               "$inflight_init": [
+                [globalBucket, []],
               ],
             });
           }
@@ -208,6 +209,7 @@ class $Root extends $stdlib.std.Resource {
             [x, ["foo"]],
           ],
           "$inflight_init": [
+            [x, []],
           ],
         });
       }

--- a/libs/wingc/src/jsify/snapshots/enum_value.snap
+++ b/libs/wingc/src/jsify/snapshots/enum_value.snap
@@ -88,6 +88,7 @@ class $Root extends $stdlib.std.Resource {
             [x, []],
           ],
           "$inflight_init": [
+            [x, []],
           ],
         });
       }

--- a/libs/wingc/src/jsify/snapshots/indirect_capture.snap
+++ b/libs/wingc/src/jsify/snapshots/indirect_capture.snap
@@ -116,6 +116,7 @@ class $Root extends $stdlib.std.Resource {
             [this, ["foo"]],
           ],
           "$inflight_init": [
+            [b, []],
           ],
         });
       }
@@ -150,6 +151,7 @@ class $Root extends $stdlib.std.Resource {
             [f, ["goo"]],
           ],
           "$inflight_init": [
+            [f, []],
           ],
         });
       }

--- a/libs/wingc/src/jsify/snapshots/inline_inflight_class.snap
+++ b/libs/wingc/src/jsify/snapshots/inline_inflight_class.snap
@@ -108,6 +108,7 @@ class $Root extends $stdlib.std.Resource {
                 [__parent_this_1.b, ["put"]],
               ],
               "$inflight_init": [
+                [__parent_this_1.b, []],
               ],
             });
           }

--- a/libs/wingc/src/jsify/snapshots/json_object.snap
+++ b/libs/wingc/src/jsify/snapshots/json_object.snap
@@ -78,6 +78,7 @@ class $Root extends $stdlib.std.Resource {
             [jsonObj1, []],
           ],
           "$inflight_init": [
+            [jsonObj1, []],
           ],
         });
       }

--- a/libs/wingc/src/jsify/snapshots/lift_binary_preflight_and_inflight_expression.snap
+++ b/libs/wingc/src/jsify/snapshots/lift_binary_preflight_and_inflight_expression.snap
@@ -78,6 +78,7 @@ class $Root extends $stdlib.std.Resource {
             [x, []],
           ],
           "$inflight_init": [
+            [x, []],
           ],
         });
       }

--- a/libs/wingc/src/jsify/snapshots/lift_binary_preflight_expression.snap
+++ b/libs/wingc/src/jsify/snapshots/lift_binary_preflight_expression.snap
@@ -79,6 +79,8 @@ class $Root extends $stdlib.std.Resource {
             [y, []],
           ],
           "$inflight_init": [
+            [x, []],
+            [y, []],
           ],
         });
       }

--- a/libs/wingc/src/jsify/snapshots/lift_element_from_collection_of_objects.snap
+++ b/libs/wingc/src/jsify/snapshots/lift_element_from_collection_of_objects.snap
@@ -79,6 +79,7 @@ class $Root extends $stdlib.std.Resource {
             [((arr, index) => { if (index < 0 || index >= arr.length) throw new Error("Index out of bounds"); return arr[index]; })(a, 0), ["put"]],
           ],
           "$inflight_init": [
+            [((arr, index) => { if (index < 0 || index >= arr.length) throw new Error("Index out of bounds"); return arr[index]; })(a, 0), []],
           ],
         });
       }

--- a/libs/wingc/src/jsify/snapshots/lift_inflight_closure.snap
+++ b/libs/wingc/src/jsify/snapshots/lift_inflight_closure.snap
@@ -129,6 +129,7 @@ class $Root extends $stdlib.std.Resource {
             [f, ["handle"]],
           ],
           "$inflight_init": [
+            [f, []],
           ],
         });
       }

--- a/libs/wingc/src/jsify/snapshots/lift_inside_preflight_method.snap
+++ b/libs/wingc/src/jsify/snapshots/lift_inside_preflight_method.snap
@@ -112,6 +112,7 @@ class $Root extends $stdlib.std.Resource {
                 [b, ["put"]],
               ],
               "$inflight_init": [
+                [b, []],
               ],
             });
           }

--- a/libs/wingc/src/jsify/snapshots/lift_self_reference.snap
+++ b/libs/wingc/src/jsify/snapshots/lift_self_reference.snap
@@ -75,6 +75,7 @@ class $Root extends $stdlib.std.Resource {
             [Foo, ["static_method"]],
           ],
           "$inflight_init": [
+            [Foo, []],
           ],
         });
       }

--- a/libs/wingc/src/jsify/snapshots/lift_string.snap
+++ b/libs/wingc/src/jsify/snapshots/lift_string.snap
@@ -76,6 +76,7 @@ class $Root extends $stdlib.std.Resource {
             [b, []],
           ],
           "$inflight_init": [
+            [b, []],
           ],
         });
       }

--- a/libs/wingc/src/jsify/snapshots/lift_this.snap
+++ b/libs/wingc/src/jsify/snapshots/lift_this.snap
@@ -149,6 +149,7 @@ class $Root extends $stdlib.std.Resource {
             [f, ["foo"]],
           ],
           "$inflight_init": [
+            [f, []],
           ],
         });
       }

--- a/libs/wingc/src/jsify/snapshots/lift_via_closure.snap
+++ b/libs/wingc/src/jsify/snapshots/lift_via_closure.snap
@@ -105,6 +105,7 @@ class $Root extends $stdlib.std.Resource {
             [bucket, ["put"]],
           ],
           "$inflight_init": [
+            [bucket, []],
           ],
         });
       }
@@ -139,6 +140,7 @@ class $Root extends $stdlib.std.Resource {
             [fn, ["handle"]],
           ],
           "$inflight_init": [
+            [fn, []],
           ],
         });
       }

--- a/libs/wingc/src/jsify/snapshots/lift_via_closure_class_explicit.snap
+++ b/libs/wingc/src/jsify/snapshots/lift_via_closure_class_explicit.snap
@@ -158,6 +158,7 @@ class $Root extends $stdlib.std.Resource {
             [fn, ["handle"]],
           ],
           "$inflight_init": [
+            [fn, []],
           ],
         });
       }

--- a/libs/wingc/src/jsify/snapshots/nested_inflight_after_preflight_operation.snap
+++ b/libs/wingc/src/jsify/snapshots/nested_inflight_after_preflight_operation.snap
@@ -134,6 +134,7 @@ class $Root extends $stdlib.std.Resource {
             [y, ["b"]],
           ],
           "$inflight_init": [
+            [y, []],
           ],
         });
       }

--- a/libs/wingc/src/jsify/snapshots/nested_preflight_operation.snap
+++ b/libs/wingc/src/jsify/snapshots/nested_preflight_operation.snap
@@ -180,6 +180,7 @@ class $Root extends $stdlib.std.Resource {
             [t.y.b, ["put"]],
           ],
           "$inflight_init": [
+            [t.y.b, []],
           ],
         });
       }

--- a/libs/wingc/src/jsify/snapshots/no_lift_shadow_inside_inner_scopes.snap
+++ b/libs/wingc/src/jsify/snapshots/no_lift_shadow_inside_inner_scopes.snap
@@ -87,6 +87,7 @@ class $Root extends $stdlib.std.Resource {
             [i, []],
           ],
           "$inflight_init": [
+            [i, []],
           ],
         });
       }

--- a/libs/wingc/src/jsify/snapshots/preflight_collection.snap
+++ b/libs/wingc/src/jsify/snapshots/preflight_collection.snap
@@ -80,6 +80,8 @@ class $Root extends $stdlib.std.Resource {
             [a.length, []],
           ],
           "$inflight_init": [
+            [((arr, index) => { if (index < 0 || index >= arr.length) throw new Error("Index out of bounds"); return arr[index]; })(a, 0), []],
+            [a.length, []],
           ],
         });
       }

--- a/libs/wingc/src/jsify/snapshots/preflight_collection_of_preflight_objects.snap
+++ b/libs/wingc/src/jsify/snapshots/preflight_collection_of_preflight_objects.snap
@@ -85,6 +85,8 @@ class $Root extends $stdlib.std.Resource {
             [arr.length, []],
           ],
           "$inflight_init": [
+            [((arr, index) => { if (index < 0 || index >= arr.length) throw new Error("Index out of bounds"); return arr[index]; })(arr, 0), []],
+            [arr.length, []],
           ],
         });
       }

--- a/libs/wingc/src/jsify/snapshots/preflight_nested_object_with_operations.snap
+++ b/libs/wingc/src/jsify/snapshots/preflight_nested_object_with_operations.snap
@@ -130,6 +130,7 @@ class $Root extends $stdlib.std.Resource {
             [a.bucky, ["list"]],
           ],
           "$inflight_init": [
+            [a.bucky, []],
           ],
         });
       }

--- a/libs/wingc/src/jsify/snapshots/preflight_object.snap
+++ b/libs/wingc/src/jsify/snapshots/preflight_object.snap
@@ -133,6 +133,7 @@ class $Root extends $stdlib.std.Resource {
             [pf_obj, ["goodbye", "hello"]],
           ],
           "$inflight_init": [
+            [pf_obj, []],
           ],
         });
       }

--- a/libs/wingc/src/jsify/snapshots/preflight_object_through_property.snap
+++ b/libs/wingc/src/jsify/snapshots/preflight_object_through_property.snap
@@ -131,6 +131,7 @@ class $Root extends $stdlib.std.Resource {
             [t.b, ["put"]],
           ],
           "$inflight_init": [
+            [t.b, []],
           ],
         });
       }

--- a/libs/wingc/src/jsify/snapshots/preflight_object_with_operations.snap
+++ b/libs/wingc/src/jsify/snapshots/preflight_object_with_operations.snap
@@ -80,6 +80,7 @@ class $Root extends $stdlib.std.Resource {
             [b, ["list", "put"]],
           ],
           "$inflight_init": [
+            [b, []],
           ],
         });
       }

--- a/libs/wingc/src/jsify/snapshots/preflight_object_with_operations_multiple_methods.snap
+++ b/libs/wingc/src/jsify/snapshots/preflight_object_with_operations_multiple_methods.snap
@@ -86,6 +86,7 @@ class $Root extends $stdlib.std.Resource {
             [b, ["list"]],
           ],
           "$inflight_init": [
+            [b, []],
           ],
         });
       }

--- a/libs/wingc/src/jsify/snapshots/preflight_value_field.snap
+++ b/libs/wingc/src/jsify/snapshots/preflight_value_field.snap
@@ -140,6 +140,9 @@ class $Root extends $stdlib.std.Resource {
             [t.name.length, []],
           ],
           "$inflight_init": [
+            [t.last, []],
+            [t.name, []],
+            [t.name.length, []],
           ],
         });
       }

--- a/libs/wingc/src/jsify/snapshots/read_primitive_value.snap
+++ b/libs/wingc/src/jsify/snapshots/read_primitive_value.snap
@@ -77,6 +77,7 @@ class $Root extends $stdlib.std.Resource {
             [x, []],
           ],
           "$inflight_init": [
+            [x, []],
           ],
         });
       }

--- a/libs/wingc/src/jsify/snapshots/ref_std_macro.snap
+++ b/libs/wingc/src/jsify/snapshots/ref_std_macro.snap
@@ -77,6 +77,7 @@ class $Root extends $stdlib.std.Resource {
             [arr.length, []],
           ],
           "$inflight_init": [
+            [arr.length, []],
           ],
         });
       }

--- a/libs/wingc/src/jsify/snapshots/reference_from_static_inflight.snap
+++ b/libs/wingc/src/jsify/snapshots/reference_from_static_inflight.snap
@@ -71,6 +71,7 @@ class $Root extends $stdlib.std.Resource {
       get _liftMap() {
         return ({
           "$inflight_init": [
+            [s, []],
           ],
         });
       }

--- a/libs/wingc/src/jsify/snapshots/reference_inflight_from_inflight.snap
+++ b/libs/wingc/src/jsify/snapshots/reference_inflight_from_inflight.snap
@@ -105,6 +105,7 @@ class $Root extends $stdlib.std.Resource {
             [s, []],
           ],
           "$inflight_init": [
+            [s, []],
           ],
         });
       }

--- a/libs/wingc/src/jsify/snapshots/reference_lift_of_collection.snap
+++ b/libs/wingc/src/jsify/snapshots/reference_lift_of_collection.snap
@@ -77,6 +77,7 @@ class $Root extends $stdlib.std.Resource {
             [a, []],
           ],
           "$inflight_init": [
+            [a, []],
           ],
         });
       }

--- a/libs/wingc/src/jsify/snapshots/reference_preflight_free_variable_with_this_in_the_expression.snap
+++ b/libs/wingc/src/jsify/snapshots/reference_preflight_free_variable_with_this_in_the_expression.snap
@@ -86,6 +86,7 @@ class $Root extends $stdlib.std.Resource {
             [this.name, []],
           ],
           "$inflight_init": [
+            [b, []],
             [this.name, []],
           ],
         });

--- a/libs/wingc/src/jsify/snapshots/reference_preflight_object_from_static_inflight.snap
+++ b/libs/wingc/src/jsify/snapshots/reference_preflight_object_from_static_inflight.snap
@@ -74,6 +74,7 @@ class $Root extends $stdlib.std.Resource {
       get _liftMap() {
         return ({
           "$inflight_init": [
+            [q, []],
           ],
         });
       }

--- a/libs/wingc/src/jsify/snapshots/reference_static_inflight.snap
+++ b/libs/wingc/src/jsify/snapshots/reference_static_inflight.snap
@@ -131,6 +131,7 @@ class $Root extends $stdlib.std.Resource {
             [MyType, ["myStaticMethod"]],
           ],
           "$inflight_init": [
+            [MyType, []],
           ],
         });
       }

--- a/libs/wingc/src/jsify/snapshots/reference_static_inflight_which_references_preflight_object.snap
+++ b/libs/wingc/src/jsify/snapshots/reference_static_inflight_which_references_preflight_object.snap
@@ -101,6 +101,7 @@ class $Root extends $stdlib.std.Resource {
       get _liftMap() {
         return ({
           "$inflight_init": [
+            [b, []],
           ],
         });
       }
@@ -142,6 +143,7 @@ class $Root extends $stdlib.std.Resource {
             [MyType, ["staticMethod"]],
           ],
           "$inflight_init": [
+            [MyType, []],
           ],
         });
       }

--- a/libs/wingc/src/jsify/snapshots/static_external_preflight_class.snap
+++ b/libs/wingc/src/jsify/snapshots/static_external_preflight_class.snap
@@ -139,6 +139,7 @@ class $Root extends $stdlib.std.Resource {
             [A, ["foo"]],
           ],
           "$inflight_init": [
+            [A, []],
           ],
         });
       }

--- a/libs/wingc/src/jsify/snapshots/static_inflight_operation.snap
+++ b/libs/wingc/src/jsify/snapshots/static_inflight_operation.snap
@@ -98,6 +98,7 @@ class $Root extends $stdlib.std.Resource {
       get _liftMap() {
         return ({
           "$inflight_init": [
+            [b, []],
           ],
         });
       }
@@ -139,6 +140,7 @@ class $Root extends $stdlib.std.Resource {
             [A, ["myop"]],
           ],
           "$inflight_init": [
+            [A, []],
           ],
         });
       }

--- a/libs/wingc/src/jsify/snapshots/transitive_reference.snap
+++ b/libs/wingc/src/jsify/snapshots/transitive_reference.snap
@@ -158,6 +158,7 @@ class $Root extends $stdlib.std.Resource {
             [t, ["checkIfEmpty"]],
           ],
           "$inflight_init": [
+            [t, []],
           ],
         });
       }

--- a/libs/wingc/src/jsify/snapshots/transitive_reference_via_inflight_class.snap
+++ b/libs/wingc/src/jsify/snapshots/transitive_reference_via_inflight_class.snap
@@ -102,6 +102,7 @@ class $Root extends $stdlib.std.Resource {
             [b, ["put"]],
           ],
           "$inflight_init": [
+            [b, []],
           ],
         });
       }

--- a/libs/wingc/src/jsify/snapshots/transitive_reference_via_static.snap
+++ b/libs/wingc/src/jsify/snapshots/transitive_reference_via_static.snap
@@ -124,6 +124,7 @@ class $Root extends $stdlib.std.Resource {
       get _liftMap() {
         return ({
           "$inflight_init": [
+            [b, []],
           ],
         });
       }
@@ -163,6 +164,7 @@ class $Root extends $stdlib.std.Resource {
             [MyType, ["putInBucket"]],
           ],
           "$inflight_init": [
+            [MyType, []],
           ],
         });
       }
@@ -197,6 +199,7 @@ class $Root extends $stdlib.std.Resource {
             [t, ["putIndirect"]],
           ],
           "$inflight_init": [
+            [t, []],
           ],
         });
       }

--- a/libs/wingc/src/jsify/snapshots/two_identical_lifts.snap
+++ b/libs/wingc/src/jsify/snapshots/two_identical_lifts.snap
@@ -86,6 +86,7 @@ class $Root extends $stdlib.std.Resource {
             [b, ["put"]],
           ],
           "$inflight_init": [
+            [b, []],
           ],
         });
       }

--- a/libs/wingc/src/lifting.rs
+++ b/libs/wingc/src/lifting.rs
@@ -235,7 +235,7 @@ impl<'a> Visit<'a> for LiftVisitor<'a> {
 
 				let mut lifts = v.lifts_stack.pop().unwrap();
 				let is_field = code.contains("this."); // TODO: starts_with?
-				lifts.lift(v.ctx.current_method().map(|(m,_)|m), property, &code, is_field);
+				lifts.lift(v.ctx.current_method().map(|(m,_)|m), property, &code);
 				lifts.capture(&Liftable::Expr(node.id), &code, is_field);
 				v.lifts_stack.push(lifts);
 				return;
@@ -295,7 +295,7 @@ impl<'a> Visit<'a> for LiftVisitor<'a> {
 			}
 
 			let mut lifts = self.lifts_stack.pop().unwrap();
-			lifts.lift(self.ctx.current_method().map(|(m, _)| m), property, &code, false);
+			lifts.lift(self.ctx.current_method().map(|(m, _)| m), property, &code);
 			self.lifts_stack.push(lifts);
 		}
 

--- a/libs/wingc/src/type_check/lifts.rs
+++ b/libs/wingc/src/type_check/lifts.rs
@@ -57,13 +57,14 @@ impl Lifts {
 	}
 
 	/// Adds a lift for an expression.
-	pub fn lift(&mut self, method: Option<Symbol>, property: Option<Symbol>, code: &str, is_field: bool) {
+	pub fn lift(&mut self, method: Option<Symbol>, property: Option<Symbol>, code: &str) {
 		let method = method.map(|m| m.name).unwrap_or(Default::default());
 
 		self.add_lift(method, code, property.as_ref().map(|s| s.name.clone()));
 
-		// add a lift to the inflight initializer or capture it if its not a field
-		if is_field {
+		// Add a lift to the inflight initializer to signify this class requires access to that preflight object.
+		// "this" is a special case since it's already in scope and doesn't need to be lifted.
+		if code != "this" {
 			self.add_lift(CLASS_INFLIGHT_INIT_NAME.to_string(), code, None);
 		}
 	}

--- a/tools/hangar/__snapshots__/test_corpus/valid/api.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/api.test.w_compile_tf-aws.md
@@ -511,6 +511,7 @@ class $Root extends $stdlib.std.Resource {
             [counter, ["inc"]],
           ],
           "$inflight_init": [
+            [counter, []],
           ],
         });
       }
@@ -545,6 +546,7 @@ class $Root extends $stdlib.std.Resource {
             [api.url, []],
           ],
           "$inflight_init": [
+            [api.url, []],
           ],
         });
       }
@@ -584,6 +586,7 @@ class $Root extends $stdlib.std.Resource {
                 [__parent_this_3.api.url, []],
               ],
               "$inflight_init": [
+                [__parent_this_3.api.url, []],
               ],
             });
           }

--- a/tools/hangar/__snapshots__/test_corpus/valid/api_cors_custom.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/api_cors_custom.test.w_compile_tf-aws.md
@@ -403,6 +403,7 @@ class $Root extends $stdlib.std.Resource {
             [api.url, []],
           ],
           "$inflight_init": [
+            [api.url, []],
           ],
         });
       }
@@ -440,6 +441,7 @@ class $Root extends $stdlib.std.Resource {
             [api.url, []],
           ],
           "$inflight_init": [
+            [api.url, []],
           ],
         });
       }
@@ -477,6 +479,7 @@ class $Root extends $stdlib.std.Resource {
             [api.url, []],
           ],
           "$inflight_init": [
+            [api.url, []],
           ],
         });
       }

--- a/tools/hangar/__snapshots__/test_corpus/valid/api_cors_default.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/api_cors_default.test.w_compile_tf-aws.md
@@ -378,6 +378,7 @@ class $Root extends $stdlib.std.Resource {
             [apiDefaultCors.url, []],
           ],
           "$inflight_init": [
+            [apiDefaultCors.url, []],
           ],
         });
       }
@@ -415,6 +416,7 @@ class $Root extends $stdlib.std.Resource {
             [apiDefaultCors.url, []],
           ],
           "$inflight_init": [
+            [apiDefaultCors.url, []],
           ],
         });
       }

--- a/tools/hangar/__snapshots__/test_corpus/valid/assert.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/assert.test.w_compile_tf-aws.md
@@ -97,6 +97,8 @@ class $Root extends $stdlib.std.Resource {
             [s2, []],
           ],
           "$inflight_init": [
+            [s1, []],
+            [s2, []],
           ],
         });
       }

--- a/tools/hangar/__snapshots__/test_corpus/valid/asynchronous_model_implicit_await_in_functions.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/asynchronous_model_implicit_await_in_functions.test.w_compile_tf-aws.md
@@ -335,6 +335,7 @@ class $Root extends $stdlib.std.Resource {
             [strToStr, ["invoke"]],
           ],
           "$inflight_init": [
+            [strToStr, []],
           ],
         });
       }

--- a/tools/hangar/__snapshots__/test_corpus/valid/bring_jsii.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/bring_jsii.test.w_compile_tf-aws.md
@@ -87,6 +87,7 @@ class $Root extends $stdlib.std.Resource {
             [greeting, []],
           ],
           "$inflight_init": [
+            [greeting, []],
           ],
         });
       }

--- a/tools/hangar/__snapshots__/test_corpus/valid/bring_local.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/bring_local.test.w_compile_tf-aws.md
@@ -324,6 +324,7 @@ class $Root extends $stdlib.std.Resource {
             [store, ["store"]],
           ],
           "$inflight_init": [
+            [store, []],
           ],
         });
       }
@@ -482,6 +483,7 @@ class Store extends $stdlib.std.Resource {
             [__parent_this_1.b, ["put"]],
           ],
           "$inflight_init": [
+            [__parent_this_1.b, []],
           ],
         });
       }

--- a/tools/hangar/__snapshots__/test_corpus/valid/bring_wing_library.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/bring_wing_library.test.w_compile_tf-aws.md
@@ -160,6 +160,7 @@ class $Root extends $stdlib.std.Resource {
             [$stdlib.core.toLiftableModuleType(fixture.Store, "", "Store"), ["makeKeyInflight"]],
           ],
           "$inflight_init": [
+            [$stdlib.core.toLiftableModuleType(fixture.Store, "", "Store"), []],
           ],
         });
       }
@@ -226,6 +227,7 @@ class Store extends $stdlib.std.Resource {
         [this.handlers, []],
       ],
       "$inflight_init": [
+        [$stdlib.core.toLiftableModuleType(myutil.Util, "", "Util"), []],
         [this.data, []],
         [this.handlers, []],
       ],

--- a/tools/hangar/__snapshots__/test_corpus/valid/bucket_keys.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/bucket_keys.test.w_compile_tf-aws.md
@@ -106,6 +106,7 @@ class $Root extends $stdlib.std.Resource {
             [b, ["list", "put"]],
           ],
           "$inflight_init": [
+            [b, []],
           ],
         });
       }

--- a/tools/hangar/__snapshots__/test_corpus/valid/call_static_of_myself.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/call_static_of_myself.test.w_compile_tf-aws.md
@@ -129,6 +129,7 @@ class $Root extends $stdlib.std.Resource {
             [Foo, ["bar"]],
           ],
           "$inflight_init": [
+            [Foo, []],
           ],
         });
       }
@@ -211,6 +212,8 @@ class $Root extends $stdlib.std.Resource {
             [foo, ["callThis"]],
           ],
           "$inflight_init": [
+            [Foo, []],
+            [foo, []],
           ],
         });
       }

--- a/tools/hangar/__snapshots__/test_corpus/valid/calling_inflight_variants.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/calling_inflight_variants.test.w_compile_tf-aws.md
@@ -221,6 +221,7 @@ class $Root extends $stdlib.std.Resource {
             [foo, ["callFn", "callFn2"]],
           ],
           "$inflight_init": [
+            [foo, []],
           ],
         });
       }

--- a/tools/hangar/__snapshots__/test_corpus/valid/capture_containers.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/capture_containers.test.w_compile_tf-aws.md
@@ -106,6 +106,15 @@ class $Root extends $stdlib.std.Resource {
             [mySet.size, []],
           ],
           "$inflight_init": [
+            [("bang" in (((arr, index) => { if (index < 0 || index >= arr.length) throw new Error("Index out of bounds"); return arr[index]; })(arrOfMap, 0))), []],
+            [("world" in (myMap)), []],
+            [((arr, index) => { if (index < 0 || index >= arr.length) throw new Error("Index out of bounds"); return arr[index]; })(arr, 0), []],
+            [((arr, index) => { if (index < 0 || index >= arr.length) throw new Error("Index out of bounds"); return arr[index]; })(arr, 1), []],
+            [((obj, args) => { if (obj[args] === undefined) throw new Error(`Json property "${args}" does not exist`); return obj[args] })(j, "b"), []],
+            [(mySet.has("my")), []],
+            [Object.keys(myMap).length, []],
+            [arr.length, []],
+            [mySet.size, []],
           ],
         });
       }

--- a/tools/hangar/__snapshots__/test_corpus/valid/capture_in_binary.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/capture_in_binary.test.w_compile_tf-aws.md
@@ -100,6 +100,8 @@ class $Root extends $stdlib.std.Resource {
             [x, []],
           ],
           "$inflight_init": [
+            [b, []],
+            [x, []],
           ],
         });
       }

--- a/tools/hangar/__snapshots__/test_corpus/valid/capture_mutables.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/capture_mutables.test.w_compile_tf-aws.md
@@ -110,6 +110,10 @@ class $Root extends $stdlib.std.Resource {
             [s.size, []],
           ],
           "$inflight_init": [
+            [Object.keys(m).length, []],
+            [a.length, []],
+            [aCloned.length, []],
+            [s.size, []],
           ],
         });
       }
@@ -144,6 +148,7 @@ class $Root extends $stdlib.std.Resource {
             [handler, ["handle"]],
           ],
           "$inflight_init": [
+            [handler, []],
           ],
         });
       }

--- a/tools/hangar/__snapshots__/test_corpus/valid/capture_primitives.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/capture_primitives.test.w_compile_tf-aws.md
@@ -214,6 +214,13 @@ class $Root extends $stdlib.std.Resource {
             [myStr, []],
           ],
           "$inflight_init": [
+            [myBool, []],
+            [myDur.hours, []],
+            [myDur.minutes, []],
+            [myDur.seconds, []],
+            [myNum, []],
+            [mySecondBool, []],
+            [myStr, []],
           ],
         });
       }

--- a/tools/hangar/__snapshots__/test_corpus/valid/capture_reassigable_class_field.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/capture_reassigable_class_field.test.w_compile_tf-aws.md
@@ -265,6 +265,7 @@ class $Root extends $stdlib.std.Resource {
             [counter, ["inc"]],
           ],
           "$inflight_init": [
+            [counter, []],
           ],
         });
       }
@@ -302,6 +303,8 @@ class $Root extends $stdlib.std.Resource {
             [kv, ["get", "set"]],
           ],
           "$inflight_init": [
+            [counter, []],
+            [kv, []],
           ],
         });
       }

--- a/tools/hangar/__snapshots__/test_corpus/valid/capture_reassignable.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/capture_reassignable.test.w_compile_tf-aws.md
@@ -102,6 +102,7 @@ class $Root extends $stdlib.std.Resource {
             [x, []],
           ],
           "$inflight_init": [
+            [x, []],
           ],
         });
       }
@@ -136,6 +137,7 @@ class $Root extends $stdlib.std.Resource {
             [handler, ["handle"]],
           ],
           "$inflight_init": [
+            [handler, []],
           ],
         });
       }

--- a/tools/hangar/__snapshots__/test_corpus/valid/capture_resource_and_data.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/capture_resource_and_data.test.w_compile_tf-aws.md
@@ -116,6 +116,9 @@ class $Root extends $stdlib.std.Resource {
             [res, ["get", "put"]],
           ],
           "$inflight_init": [
+            [data.size, []],
+            [queue, []],
+            [res, []],
           ],
         });
       }

--- a/tools/hangar/__snapshots__/test_corpus/valid/capture_resource_with_no_inflight.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/capture_resource_with_no_inflight.test.w_compile_tf-aws.md
@@ -163,6 +163,8 @@ class $Root extends $stdlib.std.Resource {
             [a.field, []],
           ],
           "$inflight_init": [
+            [a, []],
+            [a.field, []],
           ],
         });
       }

--- a/tools/hangar/__snapshots__/test_corpus/valid/capture_tokens.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/capture_tokens.test.w_compile_tf-aws.md
@@ -264,6 +264,7 @@ class $Root extends $stdlib.std.Resource {
             [this.url, []],
           ],
           "$inflight_init": [
+            [MyResource, []],
             [this.api.url, []],
             [this.url, []],
           ],
@@ -306,6 +307,7 @@ class $Root extends $stdlib.std.Resource {
             [r, ["foo"]],
           ],
           "$inflight_init": [
+            [r, []],
           ],
         });
       }
@@ -344,6 +346,9 @@ class $Root extends $stdlib.std.Resource {
             [url, []],
           ],
           "$inflight_init": [
+            [MyResource, []],
+            [api.url, []],
+            [url, []],
           ],
         });
       }

--- a/tools/hangar/__snapshots__/test_corpus/valid/captures.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/captures.test.w_compile_tf-aws.md
@@ -683,6 +683,9 @@ class $Root extends $stdlib.std.Resource {
             [bucket3, ["get"]],
           ],
           "$inflight_init": [
+            [bucket1, []],
+            [bucket2, []],
+            [bucket3, []],
           ],
         });
       }
@@ -717,6 +720,7 @@ class $Root extends $stdlib.std.Resource {
             [handler, ["handle"]],
           ],
           "$inflight_init": [
+            [handler, []],
           ],
         });
       }
@@ -751,6 +755,7 @@ class $Root extends $stdlib.std.Resource {
             [headers, []],
           ],
           "$inflight_init": [
+            [headers, []],
           ],
         });
       }

--- a/tools/hangar/__snapshots__/test_corpus/valid/class.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/class.test.w_compile_tf-aws.md
@@ -549,6 +549,7 @@ class $Root extends $stdlib.std.Resource {
             [c5, ["set", "x", "y"]],
           ],
           "$inflight_init": [
+            [c5, []],
           ],
         });
       }
@@ -676,6 +677,9 @@ class $Root extends $stdlib.std.Resource {
             [student.name, []],
           ],
           "$inflight_init": [
+            [student.hrlyWage, []],
+            [student.major, []],
+            [student.name, []],
           ],
         });
       }
@@ -740,6 +744,7 @@ class $Root extends $stdlib.std.Resource {
             [ta.hrlyWage, []],
           ],
           "$inflight_init": [
+            [ta.hrlyWage, []],
           ],
         });
       }

--- a/tools/hangar/__snapshots__/test_corpus/valid/closure_class.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/closure_class.test.w_compile_tf-aws.md
@@ -138,6 +138,7 @@ class $Root extends $stdlib.std.Resource {
             [fn, ["another", "handle"]],
           ],
           "$inflight_init": [
+            [fn, []],
           ],
         });
       }

--- a/tools/hangar/__snapshots__/test_corpus/valid/deep_equality.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/deep_equality.test.w_compile_tf-aws.md
@@ -321,6 +321,10 @@ class $Root extends $stdlib.std.Resource {
             [strB, []],
           ],
           "$inflight_init": [
+            [numA, []],
+            [numB, []],
+            [strA, []],
+            [strB, []],
           ],
         });
       }
@@ -361,6 +365,10 @@ class $Root extends $stdlib.std.Resource {
             [strC, []],
           ],
           "$inflight_init": [
+            [numA, []],
+            [numC, []],
+            [strA, []],
+            [strC, []],
           ],
         });
       }
@@ -397,6 +405,8 @@ class $Root extends $stdlib.std.Resource {
             [jsonB, []],
           ],
           "$inflight_init": [
+            [jsonA, []],
+            [jsonB, []],
           ],
         });
       }
@@ -435,6 +445,9 @@ class $Root extends $stdlib.std.Resource {
             [jsonC, []],
           ],
           "$inflight_init": [
+            [jsonA, []],
+            [jsonB, []],
+            [jsonC, []],
           ],
         });
       }
@@ -471,6 +484,8 @@ class $Root extends $stdlib.std.Resource {
             [setB, []],
           ],
           "$inflight_init": [
+            [setA, []],
+            [setB, []],
           ],
         });
       }
@@ -509,6 +524,9 @@ class $Root extends $stdlib.std.Resource {
             [setC, []],
           ],
           "$inflight_init": [
+            [setA, []],
+            [setB, []],
+            [setC, []],
           ],
         });
       }
@@ -545,6 +563,8 @@ class $Root extends $stdlib.std.Resource {
             [mapB, []],
           ],
           "$inflight_init": [
+            [mapA, []],
+            [mapB, []],
           ],
         });
       }
@@ -583,6 +603,9 @@ class $Root extends $stdlib.std.Resource {
             [mapC, []],
           ],
           "$inflight_init": [
+            [mapA, []],
+            [mapB, []],
+            [mapC, []],
           ],
         });
       }
@@ -619,6 +642,8 @@ class $Root extends $stdlib.std.Resource {
             [arrayB, []],
           ],
           "$inflight_init": [
+            [arrayA, []],
+            [arrayB, []],
           ],
         });
       }
@@ -657,6 +682,9 @@ class $Root extends $stdlib.std.Resource {
             [arrayC, []],
           ],
           "$inflight_init": [
+            [arrayA, []],
+            [arrayB, []],
+            [arrayC, []],
           ],
         });
       }
@@ -693,6 +721,8 @@ class $Root extends $stdlib.std.Resource {
             [cat2, []],
           ],
           "$inflight_init": [
+            [cat1, []],
+            [cat2, []],
           ],
         });
       }
@@ -731,6 +761,9 @@ class $Root extends $stdlib.std.Resource {
             [cat3, []],
           ],
           "$inflight_init": [
+            [cat1, []],
+            [cat2, []],
+            [cat3, []],
           ],
         });
       }

--- a/tools/hangar/__snapshots__/test_corpus/valid/double_reference.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/double_reference.test.w_compile_tf-aws.md
@@ -212,6 +212,9 @@ class $Root extends $stdlib.std.Resource {
             [initCount, ["peek"]],
           ],
           "$inflight_init": [
+            [bar, []],
+            [bar.foo, []],
+            [initCount, []],
           ],
         });
       }

--- a/tools/hangar/__snapshots__/test_corpus/valid/doubler.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/doubler.test.w_compile_tf-aws.md
@@ -360,6 +360,7 @@ class $Root extends $stdlib.std.Resource {
                 [handler, ["handle"]],
               ],
               "$inflight_init": [
+                [handler, []],
               ],
             });
           }
@@ -452,6 +453,7 @@ class $Root extends $stdlib.std.Resource {
             [f, ["invoke"]],
           ],
           "$inflight_init": [
+            [f, []],
           ],
         });
       }

--- a/tools/hangar/__snapshots__/test_corpus/valid/enums.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/enums.test.w_compile_tf-aws.md
@@ -93,6 +93,8 @@ class $Root extends $stdlib.std.Resource {
             [two, []],
           ],
           "$inflight_init": [
+            [one, []],
+            [two, []],
           ],
         });
       }

--- a/tools/hangar/__snapshots__/test_corpus/valid/expressions_string_interpolation.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/expressions_string_interpolation.test.w_compile_tf-aws.md
@@ -83,6 +83,7 @@ class $Root extends $stdlib.std.Resource {
             [number, []],
           ],
           "$inflight_init": [
+            [number, []],
           ],
         });
       }

--- a/tools/hangar/__snapshots__/test_corpus/valid/file_counter.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/file_counter.test.w_compile_tf-aws.md
@@ -249,6 +249,8 @@ class $Root extends $stdlib.std.Resource {
             [counter, ["inc"]],
           ],
           "$inflight_init": [
+            [bucket, []],
+            [counter, []],
           ],
         });
       }

--- a/tools/hangar/__snapshots__/test_corpus/valid/hello.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/hello.test.w_compile_tf-aws.md
@@ -225,6 +225,7 @@ class $Root extends $stdlib.std.Resource {
             [bucket, ["put"]],
           ],
           "$inflight_init": [
+            [bucket, []],
           ],
         });
       }

--- a/tools/hangar/__snapshots__/test_corpus/valid/impl_interface.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/impl_interface.test.w_compile_tf-aws.md
@@ -231,6 +231,7 @@ class $Root extends $stdlib.std.Resource {
             [x, ["handle"]],
           ],
           "$inflight_init": [
+            [x, []],
           ],
         });
       }
@@ -301,6 +302,7 @@ class $Root extends $stdlib.std.Resource {
             [i3, ["method2"]],
           ],
           "$inflight_init": [
+            [i3, []],
           ],
         });
       }

--- a/tools/hangar/__snapshots__/test_corpus/valid/inflight_capture_static.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/inflight_capture_static.test.w_compile_tf-aws.md
@@ -256,6 +256,7 @@ class $Root extends $stdlib.std.Resource {
             [Preflight, ["staticMethod"]],
           ],
           "$inflight_init": [
+            [Preflight, []],
           ],
         });
       }

--- a/tools/hangar/__snapshots__/test_corpus/valid/inflight_class_as_struct_members.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/inflight_class_as_struct_members.test.w_compile_tf-aws.md
@@ -180,6 +180,7 @@ class $Root extends $stdlib.std.Resource {
             [getBar, ["handle"]],
           ],
           "$inflight_init": [
+            [getBar, []],
           ],
         });
       }

--- a/tools/hangar/__snapshots__/test_corpus/valid/inflight_class_capture_const.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/inflight_class_capture_const.test.w_compile_tf-aws.md
@@ -96,6 +96,7 @@ class $Root extends $stdlib.std.Resource {
             [myConst, []],
           ],
           "$inflight_init": [
+            [myConst, []],
           ],
         });
       }
@@ -131,6 +132,7 @@ class $Root extends $stdlib.std.Resource {
             [myConst, []],
           ],
           "$inflight_init": [
+            [myConst, []],
           ],
         });
       }

--- a/tools/hangar/__snapshots__/test_corpus/valid/inflight_class_definitions.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/inflight_class_definitions.test.w_compile_tf-aws.md
@@ -447,6 +447,10 @@ class $Root extends $stdlib.std.Resource {
             [innerD, ["handle"]],
           ],
           "$inflight_init": [
+            [a, []],
+            [d, []],
+            [fn, []],
+            [innerD, []],
           ],
         });
       }

--- a/tools/hangar/__snapshots__/test_corpus/valid/inflight_class_inside_inflight_closure.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/inflight_class_inside_inflight_closure.test.w_compile_tf-aws.md
@@ -280,6 +280,7 @@ class $Root extends $stdlib.std.Resource {
                 [__parent_this_1.b, ["put"]],
               ],
               "$inflight_init": [
+                [__parent_this_1.b, []],
               ],
             });
           }
@@ -341,6 +342,7 @@ class $Root extends $stdlib.std.Resource {
             [f, ["invoke"]],
           ],
           "$inflight_init": [
+            [f, []],
           ],
         });
       }

--- a/tools/hangar/__snapshots__/test_corpus/valid/inflight_closure_autoid.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/inflight_closure_autoid.test.w_compile_tf-aws.md
@@ -103,6 +103,7 @@ class $Root extends $stdlib.std.Resource {
             [inflights, ["at"]],
           ],
           "$inflight_init": [
+            [inflights, []],
           ],
         });
       }
@@ -139,6 +140,7 @@ class $Root extends $stdlib.std.Resource {
               [i, []],
             ],
             "$inflight_init": [
+              [i, []],
             ],
           });
         }

--- a/tools/hangar/__snapshots__/test_corpus/valid/inflight_handler_singleton.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/inflight_handler_singleton.test.w_compile_tf-aws.md
@@ -375,6 +375,7 @@ class $Root extends $stdlib.std.Resource {
             [foo, ["inc"]],
           ],
           "$inflight_init": [
+            [foo, []],
           ],
         });
       }
@@ -409,6 +410,7 @@ class $Root extends $stdlib.std.Resource {
             [foo, ["inc"]],
           ],
           "$inflight_init": [
+            [foo, []],
           ],
         });
       }
@@ -448,6 +450,9 @@ class $Root extends $stdlib.std.Resource {
             [sim, []],
           ],
           "$inflight_init": [
+            [fn, []],
+            [fn2, []],
+            [sim, []],
           ],
         });
       }

--- a/tools/hangar/__snapshots__/test_corpus/valid/inflights_calling_inflights.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/inflights_calling_inflights.test.w_compile_tf-aws.md
@@ -306,6 +306,7 @@ class $Root extends $stdlib.std.Resource {
             [globalBucket, ["put"]],
           ],
           "$inflight_init": [
+            [globalBucket, []],
           ],
         });
       }
@@ -340,6 +341,7 @@ class $Root extends $stdlib.std.Resource {
             [storeInBucket, ["handle"]],
           ],
           "$inflight_init": [
+            [storeInBucket, []],
           ],
         });
       }
@@ -376,6 +378,8 @@ class $Root extends $stdlib.std.Resource {
             [globalBucket, ["get"]],
           ],
           "$inflight_init": [
+            [func1, []],
+            [globalBucket, []],
           ],
         });
       }
@@ -414,6 +418,7 @@ class $Root extends $stdlib.std.Resource {
                 [globalBucket, ["list"]],
               ],
               "$inflight_init": [
+                [globalBucket, []],
               ],
             });
           }
@@ -479,6 +484,7 @@ class $Root extends $stdlib.std.Resource {
             [x, ["foo"]],
           ],
           "$inflight_init": [
+            [x, []],
           ],
         });
       }

--- a/tools/hangar/__snapshots__/test_corpus/valid/inherit_stdlib_class.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/inherit_stdlib_class.test.w_compile_tf-aws.md
@@ -386,6 +386,7 @@ class $Root extends $stdlib.std.Resource {
             [api.url, []],
           ],
           "$inflight_init": [
+            [api.url, []],
           ],
         });
       }

--- a/tools/hangar/__snapshots__/test_corpus/valid/inheritance_class_inflight.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/inheritance_class_inflight.test.w_compile_tf-aws.md
@@ -191,6 +191,7 @@ class $Root extends $stdlib.std.Resource {
             [foo, ["bang", "bug", "over_inflight"]],
           ],
           "$inflight_init": [
+            [foo, []],
           ],
         });
       }

--- a/tools/hangar/__snapshots__/test_corpus/valid/issue_2889.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/issue_2889.test.w_compile_tf-aws.md
@@ -347,6 +347,7 @@ class $Root extends $stdlib.std.Resource {
             [api.url, []],
           ],
           "$inflight_init": [
+            [api.url, []],
           ],
         });
       }

--- a/tools/hangar/__snapshots__/test_corpus/valid/json_bucket.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/json_bucket.test.w_compile_tf-aws.md
@@ -223,6 +223,8 @@ class $Root extends $stdlib.std.Resource {
             [fileName, []],
           ],
           "$inflight_init": [
+            [b, []],
+            [fileName, []],
           ],
         });
       }
@@ -263,6 +265,10 @@ class $Root extends $stdlib.std.Resource {
             [j, []],
           ],
           "$inflight_init": [
+            [b, []],
+            [fileName, []],
+            [getJson, []],
+            [j, []],
           ],
         });
       }

--- a/tools/hangar/__snapshots__/test_corpus/valid/json_static.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/json_static.test.w_compile_tf-aws.md
@@ -106,6 +106,7 @@ class $Root extends $stdlib.std.Resource {
             [jj, []],
           ],
           "$inflight_init": [
+            [jj, []],
           ],
         });
       }

--- a/tools/hangar/__snapshots__/test_corpus/valid/lift_redefinition.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/lift_redefinition.test.w_compile_tf-aws.md
@@ -83,6 +83,7 @@ class $Root extends $stdlib.std.Resource {
             [y, []],
           ],
           "$inflight_init": [
+            [y, []],
           ],
         });
       }

--- a/tools/hangar/__snapshots__/test_corpus/valid/lift_shared_resource.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/lift_shared_resource.test.w_compile_tf-aws.md
@@ -376,6 +376,8 @@ class $Root extends $stdlib.std.Resource {
             [b2, ["list"]],
           ],
           "$inflight_init": [
+            [b1, []],
+            [b2, []],
           ],
         });
       }
@@ -411,6 +413,7 @@ class $Root extends $stdlib.std.Resource {
             [api.url, []],
           ],
           "$inflight_init": [
+            [api.url, []],
           ],
         });
       }

--- a/tools/hangar/__snapshots__/test_corpus/valid/lift_this.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/lift_this.test.w_compile_tf-aws.md
@@ -147,6 +147,7 @@ class $Root extends $stdlib.std.Resource {
             [f, ["foo"]],
           ],
           "$inflight_init": [
+            [f, []],
           ],
         });
       }

--- a/tools/hangar/__snapshots__/test_corpus/valid/lift_via_closure.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/lift_via_closure.test.w_compile_tf-aws.md
@@ -179,6 +179,7 @@ class $Root extends $stdlib.std.Resource {
             [bucket2, ["put"]],
           ],
           "$inflight_init": [
+            [bucket2, []],
           ],
         });
       }
@@ -221,6 +222,7 @@ class $Root extends $stdlib.std.Resource {
             [this.bucket, ["list"]],
           ],
           "$inflight_init": [
+            [bucket2, []],
             [this.bucket, []],
           ],
         });
@@ -256,6 +258,7 @@ class $Root extends $stdlib.std.Resource {
             [fn, ["handle"]],
           ],
           "$inflight_init": [
+            [fn, []],
           ],
         });
       }
@@ -294,6 +297,9 @@ class $Root extends $stdlib.std.Resource {
             [fn2.bucket, ["get"]],
           ],
           "$inflight_init": [
+            [bucket2, []],
+            [fn2, []],
+            [fn2.bucket, []],
           ],
         });
       }

--- a/tools/hangar/__snapshots__/test_corpus/valid/lift_via_closure_explicit.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/lift_via_closure_explicit.test.w_compile_tf-aws.md
@@ -153,6 +153,7 @@ class $Root extends $stdlib.std.Resource {
             [fn, ["handle"]],
           ],
           "$inflight_init": [
+            [fn, []],
           ],
         });
       }

--- a/tools/hangar/__snapshots__/test_corpus/valid/lift_weird_order.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/lift_weird_order.test.w_compile_tf-aws.md
@@ -182,6 +182,8 @@ class $Root extends $stdlib.std.Resource {
             [c, ["do"]],
           ],
           "$inflight_init": [
+            [b, []],
+            [c, []],
           ],
         });
       }

--- a/tools/hangar/__snapshots__/test_corpus/valid/lift_with_phase_ind.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/lift_with_phase_ind.test.w_compile_tf-aws.md
@@ -92,6 +92,9 @@ class $Root extends $stdlib.std.Resource {
             [ar.length, []],
           ],
           "$inflight_init": [
+            [((arr, index) => { if (index < 0 || index >= arr.length) throw new Error("Index out of bounds"); return arr[index]; })(ar, 0), []],
+            [ar, []],
+            [ar.length, []],
           ],
         });
       }

--- a/tools/hangar/__snapshots__/test_corpus/valid/map_entries.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/map_entries.test.w_compile_tf-aws.md
@@ -152,6 +152,9 @@ class $Root extends $stdlib.std.Resource {
             [Object.keys(map).length, []],
           ],
           "$inflight_init": [
+            [(!("bar" in (map))), []],
+            [("foo" in (map)), []],
+            [Object.keys(map).length, []],
           ],
         });
       }
@@ -186,6 +189,7 @@ class $Root extends $stdlib.std.Resource {
             [((obj, key) => { if (!(key in obj)) throw new Error(`Map does not contain key: "${key}"`); return obj[key]; })(map, "foo"), []],
           ],
           "$inflight_init": [
+            [((obj, key) => { if (!(key in obj)) throw new Error(`Map does not contain key: "${key}"`); return obj[key]; })(map, "foo"), []],
           ],
         });
       }
@@ -220,6 +224,7 @@ class $Root extends $stdlib.std.Resource {
             [Object.entries(map).map(([key, value]) => ({ key, value })), []],
           ],
           "$inflight_init": [
+            [Object.entries(map).map(([key, value]) => ({ key, value })), []],
           ],
         });
       }

--- a/tools/hangar/__snapshots__/test_corpus/valid/mutation_after_class_init.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/mutation_after_class_init.test.w_compile_tf-aws.md
@@ -414,6 +414,7 @@ class $Root extends $stdlib.std.Resource {
                 [__parent_this_2.consumer, ["handle"]],
               ],
               "$inflight_init": [
+                [__parent_this_2.consumer, []],
               ],
             });
           }
@@ -482,6 +483,7 @@ class $Root extends $stdlib.std.Resource {
             [c, ["inc"]],
           ],
           "$inflight_init": [
+            [c, []],
           ],
         });
       }
@@ -519,6 +521,8 @@ class $Root extends $stdlib.std.Resource {
             [q, ["push"]],
           ],
           "$inflight_init": [
+            [c, []],
+            [q, []],
           ],
         });
       }

--- a/tools/hangar/__snapshots__/test_corpus/valid/new_in_static.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/new_in_static.test.w_compile_tf-aws.md
@@ -165,6 +165,7 @@ class $Root extends $stdlib.std.Resource {
             [bucket, ["list"]],
           ],
           "$inflight_init": [
+            [bucket, []],
           ],
         });
       }

--- a/tools/hangar/__snapshots__/test_corpus/valid/nil.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/nil.test.w_compile_tf-aws.md
@@ -174,6 +174,7 @@ class $Root extends $stdlib.std.Resource {
             [foo, ["returnNil"]],
           ],
           "$inflight_init": [
+            [foo, []],
           ],
         });
       }
@@ -208,6 +209,7 @@ class $Root extends $stdlib.std.Resource {
             [foo, ["getOptionalValue", "setOptionalValue"]],
           ],
           "$inflight_init": [
+            [foo, []],
           ],
         });
       }

--- a/tools/hangar/__snapshots__/test_corpus/valid/on_lift.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/on_lift.test.w_compile_tf-aws.md
@@ -154,6 +154,8 @@ class $Root extends $stdlib.std.Resource {
             [foo, ["m1"]],
           ],
           "$inflight_init": [
+            [Foo, []],
+            [foo, []],
           ],
         });
       }

--- a/tools/hangar/__snapshots__/test_corpus/valid/optionals.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/optionals.test.w_compile_tf-aws.md
@@ -282,6 +282,9 @@ class $Root extends $stdlib.std.Resource {
             [payloadWithBucket.c, ["put"]],
           ],
           "$inflight_init": [
+            [((payloadWithBucket.c) != null), []],
+            [((payloadWithoutOptions.b) != null), []],
+            [payloadWithBucket.c, []],
           ],
         });
       }

--- a/tools/hangar/__snapshots__/test_corpus/valid/redis.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/redis.test.w_compile_tf-aws.md
@@ -575,6 +575,7 @@ class $Root extends $stdlib.std.Resource {
             [r, ["set"]],
           ],
           "$inflight_init": [
+            [r, []],
           ],
         });
       }
@@ -614,6 +615,9 @@ class $Root extends $stdlib.std.Resource {
             [r2, ["get", "set"]],
           ],
           "$inflight_init": [
+            [queue, []],
+            [r, []],
+            [r2, []],
           ],
         });
       }

--- a/tools/hangar/__snapshots__/test_corpus/valid/resource.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/resource.test.w_compile_tf-aws.md
@@ -801,6 +801,8 @@ class $Root extends $stdlib.std.Resource {
             [this.e, []],
           ],
           "$inflight_init": [
+            [Bar, []],
+            [Foo, []],
             [this.b, []],
             [this.e, []],
             [this.foo, []],
@@ -848,6 +850,9 @@ class $Root extends $stdlib.std.Resource {
             [res.foo, ["inflightField"]],
           ],
           "$inflight_init": [
+            [bucket, []],
+            [res, []],
+            [res.foo, []],
           ],
         });
       }
@@ -890,6 +895,7 @@ class $Root extends $stdlib.std.Resource {
                 [__parent_this_2.b, ["put"]],
               ],
               "$inflight_init": [
+                [__parent_this_2.b, []],
               ],
             });
           }
@@ -926,6 +932,7 @@ class $Root extends $stdlib.std.Resource {
                 [__parent_this_3.b, ["put"]],
               ],
               "$inflight_init": [
+                [__parent_this_3.b, []],
               ],
             });
           }
@@ -962,6 +969,7 @@ class $Root extends $stdlib.std.Resource {
                 [__parent_this_4.q, ["push"]],
               ],
               "$inflight_init": [
+                [__parent_this_4.q, []],
               ],
             });
           }
@@ -1038,6 +1046,7 @@ class $Root extends $stdlib.std.Resource {
             [bigOlPublisher, ["getObjectCount", "publish"]],
           ],
           "$inflight_init": [
+            [bigOlPublisher, []],
           ],
         });
       }

--- a/tools/hangar/__snapshots__/test_corpus/valid/resource_as_inflight_literal.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/resource_as_inflight_literal.test.w_compile_tf-aws.md
@@ -239,6 +239,7 @@ class $Root extends $stdlib.std.Resource {
             [fn, ["invoke"]],
           ],
           "$inflight_init": [
+            [fn, []],
           ],
         });
       }

--- a/tools/hangar/__snapshots__/test_corpus/valid/resource_call_static.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/resource_call_static.test.w_compile_tf-aws.md
@@ -115,6 +115,7 @@ class $Root extends $stdlib.std.Resource {
       get _liftMap() {
         return ({
           "$inflight_init": [
+            [globalCounter, []],
           ],
         });
       }
@@ -156,6 +157,7 @@ class $Root extends $stdlib.std.Resource {
             [Another, ["myStaticMethod"]],
           ],
           "$inflight_init": [
+            [Another, []],
           ],
         });
       }

--- a/tools/hangar/__snapshots__/test_corpus/valid/resource_captures.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/resource_captures.test.w_compile_tf-aws.md
@@ -469,6 +469,7 @@ class $Root extends $stdlib.std.Resource {
             [r, ["testCaptureCollectionsOfData", "testCaptureOptional", "testCapturePrimitives", "testCaptureResource", "testExpressionRecursive", "testExternal", "testInflightField", "testNestedInflightField", "testNestedResource", "testNoCapture", "testUserDefinedResource"]],
           ],
           "$inflight_init": [
+            [r, []],
           ],
         });
       }

--- a/tools/hangar/__snapshots__/test_corpus/valid/resource_captures_globals.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/resource_captures_globals.test.w_compile_tf-aws.md
@@ -470,6 +470,8 @@ class $Root extends $stdlib.std.Resource {
                 [globalCounter, ["inc"]],
               ],
               "$inflight_init": [
+                [$parentThis.localCounter, []],
+                [globalCounter, []],
               ],
             });
           }
@@ -522,6 +524,17 @@ class $Root extends $stdlib.std.Resource {
             [this.localTopic, ["publish"]],
           ],
           "$inflight_init": [
+            [((arr, index) => { if (index < 0 || index >= arr.length) throw new Error("Index out of bounds"); return arr[index]; })(globalArrayOfStr, 0), []],
+            [((obj, key) => { if (!(key in obj)) throw new Error(`Map does not contain key: "${key}"`); return obj[key]; })(globalMapOfNum, "a"), []],
+            [(globalSetOfStr.has("a")), []],
+            [Another, []],
+            [globalAnother, []],
+            [globalAnother.first.myResource, []],
+            [globalAnother.myField, []],
+            [globalBool, []],
+            [globalBucket, []],
+            [globalNum, []],
+            [globalStr, []],
             [this.localTopic, []],
           ],
         });
@@ -557,6 +570,7 @@ class $Root extends $stdlib.std.Resource {
             [res, ["myPut"]],
           ],
           "$inflight_init": [
+            [res, []],
           ],
         });
       }
@@ -591,6 +605,7 @@ class $Root extends $stdlib.std.Resource {
             [Another, ["myStaticMethod"]],
           ],
           "$inflight_init": [
+            [Another, []],
           ],
         });
       }

--- a/tools/hangar/__snapshots__/test_corpus/valid/shadowing.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/shadowing.test.w_compile_tf-aws.md
@@ -114,6 +114,7 @@ class $Root extends $stdlib.std.Resource {
             [bar, []],
           ],
           "$inflight_init": [
+            [bar, []],
           ],
         });
       }
@@ -148,6 +149,7 @@ class $Root extends $stdlib.std.Resource {
             [fn, ["handle"]],
           ],
           "$inflight_init": [
+            [fn, []],
           ],
         });
       }

--- a/tools/hangar/__snapshots__/test_corpus/valid/std_string.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/std_string.test.w_compile_tf-aws.md
@@ -87,6 +87,9 @@ class $Root extends $stdlib.std.Resource {
             [s1.indexOf("s"), []],
           ],
           "$inflight_init": [
+            [((arr, index) => { if (index < 0 || index >= arr.length) throw new Error("Index out of bounds"); return arr[index]; })((s1.split(" ")), 1), []],
+            [(s1.concat(s2)), []],
+            [s1.indexOf("s"), []],
           ],
         });
       }

--- a/tools/hangar/__snapshots__/test_corpus/valid/store.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/store.w_compile_tf-aws.md
@@ -142,6 +142,7 @@ class Store extends $stdlib.std.Resource {
             [__parent_this_1.b, ["put"]],
           ],
           "$inflight_init": [
+            [__parent_this_1.b, []],
           ],
         });
       }

--- a/tools/hangar/__snapshots__/test_corpus/valid/struct_from_json.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/struct_from_json.test.w_compile_tf-aws.md
@@ -221,6 +221,7 @@ class $Root extends $stdlib.std.Resource {
             [j, []],
           ],
           "$inflight_init": [
+            [j, []],
           ],
         });
       }
@@ -289,6 +290,7 @@ class $Root extends $stdlib.std.Resource {
             [jStudent1, []],
           ],
           "$inflight_init": [
+            [jStudent1, []],
           ],
         });
       }
@@ -329,6 +331,9 @@ class $Root extends $stdlib.std.Resource {
             [jMyStruct, []],
           ],
           "$inflight_init": [
+            [(schema.asStr()), []],
+            [expectedSchema, []],
+            [jMyStruct, []],
           ],
         });
       }

--- a/tools/hangar/__snapshots__/test_corpus/valid/super_call.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/super_call.test.w_compile_tf-aws.md
@@ -505,6 +505,7 @@ class $Root extends $stdlib.std.Resource {
             [b, ["get"]],
           ],
           "$inflight_init": [
+            [b, []],
           ],
         });
       }
@@ -538,6 +539,7 @@ class $Root extends $stdlib.std.Resource {
             [b, ["put"]],
           ],
           "$inflight_init": [
+            [b, []],
           ],
         });
       }
@@ -573,6 +575,7 @@ class $Root extends $stdlib.std.Resource {
             [extended, ["do"]],
           ],
           "$inflight_init": [
+            [extended, []],
           ],
         });
       }

--- a/tools/hangar/__snapshots__/test_corpus/valid/symbol_shadow.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/symbol_shadow.test.w_compile_tf-aws.md
@@ -163,6 +163,7 @@ class $Root extends $stdlib.std.Resource {
                 [s, []],
               ],
               "$inflight_init": [
+                [s, []],
               ],
             });
           }
@@ -223,6 +224,7 @@ class $Root extends $stdlib.std.Resource {
             [s, []],
           ],
           "$inflight_init": [
+            [s, []],
           ],
         });
       }
@@ -293,6 +295,7 @@ class $Root extends $stdlib.std.Resource {
               [s, []],
             ],
             "$inflight_init": [
+              [s, []],
             ],
           });
         }

--- a/tools/hangar/__snapshots__/test_corpus/valid/test_bucket.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/test_bucket.test.w_compile_tf-aws.md
@@ -119,6 +119,7 @@ class $Root extends $stdlib.std.Resource {
             [b, ["list", "put"]],
           ],
           "$inflight_init": [
+            [b, []],
           ],
         });
       }
@@ -153,6 +154,7 @@ class $Root extends $stdlib.std.Resource {
             [b, ["get", "put"]],
           ],
           "$inflight_init": [
+            [b, []],
           ],
         });
       }

--- a/tools/hangar/__snapshots__/test_corpus/valid/unused_lift.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/unused_lift.test.w_compile_tf-aws.md
@@ -1,4 +1,4 @@
-# [extern_implementation.test.w](../../../../../examples/tests/valid/extern_implementation.test.w) | compile | tf-aws
+# [unused_lift.test.w](../../../../../examples/tests/valid/unused_lift.test.w) | compile | tf-aws
 
 ## inflight.$Closure1-1.js
 ```js
@@ -12,7 +12,7 @@ module.exports = function({ $f }) {
       return $obj;
     }
     async handle() {
-      (await $f.call());
+      (await $f.m());
     }
   }
   return $Closure1;
@@ -24,7 +24,7 @@ module.exports = function({ $f }) {
 ```js
 "use strict";
 const $helpers = require("@winglang/sdk/lib/helpers");
-module.exports = function({ $Foo }) {
+module.exports = function({ $bar }) {
   class $Closure2 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
@@ -32,7 +32,7 @@ module.exports = function({ $Foo }) {
       return $obj;
     }
     async handle() {
-      (await $Foo.print("hey there"));
+      (await $bar.m());
     }
   }
   return $Closure2;
@@ -40,31 +40,37 @@ module.exports = function({ $Foo }) {
 //# sourceMappingURL=inflight.$Closure2-1.js.map
 ```
 
+## inflight.Bar-1.js
+```js
+"use strict";
+const $helpers = require("@winglang/sdk/lib/helpers");
+module.exports = function({ $b }) {
+  class Bar {
+    constructor({  }) {
+    }
+    static async access_b() {
+      (await $b.list());
+    }
+    async m() {
+    }
+  }
+  return Bar;
+}
+//# sourceMappingURL=inflight.Bar-1.js.map
+```
+
 ## inflight.Foo-1.js
 ```js
 "use strict";
 const $helpers = require("@winglang/sdk/lib/helpers");
-module.exports = function({  }) {
+module.exports = function({ $b }) {
   class Foo {
     constructor({  }) {
     }
-    static async regexInflight(pattern, text) {
-      return (require("../../../external_js.js")["regexInflight"])(pattern, text)
+    async access_b() {
+      (await $b.list());
     }
-    static async getUuid() {
-      return (require("../../../external_js.js")["getUuid"])()
-    }
-    static async getData() {
-      return (require("../../../external_js.js")["getData"])()
-    }
-    static async print(msg) {
-      return (require("../../../external_js.js")["print"])(msg)
-    }
-    async call() {
-      $helpers.assert((await Foo.regexInflight("[a-z]+-\\d+", "abc-123")), "Foo.regexInflight(\"[a-z]+-\\\\d+\", \"abc-123\")");
-      const uuid = (await Foo.getUuid());
-      $helpers.assert($helpers.eq(uuid.length, 36), "uuid.length == 36");
-      $helpers.assert($helpers.eq((await Foo.getData()), "Cool data!"), "Foo.getData() == \"Cool data!\"");
+    async m() {
     }
   }
   return Foo;
@@ -87,6 +93,20 @@ module.exports = function({  }) {
     "aws": [
       {}
     ]
+  },
+  "resource": {
+    "aws_s3_bucket": {
+      "cloudBucket": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/Default/cloud.Bucket/Default",
+            "uniqueId": "cloudBucket"
+          }
+        },
+        "bucket_prefix": "cloud-bucket-c87175e7-",
+        "force_destroy": false
+      }
+    }
   }
 }
 ```
@@ -108,12 +128,10 @@ class $Root extends $stdlib.std.Resource {
       constructor($scope, $id, ) {
         super($scope, $id);
       }
-      static getGreeting(name) {
-        return (require("../../../external_js.js")["getGreeting"])(name)
-      }
       static _toInflightType() {
         return `
           require("${$helpers.normalPath(__dirname)}/inflight.Foo-1.js")({
+            $b: ${$stdlib.core.liftObject(b)},
           })
         `;
       }
@@ -130,23 +148,13 @@ class $Root extends $stdlib.std.Resource {
       }
       get _liftMap() {
         return ({
-          "call": [
-            [Foo, ["getData", "getUuid", "regexInflight"]],
+          "access_b": [
+            [b, ["list"]],
+          ],
+          "m": [
           ],
           "$inflight_init": [
-            [Foo, []],
-          ],
-        });
-      }
-      static get _liftTypeMap() {
-        return ({
-          "regexInflight": [
-          ],
-          "getUuid": [
-          ],
-          "getData": [
-          ],
-          "print": [
+            [b, []],
           ],
         });
       }
@@ -178,10 +186,49 @@ class $Root extends $stdlib.std.Resource {
       get _liftMap() {
         return ({
           "handle": [
-            [f, ["call"]],
+            [f, ["m"]],
           ],
           "$inflight_init": [
             [f, []],
+          ],
+        });
+      }
+    }
+    class Bar extends $stdlib.std.Resource {
+      constructor($scope, $id, ) {
+        super($scope, $id);
+      }
+      static _toInflightType() {
+        return `
+          require("${$helpers.normalPath(__dirname)}/inflight.Bar-1.js")({
+            $b: ${$stdlib.core.liftObject(b)},
+          })
+        `;
+      }
+      _toInflight() {
+        return `
+          (await (async () => {
+            const BarClient = ${Bar._toInflightType()};
+            const client = new BarClient({
+            });
+            if (client.$inflight_init) { await client.$inflight_init(); }
+            return client;
+          })())
+        `;
+      }
+      get _liftMap() {
+        return ({
+          "m": [
+          ],
+          "$inflight_init": [
+            [b, []],
+          ],
+        });
+      }
+      static get _liftTypeMap() {
+        return ({
+          "access_b": [
+            [b, ["list"]],
           ],
         });
       }
@@ -195,7 +242,7 @@ class $Root extends $stdlib.std.Resource {
       static _toInflightType() {
         return `
           require("${$helpers.normalPath(__dirname)}/inflight.$Closure2-1.js")({
-            $Foo: ${$stdlib.core.liftObject(Foo)},
+            $bar: ${$stdlib.core.liftObject(bar)},
           })
         `;
       }
@@ -213,22 +260,23 @@ class $Root extends $stdlib.std.Resource {
       get _liftMap() {
         return ({
           "handle": [
-            [Foo, ["print"]],
+            [bar, ["m"]],
           ],
           "$inflight_init": [
-            [Foo, []],
+            [bar, []],
           ],
         });
       }
     }
-    $helpers.assert($helpers.eq((Foo.getGreeting("Wingding")), "Hello, Wingding!"), "Foo.getGreeting(\"Wingding\") == \"Hello, Wingding!\"");
+    const b = this.node.root.new("@winglang/sdk.cloud.Bucket", cloud.Bucket, this, "cloud.Bucket");
     const f = new Foo(this, "Foo");
-    this.node.root.new("@winglang/sdk.std.Test", std.Test, this, "test:call", new $Closure1(this, "$Closure1"));
-    this.node.root.new("@winglang/sdk.std.Test", std.Test, this, "test:console", new $Closure2(this, "$Closure2"));
+    this.node.root.new("@winglang/sdk.std.Test", std.Test, this, "test:Use class but not method that access lifted object", new $Closure1(this, "$Closure1"));
+    const bar = new Bar(this, "Bar");
+    this.node.root.new("@winglang/sdk.std.Test", std.Test, this, "test:Use class but not static method that access lifted object", new $Closure2(this, "$Closure2"));
   }
 }
 const $PlatformManager = new $stdlib.platform.PlatformManager({platformPaths: $platforms});
-const $APP = $PlatformManager.createApp({ outdir: $outdir, name: "extern_implementation.test", rootConstruct: $Root, isTestEnvironment: $wing_is_test, entrypointDir: process.env['WING_SOURCE_DIR'], rootId: process.env['WING_ROOT_ID'] });
+const $APP = $PlatformManager.createApp({ outdir: $outdir, name: "unused_lift.test", rootConstruct: $Root, isTestEnvironment: $wing_is_test, entrypointDir: process.env['WING_SOURCE_DIR'], rootId: process.env['WING_ROOT_ID'] });
 $APP.synth();
 //# sourceMappingURL=preflight.js.map
 ```

--- a/tools/hangar/__snapshots__/test_corpus/valid/unused_lift.test.w_test_sim.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/unused_lift.test.w_test_sim.md
@@ -1,0 +1,13 @@
+# [unused_lift.test.w](../../../../../examples/tests/valid/unused_lift.test.w) | test | sim
+
+## stdout.log
+```log
+pass ─ unused_lift.test.wsim » root/env0/test:Use class but not method that access lifted object       
+pass ─ unused_lift.test.wsim » root/env1/test:Use class but not static method that access lifted object
+ 
+ 
+Tests 2 passed (2)
+Test Files 1 passed (1)
+Duration <DURATION>
+```
+

--- a/tools/hangar/__snapshots__/test_corpus/valid/use_inflight_method_inside_init_closure.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/use_inflight_method_inside_init_closure.test.w_compile_tf-aws.md
@@ -208,6 +208,7 @@ class $Root extends $stdlib.std.Resource {
                 [__parent_this_1, ["bar"]],
               ],
               "$inflight_init": [
+                [__parent_this_1, []],
               ],
             });
           }

--- a/tools/hangar/__snapshots__/test_corpus/valid/website_with_api.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/website_with_api.test.w_compile_tf-aws.md
@@ -663,6 +663,7 @@ class $Root extends $stdlib.std.Resource {
             [usersTable, ["list"]],
           ],
           "$inflight_init": [
+            [usersTable, []],
           ],
         });
       }
@@ -698,6 +699,7 @@ class $Root extends $stdlib.std.Resource {
             [usersTable, ["insert"]],
           ],
           "$inflight_init": [
+            [usersTable, []],
           ],
         });
       }
@@ -735,6 +737,7 @@ class $Root extends $stdlib.std.Resource {
             [api.url, []],
           ],
           "$inflight_init": [
+            [api.url, []],
           ],
         });
       }
@@ -772,6 +775,7 @@ class $Root extends $stdlib.std.Resource {
             [api.url, []],
           ],
           "$inflight_init": [
+            [api.url, []],
           ],
         });
       }


### PR DESCRIPTION
See #5719
We now add **all** lifts to a class's `$inflight_init`'s bindings. This makes sure the simulator sets up those objects so it can create clients for them.

## Checklist

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [x] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
