### PR TITLE
fix: can't use `setUncaughtExceptionCaptureCallback` with `domain` module

### DIFF
--- a/libs/wingcompiler/preflight.shim.cjs
+++ b/libs/wingcompiler/preflight.shim.cjs
@@ -6,7 +6,7 @@
 /// 1. The environment variable WING_PREFLIGHT_ENTRYPOINT is a JSON string of the entrypoint to load
 /// 2. Runs in a child process with an IPC channel to the parent process
 
-process.setUncaughtExceptionCaptureCallback((reason) => {
+process.on("uncaughtException", (reason) => {
   if (reason instanceof Error) {
     // The Error object does not serialize well over IPC (even with 'advanced' serialization)
     // So we extract the properties we need to recreate most error objects

--- a/libs/wingsdk/src/shared/sandbox.ts
+++ b/libs/wingsdk/src/shared/sandbox.ts
@@ -59,7 +59,7 @@ export class Sandbox {
     // wrap contents with a shim that handles the communication with the parent process
     // we insert this shim before bundling to ensure source maps are generated correctly
     contents += `
-process.setUncaughtExceptionCaptureCallback((reason) => {
+process.on("uncaughtException", (reason) => {
   process.send({ type: "reject", reason });
 });
 


### PR DESCRIPTION
Fixes #6390

## Checklist

- [ ] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [ ] Description explains motivation and solution
- [ ] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
