### PR TITLE
fix: escape braces in tree-sitter regex

### DIFF
--- a/libs/tree-sitter-wing/grammar.js
+++ b/libs/tree-sitter-wing/grammar.js
@@ -396,7 +396,7 @@ module.exports = grammar({
             /[0-7]{1,3}/,
             /x[0-9a-fA-F]{2}/,
             /u[0-9a-fA-F]{4}/,
-            /u{[0-9a-fA-F]+}/
+            /u\{[0-9a-fA-F]+\}/
           )
         )
       ),


### PR DESCRIPTION
The regex flavor in tree-sitter is no longer disjunct between rust and js, it aligns with rust which requires escaping braces.
Generating fails in the latest cli release without this change.

@gshpychka @MarkMcCulloh 
