### PR TITLE
chore: update tree-sitter to official version

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,4 @@
 [env]
-WASI_SDK = { value = ".cargo/wasi-sdk-21.0", relative = true }
 # tree-sitter build fails with newer version of clang unless implicit-function-declaration is ignored
 CC_wasm32_wasi = { value = ".cargo/wasi-sdk-21.0/bin/clang -Wno-error=implicit-function-declaration", relative = true }
 AR_wasm32_wasi = { value = ".cargo/wasi-sdk-21.0/bin/ar", relative = true }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1308,8 +1308,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter"
-version = "0.22.4"
-source = "git+https://github.com/tree-sitter/tree-sitter.git?rev=a7a47d561d4e64eaf226f93c4d68076afa67fdda#a7a47d561d4e64eaf226f93c4d68076afa67fdda"
+version = "0.22.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "688200d842c76dd88f9a7719ecb0483f79f5a766fb1c100756d5d8a059abc71b"
 dependencies = [
  "cc",
  "regex",

--- a/libs/tree-sitter-wing/Cargo.toml
+++ b/libs/tree-sitter-wing/Cargo.toml
@@ -17,8 +17,7 @@ include = ["bindings/rust/*", "grammar.js", "queries/*", "src/*"]
 path = "bindings/rust/lib.rs"
 
 [dependencies]
-# Waiting for https://github.com/tree-sitter/tree-sitter/pull/3293 to be released
-tree-sitter = { git = "https://github.com/tree-sitter/tree-sitter.git", rev = "a7a47d561d4e64eaf226f93c4d68076afa67fdda" }
+tree-sitter = "0.22.5"
 
 [build-dependencies]
 cc = "1.0.87"

--- a/libs/tree-sitter-wing/bindings/rust/build.rs
+++ b/libs/tree-sitter-wing/bindings/rust/build.rs
@@ -16,17 +16,5 @@ fn main() {
 	c_config.file(&scanner_path);
 	println!("cargo:rerun-if-changed={}", scanner_path.to_str().unwrap());
 
-	if cfg!(target_arch = "wasm32") {
-		// This parser is used in a WASI context, so it needs to be compiled with
-		// the sysroot and other tools needed for WASI-compatible C
-		c_config.flag(
-			format!(
-				"--sysroot={}/share/wasi-sysroot",
-				env!("WASI_SDK", "WASI_SDK env not set")
-			)
-			.as_str(),
-		);
-	}
-
 	c_config.compile("tree-sitter-wing");
 }

--- a/libs/tree-sitter-wing/package.json
+++ b/libs/tree-sitter-wing/package.json
@@ -52,6 +52,6 @@
   },
   "devDependencies": {
     "nodemon": "^3.1.0",
-    "tree-sitter-cli": "0.22.4"
+    "tree-sitter-cli": "0.22.5"
   }
 }

--- a/libs/tree-sitter-wing/turbo.json
+++ b/libs/tree-sitter-wing/turbo.json
@@ -4,7 +4,7 @@
   "pipeline": {
     "build:generate": {
       "inputs": ["!*.wasm", "*", "grammar.js", "src/scanner.c"],
-      "outputs": ["src/**", "!src/scanner.c", "bindings/**", "binding.gyp"]
+      "outputs": ["src/**", "!src/scanner.c"]
     },
     "build:wasm": {
       "dependsOn": ["build:generate"],

--- a/libs/wingc/Cargo.toml
+++ b/libs/wingc/Cargo.toml
@@ -4,8 +4,7 @@ version = "0.0.0"
 edition = "2021"
 
 [dependencies]
-# Waiting for https://github.com/tree-sitter/tree-sitter/pull/3293 to be released
-tree-sitter = { git = "https://github.com/tree-sitter/tree-sitter.git", rev = "a7a47d561d4e64eaf226f93c4d68076afa67fdda" }
+tree-sitter = "0.22.5"
 derivative = "2.2"
 tree-sitter-wing = { path = "../tree-sitter-wing" }
 wingii = { path = "../wingii" }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1207,8 +1207,8 @@ importers:
         specifier: ^3.1.0
         version: 3.1.0
       tree-sitter-cli:
-        specifier: 0.22.4
-        version: 0.22.4
+        specifier: 0.22.5
+        version: 0.22.5
 
   libs/wingc:
     devDependencies:
@@ -14203,7 +14203,7 @@ packages:
     dependencies:
       semver: 7.5.4
       shelljs: 0.8.5
-      typescript: 5.5.0-dev.20240413
+      typescript: 5.5.0-dev.20240414
     dev: true
 
   /dset@3.1.2:
@@ -22378,8 +22378,8 @@ packages:
     hasBin: true
     dev: true
 
-  /tree-sitter-cli@0.22.4:
-    resolution: {integrity: sha512-Zli7yeD+ocVWm+au5YLJKLyxzvUirenomOgwapNZU8bpYt/CZMpEeya9eK/tEQAd7NDOQSvAnvhJXbPbwUdgMQ==}
+  /tree-sitter-cli@0.22.5:
+    resolution: {integrity: sha512-c3VT46Bc3a6pEd0JAwufbqEw9Q2FRLDp5E230hGvnr+Hivw+Y6jyeP+3T89KDptvn48MOPVmbgaLm69xYgLVTw==}
     hasBin: true
     requiresBuild: true
     dev: true
@@ -22836,8 +22836,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  /typescript@5.5.0-dev.20240413:
-    resolution: {integrity: sha512-9Xha/54eUa9rMSYHTmP37pxf7NoWEWR/URl9TjZy2Fd7931boHHrE7k0QrtXFs2uXaIyC9v7I/Se8pGsQ7V14A==}
+  /typescript@5.5.0-dev.20240414:
+    resolution: {integrity: sha512-VEXaVJweoalMohUIdPBNAI0OzBuzR6caL8w3XW+R8jewwxn6iD9t2zAO1DkqYmYDDYlu2kp8L61Vk9SDsvv4Hw==}
     engines: {node: '>=14.17'}
     hasBin: true
     dev: true


### PR DESCRIPTION
Turns out tree-sitter is releasing stuff much faster nowadays!

While doing this, I noticed we no longer need to hack the C build as much. Removed that the whole sysroot thing. I could remove the locked CC and AR but it has actually been pretty nice having that locked to not worry about what contributors have installed. I'd be nice to one day use zig instead.

This new tree-sitter version also seems to compile a litter faster, so that's a nice bonus.

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
