### PR TITLE
fix(compiler): no error when missing `return` and there's an inner closure that has a `return`

### DIFF
--- a/examples/tests/invalid/missing_return.test.w
+++ b/examples/tests/invalid/missing_return.test.w
@@ -23,3 +23,11 @@ let returnString2 = inflight (): str => {
     return "hi";
   }
 };
+
+// Ignore return statements in inner closures when searching for return statements
+let returnString3 = (): str => {
+  let x = (): str => {
+    return "what?"; // This should be ignored and we should produce a missing return error
+  };
+};
+//^ A function whose return type is "str" must return a value.

--- a/examples/tests/valid/while_loop_await.test.w
+++ b/examples/tests/valid/while_loop_await.test.w
@@ -2,7 +2,7 @@ bring cloud;
 
 let queue = new cloud.Queue();
 
-let handler = inflight (body: str): str => {
+let handler = inflight (body: str): void => {
     let i = 0;
     let iterator = inflight (j: num): num => {
         return j+1;

--- a/libs/wingc/src/type_check/has_type_stmt.rs
+++ b/libs/wingc/src/type_check/has_type_stmt.rs
@@ -1,5 +1,5 @@
 use crate::{
-	ast::{Stmt, StmtKind},
+	ast::{Expr, ExprKind, Stmt, StmtKind},
 	visit::{self, Visit},
 };
 
@@ -26,5 +26,13 @@ impl Visit<'_> for HasStatementVisitor {
 			_ => (),
 		}
 		visit::visit_stmt(self, node);
+	}
+
+	fn visit_expr(&mut self, node: &'_ Expr) {
+		// Don't recurse into closures. This way our search will ignore stmts in inner closures.
+		if matches!(node.kind, ExprKind::FunctionClosure(_)) {
+			return;
+		}
+		visit::visit_expr(self, node);
 	}
 }

--- a/tools/hangar/__snapshots__/invalid.ts.snap
+++ b/tools/hangar/__snapshots__/invalid.ts.snap
@@ -2712,6 +2712,18 @@ exports[`missing_return.test.w 1`] = `
   | \\\\-^ A function whose return type is \\"str\\" must return a value.
 
 
+error: A function whose return type is \\"str\\" must return a value.
+   --> ../../../examples/tests/invalid/missing_return.test.w:28:32
+   |  
+28 |   let returnString3 = (): str => {
+   | /--------------------------------^
+29 | |   let x = (): str => {
+30 | |     return \\"what?\\"; // This should be ignored and we should produce a missing return error
+31 | |   };
+32 | | };
+   | \\\\-^ A function whose return type is \\"str\\" must return a value.
+
+
  
  
 Tests 1 failed (1)


### PR DESCRIPTION
Fixes #5481

Don't recurse into inner closures when searching for a return stmt for missing `return` diagnostics.

## Checklist

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [x] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
