### PR TITLE
fix(cli)!: .env file not loaded when compiling outside sourceDir

### DIFF
--- a/apps/wing/src/cli.ts
+++ b/apps/wing/src/cli.ts
@@ -25,10 +25,16 @@ function runSubCommand(subCommand: string, subCommandPath: string = subCommand) 
     const { loadEnvVariables } = await import("./env");
     const path = await import("path");
     
+    let entryArg = args[0];
+    if (entryArg instanceof Array) {
+      entryArg = entryArg[0]; // if multiple entries are provided, use the first one
+    }
+
     loadEnvVariables({
       mode: subCommand,
-      cwd: args[0] ? path.resolve(path.dirname(args[0])) : undefined
+      cwd: entryArg ? path.resolve(path.dirname(entryArg)) : undefined,
     });
+    
     try {
       // paths other than the root path aren't working unless specified in the path arg
       const exitCode = await import(`./commands/${subCommandPath}`).then((m) => m[subCommand](...args));

--- a/apps/wing/src/cli.ts
+++ b/apps/wing/src/cli.ts
@@ -20,24 +20,11 @@ const DEFAULT_PLATFORM = ["sim"];
 
 let analyticsExportFile: Promise<string | undefined> | undefined;
 
-function runSubCommand(subCommand: string, subCommandPath: string = subCommand) {
+function runSubCommand(subCommand: string, path: string = subCommand) {
   return async (...args: any[]) => {
-    const { loadEnvVariables } = await import("./env");
-    const path = await import("path");
-    
-    let entryArg = args[0];
-    if (entryArg instanceof Array) {
-      entryArg = entryArg[0]; // if multiple entries are provided, use the first one
-    }
-
-    loadEnvVariables({
-      mode: subCommand,
-      cwd: entryArg ? path.resolve(path.dirname(entryArg)) : undefined,
-    });
-    
     try {
       // paths other than the root path aren't working unless specified in the path arg
-      const exitCode = await import(`./commands/${subCommandPath}`).then((m) => m[subCommand](...args));
+      const exitCode = await import(`./commands/${path}`).then((m) => m[subCommand](...args));
       if (exitCode === 1) {
         await exportAnalyticsHook();
         process.exitCode = 1;

--- a/apps/wing/src/commands/compile.ts
+++ b/apps/wing/src/commands/compile.ts
@@ -1,5 +1,5 @@
 import { promises as fsPromise } from "fs";
-import { relative, resolve } from "path";
+import { dirname, relative, resolve } from "path";
 
 import * as wingCompiler from "@winglang/compiler";
 import { prettyPrintError } from "@winglang/sdk/lib/util/enhanced-error";
@@ -7,6 +7,7 @@ import chalk from "chalk";
 import { CHARS_ASCII, emitDiagnostic, File, Label } from "codespan-wasm";
 import debug from "debug";
 import { glob } from "glob";
+import { loadEnvVariables } from "../env";
 
 // increase the stack trace limit to 50, useful for debugging Rust panics
 // (not setting the limit too high in case of infinite recursion)
@@ -78,7 +79,7 @@ export async function compile(entrypoint?: string, options?: CompileOptions): Pr
     }
     entrypoint = wingFiles[0];
   }
-
+  loadEnvVariables( { cwd: resolve(dirname(entrypoint)) } );
   const coloring = chalk.supportsColor ? chalk.supportsColor.hasBasic : false;
   try {
     return await wingCompiler.compile(entrypoint, {

--- a/apps/wing/src/commands/compile.ts
+++ b/apps/wing/src/commands/compile.ts
@@ -79,7 +79,7 @@ export async function compile(entrypoint?: string, options?: CompileOptions): Pr
     }
     entrypoint = wingFiles[0];
   }
-  loadEnvVariables( { cwd: resolve(dirname(entrypoint)) } );
+  loadEnvVariables({ cwd: resolve(dirname(entrypoint)) });
   const coloring = chalk.supportsColor ? chalk.supportsColor.hasBasic : false;
   try {
     return await wingCompiler.compile(entrypoint, {

--- a/apps/wing/src/commands/pack.ts
+++ b/apps/wing/src/commands/pack.ts
@@ -81,7 +81,6 @@ export async function pack(options: PackageOptions = {}): Promise<string> {
   const outdir = outfile ? path.dirname(outfile) : userDir;
 
   loadEnvVariables({ cwd: userDir });
-
   // check package.json exists
   const originalPkgJsonPath = path.join(userDir, "package.json");
   if (!(await exists(originalPkgJsonPath))) {

--- a/apps/wing/src/commands/pack.ts
+++ b/apps/wing/src/commands/pack.ts
@@ -8,6 +8,7 @@ import { BuiltinPlatform } from "@winglang/compiler";
 import packlist from "npm-packlist";
 import * as tar from "tar";
 import { compile } from "./compile";
+import { loadEnvVariables } from "../env";
 
 // TODO: add --dry-run option?
 // TODO: let the user specify library's supported targets in package.json, and compile to each before packaging
@@ -78,6 +79,8 @@ export async function pack(options: PackageOptions = {}): Promise<string> {
   const userDir = process.cwd();
   const outfile = options.outFile ? resolve(options.outFile) : undefined;
   const outdir = outfile ? path.dirname(outfile) : userDir;
+
+  loadEnvVariables({ cwd: userDir });
 
   // check package.json exists
   const originalPkgJsonPath = path.join(userDir, "package.json");

--- a/apps/wing/src/commands/run.ts
+++ b/apps/wing/src/commands/run.ts
@@ -1,5 +1,5 @@
 import { existsSync } from "fs";
-import { resolve } from "path";
+import { dirname, resolve } from "path";
 import { createConsoleApp } from "@wingconsole/app";
 import { BuiltinPlatform } from "@winglang/compiler";
 import { debug } from "debug";
@@ -7,6 +7,7 @@ import { glob } from "glob";
 import once from "lodash.once";
 import { parseNumericString } from "../util";
 import { beforeShutdown } from "../util.before-shutdown.js";
+import { loadEnvVariables } from "../env";
 
 /**
  * Options for the `run` command.
@@ -62,6 +63,8 @@ export async function run(entrypoint?: string, options?: RunOptions) {
   if (!existsSync(entrypoint)) {
     throw new Error(entrypoint + " doesn't exist");
   }
+
+  loadEnvVariables({ cwd: resolve(dirname(entrypoint))});
 
   if (options?.platform && options?.platform[0] !== BuiltinPlatform.SIM) {
     throw new Error(

--- a/apps/wing/src/commands/run.ts
+++ b/apps/wing/src/commands/run.ts
@@ -5,9 +5,9 @@ import { BuiltinPlatform } from "@winglang/compiler";
 import { debug } from "debug";
 import { glob } from "glob";
 import once from "lodash.once";
+import { loadEnvVariables } from "../env";
 import { parseNumericString } from "../util";
 import { beforeShutdown } from "../util.before-shutdown.js";
-import { loadEnvVariables } from "../env";
 
 /**
  * Options for the `run` command.
@@ -64,7 +64,7 @@ export async function run(entrypoint?: string, options?: RunOptions) {
     throw new Error(entrypoint + " doesn't exist");
   }
 
-  loadEnvVariables({ cwd: resolve(dirname(entrypoint))});
+  loadEnvVariables({ cwd: resolve(dirname(entrypoint)) });
 
   if (options?.platform && options?.platform[0] !== BuiltinPlatform.SIM) {
     throw new Error(

--- a/apps/wing/src/env.ts
+++ b/apps/wing/src/env.ts
@@ -11,12 +11,6 @@ export interface EnvLoadOptions {
    * @default process.cwd()
    */
   cwd?: string;
-
-  /**
-   * The mode to load additional environment variables from.
-   * e.g. "wing compile" has mode "compile", which will load ".env.compile" and ".env.compile.local".
-   */
-  mode?: string;
 }
 
 /**
@@ -24,9 +18,7 @@ export interface EnvLoadOptions {
  */
 export function loadEnvVariables(options?: EnvLoadOptions): Record<string, string> | undefined {
   const envDir = options?.cwd ?? process.cwd();
-  const envFiles = DEFAULT_ENV_FILES.concat(
-    options?.mode ? [`.env.${options.mode}`, `.env.${options.mode}.local`] : []
-  ).map((file) => join(envDir, file));
+  const envFiles = DEFAULT_ENV_FILES.map((file) => join(envDir, file));
 
   // Parse `envFiles` and combine their variables into a single object
   const parsed = Object.fromEntries(

--- a/libs/wingsdk/src/target-sim/secret.inflight.ts
+++ b/libs/wingsdk/src/target-sim/secret.inflight.ts
@@ -1,5 +1,3 @@
-import * as fs from "fs";
-import * as path from "path";
 import { SecretAttributes, SecretSchema } from "./schema-resources";
 import { ISecretClient, SECRET_FQN } from "../cloud";
 import {
@@ -11,18 +9,9 @@ import { Json, TraceType } from "../std";
 
 export class Secret implements ISecretClient, ISimulatorResourceInstance {
   private _context: ISimulatorContext | undefined;
-  private readonly secretsFile: string;
   private readonly name: string;
 
   constructor(props: SecretSchema) {
-    this.secretsFile = path.join(process.cwd(), ".env");
-
-    if (!fs.existsSync(this.secretsFile)) {
-      throw new Error(
-        `No secrets file found at ${this.secretsFile} while looking for secret ${props.name}`
-      );
-    }
-
     this.name = props.name;
   }
 


### PR DESCRIPTION
Closes: https://github.com/winglang/wing/issues/6346

## Breaking Change
- Removed the ability to specify command specific `.env` files

## Summary
Basically just moves the loading of environment files to the subcommands. Previously this loading was happening for all commands, which really doesnt make sense since some commands like `lsp`, `docs`, `init` dont need to load those env files. 

Also I several subcommands call the compile subcommand (secrets, test, etc..) so having subcommand specific `.env` files is additional overhead that Im not sure what the usecase it solves is. If needed, its probably just easier to just use a `--env-file` flag

## Checklist

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [x] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
