### PR TITLE
fix(sdk): functions and services are never updated in the simulator

### DIFF
--- a/libs/wingsdk/src/simulator/simulator.ts
+++ b/libs/wingsdk/src/simulator/simulator.ts
@@ -916,16 +916,13 @@ export class Simulator {
 
       case UpdatePlan.REPLACE:
         return true;
+
+      case UpdatePlan.AUTO:
+        const state = (r: BaseResourceSchema) =>
+          JSON.stringify({ props: r.props, type: r.type });
+
+        return state(oldConfig) !== state(newConfig);
     }
-
-    // the resource is already in "current", if it's different from "next", it means it was updated
-    const state = (r: BaseResourceSchema) =>
-      JSON.stringify({
-        props: r.props,
-        type: r.type,
-      });
-
-    return state(oldConfig) !== state(newConfig);
   }
 }
 
@@ -1014,7 +1011,7 @@ export interface ISimulatorResourceInstance {
    * If this is not implemented, the default behavior is to automatically replace the resource if
    * the new configuration is different from the current configuration.
    *
-   * @param newConfig The new configuration to apply
+   * @param newConfig The new configuration to apply (this could include unresolved tokens)
    */
   plan(newConfig: BaseResourceSchema): Promise<UpdatePlan>;
 }

--- a/libs/wingsdk/src/simulator/simulator.ts
+++ b/libs/wingsdk/src/simulator/simulator.ts
@@ -300,7 +300,7 @@ export class Simulator {
   public async update(simDir: string) {
     const newModel = this._loadApp(simDir);
 
-    const plan = planUpdate(
+    const plan = await this.planUpdate(
       this._model.schema.resources,
       newModel.schema.resources
     );
@@ -840,6 +840,93 @@ export class Simulator {
       throw new Error(`Invalid token: ${token}`);
     });
   }
+
+  /**
+   * Given the "current" set of resources and a "next" set of resources, calculate the diff and
+   * determine which resources need to be added, updated or deleted.
+   *
+   * Note that dependencies are not considered here but they are implicitly handled by the
+   * `startResource` and `stopResource` methods. So, for example, when a resource is updated,
+   * all of it's dependents will be stopped and started again.
+   */
+  private async planUpdate(
+    current: BaseResourceSchema[],
+    next: BaseResourceSchema[]
+  ) {
+    const currentByPath = toMap(current);
+    const nextByPath = toMap(next);
+
+    const added: string[] = [];
+    const updated: string[] = [];
+    const deleted: string[] = [];
+
+    for (const [path, nextConfig] of Object.entries(nextByPath)) {
+      const currConfig = currentByPath[path];
+
+      // if the resource is not in "current", it means it was added
+      if (!currConfig) {
+        added.push(nextConfig.path);
+        continue;
+      }
+
+      // the resource is already in "current", if it's different from "next", it means it was updated
+      if (await this.shouldReplace(path, currConfig, nextConfig)) {
+        updated.push(nextConfig.path);
+      }
+
+      // remove it from "current" so we know what's left to be deleted
+      delete currentByPath[path];
+    }
+
+    // everything left in "current" is to be deleted
+    for (const config of Object.values(currentByPath)) {
+      deleted.push(config.path);
+    }
+
+    return { added, updated, deleted };
+
+    function toMap(list: BaseResourceSchema[]): {
+      [path: string]: BaseResourceSchema;
+    } {
+      const ret: { [path: string]: BaseResourceSchema } = {};
+      for (const resource of list) {
+        if (ret[resource.path]) {
+          throw new Error(
+            `unexpected - duplicate resources with the same path: ${resource.path}`
+          );
+        }
+        ret[resource.path] = resource;
+      }
+      return ret;
+    }
+  }
+
+  private async shouldReplace(
+    path: string,
+    oldConfig: BaseResourceSchema,
+    newConfig: BaseResourceSchema
+  ) {
+    // consult the resource's "plan()" method if it has one
+    const instance = this.tryGetResource(path) as ISimulatorResourceInstance;
+    const plan = instance ? await instance.plan(newConfig) : UpdatePlan.AUTO;
+
+    switch (plan) {
+      case UpdatePlan.SKIP:
+        return false;
+
+      case UpdatePlan.REPLACE:
+        return true;
+    }
+
+    // the resource is already in "current", if it's different from "next", it means it was updated
+    const state = (r: BaseResourceSchema) =>
+      JSON.stringify({
+        props: r.props,
+        type: r.type,
+      });
+
+    return state(oldConfig) !== state(newConfig);
+  }
 }
 
 class UnresolvedTokenError extends Error {}
@@ -920,6 +1007,33 @@ export interface ISimulatorResourceInstance {
    * Save the resource's state into the state directory.
    */
   save(statedir: string): Promise<void>;
+
+  /**
+   * Determines the update plan for applying a new configuration for this resource.
+   *
+   * If this is not implemented, the default behavior is to automatically replace the resource if
+   * the new configuration is different from the current configuration.
+   *
+   * @param newConfig The new configuration to apply
+   */
+  plan(newConfig: BaseResourceSchema): Promise<UpdatePlan>;
+}
+
+export enum UpdatePlan {
+  /**
+   * Does nothing. This resource is already in the desired state.
+   */
+  SKIP = "SKIP",
+
+  /**
+   * Deletes the resource and creates a new instance with the new configuration.
+   */
+  REPLACE = "REPLACE",
+
+  /**
+   * Auto detect changes in new configuration and replace the resource.
+   */
+  AUTO = "AUTO",
 }
 
 /** Schema for simulator.json */
@@ -994,67 +1108,4 @@ export interface SimulatorServerResponse {
   readonly result?: any;
   /** The error that occurred during the method call. */
   readonly error?: any;
-}
-
-/**
- * Given the "current" set of resources and a "next" set of resources, calculate the diff and
- * determine which resources need to be added, updated or deleted.
- *
- * Note that dependencies are not considered here but they are implicitly handled by the
- * `startResource` and `stopResource` methods. So, for example, when a resource is updated,
- * all of it's dependents will be stopped and started again.
- */
-function planUpdate(current: BaseResourceSchema[], next: BaseResourceSchema[]) {
-  const currentByPath = toMap(current);
-  const nextByPath = toMap(next);
-
-  const added: string[] = [];
-  const updated: string[] = [];
-  const deleted: string[] = [];
-
-  for (const [path, nextConfig] of Object.entries(nextByPath)) {
-    const currConfig = currentByPath[path];
-
-    // if the resource is not in "current", it means it was added
-    if (!currConfig) {
-      added.push(nextConfig.path);
-      continue;
-    }
-
-    // the resource is already in "current", if it's different from "next", it means it was updated
-    const state = (r: BaseResourceSchema) =>
-      JSON.stringify({
-        props: r.props,
-        type: r.type,
-      });
-
-    if (state(currConfig) !== state(nextConfig)) {
-      updated.push(nextConfig.path);
-    }
-
-    // remove it from "current" so we know what's left to be deleted
-    delete currentByPath[path];
-  }
-
-  // everything left in "current" is to be deleted
-  for (const config of Object.values(currentByPath)) {
-    deleted.push(config.path);
-  }
-
-  return { added, updated, deleted };
-
-  function toMap(list: BaseResourceSchema[]): {
-    [path: string]: BaseResourceSchema;
-  } {
-    const ret: { [path: string]: BaseResourceSchema } = {};
-    for (const resource of list) {
-      if (ret[resource.path]) {
-        throw new Error(
-          `unexpected - duplicate resources with the same path: ${resource.path}`
-        );
-      }
-      ret[resource.path] = resource;
-    }
-    return ret;
-  }
 }

--- a/libs/wingsdk/src/simulator/simulator.ts
+++ b/libs/wingsdk/src/simulator/simulator.ts
@@ -1019,6 +1019,9 @@ export interface ISimulatorResourceInstance {
   plan(newConfig: BaseResourceSchema): Promise<UpdatePlan>;
 }
 
+/**
+ * Determines how updates are performed on this resource.
+ */
 export enum UpdatePlan {
   /**
    * Does nothing. This resource is already in the desired state.

--- a/libs/wingsdk/src/target-sim/api.inflight.ts
+++ b/libs/wingsdk/src/target-sim/api.inflight.ts
@@ -24,6 +24,7 @@ import {
 import {
   ISimulatorContext,
   ISimulatorResourceInstance,
+  UpdatePlan,
 } from "../simulator/simulator";
 import { TraceType } from "../std";
 
@@ -144,6 +145,10 @@ export class Api
 
   public async save(): Promise<void> {
     await this.saveState({ lastPort: this.port });
+  }
+
+  public async plan() {
+    return UpdatePlan.AUTO;
   }
 
   private async loadState(): Promise<StateFileContents> {

--- a/libs/wingsdk/src/target-sim/bucket.inflight.ts
+++ b/libs/wingsdk/src/target-sim/bucket.inflight.ts
@@ -21,6 +21,7 @@ import { deserialize, serialize } from "../simulator/serialization";
 import {
   ISimulatorContext,
   ISimulatorResourceInstance,
+  UpdatePlan,
 } from "../simulator/simulator";
 import { Datetime, Json, TraceType } from "../std";
 
@@ -78,6 +79,10 @@ export class Bucket implements IBucketClient, ISimulatorResourceInstance {
   }
 
   public async cleanup(): Promise<void> {}
+
+  public async plan() {
+    return UpdatePlan.AUTO;
+  }
 
   public async save(): Promise<void> {
     // no need to save individual files, since they are already persisted in the state dir

--- a/libs/wingsdk/src/target-sim/container.inflight.ts
+++ b/libs/wingsdk/src/target-sim/container.inflight.ts
@@ -4,6 +4,7 @@ import { isPath, runCommand } from "../shared/misc";
 import {
   ISimulatorContext,
   ISimulatorResourceInstance,
+  UpdatePlan,
 } from "../simulator/simulator";
 import { Duration, TraceType } from "../std";
 import { Util } from "../util";
@@ -129,6 +130,10 @@ export class Container implements IContainerClient, ISimulatorResourceInstance {
   }
 
   public async save(): Promise<void> {}
+
+  public async plan() {
+    return UpdatePlan.AUTO;
+  }
 }
 
 async function waitUntil(predicate: () => Promise<boolean>) {

--- a/libs/wingsdk/src/target-sim/counter.inflight.ts
+++ b/libs/wingsdk/src/target-sim/counter.inflight.ts
@@ -6,6 +6,7 @@ import { ICounterClient } from "../cloud";
 import {
   ISimulatorContext,
   ISimulatorResourceInstance,
+  UpdatePlan,
 } from "../simulator/simulator";
 
 const VALUES_FILENAME = "values.json";
@@ -36,6 +37,10 @@ export class Counter implements ICounterClient, ISimulatorResourceInstance {
   }
 
   public async cleanup(): Promise<void> {}
+
+  public async plan() {
+    return UpdatePlan.AUTO;
+  }
 
   public async save(): Promise<void> {
     fs.writeFileSync(

--- a/libs/wingsdk/src/target-sim/domain.inflight.ts
+++ b/libs/wingsdk/src/target-sim/domain.inflight.ts
@@ -1,6 +1,10 @@
 import { DomainSchema } from "./schema-resources";
 import { IDomainClient } from "../cloud";
-import { ISimulatorContext, ISimulatorResourceInstance } from "../simulator";
+import {
+  ISimulatorContext,
+  ISimulatorResourceInstance,
+  UpdatePlan,
+} from "../simulator";
 
 export class Domain implements IDomainClient, ISimulatorResourceInstance {
   constructor(_props: DomainSchema["props"], _context: ISimulatorContext) {}
@@ -11,4 +15,8 @@ export class Domain implements IDomainClient, ISimulatorResourceInstance {
   public async cleanup(): Promise<void> {}
 
   public async save(): Promise<void> {}
+
+  public async plan() {
+    return UpdatePlan.AUTO;
+  }
 }

--- a/libs/wingsdk/src/target-sim/endpoint.inflight.ts
+++ b/libs/wingsdk/src/target-sim/endpoint.inflight.ts
@@ -5,7 +5,11 @@ import { connect, ConnectResponse } from "@winglang/wingtunnels";
 import { EndpointAttributes, EndpointSchema } from "./schema-resources";
 import { exists } from "./util";
 import { IEndpointClient } from "../cloud";
-import { ISimulatorContext, ISimulatorResourceInstance } from "../simulator";
+import {
+  ISimulatorContext,
+  ISimulatorResourceInstance,
+  UpdatePlan,
+} from "../simulator";
 
 const STATE_FILENAME = "state.json";
 
@@ -51,6 +55,10 @@ export class Endpoint implements IEndpointClient, ISimulatorResourceInstance {
     return this.saveState({
       ...(this.lastSubdomain && { subdomain: this.lastSubdomain }),
     });
+  }
+
+  public async plan() {
+    return UpdatePlan.AUTO;
   }
 
   public async expose(): Promise<void> {

--- a/libs/wingsdk/src/target-sim/event-mapping.inflight.ts
+++ b/libs/wingsdk/src/target-sim/event-mapping.inflight.ts
@@ -7,7 +7,7 @@ import {
   PublisherHandle,
 } from "./schema-resources";
 import { ISimulatorContext } from "../simulator";
-import { ISimulatorResourceInstance } from "../simulator/simulator";
+import { ISimulatorResourceInstance, UpdatePlan } from "../simulator/simulator";
 
 export class EventMapping implements ISimulatorResourceInstance {
   private readonly publisher: PublisherHandle;
@@ -35,4 +35,8 @@ export class EventMapping implements ISimulatorResourceInstance {
   }
 
   public async save(): Promise<void> {}
+
+  public async plan() {
+    return UpdatePlan.AUTO;
+  }
 }

--- a/libs/wingsdk/src/target-sim/function.inflight.ts
+++ b/libs/wingsdk/src/target-sim/function.inflight.ts
@@ -6,6 +6,7 @@ import { Sandbox } from "../shared/sandbox";
 import {
   ISimulatorContext,
   ISimulatorResourceInstance,
+  UpdatePlan,
 } from "../simulator/simulator";
 import { TraceType } from "../std";
 
@@ -49,6 +50,12 @@ export class Function implements IFunctionClient, ISimulatorResourceInstance {
   }
 
   public async save(): Promise<void> {}
+
+  public async plan(): Promise<UpdatePlan> {
+    // for now, always replace because we can't determine if the function code
+    // has changed since the last update. see https://github.com/winglang/wing/issues/6116
+    return UpdatePlan.REPLACE;
+  }
 
   public async invoke(payload: string): Promise<string> {
     return this.context.withTrace({

--- a/libs/wingsdk/src/target-sim/on-deploy.inflight.ts
+++ b/libs/wingsdk/src/target-sim/on-deploy.inflight.ts
@@ -3,6 +3,7 @@ import { IFunctionClient, IOnDeployClient } from "../cloud";
 import {
   ISimulatorContext,
   ISimulatorResourceInstance,
+  UpdatePlan,
 } from "../simulator/simulator";
 
 export class OnDeploy implements IOnDeployClient, ISimulatorResourceInstance {
@@ -33,4 +34,8 @@ export class OnDeploy implements IOnDeployClient, ISimulatorResourceInstance {
   public async cleanup(): Promise<void> {}
 
   public async save(): Promise<void> {}
+
+  public async plan() {
+    return UpdatePlan.AUTO;
+  }
 }

--- a/libs/wingsdk/src/target-sim/queue.inflight.ts
+++ b/libs/wingsdk/src/target-sim/queue.inflight.ts
@@ -11,6 +11,7 @@ import { IFunctionClient, IQueueClient, QUEUE_FQN } from "../cloud";
 import {
   ISimulatorContext,
   ISimulatorResourceInstance,
+  UpdatePlan,
 } from "../simulator/simulator";
 import { TraceType } from "../std";
 
@@ -40,6 +41,10 @@ export class Queue
   }
 
   public async save(): Promise<void> {}
+
+  public async plan() {
+    return UpdatePlan.AUTO;
+  }
 
   public async addEventSubscription(
     subscriber: FunctionHandle,

--- a/libs/wingsdk/src/target-sim/react-app.inflight.ts
+++ b/libs/wingsdk/src/target-sim/react-app.inflight.ts
@@ -4,7 +4,11 @@ import { join } from "path";
 import { promisify } from "util";
 import { ReactAppAttributes, ReactAppSchema } from "./schema-resources";
 import { IReactAppClient, REACT_APP_FQN, WING_JS } from "../ex";
-import { ISimulatorContext, ISimulatorResourceInstance } from "../simulator";
+import {
+  ISimulatorContext,
+  ISimulatorResourceInstance,
+  UpdatePlan,
+} from "../simulator";
 import { TraceType } from "../std";
 
 export class ReactApp implements IReactAppClient, ISimulatorResourceInstance {
@@ -84,6 +88,10 @@ window.wingEnv = ${JSON.stringify(this.environmentVariables, null, 2)};`
   }
 
   public async save(): Promise<void> {}
+
+  public async plan() {
+    return UpdatePlan.AUTO;
+  }
 
   private addTrace(message: string): void {
     this.context.addTrace({

--- a/libs/wingsdk/src/target-sim/redis.inflight.ts
+++ b/libs/wingsdk/src/target-sim/redis.inflight.ts
@@ -4,6 +4,7 @@ import { RedisClientBase } from "../ex";
 import {
   ISimulatorContext,
   ISimulatorResourceInstance,
+  UpdatePlan,
 } from "../simulator/simulator";
 
 export class Redis
@@ -45,6 +46,10 @@ export class Redis
   }
 
   public async save(): Promise<void> {}
+
+  public async plan() {
+    return UpdatePlan.AUTO;
+  }
 
   public async rawClient(): Promise<any> {
     if (this.connection) {

--- a/libs/wingsdk/src/target-sim/schedule.inflight.ts
+++ b/libs/wingsdk/src/target-sim/schedule.inflight.ts
@@ -7,7 +7,11 @@ import {
   ScheduleTask,
 } from "./schema-resources";
 import { IFunctionClient, IScheduleClient, SCHEDULE_FQN } from "../cloud";
-import { ISimulatorContext, ISimulatorResourceInstance } from "../simulator";
+import {
+  ISimulatorContext,
+  ISimulatorResourceInstance,
+  UpdatePlan,
+} from "../simulator";
 import { TraceType } from "../std";
 
 export class Schedule
@@ -46,6 +50,10 @@ export class Schedule
   }
 
   public async save(): Promise<void> {}
+
+  public async plan() {
+    return UpdatePlan.AUTO;
+  }
 
   public async addEventSubscription(
     subscriber: string,

--- a/libs/wingsdk/src/target-sim/secret.inflight.ts
+++ b/libs/wingsdk/src/target-sim/secret.inflight.ts
@@ -6,6 +6,7 @@ import { ISecretClient, SECRET_FQN } from "../cloud";
 import {
   ISimulatorContext,
   ISimulatorResourceInstance,
+  UpdatePlan,
 } from "../simulator/simulator";
 import { Json, TraceType } from "../std";
 
@@ -34,6 +35,10 @@ export class Secret implements ISecretClient, ISimulatorResourceInstance {
   public async cleanup(): Promise<void> {}
 
   public async save(): Promise<void> {}
+
+  public async plan() {
+    return UpdatePlan.AUTO;
+  }
 
   public async value(): Promise<string> {
     this.context.addTrace({

--- a/libs/wingsdk/src/target-sim/service.inflight.ts
+++ b/libs/wingsdk/src/target-sim/service.inflight.ts
@@ -3,7 +3,11 @@ import { ServiceAttributes, ServiceSchema } from "./schema-resources";
 import { IServiceClient, SERVICE_FQN } from "../cloud";
 import { Bundle } from "../shared/bundling";
 import { Sandbox } from "../shared/sandbox";
-import { ISimulatorContext, ISimulatorResourceInstance } from "../simulator";
+import {
+  ISimulatorContext,
+  ISimulatorResourceInstance,
+  UpdatePlan,
+} from "../simulator";
 import { TraceType } from "../std";
 
 export class Service implements IServiceClient, ISimulatorResourceInstance {
@@ -43,6 +47,12 @@ export class Service implements IServiceClient, ISimulatorResourceInstance {
   }
 
   public async save(): Promise<void> {}
+
+  public async plan(): Promise<UpdatePlan> {
+    // for now, always replace because we can't determine if the function code
+    // has changed since the last update. see https://github.com/winglang/wing/issues/6116
+    return UpdatePlan.REPLACE;
+  }
 
   public async start(): Promise<void> {
     // Do nothing if service is already running.

--- a/libs/wingsdk/src/target-sim/state.inflight.ts
+++ b/libs/wingsdk/src/target-sim/state.inflight.ts
@@ -1,6 +1,10 @@
 import { StateSchema } from "./schema-resources";
 import { IStateClient } from "./state";
-import { ISimulatorContext, ISimulatorResourceInstance } from "../simulator";
+import {
+  ISimulatorContext,
+  ISimulatorResourceInstance,
+  UpdatePlan,
+} from "../simulator";
 import { Json } from "../std";
 
 export class State implements IStateClient, ISimulatorResourceInstance {
@@ -15,6 +19,10 @@ export class State implements IStateClient, ISimulatorResourceInstance {
   public async cleanup(): Promise<void> {}
 
   public async save(): Promise<void> {}
+
+  public async plan() {
+    return UpdatePlan.AUTO;
+  }
 
   public async set(key: string, value: any): Promise<void> {
     this.context.setResourceAttributes(this.context.resourcePath, {

--- a/libs/wingsdk/src/target-sim/table.inflight.ts
+++ b/libs/wingsdk/src/target-sim/table.inflight.ts
@@ -4,6 +4,7 @@ import { validateRow } from "../shared/table-utils";
 import {
   ISimulatorContext,
   ISimulatorResourceInstance,
+  UpdatePlan,
 } from "../simulator/simulator";
 import { Json } from "../std";
 
@@ -39,6 +40,10 @@ export class Table implements ITableClient, ISimulatorResourceInstance {
   public async cleanup(): Promise<void> {}
 
   public async save(): Promise<void> {}
+
+  public async plan() {
+    return UpdatePlan.AUTO;
+  }
 
   public async insert(key: string, row: Json): Promise<void> {
     validateRow(row, this.columns);

--- a/libs/wingsdk/src/target-sim/test-runner.inflight.ts
+++ b/libs/wingsdk/src/target-sim/test-runner.inflight.ts
@@ -1,6 +1,10 @@
 import { TestRunnerAttributes, TestRunnerSchema } from "./schema-resources";
 import { IFunctionClient } from "../cloud";
-import { ISimulatorContext, ISimulatorResourceInstance } from "../simulator";
+import {
+  ISimulatorContext,
+  ISimulatorResourceInstance,
+  UpdatePlan,
+} from "../simulator";
 import { ITestRunnerClient, TestResult } from "../std";
 
 export class TestRunner
@@ -24,6 +28,10 @@ export class TestRunner
   }
 
   public async save(): Promise<void> {}
+
+  public async plan() {
+    return UpdatePlan.AUTO;
+  }
 
   public async listTests(): Promise<string[]> {
     return Array.from(this.tests.keys());

--- a/libs/wingsdk/src/target-sim/topic.inflight.ts
+++ b/libs/wingsdk/src/target-sim/topic.inflight.ts
@@ -10,6 +10,7 @@ import { IFunctionClient, ITopicClient, TOPIC_FQN } from "../cloud";
 import {
   ISimulatorContext,
   ISimulatorResourceInstance,
+  UpdatePlan,
 } from "../simulator/simulator";
 import { TraceType } from "../std";
 
@@ -31,6 +32,10 @@ export class Topic
   public async cleanup(): Promise<void> {}
 
   public async save(): Promise<void> {}
+
+  public async plan() {
+    return UpdatePlan.AUTO;
+  }
 
   private async publishMessage(message: string) {
     for (const subscriber of this.subscribers) {

--- a/libs/wingsdk/src/target-sim/website.inflight.ts
+++ b/libs/wingsdk/src/target-sim/website.inflight.ts
@@ -7,6 +7,7 @@ import { IWebsiteClient, WEBSITE_FQN } from "../cloud";
 import {
   ISimulatorContext,
   ISimulatorResourceInstance,
+  UpdatePlan,
 } from "../simulator/simulator";
 import { TraceType } from "../std";
 
@@ -77,6 +78,10 @@ export class Website implements IWebsiteClient, ISimulatorResourceInstance {
   }
 
   public async save(): Promise<void> {}
+
+  public async plan() {
+    return UpdatePlan.AUTO;
+  }
 
   private addTrace(message: string): void {
     this.context.addTrace({


### PR DESCRIPTION
Fixes #6116 by allowing a simulator resource to determine it's update "plan" when new configuration arrives.

For now, both `cloud.Function` and `cloud.Service` always return "REPLACE" which means that these resources will always get updated. In a future commit we can be more granular about the update by calculating the bundle hash.

## Checklist

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [x] Tests added (always)
- [x] Docs updated (only required for features)
- [x] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
