### PR TITLE
fix: cli cleanup is skipped when multiple signals are sent

### DIFF
--- a/apps/wing/src/util.before-shutdown.ts
+++ b/apps/wing/src/util.before-shutdown.ts
@@ -1,3 +1,5 @@
+import once from "lodash.once";
+
 /**
  * Based on https://gist.github.com/nfantone/1eaa803772025df69d07f4dbf5df7e58.
  */
@@ -7,6 +9,16 @@ type BeforeShutdownListener = (codeOrSignal: string | number) => Promise<void> |
  * Time in milliseconds to wait before forcing shutdown.
  */
 const SHUTDOWN_TIMEOUT = 15_000;
+
+/**
+ * Signals/Events that trigger the shutdown process.
+ */
+const HANDLED_SIGNALS: (NodeJS.Signals | "beforeExit")[] = [
+  "beforeExit",
+  "SIGINT",
+  "SIGTERM",
+  "SIGHUP",
+];
 
 /**
  * A queue of listener callbacks to execute before shutting
@@ -19,10 +31,8 @@ const shutdownListeners: BeforeShutdownListener[] = [];
  * @param  fn Function to execute on shutdown.
  */
 const processOnce = (fn: BeforeShutdownListener) => {
-  process.once("beforeExit", (code) => void fn(code));
-  process.once("exit", (code) => void fn(code));
-  process.once("SIGINT", (signal) => void fn(signal));
-  process.once("SIGTERM", (signal) => void fn(signal));
+  const onceFn = once(fn);
+  HANDLED_SIGNALS.forEach((signal) => process.on(signal, (s) => void onceFn(s)));
 };
 
 /**


### PR DESCRIPTION
Finally was able to reproduce the issue locally. Depending on how it is executed, it is possible the CLI will receive multiple SIGINT signals when a user hits CTRL^C (even when pressed once).

Using process.once handled the first signal and then started our cleanup process. However, the second signal came along and no longer had a handler because the first process.once was used up. So then node returns to its default behavior, which is to immediately process.exit(). process.exit() Stops the process kills the process without waiting for the event loop to finish so thus the cleanup process is interrupted.

Other changes:
- Removed `exit` handling because that does not allow us to schedule any additional async work, so it's pointless
- Added SIGHUP handling

Reproducing: I noticed this happening with a globally installed version of the CLI, but no with my local dev version. So to test this fix, I manually replaced the compiled .js for this particular util file in the global version. I do not know why this only happens with the global version.

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
