### PR TITLE
fix(console): error screen stays on top of the sign in modal

### DIFF
--- a/apps/wing-console/console/design-system/src/modal.tsx
+++ b/apps/wing-console/console/design-system/src/modal.tsx
@@ -23,7 +23,7 @@ export const Modal = ({
     <Transition.Root show={visible} as={Fragment}>
       <Dialog
         as="div"
-        className="relative z-10"
+        className="relative z-50"
         onClose={() => setVisible?.(false)}
       >
         <Transition.Child


### PR DESCRIPTION
Update z-index value for Sign In component to fix stacking order.

Fixes #5750.