### PR TITLE
feat(docs): note omitting arguments in language reference

### DIFF
--- a/docs/docs/03-language-reference.md
+++ b/docs/docs/03-language-reference.md
@@ -952,6 +952,20 @@ f(myRequired: "hello");
 f(myOptional: 12, myRequired: "dang");
 ```
 
+A method implementation can omit any number of arguments from the end of an argument list when implementing an interface method. This is useful when you want to implement an interface method but don't need all of its arguments.
+
+```TS
+interface MyInterface {
+  myMethod(a: num, b: str, c: bool): void;
+}
+
+class MyClass impl MyInterface {
+  myMethod(a: num, b: str): void {
+    // This is a valid implementation of MyInterface.myMethod
+  }
+}
+```
+
 ##### 1.7.1.5 Function return types
 
 If a function returns an optional type, use the `return nil;` statement to indicate that the value


### PR DESCRIPTION
Add a note about a language feature that's been working for a while but we've decided to formally support.

Related to #4916

## Checklist

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [ ] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
