### PR TITLE
fix(cli): template X is not available in wing

### DIFF
--- a/apps/wing/src/commands/init.ts
+++ b/apps/wing/src/commands/init.ts
@@ -1,7 +1,7 @@
 // This file and the main function are named "init" instead of "new"
 // to avoid a conflict with the "new" keyword in JavaScript
 import { exec } from "child_process";
-import { existsSync } from "fs";
+import { existsSync, constants } from "fs";
 import { copyFile, mkdir, readFile, readdir, writeFile } from "fs/promises";
 import { join, relative } from "path";
 import { promisify } from "util";
@@ -99,7 +99,7 @@ export async function init(template: string, options: InitOptions = {}): Promise
   options.template = template;
   // Check if the template exists for the selected language
   const templatePath = join(PROJECT_TEMPLATES_DIR, language, template);
-  const templateExists = await exists(templatePath);
+  const templateExists = await exists(templatePath, constants.F_OK | constants.R_OK); // eslint-disable-line no-bitwise
   if (!templateExists) {
     throw new Error(
       `Template "${template}" is not available in ${language}. Please let us know you'd like to use this template in ${language} by opening an issue at https://github.com/winglang/wing/issues/!`

--- a/apps/wing/src/commands/init.ts
+++ b/apps/wing/src/commands/init.ts
@@ -99,7 +99,7 @@ export async function init(template: string, options: InitOptions = {}): Promise
   options.template = template;
   // Check if the template exists for the selected language
   const templatePath = join(PROJECT_TEMPLATES_DIR, language, template);
-  const templateExists = await exists(templatePath, constants.F_OK | constants.R_OK); // eslint-disable-line no-bitwise
+  const templateExists = await exists(templatePath, constants.R_OK);
   if (!templateExists) {
     throw new Error(
       `Template "${template}" is not available in ${language}. Please let us know you'd like to use this template in ${language} by opening an issue at https://github.com/winglang/wing/issues/!`

--- a/apps/wing/src/commands/pack.ts
+++ b/apps/wing/src/commands/pack.ts
@@ -224,7 +224,7 @@ async function withTempDir<T>(work: (workdir: string) => Promise<T>): Promise<T>
  */
 export async function exists(
   filePath: string,
-  permissions: number = constants.F_OK | constants.R_OK | constants.W_OK // eslint-disable-line no-bitwise
+  permissions: number = constants.R_OK | constants.W_OK // eslint-disable-line no-bitwise
 ): Promise<boolean> {
   try {
     await fs.access(filePath, permissions);

--- a/apps/wing/src/commands/pack.ts
+++ b/apps/wing/src/commands/pack.ts
@@ -218,14 +218,16 @@ async function withTempDir<T>(work: (workdir: string) => Promise<T>): Promise<T>
 }
 
 /**
- * Check if a file exists for an specific path
+ * Check if a file exists at a specific path with the given permissions
+ * @param filePath The path to the file
+ * @param permissions The permissions to check for. Defaults to checking for existence, readability, and writability.
  */
-export async function exists(filePath: string): Promise<boolean> {
+export async function exists(
+  filePath: string,
+  permissions: number = constants.F_OK | constants.R_OK | constants.W_OK // eslint-disable-line no-bitwise
+): Promise<boolean> {
   try {
-    await fs.access(
-      filePath,
-      constants.F_OK | constants.R_OK | constants.W_OK //eslint-disable-line no-bitwise
-    );
+    await fs.access(filePath, permissions);
     return true;
   } catch (er) {
     return false;


### PR DESCRIPTION
If a user's installation of wing somehow resulted in file the installation files not being owned by the user, there is a chance that the user running wing commands does not have full access to the template files. 

 For example running `sudo npm install -g winglang` would result in all the package files being owned by root, which the default would mean other users have read access but not write. For template quickstarts we should not care if the user has `write` access the important bit is just `read` so this addresses that issue

Closes: https://github.com/winglang/wing/issues/5754

## Checklist

- [ ] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [ ] Description explains motivation and solution
- [ ] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
