### PR TITLE
fix(vscode): wing debugger is not a default choice for .w files

### DIFF
--- a/apps/vscode-wing/.projenrc.ts
+++ b/apps/vscode-wing/.projenrc.ts
@@ -113,6 +113,7 @@ const contributes: VSCodeExtensionContributions = {
       type: "wing",
       label: "Wing Debug",
       program: "",
+      languages: ["wing"],
       configurationAttributes: {
         launch: {
           entrypoint: {

--- a/apps/vscode-wing/package.json
+++ b/apps/vscode-wing/package.json
@@ -116,6 +116,9 @@
         "type": "wing",
         "label": "Wing Debug",
         "program": "",
+        "languages": [
+          "wing"
+        ],
         "configurationAttributes": {
           "launch": {
             "entrypoint": {

--- a/apps/vscode-wing/src/project/vscode_types.ts
+++ b/apps/vscode-wing/src/project/vscode_types.ts
@@ -53,6 +53,7 @@ export interface VSCodeDebugger {
   readonly type: string;
   readonly runtime?: string;
   readonly program?: string;
+  readonly languages: string[];
   readonly request?: string;
   readonly variables?: string;
   readonly configurationAttributes?: any;


### PR DESCRIPTION
Missed this change in https://github.com/winglang/wing/pull/6217

Now vscode will automatically use the builtin debugger when you have a wing file open instead of asking you to pick one

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
