### PR TITLE
chore(build): upgrade deprecated github actions

### DIFF
--- a/.github/workflows/tf-aws-test.yml
+++ b/.github/workflows/tf-aws-test.yml
@@ -152,14 +152,14 @@ jobs:
 
       - name: Configure AWS credentials
         if: ${{ matrix.target == 'tf-aws' }}
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ env.AWS_REGION }}
       - name: Configure azure credentials
         if: ${{ matrix.target == 'tf-azure' }}
-        uses: azure/login@v1
+        uses: azure/login@v2
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
       - name: Execute wing test in matrix directory

--- a/docs/docs/08-guides/02-ci-cd.md
+++ b/docs/docs/08-guides/02-ci-cd.md
@@ -67,7 +67,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           role-session-name: gh-actions-winglang # makes it easy to identify, e.g. in AWS Cloudtrail
@@ -103,7 +103,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           role-session-name: gh-actions-winglang
@@ -204,7 +204,7 @@ jobs:
       - name: Compile
         run: wing compile -t tf-aws --plugins=plugin.s3-backend.js main.w
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           role-session-name: gh-actions-winglang-website-proxy


### PR DESCRIPTION
Fixing warning thrown during tests:

```sh
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: azure/login@v1, aws-actions/configure-aws-credentials@v2. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
```

## Checklist

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [ ] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
