### PR TITLE
fix: inflight() features in @wingcloud/framework do not work

### DIFF
--- a/libs/@wingcloud/framework/src/transformer.ts
+++ b/libs/@wingcloud/framework/src/transformer.ts
@@ -27,40 +27,15 @@ export class InflightTransformer {
       return false;
     }
 
-    function getImportSpecifier(node: ts.Declaration): string {
-      if (ts.isImportSpecifier(node)) {
-        return node.parent.parent.parent.moduleSpecifier.getText();
-      } else if (ts.isNamespaceImport(node)) {
-        return node.parent.parent.moduleSpecifier.getText();
-      } else if (ts.isImportClause(node)) {
-        return node.parent.moduleSpecifier.getText();
-      }
-      return "";
-    }
-
     /**
-     * Checks if the given node is a reference to the `inflight` function from this library
+     * Checks if the given node is a reference to special `inflight` symbol
+     * This will be any symbol that has a jsdoc tag `@wing inflight`
      */
     function isInflightSymbol(node: ts.Node) {
-      let sym = typeChecker.getSymbolAtLocation(node);
-      if (!sym) return false;
-
-      if (sym.name === "inflight") {
-        const decl = sym.declarations?.at(0);
-        if (!decl) {
-          return true;
-        } else {
-          const fileName = decl.getSourceFile().fileName.replaceAll("\\", "/");
-          if (fileName.includes("/@wingcloud/framework/") || fileName.includes("/wingsdk/lib/core/")) {
-            return true;
-          }
-
-          const importSpecifier = getImportSpecifier(decl)
-          return importSpecifier === '"@wingcloud/framework"' || importSpecifier === '"@winglang/sdk"';
-        }
-      }
-
-      return false;
+      let sym = typeChecker.getTypeAtLocation(node).symbol;
+      const docs = sym.getJsDocTags(typeChecker);
+      const wingDoc = docs?.find((doc) => doc.name === "wing");
+      return wingDoc?.text?.[0]?.text === "inflight";
     }
 
     return (sourceFile: ts.SourceFile) => {

--- a/libs/@wingcloud/framework/test/internal.test.ts
+++ b/libs/@wingcloud/framework/test/internal.test.ts
@@ -25,6 +25,11 @@ describe("compile", async () => {
       )) {
         test(
           file,
+          {
+            // The typescript compiler is quite slow, especially in CI
+            // See https://github.com/winglang/wing/issues/5676
+            timeout: 60000,
+          },
           async () => {
             const tmpDir = await mkdtemp(join(tmpdir(), `wingts.${file}`));
             const filePath = join(statusDir, file);
@@ -38,11 +43,6 @@ describe("compile", async () => {
             } else {
               await compilePromise;
             }
-          },
-          {
-            // The typescript compiler is quite slow, especially in CI
-            // See https://github.com/winglang/wing/issues/5676
-            timeout: 60000,
           }
         );
       }

--- a/libs/wingsdk/src/core/inflight.ts
+++ b/libs/wingsdk/src/core/inflight.ts
@@ -100,6 +100,7 @@ export function lift<TToLift extends LiftableRecord>(
  * If needed, use `lift` to bind variables to the scope of the function.
  *
  * Built-in NodeJS globals are available, such as `console` and `process`.
+ * @wing inflight
  */
 export function inflight<TFunction extends AsyncFunction>(
   fn: (ctx: {}, ...args: Parameters<TFunction>) => ReturnType<TFunction>
@@ -198,6 +199,7 @@ class Lifter<
    * Bound variables will be available as properties on the `ctx` object passed as the first argument to the function.
    *
    * Built-in NodeJS globals are available, such as `console` and `process`.
+   * @wing inflight
    */
   public inflight<TFunction extends AsyncFunction>(
     fn: (


### PR DESCRIPTION
When the inflight() function was moved to the SDK, the special auto-import and extra validation provided by the ts framework stopped working. This PR makes the logic for detecting this special function slightly more rigorous by using jsdoc tags instead of relying on detecting the source module.

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
