### PR TITLE
fix: language server occasionally duplicates types a fails compilation

### DIFF
--- a/libs/wingc/src/lsp/sync.rs
+++ b/libs/wingc/src/lsp/sync.rs
@@ -150,8 +150,7 @@ fn partial_compile(
 	}
 
 	// Reset all type information
-	types.reset_expr_types();
-	types.reset_scope_envs();
+	types.reset_per_compile_data();
 
 	// -- TYPECHECKING PHASE --
 	let mut jsii_imports = vec![];

--- a/libs/wingc/src/lsp/sync.rs
+++ b/libs/wingc/src/lsp/sync.rs
@@ -120,7 +120,7 @@ pub fn on_document_did_change(params: DidChangeTextDocumentParams) {
 fn partial_compile(
 	source_path: &Path,
 	source_text: String,
-	mut types: &mut Types, // TODO: does this need to be shared between recompiles?
+	mut types: &mut Types,
 	jsii_types: &mut TypeSystem,
 	project_data: &mut ProjectData,
 ) {
@@ -150,7 +150,7 @@ fn partial_compile(
 	}
 
 	// Reset all type information
-	types.reset_per_compile_data();
+	*types = Types::new();
 
 	// -- TYPECHECKING PHASE --
 	let mut jsii_imports = vec![];

--- a/libs/wingc/src/type_check.rs
+++ b/libs/wingc/src/type_check.rs
@@ -1664,12 +1664,6 @@ impl Types {
 		self.scope_envs[scope_id].expect("Scope should have an env")
 	}
 
-	pub fn reset_scope_envs(&mut self) {
-		for elem in self.scope_envs.iter_mut() {
-			*elem = None;
-		}
-	}
-
 	/// Obtain the type of a given expression id. Returns None if the expression has not been type checked yet. If
 	/// this is called after type checking, it should always return Some.
 	pub fn try_get_expr_type(&self, expr_id: ExprId) -> Option<TypeRef> {
@@ -1691,10 +1685,13 @@ impl Types {
 		self.json_literal_casts.get(&expr_id)
 	}
 
-	pub fn reset_expr_types(&mut self) {
-		for elem in self.type_for_expr.iter_mut() {
-			*elem = None;
-		}
+	pub fn reset_per_compile_data(&mut self) {
+		self.type_for_expr.clear();
+		self.scope_envs.clear();
+		self.inferences.clear();
+		self.json_literal_casts.clear();
+		self.type_expressions.clear();
+		self.source_file_envs.clear();
 	}
 
 	/// Given a builtin type, return the full class info from the standard library.

--- a/libs/wingc/src/type_check.rs
+++ b/libs/wingc/src/type_check.rs
@@ -1685,15 +1685,6 @@ impl Types {
 		self.json_literal_casts.get(&expr_id)
 	}
 
-	pub fn reset_per_compile_data(&mut self) {
-		self.type_for_expr.clear();
-		self.scope_envs.clear();
-		self.inferences.clear();
-		self.json_literal_casts.clear();
-		self.type_expressions.clear();
-		self.source_file_envs.clear();
-	}
-
 	/// Given a builtin type, return the full class info from the standard library.
 	///
 	/// This is needed because our builtin types have no API.


### PR DESCRIPTION
Fixes #6004, I was able to replicate consistently and see that this change fixes it

Instead of attempting to reuse `Types`, let's just create a new one. This should cause all the existing types and symbol environments to be dropped, but that's okay because we immediately populate the new one with data.

No clue how to add a real test for this. The current rust-based tests don't have a multi-file system and I'm not sure this change is worth that effort to improve (as nice as it would be)

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
