### PR TITLE
fix: unable to import JSII classes with embedded types

### DIFF
--- a/examples/jsii-fixture/src/index.ts
+++ b/examples/jsii-fixture/src/index.ts
@@ -1,3 +1,12 @@
+export class ClassWithInnerType {}
+
+export namespace ClassWithInnerType {
+  /** This type cannot be referenced in wing (yet) */
+  export interface InnerStruct {
+    readonly field: string;
+  }
+}
+
 export class JsiiClass {
   /** @internal */
   _field: number;
@@ -26,7 +35,7 @@ export class JsiiClass {
     return `Got ${arg}`;
   }
 
-  public methodWithStructParam(s: SomeStruct): string {
+  public methodWithStructParam(s: ClassWithInnerType.InnerStruct): string {
     return s.field;
   }
 }
@@ -44,7 +53,7 @@ export class JsiiClassWithPrivateConstructor {
  */
 export interface IFakeClosure {
   /** @internal */
-  (x: number): number
+  (x: number): number;
 
   fn(x: number): number;
 }

--- a/examples/tests/valid/bring_awscdk.test.w
+++ b/examples/tests/valid/bring_awscdk.test.w
@@ -1,14 +1,28 @@
-bring "aws-cdk-lib" as awscdk;
+bring "aws-cdk-lib" as cdk;
 
 class CdkDockerImageFunction {
-    function:  awscdk.aws_lambda.DockerImageFunction;
+    function:  cdk.aws_lambda.DockerImageFunction;
 
     new() {
-        this.function = new awscdk.aws_lambda.DockerImageFunction({
-            code: awscdk.aws_lambda.DockerImageCode.fromImageAsset("./test.ts"),
-        }) as "DockerImageFunction";
+      let eventBridge = new cdk.aws_events.EventBus(eventBusName: "test") as "EventBridge";
+      let rule = new cdk.aws_events.CfnRule(
+        name: "test",
+        eventBusName: eventBridge.eventBusName,
+        eventPattern: {},
+        targets: [{
+          arn: "",
+          id: "",
+        }],
+      );
+      new cdk.aws_events.Rule(eventPattern: {
+        detailType: [""],
+      });
+
+      this.function = new cdk.aws_lambda.DockerImageFunction({
+        code: cdk.aws_lambda.DockerImageCode.fromImageAsset("./test.ts"),
+      }) as "DockerImageFunction";
     }
 }
 
 // Test creating an `App` construct
-new awscdk.App();
+new cdk.App();

--- a/examples/tests/valid/bring_jsii.test.w
+++ b/examples/tests/valid/bring_jsii.test.w
@@ -14,8 +14,7 @@ test "sayHello" {
 let jsiiClass = new jsii_fixture.JsiiClass(10);
 assert(jsiiClass.applyClosure(5, (x) => { return x * 2; }) == 10);
 
-let jsiiStruct = jsii_fixture.SomeStruct { field: "struct field" };
-assert(jsiiClass.methodWithStructParam(jsiiStruct) == "struct field");
+assert(jsiiClass.methodWithStructParam({ field: "struct field" }) == "struct field");
 
 // Use a JSII interface
 class X impl jsii_fixture.ISomeInterface {

--- a/libs/wingc/src/lsp/sync.rs
+++ b/libs/wingc/src/lsp/sync.rs
@@ -151,9 +151,9 @@ fn partial_compile(
 
 	// Reset all type information
 	*types = Types::new();
+	project_data.jsii_imports.clear();
 
 	// -- TYPECHECKING PHASE --
-	let mut jsii_imports = vec![];
 
 	// Type check all files in topological order (start with files that don't require any other
 	// Wing files, then move on to files that depend on those, etc.)
@@ -165,7 +165,7 @@ fn partial_compile(
 			&file,
 			&project_data.file_graph,
 			jsii_types,
-			&mut jsii_imports,
+			&mut project_data.jsii_imports,
 		);
 
 		// Make sure all type reference are no longer considered references

--- a/libs/wingc/src/type_check/jsii_importer.rs
+++ b/libs/wingc/src/type_check/jsii_importer.rs
@@ -132,84 +132,53 @@ impl<'a> JsiiImporter<'a> {
 			return t.as_type().expect(&format!("Expected {} to be a type", type_fqn));
 		}
 		// Define new type and return it
-		self.import_type(type_fqn);
-		self
-			.wing_types
-			.libraries
-			.lookup_nested_str(type_fqn.as_str(), None)
-			.expect(&format!("Expected {} to be defined", type_fqn))
-			.0
-			.as_type()
-			.unwrap()
+		if let Some(t) = self.import_type(type_fqn) {
+			t
+		} else {
+			panic!("Expected {type_fqn} to be defined")
+		}
 	}
 
-	pub fn import_type(&mut self, type_fqn: &FQN) -> bool {
-		let type_str = type_fqn.as_str();
-
+	pub fn import_type(&mut self, type_fqn: &FQN) -> Option<TypeRef> {
 		// check if type is already imported
-		if let LookupResult::Found(sym, ..) = self.wing_types.libraries.lookup_nested_str(type_str, None) {
+		if let LookupResult::Found(sym, ..) = self.wing_types.libraries.lookup_nested_str(type_fqn.raw, None) {
 			if let SymbolKind::Namespace(n) = sym {
 				// We are trying to import a namespace directly, so let's eagerly load all of its types
 				self.deep_import_submodule_to_env(Some(n.name.clone()));
 			}
-			return true;
+			None
+		} else if let Some(jsii_interface) = self.jsii_types.find_interface(type_fqn) {
+			Some(self.import_interface(jsii_interface))
+		} else if let Some(jsii_class) = self.jsii_types.find_class(type_fqn) {
+			Some(self.import_class(jsii_class))
+		} else if let Some(jsii_enum) = self.jsii_types.find_enum(type_fqn) {
+			Some(self.import_enum(jsii_enum))
+		} else {
+			None
 		}
-
-		// Check if this is a JSII interface and import it if it is
-		let jsii_interface = self.jsii_types.find_interface(type_fqn);
-		if let Some(jsii_interface) = jsii_interface {
-			self.import_interface(jsii_interface);
-			return true;
-		}
-
-		// Check if this is a JSII class and import it if it is
-		let jsii_class = self.jsii_types.find_class(type_fqn);
-		if let Some(jsii_class) = jsii_class {
-			self.import_class(jsii_class);
-			return true;
-		}
-
-		// Check if this is a JSII enum and import it if it is
-		let jsii_enum = self.jsii_types.find_enum(type_fqn);
-		if let Some(jsii_enum) = jsii_enum {
-			self.import_enum(jsii_enum);
-			return true;
-		}
-
-		false
 	}
 
 	pub fn setup_namespaces_for(&mut self, type_name: &FQN) {
 		// First, create a namespace in the Wing type system (if there isn't one already) corresponding to the JSII assembly
 		// the type belongs to.
 		debug!("Setting up namespaces for {}", type_name);
-		let assembly = type_name.assembly();
+		let assembly = Symbol::global(type_name.assembly());
 
-		if let Some(symb) = self.wing_types.libraries.lookup_mut(&assembly.into(), None) {
-			if let SymbolKind::Namespace(_) = symb {
-				// do nothing
-			} else {
-				// TODO: make this a proper error
-				panic!(
-					"Tried importing {} but {} already defined as a {}",
-					type_name, assembly, symb
-				)
-			}
-		} else {
+		// First, setup the assembly namespace
+		if self.wing_types.libraries.lookup(&assembly, None).is_none() {
 			let ns_env = self
 				.wing_types
 				.add_symbol_env(SymbolEnv::new(None, SymbolEnvKind::Scope, Phase::Preflight, 0));
 			let ns = self.wing_types.add_namespace(Namespace {
 				name: assembly.to_string(),
 				envs: vec![ns_env],
-				loaded: false,
-				module_path: ResolveSource::ExternalModule(assembly.to_string()),
+				module_path: ResolveSource::ExternalModule(assembly.name.clone()),
 			});
 			self
 				.wing_types
 				.libraries
 				.define(
-					&Symbol::global(assembly),
+					&assembly,
 					SymbolKind::Namespace(ns),
 					AccessModifier::Public,
 					StatementIdx::Top,
@@ -218,9 +187,10 @@ impl<'a> JsiiImporter<'a> {
 		};
 
 		// Next, ensure there is a namespace for each of the namespaces in the type name
-		for (ns_idx, namespace_name) in type_name.namespaces().enumerate() {
-			let mut lookup_vec = vec![assembly];
-			lookup_vec.extend(type_name.namespaces().take(ns_idx));
+		for (ns_idx, namespace_name) in type_name.namespaces().iter().enumerate() {
+			let ns_sym = Symbol::global(*namespace_name);
+			let mut lookup_vec = vec![assembly.name.as_str()];
+			lookup_vec.extend(type_name.namespaces()[..ns_idx].iter());
 			let lookup_str = lookup_vec.join(".");
 
 			let mut parent_ns = self
@@ -232,27 +202,12 @@ impl<'a> JsiiImporter<'a> {
 				.as_namespace_ref()
 				.unwrap();
 
-			if let Some(symb) = parent_ns
-				.envs
-				.get_mut(0)
-				.unwrap()
-				.lookup_mut(&namespace_name.into(), None)
-			{
-				if let SymbolKind::Namespace(_) = symb {
-					// do nothing
-				} else {
-					// TODO: make this a proper error
-					panic!(
-						"Tried importing {} but {} already defined as a {}",
-						type_name, namespace_name, symb
-					)
-				}
-			} else {
+			if parent_ns.envs.get_mut(0).unwrap().lookup_mut(&ns_sym, None).is_none() {
 				let ns_env = self
 					.wing_types
 					.add_symbol_env(SymbolEnv::new(None, SymbolEnvKind::Scope, Phase::Preflight, 0));
 				// Special case for the SDK, we are able to alias the namespace
-				let module_path = if assembly == WINGSDK_ASSEMBLY_NAME {
+				let module_path = if assembly.name == WINGSDK_ASSEMBLY_NAME {
 					format!("{}/{}", lookup_vec.join("/"), namespace_name)
 				} else {
 					lookup_vec.join("/")
@@ -261,7 +216,6 @@ impl<'a> JsiiImporter<'a> {
 				let ns = self.wing_types.add_namespace(Namespace {
 					name: namespace_name.to_string(),
 					envs: vec![ns_env],
-					loaded: false,
 					module_path: ResolveSource::ExternalModule(module_path),
 				});
 				parent_ns
@@ -269,7 +223,7 @@ impl<'a> JsiiImporter<'a> {
 					.get_mut(0)
 					.unwrap()
 					.define(
-						&Symbol::global(namespace_name),
+						&ns_sym,
 						SymbolKind::Namespace(ns),
 						AccessModifier::Public,
 						StatementIdx::Top,
@@ -279,7 +233,7 @@ impl<'a> JsiiImporter<'a> {
 		}
 	}
 
-	pub fn import_enum(&mut self, jsii_enum: &jsii::EnumType) {
+	pub fn import_enum(&mut self, jsii_enum: &jsii::EnumType) -> TypeRef {
 		let enum_name = &jsii_enum.name;
 		let enum_fqn = FQN::from(jsii_enum.fqn.as_str());
 		let enum_symbol = Self::jsii_name_to_symbol(enum_name, &jsii_enum.location_in_module);
@@ -294,12 +248,12 @@ impl<'a> JsiiImporter<'a> {
 				.collect(),
 		}));
 
-		self.register_jsii_type(&enum_fqn, &enum_symbol, enum_type_ref);
+		self.register_jsii_type(&enum_fqn, &enum_symbol, enum_type_ref)
 	}
 
 	/// Import a JSII interface as a function instead.
 	/// These interfaces must have the @callable annotation and only one method defined, which will be the function signature.
-	fn import_closure(&mut self, jsii_interface: &wingii::jsii::InterfaceType) {
+	fn import_closure(&mut self, jsii_interface: &wingii::jsii::InterfaceType) -> TypeRef {
 		let jsii_interface_fqn = FQN::from(jsii_interface.fqn.as_str());
 		debug!("Importing closure {}", jsii_interface_fqn.as_str().green());
 
@@ -352,7 +306,7 @@ impl<'a> JsiiImporter<'a> {
 			implicit_scope_param: false,
 		}));
 
-		self.register_jsii_type(&jsii_interface_fqn, &new_type_symbol, wing_type);
+		self.register_jsii_type(&jsii_interface_fqn, &new_type_symbol, wing_type)
 	}
 
 	/// Import a JSII interface into the Wing type system.
@@ -363,11 +317,10 @@ impl<'a> JsiiImporter<'a> {
 	/// Structs can be distinguished non-structs with the "datatype: true" property in `jsii::InterfaceType`.
 	///
 	/// See https://aws.github.io/jsii/specification/2-type-system/#interfaces-structs
-	fn import_interface(&mut self, jsii_interface: &wingii::jsii::InterfaceType) {
+	fn import_interface(&mut self, jsii_interface: &wingii::jsii::InterfaceType) -> TypeRef {
 		// check if this interface has a `@callable` tag
 		if extract_docstring_tag(&jsii_interface.docs, "callable").is_some() {
-			self.import_closure(jsii_interface);
-			return;
+			return self.import_closure(jsii_interface);
 		}
 
 		let jsii_interface_fqn = FQN::from(jsii_interface.fqn.as_str());
@@ -508,6 +461,7 @@ impl<'a> JsiiImporter<'a> {
 			Type::Struct(Struct { ref mut env, .. }) | Type::Interface(Interface { ref mut env, .. }) => *env = iface_env,
 			_ => panic!("Expected {} to be an interface or struct", type_name),
 		};
+		wing_type
 	}
 
 	fn add_members_to_class_env<T: JsiiInterface>(
@@ -668,7 +622,7 @@ impl<'a> JsiiImporter<'a> {
 		})
 	}
 
-	fn import_class(&mut self, jsii_class: &'a wingii::jsii::ClassType) {
+	fn import_class(&mut self, jsii_class: &'a wingii::jsii::ClassType) -> TypeRef {
 		let mut class_phase = if is_construct_base(&jsii_class.fqn) {
 			Phase::Preflight
 		} else {
@@ -887,6 +841,7 @@ impl<'a> JsiiImporter<'a> {
 			}
 			_ => panic!("Expected {} to be a class or resource ", type_name),
 		};
+		new_type
 	}
 
 	fn optional_type_to_wing_type(&mut self, jsii_optional_type: &jsii::OptionalValue) -> TypeRef {
@@ -917,12 +872,7 @@ impl<'a> JsiiImporter<'a> {
 
 	/// Imports all types within a given submodule
 	pub fn deep_import_submodule_to_env(&mut self, submodule: Option<String>) {
-		let match_namespace = |jsii_type: &jsii::Type| match jsii_type {
-			jsii::Type::ClassType(c) => c.namespace == submodule,
-			jsii::Type::EnumType(e) => e.namespace == submodule,
-			jsii::Type::InterfaceType(i) => i.namespace == submodule,
-		};
-
+		let prefix = submodule.map(|s| format!("{}.{s}", self.jsii_spec.assembly_name));
 		for entry in self
 			.jsii_types
 			.find_assembly(&self.jsii_spec.assembly_name)
@@ -931,52 +881,43 @@ impl<'a> JsiiImporter<'a> {
 			.as_ref()
 			.unwrap()
 			.iter()
-			.skip_while(|e| !match_namespace(e.1))
+			.map(|(k, v)| (FQN::from(k.as_str()), v))
+			.skip_while(|e| !e.0.has_prefix(&prefix))
 		{
-			if match_namespace(entry.1) {
-				self.import_type(&FQN::from(entry.0.as_str()));
+			if entry.0.has_prefix(&prefix) {
+				self.import_type(&entry.0);
 			} else {
 				// the types should be well ordered, so we can break early
 				break;
 			}
 		}
-
-		// Mark the namespace as loaded after recursively importing all types to its environment
-		let mut submodule_fqn = self.jsii_spec.assembly_name.clone();
-		if let Some(submodule) = submodule {
-			submodule_fqn.push_str(&format!(".{}", submodule));
-		}
-		self.mark_namespace_as_loaded(&submodule_fqn);
-	}
-
-	fn mark_namespace_as_loaded(&mut self, module_name: &str) {
-		let n = self
-			.wing_types
-			.libraries
-			.lookup_nested_str_mut(&module_name, None)
-			.ok()
-			.expect(&format!("Namespace {} to be in libraries", module_name))
-			.0
-			.as_namespace_mut()
-			.expect(&format!("{} to be a namespace", module_name));
-
-		n.loaded = true;
 	}
 
 	/// Import all top-level types that are not in a submodule
 	pub fn import_root_types(&mut self) {
 		let assembly = self.jsii_types.find_assembly(&self.jsii_spec.assembly_name).unwrap();
+		let mut last_inner_namespace: Option<FQN> = None;
 		for entry in assembly.types.as_ref().unwrap().iter() {
-			if match entry.1 {
-				jsii::Type::ClassType(c) => c.namespace.is_none(),
-				jsii::Type::EnumType(e) => e.namespace.is_none(),
-				jsii::Type::InterfaceType(i) => i.namespace.is_none(),
-			} {
-				self.import_type(&FQN::from(entry.0.as_str()));
-			} else {
+			let ns = match entry.1 {
+				jsii::Type::ClassType(c) => &c.namespace,
+				jsii::Type::EnumType(e) => &e.namespace,
+				jsii::Type::InterfaceType(i) => &i.namespace,
+			};
+			let fqn = FQN::from(entry.0.as_str());
+
+			if let Some(ns) = ns {
+				if let Some(ref last_inner_namespace) = last_inner_namespace {
+					// If the namespace is within the last imported type (not namespace), we should consider it a top-level type
+					if ns == last_inner_namespace.type_name() {
+						self.import_type(&fqn);
+						continue;
+					}
+				}
 				// the types should be well ordered, so we can break early
 				break;
 			}
+			self.import_type(&fqn);
+			last_inner_namespace = Some(fqn)
 		}
 	}
 
@@ -1020,7 +961,6 @@ impl<'a> JsiiImporter<'a> {
 				let ns = self.wing_types.add_namespace(Namespace {
 					name: assembly.name.clone(),
 					envs: vec![ns_env],
-					loaded: false,
 					module_path: ResolveSource::ExternalModule(assembly.name.clone()),
 				});
 				self
@@ -1035,10 +975,6 @@ impl<'a> JsiiImporter<'a> {
 					.expect("Failed to define jsii root namespace");
 			}
 		}
-
-		// Mark the namespace as loaded. Note that its inner submodules might not be marked as
-		// loaded yet. But if they'll be accessed then they'll be marked as well.
-		self.mark_namespace_as_loaded(&assembly.name);
 
 		// Create a symbol in the environment for the imported module
 		// For example, `bring cloud` will create a symbol named `cloud` in the environment
@@ -1068,36 +1004,56 @@ impl<'a> JsiiImporter<'a> {
 			.unwrap();
 	}
 
-	fn register_jsii_type(&mut self, fqn: &FQN, symbol: &Symbol, type_ref: TypeRef) {
+	fn register_jsii_type(&mut self, fqn: &FQN, symbol: &Symbol, type_ref: TypeRef) -> TypeRef {
 		// make this function idempotent
 		if matches!(
 			self.wing_types.libraries.lookup_nested_str(fqn.as_str(), None),
 			LookupResult::Found(..)
 		) {
-			return;
+			return type_ref;
 		}
 
-		// make sure we have a namespace for this type
-		self.setup_namespaces_for(&fqn);
+		let parent_fqn = fqn.as_str_without_type_name();
 
-		let mut ns = self
+		// make sure we have the namespaces loaded
+		if !matches!(
+			self.wing_types.libraries.lookup_nested_str(parent_fqn, None),
+			LookupResult::Found(..)
+		) {
+			if fqn.namespaces().len() == 0 {
+				self.setup_namespaces_for(&fqn)
+			} else {
+				// load as type first in case it's a class instead of namespace
+				self.import_type(&FQN::from(parent_fqn));
+				self.setup_namespaces_for(&fqn)
+			}
+		}
+
+		let tt = self
 			.wing_types
 			.libraries
-			.lookup_nested_str_mut(fqn.as_str_without_type_name(), None)
+			.lookup_nested_str_mut(parent_fqn, None)
 			.unwrap()
-			.0
-			.as_namespace_ref()
-			.unwrap();
-		ns.envs
-			.get_mut(0)
-			.unwrap()
-			.define(
-				&symbol,
-				SymbolKind::Type(type_ref),
-				AccessModifier::Public,
-				StatementIdx::Top,
-			)
-			.expect(&format!("Invalid JSII library: failed to define type {}", fqn));
+			.0;
+		if let Some(mut ns) = tt.as_namespace_ref() {
+			ns.envs
+				.get_mut(0)
+				.unwrap()
+				.define(
+					&symbol,
+					SymbolKind::Type(type_ref),
+					AccessModifier::Public,
+					StatementIdx::Top,
+				)
+				.expect(&format!("Invalid JSII library: failed to define type {}", fqn));
+		} else if let Some(t) = tt.as_type() {
+			if t.as_env().is_none() {
+				panic!("Invalid JSII library: '{}' Is not a valid class", fqn);
+			}
+		} else {
+			panic!("Invalid JSII library: '{}' Is not a valid class or namespace", fqn);
+		}
+		type_ref
 	}
 }
 

--- a/libs/wingc/src/type_check/symbol_env.rs
+++ b/libs/wingc/src/type_check/symbol_env.rs
@@ -704,13 +704,11 @@ mod tests {
 		let ns1 = types.add_namespace(Namespace {
 			name: "ns1".to_string(),
 			envs: vec![ns1_env],
-			loaded: false,
 			module_path: ResolveSource::WingFile,
 		});
 		let ns2 = types.add_namespace(Namespace {
 			name: "ns2".to_string(),
 			envs: vec![ns2_env],
-			loaded: false,
 			module_path: ResolveSource::WingFile,
 		});
 

--- a/libs/wingc/turbo.json
+++ b/libs/wingc/turbo.json
@@ -11,7 +11,7 @@
       ]
     },
     "test": {
-      "dependsOn": ["compile", "@winglang/sdk#compile", "examples-valid#topo", "examples-invalid#topo"]
+      "dependsOn": ["@winglang/sdk#compile", "examples-valid#topo", "examples-invalid#topo"]
     },
     "dev": {
       "dependsOn": ["@winglang/sdk#compile"]

--- a/tools/hangar/__snapshots__/test_corpus/valid/bring_awscdk.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/bring_awscdk.test.w_compile_tf-aws.md
@@ -43,14 +43,17 @@ const $wing_is_test = process.env.WING_IS_TEST === "true";
 const std = $stdlib.std;
 const $helpers = $stdlib.helpers;
 const $extern = $helpers.createExternRequire(__dirname);
-const awscdk = require("aws-cdk-lib");
+const cdk = require("aws-cdk-lib");
 class $Root extends $stdlib.std.Resource {
   constructor($scope, $id) {
     super($scope, $id);
     class CdkDockerImageFunction extends $stdlib.std.Resource {
       constructor($scope, $id, ) {
         super($scope, $id);
-        this.function = this.node.root.new("aws-cdk-lib.aws_lambda.DockerImageFunction", awscdk.aws_lambda.DockerImageFunction, this, "DockerImageFunction", ({"code": (awscdk.aws_lambda.DockerImageCode.fromImageAsset("./test.ts"))}));
+        const eventBridge = this.node.root.new("aws-cdk-lib.aws_events.EventBus", cdk.aws_events.EventBus, this, "EventBridge", { eventBusName: "test" });
+        const rule = this.node.root.new("aws-cdk-lib.aws_events.CfnRule", cdk.aws_events.CfnRule, this, "CfnRule", { name: "test", eventBusName: eventBridge.eventBusName, eventPattern: ({}), targets: [({"arn": "", "id": ""})] });
+        this.node.root.new("aws-cdk-lib.aws_events.Rule", cdk.aws_events.Rule, this, "Rule", { eventPattern: ({"detailType": [""]}) });
+        this.function = this.node.root.new("aws-cdk-lib.aws_lambda.DockerImageFunction", cdk.aws_lambda.DockerImageFunction, this, "DockerImageFunction", ({"code": (cdk.aws_lambda.DockerImageCode.fromImageAsset("./test.ts"))}));
       }
       static _toInflightType() {
         return `
@@ -76,7 +79,7 @@ class $Root extends $stdlib.std.Resource {
         });
       }
     }
-    this.node.root.new("aws-cdk-lib.App", awscdk.App, );
+    this.node.root.new("aws-cdk-lib.App", cdk.App, );
   }
 }
 const $PlatformManager = new $stdlib.platform.PlatformManager({platformPaths: $platforms});

--- a/tools/hangar/__snapshots__/test_corpus/valid/bring_jsii.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/bring_jsii.test.w_compile_tf-aws.md
@@ -144,8 +144,7 @@ class $Root extends $stdlib.std.Resource {
     $helpers.assert($helpers.eq((jsiiClass.applyClosure(5, ((x) => {
       return (x * 2);
     }))), 10), "jsiiClass.applyClosure(5, (x) => { return x * 2; }) == 10");
-    const jsiiStruct = ({"field": "struct field"});
-    $helpers.assert($helpers.eq((jsiiClass.methodWithStructParam(jsiiStruct)), "struct field"), "jsiiClass.methodWithStructParam(jsiiStruct) == \"struct field\"");
+    $helpers.assert($helpers.eq((jsiiClass.methodWithStructParam(({"field": "struct field"}))), "struct field"), "jsiiClass.methodWithStructParam({ field: \"struct field\" }) == \"struct field\"");
   }
 }
 const $PlatformManager = new $stdlib.platform.PlatformManager({platformPaths: $platforms});


### PR DESCRIPTION
Fixes #6285
Fixes #5507

JSII allows types to be defined in classes (kinda, moreso that a class can also be a namespace), i.e `assembly.class.interface`. Wing does not support defining or directly referencing types like this. Previously, the JSII importer would  not import these types and also would fail to import any types that come after these types in a given namespace. Some JSII libs, like aws-cdk-lib, make extensive use of these so a lot of types were not available.

Now, the JSII importer supports importing these types and other JSII types that reference them. Wing still cannot directly reference them in type annotations, but there are cases where it is used and type checked (e.g. implicit structs).

In addition, language server completion requests do a better job of eagerly importing JSII types that aren't referenced in the rest of the file

Before
<img width="398" alt="image" src="https://github.com/winglang/wing/assets/1237390/ffed7b11-05d9-439f-b9f0-34266d3db0c5">

After
<img width="390" alt="image" src="https://github.com/winglang/wing/assets/1237390/8518eae7-dd36-4fec-801e-8c4612654b1c">


Misc:
- Reworked FQN a bit to avoid additional `.split()` calls
- Removed `loaded` from namespace struct. It was causing issues because it's not a "deep" flag. After some work in this PR is seemed to no longer be useful. If the benchmarks are bad here I'll look into seeing if it needs to be reintroduced
