### PR TITLE
fix: unable to resolve tokens inflight from awscdk platform

### DIFF
--- a/libs/wingcompiler/src/compile.ts
+++ b/libs/wingcompiler/src/compile.ts
@@ -317,13 +317,19 @@ async function runPreflightCodeInWorkerThread(
 ): Promise<void> {
   try {
     // Create a shimmed entrypoint that ensures we always load the compiler's version of the SDK
+    const sdkEntrypoint = require.resolve("@winglang/sdk");
     const shim = `\
 var Module = require('module');
 var original_resolveFilename = Module._resolveFilename;
-var WINGSDK_PATH = '${normalPath(require.resolve("@winglang/sdk"))}';
+var WINGSDK_PATH = '${normalPath(sdkEntrypoint)}';
+var WINGSDK_DIR = '${normalPath(join(sdkEntrypoint, "..", ".."))}';
 
 Module._resolveFilename = function () {
-  if(arguments[0] === '@winglang/sdk') return WINGSDK_PATH;
+  const path = arguments[0];
+  if(path === '@winglang/sdk') return WINGSDK_PATH;
+  if(path.startsWith('@winglang/sdk')){
+    arguments[0] = path.replace('@winglang/sdk', WINGSDK_DIR);
+  }
   return original_resolveFilename.apply(this, arguments);
 };
 

--- a/libs/wingcompiler/src/compile.ts
+++ b/libs/wingcompiler/src/compile.ts
@@ -321,14 +321,15 @@ async function runPreflightCodeInWorkerThread(
     const shim = `\
 var Module = require('module');
 var original_resolveFilename = Module._resolveFilename;
+var WINGSDK = '@winglang/sdk';
 var WINGSDK_PATH = '${normalPath(sdkEntrypoint)}';
 var WINGSDK_DIR = '${normalPath(join(sdkEntrypoint, "..", ".."))}';
 
 Module._resolveFilename = function () {
   const path = arguments[0];
-  if(path === '@winglang/sdk') return WINGSDK_PATH;
-  if(path.startsWith('@winglang/sdk')){
-    arguments[0] = path.replace('@winglang/sdk', WINGSDK_DIR);
+  if(path === WINGSDK) return WINGSDK_PATH;
+  if(path.startsWith(WINGSDK)){
+    arguments[0] = path.replace(WINGSDK, WINGSDK_DIR);
   }
   return original_resolveFilename.apply(this, arguments);
 };

--- a/tools/hangar/turbo.json
+++ b/tools/hangar/turbo.json
@@ -18,10 +18,12 @@
       "outputs": ["src/test_corpus/**"]
     },
     "test": {
-      "dependsOn": ["^package", "test:generate"]
+      "dependsOn": ["^package", "test:generate"],
+      "env": ["CI"]
     },
     "bench": {
-      "dependsOn": ["^package", "examples-valid#topo"]
+      "dependsOn": ["^package", "examples-valid#topo"],
+      "env": ["CI"]
     }
   }
 }

--- a/turbo.json
+++ b/turbo.json
@@ -11,6 +11,7 @@
     "tools/bump-pack/**",
     "!tools/bump-pack/node_modules/**"
   ],
+  "globalEnv": ["CI"],
   "pipeline": {
     "default": {
       "inputs": ["*.json", ".projenrc.ts"]

--- a/turbo.json
+++ b/turbo.json
@@ -11,7 +11,6 @@
     "tools/bump-pack/**",
     "!tools/bump-pack/node_modules/**"
   ],
-  "globalEnv": ["CI"],
   "pipeline": {
     "default": {
       "inputs": ["*.json", ".projenrc.ts"]


### PR DESCRIPTION
Fixes #5510

The awscdk platform was importing `registerTokenResolver()` directly from `@winglang/sdk/lib/core/tokens`. This was bypassing preflight logic to always force imports from the SDK to resolve from the same place because it was only checking for imports specifically from `@winglang/sdk` only. This caused it to load it as a different module which had a global that was unused by the rest of the SDK logic.

I was able to replicate the original issue and this fixed it in that same scenario.

Automated testing this is very difficult/slow because it requires a certain scenario that is very realistic: A global install of the SDK and a "local" install of a platform like awscdk. When you install `@winglang/platform-awscdk` it comes with its own copy of `@winglang/sdk`. In our hangar tests this gets deduped because they are installed alongside each other. Adding a way to test this is a pretty big tasks and should at least involve https://github.com/winglang/wing/issues/3390 as well

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
