### PR TITLE
chore(sdk): remove unneeded option from test

### DIFF
--- a/examples/tests/sdk_tests/bucket/signed_url.test.w
+++ b/examples/tests/sdk_tests/bucket/signed_url.test.w
@@ -92,7 +92,7 @@ test "signedUrl duration option is respected" {
   util.sleep(2s);
 
   // Download file from private bucket using expired GET presigned URL
-  let output = util.shell("curl \"{getSignedUrl}\"", { throw: false });
+  let output = util.shell("curl \"{getSignedUrl}\"");
 
   expect.equal(isExpiredTokenError(output), true);
 }


### PR DESCRIPTION
As detailed [here](https://github.com/winglang/wing/issues/5348#issuecomment-1953275490), the `curl` command always returns with 0 exit status unless the `--fail` flag is provided, so there's no need to avoid throwing errors.

## Checklist

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [ ] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
