### PR TITLE
fix(compiler): can't instantiate preflight classes in static mehtods defined in non-enty files

### DIFF
--- a/examples/tests/valid/new_in_static.test.w
+++ b/examples/tests/valid/new_in_static.test.w
@@ -1,6 +1,7 @@
 bring cloud;
 bring "constructs" as c;
 bring "jsii-fixture" as jsii_fixture;
+bring "./new_in_static_lib.w" as new_in_static_lib;
 
 class MyClass {
   pub static createBucket(scope: c.IConstruct): cloud.Bucket {
@@ -80,3 +81,8 @@ class Foo extends FooParent {
   }
 }
 let f = new Foo();
+
+// Create a preflight class from a static method defined in a lib
+// see: https://github.com/winglang/wing/issues/6188
+let lib_f = new_in_static_lib.LibClass.createFoo("lib-foo");
+

--- a/examples/tests/valid/new_in_static_lib.w
+++ b/examples/tests/valid/new_in_static_lib.w
@@ -1,0 +1,7 @@
+pub class Foo {}
+
+pub class LibClass {
+  pub static createFoo(id: str): Foo {
+    return new Foo() as id;
+  }
+}

--- a/libs/wingc/src/type_check.rs
+++ b/libs/wingc/src/type_check.rs
@@ -2727,28 +2727,6 @@ impl<'a> TypeChecker<'a> {
 					self.spanned_error(exp, format!("Cannot instantiate abstract class \"{}\"", class.name));
 				}
 
-				// error if we are trying to instantiate a preflight in a static method
-				// without an explicit scope (there is no "this" to use as the scope)
-				if class.phase == Phase::Preflight && obj_scope.is_none() {
-					// check if there is a "this" symbol in the current environment
-					let has_this = env.lookup(&"this".into(), Some(self.ctx.current_stmt_idx())).is_some();
-					// if we have a "this", it means we can use it as a default scope, so we are fine
-					if !has_this {
-						// we don't have a "this", so we need to check if we are in a static method
-						// because the entrypoint scope doesn't have a "this" but it is not static
-						let is_static = self.ctx().current_function().map(|f| f.is_static);
-						if let Some(true) = is_static {
-							self.spanned_error(
-								exp,
-								format!(
-									"Cannot instantiate preflight class \"{}\" in a static method without an explicit scope",
-									class.name
-								),
-							);
-						}
-					}
-				}
-
 				if class.phase == Phase::Independent || env.phase == class.phase {
 					(&class.env, &class.name)
 				} else {

--- a/tools/hangar/__snapshots__/test_corpus/valid/new_in_static.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/new_in_static.test.w_compile_tf-aws.md
@@ -1,6 +1,6 @@
 # [new_in_static.test.w](../../../../../examples/tests/valid/new_in_static.test.w) | compile | tf-aws
 
-## inflight.$Closure1-1.cjs
+## inflight.$Closure1-2.cjs
 ```cjs
 "use strict";
 const $helpers = require("@winglang/sdk/lib/helpers");
@@ -18,10 +18,24 @@ module.exports = function({ $bucket, $bucket3 }) {
   }
   return $Closure1;
 }
-//# sourceMappingURL=inflight.$Closure1-1.cjs.map
+//# sourceMappingURL=inflight.$Closure1-2.cjs.map
 ```
 
 ## inflight.Foo-1.cjs
+```cjs
+"use strict";
+const $helpers = require("@winglang/sdk/lib/helpers");
+module.exports = function({  }) {
+  class Foo {
+    constructor({  }) {
+    }
+  }
+  return Foo;
+}
+//# sourceMappingURL=inflight.Foo-1.cjs.map
+```
+
+## inflight.Foo-2.cjs
 ```cjs
 "use strict";
 const $helpers = require("@winglang/sdk/lib/helpers");
@@ -33,10 +47,10 @@ module.exports = function({ $FooParent }) {
   }
   return Foo;
 }
-//# sourceMappingURL=inflight.Foo-1.cjs.map
+//# sourceMappingURL=inflight.Foo-2.cjs.map
 ```
 
-## inflight.FooParent-1.cjs
+## inflight.FooParent-2.cjs
 ```cjs
 "use strict";
 const $helpers = require("@winglang/sdk/lib/helpers");
@@ -47,10 +61,24 @@ module.exports = function({  }) {
   }
   return FooParent;
 }
-//# sourceMappingURL=inflight.FooParent-1.cjs.map
+//# sourceMappingURL=inflight.FooParent-2.cjs.map
 ```
 
-## inflight.MyClass-1.cjs
+## inflight.LibClass-1.cjs
+```cjs
+"use strict";
+const $helpers = require("@winglang/sdk/lib/helpers");
+module.exports = function({  }) {
+  class LibClass {
+    constructor({  }) {
+    }
+  }
+  return LibClass;
+}
+//# sourceMappingURL=inflight.LibClass-1.cjs.map
+```
+
+## inflight.MyClass-2.cjs
 ```cjs
 "use strict";
 const $helpers = require("@winglang/sdk/lib/helpers");
@@ -61,7 +89,7 @@ module.exports = function({  }) {
   }
   return MyClass;
 }
-//# sourceMappingURL=inflight.MyClass-1.cjs.map
+//# sourceMappingURL=inflight.MyClass-2.cjs.map
 ```
 
 ## main.tf.json
@@ -150,6 +178,7 @@ const $extern = $helpers.createExternRequire(__dirname);
 const cloud = $stdlib.cloud;
 const c = require("constructs");
 const jsii_fixture = require("jsii-fixture");
+const new_in_static_lib = require("./preflight.newinstaticlib-1.cjs");
 class $Root extends $stdlib.std.Resource {
   constructor($scope, $id) {
     super($scope, $id);
@@ -178,7 +207,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("${$helpers.normalPath(__dirname)}/inflight.MyClass-1.cjs")({
+          require("${$helpers.normalPath(__dirname)}/inflight.MyClass-2.cjs")({
           })
         `;
       }
@@ -208,7 +237,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("${$helpers.normalPath(__dirname)}/inflight.$Closure1-1.cjs")({
+          require("${$helpers.normalPath(__dirname)}/inflight.$Closure1-2.cjs")({
             $bucket: ${$stdlib.core.liftObject(bucket)},
             $bucket3: ${$stdlib.core.liftObject(bucket3)},
           })
@@ -245,7 +274,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("${$helpers.normalPath(__dirname)}/inflight.FooParent-1.cjs")({
+          require("${$helpers.normalPath(__dirname)}/inflight.FooParent-2.cjs")({
           })
         `;
       }
@@ -274,7 +303,7 @@ class $Root extends $stdlib.std.Resource {
       }
       static _toInflightType() {
         return `
-          require("${$helpers.normalPath(__dirname)}/inflight.Foo-1.cjs")({
+          require("${$helpers.normalPath(__dirname)}/inflight.Foo-2.cjs")({
             $FooParent: ${$stdlib.core.liftObject(FooParent)},
           })
         `;
@@ -314,11 +343,82 @@ class $Root extends $stdlib.std.Resource {
     $helpers.assert($helpers.eq((jsii_fixture.JsiiClass.staticMethod("foo")), "Got foo"), "jsii_fixture.JsiiClass.staticMethod(\"foo\") == \"Got foo\"");
     this.node.root.new("@winglang/sdk.std.Test", std.Test, this, "test:play with buckets", new $Closure1(this, "$Closure1"));
     const f = new Foo(this, "Foo");
+    const lib_f = (new_in_static_lib.LibClass.createFoo(this, "lib-foo"));
   }
 }
 const $PlatformManager = new $stdlib.platform.PlatformManager({platformPaths: $platforms});
 const $APP = $PlatformManager.createApp({ outdir: $outdir, name: "new_in_static.test", rootConstruct: $Root, isTestEnvironment: $wing_is_test, entrypointDir: process.env['WING_SOURCE_DIR'], rootId: process.env['WING_ROOT_ID'] });
 $APP.synth();
 //# sourceMappingURL=preflight.cjs.map
+```
+
+## preflight.newinstaticlib-1.cjs
+```cjs
+"use strict";
+const $stdlib = require('@winglang/sdk');
+const std = $stdlib.std;
+const $helpers = $stdlib.helpers;
+const $extern = $helpers.createExternRequire(__dirname);
+class Foo extends $stdlib.std.Resource {
+  constructor($scope, $id, ) {
+    super($scope, $id);
+  }
+  static _toInflightType() {
+    return `
+      require("${$helpers.normalPath(__dirname)}/inflight.Foo-1.cjs")({
+      })
+    `;
+  }
+  _toInflight() {
+    return `
+      (await (async () => {
+        const FooClient = ${Foo._toInflightType()};
+        const client = new FooClient({
+        });
+        if (client.$inflight_init) { await client.$inflight_init(); }
+        return client;
+      })())
+    `;
+  }
+  get _liftMap() {
+    return ({
+      "$inflight_init": [
+      ],
+    });
+  }
+}
+class LibClass extends $stdlib.std.Resource {
+  constructor($scope, $id, ) {
+    super($scope, $id);
+  }
+  static createFoo($scope, id) {
+    return new Foo($scope, id);
+  }
+  static _toInflightType() {
+    return `
+      require("${$helpers.normalPath(__dirname)}/inflight.LibClass-1.cjs")({
+      })
+    `;
+  }
+  _toInflight() {
+    return `
+      (await (async () => {
+        const LibClassClient = ${LibClass._toInflightType()};
+        const client = new LibClassClient({
+        });
+        if (client.$inflight_init) { await client.$inflight_init(); }
+        return client;
+      })())
+    `;
+  }
+  get _liftMap() {
+    return ({
+      "$inflight_init": [
+      ],
+    });
+  }
+}
+module.exports = { Foo, LibClass };
+//# sourceMappingURL=preflight.newinstaticlib-1.cjs.map
 ```
 

--- a/tools/hangar/__snapshots__/test_corpus/valid/new_in_static_lib.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/new_in_static_lib.w_compile_tf-aws.md
@@ -1,0 +1,100 @@
+# [new_in_static_lib.w](../../../../../examples/tests/valid/new_in_static_lib.w) | compile | tf-aws
+
+## inflight.Foo-1.cjs
+```cjs
+"use strict";
+const $helpers = require("@winglang/sdk/lib/helpers");
+module.exports = function({  }) {
+  class Foo {
+    constructor({  }) {
+    }
+  }
+  return Foo;
+}
+//# sourceMappingURL=inflight.Foo-1.cjs.map
+```
+
+## inflight.LibClass-1.cjs
+```cjs
+"use strict";
+const $helpers = require("@winglang/sdk/lib/helpers");
+module.exports = function({  }) {
+  class LibClass {
+    constructor({  }) {
+    }
+  }
+  return LibClass;
+}
+//# sourceMappingURL=inflight.LibClass-1.cjs.map
+```
+
+## preflight.cjs
+```cjs
+"use strict";
+const $stdlib = require('@winglang/sdk');
+const std = $stdlib.std;
+const $helpers = $stdlib.helpers;
+const $extern = $helpers.createExternRequire(__dirname);
+class Foo extends $stdlib.std.Resource {
+  constructor($scope, $id, ) {
+    super($scope, $id);
+  }
+  static _toInflightType() {
+    return `
+      require("${$helpers.normalPath(__dirname)}/inflight.Foo-1.cjs")({
+      })
+    `;
+  }
+  _toInflight() {
+    return `
+      (await (async () => {
+        const FooClient = ${Foo._toInflightType()};
+        const client = new FooClient({
+        });
+        if (client.$inflight_init) { await client.$inflight_init(); }
+        return client;
+      })())
+    `;
+  }
+  get _liftMap() {
+    return ({
+      "$inflight_init": [
+      ],
+    });
+  }
+}
+class LibClass extends $stdlib.std.Resource {
+  constructor($scope, $id, ) {
+    super($scope, $id);
+  }
+  static createFoo($scope, id) {
+    return new Foo($scope, id);
+  }
+  static _toInflightType() {
+    return `
+      require("${$helpers.normalPath(__dirname)}/inflight.LibClass-1.cjs")({
+      })
+    `;
+  }
+  _toInflight() {
+    return `
+      (await (async () => {
+        const LibClassClient = ${LibClass._toInflightType()};
+        const client = new LibClassClient({
+        });
+        if (client.$inflight_init) { await client.$inflight_init(); }
+        return client;
+      })())
+    `;
+  }
+  get _liftMap() {
+    return ({
+      "$inflight_init": [
+      ],
+    });
+  }
+}
+module.exports = { Foo, LibClass };
+//# sourceMappingURL=preflight.cjs.map
+```
+


### PR DESCRIPTION
Fixes #6188
The fix removes a check that was in place to prevent instantiating such classes. The test itself is buggy because of #6323, so it only worked on non-entry point files. The test can be safely removed since we now allow instantiating preflight classes in static methods (see #6040).

## Checklist

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [x] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
