### PR TITLE
fix(vscode): editor.parameterHints.enabled option not respected

### DIFF
--- a/apps/vscode-wing/src/lsp.ts
+++ b/apps/vscode-wing/src/lsp.ts
@@ -1,3 +1,4 @@
+import { workspace } from "vscode";
 import { LanguageClientOptions } from "vscode-languageclient";
 import {
   LanguageClient,
@@ -40,6 +41,13 @@ export class LanguageServerManager {
       debug: run,
     };
     let clientOptions: LanguageClientOptions = {
+      initializationOptions: {
+        parameterHints: workspace
+          .getConfiguration("editor.parameterHints", {
+            languageId: "wing",
+          })
+          .get<boolean>("enabled", true),
+      },
       documentSelector: [
         { scheme: "file", language: "wing", pattern: "**/*.w" },
       ],

--- a/apps/wing/src/commands/lsp.ts
+++ b/apps/wing/src/commands/lsp.ts
@@ -81,7 +81,7 @@ export async function lsp() {
 
   let connection = createConnection(process.stdin, process.stdout);
   connection.onInitialize((params: InitializeParams) => {
-    // certain IDEs don't internally respect the `parameterHints` option, so we must check it ourselves
+    // certain IDEs don't internally respect a `parameterHints` option, so we must check it ourselves
     const signatureHelpProvider =
       params.initializationOptions?.parameterHints ?? true
         ? {

--- a/apps/wing/src/commands/lsp.ts
+++ b/apps/wing/src/commands/lsp.ts
@@ -80,16 +80,22 @@ export async function lsp() {
   };
 
   let connection = createConnection(process.stdin, process.stdout);
-  connection.onInitialize((_params: InitializeParams) => {
+  connection.onInitialize((params: InitializeParams) => {
+    // certain IDEs don't internally respect the `parameterHints` option, so we must check it ourselves
+    const signatureHelpProvider =
+      params.initializationOptions?.parameterHints ?? true
+        ? {
+            triggerCharacters: ["(", ",", ")"],
+          }
+        : undefined;
+
     const result: InitializeResult = {
       capabilities: {
         textDocumentSync: TextDocumentSyncKind.Full,
         completionProvider: {
           triggerCharacters: [".", ":"],
         },
-        signatureHelpProvider: {
-          triggerCharacters: ["(", ",", ")"],
-        },
+        signatureHelpProvider,
         codeActionProvider: true,
         hoverProvider: true,
         documentSymbolProvider: true,


### PR DESCRIPTION
No real way to add tests for this, just did local testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
