### PR TITLE
chore(docs): update TypeScript example in the `Testing` section

### DIFF
--- a/docs/docs/09-typescript/02-inflights.md
+++ b/docs/docs/09-typescript/02-inflights.md
@@ -116,7 +116,7 @@ import { main, cloud, inflight, lift } from "@wingcloud/framework";
 import assert from "node:assert";
 
 main((root, test) => {
-  const fn = cloud.Function(
+  const fn = new cloud.Function(
     root,
     "MyFn",
     inflight(async () => {


### PR DESCRIPTION
`cloud.Function` is missing the keyword `new`. Added to the code below.

```ts
import { main, cloud, inflight, lift } from "@wingcloud/framework"; 
import assert from "node:assert";

main((root, test) => {
  const fn = new cloud.Function(
    root,
    "MyFn",
    inflight(async () => {
      return "Wing!";
    })
  );

  test(
    // name of the test
    "MyFn returns 'Wing!'",
    // inflight function to run as the test
    lift({ fn }).inflight(async ({ fn }) => {
      assert.equal(await fn.invoke(), "Wing!");
    })
  );
});
```

## Checklist

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [x] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
