### PR TITLE
fix(sdk): error when cloud.Api port cannot be reused

### DIFF
--- a/libs/wingsdk/src/target-sim/api.inflight.ts
+++ b/libs/wingsdk/src/target-sim/api.inflight.ts
@@ -1,6 +1,6 @@
 import * as fs from "fs";
 import { Server } from "http";
-import { AddressInfo, createServer } from "net";
+import { AddressInfo, Socket } from "net";
 import { join } from "path";
 import express from "express";
 import { IEventPublisher } from "./event-mapping";
@@ -294,19 +294,23 @@ function asyncMiddleware(
 
 async function isPortAvailable(port: number): Promise<boolean> {
   return new Promise((resolve, _reject) => {
-    let s = createServer();
+    const s = new Socket();
     s.once("error", (err) => {
-      s.close();
-      if ((err as any).code == "EADDRINUSE") {
+      if ((err as any).code !== "ECONNREFUSED") {
         resolve(false);
       } else {
-        resolve(false);
+        // connection refused means the port is not used
+        resolve(true);
       }
+      s.destroy();
     });
-    s.once("listening", () => {
-      s.close();
-      resolve(true);
+
+    s.once("connect", () => {
+      // connection successful means the port is used
+      resolve(false);
+      s.destroy();
     });
-    s.listen(port);
+
+    s.connect(port, LOCALHOST_ADDRESS);
   });
 }

--- a/libs/wingsdk/src/target-sim/api.inflight.ts
+++ b/libs/wingsdk/src/target-sim/api.inflight.ts
@@ -296,19 +296,19 @@ async function isPortAvailable(port: number): Promise<boolean> {
   return new Promise((resolve, _reject) => {
     const s = new Socket();
     s.once("error", (err) => {
+      s.destroy();
       if ((err as any).code !== "ECONNREFUSED") {
         resolve(false);
       } else {
         // connection refused means the port is not used
         resolve(true);
       }
-      s.destroy();
     });
 
     s.once("connect", () => {
+      s.destroy();
       // connection successful means the port is used
       resolve(false);
-      s.destroy();
     });
 
     s.connect(port, LOCALHOST_ADDRESS);

--- a/libs/wingsdk/test/target-sim/api.test.ts
+++ b/libs/wingsdk/test/target-sim/api.test.ts
@@ -1,9 +1,11 @@
+import { createServer } from "net";
 import { test, expect } from "vitest";
 import { listMessages } from "./util";
 import * as cloud from "../../src/cloud";
 import { Simulator, Testing } from "../../src/simulator";
 import { ApiAttributes } from "../../src/target-sim/schema-resources";
 import { SimApp } from "../sim-app";
+import { mkdtemp } from "../util";
 
 // Handler that responds to a request with a fixed string
 const INFLIGHT_CODE = (body: string) =>
@@ -737,4 +739,31 @@ test("api reuses ports between simulator runs", async () => {
 
   // THEN
   expect(apiUrl1).toEqual(apiUrl2);
+});
+
+test("api does not use a port that is already taken", async () => {
+  const app = new SimApp();
+  new cloud.Api(app, "my_api");
+
+  // start the simulator, allocating a random port for the API
+  const s = await app.startSimulator();
+  const apiUrl1 = getApiUrl(s, "/my_api");
+  await s.stop();
+
+  // start a server on the same port
+  const port = new URL(apiUrl1).port;
+  const server = createServer();
+  server.listen(port);
+
+  // wait for the server to start
+  await new Promise((resolve) => server.on("listening", resolve));
+
+  // start the simulator again, expecting a different port
+  await s.start();
+  const apiUrl2 = getApiUrl(s, "/my_api");
+
+  expect(apiUrl1).not.toEqual(apiUrl2);
+
+  // clean up the server
+  server.close();
 });


### PR DESCRIPTION
Fixes #5793

## Checklist

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [x] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
