### PR TITLE
fix(sdk): cloud.Service shutdown code is ignored when Wing Console is stopped

### DIFF
--- a/libs/wingsdk/src/shared/sandbox.ts
+++ b/libs/wingsdk/src/shared/sandbox.ts
@@ -140,6 +140,10 @@ process.on("message", async (message) => {
     this.child = cp.fork(this.entrypoint, {
       env: childEnv,
       stdio: "pipe",
+      // keep the process detached so in the case of cloud.Service, if the parent process is killed
+      // (e.g. someone presses Ctrl+C while using Wing Console),
+      // we can gracefully call any cleanup code in the child process
+      detached: true,
       // this option allows complex objects like Error to be sent from the child process to the parent
       serialization: "advanced",
     });

--- a/libs/wingsdk/test/simulator/cleanup.test.ts
+++ b/libs/wingsdk/test/simulator/cleanup.test.ts
@@ -1,0 +1,91 @@
+import * as cp from "child_process";
+import { expect, test } from "vitest";
+import { Service } from "../../src/cloud";
+import { Testing } from "../../src/simulator";
+import { SimApp } from "../sim-app";
+
+const script = (simdir: string) => `
+const { simulator } = require("./");
+
+async function main() {
+  const sim = new simulator.Simulator({ simfile: "${simdir}" });
+  sim.onTrace({
+    callback: (trace) => {
+      console.log(trace.data.message);
+    },
+  });
+  console.log("Starting simulator");
+  await sim.start();
+  console.log("Simulator started");
+
+  process.on("SIGTERM", async () => {
+    console.log("SIGTERM received, stopping simulator...");
+    await sim.stop();
+    process.exit(1);
+  });
+}
+
+main();
+`;
+
+const code = `
+async handle() {
+  console.log("start!");
+  const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+  return async () => {
+    console.log("stopping...");
+    await sleep(1000);
+    console.log("stopped!");
+  };
+}`;
+
+// This test validates that if a process running the simulator is killed
+// and that process has code set up for gracefully shutting down the simulator,
+// then the simulator will be stopped correctly (including child processes
+// like services).
+test("simulator cleanup", async () => {
+  // Synthesize configuration for the simulator to use in the test
+  const app = new SimApp({ isTestEnvironment: true });
+  const handler = Testing.makeHandler(code);
+  new Service(app, "Service", handler);
+  const simdir = app.synth();
+
+  // Start the simulator in a child process
+  const child = cp.spawn(process.argv0, ["-e", script(simdir)], {
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+
+  // Uncomment the following lines to see the output of the child process
+  // child.stdout?.on("data", (data) => {
+  //   console.error(data.toString());
+  // });
+  // child.stderr?.on("data", (data) => {
+  //   console.error(data.toString());
+  // });
+
+  let stopped = false;
+
+  const stoppedPromise = new Promise((resolve) => {
+    child.stdout?.on("data", (data) => {
+      if (data.toString().includes("stopped!")) {
+        stopped = true;
+        resolve(undefined);
+      }
+    });
+  });
+
+  // Wait for the "Simulator started" message, then kill the child process
+  await new Promise((resolve) => {
+    child.stdout?.on("data", (data) => {
+      if (data.toString().includes("Simulator started")) {
+        child.kill("SIGTERM");
+        resolve(undefined);
+      }
+    });
+  });
+
+  // Wait for the "stopped!" message from cloud.Service (running in a grandchild process)
+  await stoppedPromise;
+
+  expect(stopped).toBe(true);
+});


### PR DESCRIPTION
Fixes #6018

If the Wing Console is terminated by Ctrl + C, it gracefully waits for resources to be shut down (thanks to https://github.com/winglang/wing/pull/6051). However there's a latent bug since the kill signal is still propagated to child processes, like those running inflight code for cloud.Service. This changes the behavior so the kill signal is longer propagated, and the simulator will be fully responsible for shutting down its child processes.

If this doesn't solve all our issues (or runaway processes occur in some other ways), then we might need some kind of daemon for tracking processes created by the Wing simulator - but I'm hoping we might be able to avoid this kind of complexity for now.

## Checklist

- [ ] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [ ] Description explains motivation and solution
- [ ] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
