### PR TITLE
fix(vscode): wrong link under goto definition of object property

### DIFF
--- a/libs/wingc/src/lsp/snapshots/goto_definition/class_init_this_field.snap
+++ b/libs/wingc/src/lsp/snapshots/goto_definition/class_init_this_field.snap
@@ -4,7 +4,7 @@ source: libs/wingc/src/lsp/goto_definition.rs
 - originSelectionRange:
     start:
       line: 6
-      character: 4
+      character: 9
     end:
       line: 6
       character: 14

--- a/libs/wingc/src/lsp/snapshots/goto_definition/user_defined_type_reference_property.snap
+++ b/libs/wingc/src/lsp/snapshots/goto_definition/user_defined_type_reference_property.snap
@@ -4,7 +4,7 @@ source: libs/wingc/src/lsp/goto_definition.rs
 - originSelectionRange:
     start:
       line: 5
-      character: 0
+      character: 4
     end:
       line: 5
       character: 17

--- a/libs/wingc/src/lsp/snapshots/hovers/builtin_instance_method.snap
+++ b/libs/wingc/src/lsp/snapshots/hovers/builtin_instance_method.snap
@@ -7,7 +7,7 @@ contents:
 range:
   start:
     line: 1
-    character: 0
+    character: 8
   end:
     line: 1
     character: 18

--- a/libs/wingc/src/lsp/snapshots/hovers/class_init_this_field.snap
+++ b/libs/wingc/src/lsp/snapshots/hovers/class_init_this_field.snap
@@ -7,7 +7,7 @@ contents:
 range:
   start:
     line: 5
-    character: 4
+    character: 9
   end:
     line: 5
     character: 14

--- a/libs/wingc/src/lsp/snapshots/hovers/class_property.snap
+++ b/libs/wingc/src/lsp/snapshots/hovers/class_property.snap
@@ -7,7 +7,7 @@ contents:
 range:
   start:
     line: 4
-    character: 0
+    character: 7
   end:
     line: 4
     character: 16

--- a/libs/wingc/src/lsp/snapshots/hovers/multipart_reference_hover_middle.snap
+++ b/libs/wingc/src/lsp/snapshots/hovers/multipart_reference_hover_middle.snap
@@ -7,7 +7,7 @@ contents:
 range:
   start:
     line: 2
-    character: 0
+    character: 2
   end:
     line: 2
     character: 5

--- a/libs/wingc/src/lsp/snapshots/hovers/static_method.snap
+++ b/libs/wingc/src/lsp/snapshots/hovers/static_method.snap
@@ -7,7 +7,7 @@ contents:
 range:
   start:
     line: 5
-    character: 0
+    character: 4
   end:
     line: 5
     character: 6

--- a/libs/wingc/src/lsp/snapshots/hovers/static_stdtype_method.snap
+++ b/libs/wingc/src/lsp/snapshots/hovers/static_stdtype_method.snap
@@ -7,7 +7,7 @@ contents:
 range:
   start:
     line: 1
-    character: 0
+    character: 5
   end:
     line: 1
     character: 14

--- a/libs/wingc/src/lsp/snapshots/hovers/user_defined_type_reference_property.snap
+++ b/libs/wingc/src/lsp/snapshots/hovers/user_defined_type_reference_property.snap
@@ -7,7 +7,7 @@ contents:
 range:
   start:
     line: 4
-    character: 0
+    character: 4
   end:
     line: 4
     character: 17

--- a/libs/wingc/src/lsp/symbol_locator.rs
+++ b/libs/wingc/src/lsp/symbol_locator.rs
@@ -194,9 +194,9 @@ impl<'a> SymbolLocator<'a> {
 			SymbolLocatorResult::Symbol(symbol) => Some(&symbol.span),
 			SymbolLocatorResult::StructField { field, .. } => Some(&field.span),
 			SymbolLocatorResult::LooseField { field, .. } => Some(&field.span),
-			SymbolLocatorResult::TypePropertyReference { span, .. }
-			| SymbolLocatorResult::ObjectPropertyReference { span, .. }
-			| SymbolLocatorResult::TypeReference { span, .. } => Some(&span),
+			SymbolLocatorResult::TypePropertyReference { property, .. }
+			| SymbolLocatorResult::ObjectPropertyReference { property, .. } => Some(&property.span),
+			SymbolLocatorResult::TypeReference { span, .. } => Some(&span),
 		}
 	}
 }


### PR DESCRIPTION
The link displayed under "goto definition" of a type/obj property reference included the entire reference instead of just the property:
![image](https://github.com/winglang/wing/assets/1160578/f70ce333-6a35-4827-ae81-f13dbdac8538)
Fixed the return span in these cases. Looks better now.

## Checklist

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [ ] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
