### PR TITLE
fix(sdk): `cloud.service` logs are not shown in cli simulator tests

### DIFF
--- a/apps/wing/src/commands/test/test.ts
+++ b/apps/wing/src/commands/test/test.ts
@@ -4,6 +4,7 @@ import { basename, join, relative, resolve, sep } from "path";
 import { promisify } from "util";
 import { BuiltinPlatform, determineTargetFromPlatforms } from "@winglang/compiler";
 import { std, simulator } from "@winglang/sdk";
+import { TraceType } from "@winglang/sdk/lib/std";
 import { Util } from "@winglang/sdk/lib/util";
 import { prettyPrintError } from "@winglang/sdk/lib/util/enhanced-error";
 import chalk from "chalk";
@@ -199,10 +200,10 @@ export async function renderTestReport(
     // add any log messages that were emitted during the test
     for (const trace of result.traces) {
       // only show detailed traces if we are in debug mode
-      if (trace.type === "resource" && process.env.DEBUG) {
+      if (trace.type === TraceType.RESOURCE && process.env.DEBUG) {
         details.push(chalk.gray("[trace] " + trace.data.message));
       }
-      if (trace.type === "log") {
+      if (trace.type === TraceType.LOG) {
         details.push(chalk.gray(trace.data.message));
       }
     }

--- a/libs/wingsdk/src/target-sim/container.inflight.ts
+++ b/libs/wingsdk/src/target-sim/container.inflight.ts
@@ -28,7 +28,7 @@ export class Container implements IContainerClient, ISimulatorResourceInstance {
       sourcePath: this.context.resourcePath,
       sourceType: "container",
       timestamp: new Date().toISOString(),
-      type: TraceType.LOG,
+      type: TraceType.RESOURCE, //system messages that will be displayed on debug mode only
     });
   }
 

--- a/libs/wingsdk/src/target-sim/test-runner.inflight.ts
+++ b/libs/wingsdk/src/target-sim/test-runner.inflight.ts
@@ -5,7 +5,7 @@ import {
   ISimulatorResourceInstance,
   UpdatePlan,
 } from "../simulator";
-import { ITestRunnerClient, TestResult } from "../std";
+import { ITestRunnerClient, TestResult, TraceType } from "../std";
 
 export class TestRunner
   implements ITestRunnerClient, ISimulatorResourceInstance
@@ -54,11 +54,18 @@ export class TestRunner
     }
     // only return traces that were added after the test was run
     const newTraces = this.context.listTraces().slice(previousTraces);
+
+    // as well as any log trace prior to that- https://github.com/winglang/wing/issues/4995
+    const logTraces = this.context
+      .listTraces()
+      .slice(0, previousTraces)
+      .filter((trace) => trace.type === TraceType.LOG);
+
     return {
       path,
       pass,
       error,
-      traces: newTraces,
+      traces: [...logTraces, ...newTraces],
     };
   }
 }

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/container/container.test.w_test_sim.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/container/container.test.w_test_sim.md
@@ -3,41 +3,9 @@
 ## stdout.log
 ```log
 pass ┌ container.test.wsim » root/env0/test:get echo
-     │ pulling hashicorp/http-echo
-     │ starting container from image hashicorp/http-echo
-     │ docker run --detach --rm --name wing-container-01HTM6SEHQW36DD99EFWFQDECS -p 5678 hashicorp/http-echo -text=bang
-     │ containerName=wing-container-01HTM6SEHQW36DD99EFWFQDECS
-     │ building locally from ./my-docker-image and tagging my-app:a9ae83b54b1ec21faa1a3255f05c095c...
-     │ starting container from image my-app:a9ae83b54b1ec21faa1a3255f05c095c
-     │ docker run --detach --rm --name wing-container-01HTM6SHS4S0453Z8TXGKMJAV3 -p 3000 my-app:a9ae83b54b1ec21faa1a3255f05c095c
-     │ containerName=wing-container-01HTM6SHS4S0453Z8TXGKMJAV3
-     │ image my-app:a9ae83b54b1ec21faa1a3255f05c095c already exists
-     │ starting container from image my-app:a9ae83b54b1ec21faa1a3255f05c095c
-     │ docker run --detach --rm --name wing-container-01HTM6SSZKK6PMJQJGTDJ7TDM1 -p 3000 my-app:a9ae83b54b1ec21faa1a3255f05c095c
-     │ containerName=wing-container-01HTM6SSZKK6PMJQJGTDJ7TDM1
-     │ image hashicorp/http-echo already exists
-     │ starting container from image hashicorp/http-echo
-     │ docker run --detach --rm --name wing-container-01HTM6STFJS0FESRNDXGYVC2FK -p 5678 hashicorp/http-echo -text=bang
-     │ containerName=wing-container-01HTM6STFJS0FESRNDXGYVC2FK
      │ bang
      └ 
 pass ┌ container.test.wsim » root/env1/test:get app 
-     │ pulling hashicorp/http-echo
-     │ starting container from image hashicorp/http-echo
-     │ docker run --detach --rm --name wing-container-01HTM6SEHQW36DD99EFWFQDECS -p 5678 hashicorp/http-echo -text=bang
-     │ containerName=wing-container-01HTM6SEHQW36DD99EFWFQDECS
-     │ building locally from ./my-docker-image and tagging my-app:a9ae83b54b1ec21faa1a3255f05c095c...
-     │ starting container from image my-app:a9ae83b54b1ec21faa1a3255f05c095c
-     │ docker run --detach --rm --name wing-container-01HTM6SHS4S0453Z8TXGKMJAV3 -p 3000 my-app:a9ae83b54b1ec21faa1a3255f05c095c
-     │ containerName=wing-container-01HTM6SHS4S0453Z8TXGKMJAV3
-     │ image my-app:a9ae83b54b1ec21faa1a3255f05c095c already exists
-     │ starting container from image my-app:a9ae83b54b1ec21faa1a3255f05c095c
-     │ docker run --detach --rm --name wing-container-01HTM6SSZKK6PMJQJGTDJ7TDM1 -p 3000 my-app:a9ae83b54b1ec21faa1a3255f05c095c
-     │ containerName=wing-container-01HTM6SSZKK6PMJQJGTDJ7TDM1
-     │ image hashicorp/http-echo already exists
-     │ starting container from image hashicorp/http-echo
-     │ docker run --detach --rm --name wing-container-01HTM6STFJS0FESRNDXGYVC2FK -p 5678 hashicorp/http-echo -text=bang
-     │ containerName=wing-container-01HTM6STFJS0FESRNDXGYVC2FK
      │ bang
      │ 
      └ Hello, Wingnuts!

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/container/container.test.w_test_sim.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/container/container.test.w_test_sim.md
@@ -3,9 +3,43 @@
 ## stdout.log
 ```log
 pass ┌ container.test.wsim » root/env0/test:get echo
+     │ pulling hashicorp/http-echo
+     │ starting container from image hashicorp/http-echo
+     │ docker run --detach --rm --name wing-container-01HTM6SEHQW36DD99EFWFQDECS -p 5678 hashicorp/http-echo -text=bang
+     │ containerName=wing-container-01HTM6SEHQW36DD99EFWFQDECS
+     │ building locally from ./my-docker-image and tagging my-app:a9ae83b54b1ec21faa1a3255f05c095c...
+     │ starting container from image my-app:a9ae83b54b1ec21faa1a3255f05c095c
+     │ docker run --detach --rm --name wing-container-01HTM6SHS4S0453Z8TXGKMJAV3 -p 3000 my-app:a9ae83b54b1ec21faa1a3255f05c095c
+     │ containerName=wing-container-01HTM6SHS4S0453Z8TXGKMJAV3
+     │ image my-app:a9ae83b54b1ec21faa1a3255f05c095c already exists
+     │ starting container from image my-app:a9ae83b54b1ec21faa1a3255f05c095c
+     │ docker run --detach --rm --name wing-container-01HTM6SSZKK6PMJQJGTDJ7TDM1 -p 3000 my-app:a9ae83b54b1ec21faa1a3255f05c095c
+     │ containerName=wing-container-01HTM6SSZKK6PMJQJGTDJ7TDM1
+     │ image hashicorp/http-echo already exists
+     │ starting container from image hashicorp/http-echo
+     │ docker run --detach --rm --name wing-container-01HTM6STFJS0FESRNDXGYVC2FK -p 5678 hashicorp/http-echo -text=bang
+     │ containerName=wing-container-01HTM6STFJS0FESRNDXGYVC2FK
      │ bang
      └ 
 pass ┌ container.test.wsim » root/env1/test:get app 
+     │ pulling hashicorp/http-echo
+     │ starting container from image hashicorp/http-echo
+     │ docker run --detach --rm --name wing-container-01HTM6SEHQW36DD99EFWFQDECS -p 5678 hashicorp/http-echo -text=bang
+     │ containerName=wing-container-01HTM6SEHQW36DD99EFWFQDECS
+     │ building locally from ./my-docker-image and tagging my-app:a9ae83b54b1ec21faa1a3255f05c095c...
+     │ starting container from image my-app:a9ae83b54b1ec21faa1a3255f05c095c
+     │ docker run --detach --rm --name wing-container-01HTM6SHS4S0453Z8TXGKMJAV3 -p 3000 my-app:a9ae83b54b1ec21faa1a3255f05c095c
+     │ containerName=wing-container-01HTM6SHS4S0453Z8TXGKMJAV3
+     │ image my-app:a9ae83b54b1ec21faa1a3255f05c095c already exists
+     │ starting container from image my-app:a9ae83b54b1ec21faa1a3255f05c095c
+     │ docker run --detach --rm --name wing-container-01HTM6SSZKK6PMJQJGTDJ7TDM1 -p 3000 my-app:a9ae83b54b1ec21faa1a3255f05c095c
+     │ containerName=wing-container-01HTM6SSZKK6PMJQJGTDJ7TDM1
+     │ image hashicorp/http-echo already exists
+     │ starting container from image hashicorp/http-echo
+     │ docker run --detach --rm --name wing-container-01HTM6STFJS0FESRNDXGYVC2FK -p 5678 hashicorp/http-echo -text=bang
+     │ containerName=wing-container-01HTM6STFJS0FESRNDXGYVC2FK
+     │ bang
+     │ 
      └ Hello, Wingnuts!
  
  

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/function/invoke.test.w_test_sim.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/function/invoke.test.w_test_sim.md
@@ -9,6 +9,9 @@ pass ┌ invoke.test.wsim » root/env0/test:invoke
      │ log inside function
      └ contains 2 lines
 pass ┌ invoke.test.wsim » root/env1/test:invoke without inputs and outputs
+     │ log inside test
+     │ log inside function
+     │ contains 2 lines
      │ no event, no return!
      └ bang!
  

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/function/invoke_async.test.w_test_sim.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/function/invoke_async.test.w_test_sim.md
@@ -5,6 +5,7 @@
 pass ┌ invoke_async.test.wsim » root/env0/test:invoke() waits for function to finish                          
      └ log inside fn
 pass ┌ invoke_async.test.wsim » root/env1/test:invokeAsync() returns without waiting for the function finishes
+     │ log inside fn
      └ log inside fn
  
  

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/http/fetch.test.w_test_sim.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/http/fetch.test.w_test_sim.md
@@ -4,7 +4,8 @@
 ```log
 pass ┌ fetch.test.wsim » root/env0/test:redirect is 'follow' by default
      └ I am the target
-pass ─ fetch.test.wsim » root/env1/test:redirect 'manual'              
+pass ┌ fetch.test.wsim » root/env1/test:redirect 'manual'              
+     └ I am the target
  
  
 Tests 2 passed (2)

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/service/http-server.test.w_test_sim.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/service/http-server.test.w_test_sim.md
@@ -3,8 +3,17 @@
 ## stdout.log
 ```log
 pass ┌ http-server.test.wsim » root/env0/test:http server is started with the service
+     │ starting service
+     │ listening on port 40383
+     │ starting service
+     │ listening on port 42209
      └ bang bang!
 pass ┌ http-server.test.wsim » root/env1/test:service.stop() closes the http server  
+     │ starting service
+     │ listening on port 40383
+     │ starting service
+     │ listening on port 42209
+     │ bang bang!
      └ closing server...
  
  

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/service/http-server.test.w_test_sim.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/service/http-server.test.w_test_sim.md
@@ -4,15 +4,15 @@
 ```log
 pass ┌ http-server.test.wsim » root/env0/test:http server is started with the service
      │ starting service
-     │ listening on port 40383
+     │ listening on port <PORT>
      │ starting service
-     │ listening on port 42209
+     │ listening on port <PORT>
      └ bang bang!
 pass ┌ http-server.test.wsim » root/env1/test:service.stop() closes the http server  
      │ starting service
-     │ listening on port 40383
+     │ listening on port <PORT>
      │ starting service
-     │ listening on port 42209
+     │ listening on port <PORT>
      │ bang bang!
      └ closing server...
  

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/service/minimal.test.w_test_sim.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/service/minimal.test.w_test_sim.md
@@ -3,6 +3,7 @@
 ## stdout.log
 ```log
 pass ┌ minimal.test.wsim » root/env0/test:start and stop
+     │ hello, service!
      └ stopping!
  
  

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/service/stateful.test.w_test_sim.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/service/stateful.test.w_test_sim.md
@@ -2,7 +2,8 @@
 
 ## stdout.log
 ```log
-pass ─ stateful.test.wsim » root/env0/test:service is ready only after onStart finishes
+pass ┌ stateful.test.wsim » root/env0/test:service is ready only after onStart finishes
+     └ starting service
  
  
 Tests 1 passed (1)

--- a/tools/hangar/__snapshots__/test_corpus/valid/inflight_handler_singleton.test.w_test_sim.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/inflight_handler_singleton.test.w_test_sim.md
@@ -4,7 +4,8 @@
 ```log
 pass ┌ inflight_handler_singleton.test.wsim » root/env0/test:single instance of Foo                              
      └ client has been reused
-pass ─ inflight_handler_singleton.test.wsim » root/env1/test:Foo state is not shared between function invocations
+pass ┌ inflight_handler_singleton.test.wsim » root/env1/test:Foo state is not shared between function invocations
+     └ client has been reused
  
  
 Tests 2 passed (2)

--- a/tools/hangar/__snapshots__/test_corpus/valid/print.test.w_test_sim.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/print.test.w_test_sim.md
@@ -8,6 +8,8 @@ pass ┌ print.test.wsim » root/env0/test:log1
      │ inflight log 1.1
      └ inflight log 1.2
 pass ┌ print.test.wsim » root/env1/test:log2
+     │ inflight log 1.1
+     │ inflight log 1.2
      │ inflight log 2.1
      └ inflight log 2.2
  

--- a/tools/hangar/__snapshots__/test_corpus/valid/redis.test.w_test_sim.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/redis.test.w_test_sim.md
@@ -2,7 +2,15 @@
 
 ## stdout.log
 ```log
-pass ─ redis.test.wsim » root/env0/test:testing Redis
+pass ┌ redis.test.wsim » root/env0/test:testing Redis
+     │ pulling redis@sha256:e50c7e23f79ae81351beacb20e004720d4bed657415e68c2b1a2b5557c075ce0
+     │ starting container from image redis@sha256:e50c7e23f79ae81351beacb20e004720d4bed657415e68c2b1a2b5557c075ce0
+     │ docker run --detach --rm --name wing-container-01HTM6XQ3TTJXF0TAE6R53DEHK -p 6379 redis@sha256:e50c7e23f79ae81351beacb20e004720d4bed657415e68c2b1a2b5557c075ce0
+     │ containerName=wing-container-01HTM6XQ3TTJXF0TAE6R53DEHK
+     │ image redis@sha256:e50c7e23f79ae81351beacb20e004720d4bed657415e68c2b1a2b5557c075ce0 already exists
+     │ starting container from image redis@sha256:e50c7e23f79ae81351beacb20e004720d4bed657415e68c2b1a2b5557c075ce0
+     │ docker run --detach --rm --name wing-container-01HTM6XV5BF3E2VRWVHTMBMBJR -p 6379 redis@sha256:e50c7e23f79ae81351beacb20e004720d4bed657415e68c2b1a2b5557c075ce0
+     └ containerName=wing-container-01HTM6XV5BF3E2VRWVHTMBMBJR
  
  
 Tests 1 passed (1)

--- a/tools/hangar/__snapshots__/test_corpus/valid/redis.test.w_test_sim.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/redis.test.w_test_sim.md
@@ -2,15 +2,7 @@
 
 ## stdout.log
 ```log
-pass ┌ redis.test.wsim » root/env0/test:testing Redis
-     │ pulling redis@sha256:e50c7e23f79ae81351beacb20e004720d4bed657415e68c2b1a2b5557c075ce0
-     │ starting container from image redis@sha256:e50c7e23f79ae81351beacb20e004720d4bed657415e68c2b1a2b5557c075ce0
-     │ docker run --detach --rm --name wing-container-01HTM6XQ3TTJXF0TAE6R53DEHK -p 6379 redis@sha256:e50c7e23f79ae81351beacb20e004720d4bed657415e68c2b1a2b5557c075ce0
-     │ containerName=wing-container-01HTM6XQ3TTJXF0TAE6R53DEHK
-     │ image redis@sha256:e50c7e23f79ae81351beacb20e004720d4bed657415e68c2b1a2b5557c075ce0 already exists
-     │ starting container from image redis@sha256:e50c7e23f79ae81351beacb20e004720d4bed657415e68c2b1a2b5557c075ce0
-     │ docker run --detach --rm --name wing-container-01HTM6XV5BF3E2VRWVHTMBMBJR -p 6379 redis@sha256:e50c7e23f79ae81351beacb20e004720d4bed657415e68c2b1a2b5557c075ce0
-     └ containerName=wing-container-01HTM6XV5BF3E2VRWVHTMBMBJR
+pass ─ redis.test.wsim » root/env0/test:testing Redis
  
  
 Tests 1 passed (1)

--- a/tools/hangar/__snapshots__/test_corpus/valid/resource.test.w_test_sim.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/resource.test.w_test_sim.md
@@ -4,7 +4,8 @@
 ```log
 pass ┌ resource.test.wsim » root/env0/test:test             
      └ counter is: 201
-pass ─ resource.test.wsim » root/env1/test:dependency cycles
+pass ┌ resource.test.wsim » root/env1/test:dependency cycles
+     └ counter is: 201
  
  
 Tests 2 passed (2)

--- a/tools/hangar/src/utils.ts
+++ b/tools/hangar/src/utils.ts
@@ -69,6 +69,8 @@ export function sanitizeOutput(output: string) {
       .replace(/\/.state\/[^ '"]+/g, "/.state/<STATE_FILE>")
       // Remove duration from test results
       .replace(/Duration \d+m[\d.]+s/g, "Duration <DURATION>")
+      // remove changing ports
+      .replace(/port \d+/g, "port <PORT>")
   );
 }
 


### PR DESCRIPTION
## Checklist
fixes: #4995 
I added Traces of type "log" to be included in the test result traces.
I haven't written a ts test since it's better to test via the snapshots

<img width="424" alt="image" src="https://github.com/winglang/wing/assets/39455181/ad35ec50-7d49-4f80-86fc-ab20cda8ef86">
<img width="478" alt="image" src="https://github.com/winglang/wing/assets/39455181/4fa6929f-b2a6-4016-97f2-6f64e140cd88">

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [ ] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
