### PR TITLE
fix(console): node title ignores the user defined resource name

### DIFF
--- a/apps/wing-console/console/ui/src/ui/elk-map-nodes.tsx
+++ b/apps/wing-console/console/ui/src/ui/elk-map-nodes.tsx
@@ -100,8 +100,11 @@ export const ContainerNode = memo(
     );
 
     const compilerNamed = useMemo(() => {
-      return !!display?.title;
-    }, [display]);
+      const cloudResourceType = resourceType
+        ? resourceType.split(".").at(-1)
+        : "";
+      return !!display?.title && display?.title !== cloudResourceType;
+    }, [display, resourceType]);
 
     return (
       // TODO: Fix a11y

--- a/apps/wing-console/console/ui/src/ui/elk-map-nodes.tsx
+++ b/apps/wing-console/console/ui/src/ui/elk-map-nodes.tsx
@@ -100,6 +100,7 @@ export const ContainerNode = memo(
     );
 
     const compilerNamed = useMemo(() => {
+      // sdk cloud resource type has a fixed convention: @winglang/sdk.cloud.*
       const cloudResourceType = resourceType
         ? resourceType.split(".").at(-1)
         : "";

--- a/apps/wing-console/console/ui/src/ui/resource-metadata.tsx
+++ b/apps/wing-console/console/ui/src/ui/resource-metadata.tsx
@@ -283,6 +283,13 @@ export const ResourceMetadata = memo(
       };
     }, [node, inbound, outbound]);
 
+    const nodeLabel = useMemo(() => {
+      const cloudResourceTypeName = node.type.split(".").at(-1) || "";
+      const compilerNamed =
+        !!node.display?.title && node.display?.title !== cloudResourceTypeName;
+      return compilerNamed ? node.display?.title : node.id;
+    }, [node]);
+
     const toggleInspectorSection = useCallback((section: string) => {
       setOpenInspectorSections(([...sections]) => {
         const index = sections.indexOf(section);
@@ -317,9 +324,7 @@ export const ResourceMetadata = memo(
           </div>
 
           <div className="flex flex-col min-w-0">
-            <div className="text-sm font-medium truncate">
-              {node?.display?.title ?? node.id}
-            </div>
+            <div className="text-sm font-medium truncate">{nodeLabel}</div>
             <div className="flex">
               <Pill>{node.type}</Pill>
             </div>
@@ -328,7 +333,7 @@ export const ResourceMetadata = memo(
         {resourceUI.data && resourceUI.data.length > 0 && (
           <InspectorSection
             icon={CubeIcon}
-            text={(node.display?.title || node.id) ?? "Properties"}
+            text={nodeLabel ?? "Properties"}
             open={openInspectorSections.includes("resourceUI")}
             onClick={() => toggleInspectorSection("resourceUI")}
             headingClassName="pl-2"


### PR DESCRIPTION
resolves: https://github.com/winglang/wing/issues/5994

for the following code:
```
bring cloud;
class A {
  new() {
    nodeof(this).title = "MyTitle";
    nodeof(this).color = "violet";
  }
}
class B {
    new() {
    }
}
new A();
new cloud.Bucket() as "MyBucket";
new cloud.Bucket();
new B();
```

the console will display the following:
![Screenshot 2024-04-11 at 12 54 26](https://github.com/winglang/wing/assets/2538825/3272018e-695a-4c6e-80c9-f8f54751ea45)


## Checklist

- [ ] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [ ] Description explains motivation and solution
- [ ] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
