### PR TITLE
fix: `wing it` does not wait for process to cleanup

### DIFF
--- a/apps/wing/src/commands/run.ts
+++ b/apps/wing/src/commands/run.ts
@@ -4,7 +4,6 @@ import { createConsoleApp } from "@wingconsole/app";
 import { BuiltinPlatform } from "@winglang/compiler";
 import { debug } from "debug";
 import { glob } from "glob";
-import once from "lodash.once";
 import { loadEnvVariables } from "../env";
 import { parseNumericString } from "../util";
 import { beforeShutdown } from "../util.before-shutdown.js";
@@ -92,9 +91,7 @@ export async function run(entrypoint?: string, options?: RunOptions) {
   const url = `http://localhost:${port}/`;
   console.log(`The Wing Console is running at ${url}`);
 
-  const onExit = once(async (exitCode: number) => {
-    await close(() => process.exit(exitCode));
+  beforeShutdown(async () => {
+    await close();
   });
-
-  beforeShutdown(() => onExit(0));
 }

--- a/apps/wing/src/util.before-shutdown.ts
+++ b/apps/wing/src/util.before-shutdown.ts
@@ -19,10 +19,10 @@ const shutdownListeners: BeforeShutdownListener[] = [];
  * @param  fn Function to execute on shutdown.
  */
 const processOnce = (fn: BeforeShutdownListener) => {
+  process.once("beforeExit", (code) => void fn(code));
+  process.once("exit", (code) => void fn(code));
   process.once("SIGINT", (signal) => void fn(signal));
   process.once("SIGTERM", (signal) => void fn(signal));
-  process.once("exit", (code) => void fn(code));
-  process.once("beforeExit", (code) => void fn(code));
 };
 
 /**
@@ -55,7 +55,11 @@ async function shutdownHandler(codeOrSignal: string | number) {
     }
   }
 
-  return process.exit(0);
+  if (typeof codeOrSignal === "string") {
+    process.exit(1);
+  } else {
+    process.exit(codeOrSignal);
+  }
 }
 
 /**

--- a/apps/wing/src/util.before-shutdown.ts
+++ b/apps/wing/src/util.before-shutdown.ts
@@ -56,7 +56,7 @@ async function shutdownHandler(codeOrSignal: string | number) {
   }
 
   if (typeof codeOrSignal === "string") {
-    process.exit(1);
+    process.exit();
   } else {
     process.exit(codeOrSignal);
   }

--- a/libs/wingsdk/src/target-sim/function.inflight.ts
+++ b/libs/wingsdk/src/target-sim/function.inflight.ts
@@ -51,7 +51,7 @@ export class Function implements IFunctionClient, ISimulatorResourceInstance {
     // and the bundling code is allowed to run after the simulator has stopped, it might fail
     // and throw an error to the user because the files the simulator was using may no longer be there there.
     await this.createBundlePromise;
-    await Promise.all(this.workers.map((w) => w.cleanup()));
+    await Promise.allSettled(this.workers.map((w) => w.cleanup()));
   }
 
   public async save(): Promise<void> {}


### PR DESCRIPTION
In my local testing this consistantly fixed my issue with [tsoa](https://github.com/winglang/winglibs/tree/main/tsoa) not killing child processes. I'm not sure which of these changes actually helped.

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
