### PR TITLE
chore(repo): ensure quality gate fails if previous steps aren't successful

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -334,7 +334,7 @@ jobs:
       - sdk-spec-test
     steps:
       - name: Check failure
-        if: needs.build.result == 'failure' || needs.e2e-test.result == 'failure' || needs.benchmark.result == 'failure' || needs.test.result == 'failure' || needs.sdk-spec-test.result == 'failure'
+        if: needs.build.result != 'success' || needs.e2e-test.result != 'success' || needs.benchmark.result != 'success' || needs.test.result != 'success' || needs.sdk-spec-test.result != 'success'
         run: exit 1
       - name: Download patches
         uses: actions/download-artifact@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -334,8 +334,12 @@ jobs:
       - sdk-spec-test
     steps:
       - name: Check failure
-        if: needs.build.result != 'success' || needs.e2e-test.result != 'success' || needs.benchmark.result != 'success' || needs.test.result != 'success' || needs.sdk-spec-test.result != 'success'
-        run: exit 1
+        # All jobs must either be sucessful or skipped
+        if: contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'failure') || contains(needs.*.result, 'action_required')|| contains(needs.*.result, 'stale')|| contains(needs.*.result, 'null')
+        run: |
+          echo "One or more jobs failed or were cancelled. Please check the logs."
+          echo '${{ toJson(needs) }}'
+          exit 1
       - name: Download patches
         uses: actions/download-artifact@v3
       - name: Check patches

--- a/tools/hangar/src/platform.test.ts
+++ b/tools/hangar/src/platform.test.ts
@@ -15,7 +15,7 @@ describe("Multiple platforms", () => {
   const appFile = path.join(platformsDir, app);
 
   test("only first platform app is used", async () => {
-    const args = ["compile"];
+    const args = ["whoopsie"];
     const platforms = ["tf-aws", "tf-azure"];
     const targetDir = path.join(platformsDir, "target", "main.tfaws");
 

--- a/tools/hangar/src/platform.test.ts
+++ b/tools/hangar/src/platform.test.ts
@@ -15,7 +15,7 @@ describe("Multiple platforms", () => {
   const appFile = path.join(platformsDir, app);
 
   test("only first platform app is used", async () => {
-    const args = ["whoopsie"];
+    const args = ["compile"];
     const platforms = ["tf-aws", "tf-azure"];
     const targetDir = path.join(platformsDir, "target", "main.tfaws");
 


### PR DESCRIPTION
The quality gate was succeeding if previous steps timed out

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
