### PR TITLE
chore: fix mutation workflow comment and wrongly updating different PRs

### DIFF
--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -27,7 +27,7 @@ jobs:
         id: download-artifacts
         uses: dawidd6/action-download-artifact@v3
         with:
-          github_token: ${{secrets.GITHUB_TOKEN}}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           run_id: ${{ github.event.workflow_run.id }}
           name: .+\.diff$
           name_is_regexp: true
@@ -37,7 +37,7 @@ jobs:
       - uses: marocchino/action-workflow_run-status@54b6e87d6cb552fc5f36dbe9a722a6048725917a
         if: steps.download-artifacts.outputs.found_artifact == 'true'
         with:
-          github_token: ${{secrets.GITHUB_TOKEN}}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Token check
         if: steps.download-artifacts.outputs.found_artifact == 'true'
@@ -50,11 +50,33 @@ jobs:
             It requires private repo read/write permissions." >> $GITHUB_STEP_SUMMARY
             exit 1
           fi
+      
+      - name: Find associated pull request
+        id: pr
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const mainRepo = context.payload.workflow_run.repository.full_name;
+            const headBranch = context.payload.workflow_run.head_branch;
+            console.log(`Searching for pull request in ${mainRepo} with head branch ${headBranch}`);
+
+            const response = await github.rest.search.issuesAndPullRequests({
+              q: `repo:${mainRepo} is:pr is:open head:${headBranch}`,
+              per_page: 1,
+            });
+            const prs = response.data.items;
+            if (prs.length < 1) {
+              throw new Error('No pull request found for the commit');
+            }
+            const prNumber = prs[0].number;
+            console.log(`Pull request number is ${prNumber}`);
+            return prNumber;
 
       - name: Unstable mutation comment
         if: steps.download-artifacts.outputs.found_artifact == 'true' && startsWith(github.event.workflow_run.head_commit.message, format('chore{0} self mutation', ':'))
         uses: thollander/actions-comment-pull-request@v2
         with:
+          pr_number: ${{ steps.pr.outputs.result }}
           mode: recreate
           message: |
             ### :x: Unstable Self-Mutation :x:
@@ -74,8 +96,7 @@ jobs:
 
       - name: Disable Git Hooks
         if: steps.download-artifacts.outputs.found_artifact == 'true'
-        run: |
-          git config --global core.hooksPath /dev/null
+        run: git config --global core.hooksPath /dev/null
 
       - name: Update PR Branch
         uses: actions/github-script@v7
@@ -84,27 +105,13 @@ jobs:
         with:
           github-token: ${{ secrets.MUTATION_TOKEN }}
           script: |
-            // use API to get the PR data since we can't rely on the context across forks
-            let head = context.payload.workflow_run.head_branch;
-            if (`${context.repo.owner}/${context.repo.repo}` !== context.payload.workflow_run.head_repository.full_name) {
-              if (context.payload.workflow_run.head_repository.name === context.repo.repo) {
-                // head is in the short form since the repo name is the same
-                head = `${context.payload.workflow_run.head_repository.owner.login}:${head}`;
-              } else {
-                head = `${context.payload.workflow_run.head_repository.full_name}:${head}`;
-              }
-            }
-
-            const pulls = await github.rest.pulls.list({
-              per_page: 1,
+            const prContextData = await github.rest.pulls.get({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              head,
+              pull_number: ${{ steps.pr.outputs.result }}
             });
-
-            const prContextData = pulls.data[0];
-            const prNumber = prContextData.number;
-            const originalSha = prContextData.head.sha;
+            const prNumber = prContextData.data.number;
+            const originalSha = prContextData.data.head.sha;
 
             try {
               console.log("Updating PR branch");
@@ -134,8 +141,6 @@ jobs:
               // That's fine, we tried our best
               console.warn(error);
             }
-
-            return prNumber;
 
       - name: Checkout Workflow Branch
         if: steps.download-artifacts.outputs.found_artifact == 'true'
@@ -179,11 +184,9 @@ jobs:
         with:
           github-token: ${{ secrets.MUTATION_TOKEN }}
           script: |
-            const prNumber = ${{ steps.branch-update.outputs.result }};
-
             await github.rest.issues.addLabels({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: prNumber,
+              issue_number: ${{ steps.pr.outputs.result }},
               labels: ["⚠️ pr/review-mutation"]
             });


### PR DESCRIPTION
Fixes #5894

Not sure what the fundamental issue is, but this is a slightly reworked set of scripts that relies more on head branch rather than headSha. Also ensures the comment works better by using the PR number. Also has a smidge more logging.

Smoke test here https://github.com/MarkMcCulloh/wing-distributed-workflow/pull/7 although it's not a conclusive test

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
