### PR TITLE
fix(vscode): missing completions for types (identifiers)

### DIFF
--- a/libs/wingc/src/lsp/completions.rs
+++ b/libs/wingc/src/lsp/completions.rs
@@ -363,6 +363,17 @@ pub fn on_completion(params: lsp_types::CompletionParams) -> CompletionResponse 
 
 						return filter_completions(completions);
 					}
+					if is_new_expression {
+						// we're in an incomplete "new" expression (i.e. `new clou`),
+						// we should attempt to use the text we have to match existing symbols
+						return filter_completions(get_current_scope_completions(
+							&types,
+							&scope_visitor,
+							&node_to_complete,
+							&preceding_text,
+						));
+					}
+
 					return vec![];
 				}
 			} else if matches!(
@@ -1307,6 +1318,21 @@ new cloud.
 		// all items are preflight
 		// TODO https://github.com/winglang/wing/issues/2512
 		// assert!(new_expression_nested.iter().all(|item| item.detail.as_ref().unwrap().starts_with("preflight")))
+	);
+
+	test_completion_list!(
+		new_expression_partial_namespace,
+		r#"
+bring cloud;
+
+struct cloudy {}
+
+new clo
+     //^
+"#,
+		assert!(!new_expression_partial_namespace.is_empty())
+		assert!(new_expression_partial_namespace.len() == 1)
+		assert!(new_expression_partial_namespace.get(0).unwrap().label == "cloud")
 	);
 
 	test_completion_list!(

--- a/libs/wingc/src/lsp/completions.rs
+++ b/libs/wingc/src/lsp/completions.rs
@@ -363,9 +363,10 @@ pub fn on_completion(params: lsp_types::CompletionParams) -> CompletionResponse 
 
 						return filter_completions(completions);
 					}
-					if is_new_expression {
-						// we're in an incomplete "new" expression (i.e. `new clou`),
-						// we should attempt to use the text we have to match existing symbols
+
+					if node_to_complete_kind == "type_identifier" {
+						// we're in an incomplete bare type (e.g. `new clou` or `extends clo`),
+						// we should attempt to use the text we have to match existing scope symbols
 						return filter_completions(get_current_scope_completions(
 							&types,
 							&scope_visitor,

--- a/libs/wingc/src/lsp/snapshots/completions/new_expression_partial_namespace.snap
+++ b/libs/wingc/src/lsp/snapshots/completions/new_expression_partial_namespace.snap
@@ -1,0 +1,10 @@
+---
+source: libs/wingc/src/lsp/completions.rs
+---
+- label: cloud
+  kind: 9
+  documentation:
+    kind: markdown
+    value: "Module `cloud`"
+  sortText: kk|cloud
+


### PR DESCRIPTION
In parser contexts where we know something is a type but it has no `.`, completions were not working.

This is for situations like the text following `new`, `impl`, `extends`. Once you start typing after that, no completions would be available.

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
