### PR TITLE
fix(sdk): cloud.Queue does not send messages in parallel

### DIFF
--- a/examples/tests/sdk_tests/queue/set_consumer.test.w
+++ b/examples/tests/sdk_tests/queue/set_consumer.test.w
@@ -31,3 +31,27 @@ test "function can push back to the queue" {
   q2.push("hello");
   util.waitUntil(inflight () => { return c2.peek() >= 2; });
 }
+
+let q3 = new cloud.Queue() as "q3";
+let c3 = new cloud.Counter() as "c3";
+
+q3.setConsumer(inflight (message) => {
+  util.sleep(10s);
+  c3.inc();
+});
+
+test "messages pushed to queue can be processed concurrently" {
+  let t1 = datetime.utcNow();
+  q3.push("message1");
+  q3.push("message2");
+  q3.push("message3");
+
+  util.waitUntil(inflight () => { return c3.peek() == 3; });
+
+  let t2 = datetime.utcNow();
+  let elapsed = duration.fromMilliseconds(t2.timestampMs - t1.timestampMs);
+
+  // If the messages were processed concurrently, the elapsed time should be less than 20s.
+  // Note: even though there is only one consumer, the consumer's default concurrency is more than 1.
+  assert(elapsed.seconds < 20, "Messages were likely not processed concurrently");
+}

--- a/libs/wingsdk/src/target-sim/queue.inflight.ts
+++ b/libs/wingsdk/src/target-sim/queue.inflight.ts
@@ -201,7 +201,7 @@ export class Queue
 
         // we don't use invokeAsync here because we want to wait for the function to finish
         // and requeue the messages if it fails
-        await fnClient
+        void fnClient
           .invoke(JSON.stringify({ messages: messages }))
           .then((result) => {
             if (this.dlq && result) {

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/queue/set_consumer.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/queue/set_consumer.test.w_compile_tf-aws.md
@@ -37,6 +37,16 @@
         },
         "name": "/aws/lambda/q2-SetConsumer0-c8ba098b",
         "retention_in_days": 30
+      },
+      "q3-SetConsumer0_CloudwatchLogGroup_1FE8714D": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/Default/q3-SetConsumer0/CloudwatchLogGroup",
+            "uniqueId": "q3-SetConsumer0_CloudwatchLogGroup_1FE8714D"
+          }
+        },
+        "name": "/aws/lambda/q3-SetConsumer0-c8cd013e",
+        "retention_in_days": 30
       }
     },
     "aws_dynamodb_table": {
@@ -73,6 +83,23 @@
         "billing_mode": "PAY_PER_REQUEST",
         "hash_key": "id",
         "name": "wing-counter-c2-c81701d2"
+      },
+      "c3": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/Default/c3/Default",
+            "uniqueId": "c3"
+          }
+        },
+        "attribute": [
+          {
+            "name": "id",
+            "type": "S"
+          }
+        ],
+        "billing_mode": "PAY_PER_REQUEST",
+        "hash_key": "id",
+        "name": "wing-counter-c3-c893f3c2"
       }
     },
     "aws_iam_role": {
@@ -90,6 +117,15 @@
           "metadata": {
             "path": "root/Default/Default/q2-SetConsumer0/IamRole",
             "uniqueId": "q2-SetConsumer0_IamRole_910A96B5"
+          }
+        },
+        "assume_role_policy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Action\":\"sts:AssumeRole\",\"Principal\":{\"Service\":\"lambda.amazonaws.com\"},\"Effect\":\"Allow\"}]}"
+      },
+      "q3-SetConsumer0_IamRole_2934E47C": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/Default/q3-SetConsumer0/IamRole",
+            "uniqueId": "q3-SetConsumer0_IamRole_2934E47C"
           }
         },
         "assume_role_policy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Action\":\"sts:AssumeRole\",\"Principal\":{\"Service\":\"lambda.amazonaws.com\"},\"Effect\":\"Allow\"}]}"
@@ -115,6 +151,16 @@
         },
         "policy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Action\":[\"sqs:ReceiveMessage\",\"sqs:ChangeMessageVisibility\",\"sqs:GetQueueUrl\",\"sqs:DeleteMessage\",\"sqs:GetQueueAttributes\"],\"Resource\":[\"${aws_sqs_queue.q2.arn}\"],\"Effect\":\"Allow\"},{\"Action\":[\"dynamodb:UpdateItem\"],\"Resource\":[\"${aws_dynamodb_table.c2.arn}\"],\"Effect\":\"Allow\"},{\"Action\":[\"sqs:GetQueueUrl\"],\"Resource\":[\"${aws_sqs_queue.q2.arn}\"],\"Effect\":\"Allow\"},{\"Action\":[\"sqs:SendMessage\"],\"Resource\":[\"${aws_sqs_queue.q2.arn}\"],\"Effect\":\"Allow\"}]}",
         "role": "${aws_iam_role.q2-SetConsumer0_IamRole_910A96B5.name}"
+      },
+      "q3-SetConsumer0_IamRolePolicy_D9B45CEB": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/Default/q3-SetConsumer0/IamRolePolicy",
+            "uniqueId": "q3-SetConsumer0_IamRolePolicy_D9B45CEB"
+          }
+        },
+        "policy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Action\":[\"sqs:ReceiveMessage\",\"sqs:ChangeMessageVisibility\",\"sqs:GetQueueUrl\",\"sqs:DeleteMessage\",\"sqs:GetQueueAttributes\"],\"Resource\":[\"${aws_sqs_queue.q3.arn}\"],\"Effect\":\"Allow\"},{\"Action\":[\"dynamodb:UpdateItem\"],\"Resource\":[\"${aws_dynamodb_table.c3.arn}\"],\"Effect\":\"Allow\"}]}",
+        "role": "${aws_iam_role.q3-SetConsumer0_IamRole_2934E47C.name}"
       }
     },
     "aws_iam_role_policy_attachment": {
@@ -137,6 +183,16 @@
         },
         "policy_arn": "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
         "role": "${aws_iam_role.q2-SetConsumer0_IamRole_910A96B5.name}"
+      },
+      "q3-SetConsumer0_IamRolePolicyAttachment_F54AC63B": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/Default/q3-SetConsumer0/IamRolePolicyAttachment",
+            "uniqueId": "q3-SetConsumer0_IamRolePolicyAttachment_F54AC63B"
+          }
+        },
+        "policy_arn": "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+        "role": "${aws_iam_role.q3-SetConsumer0_IamRole_2934E47C.name}"
       }
     },
     "aws_lambda_event_source_mapping": {
@@ -164,6 +220,20 @@
         "batch_size": 1,
         "event_source_arn": "${aws_sqs_queue.q2.arn}",
         "function_name": "${aws_lambda_function.q2-SetConsumer0.function_name}",
+        "function_response_types": [
+          "ReportBatchItemFailures"
+        ]
+      },
+      "q3_EventSourceMapping_8BF6F975": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/Default/q3/EventSourceMapping",
+            "uniqueId": "q3_EventSourceMapping_8BF6F975"
+          }
+        },
+        "batch_size": 1,
+        "event_source_arn": "${aws_sqs_queue.q3.arn}",
+        "function_name": "${aws_lambda_function.q3-SetConsumer0.function_name}",
         "function_response_types": [
           "ReportBatchItemFailures"
         ]
@@ -234,6 +304,38 @@
           "security_group_ids": [],
           "subnet_ids": []
         }
+      },
+      "q3-SetConsumer0": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/Default/q3-SetConsumer0/Default",
+            "uniqueId": "q3-SetConsumer0"
+          }
+        },
+        "architectures": [
+          "arm64"
+        ],
+        "environment": {
+          "variables": {
+            "DYNAMODB_TABLE_NAME_9b30b36d": "${aws_dynamodb_table.c3.name}",
+            "NODE_OPTIONS": "--enable-source-maps",
+            "WING_FUNCTION_NAME": "q3-SetConsumer0-c8cd013e",
+            "WING_TARGET": "tf-aws"
+          }
+        },
+        "function_name": "q3-SetConsumer0-c8cd013e",
+        "handler": "index.handler",
+        "memory_size": 1024,
+        "publish": true,
+        "role": "${aws_iam_role.q3-SetConsumer0_IamRole_2934E47C.arn}",
+        "runtime": "nodejs20.x",
+        "s3_bucket": "${aws_s3_bucket.Code.bucket}",
+        "s3_key": "${aws_s3_object.q3-SetConsumer0_S3Object_69810AFF.key}",
+        "timeout": "${aws_sqs_queue.q3.visibility_timeout_seconds}",
+        "vpc_config": {
+          "security_group_ids": [],
+          "subnet_ids": []
+        }
       }
     },
     "aws_s3_bucket": {
@@ -269,6 +371,17 @@
         "bucket": "${aws_s3_bucket.Code.bucket}",
         "key": "<ASSET_KEY>",
         "source": "<ASSET_SOURCE>"
+      },
+      "q3-SetConsumer0_S3Object_69810AFF": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/Default/q3-SetConsumer0/S3Object",
+            "uniqueId": "q3-SetConsumer0_S3Object_69810AFF"
+          }
+        },
+        "bucket": "${aws_s3_bucket.Code.bucket}",
+        "key": "<ASSET_KEY>",
+        "source": "<ASSET_SOURCE>"
       }
     },
     "aws_sqs_queue": {
@@ -292,6 +405,17 @@
         },
         "message_retention_seconds": 3600,
         "name": "q2-c8aa6380",
+        "visibility_timeout_seconds": 30
+      },
+      "q3": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/Default/q3/Default",
+            "uniqueId": "q3"
+          }
+        },
+        "message_retention_seconds": 3600,
+        "name": "q3-c8ed13d1",
         "visibility_timeout_seconds": 30
       }
     }

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/queue/set_consumer.test.w_test_sim.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/queue/set_consumer.test.w_test_sim.md
@@ -2,10 +2,11 @@
 
 ## stdout.log
 ```log
-pass ─ set_consumer.test.wsim » root/env0/test:setConsumer                        
-pass ─ set_consumer.test.wsim » root/env1/test:function can push back to the queue
+pass ─ set_consumer.test.wsim » root/env0/test:setConsumer                                           
+pass ─ set_consumer.test.wsim » root/env1/test:function can push back to the queue                   
+pass ─ set_consumer.test.wsim » root/env2/test:messages pushed to queue can be processed concurrently
 
-Tests 2 passed (2)
+Tests 3 passed (3)
 Snapshots 1 skipped
 Test Files 1 passed (1)
 Duration <DURATION>


### PR DESCRIPTION
Fixes a regression from #6060 that prevented messages from being processed in parallel (we noticed this bug when it caused test failures in one of our winglibs: https://github.com/winglang/winglibs/actions/runs/8767429765/job/24060674878).

I confirmed the updated test (set_consumer.test.w) passes when ran on my AWS account using the `tf-aws` target.

## Checklist

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [x] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
