### PR TITLE
fix(docs): fixing name of platform

### DIFF
--- a/docs/docs/055-platforms/tf-aws.md
+++ b/docs/docs/055-platforms/tf-aws.md
@@ -6,7 +6,7 @@ description: Terraform/AWS platform
 keywords: [Wing reference, Wing language, language, Wing language spec, Wing programming language, cli, terraform, aws, tf-aws, tfaws, amazon web services, platform]
 ---
 
-The `tf-gcp` [platform](../02-concepts/03-platforms.md) compiles your program for Terraform and run on AWS.
+The `tf-aws` [platform](../02-concepts/03-platforms.md) compiles your program for Terraform and run on AWS.
 
 ## Usage
 


### PR DESCRIPTION
Fixes the name of the platform being referenced, updates from `tf-gcp` to `tf-aws`

## Checklist

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [ ] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
