### PR TITLE
fix(sdk): container does not listen to port

### DIFF
--- a/libs/wingsdk/src/target-sim/container.inflight.ts
+++ b/libs/wingsdk/src/target-sim/container.inflight.ts
@@ -145,14 +145,19 @@ export class Container implements IContainerClient, ISimulatorResourceInstance {
       return {};
     }
 
-    const container = JSON.parse(
-      await runCommand("docker", ["inspect", this.containerName])
-    );
+    let hostPort: number | undefined;
+    await waitUntil(async () => {
+      const container = JSON.parse(
+        await runCommand("docker", ["inspect", this.containerName])
+      );
 
-    const hostPort =
-      container?.[0]?.NetworkSettings?.Ports?.[
-        `${this.props.containerPort}/tcp`
-      ]?.[0]?.HostPort;
+      hostPort =
+        container?.[0]?.NetworkSettings?.Ports?.[
+          `${this.props.containerPort}/tcp`
+        ]?.[0]?.HostPort;
+
+      return hostPort !== undefined;
+    });
 
     if (!hostPort) {
       throw new Error(


### PR DESCRIPTION
This change uses `waitUntil` after the docker container is up and running to ensure that the `hostPort` is correctly retrieved, as there seems to be a small time window when the container is running but the host port is not specified.

Fixes #6371
