### PR TITLE
feat: assert messages

### DIFF
--- a/docs/docs/03-language-reference.md
+++ b/docs/docs/03-language-reference.md
@@ -558,6 +558,7 @@ log("UTC: {t1.utc.toIso())}");            // output: 2023-02-09T06:21:03.000Z
 > ```TS
 > log("Hello {name}");
 > assert(x > 0);
+> assert(x > 0, "x should be positive");
 > ```
 
 [`▲ top`][top]

--- a/examples/tests/error/inflight_stacktraces.test.w
+++ b/examples/tests/error/inflight_stacktraces.test.w
@@ -21,3 +21,8 @@ test "throw from closure" {
   };
   closure();
 }
+
+test "assert with message" {
+  let x = false;
+  assert(x, "x is false");
+}

--- a/libs/wingc/src/lsp/snapshots/completions/empty.snap
+++ b/libs/wingc/src/lsp/snapshots/completions/empty.snap
@@ -10,10 +10,10 @@ source: libs/wingc/src/lsp/completions.rs
   sortText: bb|this
 - label: assert
   kind: 3
-  detail: "(condition: bool): void"
+  detail: "(condition: bool, message: str?): void"
   documentation:
     kind: markdown
-    value: "```wing\nassert: (condition: bool): void\n```\n---\nAsserts that a condition is true\n### Parameters\n- `condition` — `bool` — The condition to assert"
+    value: "```wing\nassert: (condition: bool, message: str?): void\n```\n---\nAsserts that a condition is true\n### Parameters\n- `condition` — `bool` — The condition to assert\n- `message` — `str?` — The message to log if the condition is false"
   sortText: cc|assert
   insertText: assert($1)
   insertTextFormat: 2

--- a/libs/wingc/src/lsp/snapshots/completions/hide_parent_symbols_defined_later.snap
+++ b/libs/wingc/src/lsp/snapshots/completions/hide_parent_symbols_defined_later.snap
@@ -17,10 +17,10 @@ source: libs/wingc/src/lsp/completions.rs
   sortText: bb|x
 - label: assert
   kind: 3
-  detail: "(condition: bool): void"
+  detail: "(condition: bool, message: str?): void"
   documentation:
     kind: markdown
-    value: "```wing\nassert: (condition: bool): void\n```\n---\nAsserts that a condition is true\n### Parameters\n- `condition` — `bool` — The condition to assert"
+    value: "```wing\nassert: (condition: bool, message: str?): void\n```\n---\nAsserts that a condition is true\n### Parameters\n- `condition` — `bool` — The condition to assert\n- `message` — `str?` — The message to log if the condition is false"
   sortText: cc|assert
   insertText: assert($1)
   insertTextFormat: 2

--- a/libs/wingc/src/lsp/snapshots/hovers/builtin_in_inflight.snap
+++ b/libs/wingc/src/lsp/snapshots/hovers/builtin_in_inflight.snap
@@ -3,7 +3,7 @@ source: libs/wingc/src/lsp/hover.rs
 ---
 contents:
   kind: markdown
-  value: "```wing\nassert: (condition: bool): void\n```\n---\nAsserts that a condition is true\n### Parameters\n- `condition` — `bool` — The condition to assert"
+  value: "```wing\nassert: (condition: bool, message: str?): void\n```\n---\nAsserts that a condition is true\n### Parameters\n- `condition` — `bool` — The condition to assert\n- `message` — `str?` — The message to log if the condition is false"
 range:
   start:
     line: 3

--- a/libs/wingc/src/lsp/snapshots/hovers/builtin_in_preflight.snap
+++ b/libs/wingc/src/lsp/snapshots/hovers/builtin_in_preflight.snap
@@ -3,7 +3,7 @@ source: libs/wingc/src/lsp/hover.rs
 ---
 contents:
   kind: markdown
-  value: "```wing\nassert: (condition: bool): void\n```\n---\nAsserts that a condition is true\n### Parameters\n- `condition` — `bool` — The condition to assert"
+  value: "```wing\nassert: (condition: bool, message: str?): void\n```\n---\nAsserts that a condition is true\n### Parameters\n- `condition` — `bool` — The condition to assert\n- `message` — `str?` — The message to log if the condition is false"
 range:
   start:
     line: 1

--- a/libs/wingc/src/type_check.rs
+++ b/libs/wingc/src/type_check.rs
@@ -1953,6 +1953,7 @@ impl<'a> TypeChecker<'a> {
 	}
 
 	pub fn add_builtins(&mut self, scope: &mut Scope) {
+		let optional_string = self.types.make_option(self.types.string());
 		self.add_builtin(
 			UtilityFunctions::Log.to_string().as_str(),
 			Type::Function(FunctionSignature {
@@ -1974,12 +1975,20 @@ impl<'a> TypeChecker<'a> {
 			UtilityFunctions::Assert.to_string().as_str(),
 			Type::Function(FunctionSignature {
 				this_type: None,
-				parameters: vec![FunctionParameter {
-					name: "condition".into(),
-					typeref: self.types.bool(),
-					docs: Docs::with_summary("The condition to assert"),
-					variadic: false,
-				}],
+				parameters: vec![
+					FunctionParameter {
+						name: "condition".into(),
+						typeref: self.types.bool(),
+						docs: Docs::with_summary("The condition to assert"),
+						variadic: false,
+					},
+					FunctionParameter {
+						name: "message".into(),
+						typeref: optional_string,
+						docs: Docs::with_summary("The message to log if the condition is false"),
+						variadic: false,
+					},
+				],
 				return_type: self.types.void(),
 				phase: Phase::Independent,
 				js_override: Some("$helpers.assert($args$, \"$args_text$\")".to_string()),

--- a/tools/hangar/__snapshots__/error.ts.snap
+++ b/tools/hangar/__snapshots__/error.ts.snap
@@ -18,7 +18,7 @@ Duration <DURATION>"
 `;
 
 exports[`inflight_stacktraces.test.w 1`] = `
-"fail ┌ inflight_stacktraces.test.wsim » root/env0/test:assert            
+"fail ┌ inflight_stacktraces.test.wsim » root/env0/test:assert             
      │ Error: assertion failed: false
      │   --> ../../../examples/tests/error/inflight_stacktraces.test.w:7:3
      │   | let bucket = new cloud.Bucket();
@@ -27,7 +27,7 @@ exports[`inflight_stacktraces.test.w 1`] = `
      │ 7 |   assert(false);
      │   |   ^
      └ at <ABSOLUTE>/inflight_stacktraces.test.w:7:3
-fail ┌ inflight_stacktraces.test.wsim » root/env1/test:expect.equal      
+fail ┌ inflight_stacktraces.test.wsim » root/env1/test:expect.equal       
      │ Error: AssertionError [ERR_ASSERTION]: Expected values to be strictly deep-equal:
      │ 
      │ 1 !== 2
@@ -39,7 +39,7 @@ fail ┌ inflight_stacktraces.test.wsim » root/env1/test:expect.equal
      │ 11 |   expect.equal(1,2 );
      │    |   ^
      └ at <ABSOLUTE>/inflight_stacktraces.test.w:11:3
-fail ┌ inflight_stacktraces.test.wsim » root/env2/test:bucket failed get 
+fail ┌ inflight_stacktraces.test.wsim » root/env2/test:bucket failed get  
      │ Error: Object does not exist (key=doesn't exist): Error: ENOENT: no such file or directory, open '../../../examples/tests/error/target/test/inflight_stacktraces.test.wsim/.state/<STATE_FILE>'
      │    --> ../../../examples/tests/error/inflight_stacktraces.test.w:15:3
      │    | }
@@ -48,7 +48,7 @@ fail ┌ inflight_stacktraces.test.wsim » root/env2/test:bucket failed get
      │ 15 |   bucket.get(\\"doesn't exist\\");
      │    |   ^
      └ at <ABSOLUTE>/inflight_stacktraces.test.w:15:3
-fail ┌ inflight_stacktraces.test.wsim » root/env3/test:throw from closure
+fail ┌ inflight_stacktraces.test.wsim » root/env3/test:throw from closure 
      │ Error: ouch
      │    --> ../../../examples/tests/error/inflight_stacktraces.test.w:20:5
      │    | 
@@ -58,9 +58,18 @@ fail ┌ inflight_stacktraces.test.wsim » root/env3/test:throw from closure
      │    |     ^
      │ at closure <ABSOLUTE>/inflight_stacktraces.test.w:20:5
      └ at <ABSOLUTE>/inflight_stacktraces.test.w:22:3
+fail ┌ inflight_stacktraces.test.wsim » root/env4/test:assert with message
+     │ Error: assertion failed: x is false
+     │    --> ../../../examples/tests/error/inflight_stacktraces.test.w:27:3
+     │    | 
+     │    | test \\"assert with message\\" {
+     │    |   let x = false;
+     │ 27 |   assert(x, \\"x is false\\");
+     │    |   ^
+     └ at <ABSOLUTE>/inflight_stacktraces.test.w:27:3
  
  
-Tests 4 failed (4)
+Tests 5 failed (5)
 Test Files 1 failed (1)
 Duration <DURATION>"
 `;

--- a/tools/hangar/__snapshots__/invalid.ts.snap
+++ b/tools/hangar/__snapshots__/invalid.ts.snap
@@ -1816,11 +1816,11 @@ error: Variable is not reassignable
    | ^^^^^^ Variable is not reassignable
 
 
-error: Expected type to be \\"(condition: bool): void\\", but got \\"str\\" instead
+error: Expected type to be \\"(condition: bool, message: str?): void\\", but got \\"str\\" instead
    --> ../../../examples/tests/invalid/global_symbols.test.w:12:10
    |
 12 | assert = \\"there\\";
-   |          ^^^^^^^ Expected type to be \\"(condition: bool): void\\", but got \\"str\\" instead
+   |          ^^^^^^^ Expected type to be \\"(condition: bool, message: str?): void\\", but got \\"str\\" instead
 
 
 error: Variable is not reassignable

--- a/tools/hangar/__snapshots__/test_corpus/valid/debug_env.test.w_test_sim.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/debug_env.test.w_test_sim.md
@@ -4,7 +4,7 @@
 ```log
 [symbol environment at debug_env.test.w:7:5]
 level 0: { this => A }
-level 1: { A => A [type], assert => (condition: bool): void, cloud => cloud [namespace], lift => inflight (preflightObject: Resource, qualifications: Array<str>): void, log => (message: str): void, nodeof => preflight (construct: IConstruct): Node, std => std [namespace], this => Construct, unsafeCast => (value: any): any }
+level 1: { A => A [type], assert => (condition: bool, message: str?): void, cloud => cloud [namespace], lift => inflight (preflightObject: Resource, qualifications: Array<str>): void, log => (message: str): void, nodeof => preflight (construct: IConstruct): Node, std => std [namespace], this => Construct, unsafeCast => (value: any): any }
 ```
 
 ## stdout.log


### PR DESCRIPTION
This PR adds support for writing custom assertion messages with the built-in `assert()` function:

```js
let x = -3;
assert(x >= 0, "x must be non-negative");
```

## Checklist

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [x] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
