### PR TITLE
fix(console): custom resource title is not shown in console

### DIFF
--- a/apps/wing-console/console/server/src/router/app.ts
+++ b/apps/wing-console/console/server/src/router/app.ts
@@ -551,10 +551,7 @@ function createExplorerItemFromConstructTreeNode(
   showTests = false,
   includeHiddens = false,
 ): ExplorerItem {
-  const label =
-    node.display?.sourceModule === "@winglang/sdk" && node.display?.title
-      ? node.display?.title
-      : node.id;
+  const label = node.display?.title ?? node.id;
 
   return {
     id: node.path,

--- a/apps/wing-console/console/ui/src/ui/elk-map-nodes.tsx
+++ b/apps/wing-console/console/ui/src/ui/elk-map-nodes.tsx
@@ -100,10 +100,7 @@ export const ContainerNode = memo(
     );
 
     const compilerNamed = useMemo(() => {
-      if (!display) {
-        return false;
-      }
-      return display.sourceModule === "@winglang/sdk" && display.title;
+      return !!display?.title;
     }, [display]);
 
     return (

--- a/apps/wing-console/console/ui/src/ui/resource-metadata.tsx
+++ b/apps/wing-console/console/ui/src/ui/resource-metadata.tsx
@@ -317,7 +317,9 @@ export const ResourceMetadata = memo(
           </div>
 
           <div className="flex flex-col min-w-0">
-            <div className="text-sm font-medium truncate">{node.id}</div>
+            <div className="text-sm font-medium truncate">
+              {node?.display?.title ?? node.id}
+            </div>
             <div className="flex">
               <Pill>{node.type}</Pill>
             </div>


### PR DESCRIPTION
resolves: https://github.com/winglang/wing/issues/5939

```
bring cloud;
class A {
  new() {
    nodeof(this).title = "MyTitle";
    nodeof(this).color = "violet";
  }
}
class B {
    new() {
    }
}
new A();
new cloud.Bucket();
new B();
```

![Screenshot 2024-03-17 at 17 00 19](https://github.com/winglang/wing/assets/2538825/7b8c3dec-5e57-4b5d-a6a5-871f57162e5f)


## Checklist

- [ ] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [ ] Description explains motivation and solution
- [ ] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
