### PR TITLE
chore: remove regex from docgen filter

### DIFF
--- a/apps/jsii-docgen/src/docgen/view/wing-filters.ts
+++ b/apps/jsii-docgen/src/docgen/view/wing-filters.ts
@@ -7,7 +7,6 @@ export const VISIBLE_SUBMODULES = [
   "redis",
   "http",
   "math",
-  "regex",
 ];
 export const HIDDEN_METHODS = ["toString", "toJSON", "onLift"];
 export const HIDDEN_PROPS = ["node", "display"];


### PR DESCRIPTION
This change doesn't actually do anything, I just wanted to bust the SDK docgen cache

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
