### PR TITLE
fix(console): `option+cmd+i` command leaves the map in drag mode

### DIFF
--- a/apps/wing-console/console/ui/src/ui/zoom-pane.tsx
+++ b/apps/wing-console/console/ui/src/ui/zoom-pane.tsx
@@ -1,7 +1,6 @@
 import { Button, useTheme } from "@wingconsole/design-system";
 import classNames from "classnames";
 import {
-  MouseEventHandler,
   createContext,
   forwardRef,
   useCallback,
@@ -14,7 +13,7 @@ import {
 } from "react";
 import type { DetailedHTMLProps, HTMLAttributes } from "react";
 import type { ReactNode } from "react";
-import { useEvent, useKeyPress, useKeyPressEvent } from "react-use";
+import { useEvent } from "react-use";
 
 import { MapControls } from "./map-controls.js";
 


### PR DESCRIPTION
When a user presses `option+cmd+i` to open the devtools, a spacebar keypress event is fired (on Chrome, at least). This unexpected keypress event leaves the map in drag mode and nodes can't be clicked until the spacebar is pressed again.

This PR checks the `event.altKey` property to conditionally ignore this unexpected keypress event.
