### PR TITLE
fix: keywords are highlighted incorrectly in structs

### DIFF
--- a/apps/vscode-wing/syntaxes/wing.tmLanguage.json
+++ b/apps/vscode-wing/syntaxes/wing.tmLanguage.json
@@ -7,6 +7,12 @@
       "include": "#template-string"
     },
     {
+      "include": "#object-keys"
+    },
+    {
+      "include": "#members"
+    },
+    {
       "include": "#keywords"
     },
     {
@@ -23,9 +29,6 @@
     },
     {
       "include": "#identifiers"
-    },
-    {
-      "include": "#members"
     }
   ],
   "repository": {
@@ -184,6 +187,18 @@
           "captures": {
             "1": {
               "name": "entity.name.function.wing"
+            }
+          }
+        }
+      ]
+    },
+    "object-keys": {
+      "patterns": [
+        {
+          "match": "\\b([a-zA-Z_][a-zA-Z0-9_]*)\\s*:",
+          "captures": {
+            "1": {
+              "name": "variable.wing"
             }
           }
         }


### PR DESCRIPTION
Fixes #6208
Fixes #2595

Before:
<img width="387" alt="image" src="https://github.com/winglang/wing/assets/1237390/b298340c-f855-471e-a496-b71706c79190">



After:
<img width="407" alt="image" src="https://github.com/winglang/wing/assets/1237390/85e85809-01b1-4e54-beea-a4c115cead1e">


*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
