### PR TITLE
fix(compiler): no missing `return` error when there's an inner method with `return`

### DIFF
--- a/examples/tests/invalid/missing_return.test.w
+++ b/examples/tests/invalid/missing_return.test.w
@@ -31,3 +31,13 @@ let returnString3 = (): str => {
   };
 };
 //^ A function whose return type is "str" must return a value.
+
+// Ignore return statements in inner methods when searching for return statements
+let returnString4 = (): str => {
+  class Foo {
+    pub static blah(): num {
+      return 5;
+    }
+  }
+};
+//^ A function whose return type is "str" must return a value.

--- a/libs/wingc/src/type_check/has_type_stmt.rs
+++ b/libs/wingc/src/type_check/has_type_stmt.rs
@@ -1,5 +1,5 @@
 use crate::{
-	ast::{Expr, ExprKind, FunctionDefinition, Stmt, StmtKind},
+	ast::{FunctionDefinition, Stmt, StmtKind},
 	visit::{self, Visit},
 };
 

--- a/libs/wingc/src/type_check/has_type_stmt.rs
+++ b/libs/wingc/src/type_check/has_type_stmt.rs
@@ -1,5 +1,5 @@
 use crate::{
-	ast::{Expr, ExprKind, Stmt, StmtKind},
+	ast::{Expr, ExprKind, FunctionDefinition, Stmt, StmtKind},
 	visit::{self, Visit},
 };
 
@@ -28,11 +28,8 @@ impl Visit<'_> for HasStatementVisitor {
 		visit::visit_stmt(self, node);
 	}
 
-	fn visit_expr(&mut self, node: &'_ Expr) {
-		// Don't recurse into closures. This way our search will ignore stmts in inner closures.
-		if matches!(node.kind, ExprKind::FunctionClosure(_)) {
-			return;
-		}
-		visit::visit_expr(self, node);
+	fn visit_function_definition(&mut self, _: &'_ FunctionDefinition) {
+		// Don't recurse into functions. This way our search will ignore stmts in inner functions.
+		return;
 	}
 }

--- a/tools/hangar/__snapshots__/invalid.ts.snap
+++ b/tools/hangar/__snapshots__/invalid.ts.snap
@@ -2724,6 +2724,20 @@ error: A function whose return type is \\"str\\" must return a value.
    | \\\\-^ A function whose return type is \\"str\\" must return a value.
 
 
+error: A function whose return type is \\"str\\" must return a value.
+   --> ../../../examples/tests/invalid/missing_return.test.w:36:32
+   |  
+36 |   let returnString4 = (): str => {
+   | /--------------------------------^
+37 | |   class Foo {
+38 | |     pub static blah(): num {
+39 | |       return 5;
+40 | |     }
+41 | |   }
+42 | | };
+   | \\\\-^ A function whose return type is \\"str\\" must return a value.
+
+
  
  
 Tests 1 failed (1)


### PR DESCRIPTION
Fixes #6172
This is take 2 of #5481. Now we ignore **all** inner function definitions (no just closures) when checking if a functions has a `returns` statement. Previously we didn't catch the case when there's an inner method with a `return` statement.

## Checklist

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [x] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
