### PR TITLE
chore: mutation workflow and owner comment workflow broken on forks

### DIFF
--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -67,7 +67,7 @@ jobs:
             - Flakey tests (relying on one of the above)
           comment_tag: UnstableMutation
           GITHUB_TOKEN: ${{ secrets.PROJEN_GITHUB_TOKEN }}
-      
+
       - name: Unstable mutation fail
         if: steps.download-artifacts.outputs.found_artifact == 'true' && startsWith(github.event.workflow_run.head_commit.message, format('chore{0} self mutation', ':'))
         run: exit 1
@@ -79,16 +79,27 @@ jobs:
 
       - name: Update PR Branch
         uses: actions/github-script@v7
+        id: branch-update
         if: steps.download-artifacts.outputs.found_artifact == 'true'
         with:
           github-token: ${{ secrets.MUTATION_TOKEN }}
           script: |
             // use API to get the PR data since we can't rely on the context across forks
+            let head = context.payload.workflow_run.head_branch;
+            if (`${context.repo.owner}/${context.repo.repo}` !== context.payload.workflow_run.head_repository.full_name) {
+              if (context.payload.workflow_run.head_repository.name === context.repo.repo) {
+                // head is in the short form since the repo name is the same
+                head = `${context.payload.workflow_run.head_repository.owner.login}:${head}`;
+              } else {
+                head = `${context.payload.workflow_run.head_repository.full_name}:${head}`;
+              }
+            }
+
             const pulls = await github.rest.pulls.list({
               per_page: 1,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              head: `${context.payload.workflow_run.head_repository.full_name}:${context.payload.workflow_run.head_branch}`
+              head,
             });
 
             const prContextData = pulls.data[0];
@@ -123,6 +134,8 @@ jobs:
               // That's fine, we tried our best
               console.warn(error);
             }
+
+            return prNumber;
 
       - name: Checkout Workflow Branch
         if: steps.download-artifacts.outputs.found_artifact == 'true'
@@ -166,19 +179,11 @@ jobs:
         with:
           github-token: ${{ secrets.MUTATION_TOKEN }}
           script: |
-            // use API to get the PR number since we can't rely on the context across forks
-            const pulls = await github.rest.pulls.list({
-              per_page: 1,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              head: `${context.payload.workflow_run.head_repository.full_name}:${context.payload.workflow_run.head_branch}`
-            });
-            const prNumber = pulls.data[0].number;
-            const labels = ["⚠️ pr/review-mutation"];
+            const prNumber = ${{ steps.branch-update.outputs.result }};
 
             await github.rest.issues.addLabels({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: prNumber,
-              labels: labels
+              labels: ["⚠️ pr/review-mutation"]
             });

--- a/.github/workflows/new-pull-request-comment.yml
+++ b/.github/workflows/new-pull-request-comment.yml
@@ -1,13 +1,18 @@
 name: PR Creation Comment
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
+
+permissions:
+  contents: read
+  pull-requests: write
 
 jobs:
   comment:
     runs-on: ubuntu-latest
+    if: ${{ !startsWith(github.head_ref, 'mergify/merge-queue/') }}
     steps:
       - name: Comment on new PR
         uses: thollander/actions-comment-pull-request@v2
@@ -37,4 +42,4 @@ jobs:
             | Wing Playground                                     | `@eladcon`
 
           comment_tag: New PR
-          GITHUB_TOKEN: ${{secrets.PROJEN_GITHUB_TOKEN}}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Fixes #5115

The mutation workflow is using the wrong `head` for forks when the repo name is `wing` (which it usually is). This worked before, I suspect the API changed, but in any case this fixes things.

Also updated the initial PR comment workflow to work on forks.

Tested in https://github.com/MarkMcCulloh/wing-distributed-workflow

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
