### PR TITLE
feat(sdk): support mounting sim.Container to state directories

### DIFF
--- a/libs/wingsdk/src/shared/misc.ts
+++ b/libs/wingsdk/src/shared/misc.ts
@@ -1,8 +1,9 @@
-import { ExecOptions, exec } from "child_process";
+import { ExecOptions, ExecFileOptions, exec, execFile } from "child_process";
 import { readFileSync } from "fs";
 import { promisify } from "util";
 
 const execPromise = promisify(exec);
+const execFilePromise = promisify(execFile);
 
 export function readJsonSync(file: string) {
   return JSON.parse(readFileSync(file, "utf-8"));
@@ -27,6 +28,19 @@ export function normalPath(path: string) {
  * Just a helpful wrapper around `execFile` that returns a promise.
  */
 export async function runCommand(
+  cmd: string,
+  args: string[],
+  options?: ExecFileOptions
+): Promise<any> {
+  const { stdout } = await execFilePromise(cmd, args, options);
+  return stdout;
+}
+
+/**
+ * Just a helpful wrapper around `exec` that returns a promise.
+ * This will run commands through the shell, while `runCommand` doesn't.
+ */
+export async function shell(
   cmd: string,
   args: string[],
   options?: ExecOptions

--- a/libs/wingsdk/src/shared/misc.ts
+++ b/libs/wingsdk/src/shared/misc.ts
@@ -1,8 +1,8 @@
-import { ExecFileOptions, execFile } from "child_process";
+import { ExecOptions, exec } from "child_process";
 import { readFileSync } from "fs";
 import { promisify } from "util";
 
-const execFilePromise = promisify(execFile);
+const execPromise = promisify(exec);
 
 export function readJsonSync(file: string) {
   return JSON.parse(readFileSync(file, "utf-8"));
@@ -29,9 +29,9 @@ export function normalPath(path: string) {
 export async function runCommand(
   cmd: string,
   args: string[],
-  options?: ExecFileOptions
+  options?: ExecOptions
 ): Promise<any> {
-  const { stdout } = await execFilePromise(cmd, args, options);
+  const { stdout } = await execPromise(cmd + " " + args.join(" "), options);
   return stdout;
 }
 

--- a/libs/wingsdk/src/target-sim/container.inflight.ts
+++ b/libs/wingsdk/src/target-sim/container.inflight.ts
@@ -1,6 +1,6 @@
 import { IContainerClient, HOST_PORT_ATTR } from "./container";
 import { ContainerAttributes, ContainerSchema } from "./schema-resources";
-import { isPath, runCommand } from "../shared/misc";
+import { isPath, runCommand, shell } from "../shared/misc";
 import {
   ISimulatorContext,
   ISimulatorResourceInstance,
@@ -91,7 +91,7 @@ export class Container implements IContainerClient, ISimulatorResourceInstance {
     this.log(`starting container from image ${this.imageTag}`);
     this.log(`docker ${dockerRun.join(" ")}`);
 
-    await runCommand("docker", dockerRun, {
+    await shell("docker", dockerRun, {
       env: {
         ...process.env,
         [WING_STATE_DIR_ENV]: this.context.statedir,

--- a/libs/wingsdk/src/target-sim/container.inflight.ts
+++ b/libs/wingsdk/src/target-sim/container.inflight.ts
@@ -9,6 +9,8 @@ import {
 import { Duration, TraceType } from "../std";
 import { Util } from "../util";
 
+export const WING_STATE_DIR_ENV = "WING_STATE_DIR";
+
 export class Container implements IContainerClient, ISimulatorResourceInstance {
   private readonly imageTag: string;
   private readonly containerName: string;
@@ -89,7 +91,12 @@ export class Container implements IContainerClient, ISimulatorResourceInstance {
     this.log(`starting container from image ${this.imageTag}`);
     this.log(`docker ${dockerRun.join(" ")}`);
 
-    await runCommand("docker", dockerRun);
+    await runCommand("docker", dockerRun, {
+      env: {
+        ...process.env,
+        [WING_STATE_DIR_ENV]: this.context.statedir,
+      },
+    });
 
     this.log(`containerName=${this.containerName}`);
 

--- a/libs/wingsdk/src/target-sim/container.md
+++ b/libs/wingsdk/src/target-sim/container.md
@@ -44,6 +44,23 @@ new sim.Container(
 );
 ```
 
+### Retaining state
+
+When the Wing Console is closed, all containers are stopped and removed.
+To retain the state of a container across console restarts, you can mount a volume
+to a subdirectory of the resource's simulator state directory, which is available through `$WING_STATE_DIR`:
+
+```js
+new sim.Container(
+  name: "my-service",
+  image: "./my-service",
+  containerPort: 8080,
+  volumes: ["$WING_STATE_DIR/volume1:/var/data"],
+);
+```
+
+`$WING_STATE_DIR` is a directory that is unique to that `sim.Container` instance.
+
 ## API
 
 * `name` - a name for the container.

--- a/libs/wingsdk/test/target-sim/my-docker-image.mounted-volume/Dockerfile
+++ b/libs/wingsdk/test/target-sim/my-docker-image.mounted-volume/Dockerfile
@@ -1,0 +1,4 @@
+FROM node:20.8.0-alpine
+EXPOSE 3000
+ADD index.js /app/index.js
+ENTRYPOINT [ "/app/index.js" ]

--- a/libs/wingsdk/test/target-sim/my-docker-image.mounted-volume/index.js
+++ b/libs/wingsdk/test/target-sim/my-docker-image.mounted-volume/index.js
@@ -1,0 +1,18 @@
+#!/usr/bin/env node
+const http = require("http");
+const fs = require("fs");
+
+process.on("SIGINT", () => {
+  console.info("Interrupted");
+  process.exit(0);
+});
+
+const server = http.createServer((req, res) => {
+  console.log(`request received: ${req.method} ${req.url}`);
+  res.end(fs.readdirSync("/tmp").join("\n"));
+});
+
+fs.writeFileSync("/tmp/hello.txt", "Hello, World!", "utf8");
+
+console.log("listening on port 3000");
+server.listen(3000);


### PR DESCRIPTION
To support retaining the state of `sim.Container` across separate Wing Console sessions, this PR adds the capability to reference the resource's state directory through the `WING_STATE_DIR` environment variable. This will be used by the `postgres` winglib to persist state through a mounted volume:

```js
let container = new sim.Container(
  name: "postgres",
  image: image,
  env: {
    POSTGRES_PASSWORD: "password"
  },
  volumes: ["$WING_STATE_DIR/pgdata:/var/lib/postgresql/data"],
  containerPort: 5432
);
```

Related to #6284

## Checklist

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [x] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
