### PR TITLE
chore(cli): private-api template make consumers for tf-aws only

### DIFF
--- a/apps/wing/project-templates/wing/private-api/main.w
+++ b/apps/wing/project-templates/wing/private-api/main.w
@@ -1,5 +1,6 @@
 bring cloud;
 bring http;
+bring util;
 
 /**
  * The example below is a simple note-taking app.
@@ -95,34 +96,36 @@ bring http;
 let noteService = new NoteService();
 
 // Consumer functions (not required for the app to work, but useful for testing)
-new cloud.Function(inflight (event: str?) => {
-  if let event = event {
-    let parts = event.split(":");
-    let name = parts.at(0);
-    let note = parts.at(1);
-
-    let response = http.post("{noteService.api.url}/note/{name}", {
-      body: "{note}"
-    });
-    return response.body;
-  }
-
-  return "event is required `NAME:NOTE`";
-}) as "Consumer-POST";
-
-new cloud.Function(inflight (event: str?) => {
-  if let event = event {
-    let response = http.delete("{noteService.api.url}/note/{event}");
-    return response.body;
-  }
-
-  return "event is required `NAME`";
-}) as "Consumer-DELETE";
-
-new cloud.Function(inflight (event: str?) => {
-  if let event = event {
-    return http.get("{noteService.api.url}/note?name={event}").body;
-  }
-
-  return "event is required `NAME`";
-}) as "Consumer-GET";
+if util.env("WING_TARGET") == "tf-aws" {
+  new cloud.Function(inflight (event: str?) => {
+    if let event = event {
+      let parts = event.split(":");
+      let name = parts.at(0);
+      let note = parts.at(1);
+  
+      let response = http.post("{noteService.api.url}/note/{name}", {
+        body: "{note}"
+      });
+      return response.body;
+    }
+  
+    return "event is required `NAME:NOTE`";
+  }) as "Consumer-PUT";
+  
+  new cloud.Function(inflight (event: str?) => {
+    if let event = event {
+      let response = http.delete("{noteService.api.url}/note/{event}");
+      return response.body;
+    }
+  
+    return "event is required `NAME`";
+  }) as "Consumer-DELETE";
+  
+  new cloud.Function(inflight (event: str?) => {
+    if let event = event {
+      return http.get("{noteService.api.url}/note?name={event}").body;
+    }
+  
+    return "event is required `NAME`";
+  }) as "Consumer-GET";
+}


### PR DESCRIPTION
I promise this is the last change for the Workshop tomorrow 😁 

Make the consumer functions only deploy if using `tf-aws` makes running this in the sim less confusing.

## Checklist

- [ ] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [ ] Description explains motivation and solution
- [ ] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
