### PR TITLE
fix: missing uncaught inflight exceptions when debugging

### DIFF
--- a/docs/docs/06-tools/03-debugging.md
+++ b/docs/docs/06-tools/03-debugging.md
@@ -18,7 +18,6 @@ Open the command palette and type "Debug: Open JavaScript Debug Terminal". This 
 
 - ([Issue](https://github.com/winglang/wing/issues/5988)) When using the Wing Console (`wing it`) and attempting to debug inflight code in a `test` or Function, the first execution of the test will not hit a breakpoint and will need to be run again
 - ([Issue](https://github.com/winglang/wing/issues/5986)) inflight code by default has a timeout that continues during debugging, so if execution is paused for too long the program is terminate
-- Caught/Unhandled will often not stop at expected places
 
 #### Non-VSCode Support
 

--- a/libs/wingsdk/src/shared/sandbox.ts
+++ b/libs/wingsdk/src/shared/sandbox.ts
@@ -50,14 +50,14 @@ export class Sandbox {
     // wrap contents with a shim that handles the communication with the parent process
     // we insert this shim before bundling to ensure source maps are generated correctly
     contents += `
+process.setUncaughtExceptionCaptureCallback((reason) => {
+  process.send({ type: "reject", reason });
+});
+
 process.on("message", async (message) => {
   const { fn, args } = message;
-  try {
-    const value = await exports[fn](...args);
-    process.send({ type: "resolve", value });
-  } catch (err) {
-    process.send({ type: "reject", reason: err });
-  }
+  const value = await exports[fn](...args);
+  process.send({ type: "resolve", value });
 });
 `;
     const wrappedPath = entrypoint.replace(/\.js$/, ".sandbox.js");


### PR DESCRIPTION
During normal usage, when an unhandled exception occurs inflight we will prepare a stack trace for the user to show them where things went wrong. When debugging, the `throw` itself tells you it happened first. Since we were technically catching all inflight errors, the useful concept of "break on uncaught exception" didn't work.

With this change, the original errors remain uncaught and we can still communicate that error with the parent process.

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
