### PR TITLE
feat(console): hide simulator updates feature behind a feature flag

### DIFF
--- a/apps/wing-console/console/server/src/index.ts
+++ b/apps/wing-console/console/server/src/index.ts
@@ -59,8 +59,9 @@ export type RouteNames = keyof inferRouterInputs<Router> | undefined;
 
 export { isTermsAccepted } from "./utils/terms-and-conditions.js";
 
-const enableSimUpdates = process.env.WING_ENABLE_INPLACE_UPDATES === "true"
-                      || process.env.WING_ENABLE_INPLACE_UPDATES === "1";
+const enableSimUpdates =
+  process.env.WING_ENABLE_INPLACE_UPDATES === "true" ||
+  process.env.WING_ENABLE_INPLACE_UPDATES === "1";
 
 export interface CreateConsoleServerOptions {
   wingfile: string;

--- a/apps/wing-console/console/server/src/index.ts
+++ b/apps/wing-console/console/server/src/index.ts
@@ -59,6 +59,8 @@ export type RouteNames = keyof inferRouterInputs<Router> | undefined;
 
 export { isTermsAccepted } from "./utils/terms-and-conditions.js";
 
+const enableSimUpdates = process.env.ENABLE_SIM_UPDATES === "true";
+
 export interface CreateConsoleServerOptions {
   wingfile: string;
   log: LogInterface;
@@ -134,7 +136,10 @@ export const createConsoleServer = async ({
   let isStarting = false;
   let isStopping = false;
 
-  const simulator = createSimulator({ stateDir });
+  const simulator = createSimulator({
+    stateDir,
+    enableSimUpdates,
+  });
   if (onTrace) {
     simulator.on("trace", onTrace);
   }
@@ -150,7 +155,7 @@ export const createConsoleServer = async ({
     platform,
     testing: true,
   });
-  const testSimulator = createSimulator();
+  const testSimulator = createSimulator({ enableSimUpdates });
   testCompiler.on("compiled", ({ simfile }) => {
     testSimulator.start(simfile);
   });

--- a/apps/wing-console/console/server/src/index.ts
+++ b/apps/wing-console/console/server/src/index.ts
@@ -59,7 +59,8 @@ export type RouteNames = keyof inferRouterInputs<Router> | undefined;
 
 export { isTermsAccepted } from "./utils/terms-and-conditions.js";
 
-const enableSimUpdates = process.env.ENABLE_SIM_UPDATES === "true";
+const enableSimUpdates = process.env.WING_ENABLE_INPLACE_UPDATES === "true"
+                      || process.env.WING_ENABLE_INPLACE_UPDATES === "1";
 
 export interface CreateConsoleServerOptions {
   wingfile: string;

--- a/apps/wing-console/console/server/src/utils/simulator.ts
+++ b/apps/wing-console/console/server/src/utils/simulator.ts
@@ -51,13 +51,11 @@ export const createSimulator = (props?: CreateSimulatorProps): Simulator => {
       return true;
     }
     if (props?.enableSimUpdates) {
-      console.log("Simulator updates enabled");
       await events.emit("starting", { instance });
       await instance.update(simfile);
       await events.emit("started");
       return false;
     } else {
-      console.log("Stopping simulator");
       await events.emit("stopping");
       await stopSilently(instance);
       return true;
@@ -67,7 +65,6 @@ export const createSimulator = (props?: CreateSimulatorProps): Simulator => {
     try {
       const shouldStartSim = await handleExistingInstance(simfile);
       if (shouldStartSim) {
-        console.log("Starting simulator");
         instance = new simulator.Simulator({
           simfile,
           stateDir: props?.stateDir,

--- a/apps/wing-console/console/server/src/utils/simulator.ts
+++ b/apps/wing-console/console/server/src/utils/simulator.ts
@@ -25,6 +25,7 @@ export interface Simulator {
 
 export interface CreateSimulatorProps {
   stateDir?: string;
+  enableSimUpdates?: boolean;
 }
 
 const stopSilently = async (simulator: simulator.Simulator) => {
@@ -45,13 +46,28 @@ const stopSilently = async (simulator: simulator.Simulator) => {
 export const createSimulator = (props?: CreateSimulatorProps): Simulator => {
   const events = new Emittery<SimulatorEvents>();
   let instance: simulator.Simulator | undefined;
+  const handleExistingInstance = async (simfile: string): Promise<boolean> => {
+    if (!instance) {
+      return true;
+    }
+    if (props?.enableSimUpdates) {
+      console.log("Simulator updates enabled");
+      await events.emit("starting", { instance });
+      await instance.update(simfile);
+      await events.emit("started");
+      return false;
+    } else {
+      console.log("Stopping simulator");
+      await events.emit("stopping");
+      await stopSilently(instance);
+      return true;
+    }
+  };
   const start = async (simfile: string) => {
     try {
-      if (instance) {
-        await events.emit("starting", { instance });
-        await instance.update(simfile);
-        await events.emit("started");
-      } else {
+      const shouldStartSim = await handleExistingInstance(simfile);
+      if (shouldStartSim) {
+        console.log("Starting simulator");
         instance = new simulator.Simulator({
           simfile,
           stateDir: props?.stateDir,
@@ -61,7 +77,6 @@ export const createSimulator = (props?: CreateSimulatorProps): Simulator => {
             events.emit("trace", trace);
           },
         });
-
         await events.emit("starting", { instance });
         await instance.start();
         await events.emit("started");


### PR DESCRIPTION
Simulator updates feature is not fully ready yet...
By default, open the Console without the new simulator update feature.
Enable users to use this feature by setting the following env var:
`ENABLE_SIM_UPDATES=true`

## Checklist

- [ ] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [ ] Description explains motivation and solution
- [ ] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
