### PR TITLE
fix(platforms): `sim` cant retrieve secret values compiling outside sourceDir

### DIFF
--- a/libs/wingsdk/src/target-sim/schema-resources.ts
+++ b/libs/wingsdk/src/target-sim/schema-resources.ts
@@ -209,6 +209,8 @@ export interface WebsiteAttributes {
 export interface SecretSchema {
   /** The name of the secret */
   readonly name: string;
+  /** File where secret can be read from */
+  readonly secretFile: string; // TODO: remove after https://github.com/winglang/wing/issues/6346
 }
 
 /** Runtime attributes for cloud.Secret */

--- a/libs/wingsdk/src/target-sim/secret.ts
+++ b/libs/wingsdk/src/target-sim/secret.ts
@@ -1,3 +1,4 @@
+import path from "path";
 import { Construct } from "constructs";
 import { ISimulatorResource } from "./resource";
 import { SecretSchema } from "./schema-resources";
@@ -42,6 +43,7 @@ export class Secret extends cloud.Secret implements ISimulatorResource {
   public toSimulator(): ToSimulatorOutput {
     const props: SecretSchema = {
       name: this.name!,
+      secretFile: path.join(process.env.WING_SOURCE_DIR!, ".env"),
     };
     return {
       type: cloud.SECRET_FQN,

--- a/libs/wingsdk/test/target-sim/__snapshots__/secret.test.ts.snap
+++ b/libs/wingsdk/test/target-sim/__snapshots__/secret.test.ts.snap
@@ -13,6 +13,7 @@ exports[`secrets > create a secret 1`] = `
         "path": "root/my_secret",
         "props": {
           "name": "my_secret-c84793b7",
+          "secretFile": "<ABSOLUTE PATH>/.env",
         },
         "type": "@winglang/sdk.cloud.Secret",
       },

--- a/libs/wingsdk/test/target-sim/secret.test.ts
+++ b/libs/wingsdk/test/target-sim/secret.test.ts
@@ -8,6 +8,7 @@ const SECRETS_FILE = path.join(process.cwd(), ".env");
 describe("secrets", () => {
   beforeEach(() => {
     fs.createFileSync(SECRETS_FILE);
+    process.env.WING_SOURCE_DIR = process.cwd();
   });
 
   afterEach(() => {
@@ -31,6 +32,7 @@ describe("secrets", () => {
       policy: [],
       props: {
         name: "my_secret-c84793b7",
+        secretFile: SECRETS_FILE,
       },
       type: cloud.SECRET_FQN,
     });


### PR DESCRIPTION
There is still a larger issue with `.env` files being loaded outside of source directories see: https://github.com/winglang/wing/issues/6346

but this atleast unblock some of the broken apps in WingCloud.

## Checklist

- [ ] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [ ] Description explains motivation and solution
- [ ] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
