### PR TITLE
chore(console): enable `@typescript-eslint/consistent-type-imports` eslint rule

### DIFF
--- a/apps/wing-console/console/app/src/index.ts
+++ b/apps/wing-console/console/app/src/index.ts
@@ -1,14 +1,13 @@
-import {
-  createConsoleServer,
+import type {
   CreateConsoleServerOptions,
   LogInterface,
   Updater,
   Config,
   HostUtils,
   Trace,
-  isTermsAccepted,
   LayoutConfig,
 } from "@wingconsole/server";
+import { createConsoleServer, isTermsAccepted } from "@wingconsole/server";
 import express from "express";
 
 import { createAnalytics } from "./analytics.js";

--- a/apps/wing-console/console/app/test/cloud.api/index.test.ts
+++ b/apps/wing-console/console/app/test/cloud.api/index.test.ts
@@ -1,4 +1,5 @@
-import { Page, expect, test } from "@playwright/test";
+import type { Page } from "@playwright/test";
+import { expect, test } from "@playwright/test";
 
 import { describe } from "../describe.js";
 import { getResourceNode } from "../helpers.js";

--- a/apps/wing-console/console/app/test/helpers.ts
+++ b/apps/wing-console/console/app/test/helpers.ts
@@ -1,4 +1,4 @@
-import { Page } from "@playwright/test";
+import type { Page } from "@playwright/test";
 
 export const getResourceNode = (page: Page, path: string) => {
   return page.locator(

--- a/apps/wing-console/console/design-system/src/attribute.tsx
+++ b/apps/wing-console/console/design-system/src/attribute.tsx
@@ -1,5 +1,6 @@
 import classNames from "classnames";
-import { PropsWithChildren, useId } from "react";
+import type { PropsWithChildren } from "react";
+import { useId } from "react";
 
 import { Link } from "./link.js";
 import { useTheme } from "./theme-provider.js";

--- a/apps/wing-console/console/design-system/src/button.tsx
+++ b/apps/wing-console/console/design-system/src/button.tsx
@@ -1,7 +1,8 @@
 import classNames from "classnames";
-import { PropsWithChildren, forwardRef } from "react";
+import type { PropsWithChildren } from "react";
+import { forwardRef } from "react";
 
-import { IconComponent } from "./resource-icon.js";
+import type { IconComponent } from "./resource-icon.js";
 import { useTheme } from "./theme-provider.js";
 
 interface ButtonProps {

--- a/apps/wing-console/console/design-system/src/file-preview.stories.tsx
+++ b/apps/wing-console/console/design-system/src/file-preview.stories.tsx
@@ -1,4 +1,4 @@
-import { Meta, StoryObj } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react";
 
 import { FilePreview } from "./file-preview.js";
 

--- a/apps/wing-console/console/design-system/src/headless/tree-context.ts
+++ b/apps/wing-console/console/design-system/src/headless/tree-context.ts
@@ -1,4 +1,5 @@
-import { createContext, useContext, KeyboardEvent } from "react";
+import type { KeyboardEvent } from "react";
+import { createContext, useContext } from "react";
 
 export interface TreeContext {
   expandedItems: string[];

--- a/apps/wing-console/console/design-system/src/headless/tree-item.tsx
+++ b/apps/wing-console/console/design-system/src/headless/tree-item.tsx
@@ -1,14 +1,12 @@
+import type { PropsWithChildren, ReactNode, KeyboardEvent } from "react";
 import {
   createContext,
-  PropsWithChildren,
-  ReactNode,
   useCallback,
   useContext,
   useEffect,
   useMemo,
   useRef,
   useState,
-  KeyboardEvent,
 } from "react";
 
 import { useTreeContext } from "./tree-context.js";

--- a/apps/wing-console/console/design-system/src/headless/tree-view.tsx
+++ b/apps/wing-console/console/design-system/src/headless/tree-view.tsx
@@ -1,10 +1,5 @@
-import {
-  PropsWithChildren,
-  useCallback,
-  useEffect,
-  useState,
-  KeyboardEvent,
-} from "react";
+import type { PropsWithChildren, KeyboardEvent } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 import { useControlled } from "../utils/use-controlled.js";
 

--- a/apps/wing-console/console/design-system/src/input.tsx
+++ b/apps/wing-console/console/design-system/src/input.tsx
@@ -1,7 +1,7 @@
 import classNames from "classnames";
 import { forwardRef } from "react";
 
-import { IconComponent } from "./resource-icon.js";
+import type { IconComponent } from "./resource-icon.js";
 import { useTheme } from "./theme-provider.js";
 
 export interface InputProps {

--- a/apps/wing-console/console/design-system/src/inspector-section-heading.tsx
+++ b/apps/wing-console/console/design-system/src/inspector-section-heading.tsx
@@ -1,7 +1,7 @@
 import { ChevronDownIcon, ChevronRightIcon } from "@heroicons/react/20/solid";
 import classNames from "classnames";
 
-import { IconComponent } from "./resource-icon.js";
+import type { IconComponent } from "./resource-icon.js";
 import { useTheme } from "./theme-provider.js";
 
 export interface InspectorSectionHeadingProps {

--- a/apps/wing-console/console/design-system/src/inspector-section.tsx
+++ b/apps/wing-console/console/design-system/src/inspector-section.tsx
@@ -1,7 +1,7 @@
-import { PropsWithChildren } from "react";
+import type { PropsWithChildren } from "react";
 
 import { InspectorSectionHeading } from "./inspector-section-heading.js";
-import { IconComponent } from "./resource-icon.js";
+import type { IconComponent } from "./resource-icon.js";
 
 export interface InspectorSectionProps {
   open?: boolean;

--- a/apps/wing-console/console/design-system/src/left-resizable-widget.tsx
+++ b/apps/wing-console/console/design-system/src/left-resizable-widget.tsx
@@ -1,5 +1,6 @@
 import classNames from "classnames";
-import { createRef, memo, ReactNode, useState } from "react";
+import type { ReactNode } from "react";
+import { createRef, memo, useState } from "react";
 
 export interface LeftResizableWidgetProps {
   className?: string;

--- a/apps/wing-console/console/design-system/src/loader.tsx
+++ b/apps/wing-console/console/design-system/src/loader.tsx
@@ -1,4 +1,5 @@
-import { SpinnerLoader, SpinnerLoaderSize } from "./spinner-loader.js";
+import type { SpinnerLoaderSize } from "./spinner-loader.js";
+import { SpinnerLoader } from "./spinner-loader.js";
 
 export const Loader = ({
   size,

--- a/apps/wing-console/console/design-system/src/modal.tsx
+++ b/apps/wing-console/console/design-system/src/modal.tsx
@@ -1,6 +1,7 @@
 import { Dialog, Transition } from "@headlessui/react";
 import classNames from "classnames";
-import { Fragment, ReactNode } from "react";
+import type { ReactNode } from "react";
+import { Fragment } from "react";
 
 import { useTheme } from "./theme-provider.js";
 

--- a/apps/wing-console/console/design-system/src/notification.tsx
+++ b/apps/wing-console/console/design-system/src/notification.tsx
@@ -6,10 +6,10 @@ import {
 } from "@heroicons/react/24/outline";
 import classNames from "classnames";
 import { nanoid } from "nanoid";
+import type { PropsWithChildren } from "react";
 import {
   createContext,
   Fragment,
-  PropsWithChildren,
   useContext,
   useEffect,
   useMemo,

--- a/apps/wing-console/console/design-system/src/pill.tsx
+++ b/apps/wing-console/console/design-system/src/pill.tsx
@@ -1,5 +1,5 @@
 import classNames from "classnames";
-import { PropsWithChildren } from "react";
+import type { PropsWithChildren } from "react";
 
 import { useTheme } from "./theme-provider.js";
 export interface PillProps {

--- a/apps/wing-console/console/design-system/src/progress-bar.stories.tsx
+++ b/apps/wing-console/console/design-system/src/progress-bar.stories.tsx
@@ -1,4 +1,4 @@
-import { Meta, StoryObj } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react";
 
 import { ProgressBar } from "./progress-bar.js";
 

--- a/apps/wing-console/console/design-system/src/resource-icon.tsx
+++ b/apps/wing-console/console/design-system/src/resource-icon.tsx
@@ -1,5 +1,5 @@
 import classNames from "classnames";
-import { FunctionComponent, SVGProps } from "react";
+import type { FunctionComponent, SVGProps } from "react";
 
 import {
   getResourceIconColors,

--- a/apps/wing-console/console/design-system/src/response-input.tsx
+++ b/apps/wing-console/console/design-system/src/response-input.tsx
@@ -1,5 +1,5 @@
 import classNames from "classnames";
-import { PropsWithChildren } from "react";
+import type { PropsWithChildren } from "react";
 
 import { SpinnerLoader } from "./spinner-loader.js";
 import { useTheme } from "./theme-provider.js";

--- a/apps/wing-console/console/design-system/src/right-resizable-widget.tsx
+++ b/apps/wing-console/console/design-system/src/right-resizable-widget.tsx
@@ -1,5 +1,6 @@
 import classNames from "classnames";
-import { createRef, memo, ReactNode, useState } from "react";
+import type { ReactNode } from "react";
+import { createRef, memo, useState } from "react";
 
 export interface RightResizableWidgetProps {
   className?: string;

--- a/apps/wing-console/console/design-system/src/row-input.tsx
+++ b/apps/wing-console/console/design-system/src/row-input.tsx
@@ -1,5 +1,6 @@
 import classNames from "classnames";
-import { RefObject, memo, useMemo, useState } from "react";
+import type { RefObject } from "react";
+import { memo, useMemo, useState } from "react";
 
 import { useTheme } from "./theme-provider.js";
 

--- a/apps/wing-console/console/design-system/src/scrollable-area.tsx
+++ b/apps/wing-console/console/design-system/src/scrollable-area.tsx
@@ -1,11 +1,6 @@
 import classNames from "classnames";
-import {
-  PropsWithChildren,
-  forwardRef,
-  memo,
-  useEffect,
-  useState,
-} from "react";
+import type { PropsWithChildren } from "react";
+import { forwardRef, memo, useEffect, useState } from "react";
 
 import { useTheme } from "./theme-provider.js";
 

--- a/apps/wing-console/console/design-system/src/skeleton-loader.tsx
+++ b/apps/wing-console/console/design-system/src/skeleton-loader.tsx
@@ -1,5 +1,5 @@
 import classNames from "classnames";
-import { PropsWithChildren } from "react";
+import type { PropsWithChildren } from "react";
 
 export interface SkeletonProps {
   className?: string;

--- a/apps/wing-console/console/design-system/src/slide-over.tsx
+++ b/apps/wing-console/console/design-system/src/slide-over.tsx
@@ -1,6 +1,7 @@
 import { Dialog, Transition } from "@headlessui/react";
 import { XMarkIcon } from "@heroicons/react/24/outline";
-import { Fragment, PropsWithChildren } from "react";
+import type { PropsWithChildren } from "react";
+import { Fragment } from "react";
 
 export interface SlideOverProps {
   title: string;

--- a/apps/wing-console/console/design-system/src/spinner-loader.stories.tsx
+++ b/apps/wing-console/console/design-system/src/spinner-loader.stories.tsx
@@ -1,4 +1,4 @@
-import { Meta, StoryObj } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react";
 
 import { SpinnerLoader } from "./spinner-loader.js";
 

--- a/apps/wing-console/console/design-system/src/table-row.tsx
+++ b/apps/wing-console/console/design-system/src/table-row.tsx
@@ -1,5 +1,5 @@
 import classNames from "classnames";
-import { ChangeEvent, RefObject } from "react";
+import type { ChangeEvent, RefObject } from "react";
 
 import { RowInput } from "./row-input.js";
 

--- a/apps/wing-console/console/design-system/src/tabs.tsx
+++ b/apps/wing-console/console/design-system/src/tabs.tsx
@@ -1,5 +1,6 @@
 import classNames from "classnames";
-import { ReactNode, memo, useEffect, useState } from "react";
+import type { ReactNode } from "react";
+import { memo, useEffect, useState } from "react";
 
 import { ScrollableArea } from "./scrollable-area.js";
 import { useTheme } from "./theme-provider.js";

--- a/apps/wing-console/console/design-system/src/text-highlight.tsx
+++ b/apps/wing-console/console/design-system/src/text-highlight.tsx
@@ -1,6 +1,7 @@
 import { memo, useEffect, useState } from "react";
 
-import { Theme, useTheme } from "./theme-provider.js";
+import type { Theme } from "./theme-provider.js";
+import { useTheme } from "./theme-provider.js";
 
 export interface TextHighlightProps {
   id?: string;

--- a/apps/wing-console/console/design-system/src/theme-provider.tsx
+++ b/apps/wing-console/console/design-system/src/theme-provider.tsx
@@ -1,6 +1,6 @@
+import type { PropsWithChildren } from "react";
 import {
   createContext,
-  PropsWithChildren,
   useCallback,
   useContext,
   useEffect,

--- a/apps/wing-console/console/design-system/src/toolbar-button.tsx
+++ b/apps/wing-console/console/design-system/src/toolbar-button.tsx
@@ -1,5 +1,5 @@
 import classNames from "classnames";
-import { PropsWithChildren } from "react";
+import type { PropsWithChildren } from "react";
 
 import { useTheme } from "./theme-provider.js";
 

--- a/apps/wing-console/console/design-system/src/toolbar.tsx
+++ b/apps/wing-console/console/design-system/src/toolbar.tsx
@@ -1,5 +1,5 @@
 import classNames from "classnames";
-import { PropsWithChildren } from "react";
+import type { PropsWithChildren } from "react";
 
 import { useTheme } from "./theme-provider.js";
 

--- a/apps/wing-console/console/design-system/src/top-resizable-widget.tsx
+++ b/apps/wing-console/console/design-system/src/top-resizable-widget.tsx
@@ -1,5 +1,6 @@
 import classNames from "classnames";
-import { createRef, memo, ReactNode, useState } from "react";
+import type { ReactNode } from "react";
+import { createRef, memo, useState } from "react";
 
 export interface TopResizableWidgetProps {
   className?: string;

--- a/apps/wing-console/console/design-system/src/tree-item.tsx
+++ b/apps/wing-console/console/design-system/src/tree-item.tsx
@@ -1,6 +1,7 @@
 import { ChevronRightIcon } from "@heroicons/react/24/outline";
 import classNames from "classnames";
-import { PropsWithChildren, ReactNode, KeyboardEvent, memo } from "react";
+import type { PropsWithChildren, ReactNode, KeyboardEvent } from "react";
+import { memo } from "react";
 
 import { TreeItem as HeadlessTreeItem } from "./headless/tree-item.js";
 import { useTheme } from "./theme-provider.js";

--- a/apps/wing-console/console/design-system/src/tree-view.stories.tsx
+++ b/apps/wing-console/console/design-system/src/tree-view.stories.tsx
@@ -1,5 +1,5 @@
 import { CubeIcon } from "@heroicons/react/24/outline";
-import { Meta, StoryObj } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react";
 
 import { TreeItem } from "./tree-item.js";
 import { TreeView } from "./tree-view.js";

--- a/apps/wing-console/console/design-system/src/tree-view.tsx
+++ b/apps/wing-console/console/design-system/src/tree-view.tsx
@@ -1,4 +1,4 @@
-import { PropsWithChildren } from "react";
+import type { PropsWithChildren } from "react";
 
 import { TreeView as HeadlessTreeView } from "./headless/tree-view.js";
 

--- a/apps/wing-console/console/design-system/src/tree.tsx
+++ b/apps/wing-console/console/design-system/src/tree.tsx
@@ -1,13 +1,7 @@
 import classNames from "classnames";
 import uniq from "lodash.uniq";
-import {
-  useState,
-  KeyboardEvent,
-  useEffect,
-  Ref,
-  useCallback,
-  forwardRef,
-} from "react";
+import type { KeyboardEvent, Ref } from "react";
+import { useState, useEffect, useCallback, forwardRef } from "react";
 
 import { useTheme } from "./theme-provider.js";
 

--- a/apps/wing-console/console/server/src/consoleLogger.ts
+++ b/apps/wing-console/console/server/src/consoleLogger.ts
@@ -1,7 +1,7 @@
 import { errorMessage } from "@wingconsole/error-message";
 import { nanoid } from "nanoid";
 
-import { LogInterface } from "./utils/LogInterface.js";
+import type { LogInterface } from "./utils/LogInterface.js";
 
 export type LogLevel = "verbose" | "info" | "warn" | "error";
 

--- a/apps/wing-console/console/server/src/expressServer.ts
+++ b/apps/wing-console/console/server/src/expressServer.ts
@@ -1,6 +1,6 @@
 import * as trpcExpress from "@trpc/server/adapters/express";
 import { applyWSSHandler } from "@trpc/server/adapters/ws";
-import { simulator } from "@winglang/sdk";
+import type { simulator } from "@winglang/sdk";
 import cors from "cors";
 import type Emittery from "emittery";
 import express from "express";
@@ -13,7 +13,7 @@ import type { HostUtils } from "./hostUtils.js";
 import { mergeAllRouters } from "./router/index.js";
 import type { State, Trace } from "./types.js";
 import type { Updater } from "./updater.js";
-import { Analytics } from "./utils/analytics.js";
+import type { Analytics } from "./utils/analytics.js";
 import type {
   FileLink,
   LayoutConfig,

--- a/apps/wing-console/console/server/src/index.ts
+++ b/apps/wing-console/console/server/src/index.ts
@@ -16,7 +16,7 @@ import type { State } from "./types.js";
 import type { Updater } from "./updater.js";
 import type { Analytics } from "./utils/analytics.js";
 import { createCompiler } from "./utils/compiler.js";
-import {
+import type {
   FileLink,
   LayoutConfig,
   TestItem,

--- a/apps/wing-console/console/server/src/router/api.ts
+++ b/apps/wing-console/console/server/src/router/api.ts
@@ -3,7 +3,8 @@ import fetch from "node-fetch";
 import { z } from "zod";
 
 import { createProcedure, createRouter } from "../utils/createRouter.js";
-import { ApiSchema, OpenApiSpec } from "../wingsdk.js";
+import type { ApiSchema } from "../wingsdk.js";
+import { OpenApiSpec } from "../wingsdk.js";
 
 export const createApiRouter = () => {
   return createRouter({

--- a/apps/wing-console/console/server/src/router/app.ts
+++ b/apps/wing-console/console/server/src/router/app.ts
@@ -4,21 +4,18 @@ import uniqby from "lodash.uniqby";
 import { z } from "zod";
 
 import type { Trace } from "../types.js";
-import { ConstructTreeNode } from "../utils/construct-tree.js";
-import {
+import type { ConstructTreeNode } from "../utils/construct-tree.js";
+import type {
   Node,
   NodeDisplay,
-  buildConstructTreeNodeMap,
   NodeConnection,
   ConstructTreeNodeMap,
 } from "../utils/constructTreeNodeMap.js";
-import {
-  FileLink,
-  createProcedure,
-  createRouter,
-} from "../utils/createRouter.js";
+import { buildConstructTreeNodeMap } from "../utils/constructTreeNodeMap.js";
+import type { FileLink } from "../utils/createRouter.js";
+import { createProcedure, createRouter } from "../utils/createRouter.js";
 import { isTermsAccepted, getLicense } from "../utils/terms-and-conditions.js";
-import { Simulator } from "../wingsdk.js";
+import type { Simulator } from "../wingsdk.js";
 
 const isTest = /(\/test$|\/test:([^/\\])+$)/;
 const isTestHandler = /(\/test$|\/test:.*\/Handler$)/;

--- a/apps/wing-console/console/server/src/router/bucket.ts
+++ b/apps/wing-console/console/server/src/router/bucket.ts
@@ -3,7 +3,7 @@ import fs from "node:fs";
 import { z } from "zod";
 
 import { createProcedure, createRouter } from "../utils/createRouter.js";
-import { IBucketClient } from "../wingsdk.js";
+import type { IBucketClient } from "../wingsdk.js";
 
 export const createBucketRouter = () => {
   return createRouter({

--- a/apps/wing-console/console/server/src/router/counter.ts
+++ b/apps/wing-console/console/server/src/router/counter.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 
 import { createProcedure, createRouter } from "../utils/createRouter.js";
-import { ICounterClient } from "../wingsdk.js";
+import type { ICounterClient } from "../wingsdk.js";
 
 export const createCounterRouter = () => {
   return createRouter({

--- a/apps/wing-console/console/server/src/router/dynamodb-table.ts
+++ b/apps/wing-console/console/server/src/router/dynamodb-table.ts
@@ -1,7 +1,11 @@
 import { z } from "zod";
 
 import { createProcedure, createRouter } from "../utils/createRouter.js";
-import { DynamodbTableSchema, IDynamodbTableClient, Json } from "../wingsdk.js";
+import type {
+  DynamodbTableSchema,
+  IDynamodbTableClient,
+  Json,
+} from "../wingsdk.js";
 
 export const createDynamodbTableRouter = () => {
   return createRouter({

--- a/apps/wing-console/console/server/src/router/endpoint.ts
+++ b/apps/wing-console/console/server/src/router/endpoint.ts
@@ -1,8 +1,8 @@
 import { ENDPOINT_FQN } from "@winglang/sdk/lib/cloud/endpoint.js";
-import { EndpointSchema } from "@winglang/sdk/lib/target-sim/schema-resources.js";
+import type { EndpointSchema } from "@winglang/sdk/lib/target-sim/schema-resources.js";
 
 import { createProcedure, createRouter } from "../utils/createRouter.js";
-import { Simulator } from "../wingsdk.js";
+import type { Simulator } from "../wingsdk.js";
 
 const listEndpoints = (simulator: Simulator) => {
   const endpoints = simulator

--- a/apps/wing-console/console/server/src/router/function.ts
+++ b/apps/wing-console/console/server/src/router/function.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 
 import { createProcedure, createRouter } from "../utils/createRouter.js";
-import { IFunctionClient } from "../wingsdk.js";
+import type { IFunctionClient } from "../wingsdk.js";
 
 export type ResponseEnvelope =
   | {

--- a/apps/wing-console/console/server/src/router/queue.ts
+++ b/apps/wing-console/console/server/src/router/queue.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 
 import { createProcedure, createRouter } from "../utils/createRouter.js";
-import { IQueueClient } from "../wingsdk.js";
+import type { IQueueClient } from "../wingsdk.js";
 
 export const createQueueRouter = () => {
   return createRouter({

--- a/apps/wing-console/console/server/src/router/react-app.ts
+++ b/apps/wing-console/console/server/src/router/react-app.ts
@@ -1,4 +1,4 @@
-import { ReactAppSchema } from "@winglang/sdk/lib/target-sim/schema-resources";
+import type { ReactAppSchema } from "@winglang/sdk/lib/target-sim/schema-resources";
 import { z } from "zod";
 
 import { createProcedure, createRouter } from "../utils/createRouter.js";

--- a/apps/wing-console/console/server/src/router/redis.ts
+++ b/apps/wing-console/console/server/src/router/redis.ts
@@ -3,7 +3,7 @@ import { createClient } from "redis";
 import { z } from "zod";
 
 import { createProcedure, createRouter } from "../utils/createRouter.js";
-import { IRedisClient } from "../wingsdk.js";
+import type { IRedisClient } from "../wingsdk.js";
 
 const parseRedisErrorMessage = (response: string) => {
   const emptyArgumentsText = ", with args beginning with: ";

--- a/apps/wing-console/console/server/src/router/table.ts
+++ b/apps/wing-console/console/server/src/router/table.ts
@@ -2,7 +2,8 @@ import { ColumnType as SdkColumnType } from "@winglang/sdk/lib/ex/table.js";
 import { z } from "zod";
 
 import { createProcedure, createRouter } from "../utils/createRouter.js";
-import { TableSchema, ITableClient, Json } from "../wingsdk.js";
+import type { TableSchema, ITableClient } from "../wingsdk.js";
+import { Json } from "../wingsdk.js";
 
 type ColumnType = "string" | "number" | "boolean" | "date" | "json";
 

--- a/apps/wing-console/console/server/src/router/test.ts
+++ b/apps/wing-console/console/server/src/router/test.ts
@@ -1,10 +1,10 @@
-import { TestResult } from "@winglang/sdk/lib/std";
+import type { TestResult } from "@winglang/sdk/lib/std";
 import { z } from "zod";
 
-import { ConsoleLogger } from "../consoleLogger.js";
+import type { ConsoleLogger } from "../consoleLogger.js";
 import { createProcedure, createRouter } from "../utils/createRouter.js";
 import { formatTraceError } from "../utils/format-wing-error.js";
-import { ITestRunnerClient, Simulator } from "../wingsdk.js";
+import type { ITestRunnerClient, Simulator } from "../wingsdk.js";
 
 const getTestName = (testPath: string) => {
   const test = testPath.split("/").pop() ?? testPath;

--- a/apps/wing-console/console/server/src/router/topic.ts
+++ b/apps/wing-console/console/server/src/router/topic.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 
 import { createProcedure, createRouter } from "../utils/createRouter.js";
-import { ITopicClient } from "../wingsdk.js";
+import type { ITopicClient } from "../wingsdk.js";
 
 export const createTopicRouter = () => {
   return createRouter({

--- a/apps/wing-console/console/server/src/router/website.ts
+++ b/apps/wing-console/console/server/src/router/website.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 
 import { createProcedure, createRouter } from "../utils/createRouter.js";
-import { WebsiteSchema } from "../wingsdk.js";
+import type { WebsiteSchema } from "../wingsdk.js";
 
 export const createWebsiteRouter = () => {
   return createRouter({

--- a/apps/wing-console/console/server/src/utils/construct-tree.ts
+++ b/apps/wing-console/console/server/src/utils/construct-tree.ts
@@ -1,4 +1,4 @@
-import { NodeDisplay } from "./constructTreeNodeMap.js";
+import type { NodeDisplay } from "./constructTreeNodeMap.js";
 
 /**
  * A node in the construct tree.

--- a/apps/wing-console/console/server/src/utils/constructTreeNodeMap.ts
+++ b/apps/wing-console/console/server/src/utils/constructTreeNodeMap.ts
@@ -1,4 +1,4 @@
-import { ConstructInfo, ConstructTreeNode } from "./construct-tree.js";
+import type { ConstructInfo, ConstructTreeNode } from "./construct-tree.js";
 
 export interface NodeDisplay {
   title?: string;

--- a/apps/wing-console/console/server/src/utils/createRouter.ts
+++ b/apps/wing-console/console/server/src/utils/createRouter.ts
@@ -1,10 +1,10 @@
 import { initTRPC } from "@trpc/server";
-import { simulator } from "@winglang/sdk";
+import type { simulator } from "@winglang/sdk";
 import type Emittery from "emittery";
 
-import { Config } from "../config.js";
-import { ConsoleLogger } from "../consoleLogger.js";
-import { HostUtils } from "../hostUtils.js";
+import type { Config } from "../config.js";
+import type { ConsoleLogger } from "../consoleLogger.js";
+import type { HostUtils } from "../hostUtils.js";
 import type { State, Trace } from "../types.js";
 import type { Updater } from "../updater.js";
 

--- a/apps/wing-console/console/server/src/utils/format-wing-error.ts
+++ b/apps/wing-console/console/server/src/utils/format-wing-error.ts
@@ -3,7 +3,8 @@ import { relative, resolve } from "node:path";
 
 import { CompileError, PreflightError } from "@winglang/compiler";
 import { prettyPrintError } from "@winglang/sdk/lib/util/enhanced-error";
-import { CHARS_ASCII, emitDiagnostic, File, Label } from "codespan-wasm";
+import type { File, Label } from "codespan-wasm";
+import { CHARS_ASCII, emitDiagnostic } from "codespan-wasm";
 
 function offsetFromLineAndColumn(source: string, line: number, column: number) {
   const lines = source.split("\n");

--- a/apps/wing-console/console/ui/src/App.tsx
+++ b/apps/wing-console/console/ui/src/App.tsx
@@ -6,7 +6,8 @@ import {
 } from "@wingconsole/design-system";
 import type { Trace } from "@wingconsole/server";
 
-import { LayoutProvider, LayoutType } from "./layout/layout-provider.js";
+import type { LayoutType } from "./layout/layout-provider.js";
+import { LayoutProvider } from "./layout/layout-provider.js";
 import { trpc } from "./services/trpc.js";
 import { TestsContextProvider } from "./tests-context.js";
 

--- a/apps/wing-console/console/ui/src/Console.tsx
+++ b/apps/wing-console/console/ui/src/Console.tsx
@@ -1,7 +1,7 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { httpLink, wsLink, splitLink, createWSClient } from "@trpc/client";
-import { Mode } from "@wingconsole/design-system";
-import { Trace } from "@wingconsole/server";
+import type { Mode } from "@wingconsole/design-system";
+import type { Trace } from "@wingconsole/server";
 import { useEffect, useMemo } from "react";
 
 import { App } from "./App.js";

--- a/apps/wing-console/console/ui/src/features/api-interaction-view.tsx
+++ b/apps/wing-console/console/ui/src/features/api-interaction-view.tsx
@@ -1,9 +1,9 @@
-import { OpenApiSpec } from "@wingconsole/server/src/wingsdk";
+import type { OpenApiSpec } from "@wingconsole/server/src/wingsdk";
 import { memo, useCallback, useContext, useState } from "react";
 
 import { AppContext } from "../AppContext.js";
 import { useApi } from "../services/use-api.js";
-import { ApiResponse } from "../shared/api.js";
+import type { ApiResponse } from "../shared/api.js";
 import { ApiInteraction } from "../ui/api-interaction.js";
 
 export interface ApiViewProps {

--- a/apps/wing-console/console/ui/src/features/bucket-interaction-view.tsx
+++ b/apps/wing-console/console/ui/src/features/bucket-interaction-view.tsx
@@ -1,5 +1,6 @@
-import { TreeEntry } from "@wingconsole/design-system";
-import { FormEventHandler, memo, useCallback, useMemo, useState } from "react";
+import type { TreeEntry } from "@wingconsole/design-system";
+import type { FormEventHandler } from "react";
+import { memo, useCallback, useMemo, useState } from "react";
 
 import { useBucket } from "../services/use-bucket.js";
 import { BucketInteraction } from "../ui/bucket-interaction.js";

--- a/apps/wing-console/console/ui/src/features/console-logs-filters.tsx
+++ b/apps/wing-console/console/ui/src/features/console-logs-filters.tsx
@@ -1,6 +1,6 @@
 import { MagnifyingGlassIcon, NoSymbolIcon } from "@heroicons/react/24/outline";
 import { Button, Input, Listbox } from "@wingconsole/design-system";
-import { LogLevel } from "@wingconsole/server";
+import type { LogLevel } from "@wingconsole/server";
 import debounce from "lodash.debounce";
 import { memo, useCallback, useEffect, useState } from "react";
 

--- a/apps/wing-console/console/ui/src/features/console-logs.tsx
+++ b/apps/wing-console/console/ui/src/features/console-logs.tsx
@@ -4,7 +4,7 @@ import {
   XCircleIcon,
 } from "@heroicons/react/24/outline";
 import { useTheme, ResourceIcon } from "@wingconsole/design-system";
-import { LogEntry } from "@wingconsole/server";
+import type { LogEntry } from "@wingconsole/server";
 import classNames from "classnames";
 import Linkify from "linkify-react";
 import throttle from "lodash.throttle";

--- a/apps/wing-console/console/ui/src/features/dynamodb-table-interaction-view.tsx
+++ b/apps/wing-console/console/ui/src/features/dynamodb-table-interaction-view.tsx
@@ -2,10 +2,8 @@ import { useNotifications, Attribute } from "@wingconsole/design-system";
 import { memo, useCallback, useEffect, useState } from "react";
 
 import { useDynamodbTable } from "../services/use-dynamodb-table.js";
-import {
-  DynamodbTableInteraction,
-  RawRow,
-} from "../ui/dynamodb-table-interaction.js";
+import type { RawRow } from "../ui/dynamodb-table-interaction.js";
+import { DynamodbTableInteraction } from "../ui/dynamodb-table-interaction.js";
 
 export interface DynamodbTableInteractionViewProps {
   resourcePath: string;

--- a/apps/wing-console/console/ui/src/features/map-view.tsx
+++ b/apps/wing-console/console/ui/src/features/map-view.tsx
@@ -3,7 +3,7 @@ import {
   ResourceIcon,
   SpinnerLoader,
 } from "@wingconsole/design-system";
-import { MapNode } from "@wingconsole/server";
+import type { MapNode } from "@wingconsole/server";
 import classNames from "classnames";
 import { memo } from "react";
 

--- a/apps/wing-console/console/ui/src/features/queue-metadata-view.tsx
+++ b/apps/wing-console/console/ui/src/features/queue-metadata-view.tsx
@@ -3,7 +3,7 @@ import { memo, useCallback } from "react";
 
 import { useQueue } from "../services/use-queue.js";
 import { QueueMetadata } from "../ui/queue-metadata.js";
-import { MetadataNode } from "../ui/resource-metadata.js";
+import type { MetadataNode } from "../ui/resource-metadata.js";
 
 export interface QueueMetadataProps {
   node: MetadataNode;

--- a/apps/wing-console/console/ui/src/features/table-interaction-view.tsx
+++ b/apps/wing-console/console/ui/src/features/table-interaction-view.tsx
@@ -2,7 +2,8 @@ import { useNotifications, Attribute } from "@wingconsole/design-system";
 import { memo, useCallback, useEffect, useState } from "react";
 
 import { useTable } from "../services/use-table.js";
-import { Row, RowData, TableInteraction } from "../ui/table-interaction.js";
+import type { Row, RowData } from "../ui/table-interaction.js";
+import { TableInteraction } from "../ui/table-interaction.js";
 
 export interface TableInteractionViewProps {
   resourcePath: string;

--- a/apps/wing-console/console/ui/src/layout/layout-provider.tsx
+++ b/apps/wing-console/console/ui/src/layout/layout-provider.tsx
@@ -1,6 +1,7 @@
 import { createContext } from "react";
 
-import { DefaultLayout, LayoutProps } from "./default-layout.js";
+import type { LayoutProps } from "./default-layout.js";
+import { DefaultLayout } from "./default-layout.js";
 
 export enum LayoutType {
   Default = 1,

--- a/apps/wing-console/console/ui/src/layout/status-bar.tsx
+++ b/apps/wing-console/console/ui/src/layout/status-bar.tsx
@@ -1,5 +1,5 @@
 import { useTheme, Loader } from "@wingconsole/design-system";
-import { State } from "@wingconsole/server";
+import type { State } from "@wingconsole/server";
 import classNames from "classnames";
 
 import { AutoUpdater } from "../features/auto-updater.js";

--- a/apps/wing-console/console/ui/src/services/use-api.ts
+++ b/apps/wing-console/console/ui/src/services/use-api.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo } from "react";
 
-import { ApiRequest } from "../shared/api.js";
+import type { ApiRequest } from "../shared/api.js";
 
 import { trpc } from "./trpc.js";
 

--- a/apps/wing-console/console/ui/src/services/use-endpoints.ts
+++ b/apps/wing-console/console/ui/src/services/use-endpoints.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 
-import { EndpointItem } from "../shared/endpoint-item.js";
+import type { EndpointItem } from "../shared/endpoint-item.js";
 
 import { trpc } from "./trpc.js";
 

--- a/apps/wing-console/console/ui/src/services/use-explorer.tsx
+++ b/apps/wing-console/console/ui/src/services/use-explorer.tsx
@@ -1,8 +1,9 @@
 import { ResourceIcon } from "@wingconsole/design-system";
-import { ExplorerItem } from "@wingconsole/server";
+import type { ExplorerItem } from "@wingconsole/server";
 import { useCallback, useEffect } from "react";
 
-import { TreeMenuItem, useTreeMenuItems } from "../ui/use-tree-menu-items.js";
+import type { TreeMenuItem } from "../ui/use-tree-menu-items.js";
+import { useTreeMenuItems } from "../ui/use-tree-menu-items.js";
 
 import { trpc } from "./trpc.js";
 

--- a/apps/wing-console/console/ui/src/services/use-tests.ts
+++ b/apps/wing-console/console/ui/src/services/use-tests.ts
@@ -1,8 +1,8 @@
-import { inferRouterOutputs } from "@trpc/server";
-import { Router } from "@wingconsole/server";
+import type { inferRouterOutputs } from "@trpc/server";
+import type { Router } from "@wingconsole/server";
 import { useContext, useEffect, useState } from "react";
 
-import { TestItem, TestStatus } from "../shared/test-item.js";
+import type { TestItem, TestStatus } from "../shared/test-item.js";
 import { TestsContext } from "../tests-context.js";
 
 import { trpc } from "./trpc.js";

--- a/apps/wing-console/console/ui/src/shared/api.ts
+++ b/apps/wing-console/console/ui/src/shared/api.ts
@@ -1,5 +1,5 @@
 import { KeyValueItem } from "@wingconsole/design-system";
-import { OpenApiSpec } from "@wingconsole/server/src/wingsdk";
+import type { OpenApiSpec } from "@wingconsole/server/src/wingsdk";
 
 export const HTTP_METHODS = [
   "GET",

--- a/apps/wing-console/console/ui/src/shared/use-file-link.tsx
+++ b/apps/wing-console/console/ui/src/shared/use-file-link.tsx
@@ -1,4 +1,4 @@
-import { PropsWithChildren } from "react";
+import type { PropsWithChildren } from "react";
 
 import { trpc } from "../services/trpc.js";
 

--- a/apps/wing-console/console/ui/src/shared/use-terminal-history.ts
+++ b/apps/wing-console/console/ui/src/shared/use-terminal-history.ts
@@ -1,6 +1,6 @@
 import { useCallback, useState as useReactState } from "react";
 
-import { TerminalHistoryItem } from "./ternimal.js";
+import type { TerminalHistoryItem } from "./ternimal.js";
 
 export interface UseTerminalHistoryOptions {
   useState?: typeof useReactState;

--- a/apps/wing-console/console/ui/src/tests-context.tsx
+++ b/apps/wing-console/console/ui/src/tests-context.tsx
@@ -1,4 +1,5 @@
-import { PropsWithChildren, createContext, useState } from "react";
+import type { PropsWithChildren } from "react";
+import { createContext, useState } from "react";
 
 export const TestsContext = createContext<{
   showTests: boolean;

--- a/apps/wing-console/console/ui/src/ui/api-interaction.tsx
+++ b/apps/wing-console/console/ui/src/ui/api-interaction.tsx
@@ -13,11 +13,9 @@ import { createPersistentState } from "@wingconsole/use-persistent-state";
 import classNames from "classnames";
 import { memo, useCallback, useEffect, useId, useState } from "react";
 
-import { AppMode } from "../AppContext.js";
+import type { AppMode } from "../AppContext.js";
+import type { ApiRequest, ApiResponse, ApiRoute } from "../shared/api.js";
 import {
-  ApiRequest,
-  ApiResponse,
-  ApiRoute,
   getHeaderValues,
   getRoutesFromOpenApi,
   HTTP_HEADERS,

--- a/apps/wing-console/console/ui/src/ui/api-response-body-panel.tsx
+++ b/apps/wing-console/console/ui/src/ui/api-response-body-panel.tsx
@@ -1,7 +1,7 @@
 import { useTheme, JsonResponseInput } from "@wingconsole/design-system";
 import classNames from "classnames";
 
-import { ApiResponse } from "../shared/api.js";
+import type { ApiResponse } from "../shared/api.js";
 
 const getResponseColor: (status: number) => string = (status) => {
   if (status >= 200 && status < 300) {

--- a/apps/wing-console/console/ui/src/ui/api-response-headers-panel.tsx
+++ b/apps/wing-console/console/ui/src/ui/api-response-headers-panel.tsx
@@ -1,6 +1,6 @@
 import { KeyValueList, ResponseInput } from "@wingconsole/design-system";
 
-import { ApiResponseHeader } from "../shared/api.js";
+import type { ApiResponseHeader } from "../shared/api.js";
 
 export interface ApiHeadersPanelProps {
   headers: ApiResponseHeader[];

--- a/apps/wing-console/console/ui/src/ui/bucket-interaction.tsx
+++ b/apps/wing-console/console/ui/src/ui/bucket-interaction.tsx
@@ -3,6 +3,7 @@ import {
   ArrowTopRightOnSquareIcon,
   XMarkIcon,
 } from "@heroicons/react/24/outline";
+import type { TreeEntry } from "@wingconsole/design-system";
 import {
   Button,
   FilePreview,
@@ -10,19 +11,12 @@ import {
   ResponseInput,
   ToolbarButton,
   Tree,
-  TreeEntry,
   getPreviewType,
   useTheme,
 } from "@wingconsole/design-system";
 import classNames from "classnames";
-import {
-  FormEvent,
-  useCallback,
-  useContext,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
+import type { FormEvent } from "react";
+import { useCallback, useContext, useMemo, useRef, useState } from "react";
 
 import { LayoutContext, LayoutType } from "../layout/layout-provider.js";
 

--- a/apps/wing-console/console/ui/src/ui/bucket-metadata.tsx
+++ b/apps/wing-console/console/ui/src/ui/bucket-metadata.tsx
@@ -1,7 +1,7 @@
 import { useTheme, Attribute } from "@wingconsole/design-system";
 import classNames from "classnames";
 
-import { MetadataNode } from "./resource-metadata.js";
+import type { MetadataNode } from "./resource-metadata.js";
 
 export interface BucketMetadataProps {
   node: MetadataNode;

--- a/apps/wing-console/console/ui/src/ui/counter-metadata.tsx
+++ b/apps/wing-console/console/ui/src/ui/counter-metadata.tsx
@@ -2,7 +2,7 @@ import { useTheme, Attribute } from "@wingconsole/design-system";
 import classNames from "classnames";
 import { memo } from "react";
 
-import { MetadataNode } from "./resource-metadata.js";
+import type { MetadataNode } from "./resource-metadata.js";
 
 export interface CounterMetadataProps {
   node: MetadataNode;

--- a/apps/wing-console/console/ui/src/ui/dynamodb-table-interaction.tsx
+++ b/apps/wing-console/console/ui/src/ui/dynamodb-table-interaction.tsx
@@ -1,8 +1,8 @@
 import { PlusIcon, TrashIcon } from "@heroicons/react/24/outline";
+import type { Column } from "@wingconsole/design-system";
 import {
   SpinnerLoader,
   useTheme,
-  Column,
   getInputType,
   TableRow,
 } from "@wingconsole/design-system";

--- a/apps/wing-console/console/ui/src/ui/edge-item.tsx
+++ b/apps/wing-console/console/ui/src/ui/edge-item.tsx
@@ -1,5 +1,5 @@
 import classNames from "classnames";
-import { ElkExtendedEdge } from "elkjs/lib/elk.bundled.js";
+import type { ElkExtendedEdge } from "elkjs/lib/elk.bundled.js";
 import { motion } from "framer-motion";
 import { memo, useMemo, useState } from "react";
 

--- a/apps/wing-console/console/ui/src/ui/edge-metadata.tsx
+++ b/apps/wing-console/console/ui/src/ui/edge-metadata.tsx
@@ -14,7 +14,7 @@ import {
 import classNames from "classnames";
 import { useCallback, useMemo, useState } from "react";
 
-import { MetadataNode } from "./resource-metadata.js";
+import type { MetadataNode } from "./resource-metadata.js";
 
 export interface EdgeMetadataProps {
   source: MetadataNode;

--- a/apps/wing-console/console/ui/src/ui/elk-map-nodes.tsx
+++ b/apps/wing-console/console/ui/src/ui/elk-map-nodes.tsx
@@ -1,7 +1,9 @@
-import { useTheme, IconComponent } from "@wingconsole/design-system";
-import { BaseResourceSchema, NodeDisplay } from "@wingconsole/server";
+import type { IconComponent } from "@wingconsole/design-system";
+import { useTheme } from "@wingconsole/design-system";
+import type { BaseResourceSchema, NodeDisplay } from "@wingconsole/server";
 import classNames from "classnames";
-import { PropsWithChildren, memo, useMemo } from "react";
+import type { PropsWithChildren } from "react";
+import { memo, useMemo } from "react";
 
 const getResourceBackgroudColor = (
   resourceType: BaseResourceSchema["type"] | undefined,

--- a/apps/wing-console/console/ui/src/ui/elk-map.stories.tsx
+++ b/apps/wing-console/console/ui/src/ui/elk-map.stories.tsx
@@ -1,4 +1,4 @@
-import { Meta, StoryObj } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react";
 
 import { ElkMap } from "./elk-map.js";
 

--- a/apps/wing-console/console/ui/src/ui/elk-map.tsx
+++ b/apps/wing-console/console/ui/src/ui/elk-map.tsx
@@ -1,12 +1,13 @@
 import classNames from "classnames";
-import ELK, {
+import type {
   ElkExtendedEdge,
   ElkNode,
   LayoutOptions,
 } from "elkjs/lib/elk.bundled.js";
+import ELK from "elkjs/lib/elk.bundled.js";
 import { AnimatePresence, motion } from "framer-motion";
+import type { FC } from "react";
 import {
-  FC,
   Fragment,
   memo,
   useCallback,
@@ -18,12 +19,13 @@ import {
 } from "react";
 import { createPortal } from "react-dom";
 
-import { Edge } from "../shared/Edge.js";
-import { Node } from "../shared/Node.js";
+import type { Edge } from "../shared/Edge.js";
+import type { Node } from "../shared/Node.js";
 
 import { EdgeItem } from "./edge-item.js";
 import { useNodeStaticData } from "./use-node-static-data.js";
-import { ZoomPane, ZoomPaneRef, useZoomPane } from "./zoom-pane.js";
+import type { ZoomPaneRef } from "./zoom-pane.js";
+import { ZoomPane, useZoomPane } from "./zoom-pane.js";
 
 const durationClass = "duration-500";
 

--- a/apps/wing-console/console/ui/src/ui/endpoint-tree.tsx
+++ b/apps/wing-console/console/ui/src/ui/endpoint-tree.tsx
@@ -8,7 +8,7 @@ import {
 } from "@wingconsole/design-system";
 import classNames from "classnames";
 
-import { EndpointItem } from "../shared/endpoint-item.js";
+import type { EndpointItem } from "../shared/endpoint-item.js";
 
 import { NoEndpoints } from "./no-endpoints.js";
 

--- a/apps/wing-console/console/ui/src/ui/explorer.tsx
+++ b/apps/wing-console/console/ui/src/ui/explorer.tsx
@@ -9,12 +9,12 @@ import {
   ResourceIcon,
   ScrollableArea,
 } from "@wingconsole/design-system";
-import { ExplorerItem } from "@wingconsole/server";
+import type { ExplorerItem } from "@wingconsole/server";
 import classNames from "classnames";
 import { memo, useMemo } from "react";
 
 import { NoResources } from "./no-resources.js";
-import { TreeMenuItem } from "./use-tree-menu-items.js";
+import type { TreeMenuItem } from "./use-tree-menu-items.js";
 
 const renderTreeItems = (items: TreeMenuItem[]) => {
   return items.map((item) => {

--- a/apps/wing-console/console/ui/src/ui/function-metadata.tsx
+++ b/apps/wing-console/console/ui/src/ui/function-metadata.tsx
@@ -1,7 +1,7 @@
 import { useTheme, Attribute } from "@wingconsole/design-system";
 import classNames from "classnames";
 
-import { MetadataNode } from "./resource-metadata.js";
+import type { MetadataNode } from "./resource-metadata.js";
 
 export interface FunctionMetadataProps {
   node: MetadataNode;

--- a/apps/wing-console/console/ui/src/ui/map-controls.stories.tsx
+++ b/apps/wing-console/console/ui/src/ui/map-controls.stories.tsx
@@ -1,4 +1,4 @@
-import { ComponentStory, ComponentMeta } from "@storybook/react";
+import type { ComponentStory, ComponentMeta } from "@storybook/react";
 
 import { MapControls } from "./map-controls.js";
 import { ZoomPaneProvider } from "./zoom-pane.js";

--- a/apps/wing-console/console/ui/src/ui/redis-interaction.tsx
+++ b/apps/wing-console/console/ui/src/ui/redis-interaction.tsx
@@ -2,7 +2,7 @@ import { Attribute, useTheme } from "@wingconsole/design-system";
 import classNames from "classnames";
 import { useCallback, useEffect, useId, useRef } from "react";
 
-import { TerminalHistoryItem } from "../shared/ternimal.js";
+import type { TerminalHistoryItem } from "../shared/ternimal.js";
 
 const REDIS_PROMPT = "redis>";
 

--- a/apps/wing-console/console/ui/src/ui/resource-metadata.tsx
+++ b/apps/wing-console/console/ui/src/ui/resource-metadata.tsx
@@ -7,17 +7,17 @@ import {
   CubeTransparentIcon,
   CursorArrowRaysIcon,
 } from "@heroicons/react/24/outline";
+import type { IconComponent } from "@wingconsole/design-system";
 import {
   useTheme,
   InspectorSection,
   Pill,
-  IconComponent,
   ResourceIcon,
   getResourceIconComponent,
   Attribute,
   ScrollableArea,
 } from "@wingconsole/design-system";
-import { NodeDisplay } from "@wingconsole/server";
+import type { NodeDisplay } from "@wingconsole/server";
 import classNames from "classnames";
 import { memo, useCallback, useMemo, useState } from "react";
 

--- a/apps/wing-console/console/ui/src/ui/schedule-metadata.tsx
+++ b/apps/wing-console/console/ui/src/ui/schedule-metadata.tsx
@@ -1,7 +1,7 @@
 import { useTheme, Attribute } from "@wingconsole/design-system";
 import classNames from "classnames";
 
-import { MetadataNode } from "./resource-metadata.js";
+import type { MetadataNode } from "./resource-metadata.js";
 
 export interface ScheduleMetadataProps {
   node: MetadataNode;

--- a/apps/wing-console/console/ui/src/ui/table-interaction.stories.tsx
+++ b/apps/wing-console/console/ui/src/ui/table-interaction.stories.tsx
@@ -1,4 +1,4 @@
-import { Meta, StoryObj } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react";
 
 import { TableInteraction } from "./table-interaction.js";
 

--- a/apps/wing-console/console/ui/src/ui/table-interaction.tsx
+++ b/apps/wing-console/console/ui/src/ui/table-interaction.tsx
@@ -1,8 +1,8 @@
 import { PlusIcon, TrashIcon } from "@heroicons/react/24/outline";
+import type { Column } from "@wingconsole/design-system";
 import {
   SpinnerLoader,
   useTheme,
-  Column,
   TableRow,
   getInputType,
 } from "@wingconsole/design-system";

--- a/apps/wing-console/console/ui/src/ui/test-tree.tsx
+++ b/apps/wing-console/console/ui/src/ui/test-tree.tsx
@@ -17,7 +17,7 @@ import {
 import classNames from "classnames";
 import { useMemo } from "react";
 
-import { TestItem } from "../shared/test-item.js";
+import type { TestItem } from "../shared/test-item.js";
 
 import { NoTests } from "./no-tests.js";
 

--- a/apps/wing-console/console/ui/src/ui/use-node-static-data.tsx
+++ b/apps/wing-console/console/ui/src/ui/use-node-static-data.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 
-import { Node } from "../shared/Node.js";
+import type { Node } from "../shared/Node.js";
 
 export interface NodeStaticDataOptions<T> {
   /**

--- a/apps/wing-console/console/ui/src/ui/use-tree-menu-items.tsx
+++ b/apps/wing-console/console/ui/src/ui/use-tree-menu-items.tsx
@@ -1,4 +1,5 @@
-import { ReactNode, useCallback, useState } from "react";
+import type { ReactNode } from "react";
+import { useCallback, useState } from "react";
 
 export interface TreeMenuItem {
   id: string;

--- a/apps/wing-console/console/ui/src/ui/website-interaction.tsx
+++ b/apps/wing-console/console/ui/src/ui/website-interaction.tsx
@@ -2,7 +2,7 @@ import { ArrowTopRightOnSquareIcon } from "@heroicons/react/24/solid";
 import { Attribute, useTheme } from "@wingconsole/design-system";
 import classNames from "classnames";
 
-import { AppMode } from "../AppContext.js";
+import type { AppMode } from "../AppContext.js";
 
 export interface WebsiteInteractionProps {
   url: string;

--- a/apps/wing-console/console/ui/src/ui/zoom-pane.stories.tsx
+++ b/apps/wing-console/console/ui/src/ui/zoom-pane.stories.tsx
@@ -1,4 +1,4 @@
-import { ComponentStory, ComponentMeta } from "@storybook/react";
+import type { ComponentStory, ComponentMeta } from "@storybook/react";
 
 import { ZoomPane, ZoomPaneProvider } from "./zoom-pane.js";
 

--- a/apps/wing-console/console/ui/src/ui/zoom-pane.tsx
+++ b/apps/wing-console/console/ui/src/ui/zoom-pane.tsx
@@ -1,8 +1,6 @@
 import { Button, useTheme } from "@wingconsole/design-system";
 import classNames from "classnames";
 import {
-  DetailedHTMLProps,
-  HTMLAttributes,
   MouseEventHandler,
   createContext,
   forwardRef,
@@ -14,7 +12,8 @@ import {
   useRef,
   useState,
 } from "react";
-import { ReactNode } from "react";
+import type { DetailedHTMLProps, HTMLAttributes } from "react";
+import type { ReactNode } from "react";
 import { useEvent, useKeyPressEvent } from "react-use";
 
 import { MapControls } from "./map-controls.js";

--- a/apps/wing-console/console/ui/src/widgets/logs.tsx
+++ b/apps/wing-console/console/ui/src/widgets/logs.tsx
@@ -3,7 +3,7 @@ import {
   USE_EXTERNAL_THEME_COLOR,
   useTheme,
 } from "@wingconsole/design-system";
-import { LogEntry, LogLevel } from "@wingconsole/server";
+import type { LogEntry, LogLevel } from "@wingconsole/server";
 import classNames from "classnames";
 import { useState, useRef, useEffect, useCallback, memo } from "react";
 

--- a/apps/wing-console/tools/eslint-plugin/index.cjs
+++ b/apps/wing-console/tools/eslint-plugin/index.cjs
@@ -13,7 +13,6 @@ const base = {
     "plugin:unicorn/recommended",
     "plugin:@cloudy-ts/recommended",
   ],
-
   settings: {
     react: {
       version: "detect",
@@ -50,6 +49,7 @@ const base = {
       },
     ],
     "react/display-name": ["off"],
+    "@typescript-eslint/consistent-type-imports": "error",
   },
 };
 


### PR DESCRIPTION
From `@typescript-eslint/consistent-type-imports` docs:

> Enforce consistent usage of type imports.

> TypeScript allows specifying a type keyword on imports to indicate that the export exists only in the type system, not at runtime. This allows transpilers to drop imports without knowing the types of the dependencies.
