### PR TITLE
fix(compiler): array access operator precedence

### DIFF
--- a/examples/tests/valid/indexing.test.w
+++ b/examples/tests/valid/indexing.test.w
@@ -5,6 +5,8 @@ let arr = Array<num>[1, 2, 3];
 
 assert(arr[0] == 1);
 assert(arr[2 - 5] == 1);
+assert(arr[0] != arr[1]);
+
 
 try {
   arr[-5];

--- a/libs/tree-sitter-wing/grammar.js
+++ b/libs/tree-sitter-wing/grammar.js
@@ -13,9 +13,10 @@ const PREC = {
   UNARY: 120,
   OPTIONAL_TEST: 130,
   POWER: 140,
-  MEMBER: 150,
-  CALL: 160,
-  OPTIONAL_UNWRAP: 170,
+  SUBSCRIPT: 150, // x[0]
+  MEMBER: 160,
+  CALL: 170,
+  OPTIONAL_UNWRAP: 180,
 };
 
 module.exports = grammar({
@@ -674,7 +675,7 @@ module.exports = grammar({
     map_literal_member: ($) => seq($.expression, "=>", $.expression),
     struct_literal_member: ($) => seq($.identifier, ":", $.expression),
     structured_access_expression: ($) =>
-      prec.right(seq($.expression, "[", $.expression, "]")),
+      prec.right(PREC.SUBSCRIPT, seq($.expression, "[", $.expression, "]")),
 
     json_literal: ($) =>
       choice(

--- a/libs/tree-sitter-wing/grammar.js
+++ b/libs/tree-sitter-wing/grammar.js
@@ -13,7 +13,7 @@ const PREC = {
   UNARY: 120,
   OPTIONAL_TEST: 130,
   POWER: 140,
-  SUBSCRIPT: 150, // x[0]
+  STRUCTURED_ACCESS: 150, // x[y]
   MEMBER: 160,
   CALL: 170,
   OPTIONAL_UNWRAP: 180,
@@ -675,7 +675,7 @@ module.exports = grammar({
     map_literal_member: ($) => seq($.expression, "=>", $.expression),
     struct_literal_member: ($) => seq($.identifier, ":", $.expression),
     structured_access_expression: ($) =>
-      prec.right(PREC.SUBSCRIPT, seq($.expression, "[", $.expression, "]")),
+      prec.right(PREC.STRUCTURED_ACCESS, seq($.expression, "[", $.expression, "]")),
 
     json_literal: ($) =>
       choice(

--- a/libs/tree-sitter-wing/src/grammar.json
+++ b/libs/tree-sitter-wing/src/grammar.json
@@ -192,7 +192,7 @@
     },
     "nested_identifier": {
       "type": "PREC",
-      "value": 150,
+      "value": 160,
       "content": {
         "type": "SEQ",
         "members": [
@@ -2206,7 +2206,7 @@
     },
     "call": {
       "type": "PREC_LEFT",
-      "value": 160,
+      "value": 170,
       "content": {
         "type": "SEQ",
         "members": [
@@ -3170,7 +3170,7 @@
     },
     "optional_unwrap": {
       "type": "PREC_RIGHT",
-      "value": 170,
+      "value": 180,
       "content": {
         "type": "SEQ",
         "members": [
@@ -4183,7 +4183,7 @@
     },
     "structured_access_expression": {
       "type": "PREC_RIGHT",
-      "value": 0,
+      "value": 150,
       "content": {
         "type": "SEQ",
         "members": [

--- a/libs/tree-sitter-wing/test/corpus/expressions.txt
+++ b/libs/tree-sitter-wing/test/corpus/expressions.txt
@@ -596,3 +596,55 @@ let mo = 10mo;
     value: (duration
       (months
         value: (number)))))
+
+================================================================================
+Array access
+================================================================================
+
+log(x[y]);
+x[y] += 3;
+assert(x[y] == w[z]);
+
+--------------------------------------------------------------------------------
+
+(source
+  (expression_statement
+    (call
+      (reference
+        (reference_identifier))
+      (argument_list
+        (positional_argument
+          (reference
+            (structured_access_expression
+              (reference
+                (reference_identifier))
+              (reference
+                (reference_identifier))))))))
+  (variable_assignment_statement
+    (lvalue
+      (structured_access_expression
+        (reference
+          (reference_identifier))
+        (reference
+          (reference_identifier))))
+    (assignment_operator)
+    (number))
+  (expression_statement
+    (call
+      (reference
+        (reference_identifier))
+      (argument_list
+        (positional_argument
+          (binary_expression
+            (reference
+              (structured_access_expression
+                (reference
+                  (reference_identifier))
+                (reference
+                  (reference_identifier))))
+            (reference
+              (structured_access_expression
+                (reference
+                  (reference_identifier))
+                (reference
+                  (reference_identifier))))))))))

--- a/tools/hangar/__snapshots__/test_corpus/valid/indexing.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/indexing.test.w_compile_tf-aws.md
@@ -80,6 +80,7 @@ class $Root extends $stdlib.std.Resource {
     const arr = [1, 2, 3];
     $helpers.assert($helpers.eq($helpers.lookup(arr, 0), 1), "arr[0] == 1");
     $helpers.assert($helpers.eq($helpers.lookup(arr, (2 - 5)), 1), "arr[2 - 5] == 1");
+    $helpers.assert($helpers.neq($helpers.lookup(arr, 0), $helpers.lookup(arr, 1)), "arr[0] != arr[1]");
     try {
       $helpers.lookup(arr, (-5));
     }


### PR DESCRIPTION
Fixes #6276 by adding a precedence level for array access expressions. I inserted the precedence right below member access expressions, similar to JavaScript's operator precedence [here](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Operator_precedence#table).

## Checklist

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [x] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
