### PR TITLE
chore(sdk): index resources by paths in simulator.json

### DIFF
--- a/apps/wing-console/console/server/src/router/endpoint.ts
+++ b/apps/wing-console/console/server/src/router/endpoint.ts
@@ -1,10 +1,9 @@
 import { ENDPOINT_FQN } from "@winglang/sdk/lib/cloud/endpoint.js";
 import { type Endpoint } from "@winglang/sdk/lib/target-sim/endpoint.inflight.js";
-import type { EndpointSchema } from "@winglang/sdk/lib/target-sim/schema-resources.js";
 import * as z from "zod";
 
 import { createProcedure, createRouter } from "../utils/createRouter.js";
-import type { Simulator } from "../wingsdk.js";
+import type { EndpointSchema, Simulator } from "../wingsdk.js";
 
 export type EndpointExposeStatus = "connected" | "disconnected" | "connecting";
 

--- a/apps/wing-console/console/server/src/router/react-app.ts
+++ b/apps/wing-console/console/server/src/router/react-app.ts
@@ -1,7 +1,7 @@
-import type { ReactAppSchema } from "@winglang/sdk/lib/target-sim/schema-resources";
 import { z } from "zod";
 
 import { createProcedure, createRouter } from "../utils/createRouter.js";
+import type { ReactAppSchema } from "../wingsdk.js";
 
 export const createReactAppRouter = () => {
   return createRouter({

--- a/apps/wing-console/console/server/src/wingsdk.ts
+++ b/apps/wing-console/console/server/src/wingsdk.ts
@@ -1,3 +1,12 @@
+import type { BaseResourceSchema } from "@winglang/sdk/lib/simulator/index.js";
+import type {
+  ApiSchema as ApiSchema_,
+  TableSchema as TableSchema_,
+  WebsiteSchema as WebsiteSchema_,
+  EndpointSchema as EndpointSchema_,
+  ReactAppSchema as ReactAppSchema_,
+} from "@winglang/sdk/lib/target-sim/schema-resources.js";
+
 export {
   Simulator,
   type WingSimulatorSchema,
@@ -13,6 +22,7 @@ export type {
   ICounterClient,
   ITopicClient,
   IApiClient,
+  IEndpointClient,
   OpenApiSpec,
 } from "@winglang/sdk/lib/cloud/index.js";
 
@@ -20,8 +30,18 @@ export type { ITestRunnerClient } from "@winglang/sdk/lib/std/index.js";
 
 export type { IRedisClient, ITableClient } from "@winglang/sdk/lib/ex/index.js";
 
-export type {
-  ApiSchema,
-  TableSchema,
-  WebsiteSchema,
-} from "@winglang/sdk/lib/target-sim/schema-resources.js";
+export type ApiSchema = BaseResourceSchema & {
+  props: ApiSchema_;
+};
+export type TableSchema = BaseResourceSchema & {
+  props: TableSchema_;
+};
+export type WebsiteSchema = BaseResourceSchema & {
+  props: WebsiteSchema_;
+};
+export type EndpointSchema = BaseResourceSchema & {
+  props: EndpointSchema_;
+};
+export type ReactAppSchema = BaseResourceSchema & {
+  props: ReactAppSchema_;
+};

--- a/docs/docs/04-standard-library/sim/api-reference.md
+++ b/docs/docs/04-standard-library/sim/api-reference.md
@@ -51,7 +51,7 @@ new sim.Container(props: ContainerProps);
 ##### `toSimulator` <a name="toSimulator" id="@winglang/sdk.sim.Container.toSimulator"></a>
 
 ```wing
-toSimulator(): BaseResourceSchema
+toSimulator(): ToSimulatorOutput
 ```
 
 Convert this resource to a resource schema for the simulator.
@@ -184,7 +184,7 @@ Adds a statement to the policy.
 ##### `toSimulator` <a name="toSimulator" id="@winglang/sdk.sim.Policy.toSimulator"></a>
 
 ```wing
-toSimulator(): BaseResourceSchema
+toSimulator(): ToSimulatorOutput
 ```
 
 Convert this resource to a resource schema for the simulator.
@@ -312,7 +312,7 @@ The object key retrieved through the inflight `state.get()`.
 ##### `toSimulator` <a name="toSimulator" id="@winglang/sdk.sim.State.toSimulator"></a>
 
 ```wing
-toSimulator(): BaseResourceSchema
+toSimulator(): ToSimulatorOutput
 ```
 
 Convert this resource to a resource schema for the simulator.
@@ -677,7 +677,7 @@ Interfaces shared by all preflight classes targeting the simulator.
 ##### `toSimulator` <a name="toSimulator" id="@winglang/sdk.sim.ISimulatorResource.toSimulator"></a>
 
 ```wing
-toSimulator(): BaseResourceSchema
+toSimulator(): ToSimulatorOutput
 ```
 
 Convert this resource to a resource schema for the simulator.

--- a/libs/wingsdk/src/target-sim/api.inflight.ts
+++ b/libs/wingsdk/src/target-sim/api.inflight.ts
@@ -6,8 +6,8 @@ import express from "express";
 import { IEventPublisher } from "./event-mapping";
 import {
   ApiAttributes,
-  ApiRoute,
   ApiSchema,
+  ApiRoute,
   EventSubscription,
 } from "./schema-resources";
 import { exists } from "./util";
@@ -57,7 +57,7 @@ export class Api
   private url: string | undefined;
   private port: number | undefined;
 
-  constructor(props: ApiSchema["props"]) {
+  constructor(props: ApiSchema) {
     this.routes = [];
     const { corsHeaders } = props;
 

--- a/libs/wingsdk/src/target-sim/api.ts
+++ b/libs/wingsdk/src/target-sim/api.ts
@@ -5,12 +5,12 @@ import { EventMapping } from "./event-mapping";
 import { Function } from "./function";
 import { Policy } from "./policy";
 import { ISimulatorResource } from "./resource";
-import { ApiSchema, ApiRoute } from "./schema-resources";
+import { ApiRoute, ApiSchema } from "./schema-resources";
 import { simulatorAttrToken } from "./tokens";
 import { bindSimulatorResource, makeSimulatorJsClient } from "./util";
 import * as cloud from "../cloud";
 import { convertBetweenHandlers } from "../shared/convert";
-import { BaseResourceSchema } from "../simulator/simulator";
+import { ToSimulatorOutput } from "../simulator/simulator";
 import { IInflightHost, Node, SDK_SOURCE_MODULE } from "../std";
 
 /**
@@ -234,18 +234,15 @@ export class Api extends cloud.Api implements ISimulatorResource {
     this.addEndpoint(path, cloud.HttpMethod.CONNECT, inflight, props);
   }
 
-  public toSimulator(): BaseResourceSchema {
-    const schema: ApiSchema = {
-      type: cloud.API_FQN,
-      path: this.node.path,
-      addr: this.node.addr,
-      props: {
-        openApiSpec: this._getOpenApiSpec(),
-        corsHeaders: this._generateCorsHeaders(this.corsOptions),
-      },
-      attrs: {} as any,
+  public toSimulator(): ToSimulatorOutput {
+    const props: ApiSchema = {
+      openApiSpec: this._getOpenApiSpec(),
+      corsHeaders: this._generateCorsHeaders(this.corsOptions),
     };
-    return schema;
+    return {
+      type: cloud.API_FQN,
+      props,
+    };
   }
 
   public onLift(host: IInflightHost, ops: string[]): void {

--- a/libs/wingsdk/src/target-sim/app.ts
+++ b/libs/wingsdk/src/target-sim/app.ts
@@ -13,7 +13,7 @@ import { POLICY_FQN, Policy } from "./policy";
 import { Queue } from "./queue";
 import { ReactApp } from "./react-app";
 import { Redis } from "./redis";
-import { ISimulatorResource, isSimulatorResource } from "./resource";
+import { isSimulatorResource } from "./resource";
 import { Schedule } from "./schedule";
 import { Secret } from "./secret";
 import { Service } from "./service";
@@ -270,22 +270,17 @@ export class App extends core.App {
   }
 
   private synthSimulatorFile(outdir: string) {
-    const toSimulatorWithDeps = (res: ISimulatorResource) => {
-      const cfg = res.toSimulator();
-      const deps = res.node.dependencies.map((d) => d.node.path);
-
-      return deps.length === 0
-        ? cfg
-        : {
-            ...cfg,
-            deps,
-          };
-    };
-
     const resources: Record<string, BaseResourceSchema> = {};
-    for (const resource of new core.DependencyGraph(this.node).topology()) {
-      if (isSimulatorResource(resource)) {
-        resources[resource.node.path] = toSimulatorWithDeps(resource);
+    for (const r of new core.DependencyGraph(this.node).topology()) {
+      if (isSimulatorResource(r)) {
+        const deps = r.node.dependencies.map((d) => d.node.path);
+        resources[r.node.path] = {
+          ...r.toSimulator(),
+          path: r.node.path,
+          addr: r.node.addr,
+          deps: deps.length === 0 ? undefined : deps,
+          attrs: undefined as any,
+        };
       }
     }
 

--- a/libs/wingsdk/src/target-sim/app.ts
+++ b/libs/wingsdk/src/target-sim/app.ts
@@ -43,7 +43,11 @@ import * as core from "../core";
 import { preSynthesizeAllConstructs } from "../core/app";
 import { registerTokenResolver } from "../core/tokens";
 import { TABLE_FQN, REDIS_FQN, REACT_APP_FQN } from "../ex";
-import { TypeSchema, WingSimulatorSchema } from "../simulator/simulator";
+import {
+  BaseResourceSchema,
+  TypeSchema,
+  WingSimulatorSchema,
+} from "../simulator/simulator";
 import { TEST_RUNNER_FQN } from "../std";
 
 /**
@@ -278,10 +282,12 @@ export class App extends core.App {
           };
     };
 
-    const resources = new core.DependencyGraph(this.node)
-      .topology()
-      .filter(isSimulatorResource)
-      .map(toSimulatorWithDeps);
+    const resources: Record<string, BaseResourceSchema> = {};
+    for (const resource of new core.DependencyGraph(this.node).topology()) {
+      if (isSimulatorResource(resource)) {
+        resources[resource.node.path] = toSimulatorWithDeps(resource);
+      }
+    }
 
     const types: { [fqn: string]: TypeSchema } = {};
     for (const [fqn, className] of Object.entries(SIMULATOR_CLASS_DATA)) {

--- a/libs/wingsdk/src/target-sim/bucket.inflight.ts
+++ b/libs/wingsdk/src/target-sim/bucket.inflight.ts
@@ -35,7 +35,7 @@ export class Bucket implements IBucketClient, ISimulatorResourceInstance {
   private readonly topicHandlers: Partial<Record<BucketEventType, string>>;
   private _metadata: Map<string, ObjectMetadata>;
 
-  public constructor(props: BucketSchema["props"]) {
+  public constructor(props: BucketSchema) {
     this.initialObjects = props.initialObjects ?? {};
     this._public = props.public ?? false;
     this.topicHandlers = props.topics;

--- a/libs/wingsdk/src/target-sim/bucket.ts
+++ b/libs/wingsdk/src/target-sim/bucket.ts
@@ -6,7 +6,7 @@ import { BucketSchema } from "./schema-resources";
 import { simulatorHandleToken } from "./tokens";
 import { bindSimulatorResource, makeSimulatorJsClient } from "./util";
 import * as cloud from "../cloud";
-import { BaseResourceSchema } from "../simulator/simulator";
+import { ToSimulatorOutput } from "../simulator/simulator";
 import { IInflightHost } from "../std";
 
 /**
@@ -108,19 +108,16 @@ export class Bucket extends cloud.Bucket implements ISimulatorResource {
     return join(__dirname, "bucket.onevent.inflight.js");
   }
 
-  public toSimulator(): BaseResourceSchema {
-    const schema: BucketSchema = {
-      type: cloud.BUCKET_FQN,
-      path: this.node.path,
-      addr: this.node.addr,
-      props: {
-        public: this.public,
-        initialObjects: this.initialObjects,
-        topics: this.convertTopicsToHandles(),
-      },
-      attrs: {} as any,
+  public toSimulator(): ToSimulatorOutput {
+    const props: BucketSchema = {
+      public: this.public,
+      initialObjects: this.initialObjects,
+      topics: this.convertTopicsToHandles(),
     };
-    return schema;
+    return {
+      type: cloud.BUCKET_FQN,
+      props,
+    };
   }
 
   public onLift(host: IInflightHost, ops: string[]): void {

--- a/libs/wingsdk/src/target-sim/container.inflight.ts
+++ b/libs/wingsdk/src/target-sim/container.inflight.ts
@@ -1,5 +1,5 @@
 import { IContainerClient, HOST_PORT_ATTR } from "./container";
-import { ContainerSchema, ContainerAttributes } from "./schema-resources";
+import { ContainerAttributes, ContainerSchema } from "./schema-resources";
 import { isPath, runCommand } from "../shared/misc";
 import {
   ISimulatorContext,
@@ -14,7 +14,7 @@ export class Container implements IContainerClient, ISimulatorResourceInstance {
   private readonly containerName: string;
   private _context: ISimulatorContext | undefined;
 
-  public constructor(private readonly props: ContainerSchema["props"]) {
+  public constructor(private readonly props: ContainerSchema) {
     this.imageTag = props.imageTag;
 
     this.containerName = `wing-container-${Util.ulid()}`;

--- a/libs/wingsdk/src/target-sim/container.ts
+++ b/libs/wingsdk/src/target-sim/container.ts
@@ -8,7 +8,7 @@ import { App } from "../core";
 import { INFLIGHT_SYMBOL } from "../core/types";
 import { Util as fs } from "../fs";
 import { isPath } from "../shared/misc";
-import { BaseResourceSchema } from "../simulator/simulator";
+import { ToSimulatorOutput } from "../simulator";
 import { IInflightHost, Resource } from "../std";
 
 export const SIM_CONTAINER_FQN = fqnForType("sim.Container");
@@ -99,23 +99,19 @@ export class Container extends Resource implements ISimulatorResource {
     }
   }
 
-  public toSimulator(): BaseResourceSchema {
-    const schema: ContainerSchema = {
-      type: SIM_CONTAINER_FQN,
-      path: this.node.path,
-      addr: this.node.addr,
-      props: {
-        image: this.props.image,
-        imageTag: this.imageTag,
-        containerPort: this.props.containerPort,
-        env: this.props.env,
-        args: this.props.args,
-        cwd: App.of(this).entrypointDir,
-      },
-      attrs: {} as any,
+  public toSimulator(): ToSimulatorOutput {
+    const props: ContainerSchema = {
+      image: this.props.image,
+      imageTag: this.imageTag,
+      containerPort: this.props.containerPort,
+      env: this.props.env,
+      args: this.props.args,
+      cwd: App.of(this).entrypointDir,
     };
-
-    return schema;
+    return {
+      type: SIM_CONTAINER_FQN,
+      props,
+    };
   }
 
   public onLift(host: IInflightHost, ops: string[]): void {

--- a/libs/wingsdk/src/target-sim/counter.inflight.ts
+++ b/libs/wingsdk/src/target-sim/counter.inflight.ts
@@ -16,7 +16,7 @@ export class Counter implements ICounterClient, ISimulatorResourceInstance {
   private initial: number;
   private _context: ISimulatorContext | undefined;
 
-  public constructor(props: CounterSchema["props"]) {
+  public constructor(props: CounterSchema) {
     this.initial = props.initial ?? 0;
     this.values = new Map().set("default", this.initial);
   }

--- a/libs/wingsdk/src/target-sim/counter.ts
+++ b/libs/wingsdk/src/target-sim/counter.ts
@@ -3,7 +3,7 @@ import { ISimulatorResource } from "./resource";
 import { CounterSchema } from "./schema-resources";
 import { bindSimulatorResource, makeSimulatorJsClient } from "./util";
 import * as cloud from "../cloud";
-import { BaseResourceSchema } from "../simulator/simulator";
+import { ToSimulatorOutput } from "../simulator/simulator";
 import { IInflightHost } from "../std";
 
 /**
@@ -29,17 +29,14 @@ export class Counter extends cloud.Counter implements ISimulatorResource {
     ];
   }
 
-  public toSimulator(): BaseResourceSchema {
-    const schema: CounterSchema = {
-      type: cloud.COUNTER_FQN,
-      path: this.node.path,
-      addr: this.node.addr,
-      props: {
-        initial: this.initial,
-      },
-      attrs: {} as any,
+  public toSimulator(): ToSimulatorOutput {
+    const props: CounterSchema = {
+      initial: this.initial,
     };
-    return schema;
+    return {
+      type: cloud.COUNTER_FQN,
+      props,
+    };
   }
 
   public onLift(host: IInflightHost, ops: string[]): void {

--- a/libs/wingsdk/src/target-sim/domain.inflight.ts
+++ b/libs/wingsdk/src/target-sim/domain.inflight.ts
@@ -7,7 +7,7 @@ import {
 } from "../simulator";
 
 export class Domain implements IDomainClient, ISimulatorResourceInstance {
-  constructor(_props: DomainSchema["props"]) {}
+  constructor(_props: DomainSchema) {}
   public async init(_context: ISimulatorContext): Promise<Record<string, any>> {
     return {};
   }

--- a/libs/wingsdk/src/target-sim/domain.ts
+++ b/libs/wingsdk/src/target-sim/domain.ts
@@ -1,7 +1,8 @@
 import { Construct } from "constructs";
+import { DomainSchema } from "./schema-resources";
 import { makeSimulatorJsClient } from "./util";
 import * as cloud from "../cloud";
-import { BaseResourceSchema } from "../simulator";
+import { ToSimulatorOutput } from "../simulator";
 
 /**
  * Simulator implementation of `cloud.Domain`
@@ -18,13 +19,11 @@ export class Domain extends cloud.Domain {
     return makeSimulatorJsClient(__filename, this);
   }
 
-  public toSimulator(): BaseResourceSchema {
+  public toSimulator(): ToSimulatorOutput {
+    const props: DomainSchema = {};
     return {
       type: cloud.DOMAIN_FQN,
-      path: this.node.path,
-      addr: this.node.addr,
-      props: {},
-      attrs: {},
+      props,
     };
   }
 }

--- a/libs/wingsdk/src/target-sim/endpoint.inflight.ts
+++ b/libs/wingsdk/src/target-sim/endpoint.inflight.ts
@@ -31,7 +31,7 @@ export class Endpoint implements IEndpointClient, ISimulatorResourceInstance {
   private status: EndpointExposeStatus = "disconnected";
   private _context: ISimulatorContext | undefined;
 
-  constructor(private readonly _props: EndpointSchema["props"]) {}
+  constructor(private readonly _props: EndpointSchema) {}
 
   private get context(): ISimulatorContext {
     if (!this._context) {

--- a/libs/wingsdk/src/target-sim/endpoint.ts
+++ b/libs/wingsdk/src/target-sim/endpoint.ts
@@ -2,6 +2,7 @@ import { Construct } from "constructs";
 import { EndpointSchema } from "./schema-resources";
 import { makeSimulatorJsClient } from "./util";
 import * as cloud from "../cloud";
+import { ToSimulatorOutput } from "../simulator";
 
 /**
  * Simulator implementation of `cloud.Endpoint`
@@ -25,18 +26,16 @@ export class Endpoint extends cloud.Endpoint {
     return makeSimulatorJsClient(__filename, this);
   }
 
-  public toSimulator(): EndpointSchema {
+  public toSimulator(): ToSimulatorOutput {
+    const props: EndpointSchema = {
+      inputUrl: this._inputUrl,
+      url: this.url,
+      label: this.label,
+      browserSupport: this.browserSupport,
+    };
     return {
       type: cloud.ENDPOINT_FQN,
-      path: this.node.path,
-      addr: this.node.addr,
-      props: {
-        inputUrl: this._inputUrl,
-        url: this.url,
-        label: this.label,
-        browserSupport: this.browserSupport,
-      },
-      attrs: {} as any,
+      props,
     };
   }
 }

--- a/libs/wingsdk/src/target-sim/event-mapping.inflight.ts
+++ b/libs/wingsdk/src/target-sim/event-mapping.inflight.ts
@@ -14,7 +14,7 @@ export class EventMapping implements ISimulatorResourceInstance {
   private readonly eventSubscription: EventSubscription;
   private _context: ISimulatorContext | undefined;
 
-  constructor(props: EventMappingSchema["props"]) {
+  constructor(props: EventMappingSchema) {
     this.publisher = props.publisher;
     this.subscriber = props.subscriber;
     this.eventSubscription = props.subscriptionProps;

--- a/libs/wingsdk/src/target-sim/event-mapping.ts
+++ b/libs/wingsdk/src/target-sim/event-mapping.ts
@@ -9,8 +9,8 @@ import { simulatorHandleToken } from "./tokens";
 import { bindSimulatorResource, makeSimulatorJsClient } from "./util";
 import { fqnForType } from "../constants";
 import {
-  BaseResourceSchema,
   ISimulatorResourceInstance,
+  ToSimulatorOutput,
 } from "../simulator/simulator";
 import { IInflightHost, IResource, Node, Resource } from "../std";
 
@@ -71,19 +71,16 @@ export class EventMapping extends Resource implements ISimulatorResource {
     return this._eventProps;
   }
 
-  public toSimulator(): BaseResourceSchema {
-    const schema: EventMappingSchema = {
-      type: EVENT_MAPPING_FQN,
-      path: this.node.path,
-      addr: this.node.addr,
-      props: {
-        subscriber: simulatorHandleToken(this.eventProps.subscriber),
-        publisher: simulatorHandleToken(this.eventProps.publisher),
-        subscriptionProps: this.eventProps.subscriptionProps,
-      },
-      attrs: {} as any,
+  public toSimulator(): ToSimulatorOutput {
+    const props: EventMappingSchema = {
+      subscriber: simulatorHandleToken(this.eventProps.subscriber),
+      publisher: simulatorHandleToken(this.eventProps.publisher),
+      subscriptionProps: this.eventProps.subscriptionProps,
     };
-    return schema;
+    return {
+      type: EVENT_MAPPING_FQN,
+      props,
+    };
   }
 
   public onLift(host: IInflightHost, ops: string[]): void {

--- a/libs/wingsdk/src/target-sim/function.inflight.ts
+++ b/libs/wingsdk/src/target-sim/function.inflight.ts
@@ -21,7 +21,7 @@ export class Function implements IFunctionClient, ISimulatorResourceInstance {
   private readonly workers = new Array<Sandbox>();
   private createBundlePromise!: Promise<void>;
 
-  constructor(props: FunctionSchema["props"]) {
+  constructor(props: FunctionSchema) {
     this.sourceCodeFile = props.sourceCodeFile;
     if (props.sourceCodeLanguage !== "javascript") {
       throw new Error("Only JavaScript is supported");

--- a/libs/wingsdk/src/target-sim/function.ts
+++ b/libs/wingsdk/src/target-sim/function.ts
@@ -6,7 +6,7 @@ import { simulatorHandleToken } from "./tokens";
 import { bindSimulatorResource, makeSimulatorJsClient } from "./util";
 import * as cloud from "../cloud";
 import { App } from "../core";
-import { BaseResourceSchema, PolicyStatement } from "../simulator/simulator";
+import { PolicyStatement, ToSimulatorOutput } from "../simulator/simulator";
 import { IInflightHost, IResource } from "../std";
 import { Duration } from "../std/duration";
 
@@ -46,7 +46,7 @@ export class Function
     this.permissions.push([resource, op]);
   }
 
-  public toSimulator(): BaseResourceSchema {
+  public toSimulator(): ToSimulatorOutput {
     const outdir = App.of(this).outdir;
 
     const policy: Array<PolicyStatement> = [];
@@ -57,22 +57,18 @@ export class Function
       });
     }
 
-    const schema: FunctionSchema = {
-      type: cloud.FUNCTION_FQN,
-      path: this.node.path,
-      addr: this.node.addr,
-      props: {
-        sourceCodeFile: relative(outdir, this.entrypoint),
-        sourceCodeLanguage: "javascript",
-        environmentVariables: this.env,
-        timeout: this.timeout.seconds * 1000,
-        concurrency: this.concurrency,
-      },
-      policy: policy,
-      attrs: {} as any,
+    const props: FunctionSchema = {
+      sourceCodeFile: relative(outdir, this.entrypoint),
+      sourceCodeLanguage: "javascript",
+      environmentVariables: this.env,
+      timeout: this.timeout.seconds * 1000,
+      concurrency: this.concurrency,
     };
-
-    return schema;
+    return {
+      type: cloud.FUNCTION_FQN,
+      props,
+      policy,
+    };
   }
 
   /** @internal */

--- a/libs/wingsdk/src/target-sim/on-deploy.inflight.ts
+++ b/libs/wingsdk/src/target-sim/on-deploy.inflight.ts
@@ -9,7 +9,7 @@ import {
 export class OnDeploy implements IOnDeployClient, ISimulatorResourceInstance {
   private functionHandle: string;
 
-  public constructor(props: OnDeploySchema["props"]) {
+  public constructor(props: OnDeploySchema) {
     this.functionHandle = props.functionHandle;
   }
 

--- a/libs/wingsdk/src/target-sim/on-deploy.ts
+++ b/libs/wingsdk/src/target-sim/on-deploy.ts
@@ -3,7 +3,7 @@ import { OnDeploySchema } from "./schema-resources";
 import { simulatorHandleToken } from "./tokens";
 import { bindSimulatorResource, makeSimulatorJsClient } from "./util";
 import * as cloud from "../cloud";
-import { BaseResourceSchema } from "../simulator";
+import { ToSimulatorOutput } from "../simulator";
 import { IInflight, IInflightHost, Node, SDK_SOURCE_MODULE } from "../std";
 
 export class OnDeploy extends cloud.OnDeploy {
@@ -30,17 +30,14 @@ export class OnDeploy extends cloud.OnDeploy {
     }
   }
 
-  public toSimulator(): BaseResourceSchema {
-    const schema: OnDeploySchema = {
-      type: cloud.ON_DEPLOY_FQN,
-      path: this.node.path,
-      addr: this.node.addr,
-      props: {
-        functionHandle: simulatorHandleToken(this.fn),
-      },
-      attrs: {},
+  public toSimulator(): ToSimulatorOutput {
+    const props: OnDeploySchema = {
+      functionHandle: simulatorHandleToken(this.fn),
     };
-    return schema;
+    return {
+      type: cloud.ON_DEPLOY_FQN,
+      props,
+    };
   }
 
   public onLift(host: IInflightHost, ops: string[]): void {

--- a/libs/wingsdk/src/target-sim/policy.inflight.ts
+++ b/libs/wingsdk/src/target-sim/policy.inflight.ts
@@ -7,7 +7,7 @@ import {
 } from "../simulator";
 
 export class Policy implements IPolicyClient, ISimulatorResourceInstance {
-  constructor(_props: PolicySchema["props"]) {}
+  constructor(_props: PolicySchema) {}
   public async init(_context: ISimulatorContext): Promise<Record<string, any>> {
     return {};
   }

--- a/libs/wingsdk/src/target-sim/policy.ts
+++ b/libs/wingsdk/src/target-sim/policy.ts
@@ -3,7 +3,7 @@ import { ISimulatorResource } from "./resource";
 import { PolicySchema } from "./schema-resources";
 import { simulatorHandleToken } from "./tokens";
 import { fqnForType } from "../constants";
-import { BaseResourceSchema, PolicyStatement } from "../simulator";
+import { PolicyStatement, ToSimulatorOutput } from "../simulator";
 import { IResource, Node, Resource } from "../std";
 
 export const POLICY_FQN = fqnForType("sim.Policy");
@@ -42,7 +42,7 @@ export class Policy extends Resource implements ISimulatorResource {
     this.statements.get(resource)!.add(op);
   }
 
-  public toSimulator(): BaseResourceSchema {
+  public toSimulator(): ToSimulatorOutput {
     const statements: Array<PolicyStatement> = [];
     for (const [resource, ops] of this.statements.entries()) {
       for (const op of ops) {
@@ -52,17 +52,14 @@ export class Policy extends Resource implements ISimulatorResource {
         });
       }
     }
-    const schema: PolicySchema = {
-      type: POLICY_FQN,
-      path: this.node.path,
-      addr: this.node.addr,
-      props: {
-        principal: simulatorHandleToken(this.principal),
-        statements,
-      },
-      attrs: {} as any,
+    const props: PolicySchema = {
+      principal: simulatorHandleToken(this.principal),
+      statements,
     };
-    return schema;
+    return {
+      type: POLICY_FQN,
+      props,
+    };
   }
 }
 

--- a/libs/wingsdk/src/target-sim/queue.inflight.ts
+++ b/libs/wingsdk/src/target-sim/queue.inflight.ts
@@ -25,7 +25,7 @@ export class Queue
   private readonly timeoutSeconds: number;
   private readonly retentionPeriod: number;
 
-  constructor(props: QueueSchema["props"]) {
+  constructor(props: QueueSchema) {
     this.timeoutSeconds = props.timeout;
     this.retentionPeriod = props.retentionPeriod;
     this.processLoop = runEvery(100, async () => this.processMessages()); // every 0.1 seconds

--- a/libs/wingsdk/src/target-sim/queue.ts
+++ b/libs/wingsdk/src/target-sim/queue.ts
@@ -13,7 +13,7 @@ import { bindSimulatorResource, makeSimulatorJsClient } from "./util";
 import * as cloud from "../cloud";
 import { NotImplementedError } from "../core/errors";
 import { convertBetweenHandlers } from "../shared/convert";
-import { BaseResourceSchema } from "../simulator/simulator";
+import { ToSimulatorOutput } from "../simulator";
 import { Duration, IInflightHost, Node, SDK_SOURCE_MODULE } from "../std";
 
 /**
@@ -125,18 +125,15 @@ export class Queue extends cloud.Queue implements ISimulatorResource {
     return fn;
   }
 
-  public toSimulator(): BaseResourceSchema {
-    const schema: QueueSchema = {
-      type: cloud.QUEUE_FQN,
-      path: this.node.path,
-      addr: this.node.addr,
-      props: {
-        timeout: this.timeout.seconds,
-        retentionPeriod: this.retentionPeriod.seconds,
-      },
-      attrs: {} as any,
+  public toSimulator(): ToSimulatorOutput {
+    const props: QueueSchema = {
+      timeout: this.timeout.seconds,
+      retentionPeriod: this.retentionPeriod.seconds,
     };
-    return schema;
+    return {
+      type: cloud.QUEUE_FQN,
+      props,
+    };
   }
 
   public onLift(host: IInflightHost, ops: string[]): void {

--- a/libs/wingsdk/src/target-sim/react-app.inflight.ts
+++ b/libs/wingsdk/src/target-sim/react-app.inflight.ts
@@ -21,7 +21,7 @@ export class ReactApp implements IReactAppClient, ISimulatorResourceInstance {
   private childProcess?: ChildProcess;
   private url: string;
 
-  constructor(props: ReactAppSchema["props"]) {
+  constructor(props: ReactAppSchema) {
     this.path = props.path;
     this.startCommand = props.startCommand;
     this.environmentVariables = props.environmentVariables;

--- a/libs/wingsdk/src/target-sim/react-app.ts
+++ b/libs/wingsdk/src/target-sim/react-app.ts
@@ -5,7 +5,7 @@ import { bindSimulatorResource, makeSimulatorJsClient } from "./util";
 import * as cloud from "../cloud";
 import * as core from "../core";
 import * as ex from "../ex";
-import { BaseResourceSchema } from "../simulator";
+import { ToSimulatorOutput } from "../simulator";
 import { IInflightHost } from "../std";
 
 const DEFAULT_START_COMMAND = "npm run start";
@@ -40,24 +40,21 @@ export class ReactApp extends ex.ReactApp implements ISimulatorResource {
     return this._host ?? { url: `http://localhost:${this._localPort}` };
   }
 
-  public toSimulator(): BaseResourceSchema {
-    const schema: ReactAppSchema = {
-      type: ex.REACT_APP_FQN,
-      path: this.node.path,
-      addr: this.node.addr,
-      props: {
-        path: this._projectPath,
-        startCommand: this._startCommand,
-        environmentVariables: Object.fromEntries(
-          this._environmentVariables.entries()
-        ),
-        useBuildCommand: this._useBuildCommand,
-        url: this.url,
-        localPort: this._localPort,
-      },
-      attrs: {},
+  public toSimulator(): ToSimulatorOutput {
+    const props: ReactAppSchema = {
+      path: this._projectPath,
+      startCommand: this._startCommand,
+      environmentVariables: Object.fromEntries(
+        this._environmentVariables.entries()
+      ),
+      useBuildCommand: this._useBuildCommand,
+      url: this.url,
+      localPort: this._localPort,
     };
-    return schema;
+    return {
+      type: ex.REACT_APP_FQN,
+      props,
+    };
   }
 
   public onLift(host: IInflightHost, ops: string[]): void {

--- a/libs/wingsdk/src/target-sim/redis.inflight.ts
+++ b/libs/wingsdk/src/target-sim/redis.inflight.ts
@@ -15,7 +15,7 @@ export class Redis
   private connection?: IoRedis;
   private isCleanedUp = false;
 
-  public constructor(private readonly props: RedisSchema["props"]) {
+  public constructor(private readonly props: RedisSchema) {
     super();
   }
 

--- a/libs/wingsdk/src/target-sim/redis.ts
+++ b/libs/wingsdk/src/target-sim/redis.ts
@@ -4,7 +4,7 @@ import { ISimulatorResource } from "./resource";
 import { RedisSchema } from "./schema-resources";
 import { bindSimulatorResource, makeSimulatorJsClient } from "./util";
 import * as ex from "../ex";
-import { BaseResourceSchema } from "../simulator/simulator";
+import { ToSimulatorOutput } from "../simulator";
 import { IInflightHost } from "../std";
 
 /**
@@ -36,17 +36,14 @@ export class Redis extends ex.Redis implements ISimulatorResource {
     this.hostPort = c.hostPort;
   }
 
-  public toSimulator(): BaseResourceSchema {
-    const schema: RedisSchema = {
-      type: ex.REDIS_FQN,
-      path: this.node.path,
-      addr: this.node.addr,
-      props: {
-        port: this.hostPort,
-      },
-      attrs: {} as any,
+  public toSimulator(): ToSimulatorOutput {
+    const props: RedisSchema = {
+      port: this.hostPort,
     };
-    return schema;
+    return {
+      type: ex.REDIS_FQN,
+      props,
+    };
   }
 
   public onLift(host: IInflightHost, ops: string[]): void {

--- a/libs/wingsdk/src/target-sim/resource.ts
+++ b/libs/wingsdk/src/target-sim/resource.ts
@@ -1,4 +1,4 @@
-import { BaseResourceSchema } from "../simulator/simulator";
+import { ToSimulatorOutput } from "../simulator/simulator";
 import { IInflightHost, IResource } from "../std";
 
 /**
@@ -29,7 +29,7 @@ export interface ISimulatorResource extends IResource {
   /**
    * Convert this resource to a resource schema for the simulator.
    */
-  toSimulator(): BaseResourceSchema;
+  toSimulator(): ToSimulatorOutput;
 }
 
 export function isSimulatorResource(obj: any): obj is ISimulatorResource {

--- a/libs/wingsdk/src/target-sim/schedule.inflight.ts
+++ b/libs/wingsdk/src/target-sim/schedule.inflight.ts
@@ -22,7 +22,7 @@ export class Schedule
   private interval: CronExpression;
   private intervalTimeout?: NodeJS.Timeout;
 
-  constructor(props: ScheduleSchema["props"]) {
+  constructor(props: ScheduleSchema) {
     this.interval = parseExpression(props.cronExpression, { utc: true });
     this.scheduleFunction();
   }

--- a/libs/wingsdk/src/target-sim/schedule.ts
+++ b/libs/wingsdk/src/target-sim/schedule.ts
@@ -13,7 +13,7 @@ import {
 } from "./util";
 import * as cloud from "../cloud";
 import { convertBetweenHandlers } from "../shared/convert";
-import { BaseResourceSchema } from "../simulator";
+import { ToSimulatorOutput } from "../simulator";
 import { IInflightHost, Node, SDK_SOURCE_MODULE } from "../std";
 
 /**
@@ -68,17 +68,14 @@ export class Schedule extends cloud.Schedule implements ISimulatorResource {
     return fn;
   }
 
-  public toSimulator(): BaseResourceSchema {
-    const schema: ScheduleSchema = {
-      type: cloud.SCHEDULE_FQN,
-      path: this.node.path,
-      addr: this.node.addr,
-      props: {
-        cronExpression: this.cronExpression,
-      },
-      attrs: {} as any,
+  public toSimulator(): ToSimulatorOutput {
+    const props: ScheduleSchema = {
+      cronExpression: this.cronExpression,
     };
-    return schema;
+    return {
+      type: cloud.SCHEDULE_FQN,
+      props,
+    };
   }
 
   /** @internal */

--- a/libs/wingsdk/src/target-sim/schema-resources.ts
+++ b/libs/wingsdk/src/target-sim/schema-resources.ts
@@ -1,48 +1,14 @@
-import { SIM_CONTAINER_FQN } from "./container";
-import { EVENT_MAPPING_FQN } from "./event-mapping";
-import { POLICY_FQN } from "./policy";
-import { STATE_FQN } from "./state";
-import {
-  API_FQN,
-  BUCKET_FQN,
-  COUNTER_FQN,
-  CorsHeaders,
-  DOMAIN_FQN,
-  ENDPOINT_FQN,
-  FUNCTION_FQN,
-  HttpMethod,
-  ON_DEPLOY_FQN,
-  OpenApiSpec,
-  QUEUE_FQN,
-  SCHEDULE_FQN,
-  SECRET_FQN,
-  SERVICE_FQN,
-  TOPIC_FQN,
-  WEBSITE_FQN,
-} from "../cloud";
-import { ColumnType, REACT_APP_FQN, REDIS_FQN, TABLE_FQN } from "../ex";
-import {
-  BaseResourceAttributes,
-  BaseResourceSchema,
-  PolicyStatement,
-} from "../simulator/simulator";
-import { Json, TEST_RUNNER_FQN } from "../std";
+import { CorsHeaders, HttpMethod, OpenApiSpec } from "../cloud/api";
+import { ColumnType } from "../ex";
+import { PolicyStatement } from "../simulator/simulator";
+import { Json } from "../std";
 
 export type ResourceHandle = string;
 
-/** Schema for cloud.Api */
-export interface ApiSchema extends BaseResourceSchema {
-  readonly type: typeof API_FQN;
-  readonly props: {
-    openApiSpec: OpenApiSpec;
-    corsHeaders?: CorsHeaders;
-  };
-  readonly attrs: ApiAttributes & BaseResourceAttributes;
-}
-
-export interface ApiEventSubscription extends EventSubscription {
-  /** Subscribed routes */
-  readonly routes: ApiRoute[];
+/** Properties for cloud.Api */
+export interface ApiSchema {
+  readonly openApiSpec: OpenApiSpec;
+  readonly corsHeaders?: CorsHeaders;
 }
 
 /** Runtime attributes for cloud.Api */
@@ -59,93 +25,41 @@ export interface ApiRoute {
   readonly method: HttpMethod;
 }
 
-/** Schema for cloud.Function */
-export interface FunctionSchema extends BaseResourceSchema {
-  readonly type: typeof FUNCTION_FQN;
-  readonly props: {
-    /** The path to a file containing source code to be run when invoked. */
-    readonly sourceCodeFile: string;
-    /** The language of the function's source code. */
-    readonly sourceCodeLanguage: string;
-    /** A map of environment variables to run the function with. */
-    readonly environmentVariables: Record<string, string>;
-    /** The maximum amount of time the function can run, in milliseconds. */
-    readonly timeout: number;
-    /** The maximum number of concurrent invocations that can run at one time. */
-    readonly concurrency: number;
-  };
+/** Schema for an Api event subscription */
+export interface ApiEventSubscription extends EventSubscription {
+  /** Subscribed routes */
+  readonly routes: ApiRoute[];
+}
+
+/** Properties for cloud.Function */
+export interface FunctionSchema {
+  /** The path to a file containing source code to be run when invoked. */
+  readonly sourceCodeFile: string;
+  /** The language of the function's source code. */
+  readonly sourceCodeLanguage: string;
+  /** A map of environment variables to run the function with. */
+  readonly environmentVariables: Record<string, string>;
+  /** The maximum amount of time the function can run, in milliseconds. */
+  readonly timeout: number;
+  /** The maximum number of concurrent invocations that can run at one time. */
+  readonly concurrency: number;
 }
 
 /** Runtime attributes for cloud.Function */
 export interface FunctionAttributes {}
 
 /** Schema for cloud.Queue */
-export interface QueueSchema extends BaseResourceSchema {
-  readonly type: typeof QUEUE_FQN;
-  readonly props: {
-    /** How long a queue's consumers have to process a message, in seconds */
-    readonly timeout: number;
-    /** How long a queue retains a message, in seconds */
-    readonly retentionPeriod: number;
-  };
+export interface QueueSchema {
+  /** How long a queue's consumers have to process a message, in seconds */
+  readonly timeout: number;
+  /** How long a queue retains a message, in seconds */
+  readonly retentionPeriod: number;
 }
-
-/** Schema for cloud.Service */
-export interface ServiceSchema extends BaseResourceSchema {
-  readonly type: typeof SERVICE_FQN;
-  readonly props: {
-    /** The source code of the service */
-    readonly sourceCodeFile: string;
-    /** A map of environment variables to run the function with. */
-    readonly environmentVariables: Record<string, string>;
-    /** Whether to auto-start the service. */
-    readonly autoStart: boolean;
-  };
-}
-
-/** Runtime attributes for cloud.Service */
-export interface ServiceAttributes {}
-
-/** Runtime attributes for cloud.Schedule */
-export interface ScheduleAttributes {}
-
-/** Schema for cloud.Schedule */
-export interface ScheduleSchema extends BaseResourceSchema {
-  readonly type: typeof SCHEDULE_FQN;
-  readonly props: {
-    /** The cron expression that defines when the schedule should run. */
-    readonly cronExpression: string;
-  };
-}
-
-/** Schema for cloud.Queue.props.subscribers */
-export interface ScheduleTask extends EventSubscription {
-  /** Function that should be called. */
-  readonly functionHandle: ResourceHandle;
-}
-
-export interface EventSubscription {}
-
-/** Schema for sim.EventMapping */
-export interface EventMappingSchema extends BaseResourceSchema {
-  readonly type: typeof EVENT_MAPPING_FQN;
-  readonly props: {
-    /** Function handle to call for subscriber */
-    subscriber: ResourceHandle;
-    /** Publisher handle of the event */
-    publisher: ResourceHandle;
-    /** Additional properties of event subscription */
-    subscriptionProps: EventSubscription;
-  };
-}
-
-/** Runtime attributes for cloud.EventMapping */
-export interface EventMappingAttributes {}
 
 /** Runtime attributes for cloud.Queue */
 export interface QueueAttributes {}
 
-/** Schema for cloud.Queue.props.subscribers */
+/** Schema for a Queue event subscription */
 export interface QueueSubscriber extends EventSubscription {
   /** Function that should be called. */
   readonly functionHandle: ResourceHandle;
@@ -153,81 +67,112 @@ export interface QueueSubscriber extends EventSubscription {
   readonly batchSize: number;
 }
 
-/** Schema for cloud.Topic */
-export interface TopicSchema extends BaseResourceSchema {
-  readonly type: typeof TOPIC_FQN;
-  readonly props: {};
+/** Properties for cloud.Service */
+export interface ServiceSchema {
+  /** The source code of the service */
+  readonly sourceCodeFile: string;
+  /** A map of environment variables to run the function with. */
+  readonly environmentVariables: Record<string, string>;
+  /** Whether to auto-start the service. */
+  readonly autoStart: boolean;
 }
+
+/** Runtime attributes for cloud.Service */
+export interface ServiceAttributes {}
+
+/** Properties for cloud.Schedule */
+export interface ScheduleSchema {
+  /** The cron expression that defines when the schedule should run. */
+  readonly cronExpression: string;
+}
+
+/** Runtime attributes for cloud.Schedule */
+export interface ScheduleAttributes {}
+
+/** Schema for a Schedule event subscription */
+export interface ScheduleTask extends EventSubscription {
+  /** The function that should be called. */
+  readonly functionHandle: ResourceHandle;
+}
+
+/** Base schema for an event subscription. */
+export interface EventSubscription {}
+
+/** Properties for sim.EventMapping */
+export interface EventMappingSchema {
+  /** Function handle to call for subscriber */
+  readonly subscriber: ResourceHandle;
+  /** Publisher handle of the event */
+  readonly publisher: ResourceHandle;
+  /** Additional properties of event subscription. The specific schema will depend on who the publisher is. */
+  readonly subscriptionProps: EventSubscription;
+}
+
+/** Runtime attributes for cloud.EventMapping */
+export interface EventMappingAttributes {}
+
+/** Properties for cloud.Topic */
+export interface TopicSchema {}
 
 /** Runtime attributes for cloud.Topic */
 export interface TopicAttributes {}
 
+/** Schema for a Topic event subscription */
 export interface TopicSubscriber extends EventSubscription {
   /** Function that should be called */
   readonly functionHandle: ResourceHandle;
 }
 
+/** Properties for cloud.Table */
+export interface TableSchema {
+  readonly name: string;
+  readonly columns: { [key: string]: ColumnType };
+  readonly primaryKey: string;
+  readonly initialRows: Record<string, Json>;
+}
+
 /** Runtime attributes for cloud.Table */
 export interface TableAttributes {}
 
-/** Schema for cloud.Table */
-export interface TableSchema extends BaseResourceSchema {
-  readonly type: typeof TABLE_FQN;
-  readonly props: {
-    readonly name: string;
-    readonly columns: { [key: string]: ColumnType };
-    readonly primaryKey: string;
-    readonly initialRows: Record<string, Json>;
-  };
-}
-
-/** Schema for cloud.Bucket */
-export interface BucketSchema extends BaseResourceSchema {
-  readonly type: typeof BUCKET_FQN;
-  readonly props: {
-    /** Whether the bucket should be publicly accessible. */
-    readonly public: boolean;
-    /** The initial objects uploaded to the bucket. */
-    readonly initialObjects: Record<string, string>;
-    /** Event notification topics- the record has BucketEventType as a key and a topic handle as a value  */
-    readonly topics: Record<string, string>;
-  };
+/** Properties for cloud.Bucket */
+export interface BucketSchema {
+  /** Whether the bucket should be publicly accessible. */
+  readonly public: boolean;
+  /** The initial objects uploaded to the bucket. */
+  readonly initialObjects: Record<string, string>;
+  /** Event notification topics- the record has BucketEventType as a key and a topic handle as a value  */
+  readonly topics: Record<string, string>;
 }
 
 /** Runtime attributes for cloud.Bucket */
 export interface BucketAttributes {}
 
-/** Schema for cloud.Counter */
-export interface CounterSchema extends BaseResourceSchema {
-  readonly type: typeof COUNTER_FQN;
-  readonly props: {
-    /** The initial value of the counter. */
-    readonly initial: number;
-  };
+/** Properties for cloud.Counter */
+export interface CounterSchema {
+  /** The initial value of the counter. */
+  readonly initial: number;
 }
 
 /** Runtime attributes for cloud.Counter */
 export interface CounterAttributes {}
 
-/** Schema for cloud.TestRunner */
-export interface TestRunnerSchema extends BaseResourceSchema {
-  readonly type: typeof TEST_RUNNER_FQN;
-  readonly props: {
-    /** A map from test functions to their handles. */
-    readonly tests: Record<string, ResourceHandle>;
-  };
+/** Properties for cloud.TestRunner */
+export interface TestRunnerSchema {
+  /** A map from test functions to their handles. */
+  readonly tests: Record<string, ResourceHandle>;
 }
 
 /** Runtime attributes for cloud.TestRunner */
 export interface TestRunnerAttributes {}
 
-/** Schema for redis.Redis */
-export interface RedisSchema extends BaseResourceSchema {
-  readonly type: typeof REDIS_FQN;
-  readonly props: {
-    readonly port: string;
-  };
+/** Properties for redis.Redis */
+export interface RedisSchema {
+  /** The port to run the Redis server on. */
+  readonly port: string;
 }
+
+/** Runtime attributes for ex.Redis */
+export interface RedisAttributes {}
 
 /**
  * Custom routes created in preflight.
@@ -235,18 +180,14 @@ export interface RedisSchema extends BaseResourceSchema {
  */
 export type FileRoutes = Record<string, { data: string; contentType: string }>;
 
-/** Schema for cloud.Website */
-export interface WebsiteSchema extends BaseResourceSchema {
-  readonly type: typeof WEBSITE_FQN;
-  readonly props: {
-    /** Path to the directory where all static files are hosted from */
-    staticFilesPath: string;
-    /** Map of "files" contains dynamic content inserted from preflight */
-    fileRoutes: FileRoutes;
-    /** Name of the error document for the website. */
-    errorDocument?: string;
-  };
-  readonly attrs: WebsiteAttributes & BaseResourceAttributes;
+/** Properties for cloud.Website */
+export interface WebsiteSchema {
+  /** Path to the directory where all static files are hosted from */
+  readonly staticFilesPath: string;
+  /** Map of "files" contains dynamic content inserted from preflight */
+  readonly fileRoutes: FileRoutes;
+  /** Name of the error document for the website. */
+  readonly errorDocument?: string;
 }
 
 /** Runtime attributes for cloud.Website */
@@ -255,57 +196,61 @@ export interface WebsiteAttributes {
   readonly url: string;
 }
 
-export interface ReactAppSchema extends BaseResourceSchema {
-  readonly type: typeof REACT_APP_FQN;
-  readonly props: {
-    path: string;
-    startCommand: string;
-    environmentVariables: Record<string, string>;
-    useBuildCommand: boolean;
-    url: string;
-    localPort: string | number;
-  };
+/** Properties for ex.ReactApp */
+export interface ReactAppSchema {
+  readonly path: string;
+  readonly startCommand: string;
+  readonly environmentVariables: Record<string, string>;
+  readonly useBuildCommand: boolean;
+  readonly url: string;
+  readonly localPort: string | number;
 }
+
+/** Runtime attributes for ex.ReactApp */
 export interface ReactAppAttributes {
-  url: string;
+  readonly url: string;
 }
 
-export interface RedisAttributes {}
-
-/** Schema for cloud.Secret */
-export interface SecretSchema extends BaseResourceSchema {
-  readonly type: typeof SECRET_FQN;
-  readonly props: {
-    /** The name of the secret */
-    readonly name: string;
-  };
+/** Properties for cloud.Secret */
+export interface SecretSchema {
+  /** The name of the secret */
+  readonly name: string;
 }
 
 /** Runtime attributes for cloud.Secret */
 export interface SecretAttributes {}
 
-/** Schema for cloud.OnDeploy */
-export interface OnDeploySchema extends BaseResourceSchema {
-  readonly type: typeof ON_DEPLOY_FQN;
-  readonly props: {
-    /** The function to run on deploy. */
-    readonly functionHandle: ResourceHandle;
-  };
+/** Properties for cloud.OnDeploy */
+export interface OnDeploySchema {
+  /** The function to run on deploy. */
+  readonly functionHandle: ResourceHandle;
 }
 
 /** Runtime attributes for cloud.OnDeploy */
 export interface OnDeployAttributes {}
 
-/** Schema for simulator.State */
-export interface StateSchema extends BaseResourceSchema {
-  readonly type: typeof STATE_FQN;
-  readonly props: {};
-}
+/** Properties for sim.State */
+export interface StateSchema {}
 
-/** Schema for cloud.Domain */
-export interface DomainSchema extends BaseResourceSchema {
-  readonly type: typeof DOMAIN_FQN;
-  readonly props: {};
+/** Runtime attributes for sim.State */
+export interface StateAttributes {}
+
+/** Properties for cloud.Domain */
+export interface DomainSchema {}
+
+/** Runtime attributes for cloud.Domain */
+export interface DomainAttributes {}
+
+/** Properties for cloud.Endpoint */
+export interface EndpointSchema {
+  /** The input URL of the Endpoint. */
+  readonly inputUrl: string;
+  /** The output URL of the Endpoint. */
+  readonly url: string;
+  /** The Label of the Endpoint. */
+  readonly label: string | undefined;
+  /** Browser support of the Endpoint. */
+  readonly browserSupport: boolean | undefined;
 }
 
 /** Runtime attributes for cloud.Endpoint */
@@ -320,52 +265,26 @@ export interface EndpointAttributes {
   readonly browserSupport: boolean | undefined;
 }
 
-/** Schema for cloud.Endpoint */
-export interface EndpointSchema extends BaseResourceSchema {
-  readonly type: typeof ENDPOINT_FQN;
-  readonly props: {
-    /** The input URL of the Endpoint. */
-    readonly inputUrl: string;
-    /** The output URL of the Endpoint. */
-    readonly url: string;
-    /** The Label of the Endpoint. */
-    readonly label: string | undefined;
-    /** Browser support of the Endpoint. */
-    readonly browserSupport: boolean | undefined;
-  };
-  readonly attrs: EndpointAttributes & BaseResourceAttributes;
-}
-
-/** Runtime attributes for sim.Policy */
-export interface PolicyAttributes {}
-
-/** Schema for sim.Container */
-export interface ContainerSchema extends BaseResourceSchema {
-  readonly type: typeof SIM_CONTAINER_FQN;
-  readonly props: {
-    imageTag: string;
-    image: string;
-    containerPort?: number;
-    env?: Record<string, string>;
-    args?: string[];
-    cwd: string;
-  };
-  readonly attrs: ContainerAttributes & BaseResourceAttributes;
+/** Properties for sim.Container */
+export interface ContainerSchema {
+  readonly imageTag: string;
+  readonly image: string;
+  readonly containerPort?: number;
+  readonly env?: Record<string, string>;
+  readonly args?: string[];
+  readonly cwd: string;
 }
 
 /** Runtime attributes for sim.Container */
 export interface ContainerAttributes {}
 
-/** Schema for sim.Policy */
-export interface PolicySchema extends BaseResourceSchema {
-  readonly type: typeof POLICY_FQN;
-  readonly props: PolicySchemaProps;
-  readonly attrs: PolicyAttributes & BaseResourceAttributes;
-}
-
-export interface PolicySchemaProps {
+/** Properties for sim.Policy */
+export interface PolicySchema {
   /** The resource which the policy is attached to. */
   readonly principal: ResourceHandle;
   /** The statements in the policy. */
   readonly statements: PolicyStatement[];
 }
+
+/** Runtime attributes for sim.Policy */
+export interface PolicyAttributes {}

--- a/libs/wingsdk/src/target-sim/secret.inflight.ts
+++ b/libs/wingsdk/src/target-sim/secret.inflight.ts
@@ -15,7 +15,7 @@ export class Secret implements ISecretClient, ISimulatorResourceInstance {
   private readonly secretsFile: string;
   private readonly name: string;
 
-  constructor(props: SecretSchema["props"]) {
+  constructor(props: SecretSchema) {
     this.secretsFile = path.join(os.homedir(), ".wing", "secrets.json");
     if (!fs.existsSync(this.secretsFile)) {
       throw new Error(

--- a/libs/wingsdk/src/target-sim/secret.ts
+++ b/libs/wingsdk/src/target-sim/secret.ts
@@ -4,7 +4,7 @@ import { SecretSchema } from "./schema-resources";
 import { bindSimulatorResource, makeSimulatorJsClient } from "./util";
 import * as cloud from "../cloud";
 import { ResourceNames } from "../shared/resource-names";
-import { BaseResourceSchema } from "../simulator/simulator";
+import { ToSimulatorOutput } from "../simulator";
 import { IInflightHost } from "../std";
 
 /**
@@ -40,16 +40,13 @@ export class Secret extends cloud.Secret implements ISimulatorResource {
     ];
   }
 
-  public toSimulator(): BaseResourceSchema {
-    const schema: SecretSchema = {
-      type: cloud.SECRET_FQN,
-      path: this.node.path,
-      addr: this.node.addr,
-      props: {
-        name: this.name,
-      },
-      attrs: {} as any,
+  public toSimulator(): ToSimulatorOutput {
+    const props: SecretSchema = {
+      name: this.name,
     };
-    return schema;
+    return {
+      type: cloud.SECRET_FQN,
+      props,
+    };
   }
 }

--- a/libs/wingsdk/src/target-sim/service.inflight.ts
+++ b/libs/wingsdk/src/target-sim/service.inflight.ts
@@ -21,7 +21,7 @@ export class Service implements IServiceClient, ISimulatorResourceInstance {
   private environmentVariables: Record<string, string>;
   private createBundlePromise!: Promise<void>;
 
-  constructor(props: ServiceSchema["props"]) {
+  constructor(props: ServiceSchema) {
     this.sourceCodeFile = props.sourceCodeFile;
     this.autoStart = props.autoStart;
     this.environmentVariables = props.environmentVariables ?? {};

--- a/libs/wingsdk/src/target-sim/service.ts
+++ b/libs/wingsdk/src/target-sim/service.ts
@@ -6,7 +6,7 @@ import { simulatorHandleToken } from "./tokens";
 import { bindSimulatorResource, makeSimulatorJsClient } from "./util";
 import * as cloud from "../cloud";
 import { App } from "../core";
-import { BaseResourceSchema, PolicyStatement } from "../simulator";
+import { PolicyStatement, ToSimulatorOutput } from "../simulator";
 import { IInflightHost, IResource } from "../std";
 
 export class Service
@@ -31,7 +31,7 @@ export class Service
     this.permissions.push([resource, op]);
   }
 
-  public toSimulator(): BaseResourceSchema {
+  public toSimulator(): ToSimulatorOutput {
     const policy: Array<PolicyStatement> = [];
     for (const [resource, operation] of this.permissions) {
       policy.push({
@@ -39,19 +39,16 @@ export class Service
         resourceHandle: simulatorHandleToken(resource),
       });
     }
-    const schema: ServiceSchema = {
-      type: cloud.SERVICE_FQN,
-      path: this.node.path,
-      addr: this.node.addr,
-      props: {
-        environmentVariables: this.env,
-        sourceCodeFile: relative(App.of(this).outdir, this.entrypoint),
-        autoStart: this.autoStart,
-      },
-      policy: policy,
-      attrs: {} as any,
+    const props: ServiceSchema = {
+      environmentVariables: this.env,
+      sourceCodeFile: relative(App.of(this).outdir, this.entrypoint),
+      autoStart: this.autoStart,
     };
-    return schema;
+    return {
+      type: cloud.SERVICE_FQN,
+      props,
+      policy,
+    };
   }
 
   /** @internal */

--- a/libs/wingsdk/src/target-sim/state.inflight.ts
+++ b/libs/wingsdk/src/target-sim/state.inflight.ts
@@ -9,7 +9,7 @@ import { Json } from "../std";
 
 export class State implements IStateClient, ISimulatorResourceInstance {
   private _context: ISimulatorContext | undefined;
-  constructor(_props: StateSchema["props"]) {}
+  constructor(_props: StateSchema) {}
 
   private get context(): ISimulatorContext {
     if (!this._context) {

--- a/libs/wingsdk/src/target-sim/state.ts
+++ b/libs/wingsdk/src/target-sim/state.ts
@@ -1,9 +1,10 @@
 import { ISimulatorResource } from "./resource";
+import { StateSchema } from "./schema-resources";
 import { simulatorAttrToken } from "./tokens";
 import { bindSimulatorResource, makeSimulatorJsClient } from "./util";
 import { fqnForType } from "../constants";
 import { INFLIGHT_SYMBOL } from "../core/types";
-import { BaseResourceSchema } from "../simulator/simulator";
+import { ToSimulatorOutput } from "../simulator";
 import { IInflightHost, Json, Resource } from "../std";
 
 /**
@@ -57,13 +58,11 @@ export class State extends Resource implements ISimulatorResource {
     super.onLift(host, ops);
   }
 
-  public toSimulator(): BaseResourceSchema {
+  public toSimulator(): ToSimulatorOutput {
+    const props: StateSchema = {};
     return {
       type: STATE_FQN,
-      path: this.node.path,
-      addr: this.node.addr,
-      props: {},
-      attrs: {},
+      props,
     };
   }
 }

--- a/libs/wingsdk/src/target-sim/table.inflight.ts
+++ b/libs/wingsdk/src/target-sim/table.inflight.ts
@@ -16,7 +16,7 @@ export class Table implements ITableClient, ISimulatorResourceInstance {
   private _context: ISimulatorContext | undefined;
   private readonly initialRows: Record<string, Json>;
 
-  public constructor(props: TableSchema["props"]) {
+  public constructor(props: TableSchema) {
     this.name = props.name;
     this.columns = props.columns;
     this.primaryKey = props.primaryKey;

--- a/libs/wingsdk/src/target-sim/table.ts
+++ b/libs/wingsdk/src/target-sim/table.ts
@@ -3,7 +3,7 @@ import { ISimulatorResource } from "./resource";
 import { TableSchema } from "./schema-resources";
 import { bindSimulatorResource, makeSimulatorJsClient } from "./util";
 import * as ex from "../ex";
-import { BaseResourceSchema } from "../simulator/simulator";
+import { ToSimulatorOutput } from "../simulator/simulator";
 import { Json, IInflightHost } from "../std";
 
 /**
@@ -21,20 +21,17 @@ export class Table extends ex.Table implements ISimulatorResource {
     this.initialRows[key] = { ...row, [this.primaryKey]: key } as Json;
   }
 
-  public toSimulator(): BaseResourceSchema {
-    const schema: TableSchema = {
-      type: ex.TABLE_FQN,
-      path: this.node.path,
-      addr: this.node.addr,
-      props: {
-        name: this.name,
-        columns: this.columns,
-        primaryKey: this.primaryKey,
-        initialRows: this.initialRows,
-      },
-      attrs: {} as any,
+  public toSimulator(): ToSimulatorOutput {
+    const props: TableSchema = {
+      name: this.name,
+      columns: this.columns,
+      primaryKey: this.primaryKey,
+      initialRows: this.initialRows,
     };
-    return schema;
+    return {
+      type: ex.TABLE_FQN,
+      props,
+    };
   }
 
   /** @internal */

--- a/libs/wingsdk/src/target-sim/test-runner.inflight.ts
+++ b/libs/wingsdk/src/target-sim/test-runner.inflight.ts
@@ -14,7 +14,7 @@ export class TestRunner
   private readonly tests: Map<string, string>;
   private _context: ISimulatorContext | undefined;
 
-  constructor(props: TestRunnerSchema["props"]) {
+  constructor(props: TestRunnerSchema) {
     this.tests = new Map(Object.entries(props.tests));
   }
 

--- a/libs/wingsdk/src/target-sim/test-runner.ts
+++ b/libs/wingsdk/src/target-sim/test-runner.ts
@@ -3,7 +3,7 @@ import { ISimulatorResource } from "./resource";
 import { TestRunnerSchema } from "./schema-resources";
 import { simulatorHandleToken } from "./tokens";
 import { bindSimulatorResource, makeSimulatorJsClient } from "./util";
-import { BaseResourceSchema } from "../simulator/simulator";
+import { ToSimulatorOutput } from "../simulator/simulator";
 import * as std from "../std";
 import { IInflightHost } from "../std";
 
@@ -17,18 +17,15 @@ export class TestRunner extends std.TestRunner implements ISimulatorResource {
     super(scope, id, props);
   }
 
-  public toSimulator(): BaseResourceSchema {
+  public toSimulator(): ToSimulatorOutput {
     const tests = this.getTestFunctionHandles();
-    const schema: TestRunnerSchema = {
-      type: std.TEST_RUNNER_FQN,
-      path: this.node.path,
-      addr: this.node.addr,
-      props: {
-        tests,
-      },
-      attrs: {} as any,
+    const props: TestRunnerSchema = {
+      tests,
     };
-    return schema;
+    return {
+      type: std.TEST_RUNNER_FQN,
+      props,
+    };
   }
 
   public onLift(host: IInflightHost, ops: string[]): void {

--- a/libs/wingsdk/src/target-sim/topic.inflight.ts
+++ b/libs/wingsdk/src/target-sim/topic.inflight.ts
@@ -20,7 +20,7 @@ export class Topic
   private readonly subscribers = new Array<TopicSubscriber>();
   private _context: ISimulatorContext | undefined;
 
-  constructor(_props: TopicSchema["props"]) {}
+  constructor(_props: TopicSchema) {}
 
   private get context(): ISimulatorContext {
     if (!this._context) {

--- a/libs/wingsdk/src/target-sim/topic.ts
+++ b/libs/wingsdk/src/target-sim/topic.ts
@@ -9,8 +9,7 @@ import { TopicSchema } from "./schema-resources";
 import { bindSimulatorResource, makeSimulatorJsClient } from "./util";
 import * as cloud from "../cloud";
 import { convertBetweenHandlers } from "../shared/convert";
-import { Testing } from "../simulator";
-import { BaseResourceSchema } from "../simulator/simulator";
+import { Testing, ToSimulatorOutput } from "../simulator";
 import { IInflightHost, Node, SDK_SOURCE_MODULE } from "../std";
 
 const QUEUE_PUSH_METHOD = "push";
@@ -120,14 +119,11 @@ export class Topic extends cloud.Topic implements ISimulatorResource {
     ];
   }
 
-  public toSimulator(): BaseResourceSchema {
-    const schema: TopicSchema = {
+  public toSimulator(): ToSimulatorOutput {
+    const props: TopicSchema = {};
+    return {
       type: cloud.TOPIC_FQN,
-      path: this.node.path,
-      addr: this.node.addr,
-      props: {},
-      attrs: {} as any,
+      props,
     };
-    return schema;
   }
 }

--- a/libs/wingsdk/src/target-sim/website.inflight.ts
+++ b/libs/wingsdk/src/target-sim/website.inflight.ts
@@ -19,7 +19,7 @@ export class Website implements IWebsiteClient, ISimulatorResourceInstance {
   private server?: Server;
   private url?: string;
 
-  constructor(props: WebsiteSchema["props"]) {
+  constructor(props: WebsiteSchema) {
     // Set up an express server that handles the routes.
     this.app = express();
 

--- a/libs/wingsdk/src/target-sim/website.ts
+++ b/libs/wingsdk/src/target-sim/website.ts
@@ -4,7 +4,7 @@ import { WebsiteSchema, FileRoutes } from "./schema-resources";
 import { simulatorAttrToken } from "./tokens";
 import { bindSimulatorResource, makeSimulatorJsClient } from "./util";
 import * as cloud from "../cloud";
-import { BaseResourceSchema } from "../simulator/simulator";
+import { ToSimulatorOutput } from "../simulator";
 import { IInflightHost } from "../std";
 
 /**
@@ -47,19 +47,16 @@ export class Website extends cloud.Website implements ISimulatorResource {
   }
 
   /** Returns sim schema */
-  public toSimulator(): BaseResourceSchema {
-    const schema: WebsiteSchema = {
-      type: cloud.WEBSITE_FQN,
-      path: this.node.path,
-      addr: this.node.addr,
-      props: {
-        staticFilesPath: this.path,
-        fileRoutes: this.fileRoutes,
-        errorDocument: this.errorDocument,
-      },
-      attrs: {} as any,
+  public toSimulator(): ToSimulatorOutput {
+    const props: WebsiteSchema = {
+      staticFilesPath: this.path,
+      fileRoutes: this.fileRoutes,
+      errorDocument: this.errorDocument,
     };
-    return schema;
+    return {
+      type: cloud.WEBSITE_FQN,
+      props,
+    };
   }
 
   public onLift(host: IInflightHost, ops: string[]): void {

--- a/libs/wingsdk/test/core/__snapshots__/connections.test.ts.snap
+++ b/libs/wingsdk/test/core/__snapshots__/connections.test.ts.snap
@@ -33,7 +33,6 @@ return class Handler {
     "resources": {
       "root/my_bucket": {
         "addr": "c8220a82a4ad9c25a4f236946f350d2ac081dd7bbc",
-        "attrs": {},
         "path": "root/my_bucket",
         "props": {
           "initialObjects": {},
@@ -44,7 +43,6 @@ return class Handler {
       },
       "root/my_bucket/Policy": {
         "addr": "c8b5ba55132964ee19331fb9f46241560e67fed76b",
-        "attrs": {},
         "path": "root/my_bucket/Policy",
         "props": {
           "principal": "\${wsim#root/my_bucket#attrs.handle}",
@@ -54,7 +52,6 @@ return class Handler {
       },
       "root/my_function": {
         "addr": "c85c4e0e66bf385ab6b159bab34fb32dd81aad0a1d",
-        "attrs": {},
         "path": "root/my_function",
         "policy": [],
         "props": {

--- a/libs/wingsdk/test/core/__snapshots__/connections.test.ts.snap
+++ b/libs/wingsdk/test/core/__snapshots__/connections.test.ts.snap
@@ -30,8 +30,8 @@ return class Handler {
     "version": "connections-0.1",
   },
   "simulator.json": {
-    "resources": [
-      {
+    "resources": {
+      "root/my_bucket": {
         "addr": "c8220a82a4ad9c25a4f236946f350d2ac081dd7bbc",
         "attrs": {},
         "path": "root/my_bucket",
@@ -42,7 +42,7 @@ return class Handler {
         },
         "type": "@winglang/sdk.cloud.Bucket",
       },
-      {
+      "root/my_bucket/Policy": {
         "addr": "c8b5ba55132964ee19331fb9f46241560e67fed76b",
         "attrs": {},
         "path": "root/my_bucket/Policy",
@@ -52,7 +52,7 @@ return class Handler {
         },
         "type": "@winglang/sdk.sim.Policy",
       },
-      {
+      "root/my_function": {
         "addr": "c85c4e0e66bf385ab6b159bab34fb32dd81aad0a1d",
         "attrs": {},
         "path": "root/my_function",
@@ -66,7 +66,7 @@ return class Handler {
         },
         "type": "@winglang/sdk.cloud.Function",
       },
-    ],
+    },
     "sdkVersion": "0.0.0",
     "types": {
       "@winglang/sdk.cloud.Api": {

--- a/libs/wingsdk/test/target-sim/__snapshots__/api.test.ts.snap
+++ b/libs/wingsdk/test/target-sim/__snapshots__/api.test.ts.snap
@@ -35,48 +35,8 @@ return class Handler {
     "version": "connections-0.1",
   },
   "simulator.json": {
-    "resources": [
-      {
-        "addr": "c85bd2f9eb401f27bec4d0ad16222c2876bcfe640a",
-        "attrs": {},
-        "path": "root/my_api/Endpoint",
-        "props": {
-          "inputUrl": "\${wsim#root/my_api#attrs.url}",
-          "label": "Api root/my_api",
-          "url": "\${wsim#root/my_api#attrs.url}",
-        },
-        "type": "@winglang/sdk.cloud.Endpoint",
-      },
-      {
-        "addr": "c8d2997625976ba9bc7be90fefe7930aebab104a2a",
-        "attrs": {},
-        "path": "root/my_api/Policy",
-        "props": {
-          "principal": "\${wsim#root/my_api#attrs.handle}",
-          "statements": [
-            {
-              "operation": "invoke",
-              "resourceHandle": "\${wsim#root/my_api/OnRequestHandler0#attrs.handle}",
-            },
-          ],
-        },
-        "type": "@winglang/sdk.sim.Policy",
-      },
-      {
-        "addr": "c82d41b2501ac42e07e4565202a5b87a180a01c6a2",
-        "attrs": {},
-        "path": "root/my_api/OnRequestHandler0",
-        "policy": [],
-        "props": {
-          "concurrency": 100,
-          "environmentVariables": {},
-          "sourceCodeFile": ".wing/onrequesthandler0_c82d41b2.js",
-          "sourceCodeLanguage": "javascript",
-          "timeout": 60000,
-        },
-        "type": "@winglang/sdk.cloud.Function",
-      },
-      {
+    "resources": {
+      "root/my_api": {
         "addr": "c8f2ecf2132465e146aa80cb01f4e5ab1968f4314a",
         "attrs": {},
         "path": "root/my_api",
@@ -111,7 +71,7 @@ return class Handler {
         },
         "type": "@winglang/sdk.cloud.Api",
       },
-      {
+      "root/my_api/ApiEventMapping0": {
         "addr": "c8a199e7bc539eb442a47653fe0f2b1f0bf50aa6d1",
         "attrs": {},
         "deps": [
@@ -137,7 +97,47 @@ return class Handler {
         },
         "type": "@winglang/sdk.sim.EventMapping",
       },
-    ],
+      "root/my_api/Endpoint": {
+        "addr": "c85bd2f9eb401f27bec4d0ad16222c2876bcfe640a",
+        "attrs": {},
+        "path": "root/my_api/Endpoint",
+        "props": {
+          "inputUrl": "\${wsim#root/my_api#attrs.url}",
+          "label": "Api root/my_api",
+          "url": "\${wsim#root/my_api#attrs.url}",
+        },
+        "type": "@winglang/sdk.cloud.Endpoint",
+      },
+      "root/my_api/OnRequestHandler0": {
+        "addr": "c82d41b2501ac42e07e4565202a5b87a180a01c6a2",
+        "attrs": {},
+        "path": "root/my_api/OnRequestHandler0",
+        "policy": [],
+        "props": {
+          "concurrency": 100,
+          "environmentVariables": {},
+          "sourceCodeFile": ".wing/onrequesthandler0_c82d41b2.js",
+          "sourceCodeLanguage": "javascript",
+          "timeout": 60000,
+        },
+        "type": "@winglang/sdk.cloud.Function",
+      },
+      "root/my_api/Policy": {
+        "addr": "c8d2997625976ba9bc7be90fefe7930aebab104a2a",
+        "attrs": {},
+        "path": "root/my_api/Policy",
+        "props": {
+          "principal": "\${wsim#root/my_api#attrs.handle}",
+          "statements": [
+            {
+              "operation": "invoke",
+              "resourceHandle": "\${wsim#root/my_api/OnRequestHandler0#attrs.handle}",
+            },
+          ],
+        },
+        "type": "@winglang/sdk.sim.Policy",
+      },
+    },
     "sdkVersion": "0.0.0",
     "types": {
       "@winglang/sdk.cloud.Api": {
@@ -356,48 +356,8 @@ return class Handler {
     "version": "connections-0.1",
   },
   "simulator.json": {
-    "resources": [
-      {
-        "addr": "c85bd2f9eb401f27bec4d0ad16222c2876bcfe640a",
-        "attrs": {},
-        "path": "root/my_api/Endpoint",
-        "props": {
-          "inputUrl": "\${wsim#root/my_api#attrs.url}",
-          "label": "Api root/my_api",
-          "url": "\${wsim#root/my_api#attrs.url}",
-        },
-        "type": "@winglang/sdk.cloud.Endpoint",
-      },
-      {
-        "addr": "c8d2997625976ba9bc7be90fefe7930aebab104a2a",
-        "attrs": {},
-        "path": "root/my_api/Policy",
-        "props": {
-          "principal": "\${wsim#root/my_api#attrs.handle}",
-          "statements": [
-            {
-              "operation": "invoke",
-              "resourceHandle": "\${wsim#root/my_api/OnRequestHandler0#attrs.handle}",
-            },
-          ],
-        },
-        "type": "@winglang/sdk.sim.Policy",
-      },
-      {
-        "addr": "c82d41b2501ac42e07e4565202a5b87a180a01c6a2",
-        "attrs": {},
-        "path": "root/my_api/OnRequestHandler0",
-        "policy": [],
-        "props": {
-          "concurrency": 100,
-          "environmentVariables": {},
-          "sourceCodeFile": ".wing/onrequesthandler0_c82d41b2.js",
-          "sourceCodeLanguage": "javascript",
-          "timeout": 60000,
-        },
-        "type": "@winglang/sdk.cloud.Function",
-      },
-      {
+    "resources": {
+      "root/my_api": {
         "addr": "c8f2ecf2132465e146aa80cb01f4e5ab1968f4314a",
         "attrs": {},
         "path": "root/my_api",
@@ -422,7 +382,7 @@ return class Handler {
         },
         "type": "@winglang/sdk.cloud.Api",
       },
-      {
+      "root/my_api/ApiEventMapping0": {
         "addr": "c8a199e7bc539eb442a47653fe0f2b1f0bf50aa6d1",
         "attrs": {},
         "deps": [
@@ -444,7 +404,47 @@ return class Handler {
         },
         "type": "@winglang/sdk.sim.EventMapping",
       },
-    ],
+      "root/my_api/Endpoint": {
+        "addr": "c85bd2f9eb401f27bec4d0ad16222c2876bcfe640a",
+        "attrs": {},
+        "path": "root/my_api/Endpoint",
+        "props": {
+          "inputUrl": "\${wsim#root/my_api#attrs.url}",
+          "label": "Api root/my_api",
+          "url": "\${wsim#root/my_api#attrs.url}",
+        },
+        "type": "@winglang/sdk.cloud.Endpoint",
+      },
+      "root/my_api/OnRequestHandler0": {
+        "addr": "c82d41b2501ac42e07e4565202a5b87a180a01c6a2",
+        "attrs": {},
+        "path": "root/my_api/OnRequestHandler0",
+        "policy": [],
+        "props": {
+          "concurrency": 100,
+          "environmentVariables": {},
+          "sourceCodeFile": ".wing/onrequesthandler0_c82d41b2.js",
+          "sourceCodeLanguage": "javascript",
+          "timeout": 60000,
+        },
+        "type": "@winglang/sdk.cloud.Function",
+      },
+      "root/my_api/Policy": {
+        "addr": "c8d2997625976ba9bc7be90fefe7930aebab104a2a",
+        "attrs": {},
+        "path": "root/my_api/Policy",
+        "props": {
+          "principal": "\${wsim#root/my_api#attrs.handle}",
+          "statements": [
+            {
+              "operation": "invoke",
+              "resourceHandle": "\${wsim#root/my_api/OnRequestHandler0#attrs.handle}",
+            },
+          ],
+        },
+        "type": "@winglang/sdk.sim.Policy",
+      },
+    },
     "sdkVersion": "0.0.0",
     "types": {
       "@winglang/sdk.cloud.Api": {
@@ -663,48 +663,8 @@ return class Handler {
     "version": "connections-0.1",
   },
   "simulator.json": {
-    "resources": [
-      {
-        "addr": "c85bd2f9eb401f27bec4d0ad16222c2876bcfe640a",
-        "attrs": {},
-        "path": "root/my_api/Endpoint",
-        "props": {
-          "inputUrl": "\${wsim#root/my_api#attrs.url}",
-          "label": "Api root/my_api",
-          "url": "\${wsim#root/my_api#attrs.url}",
-        },
-        "type": "@winglang/sdk.cloud.Endpoint",
-      },
-      {
-        "addr": "c8d2997625976ba9bc7be90fefe7930aebab104a2a",
-        "attrs": {},
-        "path": "root/my_api/Policy",
-        "props": {
-          "principal": "\${wsim#root/my_api#attrs.handle}",
-          "statements": [
-            {
-              "operation": "invoke",
-              "resourceHandle": "\${wsim#root/my_api/OnRequestHandler0#attrs.handle}",
-            },
-          ],
-        },
-        "type": "@winglang/sdk.sim.Policy",
-      },
-      {
-        "addr": "c82d41b2501ac42e07e4565202a5b87a180a01c6a2",
-        "attrs": {},
-        "path": "root/my_api/OnRequestHandler0",
-        "policy": [],
-        "props": {
-          "concurrency": 100,
-          "environmentVariables": {},
-          "sourceCodeFile": ".wing/onrequesthandler0_c82d41b2.js",
-          "sourceCodeLanguage": "javascript",
-          "timeout": 60000,
-        },
-        "type": "@winglang/sdk.cloud.Function",
-      },
-      {
+    "resources": {
+      "root/my_api": {
         "addr": "c8f2ecf2132465e146aa80cb01f4e5ab1968f4314a",
         "attrs": {},
         "path": "root/my_api",
@@ -729,7 +689,7 @@ return class Handler {
         },
         "type": "@winglang/sdk.cloud.Api",
       },
-      {
+      "root/my_api/ApiEventMapping0": {
         "addr": "c8a199e7bc539eb442a47653fe0f2b1f0bf50aa6d1",
         "attrs": {},
         "deps": [
@@ -751,7 +711,47 @@ return class Handler {
         },
         "type": "@winglang/sdk.sim.EventMapping",
       },
-    ],
+      "root/my_api/Endpoint": {
+        "addr": "c85bd2f9eb401f27bec4d0ad16222c2876bcfe640a",
+        "attrs": {},
+        "path": "root/my_api/Endpoint",
+        "props": {
+          "inputUrl": "\${wsim#root/my_api#attrs.url}",
+          "label": "Api root/my_api",
+          "url": "\${wsim#root/my_api#attrs.url}",
+        },
+        "type": "@winglang/sdk.cloud.Endpoint",
+      },
+      "root/my_api/OnRequestHandler0": {
+        "addr": "c82d41b2501ac42e07e4565202a5b87a180a01c6a2",
+        "attrs": {},
+        "path": "root/my_api/OnRequestHandler0",
+        "policy": [],
+        "props": {
+          "concurrency": 100,
+          "environmentVariables": {},
+          "sourceCodeFile": ".wing/onrequesthandler0_c82d41b2.js",
+          "sourceCodeLanguage": "javascript",
+          "timeout": 60000,
+        },
+        "type": "@winglang/sdk.cloud.Function",
+      },
+      "root/my_api/Policy": {
+        "addr": "c8d2997625976ba9bc7be90fefe7930aebab104a2a",
+        "attrs": {},
+        "path": "root/my_api/Policy",
+        "props": {
+          "principal": "\${wsim#root/my_api#attrs.handle}",
+          "statements": [
+            {
+              "operation": "invoke",
+              "resourceHandle": "\${wsim#root/my_api/OnRequestHandler0#attrs.handle}",
+            },
+          ],
+        },
+        "type": "@winglang/sdk.sim.Policy",
+      },
+    },
     "sdkVersion": "0.0.0",
     "types": {
       "@winglang/sdk.cloud.Api": {
@@ -970,48 +970,8 @@ return class Handler {
     "version": "connections-0.1",
   },
   "simulator.json": {
-    "resources": [
-      {
-        "addr": "c85bd2f9eb401f27bec4d0ad16222c2876bcfe640a",
-        "attrs": {},
-        "path": "root/my_api/Endpoint",
-        "props": {
-          "inputUrl": "\${wsim#root/my_api#attrs.url}",
-          "label": "Api root/my_api",
-          "url": "\${wsim#root/my_api#attrs.url}",
-        },
-        "type": "@winglang/sdk.cloud.Endpoint",
-      },
-      {
-        "addr": "c8d2997625976ba9bc7be90fefe7930aebab104a2a",
-        "attrs": {},
-        "path": "root/my_api/Policy",
-        "props": {
-          "principal": "\${wsim#root/my_api#attrs.handle}",
-          "statements": [
-            {
-              "operation": "invoke",
-              "resourceHandle": "\${wsim#root/my_api/OnRequestHandler0#attrs.handle}",
-            },
-          ],
-        },
-        "type": "@winglang/sdk.sim.Policy",
-      },
-      {
-        "addr": "c82d41b2501ac42e07e4565202a5b87a180a01c6a2",
-        "attrs": {},
-        "path": "root/my_api/OnRequestHandler0",
-        "policy": [],
-        "props": {
-          "concurrency": 100,
-          "environmentVariables": {},
-          "sourceCodeFile": ".wing/onrequesthandler0_c82d41b2.js",
-          "sourceCodeLanguage": "javascript",
-          "timeout": 60000,
-        },
-        "type": "@winglang/sdk.cloud.Function",
-      },
-      {
+    "resources": {
+      "root/my_api": {
         "addr": "c8f2ecf2132465e146aa80cb01f4e5ab1968f4314a",
         "attrs": {},
         "path": "root/my_api",
@@ -1036,7 +996,7 @@ return class Handler {
         },
         "type": "@winglang/sdk.cloud.Api",
       },
-      {
+      "root/my_api/ApiEventMapping0": {
         "addr": "c8a199e7bc539eb442a47653fe0f2b1f0bf50aa6d1",
         "attrs": {},
         "deps": [
@@ -1058,7 +1018,47 @@ return class Handler {
         },
         "type": "@winglang/sdk.sim.EventMapping",
       },
-    ],
+      "root/my_api/Endpoint": {
+        "addr": "c85bd2f9eb401f27bec4d0ad16222c2876bcfe640a",
+        "attrs": {},
+        "path": "root/my_api/Endpoint",
+        "props": {
+          "inputUrl": "\${wsim#root/my_api#attrs.url}",
+          "label": "Api root/my_api",
+          "url": "\${wsim#root/my_api#attrs.url}",
+        },
+        "type": "@winglang/sdk.cloud.Endpoint",
+      },
+      "root/my_api/OnRequestHandler0": {
+        "addr": "c82d41b2501ac42e07e4565202a5b87a180a01c6a2",
+        "attrs": {},
+        "path": "root/my_api/OnRequestHandler0",
+        "policy": [],
+        "props": {
+          "concurrency": 100,
+          "environmentVariables": {},
+          "sourceCodeFile": ".wing/onrequesthandler0_c82d41b2.js",
+          "sourceCodeLanguage": "javascript",
+          "timeout": 60000,
+        },
+        "type": "@winglang/sdk.cloud.Function",
+      },
+      "root/my_api/Policy": {
+        "addr": "c8d2997625976ba9bc7be90fefe7930aebab104a2a",
+        "attrs": {},
+        "path": "root/my_api/Policy",
+        "props": {
+          "principal": "\${wsim#root/my_api#attrs.handle}",
+          "statements": [
+            {
+              "operation": "invoke",
+              "resourceHandle": "\${wsim#root/my_api/OnRequestHandler0#attrs.handle}",
+            },
+          ],
+        },
+        "type": "@winglang/sdk.sim.Policy",
+      },
+    },
     "sdkVersion": "0.0.0",
     "types": {
       "@winglang/sdk.cloud.Api": {
@@ -1277,48 +1277,8 @@ return class Handler {
     "version": "connections-0.1",
   },
   "simulator.json": {
-    "resources": [
-      {
-        "addr": "c85bd2f9eb401f27bec4d0ad16222c2876bcfe640a",
-        "attrs": {},
-        "path": "root/my_api/Endpoint",
-        "props": {
-          "inputUrl": "\${wsim#root/my_api#attrs.url}",
-          "label": "Api root/my_api",
-          "url": "\${wsim#root/my_api#attrs.url}",
-        },
-        "type": "@winglang/sdk.cloud.Endpoint",
-      },
-      {
-        "addr": "c8d2997625976ba9bc7be90fefe7930aebab104a2a",
-        "attrs": {},
-        "path": "root/my_api/Policy",
-        "props": {
-          "principal": "\${wsim#root/my_api#attrs.handle}",
-          "statements": [
-            {
-              "operation": "invoke",
-              "resourceHandle": "\${wsim#root/my_api/OnRequestHandler0#attrs.handle}",
-            },
-          ],
-        },
-        "type": "@winglang/sdk.sim.Policy",
-      },
-      {
-        "addr": "c82d41b2501ac42e07e4565202a5b87a180a01c6a2",
-        "attrs": {},
-        "path": "root/my_api/OnRequestHandler0",
-        "policy": [],
-        "props": {
-          "concurrency": 100,
-          "environmentVariables": {},
-          "sourceCodeFile": ".wing/onrequesthandler0_c82d41b2.js",
-          "sourceCodeLanguage": "javascript",
-          "timeout": 60000,
-        },
-        "type": "@winglang/sdk.cloud.Function",
-      },
-      {
+    "resources": {
+      "root/my_api": {
         "addr": "c8f2ecf2132465e146aa80cb01f4e5ab1968f4314a",
         "attrs": {},
         "path": "root/my_api",
@@ -1343,7 +1303,7 @@ return class Handler {
         },
         "type": "@winglang/sdk.cloud.Api",
       },
-      {
+      "root/my_api/ApiEventMapping0": {
         "addr": "c8a199e7bc539eb442a47653fe0f2b1f0bf50aa6d1",
         "attrs": {},
         "deps": [
@@ -1365,7 +1325,47 @@ return class Handler {
         },
         "type": "@winglang/sdk.sim.EventMapping",
       },
-    ],
+      "root/my_api/Endpoint": {
+        "addr": "c85bd2f9eb401f27bec4d0ad16222c2876bcfe640a",
+        "attrs": {},
+        "path": "root/my_api/Endpoint",
+        "props": {
+          "inputUrl": "\${wsim#root/my_api#attrs.url}",
+          "label": "Api root/my_api",
+          "url": "\${wsim#root/my_api#attrs.url}",
+        },
+        "type": "@winglang/sdk.cloud.Endpoint",
+      },
+      "root/my_api/OnRequestHandler0": {
+        "addr": "c82d41b2501ac42e07e4565202a5b87a180a01c6a2",
+        "attrs": {},
+        "path": "root/my_api/OnRequestHandler0",
+        "policy": [],
+        "props": {
+          "concurrency": 100,
+          "environmentVariables": {},
+          "sourceCodeFile": ".wing/onrequesthandler0_c82d41b2.js",
+          "sourceCodeLanguage": "javascript",
+          "timeout": 60000,
+        },
+        "type": "@winglang/sdk.cloud.Function",
+      },
+      "root/my_api/Policy": {
+        "addr": "c8d2997625976ba9bc7be90fefe7930aebab104a2a",
+        "attrs": {},
+        "path": "root/my_api/Policy",
+        "props": {
+          "principal": "\${wsim#root/my_api#attrs.handle}",
+          "statements": [
+            {
+              "operation": "invoke",
+              "resourceHandle": "\${wsim#root/my_api/OnRequestHandler0#attrs.handle}",
+            },
+          ],
+        },
+        "type": "@winglang/sdk.sim.Policy",
+      },
+    },
     "sdkVersion": "0.0.0",
     "types": {
       "@winglang/sdk.cloud.Api": {
@@ -1584,48 +1584,8 @@ return class Handler {
     "version": "connections-0.1",
   },
   "simulator.json": {
-    "resources": [
-      {
-        "addr": "c85bd2f9eb401f27bec4d0ad16222c2876bcfe640a",
-        "attrs": {},
-        "path": "root/my_api/Endpoint",
-        "props": {
-          "inputUrl": "\${wsim#root/my_api#attrs.url}",
-          "label": "Api root/my_api",
-          "url": "\${wsim#root/my_api#attrs.url}",
-        },
-        "type": "@winglang/sdk.cloud.Endpoint",
-      },
-      {
-        "addr": "c8d2997625976ba9bc7be90fefe7930aebab104a2a",
-        "attrs": {},
-        "path": "root/my_api/Policy",
-        "props": {
-          "principal": "\${wsim#root/my_api#attrs.handle}",
-          "statements": [
-            {
-              "operation": "invoke",
-              "resourceHandle": "\${wsim#root/my_api/OnRequestHandler0#attrs.handle}",
-            },
-          ],
-        },
-        "type": "@winglang/sdk.sim.Policy",
-      },
-      {
-        "addr": "c82d41b2501ac42e07e4565202a5b87a180a01c6a2",
-        "attrs": {},
-        "path": "root/my_api/OnRequestHandler0",
-        "policy": [],
-        "props": {
-          "concurrency": 100,
-          "environmentVariables": {},
-          "sourceCodeFile": ".wing/onrequesthandler0_c82d41b2.js",
-          "sourceCodeLanguage": "javascript",
-          "timeout": 60000,
-        },
-        "type": "@winglang/sdk.cloud.Function",
-      },
-      {
+    "resources": {
+      "root/my_api": {
         "addr": "c8f2ecf2132465e146aa80cb01f4e5ab1968f4314a",
         "attrs": {},
         "path": "root/my_api",
@@ -1650,7 +1610,7 @@ return class Handler {
         },
         "type": "@winglang/sdk.cloud.Api",
       },
-      {
+      "root/my_api/ApiEventMapping0": {
         "addr": "c8a199e7bc539eb442a47653fe0f2b1f0bf50aa6d1",
         "attrs": {},
         "deps": [
@@ -1672,7 +1632,47 @@ return class Handler {
         },
         "type": "@winglang/sdk.sim.EventMapping",
       },
-    ],
+      "root/my_api/Endpoint": {
+        "addr": "c85bd2f9eb401f27bec4d0ad16222c2876bcfe640a",
+        "attrs": {},
+        "path": "root/my_api/Endpoint",
+        "props": {
+          "inputUrl": "\${wsim#root/my_api#attrs.url}",
+          "label": "Api root/my_api",
+          "url": "\${wsim#root/my_api#attrs.url}",
+        },
+        "type": "@winglang/sdk.cloud.Endpoint",
+      },
+      "root/my_api/OnRequestHandler0": {
+        "addr": "c82d41b2501ac42e07e4565202a5b87a180a01c6a2",
+        "attrs": {},
+        "path": "root/my_api/OnRequestHandler0",
+        "policy": [],
+        "props": {
+          "concurrency": 100,
+          "environmentVariables": {},
+          "sourceCodeFile": ".wing/onrequesthandler0_c82d41b2.js",
+          "sourceCodeLanguage": "javascript",
+          "timeout": 60000,
+        },
+        "type": "@winglang/sdk.cloud.Function",
+      },
+      "root/my_api/Policy": {
+        "addr": "c8d2997625976ba9bc7be90fefe7930aebab104a2a",
+        "attrs": {},
+        "path": "root/my_api/Policy",
+        "props": {
+          "principal": "\${wsim#root/my_api#attrs.handle}",
+          "statements": [
+            {
+              "operation": "invoke",
+              "resourceHandle": "\${wsim#root/my_api/OnRequestHandler0#attrs.handle}",
+            },
+          ],
+        },
+        "type": "@winglang/sdk.sim.Policy",
+      },
+    },
     "sdkVersion": "0.0.0",
     "types": {
       "@winglang/sdk.cloud.Api": {
@@ -1939,48 +1939,8 @@ return class Handler {
     "version": "connections-0.1",
   },
   "simulator.json": {
-    "resources": [
-      {
-        "addr": "c85bd2f9eb401f27bec4d0ad16222c2876bcfe640a",
-        "attrs": {},
-        "path": "root/my_api/Endpoint",
-        "props": {
-          "inputUrl": "\${wsim#root/my_api#attrs.url}",
-          "label": "Api root/my_api",
-          "url": "\${wsim#root/my_api#attrs.url}",
-        },
-        "type": "@winglang/sdk.cloud.Endpoint",
-      },
-      {
-        "addr": "c8d2997625976ba9bc7be90fefe7930aebab104a2a",
-        "attrs": {},
-        "path": "root/my_api/Policy",
-        "props": {
-          "principal": "\${wsim#root/my_api#attrs.handle}",
-          "statements": [
-            {
-              "operation": "invoke",
-              "resourceHandle": "\${wsim#root/my_api/OnRequestHandler0#attrs.handle}",
-            },
-          ],
-        },
-        "type": "@winglang/sdk.sim.Policy",
-      },
-      {
-        "addr": "c82d41b2501ac42e07e4565202a5b87a180a01c6a2",
-        "attrs": {},
-        "path": "root/my_api/OnRequestHandler0",
-        "policy": [],
-        "props": {
-          "concurrency": 100,
-          "environmentVariables": {},
-          "sourceCodeFile": ".wing/onrequesthandler0_c82d41b2.js",
-          "sourceCodeLanguage": "javascript",
-          "timeout": 60000,
-        },
-        "type": "@winglang/sdk.cloud.Function",
-      },
-      {
+    "resources": {
+      "root/my_api": {
         "addr": "c8f2ecf2132465e146aa80cb01f4e5ab1968f4314a",
         "attrs": {},
         "path": "root/my_api",
@@ -2065,7 +2025,7 @@ return class Handler {
         },
         "type": "@winglang/sdk.cloud.Api",
       },
-      {
+      "root/my_api/ApiEventMapping0": {
         "addr": "c8a199e7bc539eb442a47653fe0f2b1f0bf50aa6d1",
         "attrs": {},
         "deps": [
@@ -2111,7 +2071,47 @@ return class Handler {
         },
         "type": "@winglang/sdk.sim.EventMapping",
       },
-    ],
+      "root/my_api/Endpoint": {
+        "addr": "c85bd2f9eb401f27bec4d0ad16222c2876bcfe640a",
+        "attrs": {},
+        "path": "root/my_api/Endpoint",
+        "props": {
+          "inputUrl": "\${wsim#root/my_api#attrs.url}",
+          "label": "Api root/my_api",
+          "url": "\${wsim#root/my_api#attrs.url}",
+        },
+        "type": "@winglang/sdk.cloud.Endpoint",
+      },
+      "root/my_api/OnRequestHandler0": {
+        "addr": "c82d41b2501ac42e07e4565202a5b87a180a01c6a2",
+        "attrs": {},
+        "path": "root/my_api/OnRequestHandler0",
+        "policy": [],
+        "props": {
+          "concurrency": 100,
+          "environmentVariables": {},
+          "sourceCodeFile": ".wing/onrequesthandler0_c82d41b2.js",
+          "sourceCodeLanguage": "javascript",
+          "timeout": 60000,
+        },
+        "type": "@winglang/sdk.cloud.Function",
+      },
+      "root/my_api/Policy": {
+        "addr": "c8d2997625976ba9bc7be90fefe7930aebab104a2a",
+        "attrs": {},
+        "path": "root/my_api/Policy",
+        "props": {
+          "principal": "\${wsim#root/my_api#attrs.handle}",
+          "statements": [
+            {
+              "operation": "invoke",
+              "resourceHandle": "\${wsim#root/my_api/OnRequestHandler0#attrs.handle}",
+            },
+          ],
+        },
+        "type": "@winglang/sdk.sim.Policy",
+      },
+    },
     "sdkVersion": "0.0.0",
     "types": {
       "@winglang/sdk.cloud.Api": {
@@ -2330,48 +2330,8 @@ return class Handler {
     "version": "connections-0.1",
   },
   "simulator.json": {
-    "resources": [
-      {
-        "addr": "c85bd2f9eb401f27bec4d0ad16222c2876bcfe640a",
-        "attrs": {},
-        "path": "root/my_api/Endpoint",
-        "props": {
-          "inputUrl": "\${wsim#root/my_api#attrs.url}",
-          "label": "Api root/my_api",
-          "url": "\${wsim#root/my_api#attrs.url}",
-        },
-        "type": "@winglang/sdk.cloud.Endpoint",
-      },
-      {
-        "addr": "c8d2997625976ba9bc7be90fefe7930aebab104a2a",
-        "attrs": {},
-        "path": "root/my_api/Policy",
-        "props": {
-          "principal": "\${wsim#root/my_api#attrs.handle}",
-          "statements": [
-            {
-              "operation": "invoke",
-              "resourceHandle": "\${wsim#root/my_api/OnRequestHandler0#attrs.handle}",
-            },
-          ],
-        },
-        "type": "@winglang/sdk.sim.Policy",
-      },
-      {
-        "addr": "c82d41b2501ac42e07e4565202a5b87a180a01c6a2",
-        "attrs": {},
-        "path": "root/my_api/OnRequestHandler0",
-        "policy": [],
-        "props": {
-          "concurrency": 100,
-          "environmentVariables": {},
-          "sourceCodeFile": ".wing/onrequesthandler0_c82d41b2.js",
-          "sourceCodeLanguage": "javascript",
-          "timeout": 60000,
-        },
-        "type": "@winglang/sdk.cloud.Function",
-      },
-      {
+    "resources": {
+      "root/my_api": {
         "addr": "c8f2ecf2132465e146aa80cb01f4e5ab1968f4314a",
         "attrs": {},
         "path": "root/my_api",
@@ -2413,7 +2373,7 @@ return class Handler {
         },
         "type": "@winglang/sdk.cloud.Api",
       },
-      {
+      "root/my_api/ApiEventMapping0": {
         "addr": "c8a199e7bc539eb442a47653fe0f2b1f0bf50aa6d1",
         "attrs": {},
         "deps": [
@@ -2435,7 +2395,47 @@ return class Handler {
         },
         "type": "@winglang/sdk.sim.EventMapping",
       },
-    ],
+      "root/my_api/Endpoint": {
+        "addr": "c85bd2f9eb401f27bec4d0ad16222c2876bcfe640a",
+        "attrs": {},
+        "path": "root/my_api/Endpoint",
+        "props": {
+          "inputUrl": "\${wsim#root/my_api#attrs.url}",
+          "label": "Api root/my_api",
+          "url": "\${wsim#root/my_api#attrs.url}",
+        },
+        "type": "@winglang/sdk.cloud.Endpoint",
+      },
+      "root/my_api/OnRequestHandler0": {
+        "addr": "c82d41b2501ac42e07e4565202a5b87a180a01c6a2",
+        "attrs": {},
+        "path": "root/my_api/OnRequestHandler0",
+        "policy": [],
+        "props": {
+          "concurrency": 100,
+          "environmentVariables": {},
+          "sourceCodeFile": ".wing/onrequesthandler0_c82d41b2.js",
+          "sourceCodeLanguage": "javascript",
+          "timeout": 60000,
+        },
+        "type": "@winglang/sdk.cloud.Function",
+      },
+      "root/my_api/Policy": {
+        "addr": "c8d2997625976ba9bc7be90fefe7930aebab104a2a",
+        "attrs": {},
+        "path": "root/my_api/Policy",
+        "props": {
+          "principal": "\${wsim#root/my_api#attrs.handle}",
+          "statements": [
+            {
+              "operation": "invoke",
+              "resourceHandle": "\${wsim#root/my_api/OnRequestHandler0#attrs.handle}",
+            },
+          ],
+        },
+        "type": "@winglang/sdk.sim.Policy",
+      },
+    },
     "sdkVersion": "0.0.0",
     "types": {
       "@winglang/sdk.cloud.Api": {
@@ -2654,48 +2654,8 @@ return class Handler {
     "version": "connections-0.1",
   },
   "simulator.json": {
-    "resources": [
-      {
-        "addr": "c85bd2f9eb401f27bec4d0ad16222c2876bcfe640a",
-        "attrs": {},
-        "path": "root/my_api/Endpoint",
-        "props": {
-          "inputUrl": "\${wsim#root/my_api#attrs.url}",
-          "label": "Api root/my_api",
-          "url": "\${wsim#root/my_api#attrs.url}",
-        },
-        "type": "@winglang/sdk.cloud.Endpoint",
-      },
-      {
-        "addr": "c8d2997625976ba9bc7be90fefe7930aebab104a2a",
-        "attrs": {},
-        "path": "root/my_api/Policy",
-        "props": {
-          "principal": "\${wsim#root/my_api#attrs.handle}",
-          "statements": [
-            {
-              "operation": "invoke",
-              "resourceHandle": "\${wsim#root/my_api/OnRequestHandler0#attrs.handle}",
-            },
-          ],
-        },
-        "type": "@winglang/sdk.sim.Policy",
-      },
-      {
-        "addr": "c82d41b2501ac42e07e4565202a5b87a180a01c6a2",
-        "attrs": {},
-        "path": "root/my_api/OnRequestHandler0",
-        "policy": [],
-        "props": {
-          "concurrency": 100,
-          "environmentVariables": {},
-          "sourceCodeFile": ".wing/onrequesthandler0_c82d41b2.js",
-          "sourceCodeLanguage": "javascript",
-          "timeout": 60000,
-        },
-        "type": "@winglang/sdk.cloud.Function",
-      },
-      {
+    "resources": {
+      "root/my_api": {
         "addr": "c8f2ecf2132465e146aa80cb01f4e5ab1968f4314a",
         "attrs": {},
         "path": "root/my_api",
@@ -2729,7 +2689,7 @@ return class Handler {
         },
         "type": "@winglang/sdk.cloud.Api",
       },
-      {
+      "root/my_api/ApiEventMapping0": {
         "addr": "c8a199e7bc539eb442a47653fe0f2b1f0bf50aa6d1",
         "attrs": {},
         "deps": [
@@ -2751,7 +2711,47 @@ return class Handler {
         },
         "type": "@winglang/sdk.sim.EventMapping",
       },
-    ],
+      "root/my_api/Endpoint": {
+        "addr": "c85bd2f9eb401f27bec4d0ad16222c2876bcfe640a",
+        "attrs": {},
+        "path": "root/my_api/Endpoint",
+        "props": {
+          "inputUrl": "\${wsim#root/my_api#attrs.url}",
+          "label": "Api root/my_api",
+          "url": "\${wsim#root/my_api#attrs.url}",
+        },
+        "type": "@winglang/sdk.cloud.Endpoint",
+      },
+      "root/my_api/OnRequestHandler0": {
+        "addr": "c82d41b2501ac42e07e4565202a5b87a180a01c6a2",
+        "attrs": {},
+        "path": "root/my_api/OnRequestHandler0",
+        "policy": [],
+        "props": {
+          "concurrency": 100,
+          "environmentVariables": {},
+          "sourceCodeFile": ".wing/onrequesthandler0_c82d41b2.js",
+          "sourceCodeLanguage": "javascript",
+          "timeout": 60000,
+        },
+        "type": "@winglang/sdk.cloud.Function",
+      },
+      "root/my_api/Policy": {
+        "addr": "c8d2997625976ba9bc7be90fefe7930aebab104a2a",
+        "attrs": {},
+        "path": "root/my_api/Policy",
+        "props": {
+          "principal": "\${wsim#root/my_api#attrs.handle}",
+          "statements": [
+            {
+              "operation": "invoke",
+              "resourceHandle": "\${wsim#root/my_api/OnRequestHandler0#attrs.handle}",
+            },
+          ],
+        },
+        "type": "@winglang/sdk.sim.Policy",
+      },
+    },
     "sdkVersion": "0.0.0",
     "types": {
       "@winglang/sdk.cloud.Api": {
@@ -2950,48 +2950,8 @@ return class Handler {
     "version": "connections-0.1",
   },
   "simulator.json": {
-    "resources": [
-      {
-        "addr": "c85bd2f9eb401f27bec4d0ad16222c2876bcfe640a",
-        "attrs": {},
-        "path": "root/my_api/Endpoint",
-        "props": {
-          "inputUrl": "\${wsim#root/my_api#attrs.url}",
-          "label": "Api root/my_api",
-          "url": "\${wsim#root/my_api#attrs.url}",
-        },
-        "type": "@winglang/sdk.cloud.Endpoint",
-      },
-      {
-        "addr": "c8d2997625976ba9bc7be90fefe7930aebab104a2a",
-        "attrs": {},
-        "path": "root/my_api/Policy",
-        "props": {
-          "principal": "\${wsim#root/my_api#attrs.handle}",
-          "statements": [
-            {
-              "operation": "invoke",
-              "resourceHandle": "\${wsim#root/my_api/OnRequestHandler0#attrs.handle}",
-            },
-          ],
-        },
-        "type": "@winglang/sdk.sim.Policy",
-      },
-      {
-        "addr": "c82d41b2501ac42e07e4565202a5b87a180a01c6a2",
-        "attrs": {},
-        "path": "root/my_api/OnRequestHandler0",
-        "policy": [],
-        "props": {
-          "concurrency": 100,
-          "environmentVariables": {},
-          "sourceCodeFile": ".wing/onrequesthandler0_c82d41b2.js",
-          "sourceCodeLanguage": "javascript",
-          "timeout": 60000,
-        },
-        "type": "@winglang/sdk.cloud.Function",
-      },
-      {
+    "resources": {
+      "root/my_api": {
         "addr": "c8f2ecf2132465e146aa80cb01f4e5ab1968f4314a",
         "attrs": {},
         "path": "root/my_api",
@@ -3028,7 +2988,7 @@ return class Handler {
         },
         "type": "@winglang/sdk.cloud.Api",
       },
-      {
+      "root/my_api/ApiEventMapping0": {
         "addr": "c8a199e7bc539eb442a47653fe0f2b1f0bf50aa6d1",
         "attrs": {},
         "deps": [
@@ -3054,7 +3014,47 @@ return class Handler {
         },
         "type": "@winglang/sdk.sim.EventMapping",
       },
-    ],
+      "root/my_api/Endpoint": {
+        "addr": "c85bd2f9eb401f27bec4d0ad16222c2876bcfe640a",
+        "attrs": {},
+        "path": "root/my_api/Endpoint",
+        "props": {
+          "inputUrl": "\${wsim#root/my_api#attrs.url}",
+          "label": "Api root/my_api",
+          "url": "\${wsim#root/my_api#attrs.url}",
+        },
+        "type": "@winglang/sdk.cloud.Endpoint",
+      },
+      "root/my_api/OnRequestHandler0": {
+        "addr": "c82d41b2501ac42e07e4565202a5b87a180a01c6a2",
+        "attrs": {},
+        "path": "root/my_api/OnRequestHandler0",
+        "policy": [],
+        "props": {
+          "concurrency": 100,
+          "environmentVariables": {},
+          "sourceCodeFile": ".wing/onrequesthandler0_c82d41b2.js",
+          "sourceCodeLanguage": "javascript",
+          "timeout": 60000,
+        },
+        "type": "@winglang/sdk.cloud.Function",
+      },
+      "root/my_api/Policy": {
+        "addr": "c8d2997625976ba9bc7be90fefe7930aebab104a2a",
+        "attrs": {},
+        "path": "root/my_api/Policy",
+        "props": {
+          "principal": "\${wsim#root/my_api#attrs.handle}",
+          "statements": [
+            {
+              "operation": "invoke",
+              "resourceHandle": "\${wsim#root/my_api/OnRequestHandler0#attrs.handle}",
+            },
+          ],
+        },
+        "type": "@winglang/sdk.sim.Policy",
+      },
+    },
     "sdkVersion": "0.0.0",
     "types": {
       "@winglang/sdk.cloud.Api": {
@@ -3302,52 +3302,8 @@ return class Handler {
     "version": "connections-0.1",
   },
   "simulator.json": {
-    "resources": [
-      {
-        "addr": "c85bd2f9eb401f27bec4d0ad16222c2876bcfe640a",
-        "attrs": {},
-        "path": "root/my_api/Endpoint",
-        "props": {
-          "inputUrl": "\${wsim#root/my_api#attrs.url}",
-          "label": "Api root/my_api",
-          "url": "\${wsim#root/my_api#attrs.url}",
-        },
-        "type": "@winglang/sdk.cloud.Endpoint",
-      },
-      {
-        "addr": "c8d2997625976ba9bc7be90fefe7930aebab104a2a",
-        "attrs": {},
-        "path": "root/my_api/Policy",
-        "props": {
-          "principal": "\${wsim#root/my_api#attrs.handle}",
-          "statements": [
-            {
-              "operation": "invoke",
-              "resourceHandle": "\${wsim#root/my_api/OnRequestHandler0#attrs.handle}",
-            },
-            {
-              "operation": "invoke",
-              "resourceHandle": "\${wsim#root/my_api/OnRequestHandler1#attrs.handle}",
-            },
-          ],
-        },
-        "type": "@winglang/sdk.sim.Policy",
-      },
-      {
-        "addr": "c82d41b2501ac42e07e4565202a5b87a180a01c6a2",
-        "attrs": {},
-        "path": "root/my_api/OnRequestHandler0",
-        "policy": [],
-        "props": {
-          "concurrency": 100,
-          "environmentVariables": {},
-          "sourceCodeFile": ".wing/onrequesthandler0_c82d41b2.js",
-          "sourceCodeLanguage": "javascript",
-          "timeout": 60000,
-        },
-        "type": "@winglang/sdk.cloud.Function",
-      },
-      {
+    "resources": {
+      "root/my_api": {
         "addr": "c8f2ecf2132465e146aa80cb01f4e5ab1968f4314a",
         "attrs": {},
         "path": "root/my_api",
@@ -3382,7 +3338,7 @@ return class Handler {
         },
         "type": "@winglang/sdk.cloud.Api",
       },
-      {
+      "root/my_api/ApiEventMapping0": {
         "addr": "c8a199e7bc539eb442a47653fe0f2b1f0bf50aa6d1",
         "attrs": {},
         "deps": [
@@ -3404,21 +3360,7 @@ return class Handler {
         },
         "type": "@winglang/sdk.sim.EventMapping",
       },
-      {
-        "addr": "c84819d7712e30f38cf7731fcfbe96cbc39c7e75d3",
-        "attrs": {},
-        "path": "root/my_api/OnRequestHandler1",
-        "policy": [],
-        "props": {
-          "concurrency": 100,
-          "environmentVariables": {},
-          "sourceCodeFile": ".wing/onrequesthandler1_c84819d7.js",
-          "sourceCodeLanguage": "javascript",
-          "timeout": 60000,
-        },
-        "type": "@winglang/sdk.cloud.Function",
-      },
-      {
+      "root/my_api/ApiEventMapping1": {
         "addr": "c874047faffbf7bc1cdc78bb5f3f942cf01cd31844",
         "attrs": {},
         "deps": [
@@ -3440,7 +3382,65 @@ return class Handler {
         },
         "type": "@winglang/sdk.sim.EventMapping",
       },
-    ],
+      "root/my_api/Endpoint": {
+        "addr": "c85bd2f9eb401f27bec4d0ad16222c2876bcfe640a",
+        "attrs": {},
+        "path": "root/my_api/Endpoint",
+        "props": {
+          "inputUrl": "\${wsim#root/my_api#attrs.url}",
+          "label": "Api root/my_api",
+          "url": "\${wsim#root/my_api#attrs.url}",
+        },
+        "type": "@winglang/sdk.cloud.Endpoint",
+      },
+      "root/my_api/OnRequestHandler0": {
+        "addr": "c82d41b2501ac42e07e4565202a5b87a180a01c6a2",
+        "attrs": {},
+        "path": "root/my_api/OnRequestHandler0",
+        "policy": [],
+        "props": {
+          "concurrency": 100,
+          "environmentVariables": {},
+          "sourceCodeFile": ".wing/onrequesthandler0_c82d41b2.js",
+          "sourceCodeLanguage": "javascript",
+          "timeout": 60000,
+        },
+        "type": "@winglang/sdk.cloud.Function",
+      },
+      "root/my_api/OnRequestHandler1": {
+        "addr": "c84819d7712e30f38cf7731fcfbe96cbc39c7e75d3",
+        "attrs": {},
+        "path": "root/my_api/OnRequestHandler1",
+        "policy": [],
+        "props": {
+          "concurrency": 100,
+          "environmentVariables": {},
+          "sourceCodeFile": ".wing/onrequesthandler1_c84819d7.js",
+          "sourceCodeLanguage": "javascript",
+          "timeout": 60000,
+        },
+        "type": "@winglang/sdk.cloud.Function",
+      },
+      "root/my_api/Policy": {
+        "addr": "c8d2997625976ba9bc7be90fefe7930aebab104a2a",
+        "attrs": {},
+        "path": "root/my_api/Policy",
+        "props": {
+          "principal": "\${wsim#root/my_api#attrs.handle}",
+          "statements": [
+            {
+              "operation": "invoke",
+              "resourceHandle": "\${wsim#root/my_api/OnRequestHandler0#attrs.handle}",
+            },
+            {
+              "operation": "invoke",
+              "resourceHandle": "\${wsim#root/my_api/OnRequestHandler1#attrs.handle}",
+            },
+          ],
+        },
+        "type": "@winglang/sdk.sim.Policy",
+      },
+    },
     "sdkVersion": "0.0.0",
     "types": {
       "@winglang/sdk.cloud.Api": {
@@ -3713,52 +3713,8 @@ return class Handler {
     "version": "connections-0.1",
   },
   "simulator.json": {
-    "resources": [
-      {
-        "addr": "c85bd2f9eb401f27bec4d0ad16222c2876bcfe640a",
-        "attrs": {},
-        "path": "root/my_api/Endpoint",
-        "props": {
-          "inputUrl": "\${wsim#root/my_api#attrs.url}",
-          "label": "Api root/my_api",
-          "url": "\${wsim#root/my_api#attrs.url}",
-        },
-        "type": "@winglang/sdk.cloud.Endpoint",
-      },
-      {
-        "addr": "c8d2997625976ba9bc7be90fefe7930aebab104a2a",
-        "attrs": {},
-        "path": "root/my_api/Policy",
-        "props": {
-          "principal": "\${wsim#root/my_api#attrs.handle}",
-          "statements": [
-            {
-              "operation": "invoke",
-              "resourceHandle": "\${wsim#root/my_api/OnRequestHandler0#attrs.handle}",
-            },
-            {
-              "operation": "invoke",
-              "resourceHandle": "\${wsim#root/my_api/OnRequestHandler1#attrs.handle}",
-            },
-          ],
-        },
-        "type": "@winglang/sdk.sim.Policy",
-      },
-      {
-        "addr": "c82d41b2501ac42e07e4565202a5b87a180a01c6a2",
-        "attrs": {},
-        "path": "root/my_api/OnRequestHandler0",
-        "policy": [],
-        "props": {
-          "concurrency": 100,
-          "environmentVariables": {},
-          "sourceCodeFile": ".wing/onrequesthandler0_c82d41b2.js",
-          "sourceCodeLanguage": "javascript",
-          "timeout": 60000,
-        },
-        "type": "@winglang/sdk.cloud.Function",
-      },
-      {
+    "resources": {
+      "root/my_api": {
         "addr": "c8f2ecf2132465e146aa80cb01f4e5ab1968f4314a",
         "attrs": {},
         "path": "root/my_api",
@@ -3795,7 +3751,7 @@ return class Handler {
         },
         "type": "@winglang/sdk.cloud.Api",
       },
-      {
+      "root/my_api/ApiEventMapping0": {
         "addr": "c8a199e7bc539eb442a47653fe0f2b1f0bf50aa6d1",
         "attrs": {},
         "deps": [
@@ -3817,21 +3773,7 @@ return class Handler {
         },
         "type": "@winglang/sdk.sim.EventMapping",
       },
-      {
-        "addr": "c84819d7712e30f38cf7731fcfbe96cbc39c7e75d3",
-        "attrs": {},
-        "path": "root/my_api/OnRequestHandler1",
-        "policy": [],
-        "props": {
-          "concurrency": 100,
-          "environmentVariables": {},
-          "sourceCodeFile": ".wing/onrequesthandler1_c84819d7.js",
-          "sourceCodeLanguage": "javascript",
-          "timeout": 60000,
-        },
-        "type": "@winglang/sdk.cloud.Function",
-      },
-      {
+      "root/my_api/ApiEventMapping1": {
         "addr": "c874047faffbf7bc1cdc78bb5f3f942cf01cd31844",
         "attrs": {},
         "deps": [
@@ -3853,7 +3795,65 @@ return class Handler {
         },
         "type": "@winglang/sdk.sim.EventMapping",
       },
-    ],
+      "root/my_api/Endpoint": {
+        "addr": "c85bd2f9eb401f27bec4d0ad16222c2876bcfe640a",
+        "attrs": {},
+        "path": "root/my_api/Endpoint",
+        "props": {
+          "inputUrl": "\${wsim#root/my_api#attrs.url}",
+          "label": "Api root/my_api",
+          "url": "\${wsim#root/my_api#attrs.url}",
+        },
+        "type": "@winglang/sdk.cloud.Endpoint",
+      },
+      "root/my_api/OnRequestHandler0": {
+        "addr": "c82d41b2501ac42e07e4565202a5b87a180a01c6a2",
+        "attrs": {},
+        "path": "root/my_api/OnRequestHandler0",
+        "policy": [],
+        "props": {
+          "concurrency": 100,
+          "environmentVariables": {},
+          "sourceCodeFile": ".wing/onrequesthandler0_c82d41b2.js",
+          "sourceCodeLanguage": "javascript",
+          "timeout": 60000,
+        },
+        "type": "@winglang/sdk.cloud.Function",
+      },
+      "root/my_api/OnRequestHandler1": {
+        "addr": "c84819d7712e30f38cf7731fcfbe96cbc39c7e75d3",
+        "attrs": {},
+        "path": "root/my_api/OnRequestHandler1",
+        "policy": [],
+        "props": {
+          "concurrency": 100,
+          "environmentVariables": {},
+          "sourceCodeFile": ".wing/onrequesthandler1_c84819d7.js",
+          "sourceCodeLanguage": "javascript",
+          "timeout": 60000,
+        },
+        "type": "@winglang/sdk.cloud.Function",
+      },
+      "root/my_api/Policy": {
+        "addr": "c8d2997625976ba9bc7be90fefe7930aebab104a2a",
+        "attrs": {},
+        "path": "root/my_api/Policy",
+        "props": {
+          "principal": "\${wsim#root/my_api#attrs.handle}",
+          "statements": [
+            {
+              "operation": "invoke",
+              "resourceHandle": "\${wsim#root/my_api/OnRequestHandler0#attrs.handle}",
+            },
+            {
+              "operation": "invoke",
+              "resourceHandle": "\${wsim#root/my_api/OnRequestHandler1#attrs.handle}",
+            },
+          ],
+        },
+        "type": "@winglang/sdk.sim.Policy",
+      },
+    },
     "sdkVersion": "0.0.0",
     "types": {
       "@winglang/sdk.cloud.Api": {
@@ -4097,48 +4097,8 @@ return class Handler {
     "version": "connections-0.1",
   },
   "simulator.json": {
-    "resources": [
-      {
-        "addr": "c85bd2f9eb401f27bec4d0ad16222c2876bcfe640a",
-        "attrs": {},
-        "path": "root/my_api/Endpoint",
-        "props": {
-          "inputUrl": "\${wsim#root/my_api#attrs.url}",
-          "label": "Api root/my_api",
-          "url": "\${wsim#root/my_api#attrs.url}",
-        },
-        "type": "@winglang/sdk.cloud.Endpoint",
-      },
-      {
-        "addr": "c8d2997625976ba9bc7be90fefe7930aebab104a2a",
-        "attrs": {},
-        "path": "root/my_api/Policy",
-        "props": {
-          "principal": "\${wsim#root/my_api#attrs.handle}",
-          "statements": [
-            {
-              "operation": "invoke",
-              "resourceHandle": "\${wsim#root/my_api/OnRequestHandler0#attrs.handle}",
-            },
-          ],
-        },
-        "type": "@winglang/sdk.sim.Policy",
-      },
-      {
-        "addr": "c82d41b2501ac42e07e4565202a5b87a180a01c6a2",
-        "attrs": {},
-        "path": "root/my_api/OnRequestHandler0",
-        "policy": [],
-        "props": {
-          "concurrency": 100,
-          "environmentVariables": {},
-          "sourceCodeFile": ".wing/onrequesthandler0_c82d41b2.js",
-          "sourceCodeLanguage": "javascript",
-          "timeout": 60000,
-        },
-        "type": "@winglang/sdk.cloud.Function",
-      },
-      {
+    "resources": {
+      "root/my_api": {
         "addr": "c8f2ecf2132465e146aa80cb01f4e5ab1968f4314a",
         "attrs": {},
         "path": "root/my_api",
@@ -4163,7 +4123,7 @@ return class Handler {
         },
         "type": "@winglang/sdk.cloud.Api",
       },
-      {
+      "root/my_api/ApiEventMapping0": {
         "addr": "c8a199e7bc539eb442a47653fe0f2b1f0bf50aa6d1",
         "attrs": {},
         "deps": [
@@ -4185,7 +4145,47 @@ return class Handler {
         },
         "type": "@winglang/sdk.sim.EventMapping",
       },
-    ],
+      "root/my_api/Endpoint": {
+        "addr": "c85bd2f9eb401f27bec4d0ad16222c2876bcfe640a",
+        "attrs": {},
+        "path": "root/my_api/Endpoint",
+        "props": {
+          "inputUrl": "\${wsim#root/my_api#attrs.url}",
+          "label": "Api root/my_api",
+          "url": "\${wsim#root/my_api#attrs.url}",
+        },
+        "type": "@winglang/sdk.cloud.Endpoint",
+      },
+      "root/my_api/OnRequestHandler0": {
+        "addr": "c82d41b2501ac42e07e4565202a5b87a180a01c6a2",
+        "attrs": {},
+        "path": "root/my_api/OnRequestHandler0",
+        "policy": [],
+        "props": {
+          "concurrency": 100,
+          "environmentVariables": {},
+          "sourceCodeFile": ".wing/onrequesthandler0_c82d41b2.js",
+          "sourceCodeLanguage": "javascript",
+          "timeout": 60000,
+        },
+        "type": "@winglang/sdk.cloud.Function",
+      },
+      "root/my_api/Policy": {
+        "addr": "c8d2997625976ba9bc7be90fefe7930aebab104a2a",
+        "attrs": {},
+        "path": "root/my_api/Policy",
+        "props": {
+          "principal": "\${wsim#root/my_api#attrs.handle}",
+          "statements": [
+            {
+              "operation": "invoke",
+              "resourceHandle": "\${wsim#root/my_api/OnRequestHandler0#attrs.handle}",
+            },
+          ],
+        },
+        "type": "@winglang/sdk.sim.Policy",
+      },
+    },
     "sdkVersion": "0.0.0",
     "types": {
       "@winglang/sdk.cloud.Api": {
@@ -4404,48 +4404,8 @@ return class Handler {
     "version": "connections-0.1",
   },
   "simulator.json": {
-    "resources": [
-      {
-        "addr": "c85bd2f9eb401f27bec4d0ad16222c2876bcfe640a",
-        "attrs": {},
-        "path": "root/my_api/Endpoint",
-        "props": {
-          "inputUrl": "\${wsim#root/my_api#attrs.url}",
-          "label": "Api root/my_api",
-          "url": "\${wsim#root/my_api#attrs.url}",
-        },
-        "type": "@winglang/sdk.cloud.Endpoint",
-      },
-      {
-        "addr": "c8d2997625976ba9bc7be90fefe7930aebab104a2a",
-        "attrs": {},
-        "path": "root/my_api/Policy",
-        "props": {
-          "principal": "\${wsim#root/my_api#attrs.handle}",
-          "statements": [
-            {
-              "operation": "invoke",
-              "resourceHandle": "\${wsim#root/my_api/OnRequestHandler0#attrs.handle}",
-            },
-          ],
-        },
-        "type": "@winglang/sdk.sim.Policy",
-      },
-      {
-        "addr": "c82d41b2501ac42e07e4565202a5b87a180a01c6a2",
-        "attrs": {},
-        "path": "root/my_api/OnRequestHandler0",
-        "policy": [],
-        "props": {
-          "concurrency": 100,
-          "environmentVariables": {},
-          "sourceCodeFile": ".wing/onrequesthandler0_c82d41b2.js",
-          "sourceCodeLanguage": "javascript",
-          "timeout": 60000,
-        },
-        "type": "@winglang/sdk.cloud.Function",
-      },
-      {
+    "resources": {
+      "root/my_api": {
         "addr": "c8f2ecf2132465e146aa80cb01f4e5ab1968f4314a",
         "attrs": {},
         "path": "root/my_api",
@@ -4479,7 +4439,7 @@ return class Handler {
         },
         "type": "@winglang/sdk.cloud.Api",
       },
-      {
+      "root/my_api/ApiEventMapping0": {
         "addr": "c8a199e7bc539eb442a47653fe0f2b1f0bf50aa6d1",
         "attrs": {},
         "deps": [
@@ -4501,7 +4461,47 @@ return class Handler {
         },
         "type": "@winglang/sdk.sim.EventMapping",
       },
-    ],
+      "root/my_api/Endpoint": {
+        "addr": "c85bd2f9eb401f27bec4d0ad16222c2876bcfe640a",
+        "attrs": {},
+        "path": "root/my_api/Endpoint",
+        "props": {
+          "inputUrl": "\${wsim#root/my_api#attrs.url}",
+          "label": "Api root/my_api",
+          "url": "\${wsim#root/my_api#attrs.url}",
+        },
+        "type": "@winglang/sdk.cloud.Endpoint",
+      },
+      "root/my_api/OnRequestHandler0": {
+        "addr": "c82d41b2501ac42e07e4565202a5b87a180a01c6a2",
+        "attrs": {},
+        "path": "root/my_api/OnRequestHandler0",
+        "policy": [],
+        "props": {
+          "concurrency": 100,
+          "environmentVariables": {},
+          "sourceCodeFile": ".wing/onrequesthandler0_c82d41b2.js",
+          "sourceCodeLanguage": "javascript",
+          "timeout": 60000,
+        },
+        "type": "@winglang/sdk.cloud.Function",
+      },
+      "root/my_api/Policy": {
+        "addr": "c8d2997625976ba9bc7be90fefe7930aebab104a2a",
+        "attrs": {},
+        "path": "root/my_api/Policy",
+        "props": {
+          "principal": "\${wsim#root/my_api#attrs.handle}",
+          "statements": [
+            {
+              "operation": "invoke",
+              "resourceHandle": "\${wsim#root/my_api/OnRequestHandler0#attrs.handle}",
+            },
+          ],
+        },
+        "type": "@winglang/sdk.sim.Policy",
+      },
+    },
     "sdkVersion": "0.0.0",
     "types": {
       "@winglang/sdk.cloud.Api": {
@@ -4720,48 +4720,8 @@ return class Handler {
     "version": "connections-0.1",
   },
   "simulator.json": {
-    "resources": [
-      {
-        "addr": "c85bd2f9eb401f27bec4d0ad16222c2876bcfe640a",
-        "attrs": {},
-        "path": "root/my_api/Endpoint",
-        "props": {
-          "inputUrl": "\${wsim#root/my_api#attrs.url}",
-          "label": "Api root/my_api",
-          "url": "\${wsim#root/my_api#attrs.url}",
-        },
-        "type": "@winglang/sdk.cloud.Endpoint",
-      },
-      {
-        "addr": "c8d2997625976ba9bc7be90fefe7930aebab104a2a",
-        "attrs": {},
-        "path": "root/my_api/Policy",
-        "props": {
-          "principal": "\${wsim#root/my_api#attrs.handle}",
-          "statements": [
-            {
-              "operation": "invoke",
-              "resourceHandle": "\${wsim#root/my_api/OnRequestHandler0#attrs.handle}",
-            },
-          ],
-        },
-        "type": "@winglang/sdk.sim.Policy",
-      },
-      {
-        "addr": "c82d41b2501ac42e07e4565202a5b87a180a01c6a2",
-        "attrs": {},
-        "path": "root/my_api/OnRequestHandler0",
-        "policy": [],
-        "props": {
-          "concurrency": 100,
-          "environmentVariables": {},
-          "sourceCodeFile": ".wing/onrequesthandler0_c82d41b2.js",
-          "sourceCodeLanguage": "javascript",
-          "timeout": 60000,
-        },
-        "type": "@winglang/sdk.cloud.Function",
-      },
-      {
+    "resources": {
+      "root/my_api": {
         "addr": "c8f2ecf2132465e146aa80cb01f4e5ab1968f4314a",
         "attrs": {},
         "path": "root/my_api",
@@ -4786,7 +4746,7 @@ return class Handler {
         },
         "type": "@winglang/sdk.cloud.Api",
       },
-      {
+      "root/my_api/ApiEventMapping0": {
         "addr": "c8a199e7bc539eb442a47653fe0f2b1f0bf50aa6d1",
         "attrs": {},
         "deps": [
@@ -4808,7 +4768,47 @@ return class Handler {
         },
         "type": "@winglang/sdk.sim.EventMapping",
       },
-    ],
+      "root/my_api/Endpoint": {
+        "addr": "c85bd2f9eb401f27bec4d0ad16222c2876bcfe640a",
+        "attrs": {},
+        "path": "root/my_api/Endpoint",
+        "props": {
+          "inputUrl": "\${wsim#root/my_api#attrs.url}",
+          "label": "Api root/my_api",
+          "url": "\${wsim#root/my_api#attrs.url}",
+        },
+        "type": "@winglang/sdk.cloud.Endpoint",
+      },
+      "root/my_api/OnRequestHandler0": {
+        "addr": "c82d41b2501ac42e07e4565202a5b87a180a01c6a2",
+        "attrs": {},
+        "path": "root/my_api/OnRequestHandler0",
+        "policy": [],
+        "props": {
+          "concurrency": 100,
+          "environmentVariables": {},
+          "sourceCodeFile": ".wing/onrequesthandler0_c82d41b2.js",
+          "sourceCodeLanguage": "javascript",
+          "timeout": 60000,
+        },
+        "type": "@winglang/sdk.cloud.Function",
+      },
+      "root/my_api/Policy": {
+        "addr": "c8d2997625976ba9bc7be90fefe7930aebab104a2a",
+        "attrs": {},
+        "path": "root/my_api/Policy",
+        "props": {
+          "principal": "\${wsim#root/my_api#attrs.handle}",
+          "statements": [
+            {
+              "operation": "invoke",
+              "resourceHandle": "\${wsim#root/my_api/OnRequestHandler0#attrs.handle}",
+            },
+          ],
+        },
+        "type": "@winglang/sdk.sim.Policy",
+      },
+    },
     "sdkVersion": "0.0.0",
     "types": {
       "@winglang/sdk.cloud.Api": {
@@ -4984,8 +4984,8 @@ exports[`create an api 1`] = `
     "version": "connections-0.1",
   },
   "simulator.json": {
-    "resources": [
-      {
+    "resources": {
+      "root/my_api": {
         "addr": "c8f2ecf2132465e146aa80cb01f4e5ab1968f4314a",
         "attrs": {},
         "path": "root/my_api",
@@ -4997,7 +4997,7 @@ exports[`create an api 1`] = `
         },
         "type": "@winglang/sdk.cloud.Api",
       },
-      {
+      "root/my_api/Endpoint": {
         "addr": "c85bd2f9eb401f27bec4d0ad16222c2876bcfe640a",
         "attrs": {},
         "path": "root/my_api/Endpoint",
@@ -5008,7 +5008,7 @@ exports[`create an api 1`] = `
         },
         "type": "@winglang/sdk.cloud.Endpoint",
       },
-      {
+      "root/my_api/Policy": {
         "addr": "c8d2997625976ba9bc7be90fefe7930aebab104a2a",
         "attrs": {},
         "path": "root/my_api/Policy",
@@ -5018,7 +5018,7 @@ exports[`create an api 1`] = `
         },
         "type": "@winglang/sdk.sim.Policy",
       },
-    ],
+    },
     "sdkVersion": "0.0.0",
     "types": {
       "@winglang/sdk.cloud.Api": {

--- a/libs/wingsdk/test/target-sim/__snapshots__/api.test.ts.snap
+++ b/libs/wingsdk/test/target-sim/__snapshots__/api.test.ts.snap
@@ -38,7 +38,6 @@ return class Handler {
     "resources": {
       "root/my_api": {
         "addr": "c8f2ecf2132465e146aa80cb01f4e5ab1968f4314a",
-        "attrs": {},
         "path": "root/my_api",
         "props": {
           "openApiSpec": {
@@ -73,7 +72,6 @@ return class Handler {
       },
       "root/my_api/ApiEventMapping0": {
         "addr": "c8a199e7bc539eb442a47653fe0f2b1f0bf50aa6d1",
-        "attrs": {},
         "deps": [
           "root/my_api/OnRequestHandler0",
           "root/my_api",
@@ -99,7 +97,6 @@ return class Handler {
       },
       "root/my_api/Endpoint": {
         "addr": "c85bd2f9eb401f27bec4d0ad16222c2876bcfe640a",
-        "attrs": {},
         "path": "root/my_api/Endpoint",
         "props": {
           "inputUrl": "\${wsim#root/my_api#attrs.url}",
@@ -110,7 +107,6 @@ return class Handler {
       },
       "root/my_api/OnRequestHandler0": {
         "addr": "c82d41b2501ac42e07e4565202a5b87a180a01c6a2",
-        "attrs": {},
         "path": "root/my_api/OnRequestHandler0",
         "policy": [],
         "props": {
@@ -124,7 +120,6 @@ return class Handler {
       },
       "root/my_api/Policy": {
         "addr": "c8d2997625976ba9bc7be90fefe7930aebab104a2a",
-        "attrs": {},
         "path": "root/my_api/Policy",
         "props": {
           "principal": "\${wsim#root/my_api#attrs.handle}",
@@ -359,7 +354,6 @@ return class Handler {
     "resources": {
       "root/my_api": {
         "addr": "c8f2ecf2132465e146aa80cb01f4e5ab1968f4314a",
-        "attrs": {},
         "path": "root/my_api",
         "props": {
           "openApiSpec": {
@@ -384,7 +378,6 @@ return class Handler {
       },
       "root/my_api/ApiEventMapping0": {
         "addr": "c8a199e7bc539eb442a47653fe0f2b1f0bf50aa6d1",
-        "attrs": {},
         "deps": [
           "root/my_api/OnRequestHandler0",
           "root/my_api",
@@ -406,7 +399,6 @@ return class Handler {
       },
       "root/my_api/Endpoint": {
         "addr": "c85bd2f9eb401f27bec4d0ad16222c2876bcfe640a",
-        "attrs": {},
         "path": "root/my_api/Endpoint",
         "props": {
           "inputUrl": "\${wsim#root/my_api#attrs.url}",
@@ -417,7 +409,6 @@ return class Handler {
       },
       "root/my_api/OnRequestHandler0": {
         "addr": "c82d41b2501ac42e07e4565202a5b87a180a01c6a2",
-        "attrs": {},
         "path": "root/my_api/OnRequestHandler0",
         "policy": [],
         "props": {
@@ -431,7 +422,6 @@ return class Handler {
       },
       "root/my_api/Policy": {
         "addr": "c8d2997625976ba9bc7be90fefe7930aebab104a2a",
-        "attrs": {},
         "path": "root/my_api/Policy",
         "props": {
           "principal": "\${wsim#root/my_api#attrs.handle}",
@@ -666,7 +656,6 @@ return class Handler {
     "resources": {
       "root/my_api": {
         "addr": "c8f2ecf2132465e146aa80cb01f4e5ab1968f4314a",
-        "attrs": {},
         "path": "root/my_api",
         "props": {
           "openApiSpec": {
@@ -691,7 +680,6 @@ return class Handler {
       },
       "root/my_api/ApiEventMapping0": {
         "addr": "c8a199e7bc539eb442a47653fe0f2b1f0bf50aa6d1",
-        "attrs": {},
         "deps": [
           "root/my_api/OnRequestHandler0",
           "root/my_api",
@@ -713,7 +701,6 @@ return class Handler {
       },
       "root/my_api/Endpoint": {
         "addr": "c85bd2f9eb401f27bec4d0ad16222c2876bcfe640a",
-        "attrs": {},
         "path": "root/my_api/Endpoint",
         "props": {
           "inputUrl": "\${wsim#root/my_api#attrs.url}",
@@ -724,7 +711,6 @@ return class Handler {
       },
       "root/my_api/OnRequestHandler0": {
         "addr": "c82d41b2501ac42e07e4565202a5b87a180a01c6a2",
-        "attrs": {},
         "path": "root/my_api/OnRequestHandler0",
         "policy": [],
         "props": {
@@ -738,7 +724,6 @@ return class Handler {
       },
       "root/my_api/Policy": {
         "addr": "c8d2997625976ba9bc7be90fefe7930aebab104a2a",
-        "attrs": {},
         "path": "root/my_api/Policy",
         "props": {
           "principal": "\${wsim#root/my_api#attrs.handle}",
@@ -973,7 +958,6 @@ return class Handler {
     "resources": {
       "root/my_api": {
         "addr": "c8f2ecf2132465e146aa80cb01f4e5ab1968f4314a",
-        "attrs": {},
         "path": "root/my_api",
         "props": {
           "openApiSpec": {
@@ -998,7 +982,6 @@ return class Handler {
       },
       "root/my_api/ApiEventMapping0": {
         "addr": "c8a199e7bc539eb442a47653fe0f2b1f0bf50aa6d1",
-        "attrs": {},
         "deps": [
           "root/my_api/OnRequestHandler0",
           "root/my_api",
@@ -1020,7 +1003,6 @@ return class Handler {
       },
       "root/my_api/Endpoint": {
         "addr": "c85bd2f9eb401f27bec4d0ad16222c2876bcfe640a",
-        "attrs": {},
         "path": "root/my_api/Endpoint",
         "props": {
           "inputUrl": "\${wsim#root/my_api#attrs.url}",
@@ -1031,7 +1013,6 @@ return class Handler {
       },
       "root/my_api/OnRequestHandler0": {
         "addr": "c82d41b2501ac42e07e4565202a5b87a180a01c6a2",
-        "attrs": {},
         "path": "root/my_api/OnRequestHandler0",
         "policy": [],
         "props": {
@@ -1045,7 +1026,6 @@ return class Handler {
       },
       "root/my_api/Policy": {
         "addr": "c8d2997625976ba9bc7be90fefe7930aebab104a2a",
-        "attrs": {},
         "path": "root/my_api/Policy",
         "props": {
           "principal": "\${wsim#root/my_api#attrs.handle}",
@@ -1280,7 +1260,6 @@ return class Handler {
     "resources": {
       "root/my_api": {
         "addr": "c8f2ecf2132465e146aa80cb01f4e5ab1968f4314a",
-        "attrs": {},
         "path": "root/my_api",
         "props": {
           "openApiSpec": {
@@ -1305,7 +1284,6 @@ return class Handler {
       },
       "root/my_api/ApiEventMapping0": {
         "addr": "c8a199e7bc539eb442a47653fe0f2b1f0bf50aa6d1",
-        "attrs": {},
         "deps": [
           "root/my_api/OnRequestHandler0",
           "root/my_api",
@@ -1327,7 +1305,6 @@ return class Handler {
       },
       "root/my_api/Endpoint": {
         "addr": "c85bd2f9eb401f27bec4d0ad16222c2876bcfe640a",
-        "attrs": {},
         "path": "root/my_api/Endpoint",
         "props": {
           "inputUrl": "\${wsim#root/my_api#attrs.url}",
@@ -1338,7 +1315,6 @@ return class Handler {
       },
       "root/my_api/OnRequestHandler0": {
         "addr": "c82d41b2501ac42e07e4565202a5b87a180a01c6a2",
-        "attrs": {},
         "path": "root/my_api/OnRequestHandler0",
         "policy": [],
         "props": {
@@ -1352,7 +1328,6 @@ return class Handler {
       },
       "root/my_api/Policy": {
         "addr": "c8d2997625976ba9bc7be90fefe7930aebab104a2a",
-        "attrs": {},
         "path": "root/my_api/Policy",
         "props": {
           "principal": "\${wsim#root/my_api#attrs.handle}",
@@ -1587,7 +1562,6 @@ return class Handler {
     "resources": {
       "root/my_api": {
         "addr": "c8f2ecf2132465e146aa80cb01f4e5ab1968f4314a",
-        "attrs": {},
         "path": "root/my_api",
         "props": {
           "openApiSpec": {
@@ -1612,7 +1586,6 @@ return class Handler {
       },
       "root/my_api/ApiEventMapping0": {
         "addr": "c8a199e7bc539eb442a47653fe0f2b1f0bf50aa6d1",
-        "attrs": {},
         "deps": [
           "root/my_api/OnRequestHandler0",
           "root/my_api",
@@ -1634,7 +1607,6 @@ return class Handler {
       },
       "root/my_api/Endpoint": {
         "addr": "c85bd2f9eb401f27bec4d0ad16222c2876bcfe640a",
-        "attrs": {},
         "path": "root/my_api/Endpoint",
         "props": {
           "inputUrl": "\${wsim#root/my_api#attrs.url}",
@@ -1645,7 +1617,6 @@ return class Handler {
       },
       "root/my_api/OnRequestHandler0": {
         "addr": "c82d41b2501ac42e07e4565202a5b87a180a01c6a2",
-        "attrs": {},
         "path": "root/my_api/OnRequestHandler0",
         "policy": [],
         "props": {
@@ -1659,7 +1630,6 @@ return class Handler {
       },
       "root/my_api/Policy": {
         "addr": "c8d2997625976ba9bc7be90fefe7930aebab104a2a",
-        "attrs": {},
         "path": "root/my_api/Policy",
         "props": {
           "principal": "\${wsim#root/my_api#attrs.handle}",
@@ -1942,7 +1912,6 @@ return class Handler {
     "resources": {
       "root/my_api": {
         "addr": "c8f2ecf2132465e146aa80cb01f4e5ab1968f4314a",
-        "attrs": {},
         "path": "root/my_api",
         "props": {
           "openApiSpec": {
@@ -2027,7 +1996,6 @@ return class Handler {
       },
       "root/my_api/ApiEventMapping0": {
         "addr": "c8a199e7bc539eb442a47653fe0f2b1f0bf50aa6d1",
-        "attrs": {},
         "deps": [
           "root/my_api/OnRequestHandler0",
           "root/my_api",
@@ -2073,7 +2041,6 @@ return class Handler {
       },
       "root/my_api/Endpoint": {
         "addr": "c85bd2f9eb401f27bec4d0ad16222c2876bcfe640a",
-        "attrs": {},
         "path": "root/my_api/Endpoint",
         "props": {
           "inputUrl": "\${wsim#root/my_api#attrs.url}",
@@ -2084,7 +2051,6 @@ return class Handler {
       },
       "root/my_api/OnRequestHandler0": {
         "addr": "c82d41b2501ac42e07e4565202a5b87a180a01c6a2",
-        "attrs": {},
         "path": "root/my_api/OnRequestHandler0",
         "policy": [],
         "props": {
@@ -2098,7 +2064,6 @@ return class Handler {
       },
       "root/my_api/Policy": {
         "addr": "c8d2997625976ba9bc7be90fefe7930aebab104a2a",
-        "attrs": {},
         "path": "root/my_api/Policy",
         "props": {
           "principal": "\${wsim#root/my_api#attrs.handle}",
@@ -2333,7 +2298,6 @@ return class Handler {
     "resources": {
       "root/my_api": {
         "addr": "c8f2ecf2132465e146aa80cb01f4e5ab1968f4314a",
-        "attrs": {},
         "path": "root/my_api",
         "props": {
           "openApiSpec": {
@@ -2375,7 +2339,6 @@ return class Handler {
       },
       "root/my_api/ApiEventMapping0": {
         "addr": "c8a199e7bc539eb442a47653fe0f2b1f0bf50aa6d1",
-        "attrs": {},
         "deps": [
           "root/my_api/OnRequestHandler0",
           "root/my_api",
@@ -2397,7 +2360,6 @@ return class Handler {
       },
       "root/my_api/Endpoint": {
         "addr": "c85bd2f9eb401f27bec4d0ad16222c2876bcfe640a",
-        "attrs": {},
         "path": "root/my_api/Endpoint",
         "props": {
           "inputUrl": "\${wsim#root/my_api#attrs.url}",
@@ -2408,7 +2370,6 @@ return class Handler {
       },
       "root/my_api/OnRequestHandler0": {
         "addr": "c82d41b2501ac42e07e4565202a5b87a180a01c6a2",
-        "attrs": {},
         "path": "root/my_api/OnRequestHandler0",
         "policy": [],
         "props": {
@@ -2422,7 +2383,6 @@ return class Handler {
       },
       "root/my_api/Policy": {
         "addr": "c8d2997625976ba9bc7be90fefe7930aebab104a2a",
-        "attrs": {},
         "path": "root/my_api/Policy",
         "props": {
           "principal": "\${wsim#root/my_api#attrs.handle}",
@@ -2657,7 +2617,6 @@ return class Handler {
     "resources": {
       "root/my_api": {
         "addr": "c8f2ecf2132465e146aa80cb01f4e5ab1968f4314a",
-        "attrs": {},
         "path": "root/my_api",
         "props": {
           "openApiSpec": {
@@ -2691,7 +2650,6 @@ return class Handler {
       },
       "root/my_api/ApiEventMapping0": {
         "addr": "c8a199e7bc539eb442a47653fe0f2b1f0bf50aa6d1",
-        "attrs": {},
         "deps": [
           "root/my_api/OnRequestHandler0",
           "root/my_api",
@@ -2713,7 +2671,6 @@ return class Handler {
       },
       "root/my_api/Endpoint": {
         "addr": "c85bd2f9eb401f27bec4d0ad16222c2876bcfe640a",
-        "attrs": {},
         "path": "root/my_api/Endpoint",
         "props": {
           "inputUrl": "\${wsim#root/my_api#attrs.url}",
@@ -2724,7 +2681,6 @@ return class Handler {
       },
       "root/my_api/OnRequestHandler0": {
         "addr": "c82d41b2501ac42e07e4565202a5b87a180a01c6a2",
-        "attrs": {},
         "path": "root/my_api/OnRequestHandler0",
         "policy": [],
         "props": {
@@ -2738,7 +2694,6 @@ return class Handler {
       },
       "root/my_api/Policy": {
         "addr": "c8d2997625976ba9bc7be90fefe7930aebab104a2a",
-        "attrs": {},
         "path": "root/my_api/Policy",
         "props": {
           "principal": "\${wsim#root/my_api#attrs.handle}",
@@ -2953,7 +2908,6 @@ return class Handler {
     "resources": {
       "root/my_api": {
         "addr": "c8f2ecf2132465e146aa80cb01f4e5ab1968f4314a",
-        "attrs": {},
         "path": "root/my_api",
         "props": {
           "openApiSpec": {
@@ -2990,7 +2944,6 @@ return class Handler {
       },
       "root/my_api/ApiEventMapping0": {
         "addr": "c8a199e7bc539eb442a47653fe0f2b1f0bf50aa6d1",
-        "attrs": {},
         "deps": [
           "root/my_api/OnRequestHandler0",
           "root/my_api",
@@ -3016,7 +2969,6 @@ return class Handler {
       },
       "root/my_api/Endpoint": {
         "addr": "c85bd2f9eb401f27bec4d0ad16222c2876bcfe640a",
-        "attrs": {},
         "path": "root/my_api/Endpoint",
         "props": {
           "inputUrl": "\${wsim#root/my_api#attrs.url}",
@@ -3027,7 +2979,6 @@ return class Handler {
       },
       "root/my_api/OnRequestHandler0": {
         "addr": "c82d41b2501ac42e07e4565202a5b87a180a01c6a2",
-        "attrs": {},
         "path": "root/my_api/OnRequestHandler0",
         "policy": [],
         "props": {
@@ -3041,7 +2992,6 @@ return class Handler {
       },
       "root/my_api/Policy": {
         "addr": "c8d2997625976ba9bc7be90fefe7930aebab104a2a",
-        "attrs": {},
         "path": "root/my_api/Policy",
         "props": {
           "principal": "\${wsim#root/my_api#attrs.handle}",
@@ -3305,7 +3255,6 @@ return class Handler {
     "resources": {
       "root/my_api": {
         "addr": "c8f2ecf2132465e146aa80cb01f4e5ab1968f4314a",
-        "attrs": {},
         "path": "root/my_api",
         "props": {
           "openApiSpec": {
@@ -3340,7 +3289,6 @@ return class Handler {
       },
       "root/my_api/ApiEventMapping0": {
         "addr": "c8a199e7bc539eb442a47653fe0f2b1f0bf50aa6d1",
-        "attrs": {},
         "deps": [
           "root/my_api/OnRequestHandler0",
           "root/my_api",
@@ -3362,7 +3310,6 @@ return class Handler {
       },
       "root/my_api/ApiEventMapping1": {
         "addr": "c874047faffbf7bc1cdc78bb5f3f942cf01cd31844",
-        "attrs": {},
         "deps": [
           "root/my_api/OnRequestHandler1",
           "root/my_api",
@@ -3384,7 +3331,6 @@ return class Handler {
       },
       "root/my_api/Endpoint": {
         "addr": "c85bd2f9eb401f27bec4d0ad16222c2876bcfe640a",
-        "attrs": {},
         "path": "root/my_api/Endpoint",
         "props": {
           "inputUrl": "\${wsim#root/my_api#attrs.url}",
@@ -3395,7 +3341,6 @@ return class Handler {
       },
       "root/my_api/OnRequestHandler0": {
         "addr": "c82d41b2501ac42e07e4565202a5b87a180a01c6a2",
-        "attrs": {},
         "path": "root/my_api/OnRequestHandler0",
         "policy": [],
         "props": {
@@ -3409,7 +3354,6 @@ return class Handler {
       },
       "root/my_api/OnRequestHandler1": {
         "addr": "c84819d7712e30f38cf7731fcfbe96cbc39c7e75d3",
-        "attrs": {},
         "path": "root/my_api/OnRequestHandler1",
         "policy": [],
         "props": {
@@ -3423,7 +3367,6 @@ return class Handler {
       },
       "root/my_api/Policy": {
         "addr": "c8d2997625976ba9bc7be90fefe7930aebab104a2a",
-        "attrs": {},
         "path": "root/my_api/Policy",
         "props": {
           "principal": "\${wsim#root/my_api#attrs.handle}",
@@ -3716,7 +3659,6 @@ return class Handler {
     "resources": {
       "root/my_api": {
         "addr": "c8f2ecf2132465e146aa80cb01f4e5ab1968f4314a",
-        "attrs": {},
         "path": "root/my_api",
         "props": {
           "openApiSpec": {
@@ -3753,7 +3695,6 @@ return class Handler {
       },
       "root/my_api/ApiEventMapping0": {
         "addr": "c8a199e7bc539eb442a47653fe0f2b1f0bf50aa6d1",
-        "attrs": {},
         "deps": [
           "root/my_api/OnRequestHandler0",
           "root/my_api",
@@ -3775,7 +3716,6 @@ return class Handler {
       },
       "root/my_api/ApiEventMapping1": {
         "addr": "c874047faffbf7bc1cdc78bb5f3f942cf01cd31844",
-        "attrs": {},
         "deps": [
           "root/my_api/OnRequestHandler1",
           "root/my_api",
@@ -3797,7 +3737,6 @@ return class Handler {
       },
       "root/my_api/Endpoint": {
         "addr": "c85bd2f9eb401f27bec4d0ad16222c2876bcfe640a",
-        "attrs": {},
         "path": "root/my_api/Endpoint",
         "props": {
           "inputUrl": "\${wsim#root/my_api#attrs.url}",
@@ -3808,7 +3747,6 @@ return class Handler {
       },
       "root/my_api/OnRequestHandler0": {
         "addr": "c82d41b2501ac42e07e4565202a5b87a180a01c6a2",
-        "attrs": {},
         "path": "root/my_api/OnRequestHandler0",
         "policy": [],
         "props": {
@@ -3822,7 +3760,6 @@ return class Handler {
       },
       "root/my_api/OnRequestHandler1": {
         "addr": "c84819d7712e30f38cf7731fcfbe96cbc39c7e75d3",
-        "attrs": {},
         "path": "root/my_api/OnRequestHandler1",
         "policy": [],
         "props": {
@@ -3836,7 +3773,6 @@ return class Handler {
       },
       "root/my_api/Policy": {
         "addr": "c8d2997625976ba9bc7be90fefe7930aebab104a2a",
-        "attrs": {},
         "path": "root/my_api/Policy",
         "props": {
           "principal": "\${wsim#root/my_api#attrs.handle}",
@@ -4100,7 +4036,6 @@ return class Handler {
     "resources": {
       "root/my_api": {
         "addr": "c8f2ecf2132465e146aa80cb01f4e5ab1968f4314a",
-        "attrs": {},
         "path": "root/my_api",
         "props": {
           "openApiSpec": {
@@ -4125,7 +4060,6 @@ return class Handler {
       },
       "root/my_api/ApiEventMapping0": {
         "addr": "c8a199e7bc539eb442a47653fe0f2b1f0bf50aa6d1",
-        "attrs": {},
         "deps": [
           "root/my_api/OnRequestHandler0",
           "root/my_api",
@@ -4147,7 +4081,6 @@ return class Handler {
       },
       "root/my_api/Endpoint": {
         "addr": "c85bd2f9eb401f27bec4d0ad16222c2876bcfe640a",
-        "attrs": {},
         "path": "root/my_api/Endpoint",
         "props": {
           "inputUrl": "\${wsim#root/my_api#attrs.url}",
@@ -4158,7 +4091,6 @@ return class Handler {
       },
       "root/my_api/OnRequestHandler0": {
         "addr": "c82d41b2501ac42e07e4565202a5b87a180a01c6a2",
-        "attrs": {},
         "path": "root/my_api/OnRequestHandler0",
         "policy": [],
         "props": {
@@ -4172,7 +4104,6 @@ return class Handler {
       },
       "root/my_api/Policy": {
         "addr": "c8d2997625976ba9bc7be90fefe7930aebab104a2a",
-        "attrs": {},
         "path": "root/my_api/Policy",
         "props": {
           "principal": "\${wsim#root/my_api#attrs.handle}",
@@ -4407,7 +4338,6 @@ return class Handler {
     "resources": {
       "root/my_api": {
         "addr": "c8f2ecf2132465e146aa80cb01f4e5ab1968f4314a",
-        "attrs": {},
         "path": "root/my_api",
         "props": {
           "openApiSpec": {
@@ -4441,7 +4371,6 @@ return class Handler {
       },
       "root/my_api/ApiEventMapping0": {
         "addr": "c8a199e7bc539eb442a47653fe0f2b1f0bf50aa6d1",
-        "attrs": {},
         "deps": [
           "root/my_api/OnRequestHandler0",
           "root/my_api",
@@ -4463,7 +4392,6 @@ return class Handler {
       },
       "root/my_api/Endpoint": {
         "addr": "c85bd2f9eb401f27bec4d0ad16222c2876bcfe640a",
-        "attrs": {},
         "path": "root/my_api/Endpoint",
         "props": {
           "inputUrl": "\${wsim#root/my_api#attrs.url}",
@@ -4474,7 +4402,6 @@ return class Handler {
       },
       "root/my_api/OnRequestHandler0": {
         "addr": "c82d41b2501ac42e07e4565202a5b87a180a01c6a2",
-        "attrs": {},
         "path": "root/my_api/OnRequestHandler0",
         "policy": [],
         "props": {
@@ -4488,7 +4415,6 @@ return class Handler {
       },
       "root/my_api/Policy": {
         "addr": "c8d2997625976ba9bc7be90fefe7930aebab104a2a",
-        "attrs": {},
         "path": "root/my_api/Policy",
         "props": {
           "principal": "\${wsim#root/my_api#attrs.handle}",
@@ -4723,7 +4649,6 @@ return class Handler {
     "resources": {
       "root/my_api": {
         "addr": "c8f2ecf2132465e146aa80cb01f4e5ab1968f4314a",
-        "attrs": {},
         "path": "root/my_api",
         "props": {
           "openApiSpec": {
@@ -4748,7 +4673,6 @@ return class Handler {
       },
       "root/my_api/ApiEventMapping0": {
         "addr": "c8a199e7bc539eb442a47653fe0f2b1f0bf50aa6d1",
-        "attrs": {},
         "deps": [
           "root/my_api/OnRequestHandler0",
           "root/my_api",
@@ -4770,7 +4694,6 @@ return class Handler {
       },
       "root/my_api/Endpoint": {
         "addr": "c85bd2f9eb401f27bec4d0ad16222c2876bcfe640a",
-        "attrs": {},
         "path": "root/my_api/Endpoint",
         "props": {
           "inputUrl": "\${wsim#root/my_api#attrs.url}",
@@ -4781,7 +4704,6 @@ return class Handler {
       },
       "root/my_api/OnRequestHandler0": {
         "addr": "c82d41b2501ac42e07e4565202a5b87a180a01c6a2",
-        "attrs": {},
         "path": "root/my_api/OnRequestHandler0",
         "policy": [],
         "props": {
@@ -4795,7 +4717,6 @@ return class Handler {
       },
       "root/my_api/Policy": {
         "addr": "c8d2997625976ba9bc7be90fefe7930aebab104a2a",
-        "attrs": {},
         "path": "root/my_api/Policy",
         "props": {
           "principal": "\${wsim#root/my_api#attrs.handle}",
@@ -4987,7 +4908,6 @@ exports[`create an api 1`] = `
     "resources": {
       "root/my_api": {
         "addr": "c8f2ecf2132465e146aa80cb01f4e5ab1968f4314a",
-        "attrs": {},
         "path": "root/my_api",
         "props": {
           "openApiSpec": {
@@ -4999,7 +4919,6 @@ exports[`create an api 1`] = `
       },
       "root/my_api/Endpoint": {
         "addr": "c85bd2f9eb401f27bec4d0ad16222c2876bcfe640a",
-        "attrs": {},
         "path": "root/my_api/Endpoint",
         "props": {
           "inputUrl": "\${wsim#root/my_api#attrs.url}",
@@ -5010,7 +4929,6 @@ exports[`create an api 1`] = `
       },
       "root/my_api/Policy": {
         "addr": "c8d2997625976ba9bc7be90fefe7930aebab104a2a",
-        "attrs": {},
         "path": "root/my_api/Policy",
         "props": {
           "principal": "\${wsim#root/my_api#attrs.handle}",

--- a/libs/wingsdk/test/target-sim/__snapshots__/bucket.test.ts.snap
+++ b/libs/wingsdk/test/target-sim/__snapshots__/bucket.test.ts.snap
@@ -81,7 +81,6 @@ exports[`can add file in preflight 2`] = `
     "resources": {
       "root/my_bucket": {
         "addr": "c8220a82a4ad9c25a4f236946f350d2ac081dd7bbc",
-        "attrs": {},
         "path": "root/my_bucket",
         "props": {
           "initialObjects": {
@@ -94,7 +93,6 @@ exports[`can add file in preflight 2`] = `
       },
       "root/my_bucket/Policy": {
         "addr": "c8b5ba55132964ee19331fb9f46241560e67fed76b",
-        "attrs": {},
         "path": "root/my_bucket/Policy",
         "props": {
           "principal": "\${wsim#root/my_bucket#attrs.handle}",
@@ -257,7 +255,6 @@ exports[`can add object in preflight 2`] = `
     "resources": {
       "root/my_bucket": {
         "addr": "c8220a82a4ad9c25a4f236946f350d2ac081dd7bbc",
-        "attrs": {},
         "path": "root/my_bucket",
         "props": {
           "initialObjects": {
@@ -270,7 +267,6 @@ exports[`can add object in preflight 2`] = `
       },
       "root/my_bucket/Policy": {
         "addr": "c8b5ba55132964ee19331fb9f46241560e67fed76b",
-        "attrs": {},
         "path": "root/my_bucket/Policy",
         "props": {
           "principal": "\${wsim#root/my_bucket#attrs.handle}",
@@ -420,7 +416,6 @@ exports[`create a bucket 1`] = `
     "resources": {
       "root/my_bucket": {
         "addr": "c8220a82a4ad9c25a4f236946f350d2ac081dd7bbc",
-        "attrs": {},
         "path": "root/my_bucket",
         "props": {
           "initialObjects": {},
@@ -431,7 +426,6 @@ exports[`create a bucket 1`] = `
       },
       "root/my_bucket/Policy": {
         "addr": "c8b5ba55132964ee19331fb9f46241560e67fed76b",
-        "attrs": {},
         "path": "root/my_bucket/Policy",
         "props": {
           "principal": "\${wsim#root/my_bucket#attrs.handle}",
@@ -591,7 +585,6 @@ exports[`get invalid object throws an error 2`] = `
     "resources": {
       "root/my_bucket": {
         "addr": "c8220a82a4ad9c25a4f236946f350d2ac081dd7bbc",
-        "attrs": {},
         "path": "root/my_bucket",
         "props": {
           "initialObjects": {},
@@ -602,7 +595,6 @@ exports[`get invalid object throws an error 2`] = `
       },
       "root/my_bucket/Policy": {
         "addr": "c8b5ba55132964ee19331fb9f46241560e67fed76b",
-        "attrs": {},
         "path": "root/my_bucket/Policy",
         "props": {
           "principal": "\${wsim#root/my_bucket#attrs.handle}",

--- a/libs/wingsdk/test/target-sim/__snapshots__/bucket.test.ts.snap
+++ b/libs/wingsdk/test/target-sim/__snapshots__/bucket.test.ts.snap
@@ -78,8 +78,8 @@ exports[`can add file in preflight 2`] = `
     "version": "connections-0.1",
   },
   "simulator.json": {
-    "resources": [
-      {
+    "resources": {
+      "root/my_bucket": {
         "addr": "c8220a82a4ad9c25a4f236946f350d2ac081dd7bbc",
         "attrs": {},
         "path": "root/my_bucket",
@@ -92,7 +92,7 @@ exports[`can add file in preflight 2`] = `
         },
         "type": "@winglang/sdk.cloud.Bucket",
       },
-      {
+      "root/my_bucket/Policy": {
         "addr": "c8b5ba55132964ee19331fb9f46241560e67fed76b",
         "attrs": {},
         "path": "root/my_bucket/Policy",
@@ -102,7 +102,7 @@ exports[`can add file in preflight 2`] = `
         },
         "type": "@winglang/sdk.sim.Policy",
       },
-    ],
+    },
     "sdkVersion": "0.0.0",
     "types": {
       "@winglang/sdk.cloud.Api": {
@@ -254,8 +254,8 @@ exports[`can add object in preflight 2`] = `
     "version": "connections-0.1",
   },
   "simulator.json": {
-    "resources": [
-      {
+    "resources": {
+      "root/my_bucket": {
         "addr": "c8220a82a4ad9c25a4f236946f350d2ac081dd7bbc",
         "attrs": {},
         "path": "root/my_bucket",
@@ -268,7 +268,7 @@ exports[`can add object in preflight 2`] = `
         },
         "type": "@winglang/sdk.cloud.Bucket",
       },
-      {
+      "root/my_bucket/Policy": {
         "addr": "c8b5ba55132964ee19331fb9f46241560e67fed76b",
         "attrs": {},
         "path": "root/my_bucket/Policy",
@@ -278,7 +278,7 @@ exports[`can add object in preflight 2`] = `
         },
         "type": "@winglang/sdk.sim.Policy",
       },
-    ],
+    },
     "sdkVersion": "0.0.0",
     "types": {
       "@winglang/sdk.cloud.Api": {
@@ -417,8 +417,8 @@ exports[`create a bucket 1`] = `
     "version": "connections-0.1",
   },
   "simulator.json": {
-    "resources": [
-      {
+    "resources": {
+      "root/my_bucket": {
         "addr": "c8220a82a4ad9c25a4f236946f350d2ac081dd7bbc",
         "attrs": {},
         "path": "root/my_bucket",
@@ -429,7 +429,7 @@ exports[`create a bucket 1`] = `
         },
         "type": "@winglang/sdk.cloud.Bucket",
       },
-      {
+      "root/my_bucket/Policy": {
         "addr": "c8b5ba55132964ee19331fb9f46241560e67fed76b",
         "attrs": {},
         "path": "root/my_bucket/Policy",
@@ -439,7 +439,7 @@ exports[`create a bucket 1`] = `
         },
         "type": "@winglang/sdk.sim.Policy",
       },
-    ],
+    },
     "sdkVersion": "0.0.0",
     "types": {
       "@winglang/sdk.cloud.Api": {
@@ -588,8 +588,8 @@ exports[`get invalid object throws an error 2`] = `
     "version": "connections-0.1",
   },
   "simulator.json": {
-    "resources": [
-      {
+    "resources": {
+      "root/my_bucket": {
         "addr": "c8220a82a4ad9c25a4f236946f350d2ac081dd7bbc",
         "attrs": {},
         "path": "root/my_bucket",
@@ -600,7 +600,7 @@ exports[`get invalid object throws an error 2`] = `
         },
         "type": "@winglang/sdk.cloud.Bucket",
       },
-      {
+      "root/my_bucket/Policy": {
         "addr": "c8b5ba55132964ee19331fb9f46241560e67fed76b",
         "attrs": {},
         "path": "root/my_bucket/Policy",
@@ -610,7 +610,7 @@ exports[`get invalid object throws an error 2`] = `
         },
         "type": "@winglang/sdk.sim.Policy",
       },
-    ],
+    },
     "sdkVersion": "0.0.0",
     "types": {
       "@winglang/sdk.cloud.Api": {

--- a/libs/wingsdk/test/target-sim/__snapshots__/counter.test.ts.snap
+++ b/libs/wingsdk/test/target-sim/__snapshots__/counter.test.ts.snap
@@ -10,7 +10,6 @@ exports[`create a counter 1`] = `
     "resources": {
       "root/my_counter": {
         "addr": "c82c1419dede49fb73e65c4df6565dc606f828ef99",
-        "attrs": {},
         "path": "root/my_counter",
         "props": {
           "initial": 123,
@@ -155,7 +154,6 @@ exports[`dec 2`] = `
     "resources": {
       "root/my_counter": {
         "addr": "c82c1419dede49fb73e65c4df6565dc606f828ef99",
-        "attrs": {},
         "path": "root/my_counter",
         "props": {
           "initial": 123,
@@ -300,7 +298,6 @@ exports[`inc 2`] = `
     "resources": {
       "root/my_counter": {
         "addr": "c82c1419dede49fb73e65c4df6565dc606f828ef99",
-        "attrs": {},
         "path": "root/my_counter",
         "props": {
           "initial": 123,
@@ -445,7 +442,6 @@ exports[`key dec 2`] = `
     "resources": {
       "root/my_counter": {
         "addr": "c82c1419dede49fb73e65c4df6565dc606f828ef99",
-        "attrs": {},
         "path": "root/my_counter",
         "props": {
           "initial": 0,
@@ -590,7 +586,6 @@ exports[`key inc 2`] = `
     "resources": {
       "root/my_counter": {
         "addr": "c82c1419dede49fb73e65c4df6565dc606f828ef99",
-        "attrs": {},
         "path": "root/my_counter",
         "props": {
           "initial": 0,
@@ -733,7 +728,6 @@ exports[`key set to new value 2`] = `
     "resources": {
       "root/my_counter": {
         "addr": "c82c1419dede49fb73e65c4df6565dc606f828ef99",
-        "attrs": {},
         "path": "root/my_counter",
         "props": {
           "initial": 0,
@@ -876,7 +870,6 @@ exports[`set to new value 2`] = `
     "resources": {
       "root/my_counter": {
         "addr": "c82c1419dede49fb73e65c4df6565dc606f828ef99",
-        "attrs": {},
         "path": "root/my_counter",
         "props": {
           "initial": 123,

--- a/libs/wingsdk/test/target-sim/__snapshots__/counter.test.ts.snap
+++ b/libs/wingsdk/test/target-sim/__snapshots__/counter.test.ts.snap
@@ -7,8 +7,8 @@ exports[`create a counter 1`] = `
     "version": "connections-0.1",
   },
   "simulator.json": {
-    "resources": [
-      {
+    "resources": {
+      "root/my_counter": {
         "addr": "c82c1419dede49fb73e65c4df6565dc606f828ef99",
         "attrs": {},
         "path": "root/my_counter",
@@ -17,7 +17,7 @@ exports[`create a counter 1`] = `
         },
         "type": "@winglang/sdk.cloud.Counter",
       },
-    ],
+    },
     "sdkVersion": "0.0.0",
     "types": {
       "@winglang/sdk.cloud.Api": {
@@ -152,8 +152,8 @@ exports[`dec 2`] = `
     "version": "connections-0.1",
   },
   "simulator.json": {
-    "resources": [
-      {
+    "resources": {
+      "root/my_counter": {
         "addr": "c82c1419dede49fb73e65c4df6565dc606f828ef99",
         "attrs": {},
         "path": "root/my_counter",
@@ -162,7 +162,7 @@ exports[`dec 2`] = `
         },
         "type": "@winglang/sdk.cloud.Counter",
       },
-    ],
+    },
     "sdkVersion": "0.0.0",
     "types": {
       "@winglang/sdk.cloud.Api": {
@@ -297,8 +297,8 @@ exports[`inc 2`] = `
     "version": "connections-0.1",
   },
   "simulator.json": {
-    "resources": [
-      {
+    "resources": {
+      "root/my_counter": {
         "addr": "c82c1419dede49fb73e65c4df6565dc606f828ef99",
         "attrs": {},
         "path": "root/my_counter",
@@ -307,7 +307,7 @@ exports[`inc 2`] = `
         },
         "type": "@winglang/sdk.cloud.Counter",
       },
-    ],
+    },
     "sdkVersion": "0.0.0",
     "types": {
       "@winglang/sdk.cloud.Api": {
@@ -442,8 +442,8 @@ exports[`key dec 2`] = `
     "version": "connections-0.1",
   },
   "simulator.json": {
-    "resources": [
-      {
+    "resources": {
+      "root/my_counter": {
         "addr": "c82c1419dede49fb73e65c4df6565dc606f828ef99",
         "attrs": {},
         "path": "root/my_counter",
@@ -452,7 +452,7 @@ exports[`key dec 2`] = `
         },
         "type": "@winglang/sdk.cloud.Counter",
       },
-    ],
+    },
     "sdkVersion": "0.0.0",
     "types": {
       "@winglang/sdk.cloud.Api": {
@@ -587,8 +587,8 @@ exports[`key inc 2`] = `
     "version": "connections-0.1",
   },
   "simulator.json": {
-    "resources": [
-      {
+    "resources": {
+      "root/my_counter": {
         "addr": "c82c1419dede49fb73e65c4df6565dc606f828ef99",
         "attrs": {},
         "path": "root/my_counter",
@@ -597,7 +597,7 @@ exports[`key inc 2`] = `
         },
         "type": "@winglang/sdk.cloud.Counter",
       },
-    ],
+    },
     "sdkVersion": "0.0.0",
     "types": {
       "@winglang/sdk.cloud.Api": {
@@ -730,8 +730,8 @@ exports[`key set to new value 2`] = `
     "version": "connections-0.1",
   },
   "simulator.json": {
-    "resources": [
-      {
+    "resources": {
+      "root/my_counter": {
         "addr": "c82c1419dede49fb73e65c4df6565dc606f828ef99",
         "attrs": {},
         "path": "root/my_counter",
@@ -740,7 +740,7 @@ exports[`key set to new value 2`] = `
         },
         "type": "@winglang/sdk.cloud.Counter",
       },
-    ],
+    },
     "sdkVersion": "0.0.0",
     "types": {
       "@winglang/sdk.cloud.Api": {
@@ -873,8 +873,8 @@ exports[`set to new value 2`] = `
     "version": "connections-0.1",
   },
   "simulator.json": {
-    "resources": [
-      {
+    "resources": {
+      "root/my_counter": {
         "addr": "c82c1419dede49fb73e65c4df6565dc606f828ef99",
         "attrs": {},
         "path": "root/my_counter",
@@ -883,7 +883,7 @@ exports[`set to new value 2`] = `
         },
         "type": "@winglang/sdk.cloud.Counter",
       },
-    ],
+    },
     "sdkVersion": "0.0.0",
     "types": {
       "@winglang/sdk.cloud.Api": {

--- a/libs/wingsdk/test/target-sim/__snapshots__/file-counter.test.ts.snap
+++ b/libs/wingsdk/test/target-sim/__snapshots__/file-counter.test.ts.snap
@@ -73,8 +73,19 @@ bucket: (function() {
     "version": "connections-0.1",
   },
   "simulator.json": {
-    "resources": [
-      {
+    "resources": {
+      "root/HelloWorld/Bucket": {
+        "addr": "c80e3625bbefd53d8c61fbb978711d410b5f2a41c8",
+        "attrs": {},
+        "path": "root/HelloWorld/Bucket",
+        "props": {
+          "initialObjects": {},
+          "public": false,
+          "topics": {},
+        },
+        "type": "@winglang/sdk.cloud.Bucket",
+      },
+      "root/HelloWorld/Bucket/Policy": {
         "addr": "c86eb36bbe6e764a632afaaea5db2d4bd693c92624",
         "attrs": {},
         "path": "root/HelloWorld/Bucket/Policy",
@@ -84,7 +95,26 @@ bucket: (function() {
         },
         "type": "@winglang/sdk.sim.Policy",
       },
-      {
+      "root/HelloWorld/Counter": {
+        "addr": "c87855e817fa3df0d5ce8ae290bf53c8ce4ecd8d46",
+        "attrs": {},
+        "path": "root/HelloWorld/Counter",
+        "props": {
+          "initial": 1000,
+        },
+        "type": "@winglang/sdk.cloud.Counter",
+      },
+      "root/HelloWorld/Queue": {
+        "addr": "c8de0494647ac0bdaec85a77e2a164cfbcfecc5ca1",
+        "attrs": {},
+        "path": "root/HelloWorld/Queue",
+        "props": {
+          "retentionPeriod": 3600,
+          "timeout": 30,
+        },
+        "type": "@winglang/sdk.cloud.Queue",
+      },
+      "root/HelloWorld/Queue/Policy": {
         "addr": "c86b009930462795eeb90e647a56dbfc5356d9ea80",
         "attrs": {},
         "path": "root/HelloWorld/Queue/Policy",
@@ -103,27 +133,24 @@ bucket: (function() {
         },
         "type": "@winglang/sdk.sim.Policy",
       },
-      {
-        "addr": "c87855e817fa3df0d5ce8ae290bf53c8ce4ecd8d46",
+      "root/HelloWorld/Queue/QueueEventMapping0": {
+        "addr": "c80de7940bef4e6ad61443a5ed07362f300a117b29",
         "attrs": {},
-        "path": "root/HelloWorld/Counter",
+        "deps": [
+          "root/HelloWorld/Queue/SetConsumer0",
+          "root/HelloWorld/Queue",
+        ],
+        "path": "root/HelloWorld/Queue/QueueEventMapping0",
         "props": {
-          "initial": 1000,
+          "publisher": "\${wsim#root/HelloWorld/Queue#attrs.handle}",
+          "subscriber": "\${wsim#root/HelloWorld/Queue/SetConsumer0#attrs.handle}",
+          "subscriptionProps": {
+            "batchSize": 1,
+          },
         },
-        "type": "@winglang/sdk.cloud.Counter",
+        "type": "@winglang/sdk.sim.EventMapping",
       },
-      {
-        "addr": "c80e3625bbefd53d8c61fbb978711d410b5f2a41c8",
-        "attrs": {},
-        "path": "root/HelloWorld/Bucket",
-        "props": {
-          "initialObjects": {},
-          "public": false,
-          "topics": {},
-        },
-        "type": "@winglang/sdk.cloud.Bucket",
-      },
-      {
+      "root/HelloWorld/Queue/SetConsumer0": {
         "addr": "c8e82e9fd83d9e59c5af169a3042b9ed0b40e91185",
         "attrs": {},
         "deps": [
@@ -153,34 +180,7 @@ bucket: (function() {
         },
         "type": "@winglang/sdk.cloud.Function",
       },
-      {
-        "addr": "c8de0494647ac0bdaec85a77e2a164cfbcfecc5ca1",
-        "attrs": {},
-        "path": "root/HelloWorld/Queue",
-        "props": {
-          "retentionPeriod": 3600,
-          "timeout": 30,
-        },
-        "type": "@winglang/sdk.cloud.Queue",
-      },
-      {
-        "addr": "c80de7940bef4e6ad61443a5ed07362f300a117b29",
-        "attrs": {},
-        "deps": [
-          "root/HelloWorld/Queue/SetConsumer0",
-          "root/HelloWorld/Queue",
-        ],
-        "path": "root/HelloWorld/Queue/QueueEventMapping0",
-        "props": {
-          "publisher": "\${wsim#root/HelloWorld/Queue#attrs.handle}",
-          "subscriber": "\${wsim#root/HelloWorld/Queue/SetConsumer0#attrs.handle}",
-          "subscriptionProps": {
-            "batchSize": 1,
-          },
-        },
-        "type": "@winglang/sdk.sim.EventMapping",
-      },
-    ],
+    },
     "sdkVersion": "0.0.0",
     "types": {
       "@winglang/sdk.cloud.Api": {

--- a/libs/wingsdk/test/target-sim/__snapshots__/file-counter.test.ts.snap
+++ b/libs/wingsdk/test/target-sim/__snapshots__/file-counter.test.ts.snap
@@ -76,7 +76,6 @@ bucket: (function() {
     "resources": {
       "root/HelloWorld/Bucket": {
         "addr": "c80e3625bbefd53d8c61fbb978711d410b5f2a41c8",
-        "attrs": {},
         "path": "root/HelloWorld/Bucket",
         "props": {
           "initialObjects": {},
@@ -87,7 +86,6 @@ bucket: (function() {
       },
       "root/HelloWorld/Bucket/Policy": {
         "addr": "c86eb36bbe6e764a632afaaea5db2d4bd693c92624",
-        "attrs": {},
         "path": "root/HelloWorld/Bucket/Policy",
         "props": {
           "principal": "\${wsim#root/HelloWorld/Bucket#attrs.handle}",
@@ -97,7 +95,6 @@ bucket: (function() {
       },
       "root/HelloWorld/Counter": {
         "addr": "c87855e817fa3df0d5ce8ae290bf53c8ce4ecd8d46",
-        "attrs": {},
         "path": "root/HelloWorld/Counter",
         "props": {
           "initial": 1000,
@@ -106,7 +103,6 @@ bucket: (function() {
       },
       "root/HelloWorld/Queue": {
         "addr": "c8de0494647ac0bdaec85a77e2a164cfbcfecc5ca1",
-        "attrs": {},
         "path": "root/HelloWorld/Queue",
         "props": {
           "retentionPeriod": 3600,
@@ -116,7 +112,6 @@ bucket: (function() {
       },
       "root/HelloWorld/Queue/Policy": {
         "addr": "c86b009930462795eeb90e647a56dbfc5356d9ea80",
-        "attrs": {},
         "path": "root/HelloWorld/Queue/Policy",
         "props": {
           "principal": "\${wsim#root/HelloWorld/Queue#attrs.handle}",
@@ -135,7 +130,6 @@ bucket: (function() {
       },
       "root/HelloWorld/Queue/QueueEventMapping0": {
         "addr": "c80de7940bef4e6ad61443a5ed07362f300a117b29",
-        "attrs": {},
         "deps": [
           "root/HelloWorld/Queue/SetConsumer0",
           "root/HelloWorld/Queue",
@@ -152,7 +146,6 @@ bucket: (function() {
       },
       "root/HelloWorld/Queue/SetConsumer0": {
         "addr": "c8e82e9fd83d9e59c5af169a3042b9ed0b40e91185",
-        "attrs": {},
         "deps": [
           "root/HelloWorld/Counter",
           "root/HelloWorld/Bucket",

--- a/libs/wingsdk/test/target-sim/__snapshots__/function.test.ts.snap
+++ b/libs/wingsdk/test/target-sim/__snapshots__/function.test.ts.snap
@@ -37,8 +37,8 @@ async handle(event) {
     "version": "connections-0.1",
   },
   "simulator.json": {
-    "resources": [
-      {
+    "resources": {
+      "root/my_function": {
         "addr": "c85c4e0e66bf385ab6b159bab34fb32dd81aad0a1d",
         "attrs": {},
         "path": "root/my_function",
@@ -54,7 +54,7 @@ async handle(event) {
         },
         "type": "@winglang/sdk.cloud.Function",
       },
-    ],
+    },
     "sdkVersion": "0.0.0",
     "types": {
       "@winglang/sdk.cloud.Api": {
@@ -216,8 +216,8 @@ async handle(event) {
     "version": "connections-0.1",
   },
   "simulator.json": {
-    "resources": [
-      {
+    "resources": {
+      "root/my_function": {
         "addr": "c85c4e0e66bf385ab6b159bab34fb32dd81aad0a1d",
         "attrs": {},
         "path": "root/my_function",
@@ -231,7 +231,7 @@ async handle(event) {
         },
         "type": "@winglang/sdk.cloud.Function",
       },
-    ],
+    },
     "sdkVersion": "0.0.0",
     "types": {
       "@winglang/sdk.cloud.Api": {
@@ -393,8 +393,8 @@ async handle(event) {
     "version": "connections-0.1",
   },
   "simulator.json": {
-    "resources": [
-      {
+    "resources": {
+      "root/my_function": {
         "addr": "c85c4e0e66bf385ab6b159bab34fb32dd81aad0a1d",
         "attrs": {},
         "path": "root/my_function",
@@ -408,7 +408,7 @@ async handle(event) {
         },
         "type": "@winglang/sdk.cloud.Function",
       },
-    ],
+    },
     "sdkVersion": "0.0.0",
     "types": {
       "@winglang/sdk.cloud.Api": {
@@ -570,8 +570,8 @@ async handle(event) {
     "version": "connections-0.1",
   },
   "simulator.json": {
-    "resources": [
-      {
+    "resources": {
+      "root/my_function": {
         "addr": "c85c4e0e66bf385ab6b159bab34fb32dd81aad0a1d",
         "attrs": {},
         "path": "root/my_function",
@@ -587,7 +587,7 @@ async handle(event) {
         },
         "type": "@winglang/sdk.cloud.Function",
       },
-    ],
+    },
     "sdkVersion": "0.0.0",
     "types": {
       "@winglang/sdk.cloud.Api": {
@@ -739,8 +739,8 @@ async handle() {
     "version": "connections-0.1",
   },
   "simulator.json": {
-    "resources": [
-      {
+    "resources": {
+      "root/my_function": {
         "addr": "c85c4e0e66bf385ab6b159bab34fb32dd81aad0a1d",
         "attrs": {},
         "path": "root/my_function",
@@ -754,7 +754,7 @@ async handle() {
         },
         "type": "@winglang/sdk.cloud.Function",
       },
-    ],
+    },
     "sdkVersion": "0.0.0",
     "types": {
       "@winglang/sdk.cloud.Api": {
@@ -966,8 +966,8 @@ return class Handler {
     "version": "connections-0.1",
   },
   "simulator.json": {
-    "resources": [
-      {
+    "resources": {
+      "root/Function.0": {
         "addr": "c8d5fca2ff1b96bd65cc21384259b53ae9f3d4971c",
         "attrs": {},
         "path": "root/Function.0",
@@ -981,7 +981,7 @@ return class Handler {
         },
         "type": "@winglang/sdk.cloud.Function",
       },
-      {
+      "root/Function.1": {
         "addr": "c89ed254f66166d83153cc0a4952a15be63d47b0d2",
         "attrs": {},
         "path": "root/Function.1",
@@ -995,7 +995,7 @@ return class Handler {
         },
         "type": "@winglang/sdk.cloud.Function",
       },
-      {
+      "root/Function.2": {
         "addr": "c8cd6c39da22910102d0cfeb2cb96f2160fa79e517",
         "attrs": {},
         "path": "root/Function.2",
@@ -1009,7 +1009,7 @@ return class Handler {
         },
         "type": "@winglang/sdk.cloud.Function",
       },
-      {
+      "root/Function.3": {
         "addr": "c8badafa75a67ff66740e0c5fbbb392ab574b52b3c",
         "attrs": {},
         "path": "root/Function.3",
@@ -1023,7 +1023,7 @@ return class Handler {
         },
         "type": "@winglang/sdk.cloud.Function",
       },
-    ],
+    },
     "sdkVersion": "0.0.0",
     "types": {
       "@winglang/sdk.cloud.Api": {

--- a/libs/wingsdk/test/target-sim/__snapshots__/function.test.ts.snap
+++ b/libs/wingsdk/test/target-sim/__snapshots__/function.test.ts.snap
@@ -40,7 +40,6 @@ async handle(event) {
     "resources": {
       "root/my_function": {
         "addr": "c85c4e0e66bf385ab6b159bab34fb32dd81aad0a1d",
-        "attrs": {},
         "path": "root/my_function",
         "policy": [],
         "props": {
@@ -219,7 +218,6 @@ async handle(event) {
     "resources": {
       "root/my_function": {
         "addr": "c85c4e0e66bf385ab6b159bab34fb32dd81aad0a1d",
-        "attrs": {},
         "path": "root/my_function",
         "policy": [],
         "props": {
@@ -396,7 +394,6 @@ async handle(event) {
     "resources": {
       "root/my_function": {
         "addr": "c85c4e0e66bf385ab6b159bab34fb32dd81aad0a1d",
-        "attrs": {},
         "path": "root/my_function",
         "policy": [],
         "props": {
@@ -573,7 +570,6 @@ async handle(event) {
     "resources": {
       "root/my_function": {
         "addr": "c85c4e0e66bf385ab6b159bab34fb32dd81aad0a1d",
-        "attrs": {},
         "path": "root/my_function",
         "policy": [],
         "props": {
@@ -742,7 +738,6 @@ async handle() {
     "resources": {
       "root/my_function": {
         "addr": "c85c4e0e66bf385ab6b159bab34fb32dd81aad0a1d",
-        "attrs": {},
         "path": "root/my_function",
         "policy": [],
         "props": {
@@ -969,7 +964,6 @@ return class Handler {
     "resources": {
       "root/Function.0": {
         "addr": "c8d5fca2ff1b96bd65cc21384259b53ae9f3d4971c",
-        "attrs": {},
         "path": "root/Function.0",
         "policy": [],
         "props": {
@@ -983,7 +977,6 @@ return class Handler {
       },
       "root/Function.1": {
         "addr": "c89ed254f66166d83153cc0a4952a15be63d47b0d2",
-        "attrs": {},
         "path": "root/Function.1",
         "policy": [],
         "props": {
@@ -997,7 +990,6 @@ return class Handler {
       },
       "root/Function.2": {
         "addr": "c8cd6c39da22910102d0cfeb2cb96f2160fa79e517",
-        "attrs": {},
         "path": "root/Function.2",
         "policy": [],
         "props": {
@@ -1011,7 +1003,6 @@ return class Handler {
       },
       "root/Function.3": {
         "addr": "c8badafa75a67ff66740e0c5fbbb392ab574b52b3c",
-        "attrs": {},
         "path": "root/Function.3",
         "policy": [],
         "props": {

--- a/libs/wingsdk/test/target-sim/__snapshots__/immutable-capture.test.ts.snap
+++ b/libs/wingsdk/test/target-sim/__snapshots__/immutable-capture.test.ts.snap
@@ -29,8 +29,8 @@ my_capture: ["hello","dude"]
     "version": "connections-0.1",
   },
   "simulator.json": {
-    "resources": [
-      {
+    "resources": {
+      "root/Function": {
         "addr": "c8e6b4af896782ab4057ebb2193266e56b0b6dfeb0",
         "attrs": {},
         "path": "root/Function",
@@ -44,7 +44,7 @@ my_capture: ["hello","dude"]
         },
         "type": "@winglang/sdk.cloud.Function",
       },
-    ],
+    },
     "sdkVersion": "0.0.0",
     "types": {
       "@winglang/sdk.cloud.Api": {
@@ -190,8 +190,8 @@ my_array: [(new (require("[REDACTED]/wingsdk/src/std/duration.js").Duration)(600
     "version": "connections-0.1",
   },
   "simulator.json": {
-    "resources": [
-      {
+    "resources": {
+      "root/Function": {
         "addr": "c8e6b4af896782ab4057ebb2193266e56b0b6dfeb0",
         "attrs": {},
         "path": "root/Function",
@@ -205,7 +205,7 @@ my_array: [(new (require("[REDACTED]/wingsdk/src/std/duration.js").Duration)(600
         },
         "type": "@winglang/sdk.cloud.Function",
       },
-    ],
+    },
     "sdkVersion": "0.0.0",
     "types": {
       "@winglang/sdk.cloud.Api": {
@@ -350,8 +350,8 @@ my_array: [new Map([["foo",1],["bar",2]]),new Map([["foo",3],["bar",4]])]
     "version": "connections-0.1",
   },
   "simulator.json": {
-    "resources": [
-      {
+    "resources": {
+      "root/Function": {
         "addr": "c8e6b4af896782ab4057ebb2193266e56b0b6dfeb0",
         "attrs": {},
         "path": "root/Function",
@@ -365,7 +365,7 @@ my_array: [new Map([["foo",1],["bar",2]]),new Map([["foo",3],["bar",4]])]
         },
         "type": "@winglang/sdk.cloud.Function",
       },
-    ],
+    },
     "sdkVersion": "0.0.0",
     "types": {
       "@winglang/sdk.cloud.Api": {
@@ -509,8 +509,8 @@ my_capture: false
     "version": "connections-0.1",
   },
   "simulator.json": {
-    "resources": [
-      {
+    "resources": {
+      "root/Function": {
         "addr": "c8e6b4af896782ab4057ebb2193266e56b0b6dfeb0",
         "attrs": {},
         "path": "root/Function",
@@ -524,7 +524,7 @@ my_capture: false
         },
         "type": "@winglang/sdk.cloud.Function",
       },
-    ],
+    },
     "sdkVersion": "0.0.0",
     "types": {
       "@winglang/sdk.cloud.Api": {
@@ -670,8 +670,8 @@ my_capture: (new (require("[REDACTED]/wingsdk/src/std/duration.js").Duration)(72
     "version": "connections-0.1",
   },
   "simulator.json": {
-    "resources": [
-      {
+    "resources": {
+      "root/Function": {
         "addr": "c8e6b4af896782ab4057ebb2193266e56b0b6dfeb0",
         "attrs": {},
         "path": "root/Function",
@@ -685,7 +685,7 @@ my_capture: (new (require("[REDACTED]/wingsdk/src/std/duration.js").Duration)(72
         },
         "type": "@winglang/sdk.cloud.Function",
       },
-    ],
+    },
     "sdkVersion": "0.0.0",
     "types": {
       "@winglang/sdk.cloud.Api": {
@@ -833,8 +833,8 @@ my_capture: new Map([["foo",123],["bar",456]])
     "version": "connections-0.1",
   },
   "simulator.json": {
-    "resources": [
-      {
+    "resources": {
+      "root/Function": {
         "addr": "c8e6b4af896782ab4057ebb2193266e56b0b6dfeb0",
         "attrs": {},
         "path": "root/Function",
@@ -848,7 +848,7 @@ my_capture: new Map([["foo",123],["bar",456]])
         },
         "type": "@winglang/sdk.cloud.Function",
       },
-    ],
+    },
     "sdkVersion": "0.0.0",
     "types": {
       "@winglang/sdk.cloud.Api": {
@@ -998,8 +998,8 @@ my_map: new Map([["foo",[1,2]],["bar",[3,4]]])
     "version": "connections-0.1",
   },
   "simulator.json": {
-    "resources": [
-      {
+    "resources": {
+      "root/Function": {
         "addr": "c8e6b4af896782ab4057ebb2193266e56b0b6dfeb0",
         "attrs": {},
         "path": "root/Function",
@@ -1013,7 +1013,7 @@ my_map: new Map([["foo",[1,2]],["bar",[3,4]]])
         },
         "type": "@winglang/sdk.cloud.Function",
       },
-    ],
+    },
     "sdkVersion": "0.0.0",
     "types": {
       "@winglang/sdk.cloud.Api": {
@@ -1160,8 +1160,8 @@ my_map: new Map([["foo",[(new (require("[REDACTED]/wingsdk/src/std/duration.js")
     "version": "connections-0.1",
   },
   "simulator.json": {
-    "resources": [
-      {
+    "resources": {
+      "root/Function": {
         "addr": "c8e6b4af896782ab4057ebb2193266e56b0b6dfeb0",
         "attrs": {},
         "path": "root/Function",
@@ -1175,7 +1175,7 @@ my_map: new Map([["foo",[(new (require("[REDACTED]/wingsdk/src/std/duration.js")
         },
         "type": "@winglang/sdk.cloud.Function",
       },
-    ],
+    },
     "sdkVersion": "0.0.0",
     "types": {
       "@winglang/sdk.cloud.Api": {
@@ -1319,8 +1319,8 @@ my_capture: 123
     "version": "connections-0.1",
   },
   "simulator.json": {
-    "resources": [
-      {
+    "resources": {
+      "root/Function": {
         "addr": "c8e6b4af896782ab4057ebb2193266e56b0b6dfeb0",
         "attrs": {},
         "path": "root/Function",
@@ -1334,7 +1334,7 @@ my_capture: 123
         },
         "type": "@winglang/sdk.cloud.Function",
       },
-    ],
+    },
     "sdkVersion": "0.0.0",
     "types": {
       "@winglang/sdk.cloud.Api": {
@@ -1481,8 +1481,8 @@ my_capture: new Set(["boom","bam","bang"])
     "version": "connections-0.1",
   },
   "simulator.json": {
-    "resources": [
-      {
+    "resources": {
+      "root/Function": {
         "addr": "c8e6b4af896782ab4057ebb2193266e56b0b6dfeb0",
         "attrs": {},
         "path": "root/Function",
@@ -1496,7 +1496,7 @@ my_capture: new Set(["boom","bam","bang"])
         },
         "type": "@winglang/sdk.cloud.Function",
       },
-    ],
+    },
     "sdkVersion": "0.0.0",
     "types": {
       "@winglang/sdk.cloud.Api": {
@@ -1642,8 +1642,8 @@ my_set: new Set([(new (require("[REDACTED]/wingsdk/src/std/duration.js").Duratio
     "version": "connections-0.1",
   },
   "simulator.json": {
-    "resources": [
-      {
+    "resources": {
+      "root/Function": {
         "addr": "c8e6b4af896782ab4057ebb2193266e56b0b6dfeb0",
         "attrs": {},
         "path": "root/Function",
@@ -1657,7 +1657,7 @@ my_set: new Set([(new (require("[REDACTED]/wingsdk/src/std/duration.js").Duratio
         },
         "type": "@winglang/sdk.cloud.Function",
       },
-    ],
+    },
     "sdkVersion": "0.0.0",
     "types": {
       "@winglang/sdk.cloud.Api": {
@@ -1802,8 +1802,8 @@ my_capture: "bam bam bam"
     "version": "connections-0.1",
   },
   "simulator.json": {
-    "resources": [
-      {
+    "resources": {
+      "root/Function": {
         "addr": "c8e6b4af896782ab4057ebb2193266e56b0b6dfeb0",
         "attrs": {},
         "path": "root/Function",
@@ -1817,7 +1817,7 @@ my_capture: "bam bam bam"
         },
         "type": "@winglang/sdk.cloud.Function",
       },
-    ],
+    },
     "sdkVersion": "0.0.0",
     "types": {
       "@winglang/sdk.cloud.Api": {
@@ -1964,8 +1964,8 @@ my_capture: {"hello": "dude","world": "cup","foo": "bar",}
     "version": "connections-0.1",
   },
   "simulator.json": {
-    "resources": [
-      {
+    "resources": {
+      "root/Function": {
         "addr": "c8e6b4af896782ab4057ebb2193266e56b0b6dfeb0",
         "attrs": {},
         "path": "root/Function",
@@ -1979,7 +1979,7 @@ my_capture: {"hello": "dude","world": "cup","foo": "bar",}
         },
         "type": "@winglang/sdk.cloud.Function",
       },
-    ],
+    },
     "sdkVersion": "0.0.0",
     "types": {
       "@winglang/sdk.cloud.Api": {
@@ -2126,8 +2126,8 @@ my_struct: {"foo": new Map([["foo",1],["bar",2]]),"bar": new Map([["foo",3],["ba
     "version": "connections-0.1",
   },
   "simulator.json": {
-    "resources": [
-      {
+    "resources": {
+      "root/Function": {
         "addr": "c8e6b4af896782ab4057ebb2193266e56b0b6dfeb0",
         "attrs": {},
         "path": "root/Function",
@@ -2141,7 +2141,7 @@ my_struct: {"foo": new Map([["foo",1],["bar",2]]),"bar": new Map([["foo",3],["ba
         },
         "type": "@winglang/sdk.cloud.Function",
       },
-    ],
+    },
     "sdkVersion": "0.0.0",
     "types": {
       "@winglang/sdk.cloud.Api": {

--- a/libs/wingsdk/test/target-sim/__snapshots__/immutable-capture.test.ts.snap
+++ b/libs/wingsdk/test/target-sim/__snapshots__/immutable-capture.test.ts.snap
@@ -32,7 +32,6 @@ my_capture: ["hello","dude"]
     "resources": {
       "root/Function": {
         "addr": "c8e6b4af896782ab4057ebb2193266e56b0b6dfeb0",
-        "attrs": {},
         "path": "root/Function",
         "policy": [],
         "props": {
@@ -193,7 +192,6 @@ my_array: [(new (require("[REDACTED]/wingsdk/src/std/duration.js").Duration)(600
     "resources": {
       "root/Function": {
         "addr": "c8e6b4af896782ab4057ebb2193266e56b0b6dfeb0",
-        "attrs": {},
         "path": "root/Function",
         "policy": [],
         "props": {
@@ -353,7 +351,6 @@ my_array: [new Map([["foo",1],["bar",2]]),new Map([["foo",3],["bar",4]])]
     "resources": {
       "root/Function": {
         "addr": "c8e6b4af896782ab4057ebb2193266e56b0b6dfeb0",
-        "attrs": {},
         "path": "root/Function",
         "policy": [],
         "props": {
@@ -512,7 +509,6 @@ my_capture: false
     "resources": {
       "root/Function": {
         "addr": "c8e6b4af896782ab4057ebb2193266e56b0b6dfeb0",
-        "attrs": {},
         "path": "root/Function",
         "policy": [],
         "props": {
@@ -673,7 +669,6 @@ my_capture: (new (require("[REDACTED]/wingsdk/src/std/duration.js").Duration)(72
     "resources": {
       "root/Function": {
         "addr": "c8e6b4af896782ab4057ebb2193266e56b0b6dfeb0",
-        "attrs": {},
         "path": "root/Function",
         "policy": [],
         "props": {
@@ -836,7 +831,6 @@ my_capture: new Map([["foo",123],["bar",456]])
     "resources": {
       "root/Function": {
         "addr": "c8e6b4af896782ab4057ebb2193266e56b0b6dfeb0",
-        "attrs": {},
         "path": "root/Function",
         "policy": [],
         "props": {
@@ -1001,7 +995,6 @@ my_map: new Map([["foo",[1,2]],["bar",[3,4]]])
     "resources": {
       "root/Function": {
         "addr": "c8e6b4af896782ab4057ebb2193266e56b0b6dfeb0",
-        "attrs": {},
         "path": "root/Function",
         "policy": [],
         "props": {
@@ -1163,7 +1156,6 @@ my_map: new Map([["foo",[(new (require("[REDACTED]/wingsdk/src/std/duration.js")
     "resources": {
       "root/Function": {
         "addr": "c8e6b4af896782ab4057ebb2193266e56b0b6dfeb0",
-        "attrs": {},
         "path": "root/Function",
         "policy": [],
         "props": {
@@ -1322,7 +1314,6 @@ my_capture: 123
     "resources": {
       "root/Function": {
         "addr": "c8e6b4af896782ab4057ebb2193266e56b0b6dfeb0",
-        "attrs": {},
         "path": "root/Function",
         "policy": [],
         "props": {
@@ -1484,7 +1475,6 @@ my_capture: new Set(["boom","bam","bang"])
     "resources": {
       "root/Function": {
         "addr": "c8e6b4af896782ab4057ebb2193266e56b0b6dfeb0",
-        "attrs": {},
         "path": "root/Function",
         "policy": [],
         "props": {
@@ -1645,7 +1635,6 @@ my_set: new Set([(new (require("[REDACTED]/wingsdk/src/std/duration.js").Duratio
     "resources": {
       "root/Function": {
         "addr": "c8e6b4af896782ab4057ebb2193266e56b0b6dfeb0",
-        "attrs": {},
         "path": "root/Function",
         "policy": [],
         "props": {
@@ -1805,7 +1794,6 @@ my_capture: "bam bam bam"
     "resources": {
       "root/Function": {
         "addr": "c8e6b4af896782ab4057ebb2193266e56b0b6dfeb0",
-        "attrs": {},
         "path": "root/Function",
         "policy": [],
         "props": {
@@ -1967,7 +1955,6 @@ my_capture: {"hello": "dude","world": "cup","foo": "bar",}
     "resources": {
       "root/Function": {
         "addr": "c8e6b4af896782ab4057ebb2193266e56b0b6dfeb0",
-        "attrs": {},
         "path": "root/Function",
         "policy": [],
         "props": {
@@ -2129,7 +2116,6 @@ my_struct: {"foo": new Map([["foo",1],["bar",2]]),"bar": new Map([["foo",3],["ba
     "resources": {
       "root/Function": {
         "addr": "c8e6b4af896782ab4057ebb2193266e56b0b6dfeb0",
-        "attrs": {},
         "path": "root/Function",
         "policy": [],
         "props": {

--- a/libs/wingsdk/test/target-sim/__snapshots__/on-deploy.test.ts.snap
+++ b/libs/wingsdk/test/target-sim/__snapshots__/on-deploy.test.ts.snap
@@ -27,7 +27,6 @@ return class Handler {
     "resources": {
       "root/my_on_deploy": {
         "addr": "c8e2618b976544550a8396a3817f0bad07099f7050",
-        "attrs": {},
         "deps": [
           "root/my_on_deploy/Function",
         ],
@@ -39,7 +38,6 @@ return class Handler {
       },
       "root/my_on_deploy/Function": {
         "addr": "c83fbf14da06343c694e42a8758f43bcb1f1c2c389",
-        "attrs": {},
         "path": "root/my_on_deploy/Function",
         "policy": [],
         "props": {

--- a/libs/wingsdk/test/target-sim/__snapshots__/on-deploy.test.ts.snap
+++ b/libs/wingsdk/test/target-sim/__snapshots__/on-deploy.test.ts.snap
@@ -24,8 +24,20 @@ return class Handler {
     "version": "connections-0.1",
   },
   "simulator.json": {
-    "resources": [
-      {
+    "resources": {
+      "root/my_on_deploy": {
+        "addr": "c8e2618b976544550a8396a3817f0bad07099f7050",
+        "attrs": {},
+        "deps": [
+          "root/my_on_deploy/Function",
+        ],
+        "path": "root/my_on_deploy",
+        "props": {
+          "functionHandle": "\${wsim#root/my_on_deploy/Function#attrs.handle}",
+        },
+        "type": "@winglang/sdk.cloud.OnDeploy",
+      },
+      "root/my_on_deploy/Function": {
         "addr": "c83fbf14da06343c694e42a8758f43bcb1f1c2c389",
         "attrs": {},
         "path": "root/my_on_deploy/Function",
@@ -39,19 +51,7 @@ return class Handler {
         },
         "type": "@winglang/sdk.cloud.Function",
       },
-      {
-        "addr": "c8e2618b976544550a8396a3817f0bad07099f7050",
-        "attrs": {},
-        "deps": [
-          "root/my_on_deploy/Function",
-        ],
-        "path": "root/my_on_deploy",
-        "props": {
-          "functionHandle": "\${wsim#root/my_on_deploy/Function#attrs.handle}",
-        },
-        "type": "@winglang/sdk.cloud.OnDeploy",
-      },
-    ],
+    },
     "sdkVersion": "0.0.0",
     "types": {
       "@winglang/sdk.cloud.Api": {

--- a/libs/wingsdk/test/target-sim/__snapshots__/queue.test.ts.snap
+++ b/libs/wingsdk/test/target-sim/__snapshots__/queue.test.ts.snap
@@ -7,8 +7,8 @@ exports[`create a queue 1`] = `
     "version": "connections-0.1",
   },
   "simulator.json": {
-    "resources": [
-      {
+    "resources": {
+      "root/my_queue": {
         "addr": "c8dee4ef24593d08aa22e8845be36d0ee754fcf4cd",
         "attrs": {},
         "path": "root/my_queue",
@@ -18,7 +18,7 @@ exports[`create a queue 1`] = `
         },
         "type": "@winglang/sdk.cloud.Queue",
       },
-      {
+      "root/my_queue/Policy": {
         "addr": "c88a4c68047871c2d322479c886423828e8119d85c",
         "attrs": {},
         "path": "root/my_queue/Policy",
@@ -28,7 +28,7 @@ exports[`create a queue 1`] = `
         },
         "type": "@winglang/sdk.sim.Policy",
       },
-    ],
+    },
     "sdkVersion": "0.0.0",
     "types": {
       "@winglang/sdk.cloud.Api": {
@@ -628,8 +628,8 @@ exports[`push rejects empty message 2`] = `
     "version": "connections-0.1",
   },
   "simulator.json": {
-    "resources": [
-      {
+    "resources": {
+      "root/my_queue": {
         "addr": "c8dee4ef24593d08aa22e8845be36d0ee754fcf4cd",
         "attrs": {},
         "path": "root/my_queue",
@@ -639,7 +639,7 @@ exports[`push rejects empty message 2`] = `
         },
         "type": "@winglang/sdk.cloud.Queue",
       },
-      {
+      "root/my_queue/Policy": {
         "addr": "c88a4c68047871c2d322479c886423828e8119d85c",
         "attrs": {},
         "path": "root/my_queue/Policy",
@@ -649,7 +649,7 @@ exports[`push rejects empty message 2`] = `
         },
         "type": "@winglang/sdk.sim.Policy",
       },
-    ],
+    },
     "sdkVersion": "0.0.0",
     "types": {
       "@winglang/sdk.cloud.Api": {
@@ -802,8 +802,8 @@ exports[`queue batch size of 2, purge the queue 2`] = `
     "version": "connections-0.1",
   },
   "simulator.json": {
-    "resources": [
-      {
+    "resources": {
+      "root/my_queue": {
         "addr": "c8dee4ef24593d08aa22e8845be36d0ee754fcf4cd",
         "attrs": {},
         "path": "root/my_queue",
@@ -813,7 +813,7 @@ exports[`queue batch size of 2, purge the queue 2`] = `
         },
         "type": "@winglang/sdk.cloud.Queue",
       },
-      {
+      "root/my_queue/Policy": {
         "addr": "c88a4c68047871c2d322479c886423828e8119d85c",
         "attrs": {},
         "path": "root/my_queue/Policy",
@@ -823,7 +823,7 @@ exports[`queue batch size of 2, purge the queue 2`] = `
         },
         "type": "@winglang/sdk.sim.Policy",
       },
-    ],
+    },
     "sdkVersion": "0.0.0",
     "types": {
       "@winglang/sdk.cloud.Api": {
@@ -1033,8 +1033,18 @@ async handle(message) {
     "version": "connections-0.1",
   },
   "simulator.json": {
-    "resources": [
-      {
+    "resources": {
+      "root/my_queue": {
+        "addr": "c8dee4ef24593d08aa22e8845be36d0ee754fcf4cd",
+        "attrs": {},
+        "path": "root/my_queue",
+        "props": {
+          "retentionPeriod": 3600,
+          "timeout": 30,
+        },
+        "type": "@winglang/sdk.cloud.Queue",
+      },
+      "root/my_queue/Policy": {
         "addr": "c88a4c68047871c2d322479c886423828e8119d85c",
         "attrs": {},
         "path": "root/my_queue/Policy",
@@ -1053,31 +1063,7 @@ async handle(message) {
         },
         "type": "@winglang/sdk.sim.Policy",
       },
-      {
-        "addr": "c8e33b9b91c909e579b9d3d703146eb66c2a657ffc",
-        "attrs": {},
-        "path": "root/my_queue/SetConsumer0",
-        "policy": [],
-        "props": {
-          "concurrency": 100,
-          "environmentVariables": {},
-          "sourceCodeFile": ".wing/setconsumer0_c8e33b9b.js",
-          "sourceCodeLanguage": "javascript",
-          "timeout": 60000,
-        },
-        "type": "@winglang/sdk.cloud.Function",
-      },
-      {
-        "addr": "c8dee4ef24593d08aa22e8845be36d0ee754fcf4cd",
-        "attrs": {},
-        "path": "root/my_queue",
-        "props": {
-          "retentionPeriod": 3600,
-          "timeout": 30,
-        },
-        "type": "@winglang/sdk.cloud.Queue",
-      },
-      {
+      "root/my_queue/QueueEventMapping0": {
         "addr": "c8f9f7d56097ba3d2e0e82988718175a5d841f855e",
         "attrs": {},
         "deps": [
@@ -1094,7 +1080,33 @@ async handle(message) {
         },
         "type": "@winglang/sdk.sim.EventMapping",
       },
-      {
+      "root/my_queue/SetConsumer0": {
+        "addr": "c8e33b9b91c909e579b9d3d703146eb66c2a657ffc",
+        "attrs": {},
+        "path": "root/my_queue/SetConsumer0",
+        "policy": [],
+        "props": {
+          "concurrency": 100,
+          "environmentVariables": {},
+          "sourceCodeFile": ".wing/setconsumer0_c8e33b9b.js",
+          "sourceCodeLanguage": "javascript",
+          "timeout": 60000,
+        },
+        "type": "@winglang/sdk.cloud.Function",
+      },
+      "root/my_queue_messages": {
+        "addr": "c8e2354407fd3536187725c2b37c5327f47bb841e9",
+        "attrs": {},
+        "deps": [
+          "root/my_queue_messages/Function",
+        ],
+        "path": "root/my_queue_messages",
+        "props": {
+          "functionHandle": "\${wsim#root/my_queue_messages/Function#attrs.handle}",
+        },
+        "type": "@winglang/sdk.cloud.OnDeploy",
+      },
+      "root/my_queue_messages/Function": {
         "addr": "c8ab799f6c9c9a3cd279909012c4f322ab902f5e19",
         "attrs": {},
         "deps": [
@@ -1118,19 +1130,7 @@ async handle(message) {
         },
         "type": "@winglang/sdk.cloud.Function",
       },
-      {
-        "addr": "c8e2354407fd3536187725c2b37c5327f47bb841e9",
-        "attrs": {},
-        "deps": [
-          "root/my_queue_messages/Function",
-        ],
-        "path": "root/my_queue_messages",
-        "props": {
-          "functionHandle": "\${wsim#root/my_queue_messages/Function#attrs.handle}",
-        },
-        "type": "@winglang/sdk.cloud.OnDeploy",
-      },
-    ],
+    },
     "sdkVersion": "0.0.0",
     "types": {
       "@winglang/sdk.cloud.Api": {
@@ -1348,8 +1348,18 @@ async handle(message) {
     "version": "connections-0.1",
   },
   "simulator.json": {
-    "resources": [
-      {
+    "resources": {
+      "root/my_queue": {
+        "addr": "c8dee4ef24593d08aa22e8845be36d0ee754fcf4cd",
+        "attrs": {},
+        "path": "root/my_queue",
+        "props": {
+          "retentionPeriod": 3600,
+          "timeout": 30,
+        },
+        "type": "@winglang/sdk.cloud.Queue",
+      },
+      "root/my_queue/Policy": {
         "addr": "c88a4c68047871c2d322479c886423828e8119d85c",
         "attrs": {},
         "path": "root/my_queue/Policy",
@@ -1368,31 +1378,7 @@ async handle(message) {
         },
         "type": "@winglang/sdk.sim.Policy",
       },
-      {
-        "addr": "c8e33b9b91c909e579b9d3d703146eb66c2a657ffc",
-        "attrs": {},
-        "path": "root/my_queue/SetConsumer0",
-        "policy": [],
-        "props": {
-          "concurrency": 100,
-          "environmentVariables": {},
-          "sourceCodeFile": ".wing/setconsumer0_c8e33b9b.js",
-          "sourceCodeLanguage": "javascript",
-          "timeout": 60000,
-        },
-        "type": "@winglang/sdk.cloud.Function",
-      },
-      {
-        "addr": "c8dee4ef24593d08aa22e8845be36d0ee754fcf4cd",
-        "attrs": {},
-        "path": "root/my_queue",
-        "props": {
-          "retentionPeriod": 3600,
-          "timeout": 30,
-        },
-        "type": "@winglang/sdk.cloud.Queue",
-      },
-      {
+      "root/my_queue/QueueEventMapping0": {
         "addr": "c8f9f7d56097ba3d2e0e82988718175a5d841f855e",
         "attrs": {},
         "deps": [
@@ -1409,7 +1395,21 @@ async handle(message) {
         },
         "type": "@winglang/sdk.sim.EventMapping",
       },
-    ],
+      "root/my_queue/SetConsumer0": {
+        "addr": "c8e33b9b91c909e579b9d3d703146eb66c2a657ffc",
+        "attrs": {},
+        "path": "root/my_queue/SetConsumer0",
+        "policy": [],
+        "props": {
+          "concurrency": 100,
+          "environmentVariables": {},
+          "sourceCodeFile": ".wing/setconsumer0_c8e33b9b.js",
+          "sourceCodeLanguage": "javascript",
+          "timeout": 60000,
+        },
+        "type": "@winglang/sdk.cloud.Function",
+      },
+    },
     "sdkVersion": "0.0.0",
     "types": {
       "@winglang/sdk.cloud.Api": {

--- a/libs/wingsdk/test/target-sim/__snapshots__/queue.test.ts.snap
+++ b/libs/wingsdk/test/target-sim/__snapshots__/queue.test.ts.snap
@@ -10,7 +10,6 @@ exports[`create a queue 1`] = `
     "resources": {
       "root/my_queue": {
         "addr": "c8dee4ef24593d08aa22e8845be36d0ee754fcf4cd",
-        "attrs": {},
         "path": "root/my_queue",
         "props": {
           "retentionPeriod": 3600,
@@ -20,7 +19,6 @@ exports[`create a queue 1`] = `
       },
       "root/my_queue/Policy": {
         "addr": "c88a4c68047871c2d322479c886423828e8119d85c",
-        "attrs": {},
         "path": "root/my_queue/Policy",
         "props": {
           "principal": "\${wsim#root/my_queue#attrs.handle}",
@@ -631,7 +629,6 @@ exports[`push rejects empty message 2`] = `
     "resources": {
       "root/my_queue": {
         "addr": "c8dee4ef24593d08aa22e8845be36d0ee754fcf4cd",
-        "attrs": {},
         "path": "root/my_queue",
         "props": {
           "retentionPeriod": 3600,
@@ -641,7 +638,6 @@ exports[`push rejects empty message 2`] = `
       },
       "root/my_queue/Policy": {
         "addr": "c88a4c68047871c2d322479c886423828e8119d85c",
-        "attrs": {},
         "path": "root/my_queue/Policy",
         "props": {
           "principal": "\${wsim#root/my_queue#attrs.handle}",
@@ -805,7 +801,6 @@ exports[`queue batch size of 2, purge the queue 2`] = `
     "resources": {
       "root/my_queue": {
         "addr": "c8dee4ef24593d08aa22e8845be36d0ee754fcf4cd",
-        "attrs": {},
         "path": "root/my_queue",
         "props": {
           "retentionPeriod": 3600,
@@ -815,7 +810,6 @@ exports[`queue batch size of 2, purge the queue 2`] = `
       },
       "root/my_queue/Policy": {
         "addr": "c88a4c68047871c2d322479c886423828e8119d85c",
-        "attrs": {},
         "path": "root/my_queue/Policy",
         "props": {
           "principal": "\${wsim#root/my_queue#attrs.handle}",
@@ -1036,7 +1030,6 @@ async handle(message) {
     "resources": {
       "root/my_queue": {
         "addr": "c8dee4ef24593d08aa22e8845be36d0ee754fcf4cd",
-        "attrs": {},
         "path": "root/my_queue",
         "props": {
           "retentionPeriod": 3600,
@@ -1046,7 +1039,6 @@ async handle(message) {
       },
       "root/my_queue/Policy": {
         "addr": "c88a4c68047871c2d322479c886423828e8119d85c",
-        "attrs": {},
         "path": "root/my_queue/Policy",
         "props": {
           "principal": "\${wsim#root/my_queue#attrs.handle}",
@@ -1065,7 +1057,6 @@ async handle(message) {
       },
       "root/my_queue/QueueEventMapping0": {
         "addr": "c8f9f7d56097ba3d2e0e82988718175a5d841f855e",
-        "attrs": {},
         "deps": [
           "root/my_queue/SetConsumer0",
           "root/my_queue",
@@ -1082,7 +1073,6 @@ async handle(message) {
       },
       "root/my_queue/SetConsumer0": {
         "addr": "c8e33b9b91c909e579b9d3d703146eb66c2a657ffc",
-        "attrs": {},
         "path": "root/my_queue/SetConsumer0",
         "policy": [],
         "props": {
@@ -1096,7 +1086,6 @@ async handle(message) {
       },
       "root/my_queue_messages": {
         "addr": "c8e2354407fd3536187725c2b37c5327f47bb841e9",
-        "attrs": {},
         "deps": [
           "root/my_queue_messages/Function",
         ],
@@ -1108,7 +1097,6 @@ async handle(message) {
       },
       "root/my_queue_messages/Function": {
         "addr": "c8ab799f6c9c9a3cd279909012c4f322ab902f5e19",
-        "attrs": {},
         "deps": [
           "root/my_queue",
         ],
@@ -1351,7 +1339,6 @@ async handle(message) {
     "resources": {
       "root/my_queue": {
         "addr": "c8dee4ef24593d08aa22e8845be36d0ee754fcf4cd",
-        "attrs": {},
         "path": "root/my_queue",
         "props": {
           "retentionPeriod": 3600,
@@ -1361,7 +1348,6 @@ async handle(message) {
       },
       "root/my_queue/Policy": {
         "addr": "c88a4c68047871c2d322479c886423828e8119d85c",
-        "attrs": {},
         "path": "root/my_queue/Policy",
         "props": {
           "principal": "\${wsim#root/my_queue#attrs.handle}",
@@ -1380,7 +1366,6 @@ async handle(message) {
       },
       "root/my_queue/QueueEventMapping0": {
         "addr": "c8f9f7d56097ba3d2e0e82988718175a5d841f855e",
-        "attrs": {},
         "deps": [
           "root/my_queue/SetConsumer0",
           "root/my_queue",
@@ -1397,7 +1382,6 @@ async handle(message) {
       },
       "root/my_queue/SetConsumer0": {
         "addr": "c8e33b9b91c909e579b9d3d703146eb66c2a657ffc",
-        "attrs": {},
         "path": "root/my_queue/SetConsumer0",
         "policy": [],
         "props": {

--- a/libs/wingsdk/test/target-sim/__snapshots__/redis.test.ts.snap
+++ b/libs/wingsdk/test/target-sim/__snapshots__/redis.test.ts.snap
@@ -7,8 +7,8 @@ exports[`create a Redis resource 1`] = `
     "version": "connections-0.1",
   },
   "simulator.json": {
-    "resources": [
-      {
+    "resources": {
+      "root/my_redis": {
         "addr": "c84bd402f6d507613026d171fe74fc8ce07ced29ae",
         "attrs": {},
         "path": "root/my_redis",
@@ -17,7 +17,7 @@ exports[`create a Redis resource 1`] = `
         },
         "type": "@winglang/sdk.ex.Redis",
       },
-      {
+      "root/my_redis/Container": {
         "addr": "c80acc96b1d952059eb0beee72912b94d23302fa03",
         "attrs": {},
         "path": "root/my_redis/Container",
@@ -29,7 +29,7 @@ exports[`create a Redis resource 1`] = `
         },
         "type": "@winglang/sdk.sim.Container",
       },
-    ],
+    },
     "sdkVersion": "0.0.0",
     "types": {
       "@winglang/sdk.cloud.Api": {

--- a/libs/wingsdk/test/target-sim/__snapshots__/redis.test.ts.snap
+++ b/libs/wingsdk/test/target-sim/__snapshots__/redis.test.ts.snap
@@ -10,7 +10,6 @@ exports[`create a Redis resource 1`] = `
     "resources": {
       "root/my_redis": {
         "addr": "c84bd402f6d507613026d171fe74fc8ce07ced29ae",
-        "attrs": {},
         "path": "root/my_redis",
         "props": {
           "port": "\${wsim#root/my_redis/Container#attrs.host_port}",
@@ -19,7 +18,6 @@ exports[`create a Redis resource 1`] = `
       },
       "root/my_redis/Container": {
         "addr": "c80acc96b1d952059eb0beee72912b94d23302fa03",
-        "attrs": {},
         "path": "root/my_redis/Container",
         "props": {
           "containerPort": 6379,

--- a/libs/wingsdk/test/target-sim/__snapshots__/schedule.test.ts.snap
+++ b/libs/wingsdk/test/target-sim/__snapshots__/schedule.test.ts.snap
@@ -7,8 +7,8 @@ exports[`create a schedule 1`] = `
     "version": "connections-0.1",
   },
   "simulator.json": {
-    "resources": [
-      {
+    "resources": {
+      "root/my_schedule": {
         "addr": "c8eac5abdbcb1c98c5525dcb3d0e38c0ccdfef4aed",
         "attrs": {},
         "path": "root/my_schedule",
@@ -17,7 +17,7 @@ exports[`create a schedule 1`] = `
         },
         "type": "@winglang/sdk.cloud.Schedule",
       },
-      {
+      "root/my_schedule/Policy": {
         "addr": "c8c7f555c253f79a2cdcd8a13c6772cfd654e2bf0b",
         "attrs": {},
         "path": "root/my_schedule/Policy",
@@ -27,7 +27,7 @@ exports[`create a schedule 1`] = `
         },
         "type": "@winglang/sdk.sim.Policy",
       },
-    ],
+    },
     "sdkVersion": "0.0.0",
     "types": {
       "@winglang/sdk.cloud.Api": {
@@ -192,23 +192,17 @@ console.log("Hello from schedule!");
     "version": "connections-0.1",
   },
   "simulator.json": {
-    "resources": [
-      {
-        "addr": "c8c7f555c253f79a2cdcd8a13c6772cfd654e2bf0b",
+    "resources": {
+      "root/my_schedule": {
+        "addr": "c8eac5abdbcb1c98c5525dcb3d0e38c0ccdfef4aed",
         "attrs": {},
-        "path": "root/my_schedule/Policy",
+        "path": "root/my_schedule",
         "props": {
-          "principal": "\${wsim#root/my_schedule#attrs.handle}",
-          "statements": [
-            {
-              "operation": "invoke",
-              "resourceHandle": "\${wsim#root/my_schedule/OnTick0#attrs.handle}",
-            },
-          ],
+          "cronExpression": "* */3 * * *",
         },
-        "type": "@winglang/sdk.sim.Policy",
+        "type": "@winglang/sdk.cloud.Schedule",
       },
-      {
+      "root/my_schedule/OnTick0": {
         "addr": "c83eddbe8512d15b84969a611d4b5ca9ce55e1f808",
         "attrs": {},
         "path": "root/my_schedule/OnTick0",
@@ -222,16 +216,7 @@ console.log("Hello from schedule!");
         },
         "type": "@winglang/sdk.cloud.Function",
       },
-      {
-        "addr": "c8eac5abdbcb1c98c5525dcb3d0e38c0ccdfef4aed",
-        "attrs": {},
-        "path": "root/my_schedule",
-        "props": {
-          "cronExpression": "* */3 * * *",
-        },
-        "type": "@winglang/sdk.cloud.Schedule",
-      },
-      {
+      "root/my_schedule/OnTickMapping0": {
         "addr": "c863abe75f0d01961369ad52fd7212846989919eaf",
         "attrs": {},
         "deps": [
@@ -246,7 +231,22 @@ console.log("Hello from schedule!");
         },
         "type": "@winglang/sdk.sim.EventMapping",
       },
-    ],
+      "root/my_schedule/Policy": {
+        "addr": "c8c7f555c253f79a2cdcd8a13c6772cfd654e2bf0b",
+        "attrs": {},
+        "path": "root/my_schedule/Policy",
+        "props": {
+          "principal": "\${wsim#root/my_schedule#attrs.handle}",
+          "statements": [
+            {
+              "operation": "invoke",
+              "resourceHandle": "\${wsim#root/my_schedule/OnTick0#attrs.handle}",
+            },
+          ],
+        },
+        "type": "@winglang/sdk.sim.Policy",
+      },
+    },
     "sdkVersion": "0.0.0",
     "types": {
       "@winglang/sdk.cloud.Api": {
@@ -435,23 +435,17 @@ console.log("Hello from schedule!");
     "version": "connections-0.1",
   },
   "simulator.json": {
-    "resources": [
-      {
-        "addr": "c8c7f555c253f79a2cdcd8a13c6772cfd654e2bf0b",
+    "resources": {
+      "root/my_schedule": {
+        "addr": "c8eac5abdbcb1c98c5525dcb3d0e38c0ccdfef4aed",
         "attrs": {},
-        "path": "root/my_schedule/Policy",
+        "path": "root/my_schedule",
         "props": {
-          "principal": "\${wsim#root/my_schedule#attrs.handle}",
-          "statements": [
-            {
-              "operation": "invoke",
-              "resourceHandle": "\${wsim#root/my_schedule/OnTick0#attrs.handle}",
-            },
-          ],
+          "cronExpression": "*/10 * * * *",
         },
-        "type": "@winglang/sdk.sim.Policy",
+        "type": "@winglang/sdk.cloud.Schedule",
       },
-      {
+      "root/my_schedule/OnTick0": {
         "addr": "c83eddbe8512d15b84969a611d4b5ca9ce55e1f808",
         "attrs": {},
         "path": "root/my_schedule/OnTick0",
@@ -465,16 +459,7 @@ console.log("Hello from schedule!");
         },
         "type": "@winglang/sdk.cloud.Function",
       },
-      {
-        "addr": "c8eac5abdbcb1c98c5525dcb3d0e38c0ccdfef4aed",
-        "attrs": {},
-        "path": "root/my_schedule",
-        "props": {
-          "cronExpression": "*/10 * * * *",
-        },
-        "type": "@winglang/sdk.cloud.Schedule",
-      },
-      {
+      "root/my_schedule/OnTickMapping0": {
         "addr": "c863abe75f0d01961369ad52fd7212846989919eaf",
         "attrs": {},
         "deps": [
@@ -489,7 +474,22 @@ console.log("Hello from schedule!");
         },
         "type": "@winglang/sdk.sim.EventMapping",
       },
-    ],
+      "root/my_schedule/Policy": {
+        "addr": "c8c7f555c253f79a2cdcd8a13c6772cfd654e2bf0b",
+        "attrs": {},
+        "path": "root/my_schedule/Policy",
+        "props": {
+          "principal": "\${wsim#root/my_schedule#attrs.handle}",
+          "statements": [
+            {
+              "operation": "invoke",
+              "resourceHandle": "\${wsim#root/my_schedule/OnTick0#attrs.handle}",
+            },
+          ],
+        },
+        "type": "@winglang/sdk.sim.Policy",
+      },
+    },
     "sdkVersion": "0.0.0",
     "types": {
       "@winglang/sdk.cloud.Api": {
@@ -678,23 +678,17 @@ console.log("Hello from schedule!");
     "version": "connections-0.1",
   },
   "simulator.json": {
-    "resources": [
-      {
-        "addr": "c8c7f555c253f79a2cdcd8a13c6772cfd654e2bf0b",
+    "resources": {
+      "root/my_schedule": {
+        "addr": "c8eac5abdbcb1c98c5525dcb3d0e38c0ccdfef4aed",
         "attrs": {},
-        "path": "root/my_schedule/Policy",
+        "path": "root/my_schedule",
         "props": {
-          "principal": "\${wsim#root/my_schedule#attrs.handle}",
-          "statements": [
-            {
-              "operation": "invoke",
-              "resourceHandle": "\${wsim#root/my_schedule/OnTick0#attrs.handle}",
-            },
-          ],
+          "cronExpression": "* * * * *",
         },
-        "type": "@winglang/sdk.sim.Policy",
+        "type": "@winglang/sdk.cloud.Schedule",
       },
-      {
+      "root/my_schedule/OnTick0": {
         "addr": "c83eddbe8512d15b84969a611d4b5ca9ce55e1f808",
         "attrs": {},
         "path": "root/my_schedule/OnTick0",
@@ -708,16 +702,7 @@ console.log("Hello from schedule!");
         },
         "type": "@winglang/sdk.cloud.Function",
       },
-      {
-        "addr": "c8eac5abdbcb1c98c5525dcb3d0e38c0ccdfef4aed",
-        "attrs": {},
-        "path": "root/my_schedule",
-        "props": {
-          "cronExpression": "* * * * *",
-        },
-        "type": "@winglang/sdk.cloud.Schedule",
-      },
-      {
+      "root/my_schedule/OnTickMapping0": {
         "addr": "c863abe75f0d01961369ad52fd7212846989919eaf",
         "attrs": {},
         "deps": [
@@ -732,7 +717,22 @@ console.log("Hello from schedule!");
         },
         "type": "@winglang/sdk.sim.EventMapping",
       },
-    ],
+      "root/my_schedule/Policy": {
+        "addr": "c8c7f555c253f79a2cdcd8a13c6772cfd654e2bf0b",
+        "attrs": {},
+        "path": "root/my_schedule/Policy",
+        "props": {
+          "principal": "\${wsim#root/my_schedule#attrs.handle}",
+          "statements": [
+            {
+              "operation": "invoke",
+              "resourceHandle": "\${wsim#root/my_schedule/OnTick0#attrs.handle}",
+            },
+          ],
+        },
+        "type": "@winglang/sdk.sim.Policy",
+      },
+    },
     "sdkVersion": "0.0.0",
     "types": {
       "@winglang/sdk.cloud.Api": {

--- a/libs/wingsdk/test/target-sim/__snapshots__/schedule.test.ts.snap
+++ b/libs/wingsdk/test/target-sim/__snapshots__/schedule.test.ts.snap
@@ -10,7 +10,6 @@ exports[`create a schedule 1`] = `
     "resources": {
       "root/my_schedule": {
         "addr": "c8eac5abdbcb1c98c5525dcb3d0e38c0ccdfef4aed",
-        "attrs": {},
         "path": "root/my_schedule",
         "props": {
           "cronExpression": "*/1 * * * *",
@@ -19,7 +18,6 @@ exports[`create a schedule 1`] = `
       },
       "root/my_schedule/Policy": {
         "addr": "c8c7f555c253f79a2cdcd8a13c6772cfd654e2bf0b",
-        "attrs": {},
         "path": "root/my_schedule/Policy",
         "props": {
           "principal": "\${wsim#root/my_schedule#attrs.handle}",
@@ -195,7 +193,6 @@ console.log("Hello from schedule!");
     "resources": {
       "root/my_schedule": {
         "addr": "c8eac5abdbcb1c98c5525dcb3d0e38c0ccdfef4aed",
-        "attrs": {},
         "path": "root/my_schedule",
         "props": {
           "cronExpression": "* */3 * * *",
@@ -204,7 +201,6 @@ console.log("Hello from schedule!");
       },
       "root/my_schedule/OnTick0": {
         "addr": "c83eddbe8512d15b84969a611d4b5ca9ce55e1f808",
-        "attrs": {},
         "path": "root/my_schedule/OnTick0",
         "policy": [],
         "props": {
@@ -218,7 +214,6 @@ console.log("Hello from schedule!");
       },
       "root/my_schedule/OnTickMapping0": {
         "addr": "c863abe75f0d01961369ad52fd7212846989919eaf",
-        "attrs": {},
         "deps": [
           "root/my_schedule/OnTick0",
           "root/my_schedule",
@@ -233,7 +228,6 @@ console.log("Hello from schedule!");
       },
       "root/my_schedule/Policy": {
         "addr": "c8c7f555c253f79a2cdcd8a13c6772cfd654e2bf0b",
-        "attrs": {},
         "path": "root/my_schedule/Policy",
         "props": {
           "principal": "\${wsim#root/my_schedule#attrs.handle}",
@@ -438,7 +432,6 @@ console.log("Hello from schedule!");
     "resources": {
       "root/my_schedule": {
         "addr": "c8eac5abdbcb1c98c5525dcb3d0e38c0ccdfef4aed",
-        "attrs": {},
         "path": "root/my_schedule",
         "props": {
           "cronExpression": "*/10 * * * *",
@@ -447,7 +440,6 @@ console.log("Hello from schedule!");
       },
       "root/my_schedule/OnTick0": {
         "addr": "c83eddbe8512d15b84969a611d4b5ca9ce55e1f808",
-        "attrs": {},
         "path": "root/my_schedule/OnTick0",
         "policy": [],
         "props": {
@@ -461,7 +453,6 @@ console.log("Hello from schedule!");
       },
       "root/my_schedule/OnTickMapping0": {
         "addr": "c863abe75f0d01961369ad52fd7212846989919eaf",
-        "attrs": {},
         "deps": [
           "root/my_schedule/OnTick0",
           "root/my_schedule",
@@ -476,7 +467,6 @@ console.log("Hello from schedule!");
       },
       "root/my_schedule/Policy": {
         "addr": "c8c7f555c253f79a2cdcd8a13c6772cfd654e2bf0b",
-        "attrs": {},
         "path": "root/my_schedule/Policy",
         "props": {
           "principal": "\${wsim#root/my_schedule#attrs.handle}",
@@ -681,7 +671,6 @@ console.log("Hello from schedule!");
     "resources": {
       "root/my_schedule": {
         "addr": "c8eac5abdbcb1c98c5525dcb3d0e38c0ccdfef4aed",
-        "attrs": {},
         "path": "root/my_schedule",
         "props": {
           "cronExpression": "* * * * *",
@@ -690,7 +679,6 @@ console.log("Hello from schedule!");
       },
       "root/my_schedule/OnTick0": {
         "addr": "c83eddbe8512d15b84969a611d4b5ca9ce55e1f808",
-        "attrs": {},
         "path": "root/my_schedule/OnTick0",
         "policy": [],
         "props": {
@@ -704,7 +692,6 @@ console.log("Hello from schedule!");
       },
       "root/my_schedule/OnTickMapping0": {
         "addr": "c863abe75f0d01961369ad52fd7212846989919eaf",
-        "attrs": {},
         "deps": [
           "root/my_schedule/OnTick0",
           "root/my_schedule",
@@ -719,7 +706,6 @@ console.log("Hello from schedule!");
       },
       "root/my_schedule/Policy": {
         "addr": "c8c7f555c253f79a2cdcd8a13c6772cfd654e2bf0b",
-        "attrs": {},
         "path": "root/my_schedule/Policy",
         "props": {
           "principal": "\${wsim#root/my_schedule#attrs.handle}",

--- a/libs/wingsdk/test/target-sim/__snapshots__/secret.test.ts.snap
+++ b/libs/wingsdk/test/target-sim/__snapshots__/secret.test.ts.snap
@@ -7,8 +7,8 @@ exports[`create a secret 1`] = `
     "version": "connections-0.1",
   },
   "simulator.json": {
-    "resources": [
-      {
+    "resources": {
+      "root/my_secret": {
         "addr": "c84793b7d2beb23443f2fa7f5d120c2cf330e038e4",
         "attrs": {},
         "path": "root/my_secret",
@@ -17,7 +17,7 @@ exports[`create a secret 1`] = `
         },
         "type": "@winglang/sdk.cloud.Secret",
       },
-    ],
+    },
     "sdkVersion": "0.0.0",
     "types": {
       "@winglang/sdk.cloud.Api": {

--- a/libs/wingsdk/test/target-sim/__snapshots__/secret.test.ts.snap
+++ b/libs/wingsdk/test/target-sim/__snapshots__/secret.test.ts.snap
@@ -10,7 +10,6 @@ exports[`create a secret 1`] = `
     "resources": {
       "root/my_secret": {
         "addr": "c84793b7d2beb23443f2fa7f5d120c2cf330e038e4",
-        "attrs": {},
         "path": "root/my_secret",
         "props": {
           "name": "my_secret-c84793b7",

--- a/libs/wingsdk/test/target-sim/__snapshots__/service.test.ts.snap
+++ b/libs/wingsdk/test/target-sim/__snapshots__/service.test.ts.snap
@@ -42,7 +42,6 @@ return class Handler {
     "resources": {
       "root/my_service": {
         "addr": "c815f66e1cb1ce843a78fc0ecb05e6fc56e3b51516",
-        "attrs": {},
         "path": "root/my_service",
         "policy": [],
         "props": {

--- a/libs/wingsdk/test/target-sim/__snapshots__/service.test.ts.snap
+++ b/libs/wingsdk/test/target-sim/__snapshots__/service.test.ts.snap
@@ -39,8 +39,8 @@ return class Handler {
     "version": "connections-0.1",
   },
   "simulator.json": {
-    "resources": [
-      {
+    "resources": {
+      "root/my_service": {
         "addr": "c815f66e1cb1ce843a78fc0ecb05e6fc56e3b51516",
         "attrs": {},
         "path": "root/my_service",
@@ -52,7 +52,7 @@ return class Handler {
         },
         "type": "@winglang/sdk.cloud.Service",
       },
-    ],
+    },
     "sdkVersion": "0.0.0",
     "types": {
       "@winglang/sdk.cloud.Api": {

--- a/libs/wingsdk/test/target-sim/__snapshots__/table.test.ts.snap
+++ b/libs/wingsdk/test/target-sim/__snapshots__/table.test.ts.snap
@@ -19,7 +19,6 @@ exports[`can add row in preflight 2`] = `
     "resources": {
       "root/my_table": {
         "addr": "c8e507baf046ceb6108a9fe64c08a39ccc39ffe11c",
-        "attrs": {},
         "path": "root/my_table",
         "props": {
           "columns": {
@@ -165,7 +164,6 @@ exports[`create a table 1`] = `
     "resources": {
       "root/my_table": {
         "addr": "c8e507baf046ceb6108a9fe64c08a39ccc39ffe11c",
-        "attrs": {},
         "path": "root/my_table",
         "props": {
           "columns": {
@@ -315,7 +313,6 @@ exports[`get row 2`] = `
     "resources": {
       "root/my_table": {
         "addr": "c8e507baf046ceb6108a9fe64c08a39ccc39ffe11c",
-        "attrs": {},
         "path": "root/my_table",
         "props": {
           "columns": {
@@ -463,7 +460,6 @@ exports[`insert row 2`] = `
     "resources": {
       "root/my_table": {
         "addr": "c8e507baf046ceb6108a9fe64c08a39ccc39ffe11c",
-        "attrs": {},
         "path": "root/my_table",
         "props": {
           "columns": {
@@ -613,7 +609,6 @@ exports[`list table 2`] = `
     "resources": {
       "root/my_table": {
         "addr": "c8e507baf046ceb6108a9fe64c08a39ccc39ffe11c",
-        "attrs": {},
         "path": "root/my_table",
         "props": {
           "columns": {
@@ -762,7 +757,6 @@ exports[`tryGet row 2`] = `
     "resources": {
       "root/my_table": {
         "addr": "c8e507baf046ceb6108a9fe64c08a39ccc39ffe11c",
-        "attrs": {},
         "path": "root/my_table",
         "props": {
           "columns": {
@@ -914,7 +908,6 @@ exports[`update row 2`] = `
     "resources": {
       "root/my_table": {
         "addr": "c8e507baf046ceb6108a9fe64c08a39ccc39ffe11c",
-        "attrs": {},
         "path": "root/my_table",
         "props": {
           "columns": {

--- a/libs/wingsdk/test/target-sim/__snapshots__/table.test.ts.snap
+++ b/libs/wingsdk/test/target-sim/__snapshots__/table.test.ts.snap
@@ -16,8 +16,8 @@ exports[`can add row in preflight 2`] = `
     "version": "connections-0.1",
   },
   "simulator.json": {
-    "resources": [
-      {
+    "resources": {
+      "root/my_table": {
         "addr": "c8e507baf046ceb6108a9fe64c08a39ccc39ffe11c",
         "attrs": {},
         "path": "root/my_table",
@@ -38,7 +38,7 @@ exports[`can add row in preflight 2`] = `
         },
         "type": "@winglang/sdk.ex.Table",
       },
-    ],
+    },
     "sdkVersion": "0.0.0",
     "types": {
       "@winglang/sdk.cloud.Api": {
@@ -162,8 +162,8 @@ exports[`create a table 1`] = `
     "version": "connections-0.1",
   },
   "simulator.json": {
-    "resources": [
-      {
+    "resources": {
+      "root/my_table": {
         "addr": "c8e507baf046ceb6108a9fe64c08a39ccc39ffe11c",
         "attrs": {},
         "path": "root/my_table",
@@ -178,7 +178,7 @@ exports[`create a table 1`] = `
         },
         "type": "@winglang/sdk.ex.Table",
       },
-    ],
+    },
     "sdkVersion": "0.0.0",
     "types": {
       "@winglang/sdk.cloud.Api": {
@@ -312,8 +312,8 @@ exports[`get row 2`] = `
     "version": "connections-0.1",
   },
   "simulator.json": {
-    "resources": [
-      {
+    "resources": {
+      "root/my_table": {
         "addr": "c8e507baf046ceb6108a9fe64c08a39ccc39ffe11c",
         "attrs": {},
         "path": "root/my_table",
@@ -328,7 +328,7 @@ exports[`get row 2`] = `
         },
         "type": "@winglang/sdk.ex.Table",
       },
-    ],
+    },
     "sdkVersion": "0.0.0",
     "types": {
       "@winglang/sdk.cloud.Api": {
@@ -460,8 +460,8 @@ exports[`insert row 2`] = `
     "version": "connections-0.1",
   },
   "simulator.json": {
-    "resources": [
-      {
+    "resources": {
+      "root/my_table": {
         "addr": "c8e507baf046ceb6108a9fe64c08a39ccc39ffe11c",
         "attrs": {},
         "path": "root/my_table",
@@ -476,7 +476,7 @@ exports[`insert row 2`] = `
         },
         "type": "@winglang/sdk.ex.Table",
       },
-    ],
+    },
     "sdkVersion": "0.0.0",
     "types": {
       "@winglang/sdk.cloud.Api": {
@@ -610,8 +610,8 @@ exports[`list table 2`] = `
     "version": "connections-0.1",
   },
   "simulator.json": {
-    "resources": [
-      {
+    "resources": {
+      "root/my_table": {
         "addr": "c8e507baf046ceb6108a9fe64c08a39ccc39ffe11c",
         "attrs": {},
         "path": "root/my_table",
@@ -626,7 +626,7 @@ exports[`list table 2`] = `
         },
         "type": "@winglang/sdk.ex.Table",
       },
-    ],
+    },
     "sdkVersion": "0.0.0",
     "types": {
       "@winglang/sdk.cloud.Api": {
@@ -759,8 +759,8 @@ exports[`tryGet row 2`] = `
     "version": "connections-0.1",
   },
   "simulator.json": {
-    "resources": [
-      {
+    "resources": {
+      "root/my_table": {
         "addr": "c8e507baf046ceb6108a9fe64c08a39ccc39ffe11c",
         "attrs": {},
         "path": "root/my_table",
@@ -775,7 +775,7 @@ exports[`tryGet row 2`] = `
         },
         "type": "@winglang/sdk.ex.Table",
       },
-    ],
+    },
     "sdkVersion": "0.0.0",
     "types": {
       "@winglang/sdk.cloud.Api": {
@@ -911,8 +911,8 @@ exports[`update row 2`] = `
     "version": "connections-0.1",
   },
   "simulator.json": {
-    "resources": [
-      {
+    "resources": {
+      "root/my_table": {
         "addr": "c8e507baf046ceb6108a9fe64c08a39ccc39ffe11c",
         "attrs": {},
         "path": "root/my_table",
@@ -927,7 +927,7 @@ exports[`update row 2`] = `
         },
         "type": "@winglang/sdk.ex.Table",
       },
-    ],
+    },
     "sdkVersion": "0.0.0",
     "types": {
       "@winglang/sdk.cloud.Api": {

--- a/libs/wingsdk/test/target-sim/__snapshots__/test.test.ts.snap
+++ b/libs/wingsdk/test/target-sim/__snapshots__/test.test.ts.snap
@@ -27,22 +27,8 @@ async handle(event) {
     "version": "connections-0.1",
   },
   "simulator.json": {
-    "resources": [
-      {
-        "addr": "c86fc1804106bd848769cb0ddbcb872aa1e47943f4",
-        "attrs": {},
-        "path": "root/env0/test:my_test/Handler",
-        "policy": [],
-        "props": {
-          "concurrency": 100,
-          "environmentVariables": {},
-          "sourceCodeFile": ".wing/handler_c86fc180.js",
-          "sourceCodeLanguage": "javascript",
-          "timeout": 60000,
-        },
-        "type": "@winglang/sdk.cloud.Function",
-      },
-      {
+    "resources": {
+      "root/cloud.TestRunner": {
         "addr": "c8647dd8d2adabe83cc081ebe0ccbefe4a068ef3bf",
         "attrs": {},
         "deps": [
@@ -56,7 +42,21 @@ async handle(event) {
         },
         "type": "@winglang/sdk.std.TestRunner",
       },
-    ],
+      "root/env0/test:my_test/Handler": {
+        "addr": "c86fc1804106bd848769cb0ddbcb872aa1e47943f4",
+        "attrs": {},
+        "path": "root/env0/test:my_test/Handler",
+        "policy": [],
+        "props": {
+          "concurrency": 100,
+          "environmentVariables": {},
+          "sourceCodeFile": ".wing/handler_c86fc180.js",
+          "sourceCodeLanguage": "javascript",
+          "timeout": 60000,
+        },
+        "type": "@winglang/sdk.cloud.Function",
+      },
+    },
     "sdkVersion": "0.0.0",
     "types": {
       "@winglang/sdk.cloud.Api": {

--- a/libs/wingsdk/test/target-sim/__snapshots__/test.test.ts.snap
+++ b/libs/wingsdk/test/target-sim/__snapshots__/test.test.ts.snap
@@ -30,7 +30,6 @@ async handle(event) {
     "resources": {
       "root/cloud.TestRunner": {
         "addr": "c8647dd8d2adabe83cc081ebe0ccbefe4a068ef3bf",
-        "attrs": {},
         "deps": [
           "root/env0/test:my_test/Handler",
         ],
@@ -44,7 +43,6 @@ async handle(event) {
       },
       "root/env0/test:my_test/Handler": {
         "addr": "c86fc1804106bd848769cb0ddbcb872aa1e47943f4",
-        "attrs": {},
         "path": "root/env0/test:my_test/Handler",
         "policy": [],
         "props": {

--- a/libs/wingsdk/test/target-sim/__snapshots__/topic.test.ts.snap
+++ b/libs/wingsdk/test/target-sim/__snapshots__/topic.test.ts.snap
@@ -7,15 +7,15 @@ exports[`create a topic 1`] = `
     "version": "connections-0.1",
   },
   "simulator.json": {
-    "resources": [
-      {
+    "resources": {
+      "root/my_topic": {
         "addr": "c81b9a117401b1959f70a55462f9df8add290b0fda",
         "attrs": {},
         "path": "root/my_topic",
         "props": {},
         "type": "@winglang/sdk.cloud.Topic",
       },
-      {
+      "root/my_topic/Policy": {
         "addr": "c8635ef174eab9aa010e5bed09a712307a6b70e731",
         "attrs": {},
         "path": "root/my_topic/Policy",
@@ -25,7 +25,7 @@ exports[`create a topic 1`] = `
         },
         "type": "@winglang/sdk.sim.Policy",
       },
-    ],
+    },
     "sdkVersion": "0.0.0",
     "types": {
       "@winglang/sdk.cloud.Api": {

--- a/libs/wingsdk/test/target-sim/__snapshots__/topic.test.ts.snap
+++ b/libs/wingsdk/test/target-sim/__snapshots__/topic.test.ts.snap
@@ -10,14 +10,12 @@ exports[`create a topic 1`] = `
     "resources": {
       "root/my_topic": {
         "addr": "c81b9a117401b1959f70a55462f9df8add290b0fda",
-        "attrs": {},
         "path": "root/my_topic",
         "props": {},
         "type": "@winglang/sdk.cloud.Topic",
       },
       "root/my_topic/Policy": {
         "addr": "c8635ef174eab9aa010e5bed09a712307a6b70e731",
-        "attrs": {},
         "path": "root/my_topic/Policy",
         "props": {
           "principal": "\${wsim#root/my_topic#attrs.handle}",


### PR DESCRIPTION
This PR does some refactoring and housekeeping around the SDK and simulator:
- The simulator.json file format is updated to store resources in an object, indexed by keys
- `schema-resources.ts` is updated to have a bit less boilerplate - each schema now just refers to that resource's props
- `toSimulator()` methods have been updated to no longer have to provide `props`, `attrs`, or `addr` values

## Checklist

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [x] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
