### PR TITLE
feat(platforms): `tf-aws` implicit platform now has 2 private subnets

### DIFF
--- a/docs/docs/055-platforms/tf-aws.md
+++ b/docs/docs/055-platforms/tf-aws.md
@@ -36,6 +36,15 @@ private_subnet_ids = ["subnet-123xyz"]
 public_subnet_ids = ["subnet-123xyz"]
 ```
 
+### Implicit VPC
+
+The `tf-aws` platform can create a new VPC for you if needed. The VPC is pretty standard and includes:
+
+- A VPC with CIDR block `10.0.0.0/16`
+- An Internet Gateway
+- A NAT Gateway
+- A single public subnet with CIDR block `10.0.0.0/24`
+- Two private subnets with CIDR blocks `10.0.4.0/22` and `10.0.8.0/22` (both have Egress via NAT Gateway)
 
 ## Output
 

--- a/libs/wingsdk/src/target-tf-aws/app.ts
+++ b/libs/wingsdk/src/target-tf-aws/app.ts
@@ -253,6 +253,15 @@ export class App extends CdktfApp {
       },
     });
 
+    const privateSubnet2 = new Subnet(this, "PrivateSubnet2", {
+      vpcId: this._vpc.id,
+      cidrBlock: "10.0.8.0/22", // 10.0.8.0 - 10.0.11.255
+      availabilityZone: `${this.region}b`,
+      tags: {
+        Name: `${identifier}-private-subnet-2`,
+      },
+    });
+
     // Create the internet gateway
     const internetGateway = new InternetGateway(this, "InternetGateway", {
       vpcId: this._vpc.id,
@@ -300,6 +309,20 @@ export class App extends CdktfApp {
       },
     });
 
+    const privateRouteTable2 = new RouteTable(this, "PrivateRouteTable2", {
+      vpcId: this._vpc.id,
+      route: [
+        {
+          // This will route all traffic to the NAT gateway
+          cidrBlock: "0.0.0.0/0",
+          natGatewayId: nat.id,
+        },
+      ],
+      tags: {
+        Name: `${identifier}-private-route-table-2`,
+      },
+    });
+
     // Associate route tables with subnets
     new RouteTableAssociation(this, "PublicRouteTableAssociation", {
       subnetId: publicSubnet.id,
@@ -311,8 +334,14 @@ export class App extends CdktfApp {
       routeTableId: privateRouteTable.id,
     });
 
+    new RouteTableAssociation(this, "PrivateRouteTableAssociation2", {
+      subnetId: privateSubnet2.id,
+      routeTableId: privateRouteTable2.id,
+    });
+
     this.subnets.public.push(publicSubnet);
     this.subnets.private.push(privateSubnet);
+    this.subnets.private.push(privateSubnet2);
     return this._vpc;
   }
 }

--- a/libs/wingsdk/test/target-tf-aws/__snapshots__/api.test.ts.snap
+++ b/libs/wingsdk/test/target-tf-aws/__snapshots__/api.test.ts.snap
@@ -234,6 +234,29 @@ exports[`api will be private when vpc_api_gateway is true 1`] = `
         },
         "vpc_id": "\${aws_vpc.VPC.id}",
       },
+      "PrivateRouteTable2": {
+        "route": [
+          {
+            "carrier_gateway_id": null,
+            "cidr_block": "0.0.0.0/0",
+            "core_network_arn": null,
+            "destination_prefix_list_id": null,
+            "egress_only_gateway_id": null,
+            "gateway_id": null,
+            "ipv6_cidr_block": null,
+            "local_gateway_id": null,
+            "nat_gateway_id": "\${aws_nat_gateway.NATGateway.id}",
+            "network_interface_id": null,
+            "transit_gateway_id": null,
+            "vpc_endpoint_id": null,
+            "vpc_peering_connection_id": null,
+          },
+        ],
+        "tags": {
+          "Name": "Default-c82bf964-private-route-table-2",
+        },
+        "vpc_id": "\${aws_vpc.VPC.id}",
+      },
       "PublicRouteTable": {
         "route": [
           {
@@ -262,6 +285,10 @@ exports[`api will be private when vpc_api_gateway is true 1`] = `
       "PrivateRouteTableAssociation": {
         "route_table_id": "\${aws_route_table.PrivateRouteTable.id}",
         "subnet_id": "\${aws_subnet.PrivateSubnet.id}",
+      },
+      "PrivateRouteTableAssociation2": {
+        "route_table_id": "\${aws_route_table.PrivateRouteTable2.id}",
+        "subnet_id": "\${aws_subnet.PrivateSubnet2.id}",
       },
       "PublicRouteTableAssociation": {
         "route_table_id": "\${aws_route_table.PublicRouteTable.id}",
@@ -297,6 +324,14 @@ exports[`api will be private when vpc_api_gateway is true 1`] = `
         },
         "vpc_id": "\${aws_vpc.VPC.id}",
       },
+      "PrivateSubnet2": {
+        "availability_zone": "\${data.aws_region.Region.name}b",
+        "cidr_block": "10.0.8.0/22",
+        "tags": {
+          "Name": "Default-c82bf964-private-subnet-2",
+        },
+        "vpc_id": "\${aws_vpc.VPC.id}",
+      },
       "PublicSubnet": {
         "availability_zone": "\${data.aws_region.Region.name}a",
         "cidr_block": "10.0.0.0/24",
@@ -325,6 +360,7 @@ exports[`api will be private when vpc_api_gateway is true 1`] = `
         "service_name": "\${data.aws_vpc_endpoint_service.Api_api_apiServiceLookup_C62CF75C.service_name}",
         "subnet_ids": [
           "\${aws_subnet.PrivateSubnet.id}",
+          "\${aws_subnet.PrivateSubnet2.id}",
         ],
         "vpc_endpoint_type": "Interface",
         "vpc_id": "\${aws_vpc.VPC.id}",

--- a/libs/wingsdk/test/target-tf-aws/__snapshots__/function.test.ts.snap
+++ b/libs/wingsdk/test/target-tf-aws/__snapshots__/function.test.ts.snap
@@ -1498,6 +1498,7 @@ exports[`function will be behind a vpc when vpc_lambda is set to true 1`] = `
           ],
           "subnet_ids": [
             "\${aws_subnet.PrivateSubnet.id}",
+            "\${aws_subnet.PrivateSubnet2.id}",
           ],
         },
       },
@@ -1535,6 +1536,29 @@ exports[`function will be behind a vpc when vpc_lambda is set to true 1`] = `
         },
         "vpc_id": "\${aws_vpc.VPC.id}",
       },
+      "PrivateRouteTable2": {
+        "route": [
+          {
+            "carrier_gateway_id": null,
+            "cidr_block": "0.0.0.0/0",
+            "core_network_arn": null,
+            "destination_prefix_list_id": null,
+            "egress_only_gateway_id": null,
+            "gateway_id": null,
+            "ipv6_cidr_block": null,
+            "local_gateway_id": null,
+            "nat_gateway_id": "\${aws_nat_gateway.NATGateway.id}",
+            "network_interface_id": null,
+            "transit_gateway_id": null,
+            "vpc_endpoint_id": null,
+            "vpc_peering_connection_id": null,
+          },
+        ],
+        "tags": {
+          "Name": "Default-c82bf964-private-route-table-2",
+        },
+        "vpc_id": "\${aws_vpc.VPC.id}",
+      },
       "PublicRouteTable": {
         "route": [
           {
@@ -1563,6 +1587,10 @@ exports[`function will be behind a vpc when vpc_lambda is set to true 1`] = `
       "PrivateRouteTableAssociation": {
         "route_table_id": "\${aws_route_table.PrivateRouteTable.id}",
         "subnet_id": "\${aws_subnet.PrivateSubnet.id}",
+      },
+      "PrivateRouteTableAssociation2": {
+        "route_table_id": "\${aws_route_table.PrivateRouteTable2.id}",
+        "subnet_id": "\${aws_subnet.PrivateSubnet2.id}",
       },
       "PublicRouteTableAssociation": {
         "route_table_id": "\${aws_route_table.PublicRouteTable.id}",
@@ -1607,6 +1635,14 @@ exports[`function will be behind a vpc when vpc_lambda is set to true 1`] = `
         "cidr_block": "10.0.4.0/22",
         "tags": {
           "Name": "Default-c82bf964-private-subnet-1",
+        },
+        "vpc_id": "\${aws_vpc.VPC.id}",
+      },
+      "PrivateSubnet2": {
+        "availability_zone": "\${data.aws_region.Region.name}b",
+        "cidr_block": "10.0.8.0/22",
+        "tags": {
+          "Name": "Default-c82bf964-private-subnet-2",
         },
         "vpc_id": "\${aws_vpc.VPC.id}",
       },

--- a/libs/wingsdk/test/target-tf-aws/__snapshots__/redis.test.ts.snap
+++ b/libs/wingsdk/test/target-tf-aws/__snapshots__/redis.test.ts.snap
@@ -21,7 +21,8 @@ exports[`When creating a Redis resource > should create an elasticache cluster a
         "num_cache_nodes": 1,
         "parameter_group_name": "default.redis6.x",
         "security_group_ids": [
-          "\${aws_security_group.Redis_KEN15securityGroup_9FF06889.id}",
+          "\${aws_security_group.Redis_KEN21securityGroup_139152DE.id}",
+          "\${aws_security_group.Redis_KEN24securityGroup_6EFFC29B.id}",
         ],
         "subnet_group_name": "\${aws_elasticache_subnet_group.Redis_RedisSubnetGroup_E7D796E2.name}",
       },
@@ -31,6 +32,7 @@ exports[`When creating a Redis resource > should create an elasticache cluster a
         "name": "redis-c8cdb969-subnetGroup",
         "subnet_ids": [
           "\${aws_subnet.PrivateSubnet.id}",
+          "\${aws_subnet.PrivateSubnet2.id}",
         ],
       },
     },
@@ -75,6 +77,29 @@ exports[`When creating a Redis resource > should create an elasticache cluster a
         },
         "vpc_id": "\${aws_vpc.VPC.id}",
       },
+      "PrivateRouteTable2": {
+        "route": [
+          {
+            "carrier_gateway_id": null,
+            "cidr_block": "0.0.0.0/0",
+            "core_network_arn": null,
+            "destination_prefix_list_id": null,
+            "egress_only_gateway_id": null,
+            "gateway_id": null,
+            "ipv6_cidr_block": null,
+            "local_gateway_id": null,
+            "nat_gateway_id": "\${aws_nat_gateway.NATGateway.id}",
+            "network_interface_id": null,
+            "transit_gateway_id": null,
+            "vpc_endpoint_id": null,
+            "vpc_peering_connection_id": null,
+          },
+        ],
+        "tags": {
+          "Name": "Default-c82bf964-private-route-table-2",
+        },
+        "vpc_id": "\${aws_vpc.VPC.id}",
+      },
       "PublicRouteTable": {
         "route": [
           {
@@ -104,13 +129,17 @@ exports[`When creating a Redis resource > should create an elasticache cluster a
         "route_table_id": "\${aws_route_table.PrivateRouteTable.id}",
         "subnet_id": "\${aws_subnet.PrivateSubnet.id}",
       },
+      "PrivateRouteTableAssociation2": {
+        "route_table_id": "\${aws_route_table.PrivateRouteTable2.id}",
+        "subnet_id": "\${aws_subnet.PrivateSubnet2.id}",
+      },
       "PublicRouteTableAssociation": {
         "route_table_id": "\${aws_route_table.PublicRouteTable.id}",
         "subnet_id": "\${aws_subnet.PublicSubnet.id}",
       },
     },
     "aws_security_group": {
-      "Redis_KEN15securityGroup_9FF06889": {
+      "Redis_KEN21securityGroup_139152DE": {
         "egress": [
           {
             "cidr_blocks": [
@@ -144,6 +173,40 @@ exports[`When creating a Redis resource > should create an elasticache cluster a
         "name": "3542402a-securityGroup",
         "vpc_id": "\${aws_vpc.VPC.id}",
       },
+      "Redis_KEN24securityGroup_6EFFC29B": {
+        "egress": [
+          {
+            "cidr_blocks": [
+              "0.0.0.0/0",
+            ],
+            "description": null,
+            "from_port": 0,
+            "ipv6_cidr_blocks": null,
+            "prefix_list_ids": null,
+            "protocol": "-1",
+            "security_groups": null,
+            "self": null,
+            "to_port": 0,
+          },
+        ],
+        "ingress": [
+          {
+            "cidr_blocks": [
+              "\${aws_subnet.PrivateSubnet2.cidr_block}",
+            ],
+            "description": null,
+            "from_port": 6379,
+            "ipv6_cidr_blocks": null,
+            "prefix_list_ids": null,
+            "protocol": "tcp",
+            "security_groups": null,
+            "self": true,
+            "to_port": 6379,
+          },
+        ],
+        "name": "3542402a-securityGroup",
+        "vpc_id": "\${aws_vpc.VPC.id}",
+      },
     },
     "aws_subnet": {
       "PrivateSubnet": {
@@ -151,6 +214,14 @@ exports[`When creating a Redis resource > should create an elasticache cluster a
         "cidr_block": "10.0.4.0/22",
         "tags": {
           "Name": "Default-c82bf964-private-subnet-1",
+        },
+        "vpc_id": "\${aws_vpc.VPC.id}",
+      },
+      "PrivateSubnet2": {
+        "availability_zone": "\${data.aws_region.Region.name}b",
+        "cidr_block": "10.0.8.0/22",
+        "tags": {
+          "Name": "Default-c82bf964-private-subnet-2",
         },
         "vpc_id": "\${aws_vpc.VPC.id}",
       },

--- a/libs/wingsdk/test/target-tf-aws/function.test.ts
+++ b/libs/wingsdk/test/target-tf-aws/function.test.ts
@@ -62,7 +62,7 @@ test("function will be behind a vpc when vpc_lambda is set to true", () => {
   expect(tfResourcesOfCount(output, "aws_vpc")).toEqual(1);
   expect(tfFunction.vpc_config).toBeDefined();
   expect(tfFunction.vpc_config.security_group_ids.length).toEqual(1);
-  expect(tfFunction.vpc_config.subnet_ids.length).toEqual(1);
+  expect(tfFunction.vpc_config.subnet_ids.length).toEqual(2);
   expect(tfSanitize(output)).toMatchSnapshot();
 });
 

--- a/libs/wingsdk/test/target-tf-aws/redis.test.ts
+++ b/libs/wingsdk/test/target-tf-aws/redis.test.ts
@@ -48,8 +48,8 @@ describe("When creating a Redis resource", () => {
 
     // THEN
     expect(tfResourcesOfCount(output, "aws_vpc")).toEqual(1);
-    expect(tfResourcesOfCount(output, "aws_subnet")).toEqual(2);
-    expect(tfResourcesOfCount(output, "aws_route_table")).toEqual(2);
+    expect(tfResourcesOfCount(output, "aws_subnet")).toEqual(3);
+    expect(tfResourcesOfCount(output, "aws_route_table")).toEqual(3);
     expect(tfResourcesOfCount(output, "aws_nat_gateway")).toEqual(1);
     expect(tfResourcesOfCount(output, "aws_internet_gateway")).toEqual(1);
   });
@@ -92,10 +92,10 @@ describe("When creating multiple Redis resources", () => {
     // THEN
     // 2 clusters, 2 security groups, 1 vpc, 2 subnets, 2 route tables, 1 nat gateway, 1 internet gateway
     expect(tfResourcesOfCount(output, "aws_elasticache_cluster")).toEqual(2);
-    expect(tfResourcesOfCount(output, "aws_security_group")).toEqual(2);
+    expect(tfResourcesOfCount(output, "aws_security_group")).toEqual(4);
     expect(tfResourcesOfCount(output, "aws_vpc")).toEqual(1);
-    expect(tfResourcesOfCount(output, "aws_subnet")).toEqual(2);
-    expect(tfResourcesOfCount(output, "aws_route_table")).toEqual(2);
+    expect(tfResourcesOfCount(output, "aws_subnet")).toEqual(3);
+    expect(tfResourcesOfCount(output, "aws_route_table")).toEqual(3);
     expect(tfResourcesOfCount(output, "aws_nat_gateway")).toEqual(1);
     expect(tfResourcesOfCount(output, "aws_internet_gateway")).toEqual(1);
   });
@@ -122,7 +122,7 @@ describe("When creating multiple Redis resources", () => {
 
       // THEN
       expect(vpcConfig.security_group_ids.length).toEqual(4);
-      expect(vpcConfig.subnet_ids.length).toEqual(2);
+      expect(vpcConfig.subnet_ids.length).toEqual(4);
     });
   });
 });

--- a/libs/wingsdk/test/target-tf-aws/redis.test.ts
+++ b/libs/wingsdk/test/target-tf-aws/redis.test.ts
@@ -121,7 +121,7 @@ describe("When creating multiple Redis resources", () => {
       const vpcConfig = JSON.parse(JSON.stringify(lambda.vpc_config));
 
       // THEN
-      expect(vpcConfig.security_group_ids.length).toEqual(2);
+      expect(vpcConfig.security_group_ids.length).toEqual(4);
       expect(vpcConfig.subnet_ids.length).toEqual(2);
     });
   });

--- a/tools/hangar/__snapshots__/test_corpus/valid/redis.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/redis.test.w_compile_tf-aws.md
@@ -114,7 +114,8 @@ module.exports = function({ $queue, $r, $r2, $util_Util }) {
         "num_cache_nodes": 1,
         "parameter_group_name": "default.redis6.x",
         "security_group_ids": [
-          "${aws_security_group.Redis_KEN15securityGroup_9FF06889.id}"
+          "${aws_security_group.Redis_KEN21securityGroup_139152DE.id}",
+          "${aws_security_group.Redis_KEN24securityGroup_6EFFC29B.id}"
         ],
         "subnet_group_name": "${aws_elasticache_subnet_group.Redis_RedisSubnetGroup_E7D796E2.name}"
       },
@@ -133,7 +134,8 @@ module.exports = function({ $queue, $r, $r2, $util_Util }) {
         "num_cache_nodes": 1,
         "parameter_group_name": "default.redis6.x",
         "security_group_ids": [
-          "${aws_security_group.r2_KEN24securityGroup_AFC21ADF.id}"
+          "${aws_security_group.r2_KEN35securityGroup_DF1EB5F4.id}",
+          "${aws_security_group.r2_KEN38securityGroup_41F37500.id}"
         ],
         "subnet_group_name": "${aws_elasticache_subnet_group.r2_RedisSubnetGroup_C415566B.name}"
       }
@@ -148,7 +150,8 @@ module.exports = function({ $queue, $r, $r2, $util_Util }) {
         },
         "name": "redis-c8cdb969-subnetGroup",
         "subnet_ids": [
-          "${aws_subnet.PrivateSubnet.id}"
+          "${aws_subnet.PrivateSubnet.id}",
+          "${aws_subnet.PrivateSubnet2.id}"
         ]
       },
       "r2_RedisSubnetGroup_C415566B": {
@@ -160,7 +163,8 @@ module.exports = function({ $queue, $r, $r2, $util_Util }) {
         },
         "name": "r2-c882797c-subnetGroup",
         "subnet_ids": [
-          "${aws_subnet.PrivateSubnet.id}"
+          "${aws_subnet.PrivateSubnet.id}",
+          "${aws_subnet.PrivateSubnet2.id}"
         ]
       }
     },
@@ -259,10 +263,12 @@ module.exports = function({ $queue, $r, $r2, $util_Util }) {
         "timeout": "${aws_sqs_queue.Queue.visibility_timeout_seconds}",
         "vpc_config": {
           "security_group_ids": [
-            "${aws_security_group.Redis_KEN15securityGroup_9FF06889.id}"
+            "${aws_security_group.Redis_KEN21securityGroup_139152DE.id}",
+            "${aws_security_group.Redis_KEN24securityGroup_6EFFC29B.id}"
           ],
           "subnet_ids": [
-            "${aws_subnet.PrivateSubnet.id}"
+            "${aws_subnet.PrivateSubnet.id}",
+            "${aws_subnet.PrivateSubnet2.id}"
           ]
         }
       }
@@ -312,6 +318,35 @@ module.exports = function({ $queue, $r, $r2, $util_Util }) {
         },
         "vpc_id": "${aws_vpc.VPC.id}"
       },
+      "PrivateRouteTable2": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/PrivateRouteTable2",
+            "uniqueId": "PrivateRouteTable2"
+          }
+        },
+        "route": [
+          {
+            "carrier_gateway_id": null,
+            "cidr_block": "0.0.0.0/0",
+            "core_network_arn": null,
+            "destination_prefix_list_id": null,
+            "egress_only_gateway_id": null,
+            "gateway_id": null,
+            "ipv6_cidr_block": null,
+            "local_gateway_id": null,
+            "nat_gateway_id": "${aws_nat_gateway.NATGateway.id}",
+            "network_interface_id": null,
+            "transit_gateway_id": null,
+            "vpc_endpoint_id": null,
+            "vpc_peering_connection_id": null
+          }
+        ],
+        "tags": {
+          "Name": "Default-c82bf964-private-route-table-2"
+        },
+        "vpc_id": "${aws_vpc.VPC.id}"
+      },
       "PublicRouteTable": {
         "//": {
           "metadata": {
@@ -353,6 +388,16 @@ module.exports = function({ $queue, $r, $r2, $util_Util }) {
         "route_table_id": "${aws_route_table.PrivateRouteTable.id}",
         "subnet_id": "${aws_subnet.PrivateSubnet.id}"
       },
+      "PrivateRouteTableAssociation2": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/PrivateRouteTableAssociation2",
+            "uniqueId": "PrivateRouteTableAssociation2"
+          }
+        },
+        "route_table_id": "${aws_route_table.PrivateRouteTable2.id}",
+        "subnet_id": "${aws_subnet.PrivateSubnet2.id}"
+      },
       "PublicRouteTableAssociation": {
         "//": {
           "metadata": {
@@ -389,11 +434,11 @@ module.exports = function({ $queue, $r, $r2, $util_Util }) {
       }
     },
     "aws_security_group": {
-      "Redis_KEN15securityGroup_9FF06889": {
+      "Redis_KEN21securityGroup_139152DE": {
         "//": {
           "metadata": {
-            "path": "root/Default/Default/Redis/KEN.15]}securityGroup",
-            "uniqueId": "Redis_KEN15securityGroup_9FF06889"
+            "path": "root/Default/Default/Redis/KEN.21]}securityGroup",
+            "uniqueId": "Redis_KEN21securityGroup_139152DE"
           }
         },
         "egress": [
@@ -429,11 +474,51 @@ module.exports = function({ $queue, $r, $r2, $util_Util }) {
         "name": "3542402a-securityGroup",
         "vpc_id": "${aws_vpc.VPC.id}"
       },
-      "r2_KEN24securityGroup_AFC21ADF": {
+      "Redis_KEN24securityGroup_6EFFC29B": {
         "//": {
           "metadata": {
-            "path": "root/Default/Default/r2/KEN.24]}securityGroup",
-            "uniqueId": "r2_KEN24securityGroup_AFC21ADF"
+            "path": "root/Default/Default/Redis/KEN.24]}securityGroup",
+            "uniqueId": "Redis_KEN24securityGroup_6EFFC29B"
+          }
+        },
+        "egress": [
+          {
+            "cidr_blocks": [
+              "0.0.0.0/0"
+            ],
+            "description": null,
+            "from_port": 0,
+            "ipv6_cidr_blocks": null,
+            "prefix_list_ids": null,
+            "protocol": "-1",
+            "security_groups": null,
+            "self": null,
+            "to_port": 0
+          }
+        ],
+        "ingress": [
+          {
+            "cidr_blocks": [
+              "${aws_subnet.PrivateSubnet2.cidr_block}"
+            ],
+            "description": null,
+            "from_port": 6379,
+            "ipv6_cidr_blocks": null,
+            "prefix_list_ids": null,
+            "protocol": "tcp",
+            "security_groups": null,
+            "self": true,
+            "to_port": 6379
+          }
+        ],
+        "name": "3542402a-securityGroup",
+        "vpc_id": "${aws_vpc.VPC.id}"
+      },
+      "r2_KEN35securityGroup_DF1EB5F4": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/Default/r2/KEN.35]}securityGroup",
+            "uniqueId": "r2_KEN35securityGroup_DF1EB5F4"
           }
         },
         "egress": [
@@ -455,6 +540,46 @@ module.exports = function({ $queue, $r, $r2, $util_Util }) {
           {
             "cidr_blocks": [
               "${aws_subnet.PrivateSubnet.cidr_block}"
+            ],
+            "description": null,
+            "from_port": 6379,
+            "ipv6_cidr_blocks": null,
+            "prefix_list_ids": null,
+            "protocol": "tcp",
+            "security_groups": null,
+            "self": true,
+            "to_port": 6379
+          }
+        ],
+        "name": "30c8c4ae-securityGroup",
+        "vpc_id": "${aws_vpc.VPC.id}"
+      },
+      "r2_KEN38securityGroup_41F37500": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/Default/r2/KEN.38]}securityGroup",
+            "uniqueId": "r2_KEN38securityGroup_41F37500"
+          }
+        },
+        "egress": [
+          {
+            "cidr_blocks": [
+              "0.0.0.0/0"
+            ],
+            "description": null,
+            "from_port": 0,
+            "ipv6_cidr_blocks": null,
+            "prefix_list_ids": null,
+            "protocol": "-1",
+            "security_groups": null,
+            "self": null,
+            "to_port": 0
+          }
+        ],
+        "ingress": [
+          {
+            "cidr_blocks": [
+              "${aws_subnet.PrivateSubnet2.cidr_block}"
             ],
             "description": null,
             "from_port": 6379,
@@ -495,6 +620,20 @@ module.exports = function({ $queue, $r, $r2, $util_Util }) {
         "cidr_block": "10.0.4.0/22",
         "tags": {
           "Name": "Default-c82bf964-private-subnet-1"
+        },
+        "vpc_id": "${aws_vpc.VPC.id}"
+      },
+      "PrivateSubnet2": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/PrivateSubnet2",
+            "uniqueId": "PrivateSubnet2"
+          }
+        },
+        "availability_zone": "${data.aws_region.Region.name}b",
+        "cidr_block": "10.0.8.0/22",
+        "tags": {
+          "Name": "Default-c82bf964-private-subnet-2"
         },
         "vpc_id": "${aws_vpc.VPC.id}"
       },


### PR DESCRIPTION
Several resources require multi-az support, such as RDS clusters. This PR adds an additional private subnet to the VPC that is created implicitly for users using tf-aws platforms.

## Checklist

- [ ] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [ ] Description explains motivation and solution
- [ ] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
