### PR TITLE
fix: conflicting `SIGINT` handlers

### DIFF
--- a/apps/wing-console/console/server/package.json
+++ b/apps/wing-console/console/server/package.json
@@ -21,6 +21,7 @@
     "@winglang/compiler": "workspace:^",
     "@winglang/sdk": "workspace:^",
     "codespan-wasm": "^0.4.0",
+    "conf": "^11.0.2",
     "debug": "^4.3.4",
     "launch-editor": "^2.6.0",
     "ms": "^2.1.3"
@@ -37,7 +38,6 @@
     "@wingconsole/tsconfig": "workspace:^",
     "bump-pack": "workspace:^",
     "chokidar": "^3.5.3",
-    "conf": "^11.0.2",
     "constructs": "^10.3",
     "cors": "^2.8.5",
     "emittery": "^1.0.1",

--- a/apps/wing/package.json
+++ b/apps/wing/package.json
@@ -55,7 +55,8 @@
     "tar": "^6.2.0",
     "tiny-updater": "^3.5.1",
     "uuid": "^8.3.2",
-    "vscode-languageserver": "^8.1.0"
+    "vscode-languageserver": "^8.1.0",
+    "when-exit": "^2.1.2"
   },
   "devDependencies": {
     "@types/debug": "^4.1.8",

--- a/apps/wing/src/util.before-shutdown.ts
+++ b/apps/wing/src/util.before-shutdown.ts
@@ -1,79 +1,11 @@
-/**
- * Based on https://gist.github.com/nfantone/1eaa803772025df69d07f4dbf5df7e58.
- */
-type BeforeShutdownListener = (codeOrSignal: string | number) => Promise<void> | void;
-
-/**
- * Time in milliseconds to wait before forcing shutdown.
- */
-const SHUTDOWN_TIMEOUT = 15_000;
-
-/**
- * A queue of listener callbacks to execute before shutting
- * down the process.
- */
-const shutdownListeners: BeforeShutdownListener[] = [];
-
-/**
- * Listen for signals and execute given `fn` function once.
- * @param  fn Function to execute on shutdown.
- */
-const processOnce = (fn: BeforeShutdownListener) => {
-  process.once("SIGINT", (signal) => void fn(signal));
-  process.once("SIGTERM", (signal) => void fn(signal));
-  process.once("exit", (code) => void fn(code));
-  process.once("beforeExit", (code) => void fn(code));
-};
-
-/**
- * Sets a forced shutdown mechanism that will exit the process after `timeout` milliseconds.
- * @param timeout Time to wait before forcing shutdown (milliseconds)
- */
-const forceExitAfter = (timeout: number) => () => {
-  setTimeout(() => {
-    // Force shutdown after timeout
-    console.warn(`Could not close resources gracefully after ${timeout}ms: forcing shutdown`);
-    return process.exit(1);
-  }, timeout).unref();
-};
-
-/**
- * Main process shutdown handler. Will invoke every previously registered async shutdown listener
- * in the queue and exit with a code of `0`. Any `Promise` rejections from any listener will
- * be logged out as a warning, but won't prevent other callbacks from executing.
- */
-async function shutdownHandler(codeOrSignal: string | number) {
-  for (const listener of shutdownListeners) {
-    try {
-      await listener(codeOrSignal);
-    } catch (error) {
-      console.warn(
-        `A shutdown handler failed before completing with: ${
-          error instanceof Error ? error.message : error
-        }`
-      );
-    }
-  }
-
-  return process.exit(0);
-}
+import whenExit from "when-exit";
 
 /**
  * Registers a new shutdown listener to be invoked before exiting
  * the main process. Listener handlers are guaranteed to be called in the order
  * they were registered.
  * @param listener The shutdown listener to register.
- * @returns Echoes back the supplied `listener`.
  */
-export function beforeShutdown(listener: BeforeShutdownListener) {
-  shutdownListeners.push(listener);
-  return listener;
+export function beforeShutdown(listener: () => {}) {
+  whenExit(listener);
 }
-
-// Register shutdown callback that kills the process after `SHUTDOWN_TIMEOUT` milliseconds
-// This prevents custom shutdown handlers from hanging the process indefinitely
-processOnce(forceExitAfter(SHUTDOWN_TIMEOUT));
-
-// Register process shutdown callback
-// Will listen to incoming signal events and execute all registered handlers in the stack
-processOnce(shutdownHandler);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -314,6 +314,9 @@ importers:
       vscode-languageserver:
         specifier: ^8.1.0
         version: 8.1.0
+      when-exit:
+        specifier: ^2.1.2
+        version: 2.1.2
     devDependencies:
       '@types/debug':
         specifier: ^4.1.8
@@ -645,6 +648,9 @@ importers:
       codespan-wasm:
         specifier: ^0.4.0
         version: 0.4.0
+      conf:
+        specifier: ^11.0.2
+        version: 11.0.2
       debug:
         specifier: ^4.3.4
         version: 4.3.4(supports-color@5.5.0)
@@ -688,9 +694,6 @@ importers:
       chokidar:
         specifier: ^3.5.3
         version: 3.5.3
-      conf:
-        specifier: ^11.0.2
-        version: 11.0.2
       constructs:
         specifier: ^10.3
         version: 10.3.0
@@ -11870,7 +11873,6 @@ packages:
         optional: true
     dependencies:
       ajv: 8.12.0
-    dev: true
 
   /ajv-keywords@3.5.2(ajv@6.12.6):
     resolution: {integrity: sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==}
@@ -12265,8 +12267,7 @@ packages:
     resolution: {integrity: sha512-Xfmb4q5QV7uqTlVdMSTtO5eF4DCHfNOdaPyKlbFShkzeNP+3lj3yjjcbdjSmEY4+pDBKJ9g26aP+ImTe88UHoQ==}
     dependencies:
       stubborn-fs: 1.2.5
-      when-exit: 2.1.1
-    dev: true
+      when-exit: 2.1.2
 
   /auto-bind@4.0.0:
     resolution: {integrity: sha512-Hdw8qdNiqdJ8LqT0iK0sVzkFbzg6fhnQqqfWhBDxcHZvU75+B+ayzTy8x+k5Ix0Y92XOhOUlx74ps+bA6BeYMQ==}
@@ -13428,7 +13429,6 @@ packages:
       env-paths: 3.0.0
       json-schema-typed: 8.0.1
       semver: 7.5.4
-    dev: true
 
   /config-chain@1.1.13:
     resolution: {integrity: sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==}
@@ -13806,7 +13806,6 @@ packages:
     engines: {node: '>=12'}
     dependencies:
       mimic-fn: 4.0.0
-    dev: true
 
   /debug@2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
@@ -14182,7 +14181,6 @@ packages:
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     dependencies:
       type-fest: 2.19.0
-    dev: true
 
   /dotenv-expand@10.0.0:
     resolution: {integrity: sha512-GopVGCpVS1UKH75VKHGuQFqS1Gusej0z4FyQkPdwjil2gNIv+LNsqBlboOzpJFZKVT95GkCyWJbBSdFEFUWI2A==}
@@ -14206,7 +14204,7 @@ packages:
     dependencies:
       semver: 7.5.4
       shelljs: 0.8.5
-      typescript: 5.5.0-dev.20240415
+      typescript: 5.5.0-dev.20240419
     dev: true
 
   /dset@3.1.2:
@@ -14336,7 +14334,6 @@ packages:
   /env-paths@3.0.0:
     resolution: {integrity: sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-    dev: true
 
   /envinfo@7.10.0:
     resolution: {integrity: sha512-ZtUjZO6l5mwTHvc1L9+1q5p/R3wTopcfqMW8r5t8SJSKqeVI/LtajORwRFEKpEFuekjD0VBjwu1HMxL4UalIRw==}
@@ -17826,7 +17823,6 @@ packages:
 
   /json-schema-typed@8.0.1:
     resolution: {integrity: sha512-XQmWYj2Sm4kn4WeTYvmpKEbyPsL7nBsb647c7pMe6l02/yx2+Jfc4dT6UZkEXnIUb5LhD55r2HPsJ1milQ4rDg==}
-    dev: true
 
   /json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
@@ -21980,7 +21976,6 @@ packages:
 
   /stubborn-fs@1.2.5:
     resolution: {integrity: sha512-H2N9c26eXjzL/S/K+i/RHHcFanE74dptvvjM8iwzwbVcWY/zjBbgRqF3K0DY4+OD+uTTASTBvDoxPDaPN02D7g==}
-    dev: true
 
   /stubs@3.0.0:
     resolution: {integrity: sha512-PdHt7hHUJKxvTCgbKX9C1V/ftOcjJQgz8BZwNfV5c4B6dcGqlpelTbJ999jBGZ2jYiPAwcX5dP6oBwVlBlUbxw==}
@@ -22288,7 +22283,7 @@ packages:
     dependencies:
       ionstore: 1.0.0
       tiny-colors: 2.1.2
-      when-exit: 2.1.1
+      when-exit: 2.1.2
     dev: false
 
   /tinybench@2.5.1:
@@ -22765,7 +22760,6 @@ packages:
   /type-fest@2.19.0:
     resolution: {integrity: sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==}
     engines: {node: '>=12.20'}
-    dev: true
 
   /type-is@1.6.18:
     resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
@@ -22839,8 +22833,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  /typescript@5.5.0-dev.20240415:
-    resolution: {integrity: sha512-2FlWR0afPLL3qaO+AcMp6rWmV6nrLoRhwDYAgGn7/Kw1/K8hcW83bZnn+gzGNWfXozx/EdJuG0KfN7V/RGysjg==}
+  /typescript@5.5.0-dev.20240419:
+    resolution: {integrity: sha512-8ypxI/j8ctX5QljMci0V6iljmCDnSmardVThnbxKC8p3eRc83c2Ip6K4MmGO5yHgeEyz9rpusbM2iY/6lDZBdw==}
     engines: {node: '>=14.17'}
     hasBin: true
     dev: true
@@ -23603,8 +23597,8 @@ packages:
       webidl-conversions: 4.0.2
     dev: true
 
-  /when-exit@2.1.1:
-    resolution: {integrity: sha512-XLipGldz/UcleuGaoQjbYuWwD+ICRnzIjlldtwTaTWr7aZz8yQW49rXk6MHQnh+KxOiWiJpM1vIyaxprOnlW4g==}
+  /when-exit@2.1.2:
+    resolution: {integrity: sha512-u9J+toaf3CCxCAzM/484qNAxQE75rFdVgiFEEV8Xps2gzYhf0tx73s1WXDQhkwV17E3MxRMz40m7Ekd2/121Lg==}
 
   /which-boxed-primitive@1.0.2:
     resolution: {integrity: sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==}


### PR DESCRIPTION
There were two competing `SIGINT` handlers and the result was unreleased Console resources. This PR does the following:

- Moves the `@wingconsole/server`'s `conf` dev dependency to dependencies, so we don't bundle `when-exit`
- Uses the same `when-exit` package in `winglang`

By applying the listed changes above, all `SIGINT` handlers will be managed by `when-exit`, so there shouldn't be any conflict now.

Fixes #6018.