### PR TITLE
fix(sdk): cloud.Api routes update incorrectly

### DIFF
--- a/libs/wingsdk/test/simulator/simulator.test.ts
+++ b/libs/wingsdk/test/simulator/simulator.test.ts
@@ -638,6 +638,51 @@ describe("in-place updates", () => {
       "root/Service started",
     ]);
   });
+
+  test("cloud.Api routes are updated", async () => {
+    const app = new SimApp();
+    const handler = Testing.makeHandler(
+      `async handle(req) { return { status: 200 }; }`
+    );
+    const api = new Api(app, "Api");
+    api.get("/hello", handler);
+
+    const sim = await app.startSimulator();
+    const apiUrl = sim.getResourceConfig("/Api").attrs.url as string;
+    const response1 = await fetch(`${apiUrl}/hello`, { method: "GET" });
+    expect(response1.status).toEqual(200);
+
+    const app2 = new SimApp();
+    const api2 = new Api(app2, "Api");
+    api2.get("/world", handler);
+
+    const app2Dir = app2.synth();
+    await sim.update(app2Dir);
+
+    // /hello route should be removed
+    const response2 = await fetch(`${apiUrl}/hello`, { method: "GET" });
+    expect(response2.status).toEqual(404);
+
+    // /world route should be added
+    const response3 = await fetch(`${apiUrl}/world`, { method: "GET" });
+    expect(response3.status).toEqual(200);
+
+    expect(simTraces(sim)).toEqual([
+      "root/Api started",
+      "root/Api/Endpoint started",
+      "root/Api/OnRequestHandler0 started",
+      "root/Api/ApiEventMapping0 started",
+      "Update: 0 added, 3 updated, 0 deleted",
+      "root/Api/ApiEventMapping0 stopped",
+      "root/Api/OnRequestHandler0 stopped",
+      "root/Api/Endpoint stopped",
+      "root/Api stopped",
+      "root/Api started",
+      "root/Api/Endpoint started",
+      "root/Api/OnRequestHandler0 started",
+      "root/Api/ApiEventMapping0 started",
+    ]);
+  });
 });
 
 test("debugging inspector inherited by sandbox", async () => {


### PR DESCRIPTION
Fixes #6135 

There's a bug where `cloud.Api` endpoints can't be called in the simulator after the simulator is updated. The root cause was because the HTTP router used in the implementation wasn't getting updated properly when routes were removed.

Currently whenever the simulator reloads, all `cloud.Function` resources are deleted and recreated (a side effect of https://github.com/winglang/wing/pull/6117). Each `cloud.Api` route corresponds to a `cloud.Function` -- so this means all routes are removed and re-added as well. This should be fine, but routes were not getting removed from the express router instance, so the route handlers continued handling requests and try calling old `cloud.Function` instances that no longer existed.

----

This PR fixes the bug by tracking and removing Express.js's internal route handlers when necessary. I couldn't find docs for Express v4 saying it supports this. An alternative approach offered in (link to PR).

## Checklist

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [x] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
