### PR TITLE
feat(sdk): expose `endpoint` for `sim.DynamodbTable`

### DIFF
--- a/libs/wingsdk/src/target-sim/dynamodb-table.inflight.ts
+++ b/libs/wingsdk/src/target-sim/dynamodb-table.inflight.ts
@@ -30,6 +30,7 @@ export class DynamodbTable
     process.env.WING_DYNAMODB_IMAGE ?? "amazon/dynamodb-local:2.0.0";
   private readonly context: ISimulatorContext;
   private client?: DynamoDBClient;
+  private _endpoint?: string;
 
   public constructor(
     private props: DynamodbTableSchema["props"],
@@ -51,6 +52,8 @@ export class DynamodbTable
         containerPort: "8000",
       });
 
+      this._endpoint = `http://0.0.0.0:${hostPort}`;
+
       // dynamodb url based on host port
       this.client = new DynamoDBClient({
         region: "local",
@@ -58,7 +61,7 @@ export class DynamodbTable
           accessKeyId: "x",
           secretAccessKey: "y",
         },
-        endpoint: `http://0.0.0.0:${hostPort}`,
+        endpoint: this._endpoint,
       });
 
       await this.createTable();
@@ -75,10 +78,22 @@ export class DynamodbTable
     this.client?.destroy();
     // stop the dynamodb container
     await runCommand("docker", ["rm", "-f", this.containerName]);
+    this._endpoint = undefined;
   }
 
   public async save(): Promise<void> {}
 
+  /**
+   * Returns the local endpoint of the DynamoDB table.
+   */
+  public async endpoint(): string {
+    if (!this._endpoint) {
+      throw new Error("DynamoDB hasn't been started");
+    }
+    
+    return this._endpoint;
+  }
+  
   public async _rawClient(): Promise<DynamoDBClient> {
     if (this.client) {
       return this.client;


### PR DESCRIPTION
Allow obtaining the endpoint used by the local DynamoDB service. This is needed in order to be able to create clients.

## Checklist

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [ ] Tests added (always)
- [x] Docs updated (only required for features)
- [x] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
