### PR TITLE
chore: improve log filtering

### DIFF
--- a/apps/wing/src/commands/test/test.ts
+++ b/apps/wing/src/commands/test/test.ts
@@ -470,7 +470,7 @@ async function testSimulator(synthDir: string, options: TestOptions) {
         testName = testMappings[env] ?? testName;
       }
 
-      if (testFilter && !testName.includes(testFilter) && process.env.DEBUG !== "verbose") {
+      if (testFilter && !testName.includes(testFilter) && testName !== "(no test)") {
         // This test does not match the filter, so skip it.
         return;
       }

--- a/apps/wing/src/commands/test/test.ts
+++ b/apps/wing/src/commands/test/test.ts
@@ -464,16 +464,13 @@ async function testSimulator(synthDir: string, options: TestOptions) {
 
     const printEvent = async (event: std.Trace) => {
       const env = extractTestEnvFromPath(event.sourcePath);
-      if (env === undefined) {
-        // This event is not associated with any test environment, so skip it.
-        return;
+
+      let testName = "(no test)";
+      if (env !== undefined) {
+        testName = testMappings[env] ?? testName;
       }
-      const testName = testMappings[env];
-      if (testName === undefined) {
-        // This event is not associated with any test environment, so skip it.
-        return;
-      }
-      if (testFilter && !testName.includes(testFilter)) {
+
+      if (testFilter && !testName.includes(testFilter) && process.env.DEBUG !== "verbose") {
         // This test does not match the filter, so skip it.
         return;
       }

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/queue/push.test.w_test_sim.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/queue/push.test.w_test_sim.md
@@ -2,6 +2,8 @@
 
 ## stdout.log
 ```log
+[ERROR] (no test) | Push (messages=). Error: Empty messages are not allowed
+[ERROR] (no test) | Push (messages=Foo,). Error: Empty messages are not allowed
 pass ─ push.test.wsim » root/env0/push
 
 Tests 1 passed (1)


### PR DESCRIPTION
When `wing test` is run against the simulator, logs are streamed to the CLI output. But for technical reasons not all logs are associated with tests. For example, there's a singleton class named `TestRunner` which can have an overridden implementation per target. This is a side effect of how we currently implement test isolation as construct subtrees.

As a small improvement, when events are emitted from these resources, this PR changes the current behavior so they're logged to standard output with the "(no test)" label instead of being ignored.

## Checklist

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [ ] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
