### PR TITLE
chore: skip container e2e tests on windows/mac

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -220,6 +220,10 @@ jobs:
             node: "18"
             full_run: false
     steps:
+      - name: Switch to Linux Containers on Windows
+        if: matrix.runner == 'windows'
+        run: Start-Process -NoNewWindow -Wait "$Env:ProgramFiles\Docker\Docker\DockerCli.exe" -ArgumentList ['-SwitchLinuxEngine']
+
       - name: Checkout
         uses: actions/checkout@v4
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -220,10 +220,6 @@ jobs:
             node: "18"
             full_run: false
     steps:
-      - name: Switch to Linux Containers on Windows
-        if: matrix.runner == 'windows'
-        run: Start-Process -NoNewWindow -Wait "$Env:ProgramFiles\Docker\Docker\DockerCli.exe" -ArgumentList ['-SwitchLinuxEngine']
-
       - name: Checkout
         uses: actions/checkout@v4
 

--- a/examples/tests/sdk_tests/container/container.test.w
+++ b/examples/tests/sdk_tests/container/container.test.w
@@ -1,3 +1,9 @@
+/*\
+skipPlatforms:
+  - win32
+  - darwin
+\*/
+
 bring sim;
 bring http;
 bring util;


### PR DESCRIPTION
In our current CI, we can't run tests with containers on windows or mac

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
