### PR TITLE
fix(sdk): allow Node.js 20 for `cloud.Function` on `tf-azure` platform

### DIFF
--- a/libs/wingsdk/.projenrc.ts
+++ b/libs/wingsdk/.projenrc.ts
@@ -7,7 +7,7 @@ const AWS_SDK_VERSION = "3.490.0";
 const CDKTF_PROVIDERS = [
   "aws@~>5.31.0",
   "random@~>3.5.1",
-  "azurerm@~>3.54.0",
+  "azurerm@~>3.96.0",
   "google@~>5.10.0",
 ];
 

--- a/libs/wingsdk/cdktf.json
+++ b/libs/wingsdk/cdktf.json
@@ -4,7 +4,7 @@
   "terraformProviders": [
     "aws@~>5.31.0",
     "random@~>3.5.1",
-    "azurerm@~>3.54.0",
+    "azurerm@~>3.96.0",
     "google@~>5.10.0"
   ],
   "codeMakerOutput": "src/.gen",


### PR DESCRIPTION
AzureRM Terraform provider [v3.96.0](https://github.com/hashicorp/terraform-provider-azurerm/releases/tag/v3.96.0) adds Azure Functions Support for Node.js 20, resolving the problem with the deployment.

Closes #5623

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
