### PR TITLE
fix(compiler): imported JSII types are considered defined after other types (and can't be referenced by them)

### DIFF
--- a/libs/wingc/src/type_check.rs
+++ b/libs/wingc/src/type_check.rs
@@ -5132,7 +5132,6 @@ impl<'a> TypeChecker<'a> {
 				assembly_name: assembly_name.to_string(),
 				namespace_filter,
 				alias: alias.clone(),
-				import_statement_idx: stmt.map(|s| s.idx).unwrap_or(0),
 			});
 
 			self
@@ -5143,10 +5142,7 @@ impl<'a> TypeChecker<'a> {
 		};
 
 		// check if we've already defined the given alias in the current scope
-		if env
-			.lookup(&jsii.alias.name.as_str().into(), Some(jsii.import_statement_idx))
-			.is_some()
-		{
+		if env.lookup(&jsii.alias.name.as_str().into(), None).is_some() {
 			self.spanned_error(alias, format!("\"{}\" is already defined", alias.name));
 		} else {
 			let mut importer = JsiiImporter::new(&jsii, self.types, self.jsii_types);

--- a/libs/wingc/src/type_check/jsii_importer.rs
+++ b/libs/wingc/src/type_check/jsii_importer.rs
@@ -29,12 +29,6 @@ trait JsiiInterface {
 	fn properties(&self) -> &Option<Vec<jsii::Property>>;
 }
 
-fn color() {
-	Colorize::color();
-}
-
-use colored::Colorize;
-
 impl JsiiInterface for jsii::ClassType {
 	fn methods(&self) -> &Option<Vec<jsii::Method>> {
 		&self.methods

--- a/libs/wingc/src/type_check/jsii_importer.rs
+++ b/libs/wingc/src/type_check/jsii_importer.rs
@@ -12,7 +12,7 @@ use crate::{
 	},
 	CONSTRUCT_BASE_CLASS, WINGSDK_ASSEMBLY_NAME, WINGSDK_DURATION, WINGSDK_JSON, WINGSDK_MUT_JSON, WINGSDK_RESOURCE,
 };
-use colored::Colorize;
+//use colored::Colorize;
 use wingii::{
 	fqn::FQN,
 	jsii::{self, CollectionKind, PrimitiveType, TypeReference},
@@ -28,6 +28,12 @@ trait JsiiInterface {
 	fn methods(&self) -> &Option<Vec<jsii::Method>>;
 	fn properties(&self) -> &Option<Vec<jsii::Property>>;
 }
+
+fn color() {
+	Colorize::color();
+}
+
+use colored::Colorize;
 
 impl JsiiInterface for jsii::ClassType {
 	fn methods(&self) -> &Option<Vec<jsii::Method>> {
@@ -61,11 +67,6 @@ pub struct JsiiImportSpec {
 	pub namespace_filter: Vec<String>,
 	/// The name to assign to the module in the Wing type system.
 	pub alias: Symbol,
-	/// The index of the import statement that triggered this import. This is required so we'll know
-	/// later on if types defined by this import come before or after other statements in the code.
-	/// If type definitions in wing are always location agnostic this doesn't really matter and we
-	/// might be able to remove this.
-	pub import_statement_idx: usize,
 }
 
 pub struct JsiiImporter<'a> {
@@ -409,7 +410,7 @@ impl<'a> JsiiImporter<'a> {
 					None,
 					SymbolEnvKind::Type(self.wing_types.void()),
 					Phase::Independent, // structs are phase-independent
-					self.jsii_spec.import_statement_idx,
+					0,
 				),
 			})),
 			false => self.wing_types.add_type(Type::Interface(Interface {
@@ -419,12 +420,7 @@ impl<'a> JsiiImporter<'a> {
 				extends: vec![],
 				docs: Docs::from(&jsii_interface.docs),
 				// Will be replaced below
-				env: SymbolEnv::new(
-					None,
-					SymbolEnvKind::Type(self.wing_types.void()),
-					phase,
-					self.jsii_spec.import_statement_idx,
-				),
+				env: SymbolEnv::new(None, SymbolEnvKind::Type(self.wing_types.void()), phase, 0),
 			})),
 		};
 
@@ -441,12 +437,7 @@ impl<'a> JsiiImporter<'a> {
 			}
 		};
 
-		let mut iface_env = SymbolEnv::new(
-			None,
-			SymbolEnvKind::Type(wing_type),
-			phase,
-			self.jsii_spec.import_statement_idx,
-		);
+		let mut iface_env = SymbolEnv::new(None, SymbolEnvKind::Type(wing_type), phase, 0);
 		iface_env.type_parameters = self.type_param_from_docs(&jsii_interface_fqn, &jsii_interface.docs);
 
 		self.add_members_to_class_env(
@@ -1076,7 +1067,7 @@ impl<'a> JsiiImporter<'a> {
 				&self.jsii_spec.alias,
 				SymbolKind::Namespace(ns),
 				AccessModifier::Private,
-				StatementIdx::Index(self.jsii_spec.import_statement_idx),
+				StatementIdx::Top,
 			)
 			.unwrap();
 	}


### PR DESCRIPTION
Fixes #6920
Related to #5683 
Removed the statement index from JSII import spec so everything imported from a JSII module is considered define at the top level of the file. This makes types imported from JSII behave the same way as other types since #5683.

**Note** there's still a difference between how imported JSII types and other types behave in regards to whether they can be used before being defined: classes. In #5683 we avoided hoisting class types to the "top of the file" so you can't do something like:
```
new X(); // Error `X` not defined
class X {}
```
But this PR makes JSII classes hoisted to the top so for them this will work:
```
new jsii_module.X();
bring jsii_module;
```
I think in the long run the desired behavior is to hoist all class types. So I'm fine with this currently only working for JSII.

## Checklist

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [ ] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
