### PR TITLE
fix: react-vite template fails to `npm install` on Windows

### DIFF
--- a/apps/wing/project-templates/wing/react-vite/package.json
+++ b/apps/wing/project-templates/wing/react-vite/package.json
@@ -5,8 +5,8 @@
   "author": "Your Name",
   "license": "MIT",
   "scripts": {
-    "install:backend": "npm install --prefix backend",
-    "install:frontend": "npm install --prefix frontend",
+    "install:backend": "cd backend && npm install",
+    "install:frontend": "cd frontend && npm install",
     "postinstall": "npm run install:backend && npm run install:frontend"
   },
   "dependencies": {


### PR DESCRIPTION
Seems like a bug on Windows where using `--prefix` causes npm to use the wrong postinstall hook 🤷

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
