### PR TITLE
chore: fix nondeterministic bucket sim test

### DIFF
--- a/libs/wingsdk/test/target-sim/__snapshots__/bucket.test.ts.snap
+++ b/libs/wingsdk/test/target-sim/__snapshots__/bucket.test.ts.snap
@@ -733,9 +733,5 @@ exports[`update an object in bucket 1`] = `
   "InvokeAsync (payload="1.txt").",
   "Put (key=1.txt).",
   "Put (key=1.txt).",
-  "@winglang/sdk.sim.EventMapping deleted.",
-  "@winglang/sdk.cloud.Function deleted.",
-  "@winglang/sdk.cloud.Bucket deleted.",
-  "@winglang/sdk.cloud.Topic deleted.",
 ]
 `;

--- a/libs/wingsdk/test/target-sim/bucket.test.ts
+++ b/libs/wingsdk/test/target-sim/bucket.test.ts
@@ -52,8 +52,8 @@ test("update an object in bucket", async () => {
   await waitUntilTraceCount(s, 5, (trace) => trace.data.message.includes(KEY));
 
   // THEN
-  await s.stop();
   expect(listMessages(s)).toMatchSnapshot();
+  await s.stop();
 });
 
 test("bucket on event creates 3 topics, and sends the right event and key in the event handlers", async () => {


### PR DESCRIPTION
Fixes #5895

The goal of the test is to make sure we don't emit events for object creation twice. We can just avoid the problem of stopping the sim by doing it after getting the snapshot fails.

No matter what, the sim will be stopped due to the way the test SimApp works.

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
