### PR TITLE
feat(console): fade out node borders

### DIFF
--- a/apps/wing-console/console/ui/src/ui/edge-item.tsx
+++ b/apps/wing-console/console/ui/src/ui/edge-item.tsx
@@ -49,7 +49,7 @@ export const EdgeItem = memo(
           (highlighted || selected) &&
             "stroke-[1.5px] stroke-sky-500 dark:stroke-sky-400",
           !highlighted && !selected && "stroke-slate-400 dark:stroke-slate-750",
-          fade && "opacity-40",
+          fade && "opacity-30",
           "transition-all",
         )}
       >
@@ -58,7 +58,7 @@ export const EdgeItem = memo(
             opacity: 0,
           }}
           animate={{
-            opacity: fade ? 0.3 : 1,
+            opacity: 1,
           }}
           style={{ translateX: offset.x, translateY: offset.y }}
           transition={{ duration: transitionDuration }}

--- a/apps/wing-console/console/ui/src/ui/elk-map-nodes.tsx
+++ b/apps/wing-console/console/ui/src/ui/elk-map-nodes.tsx
@@ -115,13 +115,9 @@ export const ContainerNode = memo(
             "px-3 py-2.5",
             "relative",
             "rounded-lg overflow-hidden",
-            "group-focus:border-sky-300 dark:group-focus:border-sky-500",
             "bg-white dark:bg-slate-700",
             {
               "rounded-b-none": open,
-              "border-b-0": open,
-              [theme.border3]: !selected,
-              "border-sky-300 dark:border-sky-500": selected,
             },
             "cursor-pointer",
           )}
@@ -136,8 +132,6 @@ export const ContainerNode = memo(
                   "transition-all",
                   "rounded-lg",
                   {
-                    [theme.border3]: !selected,
-                    "border-sky-300 dark:border-sky-500": selected,
                     "opacity-30": fade,
                   },
                 )}
@@ -188,6 +182,7 @@ export const ContainerNode = memo(
           <div
             className={classNames("flex-1 flex items-stretch", "border-t", {
               [theme.border3]: !selected,
+              "border-opacity-30": fade,
               "border-sky-200 dark:border-sky-400": selected,
             })}
           >
@@ -208,6 +203,7 @@ export const ContainerNode = memo(
             "border",
             selected && "border-sky-500 dark:border-sky-500",
             !selected && "border-slate-300 dark:border-slate-700",
+            fade && "border-opacity-30",
             "shadow-sm",
           )}
         ></div>


### PR DESCRIPTION
Map nodes in the Console will have their borders faded out in order to allow focusing on the selected node and their relevant connections.