### PR TITLE
feat: add color property to display info object

### DIFF
--- a/apps/wing-console/console/design-system/src/utils/colors.ts
+++ b/apps/wing-console/console/design-system/src/utils/colors.ts
@@ -1,0 +1,12 @@
+export type Colors =
+  | "orange"
+  | "sky"
+  | "emerald"
+  | "lime"
+  | "pink"
+  | "amber"
+  | "cyan"
+  | "purple"
+  | "red"
+  | "violet"
+  | "slate";

--- a/apps/wing-console/console/design-system/src/utils/icon-utils.ts
+++ b/apps/wing-console/console/design-system/src/utils/icon-utils.ts
@@ -30,6 +30,8 @@ import { DynamoDBIcon } from "../icons/dynamodb-icon.js";
 import { ReactIcon } from "../icons/react-icon.js";
 import { RedisIcon } from "../icons/redis-icon.js";
 
+import type { Colors } from "./colors.js";
+
 const isTest = /(\/test$|\/test:([^/\\])+$)/;
 const isTestHandler = /(\/test$|\/test:.*\/Handler$)/;
 
@@ -93,106 +95,162 @@ export const getResourceIconComponent = (
   }
 };
 
+interface ColorSet {
+  default: string;
+  groupHover: string;
+  forceDarken: string;
+}
+
+const colors: Record<Colors, ColorSet> = {
+  orange: {
+    default: "text-orange-500 dark:text-orange-400",
+    groupHover: "group-hover:text-orange-600 dark:group-hover:text-orange-300",
+    forceDarken: "text-orange-600 dark:text-orange-300",
+  },
+  sky: {
+    default: "text-sky-500 dark:text-sky-400",
+    groupHover: "group-hover:text-sky-600 dark:group-hover:text-sky-300",
+    forceDarken: "text-sky-600 dark:text-sky-300",
+  },
+  emerald: {
+    default: "text-emerald-500 dark:text-emerald-400",
+    groupHover:
+      "group-hover:text-emerald-600 dark:group-hover:text-emerald-300",
+    forceDarken: "text-emerald-600 dark:text-emerald-300",
+  },
+  lime: {
+    default: "text-lime-500 dark:text-lime-400",
+    groupHover: "group-hover:text-lime-600 dark:group-hover:text-lime-300",
+    forceDarken: "text-lime-600 dark:text-lime-300",
+  },
+  pink: {
+    default: "text-pink-500 dark:text-pink-400",
+    groupHover: "group-hover:text-pink-600 dark:group-hover:text-pink-300",
+    forceDarken: "text-pink-600 dark:text-pink-300",
+  },
+  amber: {
+    default: "text-amber-500 dark:text-amber-400",
+    groupHover: "group-hover:text-amber-600 dark:group-hover:text-amber-300",
+    forceDarken: "text-amber-600 dark:text-amber-300",
+  },
+  cyan: {
+    default: "text-cyan-500 dark:text-cyan-400",
+    groupHover: "group-hover:text-cyan-600 dark:group-hover:text-cyan-300",
+    forceDarken: "text-cyan-600 dark:text-cyan-300",
+  },
+  purple: {
+    default: "text-purple-500 dark:text-purple-400",
+    groupHover: "group-hover:text-purple-600 dark:group-hover:text-purple-300",
+    forceDarken: "text-purple-600 dark:text-purple-300",
+  },
+  red: {
+    default: "text-red-700 dark:text-red-400",
+    groupHover: "group-hover:text-red-700 dark:group-hover:text-red-300",
+    forceDarken: "text-red-700 dark:text-red-300",
+  },
+  violet: {
+    default: "text-violet-700 dark:text-violet-400",
+    groupHover: "group-hover:text-violet-700 dark:group-hover:text-violet-300",
+    forceDarken: "text-violet-700 dark:text-violet-300",
+  },
+  slate: {
+    default: "text-slate-500 dark:text-slate-400",
+    groupHover: "group-hover:text-slate-600 dark:group-hover:text-slate-300",
+    forceDarken: "text-slate-600 dark:text-slate-300",
+  },
+};
+
 export const getResourceIconColors = (options: {
   resourceType: string | undefined;
   darkenOnGroupHover?: boolean;
   forceDarken?: boolean;
+  color?: Colors;
 }) => {
   switch (options.resourceType) {
     case "@winglang/sdk.cloud.Bucket": {
       return [
-        "text-orange-500 dark:text-orange-400",
-        options.darkenOnGroupHover &&
-          "group-hover:text-orange-600 dark:group-hover:text-orange-300",
-        options.forceDarken && "text-orange-600 dark:text-orange-300",
+        colors.orange.default,
+        options.darkenOnGroupHover && colors.orange.groupHover,
+        options.forceDarken && colors.orange.forceDarken,
       ];
     }
     case "@winglang/sdk.cloud.Function": {
       return [
-        "text-sky-500 dark:text-sky-400",
-        options.darkenOnGroupHover &&
-          "group-hover:text-sky-600 dark:group-hover:text-sky-300",
-        options.forceDarken && "text-sky-600 dark:text-sky-300",
+        colors.sky.default,
+        options.darkenOnGroupHover && colors.sky.groupHover,
+        options.forceDarken && colors.sky.forceDarken,
       ];
     }
     case "@winglang/sdk.cloud.Queue": {
       return [
-        "text-emerald-500 dark:text-emerald-400",
-        options.darkenOnGroupHover &&
-          "group-hover:text-emerald-600 dark:group-hover:text-emerald-300",
-        options.forceDarken && "text-emerald-600 dark:text-emerald-300",
+        colors.emerald.default,
+        options.darkenOnGroupHover && colors.emerald.groupHover,
+        options.forceDarken && colors.emerald.forceDarken,
       ];
     }
     case "@winglang/sdk.cloud.Counter": {
       return [
-        "text-lime-500 dark:text-lime-400",
-        options.darkenOnGroupHover &&
-          "group-hover:text-lime-600 dark:group-hover:text-lime-300",
-        options.forceDarken && "text-lime-600 dark:text-lime-300",
+        colors.lime.default,
+        options.darkenOnGroupHover && colors.lime.groupHover,
+        options.forceDarken && colors.lime.forceDarken,
       ];
     }
     case "@winglang/sdk.cloud.Topic": {
       return [
-        "text-pink-500 dark:text-pink-400",
-        options.darkenOnGroupHover &&
-          "group-hover:text-pink-600 dark:group-hover:text-pink-300",
-        options.forceDarken && "text-pink-600 dark:text-pink-300",
+        colors.pink.default,
+        options.darkenOnGroupHover && colors.pink.groupHover,
+        options.forceDarken && colors.pink.forceDarken,
       ];
     }
     case "@winglang/sdk.cloud.Api": {
       return [
-        "text-amber-500 dark:text-amber-400",
-        options.darkenOnGroupHover &&
-          "group-hover:text-amber-600 dark:group-hover:text-amber-300",
-        options.forceDarken && "text-amber-600 dark:text-amber-300",
+        colors.amber.default,
+        options.darkenOnGroupHover && colors.amber.groupHover,
+        options.forceDarken && colors.amber.forceDarken,
       ];
     }
     case "@winglang/sdk.ex.Table": {
       return [
-        "text-cyan-500 dark:text-cyan-400",
-        options.darkenOnGroupHover &&
-          "group-hover:text-cyan-600 dark:group-hover:text-cyan-300",
-        options.forceDarken && "text-cyan-600 dark:text-cyan-300",
+        colors.cyan.default,
+        options.darkenOnGroupHover && colors.cyan.groupHover,
+        options.forceDarken && colors.cyan.forceDarken,
       ];
     }
     case "@winglang/sdk.cloud.Schedule": {
       return [
-        "text-purple-500 dark:text-purple-400",
-        options.darkenOnGroupHover &&
-          "group-hover:text-purple-600 dark:group-hover:text-purple-300",
-        options.forceDarken && "text-purple-600 dark:text-purple-300",
+        colors.purple.default,
+        options.darkenOnGroupHover && colors.purple.groupHover,
+        options.forceDarken && colors.purple.forceDarken,
       ];
     }
     case "@winglang/sdk.ex.Redis": {
       return [
-        "text-red-700 dark:text-red-400",
-        options.darkenOnGroupHover &&
-          "group-hover:text-red-700 dark:group-hover:text-red-300",
-        options.forceDarken && "text-red-700 dark:text-red-300",
+        colors.red.default,
+        options.darkenOnGroupHover && colors.red.groupHover,
+        options.forceDarken && colors.red.forceDarken,
       ];
     }
     case "@winglang/sdk.cloud.Website": {
       return [
-        "text-violet-700 dark:text-violet-400",
-        options.darkenOnGroupHover &&
-          "group-hover:text-violet-700 dark:group-hover:text-violet-300",
-        options.forceDarken && "text-violet-700 dark:text-violet-300",
+        colors.violet.default,
+        options.darkenOnGroupHover && colors.violet.groupHover,
+        options.forceDarken && colors.violet.forceDarken,
       ];
     }
     case "@winglang/sdk.ex.ReactApp": {
       return [
-        "text-sky-500 dark:text-sky-400",
-        options.darkenOnGroupHover &&
-          "group-hover:text-sky-600 dark:group-hover:text-sky-300",
-        options.forceDarken && "text-sky-600 dark:text-sky-300",
+        colors.sky.default,
+        options.darkenOnGroupHover && colors.sky.groupHover,
+        options.forceDarken && colors.sky.forceDarken,
       ];
     }
     default: {
+      let color: Colors =
+        options.color && colors[options.color] ? options.color : "slate";
       return [
-        "text-slate-500 dark:text-slate-400",
-        options.darkenOnGroupHover &&
-          "group-hover:text-slate-600 dark:group-hover:text-slate-300",
-        options.forceDarken && "text-slate-600 dark:text-slate-300",
+        colors[color].default,
+        options.darkenOnGroupHover && colors[color].groupHover,
+        options.forceDarken && colors[color].forceDarken,
       ];
     }
   }

--- a/apps/wing-console/console/server/src/router/app.ts
+++ b/apps/wing-console/console/server/src/router/app.ts
@@ -263,6 +263,7 @@ export const createAppRouter = () => {
                 id: sourceNode.id,
                 path: sourceNode.path,
                 type: getResourceType(sourceNode, simulator),
+                display: sourceNode.display,
               };
             })
             .filter(({ path }) => {
@@ -283,6 +284,7 @@ export const createAppRouter = () => {
                 id: targetNode.id,
                 path: targetNode.path,
                 type: getResourceType(targetNode, simulator),
+                display: targetNode.display,
               };
             })
             .filter(({ path }) => {

--- a/apps/wing-console/console/server/src/utils/constructTreeNodeMap.ts
+++ b/apps/wing-console/console/server/src/utils/constructTreeNodeMap.ts
@@ -5,6 +5,7 @@ export interface NodeDisplay {
   description?: string;
   sourceModule?: string;
   hidden?: boolean;
+  color?: string;
 }
 
 export interface NodeConnection {

--- a/apps/wing-console/console/ui/src/features/map-view.tsx
+++ b/apps/wing-console/console/ui/src/features/map-view.tsx
@@ -45,6 +45,7 @@ const Node = memo(
             <ResourceIcon
               resourceType={node.data?.type}
               resourcePath={node.data?.path}
+              color={node.data?.display?.color}
               solid
               {...props}
             />

--- a/apps/wing-console/console/ui/src/services/use-explorer.tsx
+++ b/apps/wing-console/console/ui/src/services/use-explorer.tsx
@@ -18,6 +18,7 @@ const createTreeMenuItemFromExplorerTreeItem = (
         resourceType={item.type}
         resourcePath={item.id}
         className="w-4 h-4"
+        color={item.display?.color}
       />
     ) : undefined,
     children: item.childItems?.map((item) =>

--- a/apps/wing-console/console/ui/src/ui/edge-metadata.tsx
+++ b/apps/wing-console/console/ui/src/ui/edge-metadata.tsx
@@ -109,6 +109,7 @@ export const EdgeMetadata = ({
                     className="w-4 h-4"
                     resourceType={source.type}
                     resourcePath={source.path}
+                    color={source.display?.color}
                   />
                 </div>
                 <div className="truncate">{source.id}</div>
@@ -132,6 +133,7 @@ export const EdgeMetadata = ({
                     className="w-4 h-4"
                     resourceType={target.type}
                     resourcePath={target.path}
+                    color={target.display?.color}
                   />
                 </div>
                 <div className="truncate">{target.id}</div>

--- a/apps/wing-console/console/ui/src/ui/elk-map-nodes.tsx
+++ b/apps/wing-console/console/ui/src/ui/elk-map-nodes.tsx
@@ -1,49 +1,65 @@
 import type { IconComponent } from "@wingconsole/design-system";
 import { useTheme } from "@wingconsole/design-system";
+import type { Colors } from "@wingconsole/design-system/src/utils/colors";
 import type { BaseResourceSchema, NodeDisplay } from "@wingconsole/server";
 import classNames from "classnames";
 import type { PropsWithChildren } from "react";
 import { memo, useMemo } from "react";
 
+const colorSet: Record<Colors, string> = {
+  orange: "bg-orange-500 dark:bg-orange-600",
+  sky: "bg-sky-500 dark:bg-sky-600",
+  emerald: "bg-emerald-500 dark:bg-emerald-600",
+  lime: "bg-lime-500 dark:bg-lime-600",
+  pink: "bg-pink-500 dark:bg-pink-600",
+  amber: "bg-amber-500 dark:bg-amber-600",
+  cyan: "bg-cyan-500 dark:bg-cyan-600",
+  purple: "bg-purple-500 dark:bg-purple-600",
+  red: "bg-red-700 dark:bg-red-600",
+  violet: "bg-violet-500 dark:bg-violet-600",
+  slate: "bg-slate-400 dark:bg-slate-600",
+};
+
 const getResourceBackgroudColor = (
   resourceType: BaseResourceSchema["type"] | undefined,
+  color: Colors = "slate",
 ) => {
   switch (resourceType) {
     case "@winglang/sdk.cloud.Bucket": {
-      return "bg-orange-500 dark:bg-orange-600";
+      return colorSet.orange;
     }
     case "@winglang/sdk.cloud.Function": {
-      return "bg-sky-500 dark:bg-sky-600";
+      return colorSet.sky;
     }
     case "@winglang/sdk.cloud.Queue": {
-      return "bg-emerald-500 dark:bg-emerald-600";
+      return colorSet.emerald;
     }
     case "@winglang/sdk.cloud.Counter": {
-      return "bg-lime-500 dark:bg-lime-600";
+      return colorSet.lime;
     }
     case "@winglang/sdk.cloud.Topic": {
-      return "bg-pink-500 dark:bg-pink-600";
+      return colorSet.pink;
     }
     case "@winglang/sdk.cloud.Api": {
-      return "bg-amber-500 dark:bg-amber-600";
+      return colorSet.amber;
     }
     case "@winglang/sdk.ex.Table": {
-      return "bg-cyan-500 dark:bg-cyan-600";
+      return colorSet.cyan;
     }
     case "@winglang/sdk.cloud.Schedule": {
-      return "bg-purple-500 dark:bg-purple-600";
+      return colorSet.purple;
     }
     case "@winglang/sdk.ex.Redis": {
-      return "bg-red-700 dark:bg-red-600";
+      return colorSet.red;
     }
     case "@winglang/sdk.cloud.Website": {
-      return "bg-violet-500 dark:bg-violet-600";
+      return colorSet.violet;
     }
     case "@winglang/sdk.ex.ReactApp": {
-      return "bg-sky-500 dark:bg-sky-600";
+      return colorSet.sky;
     }
     default: {
-      return "bg-slate-400 dark:bg-slate-600";
+      return colorSet[color] ?? colorSet.slate;
     }
   }
 };
@@ -79,8 +95,8 @@ export const ContainerNode = memo(
   }: PropsWithChildren<ContainerNodeProps>) => {
     const { theme } = useTheme();
     const bgColor = useMemo(
-      () => getResourceBackgroudColor(resourceType),
-      [resourceType],
+      () => getResourceBackgroudColor(resourceType, display?.color as Colors),
+      [resourceType, display?.color],
     );
 
     const compilerNamed = useMemo(() => {

--- a/apps/wing-console/console/ui/src/ui/explorer.tsx
+++ b/apps/wing-console/console/ui/src/ui/explorer.tsx
@@ -44,7 +44,7 @@ const createTreeMenuItemFromExplorerTreeItem = (
         resourceType={item.type}
         resourcePath={item.label}
         className="w-4 h-4"
-        // darkenOnGroupHover
+        color={item.display?.color}
       />
     ) : undefined,
     children: item.childItems?.map((item) =>

--- a/apps/wing-console/console/ui/src/ui/resource-metadata.tsx
+++ b/apps/wing-console/console/ui/src/ui/resource-metadata.tsx
@@ -125,6 +125,7 @@ interface Relationship {
   id: string;
   path: string;
   type: string;
+  display?: NodeDisplay;
 }
 
 export interface MetadataNode {
@@ -252,6 +253,7 @@ export const ResourceMetadata = memo(
                 resourceType={relationship.type}
                 resourcePath={relationship.path}
                 className="w-4 h-4"
+                color={relationship.display?.color}
               />
             ),
           })),
@@ -269,6 +271,7 @@ export const ResourceMetadata = memo(
                 resourceType={relationship.type}
                 resourcePath={relationship.path}
                 className="w-4 h-4"
+                color={relationship.display?.color}
               />
             ),
           })),
@@ -309,6 +312,7 @@ export const ResourceMetadata = memo(
               className="w-6 h-6"
               resourceType={node.type}
               resourcePath={node.path}
+              color={node.display?.color}
             />
           </div>
 
@@ -322,7 +326,7 @@ export const ResourceMetadata = memo(
         {resourceUI.data && resourceUI.data.length > 0 && (
           <InspectorSection
             icon={CubeIcon}
-            text="Properties"
+            text={(node.display?.title || node.id) ?? "Properties"}
             open={openInspectorSections.includes("resourceUI")}
             onClick={() => toggleInspectorSection("resourceUI")}
             headingClassName="pl-2"

--- a/libs/wingsdk/src/core/tree.ts
+++ b/libs/wingsdk/src/core/tree.ts
@@ -4,6 +4,7 @@ import { IConstruct } from "constructs";
 import { App } from "./app";
 import { IResource, Node, Resource } from "../std";
 import { VisualComponent } from "../ui/base";
+import { Colors, isOfTypeColors } from "../ui/colors";
 
 export const TREE_FILE_PATH = "tree.json";
 
@@ -75,6 +76,11 @@ export interface DisplayInfo {
    * @default - no UI components
    */
   readonly ui?: any[]; // UIComponent
+
+  /**
+   * The color of the resource in the UI.
+   */
+  readonly color?: Colors;
 }
 
 /** @internal */
@@ -206,13 +212,20 @@ function synthDisplay(construct: IConstruct): DisplayInfo | undefined {
     }
   }
 
-  if (display.description || display.title || display.hidden || ui) {
+  if (
+    display.description ||
+    display.title ||
+    display.hidden ||
+    ui ||
+    display.color
+  ) {
     return {
       title: display.title,
       description: display.description,
       hidden: display.hidden,
       sourceModule: display.sourceModule,
       ui: ui.length > 0 ? ui : undefined,
+      color: isOfTypeColors(display.color) ? display.color : undefined,
     };
   }
   return;

--- a/libs/wingsdk/src/std/node.ts
+++ b/libs/wingsdk/src/std/node.ts
@@ -62,6 +62,11 @@ export class Node {
    */
   public hidden?: boolean;
 
+  /**
+   * The color of the construct for display purposes.
+   */
+  public color?: string;
+
   private readonly _constructsNode: ConstructsNode;
   private readonly _connections: Connections;
   private _app: IApp | undefined;

--- a/libs/wingsdk/src/ui/colors.ts
+++ b/libs/wingsdk/src/ui/colors.ts
@@ -1,0 +1,28 @@
+export type Colors =
+  | "orange"
+  | "sky"
+  | "emerald"
+  | "lime"
+  | "pink"
+  | "amber"
+  | "cyan"
+  | "purple"
+  | "red"
+  | "violet"
+  | "slate";
+
+export const isOfTypeColors = (keyInput?: string): keyInput is Colors => {
+  return [
+    "orange",
+    "sky",
+    "emerald",
+    "lime",
+    "pink",
+    "amber",
+    "cyan",
+    "purple",
+    "red",
+    "violet",
+    "slate",
+  ].includes(keyInput || "");
+};

--- a/libs/wingsdk/src/ui/index.ts
+++ b/libs/wingsdk/src/ui/index.ts
@@ -1,4 +1,5 @@
 export * from "./base";
 export * from "./button";
+export * from "./colors";
 export * from "./field";
 export * from "./section";


### PR DESCRIPTION
Add ability to customize a custom resource color in the Console.

<img width="690" alt="Screenshot 2024-03-11 at 21 36 33" src="https://github.com/winglang/wing/assets/2538825/265f1f87-1afa-4bf6-9c20-40ec85c8be4f">


## Checklist

- [ ] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [ ] Description explains motivation and solution
- [ ] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
