### PR TITLE
fix(compiler): unknown property diagnostic is same as unknown symbol 

### DIFF
--- a/examples/tests/invalid/immutable_container_types.test.w
+++ b/examples/tests/invalid/immutable_container_types.test.w
@@ -1,7 +1,7 @@
 let m1 = Map<str>{"a" => "hi"};
 
 m1.set("a", "bye");
-// ^^^ Property "set" doesn't exist in "Map" (TODO: better error message https://github.com/winglang/wing/issues/1660)
+// ^^^ Member "set" doesn't exist in "Map" (TODO: better error message https://github.com/winglang/wing/issues/1660)
 
 let m2: Map<str> = MutMap<str> {};
 //                 ^^^^^^^^^^^^^^ Expected type to be "Map<str>", but got "MutMap<str>" instead
@@ -9,25 +9,25 @@ let m3 = Map<bool> { "a" => "A" };
 //                          ^^^ Expected type to be "bool", but got "str" instead
 let m4 = {"1" => 1, "2" => 2 };
 m4.set("2", 3);
-// ^^^ Property "set" doesn't exist in "Map"
+// ^^^ Member "set" doesn't exist in "Map"
 let m5 = m4.copy();
-//          ^^^^ Property "copy" doesn't exist in "Map"
+//          ^^^^ Member "copy" doesn't exist in "Map"
 m4.delete("1");
-// ^^^^^^ Property "delete" doesn't exist in "Map"
+// ^^^^^^ Member "delete" doesn't exist in "Map"
 m4.clear();
-// ^^^^^ Property "clear" doesn't exist in "Map"
+// ^^^^^ Member "clear" doesn't exist in "Map"
 
 
 let s1: Set<Array<num>> = MutSet<Array<num>>[[1]];
 //                        ^^^^^^^^^^^^^^^^^^^^^^^^ Expected type to be "Set<Array<num>>", but got "MutSet<Array<num>>" instead
 let s2 = Set<str> ["a", "b", "c"];
 s2.delete("a");
-// ^^^^^^ Property "delete" doesn't exist in "Set"
+// ^^^^^^ Member "delete" doesn't exist in "Set"
 s2.add("d");
-// ^^^ Property "add" doesn't exist in "Set"
+// ^^^ Member "add" doesn't exist in "Set"
 let s3 = s2.copy();
-//          ^^^^ Property "copy" doesn't exist in "Set"
+//          ^^^^ Member "copy" doesn't exist in "Set"
 s2.clear();
-// ^^^^^ Property "clear" doesn't exist in "Set"
+// ^^^^^ Member "clear" doesn't exist in "Set"
 let s4: Set<bool> = Set<bool>[[3]];
 //                  ^^^^^ Expected type to be "Set<bool>", but got "Set<Array<num>>" instead

--- a/examples/tests/invalid/immutable_container_types.test.w
+++ b/examples/tests/invalid/immutable_container_types.test.w
@@ -1,7 +1,7 @@
 let m1 = Map<str>{"a" => "hi"};
 
 m1.set("a", "bye");
-// ^^^ Unknown symbol "set" (TODO: better error message https://github.com/winglang/wing/issues/1660)
+// ^^^ Property "set" doesn't exist in "Map" (TODO: better error message https://github.com/winglang/wing/issues/1660)
 
 let m2: Map<str> = MutMap<str> {};
 //                 ^^^^^^^^^^^^^^ Expected type to be "Map<str>", but got "MutMap<str>" instead
@@ -9,25 +9,25 @@ let m3 = Map<bool> { "a" => "A" };
 //                          ^^^ Expected type to be "bool", but got "str" instead
 let m4 = {"1" => 1, "2" => 2 };
 m4.set("2", 3);
-// ^^^ Unknown symbol "set"
+// ^^^ Property "set" doesn't exist in "Map"
 let m5 = m4.copy();
-//          ^^^^ Unknown symbol "copy"
+//          ^^^^ Property "copy" doesn't exist in "Map"
 m4.delete("1");
-// ^^^^^^ Unknown symbol "delete"
+// ^^^^^^ Property "delete" doesn't exist in "Map"
 m4.clear();
-// ^^^^^ Unknown symbol "clear"
+// ^^^^^ Property "clear" doesn't exist in "Map"
 
 
 let s1: Set<Array<num>> = MutSet<Array<num>>[[1]];
 //                        ^^^^^^^^^^^^^^^^^^^^^^^^ Expected type to be "Set<Array<num>>", but got "MutSet<Array<num>>" instead
 let s2 = Set<str> ["a", "b", "c"];
 s2.delete("a");
-// ^^^^^^ Unknown symbol "delete"
+// ^^^^^^ Property "delete" doesn't exist in "Set"
 s2.add("d");
-// ^^^ Unknown symbol "add"
+// ^^^ Property "add" doesn't exist in "Set"
 let s3 = s2.copy();
-//          ^^^^ Unknown symbol "copy"
+//          ^^^^ Property "copy" doesn't exist in "Set"
 s2.clear();
-// ^^^^^ Unknown symbol "clear"
+// ^^^^^ Property "clear" doesn't exist in "Set"
 let s4: Set<bool> = Set<bool>[[3]];
 //                  ^^^^^ Expected type to be "Set<bool>", but got "Set<Array<num>>" instead

--- a/examples/tests/invalid/json.test.w
+++ b/examples/tests/invalid/json.test.w
@@ -17,7 +17,7 @@ let a: Array<str> = j;
 // Immutable Json
 let foreverJson = Json {a: "hello"};
 foreverJson.set("a", "world!");
-//          ^^^ Unknown symbol "set" (TODO: better error message https://github.com/winglang/wing/issues/1660)
+//          ^^^ Property "set" doesn't exist in "Json" (TODO: better error message https://github.com/winglang/wing/issues/1660)
 
 let bkt = new cloud.Bucket();
 let jArr = Json [bkt];

--- a/examples/tests/invalid/json.test.w
+++ b/examples/tests/invalid/json.test.w
@@ -17,7 +17,7 @@ let a: Array<str> = j;
 // Immutable Json
 let foreverJson = Json {a: "hello"};
 foreverJson.set("a", "world!");
-//          ^^^ Property "set" doesn't exist in "Json" (TODO: better error message https://github.com/winglang/wing/issues/1660)
+//          ^^^ Member "set" doesn't exist in "Json" (TODO: better error message https://github.com/winglang/wing/issues/1660)
 
 let bkt = new cloud.Bucket();
 let jArr = Json [bkt];

--- a/examples/tests/invalid/json_static.test.w
+++ b/examples/tests/invalid/json_static.test.w
@@ -2,4 +2,4 @@ let immutObj = Json {a: 123, b: "hello", c: [1, 2, 3]};
 let mutObj = Json.deepCopyMut(immutObj);
 
 immutObj.set("a", "foo");
-//       ^^^ Property "set" doesn't exist in "Json" (TODO: better error message https://github.com/winglang/wing/issues/1660) 
+//       ^^^ Member "set" doesn't exist in "Json" (TODO: better error message https://github.com/winglang/wing/issues/1660) 

--- a/examples/tests/invalid/json_static.test.w
+++ b/examples/tests/invalid/json_static.test.w
@@ -2,4 +2,4 @@ let immutObj = Json {a: 123, b: "hello", c: [1, 2, 3]};
 let mutObj = Json.deepCopyMut(immutObj);
 
 immutObj.set("a", "foo");
-//       ^^^ Unknown symbol "set" (TODO: better error message https://github.com/winglang/wing/issues/1660) 
+//       ^^^ Property "set" doesn't exist in "Json" (TODO: better error message https://github.com/winglang/wing/issues/1660) 

--- a/examples/tests/invalid/primitives.test.w
+++ b/examples/tests/invalid/primitives.test.w
@@ -7,8 +7,8 @@ log(y[0]);
 
 let arr = [1, 2, 3];
 let join = arr.blabla(",");
-             //^ blabla is not a valid method
+             //^ Property "blabla" doesn't not exist in "Array"
 arr.push(4);
-  //^ push is not a valid method (array is immutable)
+  //^ Property "push" doesn't not exist in "Array"
 let n: str = arr.at(0);
            //^ expected str, got num

--- a/examples/tests/invalid/structs.test.w
+++ b/examples/tests/invalid/structs.test.w
@@ -30,7 +30,7 @@ let a = A {
   x: "Sup"
 };
 log(a.badField);
-//    ^^^^^^^^ Unknown symbol "badField"
+//    ^^^^^^^^ Property "badField" doesn't exist on "A"
 
 // two inherits with same field name but different type
 struct Razzle {

--- a/examples/tests/invalid/unknown_symbol.test.w
+++ b/examples/tests/invalid/unknown_symbol.test.w
@@ -18,16 +18,24 @@ class SomeResource {
 
   inflight getTask(id: str): str {
     this.bucket.assert(2 + "2");
-               //^ Unknown symbol
+               //^ Property "assert" doesn't exist in "Bucket"
                           //^ Expected type to be "num", but got "str" instead
     return this.bucket.methodWhichIsNotPartOfBucketApi(id);
-                      //^ Unknown symbol
+                      //^ Property "methodWhichIsNotPartOfBucketApi" doesn't exist in "Bucket"
   }
 }
 
 class A extends B {
               //^ Unknown symbol
 }
+
+class SomeResourceChild extends SomeResource {
+}
+
+let src = new SomeResourceChild();
+// Make sure the error states the class and not its parent
+src.dodo();
+   //^ Property "dodo" doesn't exist in "SomeResourceChild"
 
 unknown = 1;
 //^ Unknown symbol

--- a/examples/tests/invalid/unknown_symbol.test.w
+++ b/examples/tests/invalid/unknown_symbol.test.w
@@ -18,10 +18,10 @@ class SomeResource {
 
   inflight getTask(id: str): str {
     this.bucket.assert(2 + "2");
-               //^ Property "assert" doesn't exist in "Bucket"
+               //^ Member "assert" doesn't exist in "Bucket"
                           //^ Expected type to be "num", but got "str" instead
     return this.bucket.methodWhichIsNotPartOfBucketApi(id);
-                      //^ Property "methodWhichIsNotPartOfBucketApi" doesn't exist in "Bucket"
+                      //^ Member "methodWhichIsNotPartOfBucketApi" doesn't exist in "Bucket"
   }
 }
 
@@ -35,7 +35,7 @@ class SomeResourceChild extends SomeResource {
 let src = new SomeResourceChild();
 // Make sure the error states the class and not its parent
 src.dodo();
-   //^ Property "dodo" doesn't exist in "SomeResourceChild"
+   //^ Member "dodo" doesn't exist in "SomeResourceChild"
 
 unknown = 1;
 //^ Unknown symbol

--- a/libs/wingc/src/jsify/snapshots/fails_if_referencing_unknown_field.snap
+++ b/libs/wingc/src/jsify/snapshots/fails_if_referencing_unknown_field.snap
@@ -2,4 +2,4 @@
 source: libs/wingc/src/jsify/tests.rs
 ---
 ## Errors
-Property "b" doesn't not exist in "MyInflightClass" 3:13
+Member "b" doesn't exist in "MyInflightClass" 3:13

--- a/libs/wingc/src/jsify/snapshots/fails_if_referencing_unknown_field.snap
+++ b/libs/wingc/src/jsify/snapshots/fails_if_referencing_unknown_field.snap
@@ -2,4 +2,4 @@
 source: libs/wingc/src/jsify/tests.rs
 ---
 ## Errors
-Unknown symbol "b" 3:13
+Property "b" doesn't not exist in "MyInflightClass" 3:13

--- a/libs/wingc/src/jsify/snapshots/fails_when_referencing_this_from_static.snap
+++ b/libs/wingc/src/jsify/snapshots/fails_when_referencing_this_from_static.snap
@@ -2,4 +2,4 @@
 source: libs/wingc/src/jsify/tests.rs
 ---
 ## Errors
-Property "print" doesn't not exist in "Construct" 3:13
+Member "print" doesn't exist in "Construct" 3:13

--- a/libs/wingc/src/jsify/snapshots/fails_when_referencing_this_from_static.snap
+++ b/libs/wingc/src/jsify/snapshots/fails_when_referencing_this_from_static.snap
@@ -2,4 +2,4 @@
 source: libs/wingc/src/jsify/tests.rs
 ---
 ## Errors
-Unknown symbol "print" 3:13
+Property "print" doesn't not exist in "Construct" 3:13

--- a/libs/wingc/src/type_check.rs
+++ b/libs/wingc/src/type_check.rs
@@ -6021,11 +6021,18 @@ where
 	T: Spanned + Display,
 {
 	match lookup_result {
-		LookupResult::NotFound(s) => TypeError {
-			message: format!("Unknown symbol \"{s}\""),
-			span: s.span(),
-			annotations: vec![],
-		},
+		LookupResult::NotFound(s, maybe_t) => {
+			let message = if let Some(env_type) = maybe_t {
+				format!("Property \"{s}\" doesn't not exist in \"{env_type}\"")
+			} else {
+				format!("Unknown symbol \"{s}\"")
+			};
+			TypeError {
+				message,
+				span: s.span(),
+				annotations: vec![],
+			}
+		}
 		LookupResult::NotPublic(kind, lookup_info) => TypeError {
 			message: {
 				let access = lookup_info.access.to_string();

--- a/libs/wingc/src/type_check.rs
+++ b/libs/wingc/src/type_check.rs
@@ -6023,7 +6023,7 @@ where
 	match lookup_result {
 		LookupResult::NotFound(s, maybe_t) => {
 			let message = if let Some(env_type) = maybe_t {
-				format!("Property \"{s}\" doesn't not exist in \"{env_type}\"")
+				format!("Member \"{s}\" doesn't exist in \"{env_type}\"")
 			} else {
 				format!("Unknown symbol \"{s}\"")
 			};

--- a/libs/wingc/src/type_check/symbol_env.rs
+++ b/libs/wingc/src/type_check/symbol_env.rs
@@ -114,7 +114,7 @@ pub enum LookupResult<'a> {
 	/// A matching symbol was found but it's not public
 	NotPublic(reference([a], [SymbolKind]), SymbolLookupInfo),
 	/// The symbol was not found in the environment, contains the name of the symbol or part of it that was not found
-	/// If the lookup environment was a type environment, the type is also included
+	/// If the lookup environment was a type environment (SymbolEnvKind::Type) such as a class, the type is also included
 	NotFound(Symbol, Option<TypeRef>),
 	/// A symbol with a matching name was found in multiple environments.
 	MultipleFound,

--- a/libs/wingc/src/type_check/symbol_env.rs
+++ b/libs/wingc/src/type_check/symbol_env.rs
@@ -114,7 +114,8 @@ pub enum LookupResult<'a> {
 	/// A matching symbol was found but it's not public
 	NotPublic(reference([a], [SymbolKind]), SymbolLookupInfo),
 	/// The symbol was not found in the environment, contains the name of the symbol or part of it that was not found
-	NotFound(Symbol),
+	/// If the lookup environment was a type environment, the type is also included
+	NotFound(Symbol, Option<TypeRef>),
 	/// A symbol with a matching name was found in multiple environments.
 	MultipleFound,
 	/// The symbol exists in the environment but it's not defined yet (based on the statement
@@ -134,7 +135,7 @@ impl<'a> LookupResult<'a> {
 		match self {
 			LookupResult::Found(kind, info) => (kind, info),
 			LookupResult::NotPublic(x, _) => panic!("LookupResult::unwrap({x}) called on LookupResult::NotPublic"),
-			LookupResult::NotFound(x) => panic!("LookupResult::unwrap({x}) called on LookupResult::NotFound"),
+			LookupResult::NotFound(x, ..) => panic!("LookupResult::unwrap({x}) called on LookupResult::NotFound"),
 			LookupResult::MultipleFound => panic!("LookupResult::unwrap() called on LookupResult::MultipleFound"),
 			LookupResult::DefinedLater(_) => panic!("LookupResult::unwrap() called on LookupResult::DefinedLater"),
 			LookupResult::ExpectedNamespace(symbol) => panic!(
@@ -336,13 +337,26 @@ impl SymbolEnv {
 			);
 		}
 
+		// Get the type of this env (if it's a type env) to include in the result
+		let env_type = if let SymbolEnvKind::Type(t) = self.kind {
+			Some(t)
+		} else {
+			None
+		};
+
 		// we couldn't find the symbol in the current environment, let's look up in the parent
 		// environment.
 		if let Some(ref_annotation([parent_env])) = self.parent {
-			return parent_env.lookup_ext(symbol, not_after_stmt_idx.map(|_| self.statement_idx));
+			let res = parent_env.lookup_ext(symbol, not_after_stmt_idx.map(|_| self.statement_idx));
+			// The `NotFound` result needs to include the type of the original (non-parent) environment (if applicable)
+			let res = match res {
+				LookupResult::NotFound(s, ..) => LookupResult::NotFound(s, env_type),
+				_ => res,
+			};
+			return res;
 		}
 
-		LookupResult::NotFound(symbol.clone())
+		LookupResult::NotFound(symbol.clone(), env_type)
 	}
 
 	#[allow(clippy::needless_arbitrary_self_type)]
@@ -384,7 +398,7 @@ impl SymbolEnv {
 
 			// Look up the result in each env. If there are multiple results, throw a special error
 			// otherwise proceed normally
-			let mut lookup_result = LookupResult::NotFound((*next_symb).clone());
+			let mut lookup_result = LookupResult::NotFound((*next_symb).clone(), None);
 			for env in ns.envs.vec_iter() {
 				// invariant: lookup_result is never "ExpectedNamespace" or "MultipleFound"
 
@@ -416,7 +430,7 @@ impl SymbolEnv {
 				if (matches!(partial_result, LookupResult::Found(_, _))
 					|| matches!(partial_result, LookupResult::DefinedLater(_)))
 					&& (matches!(lookup_result, LookupResult::NotPublic(_, _))
-						|| matches!(lookup_result, LookupResult::NotFound(_)))
+						|| matches!(lookup_result, LookupResult::NotFound(..)))
 				{
 					lookup_result = partial_result;
 				}
@@ -424,7 +438,7 @@ impl SymbolEnv {
 				// result if we're currently "NotFound". "Found", "DefinedLater", and any
 				// existing "NotPublic" results take precedence.
 				else if (matches!(partial_result, LookupResult::NotPublic(_, _)))
-					&& (matches!(lookup_result, LookupResult::NotFound(_)))
+					&& (matches!(lookup_result, LookupResult::NotFound(..)))
 				{
 					lookup_result = partial_result;
 				}
@@ -610,7 +624,7 @@ mod tests {
 		// Lookup non-existent variable
 		assert!(matches!(
 			parent_env.lookup_nested_str("non_existent_var", None),
-			LookupResult::NotFound(_)
+			LookupResult::NotFound(..)
 		));
 
 		// Lookup globally visible variable
@@ -658,7 +672,7 @@ mod tests {
 		// Lookup for a child var in the parent env
 		assert!(matches!(
 			parent_env.lookup_nested_str("child_global_var", None),
-			LookupResult::NotFound(_)
+			LookupResult::NotFound(..)
 		));
 
 		// Lookup for a var in the child env
@@ -770,7 +784,7 @@ mod tests {
 		// Perform a nested lookup for a non-existent var
 		let res = child_env.lookup_nested_str("ns1.ns2.non_existent", None);
 		match res {
-			LookupResult::NotFound(s) => {
+			LookupResult::NotFound(s, ..) => {
 				assert!(s.name == "non_existent")
 			}
 			_ => panic!("Expected LookupResult::NotFount(_) but got {:?}", res),
@@ -779,7 +793,7 @@ mod tests {
 		// Perform a nested lookup through a non-existent namespace
 		let res = child_env.lookup_nested_str("ns1.non_existent.ns2_var", None);
 		match res {
-			LookupResult::NotFound(s) => {
+			LookupResult::NotFound(s, ..) => {
 				assert!(s.name == "non_existent")
 			}
 			_ => panic!("Expected LookupResult::NotFount(_) but got {:?}", res),

--- a/tools/hangar/__snapshots__/invalid.ts.snap
+++ b/tools/hangar/__snapshots__/invalid.ts.snap
@@ -389,18 +389,18 @@ error: Cannot access static property \\"m\\" from instance
    |     ^ Cannot access static property \\"m\\" from instance
 
 
-error: Property \\"instanceField\\" doesn't not exist in \\"Construct\\"
+error: Member \\"instanceField\\" doesn't exist in \\"Construct\\"
   --> ../../../examples/tests/invalid/access_static_from_instance.test.w:7:10
   |
 7 |     this.instanceField = 1; // Can't access instance fields from static methods
-  |          ^^^^^^^^^^^^^ Property \\"instanceField\\" doesn't not exist in \\"Construct\\"
+  |          ^^^^^^^^^^^^^ Member \\"instanceField\\" doesn't exist in \\"Construct\\"
 
 
-error: Property \\"f\\" doesn't not exist in \\"Construct\\"
+error: Member \\"f\\" doesn't exist in \\"Construct\\"
   --> ../../../examples/tests/invalid/access_static_from_instance.test.w:8:10
   |
 8 |     this.f = 1; // Can't access static fields through \`this\`
-  |          ^ Property \\"f\\" doesn't not exist in \\"Construct\\"
+  |          ^ Member \\"f\\" doesn't exist in \\"Construct\\"
 
 
  
@@ -1125,11 +1125,11 @@ error: Expected type to be \\"Array<num>\\", but got \\"Array<str>\\" instead
   |                        ^^^^ Expected type to be \\"Array<num>\\", but got \\"Array<str>\\" instead
 
 
-error: Property \\"someRandomMethod\\" doesn't not exist in \\"Array\\"
+error: Member \\"someRandomMethod\\" doesn't exist in \\"Array\\"
   --> ../../../examples/tests/invalid/container_types.test.w:6:6
   |
 6 | arr1.someRandomMethod();
-  |      ^^^^^^^^^^^^^^^^ Property \\"someRandomMethod\\" doesn't not exist in \\"Array\\"
+  |      ^^^^^^^^^^^^^^^^ Member \\"someRandomMethod\\" doesn't exist in \\"Array\\"
 
 
 error: Expected type to be \\"num\\", but got \\"num?\\" instead
@@ -1160,11 +1160,11 @@ error: Expected type to be \\"Map<num>\\", but got \\"Map<str>\\" instead
    |                    ^^ Expected type to be \\"Map<num>\\", but got \\"Map<str>\\" instead
 
 
-error: Property \\"someRandomMethod\\" doesn't not exist in \\"Map\\"
+error: Member \\"someRandomMethod\\" doesn't exist in \\"Map\\"
    --> ../../../examples/tests/invalid/container_types.test.w:17:4
    |
 17 | m1.someRandomMethod();
-   |    ^^^^^^^^^^^^^^^^ Property \\"someRandomMethod\\" doesn't not exist in \\"Map\\"
+   |    ^^^^^^^^^^^^^^^^ Member \\"someRandomMethod\\" doesn't exist in \\"Map\\"
 
 
 error: Expected type to be \\"str\\", but got \\"num\\" instead
@@ -1216,11 +1216,11 @@ error: Expected type to be \\"Set<str>\\", but got \\"Set<num>\\" instead
    |                    ^^ Expected type to be \\"Set<str>\\", but got \\"Set<num>\\" instead
 
 
-error: Property \\"someRandomMethod\\" doesn't not exist in \\"Set\\"
+error: Member \\"someRandomMethod\\" doesn't exist in \\"Set\\"
    --> ../../../examples/tests/invalid/container_types.test.w:29:4
    |
 29 | s1.someRandomMethod();
-   |    ^^^^^^^^^^^^^^^^ Property \\"someRandomMethod\\" doesn't not exist in \\"Set\\"
+   |    ^^^^^^^^^^^^^^^^ Member \\"someRandomMethod\\" doesn't exist in \\"Set\\"
 
 
 error: Expected type to be \\"Array<str>\\", but got \\"MutArray<str>\\" instead
@@ -1237,11 +1237,11 @@ error: Expected type to be \\"MutMap<num>\\", but got \\"Map<num>\\" instead
    |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Expected type to be \\"MutMap<num>\\", but got \\"Map<num>\\" instead
 
 
-error: Property \\"copyMut\\" doesn't not exist in \\"MutMap\\"
+error: Member \\"copyMut\\" doesn't exist in \\"MutMap\\"
    --> ../../../examples/tests/invalid/container_types.test.w:37:15
    |
 37 | let mm3 = mm2.copyMut();
-   |               ^^^^^^^ Property \\"copyMut\\" doesn't not exist in \\"MutMap\\"
+   |               ^^^^^^^ Member \\"copyMut\\" doesn't exist in \\"MutMap\\"
 
 
 error: Expected type to be \\"MutSet<str>\\", but got \\"Array<str>\\" instead
@@ -1258,11 +1258,11 @@ error: Expected type to be \\"num\\", but got \\"bool\\" instead
    |                                    ^^^^ Expected type to be \\"num\\", but got \\"bool\\" instead
 
 
-error: Property \\"copyMut\\" doesn't not exist in \\"MutSet\\"
+error: Member \\"copyMut\\" doesn't exist in \\"MutSet\\"
    --> ../../../examples/tests/invalid/container_types.test.w:46:15
    |
 46 | let ss4 = ss3.copyMut();
-   |               ^^^^^^^ Property \\"copyMut\\" doesn't not exist in \\"MutSet\\"
+   |               ^^^^^^^ Member \\"copyMut\\" doesn't exist in \\"MutSet\\"
 
 
  
@@ -1788,11 +1788,11 @@ Duration <DURATION>"
 `;
 
 exports[`immutable_container_types.test.w 1`] = `
-"error: Property \\"set\\" doesn't not exist in \\"Map\\"
+"error: Member \\"set\\" doesn't exist in \\"Map\\"
   --> ../../../examples/tests/invalid/immutable_container_types.test.w:3:4
   |
 3 | m1.set(\\"a\\", \\"bye\\");
-  |    ^^^ Property \\"set\\" doesn't not exist in \\"Map\\"
+  |    ^^^ Member \\"set\\" doesn't exist in \\"Map\\"
 
 
 error: Expected type to be \\"Map<str>\\", but got \\"MutMap<str>\\" instead
@@ -1809,32 +1809,32 @@ error: Expected type to be \\"bool\\", but got \\"str\\" instead
   |                             ^^^ Expected type to be \\"bool\\", but got \\"str\\" instead
 
 
-error: Property \\"set\\" doesn't not exist in \\"Map\\"
+error: Member \\"set\\" doesn't exist in \\"Map\\"
    --> ../../../examples/tests/invalid/immutable_container_types.test.w:11:4
    |
 11 | m4.set(\\"2\\", 3);
-   |    ^^^ Property \\"set\\" doesn't not exist in \\"Map\\"
+   |    ^^^ Member \\"set\\" doesn't exist in \\"Map\\"
 
 
-error: Property \\"copy\\" doesn't not exist in \\"Map\\"
+error: Member \\"copy\\" doesn't exist in \\"Map\\"
    --> ../../../examples/tests/invalid/immutable_container_types.test.w:13:13
    |
 13 | let m5 = m4.copy();
-   |             ^^^^ Property \\"copy\\" doesn't not exist in \\"Map\\"
+   |             ^^^^ Member \\"copy\\" doesn't exist in \\"Map\\"
 
 
-error: Property \\"delete\\" doesn't not exist in \\"Map\\"
+error: Member \\"delete\\" doesn't exist in \\"Map\\"
    --> ../../../examples/tests/invalid/immutable_container_types.test.w:15:4
    |
 15 | m4.delete(\\"1\\");
-   |    ^^^^^^ Property \\"delete\\" doesn't not exist in \\"Map\\"
+   |    ^^^^^^ Member \\"delete\\" doesn't exist in \\"Map\\"
 
 
-error: Property \\"clear\\" doesn't not exist in \\"Map\\"
+error: Member \\"clear\\" doesn't exist in \\"Map\\"
    --> ../../../examples/tests/invalid/immutable_container_types.test.w:17:4
    |
 17 | m4.clear();
-   |    ^^^^^ Property \\"clear\\" doesn't not exist in \\"Map\\"
+   |    ^^^^^ Member \\"clear\\" doesn't exist in \\"Map\\"
 
 
 error: Expected type to be \\"Set<Array<num>>\\", but got \\"MutSet<Array<num>>\\" instead
@@ -1844,32 +1844,32 @@ error: Expected type to be \\"Set<Array<num>>\\", but got \\"MutSet<Array<num>>\
    |                           ^^^^^^^^^^^^^^^^^^^^^^^ Expected type to be \\"Set<Array<num>>\\", but got \\"MutSet<Array<num>>\\" instead
 
 
-error: Property \\"delete\\" doesn't not exist in \\"Set\\"
+error: Member \\"delete\\" doesn't exist in \\"Set\\"
    --> ../../../examples/tests/invalid/immutable_container_types.test.w:24:4
    |
 24 | s2.delete(\\"a\\");
-   |    ^^^^^^ Property \\"delete\\" doesn't not exist in \\"Set\\"
+   |    ^^^^^^ Member \\"delete\\" doesn't exist in \\"Set\\"
 
 
-error: Property \\"add\\" doesn't not exist in \\"Set\\"
+error: Member \\"add\\" doesn't exist in \\"Set\\"
    --> ../../../examples/tests/invalid/immutable_container_types.test.w:26:4
    |
 26 | s2.add(\\"d\\");
-   |    ^^^ Property \\"add\\" doesn't not exist in \\"Set\\"
+   |    ^^^ Member \\"add\\" doesn't exist in \\"Set\\"
 
 
-error: Property \\"copy\\" doesn't not exist in \\"Set\\"
+error: Member \\"copy\\" doesn't exist in \\"Set\\"
    --> ../../../examples/tests/invalid/immutable_container_types.test.w:28:13
    |
 28 | let s3 = s2.copy();
-   |             ^^^^ Property \\"copy\\" doesn't not exist in \\"Set\\"
+   |             ^^^^ Member \\"copy\\" doesn't exist in \\"Set\\"
 
 
-error: Property \\"clear\\" doesn't not exist in \\"Set\\"
+error: Member \\"clear\\" doesn't exist in \\"Set\\"
    --> ../../../examples/tests/invalid/immutable_container_types.test.w:30:4
    |
 30 | s2.clear();
-   |    ^^^^^ Property \\"clear\\" doesn't not exist in \\"Set\\"
+   |    ^^^^^ Member \\"clear\\" doesn't exist in \\"Set\\"
 
 
 error: Expected type to be \\"bool\\", but got \\"Array<num>\\" instead
@@ -2486,11 +2486,11 @@ error: Expected type to be \\"Array<str>\\", but got \\"str\\" instead
    |                     ^ Expected type to be \\"Array<str>\\", but got \\"str\\" instead
 
 
-error: Property \\"set\\" doesn't not exist in \\"Json\\"
+error: Member \\"set\\" doesn't exist in \\"Json\\"
    --> ../../../examples/tests/invalid/json.test.w:19:13
    |
 19 | foreverJson.set(\\"a\\", \\"world!\\");
-   |             ^^^ Property \\"set\\" doesn't not exist in \\"Json\\"
+   |             ^^^ Member \\"set\\" doesn't exist in \\"Json\\"
 
 
 error: Expected type to be \\"num?\\", but got \\"str?\\" instead
@@ -2601,11 +2601,11 @@ Duration <DURATION>"
 `;
 
 exports[`json_static.test.w 1`] = `
-"error: Property \\"set\\" doesn't not exist in \\"Json\\"
+"error: Member \\"set\\" doesn't exist in \\"Json\\"
   --> ../../../examples/tests/invalid/json_static.test.w:4:10
   |
 4 | immutObj.set(\\"a\\", \\"foo\\");
-  |          ^^^ Property \\"set\\" doesn't not exist in \\"Json\\"
+  |          ^^^ Member \\"set\\" doesn't exist in \\"Json\\"
 
 
  
@@ -2699,11 +2699,11 @@ error: Expected type to be \\"MutArray<num>\\", but got \\"MutArray<str>\\" inst
   |                           ^^^^ Expected type to be \\"MutArray<num>\\", but got \\"MutArray<str>\\" instead
 
 
-error: Property \\"someMethod\\" doesn't not exist in \\"MutArray\\"
+error: Member \\"someMethod\\" doesn't exist in \\"MutArray\\"
   --> ../../../examples/tests/invalid/mut_container_types.test.w:6:6
   |
 6 | arr1.someMethod();
-  |      ^^^^^^^^^^ Property \\"someMethod\\" doesn't not exist in \\"MutArray\\"
+  |      ^^^^^^^^^^ Member \\"someMethod\\" doesn't exist in \\"MutArray\\"
 
 
 error: Expected type to be \\"num\\", but got \\"str\\" instead
@@ -2727,11 +2727,11 @@ error: Expected type to be \\"MutSet<num>\\", but got \\"MutSet<str>\\" instead
    |                       ^^ Expected type to be \\"MutSet<num>\\", but got \\"MutSet<str>\\" instead
 
 
-error: Property \\"someMethod\\" doesn't not exist in \\"MutSet\\"
+error: Member \\"someMethod\\" doesn't exist in \\"MutSet\\"
    --> ../../../examples/tests/invalid/mut_container_types.test.w:14:4
    |
 14 | s3.someMethod();
-   |    ^^^^^^^^^^ Property \\"someMethod\\" doesn't not exist in \\"MutSet\\"
+   |    ^^^^^^^^^^ Member \\"someMethod\\" doesn't exist in \\"MutSet\\"
 
 
 error: Expected type to be \\"num\\", but got \\"str\\" instead
@@ -3064,18 +3064,18 @@ exports[`primitives.test.w 1`] = `
   |     ^^^^ Unexpected reference \\"structured_access_expression\\"
 
 
-error: Property \\"blabla\\" doesn't not exist in \\"Array\\"
+error: Member \\"blabla\\" doesn't exist in \\"Array\\"
   --> ../../../examples/tests/invalid/primitives.test.w:9:16
   |
 9 | let join = arr.blabla(\\",\\");
-  |                ^^^^^^ Property \\"blabla\\" doesn't not exist in \\"Array\\"
+  |                ^^^^^^ Member \\"blabla\\" doesn't exist in \\"Array\\"
 
 
-error: Property \\"push\\" doesn't not exist in \\"Array\\"
+error: Member \\"push\\" doesn't exist in \\"Array\\"
    --> ../../../examples/tests/invalid/primitives.test.w:11:5
    |
 11 | arr.push(4);
-   |     ^^^^ Property \\"push\\" doesn't not exist in \\"Array\\"
+   |     ^^^^ Member \\"push\\" doesn't exist in \\"Array\\"
 
 
 error: Expected type to be \\"str\\", but got \\"num\\" instead
@@ -3716,11 +3716,11 @@ error: Struct fields must have immutable types
    |   ^ Struct fields must have immutable types
 
 
-error: Property \\"badField\\" doesn't not exist in \\"A\\"
+error: Member \\"badField\\" doesn't exist in \\"A\\"
    --> ../../../examples/tests/invalid/structs.test.w:32:7
    |
 32 | log(a.badField);
-   |       ^^^^^^^^ Property \\"badField\\" doesn't not exist in \\"A\\"
+   |       ^^^^^^^^ Member \\"badField\\" doesn't exist in \\"A\\"
 
 
 error: Struct \\"Showtime\\" extends \\"Dazzle\\" which introduces a conflicting member \\"a\\" (num != str)
@@ -3949,11 +3949,11 @@ Duration <DURATION>"
 `;
 
 exports[`unknown_field.test.w 1`] = `
-"error: Property \\"a\\" doesn't not exist in \\"String\\"
+"error: Member \\"a\\" doesn't exist in \\"String\\"
   --> ../../../examples/tests/invalid/unknown_field.test.w:1:12
   |
 1 | std.String.a.b.c.fromJson();
-  |            ^ Property \\"a\\" doesn't not exist in \\"String\\"
+  |            ^ Member \\"a\\" doesn't exist in \\"String\\"
 
 
  
@@ -4014,11 +4014,11 @@ error: Unknown symbol \\"B\\"
    |                 ^ Unknown symbol \\"B\\"
 
 
-error: Property \\"dodo\\" doesn't not exist in \\"SomeResourceChild\\"
+error: Member \\"dodo\\" doesn't exist in \\"SomeResourceChild\\"
    --> ../../../examples/tests/invalid/unknown_symbol.test.w:37:5
    |
 37 | src.dodo();
-   |     ^^^^ Property \\"dodo\\" doesn't not exist in \\"SomeResourceChild\\"
+   |     ^^^^ Member \\"dodo\\" doesn't exist in \\"SomeResourceChild\\"
 
 
 error: Unknown symbol \\"unknown\\"
@@ -4035,18 +4035,18 @@ error: Binary operator '+' cannot be applied to operands of type 'num' and 'str'
    |                        ^^^^^^^ Binary operator '+' cannot be applied to operands of type 'num' and 'str'; only (num, num) and (str, str) are supported
 
 
-error: Property \\"assert\\" doesn't not exist in \\"Bucket\\"
+error: Member \\"assert\\" doesn't exist in \\"Bucket\\"
    --> ../../../examples/tests/invalid/unknown_symbol.test.w:20:17
    |
 20 |     this.bucket.assert(2 + \\"2\\");
-   |                 ^^^^^^ Property \\"assert\\" doesn't not exist in \\"Bucket\\"
+   |                 ^^^^^^ Member \\"assert\\" doesn't exist in \\"Bucket\\"
 
 
-error: Property \\"methodWhichIsNotPartOfBucketApi\\" doesn't not exist in \\"Bucket\\"
+error: Member \\"methodWhichIsNotPartOfBucketApi\\" doesn't exist in \\"Bucket\\"
    --> ../../../examples/tests/invalid/unknown_symbol.test.w:23:24
    |
 23 |     return this.bucket.methodWhichIsNotPartOfBucketApi(id);
-   |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Property \\"methodWhichIsNotPartOfBucketApi\\" doesn't not exist in \\"Bucket\\"
+   |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Member \\"methodWhichIsNotPartOfBucketApi\\" doesn't exist in \\"Bucket\\"
 
 
  

--- a/tools/hangar/__snapshots__/invalid.ts.snap
+++ b/tools/hangar/__snapshots__/invalid.ts.snap
@@ -389,18 +389,18 @@ error: Cannot access static property \\"m\\" from instance
    |     ^ Cannot access static property \\"m\\" from instance
 
 
-error: Unknown symbol \\"instanceField\\"
+error: Property \\"instanceField\\" doesn't not exist in \\"Construct\\"
   --> ../../../examples/tests/invalid/access_static_from_instance.test.w:7:10
   |
 7 |     this.instanceField = 1; // Can't access instance fields from static methods
-  |          ^^^^^^^^^^^^^ Unknown symbol \\"instanceField\\"
+  |          ^^^^^^^^^^^^^ Property \\"instanceField\\" doesn't not exist in \\"Construct\\"
 
 
-error: Unknown symbol \\"f\\"
+error: Property \\"f\\" doesn't not exist in \\"Construct\\"
   --> ../../../examples/tests/invalid/access_static_from_instance.test.w:8:10
   |
 8 |     this.f = 1; // Can't access static fields through \`this\`
-  |          ^ Unknown symbol \\"f\\"
+  |          ^ Property \\"f\\" doesn't not exist in \\"Construct\\"
 
 
  
@@ -1125,11 +1125,11 @@ error: Expected type to be \\"Array<num>\\", but got \\"Array<str>\\" instead
   |                        ^^^^ Expected type to be \\"Array<num>\\", but got \\"Array<str>\\" instead
 
 
-error: Unknown symbol \\"someRandomMethod\\"
+error: Property \\"someRandomMethod\\" doesn't not exist in \\"Array\\"
   --> ../../../examples/tests/invalid/container_types.test.w:6:6
   |
 6 | arr1.someRandomMethod();
-  |      ^^^^^^^^^^^^^^^^ Unknown symbol \\"someRandomMethod\\"
+  |      ^^^^^^^^^^^^^^^^ Property \\"someRandomMethod\\" doesn't not exist in \\"Array\\"
 
 
 error: Expected type to be \\"num\\", but got \\"num?\\" instead
@@ -1160,11 +1160,11 @@ error: Expected type to be \\"Map<num>\\", but got \\"Map<str>\\" instead
    |                    ^^ Expected type to be \\"Map<num>\\", but got \\"Map<str>\\" instead
 
 
-error: Unknown symbol \\"someRandomMethod\\"
+error: Property \\"someRandomMethod\\" doesn't not exist in \\"Map\\"
    --> ../../../examples/tests/invalid/container_types.test.w:17:4
    |
 17 | m1.someRandomMethod();
-   |    ^^^^^^^^^^^^^^^^ Unknown symbol \\"someRandomMethod\\"
+   |    ^^^^^^^^^^^^^^^^ Property \\"someRandomMethod\\" doesn't not exist in \\"Map\\"
 
 
 error: Expected type to be \\"str\\", but got \\"num\\" instead
@@ -1216,11 +1216,11 @@ error: Expected type to be \\"Set<str>\\", but got \\"Set<num>\\" instead
    |                    ^^ Expected type to be \\"Set<str>\\", but got \\"Set<num>\\" instead
 
 
-error: Unknown symbol \\"someRandomMethod\\"
+error: Property \\"someRandomMethod\\" doesn't not exist in \\"Set\\"
    --> ../../../examples/tests/invalid/container_types.test.w:29:4
    |
 29 | s1.someRandomMethod();
-   |    ^^^^^^^^^^^^^^^^ Unknown symbol \\"someRandomMethod\\"
+   |    ^^^^^^^^^^^^^^^^ Property \\"someRandomMethod\\" doesn't not exist in \\"Set\\"
 
 
 error: Expected type to be \\"Array<str>\\", but got \\"MutArray<str>\\" instead
@@ -1237,11 +1237,11 @@ error: Expected type to be \\"MutMap<num>\\", but got \\"Map<num>\\" instead
    |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Expected type to be \\"MutMap<num>\\", but got \\"Map<num>\\" instead
 
 
-error: Unknown symbol \\"copyMut\\"
+error: Property \\"copyMut\\" doesn't not exist in \\"MutMap\\"
    --> ../../../examples/tests/invalid/container_types.test.w:37:15
    |
 37 | let mm3 = mm2.copyMut();
-   |               ^^^^^^^ Unknown symbol \\"copyMut\\"
+   |               ^^^^^^^ Property \\"copyMut\\" doesn't not exist in \\"MutMap\\"
 
 
 error: Expected type to be \\"MutSet<str>\\", but got \\"Array<str>\\" instead
@@ -1258,11 +1258,11 @@ error: Expected type to be \\"num\\", but got \\"bool\\" instead
    |                                    ^^^^ Expected type to be \\"num\\", but got \\"bool\\" instead
 
 
-error: Unknown symbol \\"copyMut\\"
+error: Property \\"copyMut\\" doesn't not exist in \\"MutSet\\"
    --> ../../../examples/tests/invalid/container_types.test.w:46:15
    |
 46 | let ss4 = ss3.copyMut();
-   |               ^^^^^^^ Unknown symbol \\"copyMut\\"
+   |               ^^^^^^^ Property \\"copyMut\\" doesn't not exist in \\"MutSet\\"
 
 
  
@@ -1788,11 +1788,11 @@ Duration <DURATION>"
 `;
 
 exports[`immutable_container_types.test.w 1`] = `
-"error: Unknown symbol \\"set\\"
+"error: Property \\"set\\" doesn't not exist in \\"Map\\"
   --> ../../../examples/tests/invalid/immutable_container_types.test.w:3:4
   |
 3 | m1.set(\\"a\\", \\"bye\\");
-  |    ^^^ Unknown symbol \\"set\\"
+  |    ^^^ Property \\"set\\" doesn't not exist in \\"Map\\"
 
 
 error: Expected type to be \\"Map<str>\\", but got \\"MutMap<str>\\" instead
@@ -1809,32 +1809,32 @@ error: Expected type to be \\"bool\\", but got \\"str\\" instead
   |                             ^^^ Expected type to be \\"bool\\", but got \\"str\\" instead
 
 
-error: Unknown symbol \\"set\\"
+error: Property \\"set\\" doesn't not exist in \\"Map\\"
    --> ../../../examples/tests/invalid/immutable_container_types.test.w:11:4
    |
 11 | m4.set(\\"2\\", 3);
-   |    ^^^ Unknown symbol \\"set\\"
+   |    ^^^ Property \\"set\\" doesn't not exist in \\"Map\\"
 
 
-error: Unknown symbol \\"copy\\"
+error: Property \\"copy\\" doesn't not exist in \\"Map\\"
    --> ../../../examples/tests/invalid/immutable_container_types.test.w:13:13
    |
 13 | let m5 = m4.copy();
-   |             ^^^^ Unknown symbol \\"copy\\"
+   |             ^^^^ Property \\"copy\\" doesn't not exist in \\"Map\\"
 
 
-error: Unknown symbol \\"delete\\"
+error: Property \\"delete\\" doesn't not exist in \\"Map\\"
    --> ../../../examples/tests/invalid/immutable_container_types.test.w:15:4
    |
 15 | m4.delete(\\"1\\");
-   |    ^^^^^^ Unknown symbol \\"delete\\"
+   |    ^^^^^^ Property \\"delete\\" doesn't not exist in \\"Map\\"
 
 
-error: Unknown symbol \\"clear\\"
+error: Property \\"clear\\" doesn't not exist in \\"Map\\"
    --> ../../../examples/tests/invalid/immutable_container_types.test.w:17:4
    |
 17 | m4.clear();
-   |    ^^^^^ Unknown symbol \\"clear\\"
+   |    ^^^^^ Property \\"clear\\" doesn't not exist in \\"Map\\"
 
 
 error: Expected type to be \\"Set<Array<num>>\\", but got \\"MutSet<Array<num>>\\" instead
@@ -1844,32 +1844,32 @@ error: Expected type to be \\"Set<Array<num>>\\", but got \\"MutSet<Array<num>>\
    |                           ^^^^^^^^^^^^^^^^^^^^^^^ Expected type to be \\"Set<Array<num>>\\", but got \\"MutSet<Array<num>>\\" instead
 
 
-error: Unknown symbol \\"delete\\"
+error: Property \\"delete\\" doesn't not exist in \\"Set\\"
    --> ../../../examples/tests/invalid/immutable_container_types.test.w:24:4
    |
 24 | s2.delete(\\"a\\");
-   |    ^^^^^^ Unknown symbol \\"delete\\"
+   |    ^^^^^^ Property \\"delete\\" doesn't not exist in \\"Set\\"
 
 
-error: Unknown symbol \\"add\\"
+error: Property \\"add\\" doesn't not exist in \\"Set\\"
    --> ../../../examples/tests/invalid/immutable_container_types.test.w:26:4
    |
 26 | s2.add(\\"d\\");
-   |    ^^^ Unknown symbol \\"add\\"
+   |    ^^^ Property \\"add\\" doesn't not exist in \\"Set\\"
 
 
-error: Unknown symbol \\"copy\\"
+error: Property \\"copy\\" doesn't not exist in \\"Set\\"
    --> ../../../examples/tests/invalid/immutable_container_types.test.w:28:13
    |
 28 | let s3 = s2.copy();
-   |             ^^^^ Unknown symbol \\"copy\\"
+   |             ^^^^ Property \\"copy\\" doesn't not exist in \\"Set\\"
 
 
-error: Unknown symbol \\"clear\\"
+error: Property \\"clear\\" doesn't not exist in \\"Set\\"
    --> ../../../examples/tests/invalid/immutable_container_types.test.w:30:4
    |
 30 | s2.clear();
-   |    ^^^^^ Unknown symbol \\"clear\\"
+   |    ^^^^^ Property \\"clear\\" doesn't not exist in \\"Set\\"
 
 
 error: Expected type to be \\"bool\\", but got \\"Array<num>\\" instead
@@ -2486,11 +2486,11 @@ error: Expected type to be \\"Array<str>\\", but got \\"str\\" instead
    |                     ^ Expected type to be \\"Array<str>\\", but got \\"str\\" instead
 
 
-error: Unknown symbol \\"set\\"
+error: Property \\"set\\" doesn't not exist in \\"Json\\"
    --> ../../../examples/tests/invalid/json.test.w:19:13
    |
 19 | foreverJson.set(\\"a\\", \\"world!\\");
-   |             ^^^ Unknown symbol \\"set\\"
+   |             ^^^ Property \\"set\\" doesn't not exist in \\"Json\\"
 
 
 error: Expected type to be \\"num?\\", but got \\"str?\\" instead
@@ -2601,11 +2601,11 @@ Duration <DURATION>"
 `;
 
 exports[`json_static.test.w 1`] = `
-"error: Unknown symbol \\"set\\"
+"error: Property \\"set\\" doesn't not exist in \\"Json\\"
   --> ../../../examples/tests/invalid/json_static.test.w:4:10
   |
 4 | immutObj.set(\\"a\\", \\"foo\\");
-  |          ^^^ Unknown symbol \\"set\\"
+  |          ^^^ Property \\"set\\" doesn't not exist in \\"Json\\"
 
 
  
@@ -2699,11 +2699,11 @@ error: Expected type to be \\"MutArray<num>\\", but got \\"MutArray<str>\\" inst
   |                           ^^^^ Expected type to be \\"MutArray<num>\\", but got \\"MutArray<str>\\" instead
 
 
-error: Unknown symbol \\"someMethod\\"
+error: Property \\"someMethod\\" doesn't not exist in \\"MutArray\\"
   --> ../../../examples/tests/invalid/mut_container_types.test.w:6:6
   |
 6 | arr1.someMethod();
-  |      ^^^^^^^^^^ Unknown symbol \\"someMethod\\"
+  |      ^^^^^^^^^^ Property \\"someMethod\\" doesn't not exist in \\"MutArray\\"
 
 
 error: Expected type to be \\"num\\", but got \\"str\\" instead
@@ -2727,11 +2727,11 @@ error: Expected type to be \\"MutSet<num>\\", but got \\"MutSet<str>\\" instead
    |                       ^^ Expected type to be \\"MutSet<num>\\", but got \\"MutSet<str>\\" instead
 
 
-error: Unknown symbol \\"someMethod\\"
+error: Property \\"someMethod\\" doesn't not exist in \\"MutSet\\"
    --> ../../../examples/tests/invalid/mut_container_types.test.w:14:4
    |
 14 | s3.someMethod();
-   |    ^^^^^^^^^^ Unknown symbol \\"someMethod\\"
+   |    ^^^^^^^^^^ Property \\"someMethod\\" doesn't not exist in \\"MutSet\\"
 
 
 error: Expected type to be \\"num\\", but got \\"str\\" instead
@@ -3064,18 +3064,18 @@ exports[`primitives.test.w 1`] = `
   |     ^^^^ Unexpected reference \\"structured_access_expression\\"
 
 
-error: Unknown symbol \\"blabla\\"
+error: Property \\"blabla\\" doesn't not exist in \\"Array\\"
   --> ../../../examples/tests/invalid/primitives.test.w:9:16
   |
 9 | let join = arr.blabla(\\",\\");
-  |                ^^^^^^ Unknown symbol \\"blabla\\"
+  |                ^^^^^^ Property \\"blabla\\" doesn't not exist in \\"Array\\"
 
 
-error: Unknown symbol \\"push\\"
+error: Property \\"push\\" doesn't not exist in \\"Array\\"
    --> ../../../examples/tests/invalid/primitives.test.w:11:5
    |
 11 | arr.push(4);
-   |     ^^^^ Unknown symbol \\"push\\"
+   |     ^^^^ Property \\"push\\" doesn't not exist in \\"Array\\"
 
 
 error: Expected type to be \\"str\\", but got \\"num\\" instead
@@ -3716,11 +3716,11 @@ error: Struct fields must have immutable types
    |   ^ Struct fields must have immutable types
 
 
-error: Unknown symbol \\"badField\\"
+error: Property \\"badField\\" doesn't not exist in \\"A\\"
    --> ../../../examples/tests/invalid/structs.test.w:32:7
    |
 32 | log(a.badField);
-   |       ^^^^^^^^ Unknown symbol \\"badField\\"
+   |       ^^^^^^^^ Property \\"badField\\" doesn't not exist in \\"A\\"
 
 
 error: Struct \\"Showtime\\" extends \\"Dazzle\\" which introduces a conflicting member \\"a\\" (num != str)
@@ -3949,11 +3949,11 @@ Duration <DURATION>"
 `;
 
 exports[`unknown_field.test.w 1`] = `
-"error: Unknown symbol \\"a\\"
+"error: Property \\"a\\" doesn't not exist in \\"String\\"
   --> ../../../examples/tests/invalid/unknown_field.test.w:1:12
   |
 1 | std.String.a.b.c.fromJson();
-  |            ^ Unknown symbol \\"a\\"
+  |            ^ Property \\"a\\" doesn't not exist in \\"String\\"
 
 
  
@@ -3980,9 +3980,9 @@ Duration <DURATION>"
 
 exports[`unknown_symbol.test.w 1`] = `
 "error: Reserved word
-   --> ../../../examples/tests/invalid/unknown_symbol.test.w:35:5
+   --> ../../../examples/tests/invalid/unknown_symbol.test.w:43:5
    |
-35 | let let = 2;
+43 | let let = 2;
    |     ^^^ Reserved word
 
 
@@ -4014,10 +4014,17 @@ error: Unknown symbol \\"B\\"
    |                 ^ Unknown symbol \\"B\\"
 
 
-error: Unknown symbol \\"unknown\\"
-   --> ../../../examples/tests/invalid/unknown_symbol.test.w:32:1
+error: Property \\"dodo\\" doesn't not exist in \\"SomeResourceChild\\"
+   --> ../../../examples/tests/invalid/unknown_symbol.test.w:37:5
    |
-32 | unknown = 1;
+37 | src.dodo();
+   |     ^^^^ Property \\"dodo\\" doesn't not exist in \\"SomeResourceChild\\"
+
+
+error: Unknown symbol \\"unknown\\"
+   --> ../../../examples/tests/invalid/unknown_symbol.test.w:40:1
+   |
+40 | unknown = 1;
    | ^^^^^^^ Unknown symbol \\"unknown\\"
 
 
@@ -4028,18 +4035,18 @@ error: Binary operator '+' cannot be applied to operands of type 'num' and 'str'
    |                        ^^^^^^^ Binary operator '+' cannot be applied to operands of type 'num' and 'str'; only (num, num) and (str, str) are supported
 
 
-error: Unknown symbol \\"assert\\"
+error: Property \\"assert\\" doesn't not exist in \\"Bucket\\"
    --> ../../../examples/tests/invalid/unknown_symbol.test.w:20:17
    |
 20 |     this.bucket.assert(2 + \\"2\\");
-   |                 ^^^^^^ Unknown symbol \\"assert\\"
+   |                 ^^^^^^ Property \\"assert\\" doesn't not exist in \\"Bucket\\"
 
 
-error: Unknown symbol \\"methodWhichIsNotPartOfBucketApi\\"
+error: Property \\"methodWhichIsNotPartOfBucketApi\\" doesn't not exist in \\"Bucket\\"
    --> ../../../examples/tests/invalid/unknown_symbol.test.w:23:24
    |
 23 |     return this.bucket.methodWhichIsNotPartOfBucketApi(id);
-   |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Unknown symbol \\"methodWhichIsNotPartOfBucketApi\\"
+   |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Property \\"methodWhichIsNotPartOfBucketApi\\" doesn't not exist in \\"Bucket\\"
 
 
  


### PR DESCRIPTION
Fixes #2769
A revisit of #5761 
`x_instance.unkonwn_prop` resulted in:
```
Unknown symbol "unkonwn_prop"
```
And now results in:
```
Property "unkonwn_prop" doesn't exist in "X"
```

## Checklist

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [x] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
