### PR TITLE
fix(console): playwright install fails

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -129,7 +129,8 @@ jobs:
 
       - name: Install Playwright
         working-directory: apps/wing-console/console/app
-        run: pnpm exec playwright install --with-deps
+        run: sudo rm /etc/apt/sources.list.d/microsoft-prod.list
+          pnpm exec playwright install --with-deps
 
       - name: Test
         run: pnpm test:ci

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -129,7 +129,7 @@ jobs:
 
       - name: Install Playwright
         working-directory: apps/wing-console/console/app
-        run: sudo rm /etc/apt/sources.list.d/microsoft-prod.list
+        run: sudo rm /etc/apt/sources.list.d/microsoft-prod.list &&
           pnpm exec playwright install --with-deps
 
       - name: Test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -129,7 +129,8 @@ jobs:
 
       - name: Install Playwright
         working-directory: apps/wing-console/console/app
-        run: sudo rm /etc/apt/sources.list.d/microsoft-prod.list &&
+        run: |
+          sudo rm /etc/apt/sources.list.d/microsoft-prod.list
           pnpm exec playwright install --with-deps
 
       - name: Test


### PR DESCRIPTION
Running `playwright install --with-deps` fails because it executes `apt update` in the background, which is failing on the `latest ubuntu-22.04` image release.

Related to [Issue #9733](https://github.com/actions/runner-images/issues/9733).

Thanks to the temporary fix provided [here](https://github.com/actions/runner-images/issues/9733#issuecomment-2074655660) 🙌.