### PR TITLE
fix(compiler): unable to extend jsii classes in non-entrypoint

### DIFF
--- a/examples/tests/valid/bring_extend_non_entry.test.w
+++ b/examples/tests/valid/bring_extend_non_entry.test.w
@@ -1,0 +1,3 @@
+bring "./extend_non_entrypoint.w" as lib;
+
+let f = new lib.Foo();

--- a/examples/tests/valid/extend_non_entrypoint.w
+++ b/examples/tests/valid/extend_non_entrypoint.w
@@ -1,0 +1,5 @@
+bring "cdk8s" as cdk8s;
+
+pub class Foo extends cdk8s.Chart {
+
+}

--- a/libs/wingc/src/jsify.rs
+++ b/libs/wingc/src/jsify.rs
@@ -1465,7 +1465,7 @@ impl<'a> JSifier<'a> {
 				if let Some(fqn) = &parent_type.as_class().unwrap().fqn {
 					code.append(new_code!(
 						&class.name.span,
-						" extends (this.node.root.typeForFqn(\"",
+						" extends (this?.node?.root?.typeForFqn(\"",
 						fqn,
 						"\") ?? ",
 						self.jsify_user_defined_type(parent, ctx),

--- a/tools/hangar/__snapshots__/test_corpus/valid/bring_extend_non_entry.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/bring_extend_non_entry.test.w_compile_tf-aws.md
@@ -1,0 +1,98 @@
+# [bring_extend_non_entry.test.w](../../../../../examples/tests/valid/bring_extend_non_entry.test.w) | compile | tf-aws
+
+## inflight.Foo-1.js
+```js
+"use strict";
+const $helpers = require("@winglang/sdk/lib/helpers");
+module.exports = function({ $cdk8s_Chart }) {
+  class Foo extends $cdk8s_Chart {
+    constructor({  }) {
+      super({  });
+    }
+  }
+  return Foo;
+}
+//# sourceMappingURL=inflight.Foo-1.js.map
+```
+
+## main.tf.json
+```json
+{
+  "//": {
+    "metadata": {
+      "backend": "local",
+      "stackName": "root",
+      "version": "0.20.3"
+    },
+    "outputs": {}
+  },
+  "provider": {
+    "aws": [
+      {}
+    ]
+  }
+}
+```
+
+## preflight.extendnonentrypoint-1.js
+```js
+"use strict";
+const $stdlib = require('@winglang/sdk');
+const std = $stdlib.std;
+const $helpers = $stdlib.helpers;
+const cdk8s = require("cdk8s");
+class Foo extends (this?.node?.root?.typeForFqn("cdk8s.Chart") ?? cdk8s.Chart) {
+  constructor($scope, $id, ) {
+    super($scope, $id);
+  }
+  static _toInflightType() {
+    return `
+      require("${$helpers.normalPath(__dirname)}/inflight.Foo-1.js")({
+        $cdk8s_Chart: ${$stdlib.core.liftObject($stdlib.core.toLiftableModuleType(cdk8s.Chart, "cdk8s", "Chart"))},
+      })
+    `;
+  }
+  _toInflight() {
+    return `
+      (await (async () => {
+        const FooClient = ${Foo._toInflightType()};
+        const client = new FooClient({
+        });
+        if (client.$inflight_init) { await client.$inflight_init(); }
+        return client;
+      })())
+    `;
+  }
+  get _liftMap() {
+    return $stdlib.core.mergeLiftDeps(super._liftMap, {
+      "$inflight_init": [
+      ],
+    });
+  }
+}
+module.exports = { Foo };
+//# sourceMappingURL=preflight.extendnonentrypoint-1.js.map
+```
+
+## preflight.js
+```js
+"use strict";
+const $stdlib = require('@winglang/sdk');
+const $platforms = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLATFORMS);
+const $outdir = process.env.WING_SYNTH_DIR ?? ".";
+const $wing_is_test = process.env.WING_IS_TEST === "true";
+const std = $stdlib.std;
+const $helpers = $stdlib.helpers;
+const lib = require("./preflight.extendnonentrypoint-1.js");
+class $Root extends $stdlib.std.Resource {
+  constructor($scope, $id) {
+    super($scope, $id);
+    const f = new lib.Foo(this, "Foo");
+  }
+}
+const $PlatformManager = new $stdlib.platform.PlatformManager({platformPaths: $platforms});
+const $APP = $PlatformManager.createApp({ outdir: $outdir, name: "bring_extend_non_entry.test", rootConstruct: $Root, isTestEnvironment: $wing_is_test, entrypointDir: process.env['WING_SOURCE_DIR'], rootId: process.env['WING_ROOT_ID'] });
+$APP.synth();
+//# sourceMappingURL=preflight.js.map
+```
+

--- a/tools/hangar/__snapshots__/test_corpus/valid/bring_extend_non_entry.test.w_test_sim.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/bring_extend_non_entry.test.w_test_sim.md
@@ -1,0 +1,12 @@
+# [bring_extend_non_entry.test.w](../../../../../examples/tests/valid/bring_extend_non_entry.test.w) | test | sim
+
+## stdout.log
+```log
+pass ─ bring_extend_non_entry.test.wsim (no tests)
+ 
+ 
+Tests 1 passed (1)
+Test Files 1 passed (1)
+Duration <DURATION>
+```
+

--- a/tools/hangar/__snapshots__/test_corpus/valid/extend_non_entrypoint.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/extend_non_entrypoint.w_compile_tf-aws.md
@@ -1,0 +1,57 @@
+# [extend_non_entrypoint.w](../../../../../examples/tests/valid/extend_non_entrypoint.w) | compile | tf-aws
+
+## inflight.Foo-1.js
+```js
+"use strict";
+const $helpers = require("@winglang/sdk/lib/helpers");
+module.exports = function({ $cdk8s_Chart }) {
+  class Foo extends $cdk8s_Chart {
+    constructor({  }) {
+      super({  });
+    }
+  }
+  return Foo;
+}
+//# sourceMappingURL=inflight.Foo-1.js.map
+```
+
+## preflight.js
+```js
+"use strict";
+const $stdlib = require('@winglang/sdk');
+const std = $stdlib.std;
+const $helpers = $stdlib.helpers;
+const cdk8s = require("cdk8s");
+class Foo extends (this?.node?.root?.typeForFqn("cdk8s.Chart") ?? cdk8s.Chart) {
+  constructor($scope, $id, ) {
+    super($scope, $id);
+  }
+  static _toInflightType() {
+    return `
+      require("${$helpers.normalPath(__dirname)}/inflight.Foo-1.js")({
+        $cdk8s_Chart: ${$stdlib.core.liftObject($stdlib.core.toLiftableModuleType(cdk8s.Chart, "cdk8s", "Chart"))},
+      })
+    `;
+  }
+  _toInflight() {
+    return `
+      (await (async () => {
+        const FooClient = ${Foo._toInflightType()};
+        const client = new FooClient({
+        });
+        if (client.$inflight_init) { await client.$inflight_init(); }
+        return client;
+      })())
+    `;
+  }
+  get _liftMap() {
+    return $stdlib.core.mergeLiftDeps(super._liftMap, {
+      "$inflight_init": [
+      ],
+    });
+  }
+}
+module.exports = { Foo };
+//# sourceMappingURL=preflight.js.map
+```
+

--- a/tools/hangar/__snapshots__/test_corpus/valid/inherit_stdlib_class.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/inherit_stdlib_class.test.w_compile_tf-aws.md
@@ -294,7 +294,7 @@ const http = $stdlib.http;
 class $Root extends $stdlib.std.Resource {
   constructor($scope, $id) {
     super($scope, $id);
-    class AnApi extends (this.node.root.typeForFqn("@winglang/sdk.cloud.Api") ?? cloud.Api) {
+    class AnApi extends (this?.node?.root?.typeForFqn("@winglang/sdk.cloud.Api") ?? cloud.Api) {
       constructor($scope, $id, ) {
         super($scope, $id);
       }


### PR DESCRIPTION
**NOTE: ** This is really actually only a bandaid solution. It fixes half the problem.

There is a larger issue at hand described in: https://github.com/winglang/wing/issues/6093 

The real issue is that we need a way to pass App instance or Platform manager to non-entrypoint files to use methods like `typeForFqn` or `new` but theres a pretty nasty cyclical dependency issue. 

currently working on another pr, that will probably take more time, in the meantime this unblocks: https://github.com/winglang/wing/issues/4791

## Checklist

- [ ] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [ ] Description explains motivation and solution
- [ ] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
