### PR TITLE
fix(sdk): unexpected end of JSON input error

### DIFF
--- a/libs/wingsdk/src/target-sim/api.inflight.ts
+++ b/libs/wingsdk/src/target-sim/api.inflight.ts
@@ -162,7 +162,7 @@ export class Api
   }
 
   private async saveState(state: StateFileContents): Promise<void> {
-    await fs.promises.writeFile(
+    fs.writeFileSync(
       join(this.context.statedir, STATE_FILENAME),
       JSON.stringify(state)
     );

--- a/libs/wingsdk/src/target-sim/bucket.inflight.ts
+++ b/libs/wingsdk/src/target-sim/bucket.inflight.ts
@@ -15,15 +15,16 @@ import {
   BucketDeleteOptions,
   BucketGetOptions,
   BucketTryGetOptions,
+  BUCKET_FQN,
 } from "../cloud";
 import { deserialize, serialize } from "../simulator/serialization";
 import {
   ISimulatorContext,
   ISimulatorResourceInstance,
 } from "../simulator/simulator";
-import { Datetime, Json } from "../std";
+import { Datetime, Json, TraceType } from "../std";
 
-const METADATA_FILENAME = "metadata.json";
+export const METADATA_FILENAME = "metadata.json";
 
 export class Bucket implements IBucketClient, ISimulatorResourceInstance {
   private readonly _fileDir: string;
@@ -56,8 +57,12 @@ export class Bucket implements IBucketClient, ISimulatorResourceInstance {
         join(this.context.statedir, METADATA_FILENAME),
         "utf-8"
       );
-      const metadata = deserialize(metadataContents);
-      this._metadata = new Map(metadata);
+      try {
+        const metadata = deserialize(metadataContents);
+        this._metadata = new Map(metadata);
+      } catch (e) {
+        this.addTrace(`Failed to deserialize metadata: ${(e as Error).stack}`);
+      }
     }
 
     for (const [key, value] of Object.entries(this.initialObjects)) {
@@ -352,5 +357,15 @@ export class Bucket implements IBucketClient, ISimulatorResourceInstance {
 
   private hashKey(key: string): string {
     return crypto.createHash("sha512").update(key).digest("hex").slice(-32);
+  }
+
+  private addTrace(message: string): void {
+    this.context.addTrace({
+      data: { message },
+      type: TraceType.RESOURCE,
+      sourcePath: this.context.resourcePath,
+      sourceType: BUCKET_FQN,
+      timestamp: new Date().toISOString(),
+    });
   }
 }

--- a/libs/wingsdk/src/target-sim/bucket.inflight.ts
+++ b/libs/wingsdk/src/target-sim/bucket.inflight.ts
@@ -58,11 +58,6 @@ export class Bucket implements IBucketClient, ISimulatorResourceInstance {
       );
       const metadata = deserialize(metadataContents);
       this._metadata = new Map(metadata);
-    } else {
-      await fs.promises.writeFile(
-        join(this.context.statedir, METADATA_FILENAME),
-        serialize({})
-      );
     }
 
     for (const [key, value] of Object.entries(this.initialObjects)) {
@@ -82,7 +77,7 @@ export class Bucket implements IBucketClient, ISimulatorResourceInstance {
   public async save(): Promise<void> {
     // no need to save individual files, since they are already persisted in the state dir
     // during the bucket's lifecycle
-    await fs.promises.writeFile(
+    fs.writeFileSync(
       join(this.context.statedir, METADATA_FILENAME),
       serialize(Array.from(this._metadata.entries())) // metadata contains Datetime values, so we need to serialize it
     );

--- a/libs/wingsdk/src/target-sim/counter.inflight.ts
+++ b/libs/wingsdk/src/target-sim/counter.inflight.ts
@@ -38,7 +38,7 @@ export class Counter implements ICounterClient, ISimulatorResourceInstance {
   public async cleanup(): Promise<void> {}
 
   public async save(): Promise<void> {
-    await fs.promises.writeFile(
+    fs.writeFileSync(
       join(this.context.statedir, VALUES_FILENAME),
       JSON.stringify(Array.from(this.values.entries()))
     );

--- a/libs/wingsdk/src/target-sim/endpoint.inflight.ts
+++ b/libs/wingsdk/src/target-sim/endpoint.inflight.ts
@@ -1,4 +1,5 @@
-import { readFile, writeFile } from "node:fs/promises";
+import { writeFileSync } from "fs";
+import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { connect, ConnectResponse } from "@winglang/wingtunnels";
 import { EndpointAttributes, EndpointSchema } from "./schema-resources";
@@ -86,7 +87,7 @@ export class Endpoint implements IEndpointClient, ISimulatorResourceInstance {
   }
 
   private async saveState(state: StateFileContents): Promise<void> {
-    await writeFile(
+    writeFileSync(
       join(this._context.statedir, STATE_FILENAME),
       JSON.stringify(state)
     );

--- a/libs/wingsdk/test/target-sim/bucket.test.ts
+++ b/libs/wingsdk/test/target-sim/bucket.test.ts
@@ -1,11 +1,12 @@
 import * as fs from "fs";
-import { resolve } from "path";
-import { vi, test, expect } from "vitest";
+import { resolve, join } from "path";
+import { test, expect } from "vitest";
 import { listMessages, treeJsonOf, waitUntilTraceCount } from "./util";
 import * as cloud from "../../src/cloud";
 import { BucketEventType } from "../../src/cloud";
 import { Testing } from "../../src/simulator";
 import { Node } from "../../src/std";
+import { METADATA_FILENAME } from "../../src/target-sim/bucket.inflight";
 import { SimApp } from "../sim-app";
 import { mkdtemp } from "../util";
 
@@ -904,6 +905,35 @@ test("bucket is stateful across simulations", async () => {
   expect(dataB).toEqual("2"); // "b" will be remembered
   expect(metadata1).not.toEqual(metadata3);
   expect(metadata2).toEqual(metadata4);
+});
+
+test("bucket ignores corrupted state file", async () => {
+  // GIVEN
+  const app = new SimApp();
+  new cloud.Bucket(app, "my_bucket");
+
+  // run simulator one time
+  const stateDir = mkdtemp();
+  const s = await app.startSimulator(stateDir);
+  const client = s.getResource("/my_bucket") as cloud.IBucketClient;
+  await client.put("a", "1");
+  await s.stop();
+
+  // WHEN
+  // corrupt the state file
+  const metadata = join(s.getResourceStateDir("/my_bucket"), METADATA_FILENAME);
+  fs.writeFileSync(metadata, "corrupted");
+
+  // restart the simulator
+  await s.start();
+  const client2 = s.getResource("/my_bucket") as cloud.IBucketClient;
+  await client2.put("b", "2");
+  const files = await client2.list();
+  await s.stop();
+
+  // THEN
+  // we lost all metadata, but the bucket is still functional
+  expect(files).toEqual(["b"]);
 });
 
 // Deceided to seperate this feature in a different release,(see https://github.com/winglang/wing/issues/4143)


### PR DESCRIPTION
Fixes #6010

The underlying issue is caused by state files only getting partially written to disk when the simulator host process is killed in the middle of its shutdown. Due to the weird sequencing of operations, an empty file would end up being written (instead of no file or a file with valid JSON). Using synchronous calls for saving state files should reduce these kinds occurrences.

No tests were added because there isn't really a reliable way to kill a process precisely in the middle of a asynchronous Node.js function call. 

There's still a bug lurking where the console isn't letting the simulator finish shutting down, but this extra resiliency shouldn't hurt.

## Checklist

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [x] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
