### PR TITLE
chore(repo): increase days before issue turns stale

### DIFF
--- a/.github/workflows/close-stale.yml
+++ b/.github/workflows/close-stale.yml
@@ -14,11 +14,12 @@ jobs:
     steps:
       - uses: actions/stale@v9
         with:
+          days-before-issue-stale: 90
           days-before-pr-stale: 20
           stale-issue-message: |
             Hi,
 
-            This issue hasn't seen activity in 60 days. Therefore, we are marking this issue as stale for now. It will be closed after 7 days.
+            This issue hasn't seen activity in 90 days. Therefore, we are marking this issue as stale for now. It will be closed after 7 days.
             Feel free to re-open this issue when there's an update or relevant information to be added.
             Thanks!
           stale-pr-message: |
@@ -28,4 +29,3 @@ jobs:
             If you need help with the PR, do not hesitate to reach out in the winglang community slack at [winglang.slack.com](https://winglang.slack.com).
             Feel free to re-open this PR when it is still relevant and ready to be worked on again.
             Thanks!
-


### PR DESCRIPTION
Seems like we review stale issues too often.
We decided to increase the number of days before an inactive issue becomes stale from 60 to 90 days.

## Checklist

- [ ] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [ ] Description explains motivation and solution
- [ ] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
