### PR TITLE
chore: turbo missing cache output for wing-fixture

### DIFF
--- a/examples/wing-fixture/turbo.json
+++ b/examples/wing-fixture/turbo.json
@@ -4,7 +4,8 @@
     "pipeline": {
       "compile": {
         "dependsOn": ["^compile"],
-        "inputs": ["**/*.w", "**/*.js", "**/*.ts"]
+        "inputs": ["**/*.w", "**/*.js", "**/*.ts"],
+        "outputs": ["target/wing-fixture.wsim/**"]
       },
       "topo": {}
     }


### PR DESCRIPTION
This was causing some workflows on this repo to fail because files were missing after a cache hit on `@winglibs/testfixture:compile`

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
