### PR TITLE
fix: invokeAsync can fail during simulator cleanup

### DIFF
--- a/libs/wingsdk/src/target-sim/function.inflight.ts
+++ b/libs/wingsdk/src/target-sim/function.inflight.ts
@@ -51,10 +51,7 @@ export class Function implements IFunctionClient, ISimulatorResourceInstance {
     // and the bundling code is allowed to run after the simulator has stopped, it might fail
     // and throw an error to the user because the files the simulator was using may no longer be there there.
     await this.createBundlePromise;
-
-    for (const worker of this.workers) {
-      await worker.cleanup();
-    }
+    await Promise.all(this.workers.map((w) => w.cleanup()));
   }
 
   public async save(): Promise<void> {}

--- a/libs/wingsdk/test/target-sim/function.test.ts
+++ b/libs/wingsdk/test/target-sim/function.test.ts
@@ -82,7 +82,7 @@ test("invoke function succeeds", async () => {
   expect(app.snapshot()).toMatchSnapshot();
 });
 
-test.only("async invoke function cleanup while running", async () => {
+test("async invoke function cleanup while running", async () => {
   // GIVEN
   const app = new SimApp();
   const handler = Testing.makeHandler(`

--- a/libs/wingsdk/test/target-sim/function.test.ts
+++ b/libs/wingsdk/test/target-sim/function.test.ts
@@ -82,6 +82,32 @@ test("invoke function succeeds", async () => {
   expect(app.snapshot()).toMatchSnapshot();
 });
 
+test.only("async invoke function cleanup while running", async () => {
+  // GIVEN
+  const app = new SimApp();
+  const handler = Testing.makeHandler(`
+  async handle(event) {
+    // sleep forever
+    await new Promise(() => {});
+  }`);
+  new cloud.Function(app, "my_function", handler);
+
+  const s = await app.startSimulator();
+
+  const client = s.getResource("/my_function") as cloud.IFunctionClient;
+
+  // WHEN
+  await client.invokeAsync();
+
+  // THEN
+  await s.stop();
+
+  // wait for a small time to let the child process fail to exit
+  await new Promise((resolve) => setTimeout(resolve, 150));
+
+  expect(s.listTraces().every((t) => t.data.error === undefined)).toBe(true);
+}, 10000);
+
 test("invoke function with environment variables", async () => {
   // GIVEN
   const app = new SimApp();


### PR DESCRIPTION
hangar sometimes run into this:

`InvokeAsync (payload=undefined) failure. Error: Process exited with code null, signal SIGTERM`

I believe this can happen if InvokeAsync is running while it receive the SIGTERM cleanup. This should not be considered a failure, just a normal part of the cleanup process.

The test relies on a sleep so I'm open to better ideas, but it does replicate the issue on `main`

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
