### PR TITLE
revert(console)!: use `simulator.update()` (#6069)

### DIFF
--- a/apps/wing-console/console/server/src/utils/simulator.ts
+++ b/apps/wing-console/console/server/src/utils/simulator.ts
@@ -48,24 +48,24 @@ export const createSimulator = (props?: CreateSimulatorProps): Simulator => {
   const start = async (simfile: string) => {
     try {
       if (instance) {
-        await events.emit("starting", { instance });
-        await instance.update(simfile);
-        await events.emit("started");
-      } else {
-        instance = new simulator.Simulator({
-          simfile,
-          stateDir: props?.stateDir,
-        });
-        instance.onTrace({
-          callback(trace) {
-            events.emit("trace", trace);
-          },
-        });
-
-        await events.emit("starting", { instance });
-        await instance.start();
-        await events.emit("started");
+        await events.emit("stopping");
+        await stopSilently(instance);
       }
+
+      instance = new simulator.Simulator({
+        simfile,
+        stateDir: props?.stateDir,
+      });
+      instance.onTrace({
+        callback(trace) {
+          events.emit("trace", trace);
+        },
+      });
+
+      await events.emit("starting", { instance });
+
+      await instance.start();
+      await events.emit("started");
     } catch (error) {
       await events.emit(
         "error",


### PR DESCRIPTION
This reverts commit 08ff90b4c9b2099f87d98ed848e16af5d8ee60ad.

The `cloud.Function`s don't get replaced after changing the source code of a wingfile.