### PR TITLE
chore(wingc): initial commit to support new syntaxis for set definition

### DIFF
--- a/examples/tests/sdk_tests/std/set.test.w
+++ b/examples/tests/sdk_tests/std/set.test.w
@@ -1,6 +1,6 @@
 //-----------------------------------------------------------------------------
 // toArray()
-let mySet = Set<num> {1, 2, 3};
+let mySet = Set<num> [1, 2, 3];
 let myArrayFromSet = mySet.toArray();
 assert(myArrayFromSet.at(0) == 1);
 assert(myArrayFromSet.at(1) == 2);
@@ -8,7 +8,7 @@ assert(myArrayFromSet.at(2) == 3);
 assert(myArrayFromSet.length == mySet.size);
 assert(myArrayFromSet.length == 3);
 
-let myMutSet = MutSet<str> {"a", "b", "c"};
+let myMutSet = MutSet<str> ["a", "b", "c"];
 let myArrayFromMutSet = myMutSet.toArray();
 assert(myArrayFromMutSet.at(0) == "a");
 assert(myArrayFromMutSet.at(1) == "b");
@@ -21,16 +21,16 @@ assert(myArrayFromMutSet.length == 3);
 // container types are equal regardless of the mutability if they have the same
 // content but in all scenraios the type is specified for better readability
 
-assert(Set<num>{1, 2} == MutSet<num>{1, 2});
-assert(Set<bool>{true, false} == MutSet<bool>{false, true});
+assert(Set<num>[1, 2] == MutSet<num>[1, 2]);
+assert(Set<bool>[true, false] == MutSet<bool>[false, true]);
 
 test "equality"{
-    assert(Set<num>{1, 2} == MutSet<num>{1, 2});
-    assert(Set<bool>{true, false} == MutSet<bool>{false, true});
+    assert(Set<num>[1, 2] == MutSet<num>[1, 2]);
+    assert(Set<bool>[true, false] == MutSet<bool>[false, true]);
 }
 
 
-let openings = MutSet<str> {"A Cruel Angel's Thesis", "Lilium", "Unravel", "TOP"};
+let openings = MutSet<str> ["A Cruel Angel's Thesis", "Lilium", "Unravel", "TOP"];
 let immutOpenings: Set<str> = openings.copy();
 assert(immutOpenings.copyMut() == openings);
 openings.add("Abnormalize");
@@ -41,7 +41,7 @@ openings.clear();
 assert(openings.size == 0);
 
 test "mutability" {
-    let openings = MutSet<str> {"A Cruel Angel's Thesis", "Lilium", "Unravel", "TOP"};
+    let openings = MutSet<str> ["A Cruel Angel's Thesis", "Lilium", "Unravel", "TOP"];
     let immutOpenings: Set<str> = openings.copy();
     assert(immutOpenings.copyMut() == openings);
     openings.add("Abnormalize");
@@ -53,10 +53,10 @@ test "mutability" {
 }
 
 
-let maleVA = {"Kenjiro Tsuda", "Akira Ishida", "Yoshitsugu Matsuoka"};
+let maleVA = Set<str> ["Kenjiro Tsuda", "Akira Ishida", "Yoshitsugu Matsuoka"];
 assert(maleVA.size == 3);
 
-let femaleVA = MutSet<str>{"Saori Hayami", "Miyuki Sawashiro"};
+let femaleVA = MutSet<str>["Saori Hayami", "Miyuki Sawashiro"];
 assert(femaleVA.size == 2);
 femaleVA.add("Maaya Sakamoto");
 assert(femaleVA.size == 3);
@@ -64,10 +64,10 @@ femaleVA.clear();
 assert(femaleVA.size == 0);
 
 test "size()" {
-    let maleVA = {"Kenjiro Tsuda", "Akira Ishida", "Yoshitsugu Matsuoka"};
+    let maleVA = Set<str> ["Kenjiro Tsuda", "Akira Ishida", "Yoshitsugu Matsuoka"];
     assert(maleVA.size == 3);
 
-    let femaleVA = MutSet<str>{"Saori Hayami", "Miyuki Sawashiro"};
+    let femaleVA = MutSet<str>["Saori Hayami", "Miyuki Sawashiro"];
     assert(femaleVA.size == 2);
     femaleVA.add("Maaya Sakamoto");
     assert(femaleVA.size == 3);
@@ -76,11 +76,11 @@ test "size()" {
 }
 
 
-let genre = {"isekai", "mecha", "cyberpunk"};
+let genre = Set<str> ["isekai", "mecha", "cyberpunk"];
 assert(genre.has("drama") == false);
 assert(genre.has("mecha"));
 
-let mutGenre = MutSet<str> {"rom-com", "sports", "sci-fi"};
+let mutGenre = MutSet<str> ["rom-com", "sports", "sci-fi"];
 assert(mutGenre.has("psychological") == false);
 assert(mutGenre.has("rom-com"));
 mutGenre.delete("rom-com");
@@ -89,11 +89,11 @@ assert(mutGenre.has("psychological"));
 assert(mutGenre.has("rom-com") == false);
 
 test "has()" {
-    let genre = {"isekai", "mecha", "cyberpunk"};
+    let genre = Set<str> ["isekai", "mecha", "cyberpunk"];
     assert(genre.has("drama") == false);
     assert(genre.has("mecha"));
 
-    let mutGenre = MutSet<str> {"rom-com", "sports", "sci-fi"};
+    let mutGenre = MutSet<str> ["rom-com", "sports", "sci-fi"];
     assert(mutGenre.has("psychological") == false);
     assert(mutGenre.has("rom-com"));
     mutGenre.delete("rom-com");
@@ -103,14 +103,14 @@ test "has()" {
 }
 
 
-let endings = Set<bool>{};
+let endings = Set<bool>[];
 assert(endings.toArray() == Array<bool>[]);
-let strEndings = {"Somewhere, Faraway, Everyone is Listening to a Ballad"};
+let strEndings = Set<str> ["Somewhere, Faraway, Everyone is Listening to a Ballad"];
 assert(strEndings.toArray() == ["Somewhere, Faraway, Everyone is Listening to a Ballad"]);
 let copyEndings = endings.copyMut();
 assert(copyEndings.toArray() == endings.toArray());
 
-let mutEndings = MutSet<Array<str>> {["Fly Me To The Moon", "Slump"], ["Heikousen"]};
+let mutEndings = MutSet<Array<str>> [["Fly Me To The Moon", "Slump"], ["Heikousen"]];
 assert(mutEndings.toArray() == [["Fly Me To The Moon", "Slump"], ["Heikousen"]]);
 mutEndings.add(["Wagamama"]);
 assert(mutEndings.toArray() == [["Fly Me To The Moon", "Slump"], ["Heikousen"], ["Wagamama"]]);
@@ -118,14 +118,14 @@ let immutEndings = mutEndings.copy();
 assert(immutEndings.toArray() == mutEndings.toArray());
 
 test "toArray()" {
-    let endings = Set<bool>{};
+    let endings = Set<bool>[];
     assert(endings.toArray() == Array<bool>[]);
-    let strEndings = {"Somewhere, Faraway, Everyone is Listening to a Ballad"};
+    let strEndings = Set<str> ["Somewhere, Faraway, Everyone is Listening to a Ballad"];
     assert(strEndings.toArray() == ["Somewhere, Faraway, Everyone is Listening to a Ballad"]);
     let copyEndings = endings.copyMut();
     assert(copyEndings.toArray() == endings.toArray());
 
-    let mutEndings = MutSet<Array<str>> {["Fly Me To The Moon", "Slump"], ["Heikousen"]};
+    let mutEndings = MutSet<Array<str>> [["Fly Me To The Moon", "Slump"], ["Heikousen"]];
     assert(mutEndings.toArray() == [["Fly Me To The Moon", "Slump"], ["Heikousen"]]);
     mutEndings.add(["Wagamama"]);
     assert(mutEndings.toArray() == [["Fly Me To The Moon", "Slump"], ["Heikousen"], ["Wagamama"]]);
@@ -134,36 +134,36 @@ test "toArray()" {
 }
 
 
-let talkingQuirks = {"dattebane", "battebayo", "dattebasa"};
-assert(talkingQuirks.copyMut() == MutSet<str> {"dattebane", "battebayo", "dattebasa"});
+let talkingQuirks = Set<str> ["dattebane", "battebayo", "dattebasa"];
+assert(talkingQuirks.copyMut() == MutSet<str> ["dattebane", "battebayo", "dattebasa"]);
 
 test "copyMut()" {
-    let talkingQuirks = {"dattebane", "battebayo", "dattebasa"};
-assert(talkingQuirks.copyMut() == MutSet<str> {"dattebane", "battebayo", "dattebasa"});
+    let talkingQuirks = Set<str> ["dattebane", "battebayo", "dattebasa"];
+    assert(talkingQuirks.copyMut() == MutSet<str> ["dattebane", "battebayo", "dattebasa"]);
 }
 
 
-let evaRebuild = MutSet<num> {1.11, 2.22, 3.33};
+let evaRebuild = MutSet<num> [1.11, 2.22, 3.33];
 evaRebuild.add(3.0+1.0);
 assert(evaRebuild.has(3.0+1.0));
-assert(evaRebuild == MutSet<num>{1.11, 2.22, 3.33, 3.0+1.0});
+assert(evaRebuild == MutSet<num>[1.11, 2.22, 3.33, 3.0+1.0]);
 
 test "add()" {
-    let evaRebuild = MutSet<num> {1.11, 2.22, 3.33};
+    let evaRebuild = MutSet<num> [1.11, 2.22, 3.33];
     evaRebuild.add(3.0+1.0);
     assert(evaRebuild.has(3.0+1.0));
-    assert(evaRebuild == MutSet<num>{1.11, 2.22, 3.33, 3.0+1.0});
+    assert(evaRebuild == MutSet<num>[1.11, 2.22, 3.33, 3.0+1.0]);
 }
 
 
-let studios = MutSet<str> {"Gainax", "Ghibli", "Production I.G.", "Shaft"};
+let studios = MutSet<str> ["Gainax", "Ghibli", "Production I.G.", "Shaft"];
 assert(studios.delete("Gainax"));
 assert(studios.has("Gainax") == false);
 assert(studios.delete("Sunrise") == false);
 assert(studios.size == 3);
 
 test "delete()" {
-    let studios = MutSet<str> {"Gainax", "Ghibli", "Production I.G.", "Shaft"};
+    let studios = MutSet<str> ["Gainax", "Ghibli", "Production I.G.", "Shaft"];
     assert(studios.delete("Gainax"));
     assert(studios.has("Gainax") == false);
     assert(studios.delete("Sunrise") == false);
@@ -171,7 +171,7 @@ test "delete()" {
 }
 
 
-let demographics = MutSet<str> {"shounen", "shoujo", "josei", "seinen"};
+let demographics = MutSet<str> ["shounen", "shoujo", "josei", "seinen"];
 demographics.clear();
 assert(demographics.size == 0);
 demographics.add("kodomo");
@@ -179,7 +179,7 @@ demographics.clear();
 assert(demographics.has("kodomo") == false);
 
 test "clear()" {
-    let demographics = MutSet<str> {"shounen", "shoujo", "josei", "seinen"};
+    let demographics = MutSet<str> ["shounen", "shoujo", "josei", "seinen"];
     demographics.clear();
     assert(demographics.size == 0);
     demographics.add("kodomo");
@@ -188,17 +188,17 @@ test "clear()" {
 }
 
 
-let acronyms = MutSet<Map<str>> {{"SEL" => "Serial Experiments Lain", "NGE" => "Neon Genesis Evangelion"}};
+let acronyms = MutSet<Map<str>> [{"SEL" => "Serial Experiments Lain", "NGE" => "Neon Genesis Evangelion"}];
 let copyAcronyms = acronyms.copy();
-assert(copyAcronyms == {{"SEL" => "Serial Experiments Lain", "NGE" => "Neon Genesis Evangelion"}});
+assert(copyAcronyms == Set<Map<str>>[{"SEL" => "Serial Experiments Lain", "NGE" => "Neon Genesis Evangelion"}]);
 acronyms.add({"DomeKano" => "Domestic na Kanojo"});
 let copyAcronymsNew = acronyms.copy().copyMut();
 assert(copyAcronymsNew == acronyms);
 
 test "copy()" {
-    let acronyms = MutSet<Map<str>> {{"SEL" => "Serial Experiments Lain", "NGE" => "Neon Genesis Evangelion"}};
+    let acronyms = MutSet<Map<str>> [{"SEL" => "Serial Experiments Lain", "NGE" => "Neon Genesis Evangelion"}];
     let copyAcronyms = acronyms.copy();
-    assert(copyAcronyms == {{"SEL" => "Serial Experiments Lain", "NGE" => "Neon Genesis Evangelion"}});
+    assert(copyAcronyms == Set<Map<str>>[{"SEL" => "Serial Experiments Lain", "NGE" => "Neon Genesis Evangelion"}]);
     acronyms.add({"DomeKano" => "Domestic na Kanojo"});
     let copyAcronymsNew = acronyms.copy().copyMut();
     assert(copyAcronymsNew == acronyms);

--- a/examples/tests/valid/capture_containers.test.w
+++ b/examples/tests/valid/capture_containers.test.w
@@ -1,7 +1,7 @@
 bring cloud;
 
 let arr = ["hello", "world"];
-let mySet = {"my", "my", "set"};
+let mySet = Set<str>["my", "my", "set"];
 let myMap = {"hello" => 123, "world" => 999};
 let arrOfMap = [{"bang" => 123}];
 let j = Json {a: "hello", b: "world"};

--- a/examples/tests/valid/capture_mutables.test.w
+++ b/examples/tests/valid/capture_mutables.test.w
@@ -1,5 +1,5 @@
 let a = MutArray<str>["hello"];
-let s = MutSet<num>{12};
+let s = MutSet<num>[12];
 let m = MutMap<bool>{"hello" => true};
 
 let aCloned = (Array<str>["hello"]).copyMut();

--- a/examples/tests/valid/capture_resource_and_data.test.w
+++ b/examples/tests/valid/capture_resource_and_data.test.w
@@ -1,6 +1,6 @@
 bring cloud;
 
-let data = {1,2,3};
+let data = Set<num>[1,2,3];
 let res = new cloud.Bucket();
 let queue = new cloud.Queue();
 

--- a/examples/tests/valid/container_types.test.w
+++ b/examples/tests/valid/container_types.test.w
@@ -120,9 +120,9 @@ try {
 let num9 = 9;
 let m10 = {
   // Just a string
-  "a" => 1, 
+  "a" => 1,
   // Same string again (should overwrite)
-  "a" => 2, 
+  "a" => 2,
   // Interpolation
   "{num9+1}" => 9,
   // Same interpolation again (should overwrite)
@@ -136,20 +136,20 @@ assert(m10.get("10") == 10);
 assert(m10.get("99") == 99);
 
 //Set tests
-let emptySet = Set<num>{};
+let emptySet = Set<num>[];
 assert(emptySet.size == 0);
-let emptySet2 = MutSet<num>{};
+let emptySet2 = MutSet<num>[];
 assert(emptySet2.size == 0);
-let s2: Set<num> = {1, 2, 3};
+let s2: Set<num> = Set<num>[1, 2, 3];
 assert(s2.size == 3);
 assert(s2.has(1));
-let s3 = Set<num> {1, 2, 3};
+let s3 = Set<num>[1, 2, 3];
 assert(s3.size == 3);
 assert(s3.has(1));
-let s4: Set<num> = Set<num> {1, 2, 3};
+let s4: Set<num> = Set<num>[1, 2, 3];
 assert(s4.size == 3);
 assert(s4.has(1));
-let s6: Set<cloud.Bucket> = {bucket1, bucket2, bucket3};
+let s6: Set<cloud.Bucket> = Set<cloud.Bucket>[bucket1, bucket2, bucket3];
 assert(s6.size == 3);
 assert(s6.has(bucket2));
 let s7: Set<num> = s2;

--- a/examples/tests/valid/deep_equality.test.w
+++ b/examples/tests/valid/deep_equality.test.w
@@ -42,9 +42,9 @@ test "Json with different values" {
 //-----------------------------------------------------------------------------
 // Set
 //-----------------------------------------------------------------------------
-let setA = { 1,2,3 };
-let setB = MutSet<num>{ 1,2,3 };
-let setC = { 4,5,6 };
+let setA = Set<num>[ 1,2,3 ];
+let setB = MutSet<num>[ 1,2,3 ];
+let setC = Set<num>[ 4,5,6 ];
 
 test "Set types with the same value" {
   assert(setA == setA);

--- a/examples/tests/valid/for_loop.test.w
+++ b/examples/tests/valid/for_loop.test.w
@@ -1,5 +1,5 @@
 let words = ["wing", "lang", "dang"];
-let uniqueNumbers = { 1, 2, 3 };
+let uniqueNumbers = Set<num>[ 1, 2, 3 ];
 
 for word in words {
   for number in uniqueNumbers {

--- a/examples/tests/valid/inference.test.w
+++ b/examples/tests/valid/inference.test.w
@@ -19,7 +19,7 @@ clonedArray2.push(2);
 clonedArray2.push(clonedArray2.at(0) + clonedArray2.at(1));
 assert(clonedArray2.at(2) == 3);
 
-let emptySet = {clonedArray2.at(2)};
+let emptySet = Set<num>[clonedArray2.at(2)];
 let clonedSet = emptySet.copyMut();
 clonedSet.add(4);
 

--- a/examples/tests/valid/json.test.w
+++ b/examples/tests/valid/json.test.w
@@ -162,7 +162,7 @@ if let val = jsonElements.tryGet("strings")?.tryGet("single")?.asStr() {
 }
 
 if let vals = jsonElements.tryGet("strings")?.tryGet("array") {
-  // Try getting an index 
+  // Try getting an index
   if let hello = vals.tryGetAt(0) {
     assert(hello == "Hello");
   } else {
@@ -228,9 +228,9 @@ struct StructyJson {
 }
 
 let arrayStruct: Array<StructyJson> = [ { foo: "", stuff: [] } ];
-let setStruct: Set<StructyJson> = { { foo: "", stuff: [] } };
+let setStruct: Set<StructyJson> = Set<StructyJson>[ { foo: "", stuff: [] } ];
 let mapStruct: Map<StructyJson> = { "1" => ({ foo: "", stuff: [] }) };
-let deepCollectionStruct: Map<Array<Set<StructyJson>>> = { "1" => [ { { foo: "", stuff: [] } } ] };
+let deepCollectionStruct: Map<Array<Set<StructyJson>>> = { "1" => [ Set<StructyJson>[ { foo: "", stuff: [] } ] ] };
 
 let notJsonMissingField: StructyJson = {
   foo: "bar",

--- a/examples/tests/valid/mut_container_types.test.w
+++ b/examples/tests/valid/mut_container_types.test.w
@@ -17,9 +17,9 @@ assert(arr1.length == 4);
 assert(arr4.at(0) == "a");
 
 //Set tests
-let s1 = MutSet<num>{1, 2, 3, 3};
-let s2: MutSet<str> = MutSet<str>{"hello", "world", "hello"};
-let s3 = MutSet<cloud.Bucket>{bucket1, bucket2, bucket2};
+let s1 = MutSet<num>[1, 2, 3, 3];
+let s2: MutSet<str> = MutSet<str>["hello", "world", "hello"];
+let s3 = MutSet<cloud.Bucket>[bucket1, bucket2, bucket2];
 s1.add(5);
 s2.add("bye");
 s3.add(bucket3);
@@ -48,4 +48,3 @@ m2.clear();
 assert(m2.size() == 0);
 assert(m1.get("hello") == "goodbye");
 assert(m6.get("a").get("foo") == "bar");
-

--- a/examples/tests/valid/resource_captures.test.w
+++ b/examples/tests/valid/resource_captures.test.w
@@ -58,7 +58,7 @@ class MyResource {
       "k1" => 11,
       "k2" => 22
     };
-    this.setOfStr = {"s1", "s2", "s1"};
+    this.setOfStr = Set<str>["s1", "s2", "s1"];
 
     this.another = new Another();
     this.myQueue = new cloud.Queue();

--- a/examples/tests/valid/resource_captures_globals.test.w
+++ b/examples/tests/valid/resource_captures_globals.test.w
@@ -7,7 +7,7 @@ let globalBool = true;
 let globalNum = 42;
 let globalArrayOfStr = ["hello", "world"];
 let globalMapOfNum = Map<num>{ "a" => -5, "b" => 2 };
-let globalSetOfStr = Set<str>{ "a", "b" };
+let globalSetOfStr = Set<str>[ "a", "b" ];
 
 class First {
   pub myResource: cloud.Bucket;

--- a/examples/tests/valid/std_containers.test.w
+++ b/examples/tests/valid/std_containers.test.w
@@ -23,7 +23,7 @@ let mergedMutArray = mutArray.concat(mutArray2);
 assert(mergedMutArray.length == 7);
 assert(mergedMutArray.at(5) == "that");
 
-let sSet = {"one", "two"};
+let sSet = Set<str>["one", "two"];
 let mutSet = sSet.copyMut();
 mutSet.add("three");
 let immutSet = mutSet.copy();
@@ -55,10 +55,10 @@ let heterogeneousDoubleArray = Array<Array<Animal>>[
   Array<Animal>[new Cat() as "C3", new Dog() as "D2"],
   [new Animal() as "A1"],
 ];
-let heterogeneousSet = Set<Animal>{
+let heterogeneousSet = Set<Animal>[
   new Cat() as "C4",
   new Dog() as "D3",
-};
+];
 let heterogeneousMap = Map<Animal>{
   "cat" => new Cat() as "C5",
   "dog" => new Dog() as "D4",

--- a/libs/tree-sitter-wing/test/corpus/expressions.txt
+++ b/libs/tree-sitter-wing/test/corpus/expressions.txt
@@ -175,9 +175,9 @@ New expression with id and scope on different lines
 ================================================================================
 
 new A()
-  as 
-  "b" 
-  in 
+  as
+  "b"
+  in
   c;
 
 --------------------------------------------------------------------------------
@@ -355,18 +355,13 @@ tryGet()!;
 Set Literal
 ================================================================================
 
-{1, 2, 3};
-Set<num> { 1, 2, 3 };
+Set<num>[ 1, 2, 3 ];
+
 --------------------------------------------------------------------------------
 
 (source
   (expression_statement
-    (set_literal
-      element: (number)
-      element: (number)
-      element: (number)))
-  (expression_statement
-    (set_literal
+    (array_or_set_literal
       type: (immutable_container_type
         type_parameter: (builtin_type))
       element: (number)
@@ -390,9 +385,9 @@ Empty Json Map Literal
 Map Literal
 ================================================================================
 
-{ 
-  "a" => 1, 
-  "b" => 2, 
+{
+  "a" => 1,
+  "b" => 2,
   str_func() => 3,
 };
 
@@ -424,12 +419,12 @@ Array<str>[];
 
 (source
   (expression_statement
-    (array_literal
+    (array_or_set_literal
       element: (number)
       element: (number)
       element: (number)))
   (expression_statement
-    (array_literal
+    (array_or_set_literal
       type: (immutable_container_type
         type_parameter: (builtin_type)))))
 
@@ -446,7 +441,7 @@ let a: Array<num> = [];
     name: (identifier)
     type: (immutable_container_type
       type_parameter: (builtin_type))
-    value: (array_literal)))
+    value: (array_or_set_literal)))
 
 ================================================================================
 Container Type Constructor Invocation

--- a/libs/wingc/src/lsp/completions.rs
+++ b/libs/wingc/src/lsp/completions.rs
@@ -367,7 +367,7 @@ pub fn on_completion(params: lsp_types::CompletionParams) -> CompletionResponse 
 				}
 			} else if matches!(
 				nearest_non_reference.kind(),
-				"struct_literal" | "json_map_literal" | "set_literal" | "struct_literal_member"
+				"struct_literal" | "json_map_literal" | "struct_literal_member"
 			) {
 				// check to see if ":" is the last character of the same line up to the cursor
 				// if it is, we want an expression instead of struct completions
@@ -520,7 +520,7 @@ fn get_current_scope_completions(
 
 		// { a: } or { a: 1, b: }
 		//     ^               ^
-		"set_literal" | "struct_literal" | "json_map_literal" | "json_literal_member" => {
+		"struct_literal" | "json_map_literal" | "json_literal_member" => {
 			in_type = false;
 		}
 
@@ -583,7 +583,6 @@ fn get_current_scope_completions(
 			"argument_list"
 			| "call"
 			| "struct_literal"
-			| "set_literal"
 			| "struct_literal_member"
 			| "new_expression"
 			| "keyword_argument_value" => {
@@ -1296,7 +1295,7 @@ mod tests {
 		r#"
 bring cloud;
 
-new cloud. 
+new cloud.
         //^
 "#,
 		assert!(!new_expression_nested.is_empty())
@@ -1316,7 +1315,7 @@ class Resource {
 	static hello() {}
 }
 
-Resource. 
+Resource.
        //^
 "#,
 		assert!(!static_method_call.is_empty())
@@ -1332,10 +1331,10 @@ let a = 1;
 if a == 1 {
 	let x = "";
 }
-	
-let b =  
+
+let b =
 			//^
-			
+
 let c = 3;
 "#,
 		assert!(!only_show_symbols_in_scope.is_empty())
@@ -1357,7 +1356,7 @@ if a.
 	test_completion_list!(
 		json_statics,
 		r#"
-Json. 
+Json.
    //^"#,
 		assert!(!json_statics.is_empty())
 	);
@@ -1454,7 +1453,7 @@ x..
 		inside_class_declaration,
 		r#"
 class Foo {
-   
+
 //^
 }
 "#,
@@ -1547,7 +1546,7 @@ j.tryGet("").
 		r#"
 struct Foo {}
 
-let x: 
+let x:
     //^
 "#,
 		assert!(!type_annotation_shows_struct.is_empty())
@@ -1558,8 +1557,8 @@ let x:
 		struct_definition_middle,
 		r#"
 struct Foo {
-   
-//^ 
+
+//^
 }
 "#,
 		assert!(struct_definition_middle.is_empty())
@@ -1572,7 +1571,7 @@ bring cloud;
 
 struct Foo {
 	x:
-	//^ 
+	//^
 }
 "#
 	);
@@ -1733,7 +1732,7 @@ let x: Outer = { bThing: {   } }
 	test_completion_list!(
 		bring_suggestions,
 		r#"
-bring 
+bring
     //^
 "#
 	);
@@ -1749,7 +1748,7 @@ bring c
 	test_completion_list!(
 		bring_alias,
 		r#"
-bring "" as 
+bring "" as
 	        //^
 "#,
 		assert!(bring_alias.is_empty())
@@ -1767,7 +1766,7 @@ let a
 	test_completion_list!(
 		definition_identifier,
 		r#"
-let 
+let
   //^
 "#,
 		assert!(definition_identifier.is_empty())
@@ -1794,7 +1793,7 @@ for x i
 	test_completion_list!(
 		comment,
 		r#"
-let x = // hi 
+let x = // hi
             //^
 "#,
 		assert!(comment.is_empty())
@@ -1830,7 +1829,7 @@ x.
 		r#"
 class S {
   a: num;
-  new() { 
+  new() {
     this.
        //^
   }
@@ -1846,7 +1845,7 @@ struct S { ab: num; }
 
 test "" {
   let x = S {
-    
+
   //^
   };
 }
@@ -1857,7 +1856,7 @@ test "" {
 	test_completion_list!(
 		no_completions_after_let,
 		r#"
-let 
+let
   //^
 let y = 3;
 "#,
@@ -1869,7 +1868,7 @@ let y = 3;
 		r#"
 let x = 2;
 test "" {
-  
+
 //^
 }
 let y = 3;


### PR DESCRIPTION
Based on #4843 

## Description

Implemented new syntaxis for the `Set` and `MutSet` keywords. From now on, sets will be defined using the identical syntaxes used for Arrays with the difference that there won't be any implicit definition of a set (before it was plain `{}`)

Example

```rust
let set : Set<num> = Set<num> [1,2,3];
```

I limited myself to adding more tests since this was more a functionality related to all the tests we already had in place.

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
