### PR TITLE
chore(docs): update typescript example and fix typo

### DIFF
--- a/docs/docs/09-typescript/02-inflights.md
+++ b/docs/docs/09-typescript/02-inflights.md
@@ -68,7 +68,7 @@ main((root) => {
 ```
 
 Normal functions and classes cannot be lifted.
-Unlike other variable, imports can be referenced as-is from within inflight closures. The imports will be bundled into the inflight's environment.
+Unlike other variables, imports can be referenced as-is from within inflight closures. The imports will be bundled into the inflight's environment.
 
 ```ts
 import { main, inflight } from "@wingcloud/framework";
@@ -93,7 +93,7 @@ import { main, cloud, lift } from "@wingcloud/framework";
 main((root) => {
   const bucket = new cloud.Bucket(root, "MyBucket");
 
-  cloud.Function(
+  new cloud.Function(
     root,
     "MyFn",
     lift({ bucket })


### PR DESCRIPTION
in this example in the TypeScript docs under "Permissions" I get an error unless the keyword "new" is included in front of the  cloud.Function

There was also a typo in the same doc.

```ts
import { main, cloud, lift } from "@wingcloud/framework";

main((root) => {
  const bucket = new cloud.Bucket(root, "MyBucket");

  new cloud.Function(
    root,
    "MyFn",
    lift({ bucket })
      .grant({ bucket: ["get"] })
      .inflight(async ({ bucket }) => {
        await bucket.put("hello.txt", "Wing!");
        //           ^^^ Type error, no `put` permissions!
        return "Wing!";
      })
  );
});
```
## Checklist

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [x] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
