### PR TITLE
fix(cli): handle shutdown events gracefully

### DIFF
--- a/apps/wing/package.json
+++ b/apps/wing/package.json
@@ -47,6 +47,7 @@
     "dotenv-expand": "^10.0.0",
     "glob": "^10.3.10",
     "inquirer": "^8",
+    "lodash.once": "^4.1.1",
     "nanoid": "^3.3.6",
     "npm-packlist": "^8.0.0",
     "open": "^8.4.2",
@@ -59,6 +60,7 @@
   "devDependencies": {
     "@types/debug": "^4.1.8",
     "@types/inquirer": "^9.0.7",
+    "@types/lodash.once": "^4.1.9",
     "@types/node": "^20.11.0",
     "@types/node-persist": "^3.1.4",
     "@types/npm-packlist": "^7.0.1",

--- a/apps/wing/src/util.before-shutdown.ts
+++ b/apps/wing/src/util.before-shutdown.ts
@@ -1,0 +1,79 @@
+/**
+ * Based on https://gist.github.com/nfantone/1eaa803772025df69d07f4dbf5df7e58.
+ */
+type BeforeShutdownListener = (codeOrSignal: string | number) => Promise<void> | void;
+
+/**
+ * Time in milliseconds to wait before forcing shutdown.
+ */
+const SHUTDOWN_TIMEOUT = 15_000;
+
+/**
+ * A queue of listener callbacks to execute before shutting
+ * down the process.
+ */
+const shutdownListeners: BeforeShutdownListener[] = [];
+
+/**
+ * Listen for signals and execute given `fn` function once.
+ * @param  fn Function to execute on shutdown.
+ */
+const processOnce = (fn: BeforeShutdownListener) => {
+  process.once("SIGINT", (signal) => void fn(signal));
+  process.once("SIGTERM", (signal) => void fn(signal));
+  process.once("exit", (code) => void fn(code));
+  process.once("beforeExit", (code) => void fn(code));
+};
+
+/**
+ * Sets a forced shutdown mechanism that will exit the process after `timeout` milliseconds.
+ * @param timeout Time to wait before forcing shutdown (milliseconds)
+ */
+const forceExitAfter = (timeout: number) => () => {
+  setTimeout(() => {
+    // Force shutdown after timeout
+    console.warn(`Could not close resources gracefully after ${timeout}ms: forcing shutdown`);
+    return process.exit(1);
+  }, timeout).unref();
+};
+
+/**
+ * Main process shutdown handler. Will invoke every previously registered async shutdown listener
+ * in the queue and exit with a code of `0`. Any `Promise` rejections from any listener will
+ * be logged out as a warning, but won't prevent other callbacks from executing.
+ */
+async function shutdownHandler(codeOrSignal: string | number) {
+  for (const listener of shutdownListeners) {
+    try {
+      await listener(codeOrSignal);
+    } catch (error) {
+      console.warn(
+        `A shutdown handler failed before completing with: ${
+          error instanceof Error ? error.message : error
+        }`
+      );
+    }
+  }
+
+  return process.exit(0);
+}
+
+/**
+ * Registers a new shutdown listener to be invoked before exiting
+ * the main process. Listener handlers are guaranteed to be called in the order
+ * they were registered.
+ * @param listener The shutdown listener to register.
+ * @returns Echoes back the supplied `listener`.
+ */
+export function beforeShutdown(listener: BeforeShutdownListener) {
+  shutdownListeners.push(listener);
+  return listener;
+}
+
+// Register shutdown callback that kills the process after `SHUTDOWN_TIMEOUT` milliseconds
+// This prevents custom shutdown handlers from hanging the process indefinitely
+processOnce(forceExitAfter(SHUTDOWN_TIMEOUT));
+
+// Register process shutdown callback
+// Will listen to incoming signal events and execute all registered handlers in the stack
+processOnce(shutdownHandler);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -287,6 +287,9 @@ importers:
       inquirer:
         specifier: ^8
         version: 8.2.6
+      lodash.once:
+        specifier: ^4.1.1
+        version: 4.1.1
       nanoid:
         specifier: ^3.3.6
         version: 3.3.6
@@ -318,6 +321,9 @@ importers:
       '@types/inquirer':
         specifier: ^9.0.7
         version: 9.0.7
+      '@types/lodash.once':
+        specifier: ^4.1.9
+        version: 4.1.9
       '@types/node':
         specifier: ^20.11.0
         version: 20.11.0
@@ -10518,6 +10524,12 @@ packages:
       '@types/lodash': 4.14.199
     dev: true
 
+  /@types/lodash.once@4.1.9:
+    resolution: {integrity: sha512-nvZ7GYfyZB6CUmXL+7HSXg53rFpc49FsKuRmMiCIGhgJB/yyTip8uHk4mxGyVJOl87dXPlf3qy42WsjOcIrnmg==}
+    dependencies:
+      '@types/lodash': 4.14.199
+    dev: true
+
   /@types/lodash.throttle@4.1.7:
     resolution: {integrity: sha512-znwGDpjCHQ4FpLLx19w4OXDqq8+OvREa05H89obtSyXyOFKL3dDjCslsmfBz0T2FU8dmf5Wx1QvogbINiGIu9g==}
     dependencies:
@@ -14175,7 +14187,7 @@ packages:
     dependencies:
       semver: 7.5.4
       shelljs: 0.8.5
-      typescript: 5.5.0-dev.20240321
+      typescript: 5.5.0-dev.20240325
     dev: true
 
   /dset@3.1.2:
@@ -22783,8 +22795,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  /typescript@5.5.0-dev.20240321:
-    resolution: {integrity: sha512-QEUqMB18VAUQBHtHlq8BfjxGZzFkavH5fhZn+I97N67mDZTa86n1S8kiRKmrbxVwPAdvn3DYtJzcGq5OvdWkmQ==}
+  /typescript@5.5.0-dev.20240325:
+    resolution: {integrity: sha512-3kSBj+PWimbJvH3s/sQiIU7zBIOWAEpHdD3lykIykePugc1qXNIK8d5/WJJNpzH4q2n6gY8pz8lLoe/HanVGnA==}
     engines: {node: '>=14.17'}
     hasBin: true
     dev: true


### PR DESCRIPTION
Previously, the `wing it` didn't wait for the Console to close and release its resources.