### PR TITLE
chore(cli): improve error output

### DIFF
--- a/apps/wing-console/console/server/src/utils/format-wing-error.ts
+++ b/apps/wing-console/console/server/src/utils/format-wing-error.ts
@@ -31,7 +31,7 @@ export const formatWingError = async (error: unknown, entryPoint?: string) => {
             fileId: filePath,
             rangeStart: start,
             rangeEnd: end,
-            message,
+            message: "",
             style: "primary",
           });
         }

--- a/apps/wing/src/commands/compile.ts
+++ b/apps/wing/src/commands/compile.ts
@@ -117,7 +117,7 @@ export async function compile(entrypoint?: string, options?: CompileOptions): Pr
             fileId: filePath,
             rangeStart: start,
             rangeEnd: end,
-            message,
+            message: "",
             style: "primary",
           });
         }

--- a/tools/hangar/__snapshots__/invalid.ts.snap
+++ b/tools/hangar/__snapshots__/invalid.ts.snap
@@ -5,7 +5,7 @@ exports[`access_hidden_namespace.test.w 1`] = `
   --> ../../../examples/tests/invalid/access_hidden_namespace.test.w:7:5
   |
 7 | new core.NodeJsCode(\\"<ABSOLUTE>/test.txt\\"); // This should fail even though \`fs.TextFile\` extends \`core.FileBase\` because we didn't bring in \`core\` explicitly.
-  |     ^^^^ Unknown symbol \\"core\\"
+  |     ^^^^
 
 
 
@@ -20,28 +20,28 @@ exports[`access_modifiers.test.w 1`] = `
    --> ../../../examples/tests/invalid/access_modifiers.test.w:49:3
    |
 49 |   private_method() {}
-   |   ^^^^^^^^^^^^^^ Method \\"private_method\\" is private in \\"Foo\\" but it's an implementation of \\"SomeInterface\\". Interface members must be public.
+   |   ^^^^^^^^^^^^^^
 
 
 error: Method \\"protected_method\\" is protected in \\"Foo\\" but it's an implementation of \\"SomeInterface\\". Interface members must be public.
    --> ../../../examples/tests/invalid/access_modifiers.test.w:47:13
    |
 47 |   protected protected_method() {}
-   |             ^^^^^^^^^^^^^^^^ Method \\"protected_method\\" is protected in \\"Foo\\" but it's an implementation of \\"SomeInterface\\". Interface members must be public.
+   |             ^^^^^^^^^^^^^^^^
 
 
 error: Cannot override private method \\"method\\" of \\"Foo\\"
    --> ../../../examples/tests/invalid/access_modifiers.test.w:58:3
    |
 58 |   method() {
-   |   ^^^^^^ Cannot override private method \\"method\\" of \\"Foo\\"
+   |   ^^^^^^
 
 
 error: Cannot override private method \\"method\\" of \\"Bar\\"
    --> ../../../examples/tests/invalid/access_modifiers.test.w:81:3
    |
 81 |   method() {
-   |   ^^^^^^ Cannot override private method \\"method\\" of \\"Bar\\"
+   |   ^^^^^^
 
 
 error: Cannot access protected member \\"protected_field\\" of \\"Foo\\"
@@ -51,7 +51,7 @@ error: Cannot access protected member \\"protected_field\\" of \\"Foo\\"
     |             --------------- defined here
     .
 109 | log(foo.protected_field);
-    |         ^^^^^^^^^^^^^^^ Cannot access protected member \\"protected_field\\" of \\"Foo\\"
+    |         ^^^^^^^^^^^^^^^
     |
     = hint: the definition of \\"protected_field\\" needs a broader access modifier like \\"pub\\" to be used outside of \\"Foo\\"
 
@@ -63,7 +63,7 @@ error: Cannot access private member \\"private_field\\" of \\"Foo\\"
     |   ------------- defined here
     .
 111 | log(foo.private_field);
-    |         ^^^^^^^^^^^^^ Cannot access private member \\"private_field\\" of \\"Foo\\"
+    |         ^^^^^^^^^^^^^
     |
     = hint: the definition of \\"private_field\\" needs a broader access modifier like \\"pub\\" or \\"protected\\" to be used outside of \\"Foo\\"
 
@@ -75,7 +75,7 @@ error: Cannot access protected member \\"protected_static_method\\" of \\"Foo\\"
     |                    ----------------------- defined here
     .
 115 | Foo.protected_static_method();
-    |     ^^^^^^^^^^^^^^^^^^^^^^^ Cannot access protected member \\"protected_static_method\\" of \\"Foo\\"
+    |     ^^^^^^^^^^^^^^^^^^^^^^^
     |
     = hint: the definition of \\"protected_static_method\\" needs a broader access modifier like \\"pub\\" to be used outside of \\"Foo\\"
 
@@ -87,7 +87,7 @@ error: Cannot access private member \\"private_static_method\\" of \\"Foo\\"
     |          --------------------- defined here
     .
 117 | Foo.private_static_method();
-    |     ^^^^^^^^^^^^^^^^^^^^^ Cannot access private member \\"private_static_method\\" of \\"Foo\\"
+    |     ^^^^^^^^^^^^^^^^^^^^^
     |
     = hint: the definition of \\"private_static_method\\" needs a broader access modifier like \\"pub\\" or \\"protected\\" to be used outside of \\"Foo\\"
 
@@ -96,42 +96,42 @@ error: Cannot override public method \\"public_method\\" of \\"Foo\\" with a pri
     --> ../../../examples/tests/invalid/access_modifiers.test.w:157:3
     |
 157 |   public_method() {}
-    |   ^^^^^^^^^^^^^ Cannot override public method \\"public_method\\" of \\"Foo\\" with a private method
+    |   ^^^^^^^^^^^^^
 
 
 error: Cannot override protected method \\"protected_method\\" of \\"Foo\\" with a private method
     --> ../../../examples/tests/invalid/access_modifiers.test.w:159:3
     |
 159 |   protected_method() {}
-    |   ^^^^^^^^^^^^^^^^ Cannot override protected method \\"protected_method\\" of \\"Foo\\" with a private method
+    |   ^^^^^^^^^^^^^^^^
 
 
 error: Cannot override private method \\"private_method\\" of \\"Foo\\"
     --> ../../../examples/tests/invalid/access_modifiers.test.w:161:3
     |
 161 |   private_method() {}
-    |   ^^^^^^^^^^^^^^ Cannot override private method \\"private_method\\" of \\"Foo\\"
+    |   ^^^^^^^^^^^^^^
 
 
 error: Cannot override public method \\"public_method\\" of \\"Foo\\" with a protected method
     --> ../../../examples/tests/invalid/access_modifiers.test.w:166:13
     |
 166 |   protected public_method() {}
-    |             ^^^^^^^^^^^^^ Cannot override public method \\"public_method\\" of \\"Foo\\" with a protected method
+    |             ^^^^^^^^^^^^^
 
 
 error: Cannot override private method \\"private_method\\" of \\"Foo\\"
     --> ../../../examples/tests/invalid/access_modifiers.test.w:169:13
     |
 169 |   protected private_method() {}
-    |             ^^^^^^^^^^^^^^ Cannot override private method \\"private_method\\" of \\"Foo\\"
+    |             ^^^^^^^^^^^^^^
 
 
 error: Cannot override private method \\"private_method\\" of \\"Foo\\"
     --> ../../../examples/tests/invalid/access_modifiers.test.w:176:7
     |
 176 |   pub private_method() {}
-    |       ^^^^^^^^^^^^^^ Cannot override private method \\"private_method\\" of \\"Foo\\"
+    |       ^^^^^^^^^^^^^^
 
 
 error: Cannot access private member \\"private_field\\" of \\"Bar\\"
@@ -141,7 +141,7 @@ error: Cannot access private member \\"private_field\\" of \\"Bar\\"
    |   ------------- defined here
    .
 61 |     log(this.private_field);
-   |              ^^^^^^^^^^^^^ Cannot access private member \\"private_field\\" of \\"Bar\\"
+   |              ^^^^^^^^^^^^^
    |
    = hint: the definition of \\"private_field\\" needs a broader access modifier like \\"pub\\" or \\"protected\\" to be used outside of \\"Bar\\"
 
@@ -153,7 +153,7 @@ error: Cannot access private member \\"private_method\\" of \\"Bar\\"
    |   -------------- defined here
    .
 66 |     this.private_method();
-   |          ^^^^^^^^^^^^^^ Cannot access private member \\"private_method\\" of \\"Bar\\"
+   |          ^^^^^^^^^^^^^^
    |
    = hint: the definition of \\"private_method\\" needs a broader access modifier like \\"pub\\" or \\"protected\\" to be used outside of \\"Bar\\"
 
@@ -165,7 +165,7 @@ error: Cannot access private member \\"private_static_method\\" of \\"Foo\\"
    |          --------------------- defined here
    .
 74 |     Foo.private_static_method();
-   |         ^^^^^^^^^^^^^^^^^^^^^ Cannot access private member \\"private_static_method\\" of \\"Foo\\"
+   |         ^^^^^^^^^^^^^^^^^^^^^
    |
    = hint: the definition of \\"private_static_method\\" needs a broader access modifier like \\"pub\\" or \\"protected\\" to be used outside of \\"Foo\\"
 
@@ -177,7 +177,7 @@ error: Cannot access private member \\"private_field\\" of \\"Baz\\"
    |   ------------- defined here
    .
 84 |     log(this.private_field);
-   |              ^^^^^^^^^^^^^ Cannot access private member \\"private_field\\" of \\"Baz\\"
+   |              ^^^^^^^^^^^^^
    |
    = hint: the definition of \\"private_field\\" needs a broader access modifier like \\"pub\\" or \\"protected\\" to be used outside of \\"Baz\\"
 
@@ -189,7 +189,7 @@ error: Cannot access private member \\"private_method\\" of \\"Baz\\"
    |   -------------- defined here
    .
 89 |     this.private_method();
-   |          ^^^^^^^^^^^^^^ Cannot access private member \\"private_method\\" of \\"Baz\\"
+   |          ^^^^^^^^^^^^^^
    |
    = hint: the definition of \\"private_method\\" needs a broader access modifier like \\"pub\\" or \\"protected\\" to be used outside of \\"Baz\\"
 
@@ -201,7 +201,7 @@ error: Cannot access private member \\"private_static_method\\" of \\"Foo\\"
    |          --------------------- defined here
    .
 97 |     Foo.private_static_method();
-   |         ^^^^^^^^^^^^^^^^^^^^^ Cannot access private member \\"private_static_method\\" of \\"Foo\\"
+   |         ^^^^^^^^^^^^^^^^^^^^^
    |
    = hint: the definition of \\"private_static_method\\" needs a broader access modifier like \\"pub\\" or \\"protected\\" to be used outside of \\"Foo\\"
 
@@ -213,7 +213,7 @@ error: Cannot access private member \\"private_static_method\\" of \\"Bar\\"
     |          --------------------- defined here
     .
 102 |     Bar.private_static_method();
-    |         ^^^^^^^^^^^^^^^^^^^^^ Cannot access private member \\"private_static_method\\" of \\"Bar\\"
+    |         ^^^^^^^^^^^^^^^^^^^^^
     |
     = hint: the definition of \\"private_static_method\\" needs a broader access modifier like \\"pub\\" or \\"protected\\" to be used outside of \\"Bar\\"
 
@@ -225,7 +225,7 @@ error: Cannot access protected member \\"protected_field\\" of \\"Foo\\"
     |             --------------- defined here
     .
 123 |     log(foo.protected_field);
-    |             ^^^^^^^^^^^^^^^ Cannot access protected member \\"protected_field\\" of \\"Foo\\"
+    |             ^^^^^^^^^^^^^^^
     |
     = hint: the definition of \\"protected_field\\" needs a broader access modifier like \\"pub\\" to be used outside of \\"Foo\\"
 
@@ -237,7 +237,7 @@ error: Cannot access private member \\"private_field\\" of \\"Foo\\"
     |   ------------- defined here
     .
 125 |     log(foo.private_field);
-    |             ^^^^^^^^^^^^^ Cannot access private member \\"private_field\\" of \\"Foo\\"
+    |             ^^^^^^^^^^^^^
     |
     = hint: the definition of \\"private_field\\" needs a broader access modifier like \\"pub\\" or \\"protected\\" to be used outside of \\"Foo\\"
 
@@ -249,7 +249,7 @@ error: Cannot access protected member \\"protected_method\\" of \\"Foo\\"
     |             ---------------- defined here
     .
 129 |     foo.protected_method();
-    |         ^^^^^^^^^^^^^^^^ Cannot access protected member \\"protected_method\\" of \\"Foo\\"
+    |         ^^^^^^^^^^^^^^^^
     |
     = hint: the definition of \\"protected_method\\" needs a broader access modifier like \\"pub\\" to be used outside of \\"Foo\\"
 
@@ -261,7 +261,7 @@ error: Cannot access private member \\"private_method\\" of \\"Foo\\"
     |   -------------- defined here
     .
 131 |     foo.private_method();
-    |         ^^^^^^^^^^^^^^ Cannot access private member \\"private_method\\" of \\"Foo\\"
+    |         ^^^^^^^^^^^^^^
     |
     = hint: the definition of \\"private_method\\" needs a broader access modifier like \\"pub\\" or \\"protected\\" to be used outside of \\"Foo\\"
 
@@ -273,7 +273,7 @@ error: Cannot access protected member \\"protected_static_method\\" of \\"Foo\\"
     |                    ----------------------- defined here
     .
 137 |     Foo.protected_static_method();
-    |         ^^^^^^^^^^^^^^^^^^^^^^^ Cannot access protected member \\"protected_static_method\\" of \\"Foo\\"
+    |         ^^^^^^^^^^^^^^^^^^^^^^^
     |
     = hint: the definition of \\"protected_static_method\\" needs a broader access modifier like \\"pub\\" to be used outside of \\"Foo\\"
 
@@ -285,7 +285,7 @@ error: Cannot access private member \\"private_static_method\\" of \\"Foo\\"
     |          --------------------- defined here
     .
 139 |     Foo.private_static_method();
-    |         ^^^^^^^^^^^^^^^^^^^^^ Cannot access private member \\"private_static_method\\" of \\"Foo\\"
+    |         ^^^^^^^^^^^^^^^^^^^^^
     |
     = hint: the definition of \\"private_static_method\\" needs a broader access modifier like \\"pub\\" or \\"protected\\" to be used outside of \\"Foo\\"
 
@@ -302,7 +302,7 @@ exports[`access_private_apis.test.w 1`] = `
   --> ../../../examples/tests/invalid/access_private_apis.test.w:3:5
   |
 3 | new subdir2.MyPrivateClass();
-  |     ^^^^^^^^^^^^^^^^^^^^^^ Class \\"subdir2.MyPrivateClass\\" is private
+  |     ^^^^^^^^^^^^^^^^^^^^^^
   |
   --> ../../../examples/tests/invalid/subdir2/file.w:1:7
   |
@@ -314,7 +314,7 @@ error: Class \\"subdir2.inner.MyOtherPrivateClass\\" is private
   --> ../../../examples/tests/invalid/access_private_apis.test.w:6:5
   |
 6 | new subdir2.inner.MyOtherPrivateClass();
-  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Class \\"subdir2.inner.MyOtherPrivateClass\\" is private
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   --> ../../../examples/tests/invalid/subdir2/inner/blah.w:1:7
   |
@@ -326,7 +326,7 @@ error: Interface \\"subdir2.MyPrivateInterface\\" is private
    --> ../../../examples/tests/invalid/access_private_apis.test.w:11:14
    |
 11 | class A impl subdir2.MyPrivateInterface {}
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ Interface \\"subdir2.MyPrivateInterface\\" is private
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    --> ../../../examples/tests/invalid/subdir2/file.w:7:11
    |
@@ -338,14 +338,14 @@ error: Expected an interface, instead found type \\"unresolved\\"
    --> ../../../examples/tests/invalid/access_private_apis.test.w:11:14
    |
 11 | class A impl subdir2.MyPrivateInterface {}
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ Expected an interface, instead found type \\"unresolved\\"
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 
 error: Struct \\"subdir2.MyPrivateStruct\\" is private
    --> ../../../examples/tests/invalid/access_private_apis.test.w:14:9
    |
 14 | let s = subdir2.MyPrivateStruct {};
-   |         ^^^^^^^^^^^^^^^^^^^^^^^ Struct \\"subdir2.MyPrivateStruct\\" is private
+   |         ^^^^^^^^^^^^^^^^^^^^^^^
    |
    --> ../../../examples/tests/invalid/subdir2/file.w:3:8
    |
@@ -357,7 +357,7 @@ error: Expected identifier \\"subdir2\\" to be a variable, but it's a namespace
    --> ../../../examples/tests/invalid/access_private_apis.test.w:17:9
    |
 17 | let e = subdir2.MyPrivateEnum.A;
-   |         ^^^^^^^ Expected identifier \\"subdir2\\" to be a variable, but it's a namespace
+   |         ^^^^^^^
 
 
 
@@ -372,35 +372,35 @@ exports[`access_static_from_instance.test.w 1`] = `
   --> ../../../examples/tests/invalid/access_static_from_instance.test.w:4:3
   |
 4 |   pub static f: num;
-  |   ^^^^^^^^^^^^^^^^^^ Static class fields not supported yet, see https://github.com/winglang/wing/issues/1668
+  |   ^^^^^^^^^^^^^^^^^^
 
 
 error: Cannot access static property \\"f\\" from instance
    --> ../../../examples/tests/invalid/access_static_from_instance.test.w:19:5
    |
 19 | foo.f; // Can't access static fields through instances
-   |     ^ Cannot access static property \\"f\\" from instance
+   |     ^
 
 
 error: Cannot access static property \\"m\\" from instance
    --> ../../../examples/tests/invalid/access_static_from_instance.test.w:20:5
    |
 20 | foo.m(); // Can't access static methods through instances
-   |     ^ Cannot access static property \\"m\\" from instance
+   |     ^
 
 
 error: Member \\"instanceField\\" doesn't exist in \\"Construct\\"
   --> ../../../examples/tests/invalid/access_static_from_instance.test.w:7:10
   |
 7 |     this.instanceField = 1; // Can't access instance fields from static methods
-  |          ^^^^^^^^^^^^^ Member \\"instanceField\\" doesn't exist in \\"Construct\\"
+  |          ^^^^^^^^^^^^^
 
 
 error: Member \\"f\\" doesn't exist in \\"Construct\\"
   --> ../../../examples/tests/invalid/access_static_from_instance.test.w:8:10
   |
 8 |     this.f = 1; // Can't access static fields through \`this\`
-  |          ^ Member \\"f\\" doesn't exist in \\"Construct\\"
+  |          ^
 
 
 
@@ -431,28 +431,28 @@ exports[`bring.test.w 1`] = `
   --> ../../../examples/tests/invalid/bring.test.w:6:7
   |
 6 | bring ;
-  |       ^ Expected module specification (see https://www.winglang.io/docs/libraries)
+  |       ^
 
 
 error: Could not find a trusted library \\"@winglibs/c\\" installed. Did you mean to run \`npm i @winglibs/c\`?
   --> ../../../examples/tests/invalid/bring.test.w:8:1
   |
 8 | bring c;
-  | ^^^^^^^^ Could not find a trusted library \\"@winglibs/c\\" installed. Did you mean to run \`npm i @winglibs/c\`?
+  | ^^^^^^^^
 
 
 error: Redundant bring of \\"std\\"
   --> ../../../examples/tests/invalid/bring.test.w:1:1
   |
 1 | bring std;
-  | ^^^^^^^^^^ Redundant bring of \\"std\\"
+  | ^^^^^^^^^^
 
 
 error: \\"cloud\\" is already defined
   --> ../../../examples/tests/invalid/bring.test.w:4:7
   |
 4 | bring cloud;
-  |       ^^^^^ \\"cloud\\" is already defined
+  |       ^^^^^
 
 
 
@@ -484,14 +484,14 @@ exports[`bring_jsii.test.w 1`] = `
   --> ../../../examples/tests/invalid/bring_jsii.test.w:1:1
   |
 1 | bring \\"jsii-code-samples\\";
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^ bring \\"jsii-code-samples\\" must be assigned to an identifier (e.g. bring \\"foo\\" as foo)
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 
 error: Unable to load \\"foobar\\": Module not found in \\"<ABSOLUTE>/bring_jsii.test.w\\"
   --> ../../../examples/tests/invalid/bring_jsii.test.w:4:1
   |
 4 | bring \\"foobar\\" as baz;
-  | ^^^^^^^^^^^^^^^^^^^^^^ Unable to load \\"foobar\\": Module not found in \\"<ABSOLUTE>/bring_jsii.test.w\\"
+  | ^^^^^^^^^^^^^^^^^^^^^^
 
 
 
@@ -506,21 +506,21 @@ exports[`bring_local_dir.test.w 1`] = `
   --> ../../../examples/tests/invalid/bring_local_dir.test.w:4:7
   |
 4 | bring \\"/subdir\\" as baz;
-  |       ^^^^^^^^^ Cannot bring \\"/subdir\\" since it is not a relative path
+  |       ^^^^^^^^^
 
 
 error: Symbol \\"Foo\\" has multiple definitions in \\"<ABSOLUTE>/inner\\"
   --> ../../../examples/tests/invalid/subdir/other.w:1:1
   |
 1 | bring \\"./inner\\" as inner;
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^ Symbol \\"Foo\\" has multiple definitions in \\"<ABSOLUTE>/inner\\"
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 
 error: Symbol \\"Foo\\" has multiple definitions in \\"<ABSOLUTE>/inner\\"
   --> ../../../examples/tests/invalid/bring_local_dir.test.w:1:1
   |
 1 | bring \\"./subdir\\" as subdir;
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Symbol \\"Foo\\" has multiple definitions in \\"<ABSOLUTE>/inner\\"
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 
 
@@ -535,28 +535,28 @@ exports[`bring_local_self.test.w 1`] = `
   --> ../../../examples/tests/invalid/bring_local_self.test.w:1:7
   |
 1 | bring \\"./bring_local_self.main.w\\" as foo;
-  |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Cannot find module \\"./bring_local_self.main.w\\"
+  |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 
 error: Cannot find module \\"./non-existent.w\\"
   --> ../../../examples/tests/invalid/bring_local_self.test.w:4:7
   |
 4 | bring \\"./non-existent.w\\" as bar;
-  |       ^^^^^^^^^^^^^^^^^^ Cannot find module \\"./non-existent.w\\"
+  |       ^^^^^^^^^^^^^^^^^^
 
 
 error: Cannot bring \\"/hello.w\\" since it is not a relative path
   --> ../../../examples/tests/invalid/bring_local_self.test.w:7:7
   |
 7 | bring \\"/hello.w\\" as baz;
-  |       ^^^^^^^^^^ Cannot bring \\"/hello.w\\" since it is not a relative path
+  |       ^^^^^^^^^^
 
 
 error: Cannot bring module \\"./bring_local_dir.test.w\\" since it is an entrypoint file
    --> ../../../examples/tests/invalid/bring_local_self.test.w:10:7
    |
 10 | bring \\"./bring_local_dir.test.w\\" as qux;
-   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^ Cannot bring module \\"./bring_local_dir.test.w\\" since it is an entrypoint file
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 
 
@@ -571,28 +571,28 @@ exports[`bring_local_variables.test.w 1`] = `
   --> ../../../examples/tests/invalid/file_with_variables.w:5:1
   |
 5 | let x = 5;
-  | ^^^^^^^^^^ Module files cannot have statements besides classes, interfaces, enums, and structs. Rename the file to end with \`.main.w\` or \`.test.w\` to make this an entrypoint file.
+  | ^^^^^^^^^^
 
 
 error: Module files cannot have statements besides classes, interfaces, enums, and structs. Rename the file to end with \`.main.w\` or \`.test.w\` to make this an entrypoint file.
   --> ../../../examples/tests/invalid/file_with_variables.w:6:1
   |
 6 | let y = [\\"hello\\", \\"world\\"];
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Module files cannot have statements besides classes, interfaces, enums, and structs. Rename the file to end with \`.main.w\` or \`.test.w\` to make this an entrypoint file.
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 
 error: Module files cannot have statements besides classes, interfaces, enums, and structs. Rename the file to end with \`.main.w\` or \`.test.w\` to make this an entrypoint file.
   --> ../../../examples/tests/invalid/file_with_variables.w:7:1
   |
 7 | let z = new cloud.Bucket();
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Module files cannot have statements besides classes, interfaces, enums, and structs. Rename the file to end with \`.main.w\` or \`.test.w\` to make this an entrypoint file.
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 
 error: Preflight field \\"x\\" is not initialized
    --> ../../../examples/tests/invalid/file_with_variables.w:10:3
    |
 10 |   x: num;
-   |   ^ Preflight field \\"x\\" is not initialized
+   |   ^
 
 
 
@@ -607,21 +607,21 @@ exports[`bring_non_std_construct.test.w 1`] = `
   --> ../../../examples/tests/invalid/bring_non_std_construct.test.w:8:1
   |
 8 | new cdktf.S3Backend();
-  | ^^^^^^^^^^^^^^^^^^^^^ Expected 2 positional argument(s) or named arguments for the last parameter but got 0
+  | ^^^^^^^^^^^^^^^^^^^^^
 
 
 error: Cannot set id of non-standard preflight class \\"S3Backend\\" using \`as\`
    --> ../../../examples/tests/invalid/bring_non_std_construct.test.w:13:85
    |
 13 |     new cdktf.S3Backend(this, cdktf.S3BackendConfig {bucket: \\"foo\\", key: \\"bar\\"}) as \\"s3_backend\\";
-   |                                                                                     ^^^^^^^^^^^^ Cannot set id of non-standard preflight class \\"S3Backend\\" using \`as\`
+   |                                                                                     ^^^^^^^^^^^^
 
 
 error: Cannot set scope of non-standard preflight class \\"S3Backend\\" using \`in\`
    --> ../../../examples/tests/invalid/bring_non_std_construct.test.w:15:85
    |
 15 |     new cdktf.S3Backend(this, cdktf.S3BackendConfig {bucket: \\"foo\\", key: \\"bar\\"}) in this;
-   |                                                                                     ^^^^ Cannot set scope of non-standard preflight class \\"S3Backend\\" using \`in\`
+   |                                                                                     ^^^^
 
 
 
@@ -636,28 +636,28 @@ exports[`bypass_return.test.w 1`] = `
   --> ../../../examples/tests/invalid/bypass_return.test.w:2:12
   |
 2 |     return \\"a\\";
-  |            ^^^ Expected type to be \\"num\\", but got \\"str\\" instead
+  |            ^^^
 
 
 error: Expected type to be \\"num\\", but got \\"str\\" instead
   --> ../../../examples/tests/invalid/bypass_return.test.w:8:12
   |
 8 |     return \\"a\\";
-  |            ^^^ Expected type to be \\"num\\", but got \\"str\\" instead
+  |            ^^^
 
 
 error: A function whose return type is \\"num\\" must return a value.
    --> ../../../examples/tests/invalid/bypass_return.test.w:15:28
    |
 15 | let emptyBody = (): num => {};
-   |                            ^^ A function whose return type is \\"num\\" must return a value.
+   |                            ^^
 
 
 error: Expected type to be \\"num\\", but got \\"str\\" instead
    --> ../../../examples/tests/invalid/bypass_return.test.w:20:12
    |
 20 |     return \\"a\\";
-   |            ^^^ Expected type to be \\"num\\", but got \\"str\\" instead
+   |            ^^^
 
 
 
@@ -672,14 +672,14 @@ exports[`call_inflight_from_preflight.test.w 1`] = `
   --> ../../../examples/tests/invalid/call_inflight_from_preflight.test.w:4:1
   |
 4 | util.sleep(1s);
-  | ^^^^^^^^^^^^^^ Cannot call into inflight phase while preflight
+  | ^^^^^^^^^^^^^^
 
 
 error: Cannot call into inflight phase while preflight
    --> ../../../examples/tests/invalid/call_inflight_from_preflight.test.w:12:1
    |
 12 | foo.do();
-   | ^^^^^^^^ Cannot call into inflight phase while preflight
+   | ^^^^^^^^
 
 
 
@@ -694,21 +694,21 @@ exports[`capture_redefinition.test.w 1`] = `
   --> ../../../examples/tests/invalid/capture_redefinition.test.w:5:7
   |
 5 |   log(y);
-  |       ^ Cannot access \\"y\\" because it is shadowed by another symbol with the same name
+  |       ^
 
 
 error: Cannot access \\"y\\" because it is shadowed by another symbol with the same name
    --> ../../../examples/tests/invalid/capture_redefinition.test.w:14:9
    |
 14 |     log(y);
-   |         ^ Cannot access \\"y\\" because it is shadowed by another symbol with the same name
+   |         ^
 
 
 error: Cannot access \\"x\\" because it is shadowed by another symbol with the same name
    --> ../../../examples/tests/invalid/capture_redefinition.test.w:22:7
    |
 22 |   log(x);
-   |       ^ Cannot access \\"x\\" because it is shadowed by another symbol with the same name
+   |       ^
 
 
 
@@ -723,161 +723,161 @@ exports[`class.test.w 1`] = `
    --> ../../../examples/tests/invalid/class.test.w:86:5
    |
 86 |     super();
-   |     ^^^^^^^^ Call to super constructor can only be made from derived classes
+   |     ^^^^^^^^
 
 
 error: Call to super constructor must be first statement in constructor
    --> ../../../examples/tests/invalid/class.test.w:98:5
    |
 98 |     super(name, major);
-   |     ^^^^^^^^^^^^^^^^^^^ Call to super constructor must be first statement in constructor
+   |     ^^^^^^^^^^^^^^^^^^^
 
 
 error: Call to super constructor can only be done from within class constructor
     --> ../../../examples/tests/invalid/class.test.w:103:5
     |
 103 |     super(\\"cool\\", \\"blue\\");
-    |     ^^^^^^^^^^^^^^^^^^^^^^ Call to super constructor can only be done from within class constructor
+    |     ^^^^^^^^^^^^^^^^^^^^^^
 
 
 error: Call to super constructor can only be done from within a class constructor
     --> ../../../examples/tests/invalid/class.test.w:108:4
     |
 108 |    super();
-    |    ^^^^^^^^ Call to super constructor can only be done from within a class constructor
+    |    ^^^^^^^^
 
 
 error: Reserved method name. Constructors are declared with a method named \\"new\\"
     --> ../../../examples/tests/invalid/class.test.w:160:3
     |
 160 |   constructor() {
-    |   ^^^^^^^^^^^ Reserved method name. Constructors are declared with a method named \\"new\\"
+    |   ^^^^^^^^^^^
 
 
 error: Expected block
    --> ../../../examples/tests/invalid/class.test.w:17:16
    |
 17 |   new(foo: str)
-   |                ^ Expected block
+   |                ^
 
 
 error: Preflight field \\"x\\" is not initialized
   --> ../../../examples/tests/invalid/class.test.w:4:4
   |
 4 |    x:num;
-  |    ^ Preflight field \\"x\\" is not initialized
+  |    ^
 
 
 error: Expected 0 positional argument(s) but got 1
   --> ../../../examples/tests/invalid/class.test.w:9:1
   |
 9 | new C2(1);
-  | ^^^^^^^^^ Expected 0 positional argument(s) but got 1
+  | ^^^^^^^^^
 
 
 error: No named arguments expected
    --> ../../../examples/tests/invalid/class.test.w:13:1
    |
 13 | new C9(token: \\"1\\");
-   | ^^^^^^^^^^^^^^^^^^ No named arguments expected
+   | ^^^^^^^^^^^^^^^^^^
 
 
 error: Expected 1 positional argument(s) but got 0
    --> ../../../examples/tests/invalid/class.test.w:19:1
    |
 19 | new C10(); 
-   | ^^^^^^^^^ Expected 1 positional argument(s) but got 0
+   | ^^^^^^^^^
 
 
 error: No named arguments expected
    --> ../../../examples/tests/invalid/class.test.w:22:1
    |
 22 | new C10(foo: \\"bar\\"); 
-   | ^^^^^^^^^^^^^^^^^^^ No named arguments expected
+   | ^^^^^^^^^^^^^^^^^^^
 
 
 error: Expected 1 positional argument(s) but got 0
    --> ../../../examples/tests/invalid/class.test.w:22:1
    |
 22 | new C10(foo: \\"bar\\"); 
-   | ^^^^^^^^^^^^^^^^^^^ Expected 1 positional argument(s) but got 0
+   | ^^^^^^^^^^^^^^^^^^^
 
 
 error: No named arguments expected
    --> ../../../examples/tests/invalid/class.test.w:25:1
    |
 25 | new C10(\\"hello\\", foo: \\"bar\\"); 
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ No named arguments expected
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 
 error: Inflight field \\"x\\" is not initialized
    --> ../../../examples/tests/invalid/class.test.w:37:16
    |
 37 |   inflight var x: num;
-   |                ^ Inflight field \\"x\\" is not initialized
+   |                ^
 
 
 error: Inflight field \\"y\\" is not initialized
    --> ../../../examples/tests/invalid/class.test.w:39:12
    |
 39 |   inflight y: str;
-   |            ^ Inflight field \\"y\\" is not initialized
+   |            ^
 
 
 error: Inflight field \\"x\\" is not initialized
    --> ../../../examples/tests/invalid/class.test.w:44:12
    |
 44 |   inflight x: num;
-   |            ^ Inflight field \\"x\\" is not initialized
+   |            ^
 
 
 error: Inflight field \\"x\\" is not initialized
    --> ../../../examples/tests/invalid/class.test.w:50:12
    |
 50 |   inflight x: num;
-   |            ^ Inflight field \\"x\\" is not initialized
+   |            ^
 
 
 error: \\"y\\" cannot be initialized in the inflight constructor
    --> ../../../examples/tests/invalid/class.test.w:61:10
    |
 61 |     this.y = 1;
-   |          ^ \\"y\\" cannot be initialized in the inflight constructor
+   |          ^
 
 
 error: \\"x\\" cannot be initialized in the preflight constructor
    --> ../../../examples/tests/invalid/class.test.w:56:10
    |
 56 |     this.x = 1;
-   |          ^ \\"x\\" cannot be initialized in the preflight constructor
+   |          ^
 
 
 error: Preflight field \\"y\\" is not initialized
    --> ../../../examples/tests/invalid/class.test.w:52:3
    |
 52 |   y: num;
-   |   ^ Preflight field \\"y\\" is not initialized
+   |   ^
 
 
 error: Expected \\"x\\" to be a type but it's a variable
    --> ../../../examples/tests/invalid/class.test.w:68:18
    |
 68 | class C7 extends x {
-   |                  ^ Expected \\"x\\" to be a type but it's a variable
+   |                  ^
 
 
 error: Expected \\"S1\\" to be a class
    --> ../../../examples/tests/invalid/class.test.w:74:18
    |
 74 | class C8 extends S1 {
-   |                  ^^ Expected \\"S1\\" to be a class
+   |                  ^^
 
 
 error: Unknown symbol \\"C11\\"
    --> ../../../examples/tests/invalid/class.test.w:78:19
    |
 78 | class C11 extends C11 {
-   |                   ^^^ Unknown symbol \\"C11\\"
+   |                   ^^^
 
 
 error: Missing super() call as first statement of PaidStudent's constructor
@@ -889,14 +889,14 @@ error: Missing super() call as first statement of PaidStudent's constructor
  98 | |     super(name, major);
  99 | | //  ^^^^^^^^^^^^^^^^^^^ Expected call to super to be first statement in constructor
 100 | |   }
-    | \\\\---^ Missing super() call as first statement of PaidStudent's constructor
+    | \\\\---^
 
 
 error: Cannot instantiate abstract class \\"Resource\\"
     --> ../../../examples/tests/invalid/class.test.w:165:1
     |
 165 | new std.Resource();
-    | ^^^^^^^^^^^^^^^^^^ Cannot instantiate abstract class \\"Resource\\"
+    | ^^^^^^^^^^^^^^^^^^
 
 
 error: Symbol \\"z\\" already defined in this scope
@@ -906,7 +906,7 @@ error: Symbol \\"z\\" already defined in this scope
     |   - previous definition
     .
 183 |   z: str;
-    |   ^ Symbol \\"z\\" already defined in this scope
+    |   ^
 
 
 error: Symbol \\"z\\" already defined in this scope
@@ -915,7 +915,7 @@ error: Symbol \\"z\\" already defined in this scope
 170 |   z: num;
     |   - previous definition
 171 |   z(): num {
-    |   ^ Symbol \\"z\\" already defined in this scope
+    |   ^
 
 
 error: Symbol \\"z\\" already defined in this scope
@@ -925,7 +925,7 @@ error: Symbol \\"z\\" already defined in this scope
     |   - previous definition
     .
 185 |   z(): str {
-    |   ^ Symbol \\"z\\" already defined in this scope
+    |   ^
 
 
 error: Symbol \\"z\\" already defined in this scope
@@ -935,14 +935,14 @@ error: Symbol \\"z\\" already defined in this scope
     |   - previous definition
     .
 215 |   z: str;
-    |   ^ Symbol \\"z\\" already defined in this scope
+    |   ^
 
 
 error: Symbol \\"z\\" already defined in this scope
     --> ../../../examples/tests/invalid/class.test.w:196:3
     |
 196 |   z(): num {
-    |   ^ Symbol \\"z\\" already defined in this scope
+    |   ^
     .
 204 |   z: num;
     |   - previous definition
@@ -955,105 +955,105 @@ error: Symbol \\"z\\" already defined in this scope
     |   - previous definition
     .
 208 |   z(): str {
-    |   ^ Symbol \\"z\\" already defined in this scope
+    |   ^
 
 
 error: Expected type to be \\"num\\", but got \\"str\\" instead
    --> ../../../examples/tests/invalid/class.test.w:31:14
    |
 31 |     this.x = \\"Hi\\";
-   |              ^^^^ Expected type to be \\"num\\", but got \\"str\\" instead
+   |              ^^^^
 
 
 error: Variable cannot be reassigned from inflight
    --> ../../../examples/tests/invalid/class.test.w:61:5
    |
 61 |     this.y = 1;
-   |     ^^^^^^ Variable cannot be reassigned from inflight
+   |     ^^^^^^
 
 
 error: Expected type to be \\"num\\", but got \\"str\\" instead
     --> ../../../examples/tests/invalid/class.test.w:123:11
     |
 123 |     super(someStr);
-    |           ^^^^^^^ Expected type to be \\"num\\", but got \\"str\\" instead
+    |           ^^^^^^^
 
 
 error: Expected 1 positional argument(s) but got 0
     --> ../../../examples/tests/invalid/class.test.w:132:5
     |
 132 |     super();
-    |     ^^^^^^^^ Expected 1 positional argument(s) but got 0
+    |     ^^^^^^^^
 
 
 error: Expected 1 positional argument(s) but got 2
     --> ../../../examples/tests/invalid/class.test.w:141:5
     |
 141 |     super(someNum, someStr);
-    |     ^^^^^^^^^^^^^^^^^^^^^^^^ Expected 1 positional argument(s) but got 2
+    |     ^^^^^^^^^^^^^^^^^^^^^^^^
 
 
 error: Expected 1 positional argument(s) but got 0
     --> ../../../examples/tests/invalid/class.test.w:157:5
     |
 157 |     super();
-    |     ^^^^^^^^ Expected 1 positional argument(s) but got 0
+    |     ^^^^^^^^
 
 
 error: Binary operator '+' cannot be applied to operands of type 'num' and 'str'; only (num, num) and (str, str) are supported
     --> ../../../examples/tests/invalid/class.test.w:174:5
     |
 174 |     2 + \\"2\\";
-    |     ^^^^^^^ Binary operator '+' cannot be applied to operands of type 'num' and 'str'; only (num, num) and (str, str) are supported
+    |     ^^^^^^^
 
 
 error: Expected type to be \\"num\\", but got \\"str\\" instead
     --> ../../../examples/tests/invalid/class.test.w:177:12
     |
 177 |     return \\"hello\\";
-    |            ^^^^^^^ Expected type to be \\"num\\", but got \\"str\\" instead
+    |            ^^^^^^^
 
 
 error: Binary operator '+' cannot be applied to operands of type 'num' and 'str'; only (num, num) and (str, str) are supported
     --> ../../../examples/tests/invalid/class.test.w:187:5
     |
 187 |     2 + \\"2\\";
-    |     ^^^^^^^ Binary operator '+' cannot be applied to operands of type 'num' and 'str'; only (num, num) and (str, str) are supported
+    |     ^^^^^^^
 
 
 error: Expected type to be \\"str\\", but got \\"num\\" instead
     --> ../../../examples/tests/invalid/class.test.w:189:12
     |
 189 |     return 5;
-    |            ^ Expected type to be \\"str\\", but got \\"num\\" instead
+    |            ^
 
 
 error: Binary operator '+' cannot be applied to operands of type 'num' and 'str'; only (num, num) and (str, str) are supported
     --> ../../../examples/tests/invalid/class.test.w:199:5
     |
 199 |     2 + \\"2\\";
-    |     ^^^^^^^ Binary operator '+' cannot be applied to operands of type 'num' and 'str'; only (num, num) and (str, str) are supported
+    |     ^^^^^^^
 
 
 error: Expected type to be \\"num\\", but got \\"str\\" instead
     --> ../../../examples/tests/invalid/class.test.w:201:12
     |
 201 |     return \\"hello\\";
-    |            ^^^^^^^ Expected type to be \\"num\\", but got \\"str\\" instead
+    |            ^^^^^^^
 
 
 error: Binary operator '+' cannot be applied to operands of type 'num' and 'str'; only (num, num) and (str, str) are supported
     --> ../../../examples/tests/invalid/class.test.w:210:5
     |
 210 |     2 + \\"2\\";
-    |     ^^^^^^^ Binary operator '+' cannot be applied to operands of type 'num' and 'str'; only (num, num) and (str, str) are supported
+    |     ^^^^^^^
 
 
 error: Expected type to be \\"str\\", but got \\"num\\" instead
     --> ../../../examples/tests/invalid/class.test.w:212:12
     |
 212 |     return 5;
-    |            ^ Expected type to be \\"str\\", but got \\"num\\" instead
+    |            ^
 
 
 
@@ -1071,7 +1071,7 @@ exports[`cloud_function_expects_inflight.test.w 1`] = `
   | /--------------------^
 4 | |   return \\"Hello {name}\\";
 5 | | });
-  | \\\\-^ Expected type to be \\"inflight (event: str?): str?\\", but got \\"preflight (name: str): str\\" instead
+  | \\\\-^
   |  
   = hint: expected phase to be inflight, but got preflight instead
 
@@ -1084,7 +1084,7 @@ error: Expected type to be \\"inflight (message: str): void\\", but got \\"infli
 10 | |                      // ^ \\"num\\" doesn't match the expected type \\"str\\"
 11 | |   return;
 12 | | });
-   | \\\\-^ Expected type to be \\"inflight (message: str): void\\", but got \\"inflight (x: num): unknown\\" instead
+   | \\\\-^
 
 
 
@@ -1099,182 +1099,182 @@ exports[`container_types.test.w 1`] = `
    --> ../../../examples/tests/invalid/container_types.test.w:14:25
    |
 14 | let m2: Map<num> = [\\"a\\" => 1, \\"b\\" => \\"2\\", \\"c\\" => 3];
-   |                         ^^^^ Unknown parser error
+   |                         ^^^^
 
 
 error: Unexpected 'string'
    --> ../../../examples/tests/invalid/container_types.test.w:14:31
    |
 14 | let m2: Map<num> = [\\"a\\" => 1, \\"b\\" => \\"2\\", \\"c\\" => 3];
-   |                               ^^^ Unexpected 'string'
+   |                               ^^^
 
 
 error: Unknown parser error
    --> ../../../examples/tests/invalid/container_types.test.w:14:47
    |
 14 | let m2: Map<num> = [\\"a\\" => 1, \\"b\\" => \\"2\\", \\"c\\" => 3];
-   |                                               ^^^^ Unknown parser error
+   |                                               ^^^^
 
 
 error: Unknown parser error
    --> ../../../examples/tests/invalid/container_types.test.w:41:24
    |
 41 | let ss1: MutSet<str> = Set[\\"c\\"];
-   |                        ^^^ Unknown parser error
+   |                        ^^^
 
 
 error: Expected type to be \\"num\\", but got \\"str\\" instead
   --> ../../../examples/tests/invalid/container_types.test.w:2:28
   |
 2 | let arr1: Array<num> = [1, \\"2\\", 3];
-  |                            ^^^ Expected type to be \\"num\\", but got \\"str\\" instead
+  |                            ^^^
 
 
 error: Expected type to be \\"Array<num>\\", but got \\"Array<str>\\" instead
   --> ../../../examples/tests/invalid/container_types.test.w:5:24
   |
 5 | let arr4: Array<num> = arr3;
-  |                        ^^^^ Expected type to be \\"Array<num>\\", but got \\"Array<str>\\" instead
+  |                        ^^^^
 
 
 error: Member \\"someRandomMethod\\" doesn't exist in \\"Array\\"
   --> ../../../examples/tests/invalid/container_types.test.w:6:6
   |
 6 | arr1.someRandomMethod();
-  |      ^^^^^^^^^^^^^^^^ Member \\"someRandomMethod\\" doesn't exist in \\"Array\\"
+  |      ^^^^^^^^^^^^^^^^
 
 
 error: Expected type to be \\"num\\", but got \\"num?\\" instead
   --> ../../../examples/tests/invalid/container_types.test.w:9:16
   |
 9 | let val: num = arr5.tryAt(0);
-  |                ^^^^^^^^^^^^^ Expected type to be \\"num\\", but got \\"num?\\" instead
+  |                ^^^^^^^^^^^^^
 
 
 error: Expected type to be \\"num\\", but got \\"str\\" instead
    --> ../../../examples/tests/invalid/container_types.test.w:13:38
    |
 13 | let m1: Map<num> = {\\"a\\" => 1, \\"b\\" => \\"2\\", \\"c\\" => 3};
-   |                                      ^^^ Expected type to be \\"num\\", but got \\"str\\" instead
+   |                                      ^^^
 
 
 error: Expected type to be \\"Map<num>\\", but got \\"Array<str>\\" instead
    --> ../../../examples/tests/invalid/container_types.test.w:14:20
    |
 14 | let m2: Map<num> = [\\"a\\" => 1, \\"b\\" => \\"2\\", \\"c\\" => 3];
-   |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Expected type to be \\"Map<num>\\", but got \\"Array<str>\\" instead
+   |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 
 error: Expected type to be \\"Map<num>\\", but got \\"Map<str>\\" instead
    --> ../../../examples/tests/invalid/container_types.test.w:16:20
    |
 16 | let m4: Map<num> = m3;
-   |                    ^^ Expected type to be \\"Map<num>\\", but got \\"Map<str>\\" instead
+   |                    ^^
 
 
 error: Member \\"someRandomMethod\\" doesn't exist in \\"Map\\"
    --> ../../../examples/tests/invalid/container_types.test.w:17:4
    |
 17 | m1.someRandomMethod();
-   |    ^^^^^^^^^^^^^^^^ Member \\"someRandomMethod\\" doesn't exist in \\"Map\\"
+   |    ^^^^^^^^^^^^^^^^
 
 
 error: Expected type to be \\"str\\", but got \\"num\\" instead
    --> ../../../examples/tests/invalid/container_types.test.w:20:35
    |
 20 | let m5 = {\\"a\\" => 1, \\"{1+1}\\" => 2, 1+1 => 3};
-   |                                   ^^^ Expected type to be \\"str\\", but got \\"num\\" instead
+   |                                   ^^^
 
 
 error: Expected type to be \\"num\\", but got \\"str\\" instead
    --> ../../../examples/tests/invalid/container_types.test.w:24:24
    |
 24 | let s1: Set<num> = [1, \\"2\\", 3];
-   |                        ^^^ Expected type to be \\"num\\", but got \\"str\\" instead
+   |                        ^^^
 
 
 error: Expected type to be \\"Set<num>\\", but got \\"Array<num>\\" instead
    --> ../../../examples/tests/invalid/container_types.test.w:24:20
    |
 24 | let s1: Set<num> = [1, \\"2\\", 3];
-   |                    ^^^^^^^^^^^ Expected type to be \\"Set<num>\\", but got \\"Array<num>\\" instead
+   |                    ^^^^^^^^^^^
 
 
 error: Expected type to be \\"num\\", but got \\"str\\" instead
    --> ../../../examples/tests/invalid/container_types.test.w:25:23
    |
 25 | let s2 = Set<num> [1, \\"2\\", 3];
-   |                       ^^^ Expected type to be \\"num\\", but got \\"str\\" instead
+   |                       ^^^
 
 
 error: Expected type to be \\"num\\", but got \\"str\\" instead
    --> ../../../examples/tests/invalid/container_types.test.w:26:24
    |
 26 | let s3: Set<num> = [1, \\"2\\", 3];
-   |                        ^^^ Expected type to be \\"num\\", but got \\"str\\" instead
+   |                        ^^^
 
 
 error: Expected type to be \\"Set<num>\\", but got \\"Array<num>\\" instead
    --> ../../../examples/tests/invalid/container_types.test.w:26:20
    |
 26 | let s3: Set<num> = [1, \\"2\\", 3];
-   |                    ^^^^^^^^^^^ Expected type to be \\"Set<num>\\", but got \\"Array<num>\\" instead
+   |                    ^^^^^^^^^^^
 
 
 error: Expected type to be \\"Set<str>\\", but got \\"Set<num>\\" instead
    --> ../../../examples/tests/invalid/container_types.test.w:28:20
    |
 28 | let s5: Set<str> = s4;
-   |                    ^^ Expected type to be \\"Set<str>\\", but got \\"Set<num>\\" instead
+   |                    ^^
 
 
 error: Member \\"someRandomMethod\\" doesn't exist in \\"Set\\"
    --> ../../../examples/tests/invalid/container_types.test.w:29:4
    |
 29 | s1.someRandomMethod();
-   |    ^^^^^^^^^^^^^^^^ Member \\"someRandomMethod\\" doesn't exist in \\"Set\\"
+   |    ^^^^^^^^^^^^^^^^
 
 
 error: Expected type to be \\"Array<str>\\", but got \\"MutArray<str>\\" instead
    --> ../../../examples/tests/invalid/container_types.test.w:31:21
    |
 31 | let a: Array<str> = MutArray<str>[];
-   |                     ^^^^^^^^^^^^^^^ Expected type to be \\"Array<str>\\", but got \\"MutArray<str>\\" instead
+   |                     ^^^^^^^^^^^^^^^
 
 
 error: Expected type to be \\"MutMap<num>\\", but got \\"Map<num>\\" instead
    --> ../../../examples/tests/invalid/container_types.test.w:34:24
    |
 34 | let mm1: MutMap<num> = { \\"a\\" => 1, \\"b\\" => 2, \\"c\\" => 3 };
-   |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Expected type to be \\"MutMap<num>\\", but got \\"Map<num>\\" instead
+   |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 
 error: Member \\"copyMut\\" doesn't exist in \\"MutMap\\"
    --> ../../../examples/tests/invalid/container_types.test.w:37:15
    |
 37 | let mm3 = mm2.copyMut();
-   |               ^^^^^^^ Member \\"copyMut\\" doesn't exist in \\"MutMap\\"
+   |               ^^^^^^^
 
 
 error: Expected type to be \\"MutSet<str>\\", but got \\"Array<str>\\" instead
    --> ../../../examples/tests/invalid/container_types.test.w:41:27
    |
 41 | let ss1: MutSet<str> = Set[\\"c\\"];
-   |                           ^^^^^ Expected type to be \\"MutSet<str>\\", but got \\"Array<str>\\" instead
+   |                           ^^^^^
 
 
 error: Expected type to be \\"num\\", but got \\"bool\\" instead
    --> ../../../examples/tests/invalid/container_types.test.w:43:36
    |
 43 | let ss2: MutSet<num> = MutSet<num>[true];
-   |                                    ^^^^ Expected type to be \\"num\\", but got \\"bool\\" instead
+   |                                    ^^^^
 
 
 error: Member \\"copyMut\\" doesn't exist in \\"MutSet\\"
    --> ../../../examples/tests/invalid/container_types.test.w:46:15
    |
 46 | let ss4 = ss3.copyMut();
-   |               ^^^^^^^ Member \\"copyMut\\" doesn't exist in \\"MutSet\\"
+   |               ^^^^^^^
 
 
 
@@ -1289,77 +1289,77 @@ exports[`ctor_super.test.w 1`] = `
   --> ../../../examples/tests/invalid/ctor_super.test.w:9:7
   |
 9 | class PreflighChild1 extends PreflightBaseWithCtorParam {}
-  |       ^^^^^^^^^^^^^^ Missing super() call as first statement of PreflighChild1's constructor
+  |       ^^^^^^^^^^^^^^
 
 
 error: Missing super() call as first statement of PreflighChild2's constructor
    --> ../../../examples/tests/invalid/ctor_super.test.w:13:15
    |
 13 |   new(a: num) {}
-   |               ^^ Missing super() call as first statement of PreflighChild2's constructor
+   |               ^^
 
 
 error: Missing super() call as first statement of InflightChild1's constructor
    --> ../../../examples/tests/invalid/ctor_super.test.w:29:16
    |
 29 | inflight class InflightChild1 extends InflightBaseWithCtorParam {}
-   |                ^^^^^^^^^^^^^^ Missing super() call as first statement of InflightChild1's constructor
+   |                ^^^^^^^^^^^^^^
 
 
 error: Missing super() call as first statement of InflightChild2's constructor
    --> ../../../examples/tests/invalid/ctor_super.test.w:33:15
    |
 33 |   new(a: num) {}
-   |               ^^ Missing super() call as first statement of InflightChild2's constructor
+   |               ^^
 
 
 error: Missing super() call as first statement of InflightChild4's constructor
    --> ../../../examples/tests/invalid/ctor_super.test.w:45:9
    |
 45 |   new() {}
-   |         ^^ Missing super() call as first statement of InflightChild4's constructor
+   |         ^^
 
 
 error: Expected 1 positional argument(s) but got 0
    --> ../../../examples/tests/invalid/ctor_super.test.w:19:5
    |
 19 |     super();
-   |     ^^^^^^^^ Expected 1 positional argument(s) but got 0
+   |     ^^^^^^^^
 
 
 error: Expected 1 positional argument(s) but got 0
    --> ../../../examples/tests/invalid/ctor_super.test.w:39:5
    |
 39 |     super();
-   |     ^^^^^^^^ Expected 1 positional argument(s) but got 0
+   |     ^^^^^^^^
 
 
 error: Missing super() call as first statement of InflightChild1's constructor
    --> ../../../examples/tests/invalid/ctor_super.test.w:55:9
    |
 55 |   class InflightChild1 extends InflightBaseWithCtorParam {}
-   |         ^^^^^^^^^^^^^^ Missing super() call as first statement of InflightChild1's constructor
+   |         ^^^^^^^^^^^^^^
 
 
 error: Missing super() call as first statement of InflightChild2's constructor
    --> ../../../examples/tests/invalid/ctor_super.test.w:59:17
    |
 59 |     new(a: num) {}
-   |                 ^^ Missing super() call as first statement of InflightChild2's constructor
+   |                 ^^
 
 
 error: Missing super() call as first statement of InflightChild4's constructor
    --> ../../../examples/tests/invalid/ctor_super.test.w:71:11
    |
 71 |     new() {}
-   |           ^^ Missing super() call as first statement of InflightChild4's constructor
+   |           ^^
 
 
 error: Expected 1 positional argument(s) but got 0
    --> ../../../examples/tests/invalid/ctor_super.test.w:65:7
    |
 65 |       super();
-   |       ^^^^^^^^ Expected 1 positional argument(s) but got 0
+   |       ^^^^^^^^
 
 
 
@@ -1380,14 +1380,14 @@ error: Could not type check \\"<ABSOLUTE>/cyclic_bring2.w\\" due to cyclic bring
   --> ../../../examples/tests/invalid/cyclic_bring1.w:1:1
   |
 1 | bring \\"./cyclic_bring2.w\\" as foo;
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Could not type check \\"<ABSOLUTE>/cyclic_bring2.w\\" due to cyclic bring statements
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 
 error: Could not type check \\"<ABSOLUTE>/cyclic_bring3.w\\" due to cyclic bring statements
   --> ../../../examples/tests/invalid/cyclic_bring2.w:1:1
   |
 1 | bring \\"./cyclic_bring3.w\\" as foo;
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Could not type check \\"<ABSOLUTE>/cyclic_bring3.w\\" due to cyclic bring statements
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 
 
@@ -1408,14 +1408,14 @@ error: Could not type check \\"<ABSOLUTE>/cyclic_bring3.w\\" due to cyclic bring
   --> ../../../examples/tests/invalid/cyclic_bring2.w:1:1
   |
 1 | bring \\"./cyclic_bring3.w\\" as foo;
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Could not type check \\"<ABSOLUTE>/cyclic_bring3.w\\" due to cyclic bring statements
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 
 error: Could not type check \\"<ABSOLUTE>/cyclic_bring1.w\\" due to cyclic bring statements
   --> ../../../examples/tests/invalid/cyclic_bring3.w:1:1
   |
 1 | bring \\"./cyclic_bring1.w\\" as foo;
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Could not type check \\"<ABSOLUTE>/cyclic_bring1.w\\" due to cyclic bring statements
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 
 
@@ -1436,14 +1436,14 @@ error: Could not type check \\"<ABSOLUTE>/cyclic_bring1.w\\" due to cyclic bring
   --> ../../../examples/tests/invalid/cyclic_bring3.w:1:1
   |
 1 | bring \\"./cyclic_bring1.w\\" as foo;
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Could not type check \\"<ABSOLUTE>/cyclic_bring1.w\\" due to cyclic bring statements
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 
 error: Could not type check \\"<ABSOLUTE>/cyclic_bring2.w\\" due to cyclic bring statements
   --> ../../../examples/tests/invalid/cyclic_bring1.w:1:1
   |
 1 | bring \\"./cyclic_bring2.w\\" as foo;
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Could not type check \\"<ABSOLUTE>/cyclic_bring2.w\\" due to cyclic bring statements
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 
 
@@ -1458,7 +1458,7 @@ exports[`diags_with_multibyte_chars.test.w 1`] = `
   --> ../../../examples/tests/invalid/diags_with_multibyte_chars.test.w:4:1
   |
 4 | asdf;
-  | ^^^^ Unknown symbol \\"asdf\\"
+  | ^^^^
 
 
 
@@ -1473,14 +1473,14 @@ exports[`enums.test.w 1`] = `
   --> ../../../examples/tests/invalid/enums.test.w:5:21
   |
 5 | let four = SomeEnum.FOUR;
-  |                     ^^^^ Enum \\"SomeEnum\\" does not contain value \\"FOUR\\"
+  |                     ^^^^
 
 
 error: Property not found
   --> ../../../examples/tests/invalid/enums.test.w:8:24
   |
 8 | let two = SomeEnum.TWO.TWO;
-  |                        ^^^ Property not found
+  |                        ^^^
 
 
 
@@ -1495,70 +1495,70 @@ exports[`explicit_lift_qualification.test.w 1`] = `
    --> ../../../examples/tests/invalid/explicit_lift_qualification.test.w:22:10
    |
 22 |     lift(prelight_string, [\\"contains\\"]); // Explicit qualification on preflight non-class
-   |          ^^^^^^^^^^^^^^^ Expected type to be \\"IResource\\", but got \\"str\\" instead
+   |          ^^^^^^^^^^^^^^^
 
 
 error: lift() calls must be at the top of the method
    --> ../../../examples/tests/invalid/explicit_lift_qualification.test.w:18:5
    |
 18 |     lift(b, [\\"put\\"]); // Explicit qualification with inflight object, lift call as non first statement
-   |     ^^^^^^^^^^^^^^^^^ lift() calls must be at the top of the method
+   |     ^^^^^^^^^^^^^^^^^
 
 
 error: lift() calls must be at the top of the method
    --> ../../../examples/tests/invalid/explicit_lift_qualification.test.w:22:5
    |
 22 |     lift(prelight_string, [\\"contains\\"]); // Explicit qualification on preflight non-class
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ lift() calls must be at the top of the method
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 
 error: lift() calls must be at the top of the method
    --> ../../../examples/tests/invalid/explicit_lift_qualification.test.w:27:5
    |
 27 |     lift(bucket, [inflight_qualifier]); // Explicit qualification with inflight qualifiers, lift call as non first statement
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ lift() calls must be at the top of the method
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 
 error: Expected a preflight object as first argument to \`lift\` builtin, found inflight expression instead
    --> ../../../examples/tests/invalid/explicit_lift_qualification.test.w:18:10
    |
 18 |     lift(b, [\\"put\\"]); // Explicit qualification with inflight object, lift call as non first statement
-   |          ^ Expected a preflight object as first argument to \`lift\` builtin, found inflight expression instead
+   |          ^
 
 
 error: Qualification list must not contain any inflight elements
    --> ../../../examples/tests/invalid/explicit_lift_qualification.test.w:27:18
    |
 27 |     lift(bucket, [inflight_qualifier]); // Explicit qualification with inflight qualifiers, lift call as non first statement
-   |                  ^^^^^^^^^^^^^^^^^^^^ Qualification list must not contain any inflight elements
+   |                  ^^^^^^^^^^^^^^^^^^^^
 
 
 error: lift() calls are only allowed in inflight methods and closures defined in preflight
    --> ../../../examples/tests/invalid/explicit_lift_qualification.test.w:32:7
    |
 32 |       lift(bucket, [\\"get\\"]); // lift() call in inner closure
-   |       ^^^^^^^^^^^^^^^^^^^^^^ lift() calls are only allowed in inflight methods and closures defined in preflight
+   |       ^^^^^^^^^^^^^^^^^^^^^^
 
 
 error: lift() calls are only allowed in inflight methods and closures defined in preflight
    --> ../../../examples/tests/invalid/explicit_lift_qualification.test.w:37:9
    |
 37 |         lift(bucket, [\\"get\\"]); // lift() call in inner class
-   |         ^^^^^^^^^^^^^^^^^^^^^^ lift() calls are only allowed in inflight methods and closures defined in preflight
+   |         ^^^^^^^^^^^^^^^^^^^^^^
 
 
 error: Expression of type \\"Bucket\\" references an unknown preflight object, can't qualify its capabilities. Use \`lift()\` to explicitly qualify the preflight object to disable this error.
    --> ../../../examples/tests/invalid/explicit_lift_qualification.test.w:45:5
    |
 45 |     b.put(\\"k\\", \\"v\\"); // With no explicit qualification this should be an error
-   |     ^ Expression of type \\"Bucket\\" references an unknown preflight object, can't qualify its capabilities. Use \`lift()\` to explicitly qualify the preflight object to disable this error.
+   |     ^
 
 
 error: Expression of type \\"IPreflightInterface\\" references an unknown preflight object, can't qualify its capabilities. Use \`lift()\` to explicitly qualify the preflight object to disable this error.
    --> ../../../examples/tests/invalid/explicit_lift_qualification.test.w:49:5
    |
 49 |     i.method(); // With no explicit qualification this should be an error
-   |     ^ Expression of type \\"IPreflightInterface\\" references an unknown preflight object, can't qualify its capabilities. Use \`lift()\` to explicitly qualify the preflight object to disable this error.
+   |     ^
 
 
 
@@ -1573,7 +1573,7 @@ exports[`extern.test.w 1`] = `
   --> ../../../examples/tests/invalid/extern.test.w:2:3
   |
 2 |   extern \\"./sad.js\\" static getNum(): num;
-  |   ^^^^^^^^^^^^^^^^^ File not found: \\"./sad.js\\"
+  |   ^^^^^^^^^^^^^^^^^
 
 
 
@@ -1588,7 +1588,7 @@ exports[`extern_static.test.w 1`] = `
   --> ../../../examples/tests/invalid/extern_static.test.w:2:45
   |
 2 |   extern \\"../valid/external_ts.ts\\" inflight getGreeting(name: str): str;
-  |                                             ^^^^^^^^^^^ Extern methods must be declared \\"static\\" (they cannot access instance members)
+  |                                             ^^^^^^^^^^^
 
 
 
@@ -1603,28 +1603,28 @@ exports[`file_with_variables.w 1`] = `
   --> ../../../examples/tests/invalid/file_with_variables.w:5:1
   |
 5 | let x = 5;
-  | ^^^^^^^^^^ Module files cannot have statements besides classes, interfaces, enums, and structs. Rename the file to end with \`.main.w\` or \`.test.w\` to make this an entrypoint file.
+  | ^^^^^^^^^^
 
 
 error: Module files cannot have statements besides classes, interfaces, enums, and structs. Rename the file to end with \`.main.w\` or \`.test.w\` to make this an entrypoint file.
   --> ../../../examples/tests/invalid/file_with_variables.w:6:1
   |
 6 | let y = [\\"hello\\", \\"world\\"];
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Module files cannot have statements besides classes, interfaces, enums, and structs. Rename the file to end with \`.main.w\` or \`.test.w\` to make this an entrypoint file.
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 
 error: Module files cannot have statements besides classes, interfaces, enums, and structs. Rename the file to end with \`.main.w\` or \`.test.w\` to make this an entrypoint file.
   --> ../../../examples/tests/invalid/file_with_variables.w:7:1
   |
 7 | let z = new cloud.Bucket();
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Module files cannot have statements besides classes, interfaces, enums, and structs. Rename the file to end with \`.main.w\` or \`.test.w\` to make this an entrypoint file.
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 
 error: Preflight field \\"x\\" is not initialized
    --> ../../../examples/tests/invalid/file_with_variables.w:10:3
    |
 10 |   x: num;
-   |   ^ Preflight field \\"x\\" is not initialized
+   |   ^
 
 
 
@@ -1639,14 +1639,14 @@ exports[`for_loop.test.w 1`] = `
   --> ../../../examples/tests/invalid/for_loop.test.w:5:5
   |
 5 | for test in bucket {
-  |     ^^^^ Reserved word
+  |     ^^^^
 
 
 error: Unable to iterate over \\"Bucket\\"
   --> ../../../examples/tests/invalid/for_loop.test.w:5:13
   |
 5 | for test in bucket {
-  |             ^^^^^^ Unable to iterate over \\"Bucket\\"
+  |             ^^^^^^
 
 
 
@@ -1661,91 +1661,91 @@ exports[`function_call_arity.test.w 1`] = `
    --> ../../../examples/tests/invalid/function_call_arity.test.w:31:61
    |
 31 | invalidCombinationFunc2(1, 2, prefix: \\"debug\\", priority: 0, \\"hello\\", \\"world\\");
-   |                                                             ^^^^^^^ Positional arguments must come before named arguments
+   |                                                             ^^^^^^^
 
 
 error: Positional arguments must come before named arguments
    --> ../../../examples/tests/invalid/function_call_arity.test.w:31:70
    |
 31 | invalidCombinationFunc2(1, 2, prefix: \\"debug\\", priority: 0, \\"hello\\", \\"world\\");
-   |                                                                      ^^^^^^^ Positional arguments must come before named arguments
+   |                                                                      ^^^^^^^
 
 
 error: Expected 2 positional argument(s) but got 0
   --> ../../../examples/tests/invalid/function_call_arity.test.w:2:1
   |
 2 | func(); // Expected {} positional arguments but got {}
-  | ^^^^^^ Expected 2 positional argument(s) but got 0
+  | ^^^^^^
 
 
 error: Expected between 2 and 3 positional arguments but got 1
   --> ../../../examples/tests/invalid/function_call_arity.test.w:5:1
   |
 5 | optionalParamsFunc(1); // Expected between {} and {} positional arguments but got {}
-  | ^^^^^^^^^^^^^^^^^^^^^ Expected between 2 and 3 positional arguments but got 1
+  | ^^^^^^^^^^^^^^^^^^^^^
 
 
 error: Expected 2 positional argument(s) + variadic args but got 0
   --> ../../../examples/tests/invalid/function_call_arity.test.w:8:1
   |
 8 | variadicFunc(); // Expected {} positional arguments + variadic args but got {}
-  | ^^^^^^^^^^^^^^ Expected 2 positional argument(s) + variadic args but got 0
+  | ^^^^^^^^^^^^^^
 
 
 error: Expected between 2 and 3 positional arguments + variadic args but got 1
    --> ../../../examples/tests/invalid/function_call_arity.test.w:12:1
    |
 12 | variadicOptionalParamsFunc(2); // Expected between {} and {} positional arguments + variadic args but got {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Expected between 2 and 3 positional arguments + variadic args but got 1
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 
 error: Expected 3 positional argument(s) or named arguments for the last parameter but got 0
    --> ../../../examples/tests/invalid/function_call_arity.test.w:20:1
    |
 20 | namedFunc(); // Expected {} positional arguments or named arguments for the last parameter but got {}
-   | ^^^^^^^^^^^ Expected 3 positional argument(s) or named arguments for the last parameter but got 0
+   | ^^^^^^^^^^^
 
 
 error: Optional parameters must always be after all non-optional parameters.
    --> ../../../examples/tests/invalid/function_call_arity.test.w:22:49
    |
 22 | let namedOptionalParamsFunc = (n: num, b: bool, s: str?, opts: Options) => {};
-   |                                                 ^ Optional parameters must always be after all non-optional parameters.
+   |                                                 ^
 
 
 error: Expected between 3 and 4 positional arguments or named arguments for the last parameter but got 1
    --> ../../../examples/tests/invalid/function_call_arity.test.w:23:1
    |
 23 | namedOptionalParamsFunc(3); // Expected between {} and {} positional arguments or named arguments for the last parameter but got {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^ Expected between 3 and 4 positional arguments or named arguments for the last parameter but got 1
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 
 error: Variadic parameters must always be the last parameter in a function.
    --> ../../../examples/tests/invalid/function_call_arity.test.w:27:51
    |
 27 | let invalidCombinationFunc = (n: num, b: bool, ...variadic: Array<str>, opts: Options) => {};
-   |                                                   ^^^^^^^^ Variadic parameters must always be the last parameter in a function.
+   |                                                   ^^^^^^^^
 
 
 error: No named arguments expected
    --> ../../../examples/tests/invalid/function_call_arity.test.w:31:1
    |
 31 | invalidCombinationFunc2(1, 2, prefix: \\"debug\\", priority: 0, \\"hello\\", \\"world\\");
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ No named arguments expected
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 
 error: Expected type to be \\"bool\\", but got \\"num\\" instead
    --> ../../../examples/tests/invalid/function_call_arity.test.w:31:28
    |
 31 | invalidCombinationFunc2(1, 2, prefix: \\"debug\\", priority: 0, \\"hello\\", \\"world\\");
-   |                            ^ Expected type to be \\"bool\\", but got \\"num\\" instead
+   |                            ^
 
 
 error: Expected type to be \\"Options\\", but got \\"str\\" instead
    --> ../../../examples/tests/invalid/function_call_arity.test.w:31:61
    |
 31 | invalidCombinationFunc2(1, 2, prefix: \\"debug\\", priority: 0, \\"hello\\", \\"world\\");
-   |                                                             ^^^^^^^ Expected type to be \\"Options\\", but got \\"str\\" instead
+   |                                                             ^^^^^^^
 
 
 
@@ -1760,28 +1760,28 @@ exports[`function_call_variadic.test.w 1`] = `
   --> ../../../examples/tests/invalid/function_call_variadic.test.w:3:6
   |
 3 | func(1, 2, 3); // should fail due to wrong type for variadic
-  |      ^ Expected type to be \\"str\\", but got \\"num\\" instead
+  |      ^
 
 
 error: Expected type to be \\"str\\", but got \\"num\\" instead
   --> ../../../examples/tests/invalid/function_call_variadic.test.w:3:9
   |
 3 | func(1, 2, 3); // should fail due to wrong type for variadic
-  |         ^ Expected type to be \\"str\\", but got \\"num\\" instead
+  |         ^
 
 
 error: Expected type to be \\"str\\", but got \\"num\\" instead
   --> ../../../examples/tests/invalid/function_call_variadic.test.w:3:12
   |
 3 | func(1, 2, 3); // should fail due to wrong type for variadic
-  |            ^ Expected type to be \\"str\\", but got \\"num\\" instead
+  |            ^
 
 
 error: Expected type to be \\"str\\", but got \\"Array<str>\\" instead
   --> ../../../examples/tests/invalid/function_call_variadic.test.w:4:6
   |
 4 | func([\\"a\\", \\"b\\", \\"c\\"]); // should fail as the parameter is variadic
-  |      ^^^^^^^^^^^^^^^ Expected type to be \\"str\\", but got \\"Array<str>\\" instead
+  |      ^^^^^^^^^^^^^^^
 
 
 
@@ -1796,21 +1796,21 @@ exports[`function_type.test.w 1`] = `
   --> ../../../examples/tests/invalid/function_type.test.w:3:3
   |
 3 |   my_method(x: num);
-  |   ^^^^^^^^^^^^^^^^^^ Expected function return type
+  |   ^^^^^^^^^^^^^^^^^^
 
 
 error: Expected function return type
   --> ../../../examples/tests/invalid/function_type.test.w:5:3
   |
 5 |   inflight my_method2(x: num);
-  |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Expected function return type
+  |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 
 error: Optional parameters must always be after all non-optional parameters.
   --> ../../../examples/tests/invalid/function_type.test.w:9:25
   |
 9 | let my_func3 = (a: num, b: str?, c: bool) => {};
-  |                         ^ Optional parameters must always be after all non-optional parameters.
+  |                         ^
 
 
 
@@ -1825,49 +1825,49 @@ exports[`function_variadic_definition.test.w 1`] = `
    --> ../../../examples/tests/invalid/function_variadic_definition.test.w:15:13
    |
 15 | f5(args: 1, 2);
-   |             ^ Positional arguments must come before named arguments
+   |             ^
 
 
 error: Variadic parameters must always be the last parameter in a function.
   --> ../../../examples/tests/invalid/function_variadic_definition.test.w:1:14
   |
 1 | let f1 = (...args: Array<num>, x:num) => {};
-  |              ^^^^ Variadic parameters must always be the last parameter in a function.
+  |              ^^^^
 
 
 error: Variadic parameters must always be the last parameter in a function.
   --> ../../../examples/tests/invalid/function_variadic_definition.test.w:4:14
   |
 4 | let f2 = (...nums: Array<num>, ...strs: Array<str>) => {};
-  |              ^^^^ Variadic parameters must always be the last parameter in a function.
+  |              ^^^^
 
 
 error: Expected type to be \\"num\\", but got \\"bool\\" instead
   --> ../../../examples/tests/invalid/function_variadic_definition.test.w:8:7
   |
 8 | f3(1, true, 2);
-  |       ^^^^ Expected type to be \\"num\\", but got \\"bool\\" instead
+  |       ^^^^
 
 
 error: Variadic parameters must be type Array or MutArray.
    --> ../../../examples/tests/invalid/function_variadic_definition.test.w:11:14
    |
 11 | let f4 = (...args: Set<num>) => {};
-   |              ^^^^ Variadic parameters must be type Array or MutArray.
+   |              ^^^^
 
 
 error: No named arguments expected
    --> ../../../examples/tests/invalid/function_variadic_definition.test.w:15:1
    |
 15 | f5(args: 1, 2);
-   | ^^^^^^^^^^^^^^ No named arguments expected
+   | ^^^^^^^^^^^^^^
 
 
 error: Expected type to be \\"Bucket\\", but got \\"bool\\" instead
    --> ../../../examples/tests/invalid/function_variadic_definition.test.w:24:21
    |
 24 | funcBucket(bucket1, true, bucket2);
-   |                     ^^^^ Expected type to be \\"Bucket\\", but got \\"bool\\" instead
+   |                     ^^^^
 
 
 
@@ -1882,84 +1882,84 @@ exports[`global_symbols.test.w 1`] = `
   --> ../../../examples/tests/invalid/global_symbols.test.w:1:5
   |
 1 | let log = \\"hi\\";
-  |     ^^^ Symbol \\"log\\" already defined in this scope
+  |     ^^^
 
 
 error: Symbol \\"assert\\" already defined in this scope
   --> ../../../examples/tests/invalid/global_symbols.test.w:3:5
   |
 3 | let assert = \\"there\\";
-  |     ^^^^^^ Symbol \\"assert\\" already defined in this scope
+  |     ^^^^^^
 
 
 error: Symbol \\"unsafeCast\\" already defined in this scope
   --> ../../../examples/tests/invalid/global_symbols.test.w:5:5
   |
 5 | let unsafeCast = \\"wingnuts\\";
-  |     ^^^^^^^^^^ Symbol \\"unsafeCast\\" already defined in this scope
+  |     ^^^^^^^^^^
 
 
 error: Symbol \\"nodeof\\" already defined in this scope
   --> ../../../examples/tests/invalid/global_symbols.test.w:7:5
   |
 7 | let nodeof = \\"!\\";
-  |     ^^^^^^ Symbol \\"nodeof\\" already defined in this scope
+  |     ^^^^^^
 
 
 error: Variable is not reassignable
    --> ../../../examples/tests/invalid/global_symbols.test.w:10:1
    |
 10 | log = \\"hi\\";
-   | ^^^ Variable is not reassignable
+   | ^^^
 
 
 error: Expected type to be \\"(message: str): void\\", but got \\"str\\" instead
    --> ../../../examples/tests/invalid/global_symbols.test.w:10:7
    |
 10 | log = \\"hi\\";
-   |       ^^^^ Expected type to be \\"(message: str): void\\", but got \\"str\\" instead
+   |       ^^^^
 
 
 error: Variable is not reassignable
    --> ../../../examples/tests/invalid/global_symbols.test.w:12:1
    |
 12 | assert = \\"there\\";
-   | ^^^^^^ Variable is not reassignable
+   | ^^^^^^
 
 
 error: Expected type to be \\"(condition: bool, message: str?): void\\", but got \\"str\\" instead
    --> ../../../examples/tests/invalid/global_symbols.test.w:12:10
    |
 12 | assert = \\"there\\";
-   |          ^^^^^^^ Expected type to be \\"(condition: bool, message: str?): void\\", but got \\"str\\" instead
+   |          ^^^^^^^
 
 
 error: Variable is not reassignable
    --> ../../../examples/tests/invalid/global_symbols.test.w:14:1
    |
 14 | unsafeCast = \\"wingnuts\\";
-   | ^^^^^^^^^^ Variable is not reassignable
+   | ^^^^^^^^^^
 
 
 error: Expected type to be \\"(value: any): any\\", but got \\"str\\" instead
    --> ../../../examples/tests/invalid/global_symbols.test.w:14:14
    |
 14 | unsafeCast = \\"wingnuts\\";
-   |              ^^^^^^^^^^ Expected type to be \\"(value: any): any\\", but got \\"str\\" instead
+   |              ^^^^^^^^^^
 
 
 error: Variable is not reassignable
    --> ../../../examples/tests/invalid/global_symbols.test.w:16:1
    |
 16 | nodeof = \\"!\\";
-   | ^^^^^^ Variable is not reassignable
+   | ^^^^^^
 
 
 error: Expected type to be \\"preflight (construct: IConstruct): Node\\", but got \\"str\\" instead
    --> ../../../examples/tests/invalid/global_symbols.test.w:16:10
    |
 16 | nodeof = \\"!\\";
-   |          ^^^ Expected type to be \\"preflight (construct: IConstruct): Node\\", but got \\"str\\" instead
+   |          ^^^
 
 
 
@@ -1974,91 +1974,91 @@ exports[`immutable_container_types.test.w 1`] = `
   --> ../../../examples/tests/invalid/immutable_container_types.test.w:3:4
   |
 3 | m1.set(\\"a\\", \\"bye\\");
-  |    ^^^ Member \\"set\\" doesn't exist in \\"Map\\"
+  |    ^^^
 
 
 error: Expected type to be \\"Map<str>\\", but got \\"MutMap<str>\\" instead
   --> ../../../examples/tests/invalid/immutable_container_types.test.w:6:20
   |
 6 | let m2: Map<str> = MutMap<str> {};
-  |                    ^^^^^^^^^^^^^^ Expected type to be \\"Map<str>\\", but got \\"MutMap<str>\\" instead
+  |                    ^^^^^^^^^^^^^^
 
 
 error: Expected type to be \\"bool\\", but got \\"str\\" instead
   --> ../../../examples/tests/invalid/immutable_container_types.test.w:8:29
   |
 8 | let m3 = Map<bool> { \\"a\\" => \\"A\\" };
-  |                             ^^^ Expected type to be \\"bool\\", but got \\"str\\" instead
+  |                             ^^^
 
 
 error: Member \\"set\\" doesn't exist in \\"Map\\"
    --> ../../../examples/tests/invalid/immutable_container_types.test.w:11:4
    |
 11 | m4.set(\\"2\\", 3);
-   |    ^^^ Member \\"set\\" doesn't exist in \\"Map\\"
+   |    ^^^
 
 
 error: Member \\"copy\\" doesn't exist in \\"Map\\"
    --> ../../../examples/tests/invalid/immutable_container_types.test.w:13:13
    |
 13 | let m5 = m4.copy();
-   |             ^^^^ Member \\"copy\\" doesn't exist in \\"Map\\"
+   |             ^^^^
 
 
 error: Member \\"delete\\" doesn't exist in \\"Map\\"
    --> ../../../examples/tests/invalid/immutable_container_types.test.w:15:4
    |
 15 | m4.delete(\\"1\\");
-   |    ^^^^^^ Member \\"delete\\" doesn't exist in \\"Map\\"
+   |    ^^^^^^
 
 
 error: Member \\"clear\\" doesn't exist in \\"Map\\"
    --> ../../../examples/tests/invalid/immutable_container_types.test.w:17:4
    |
 17 | m4.clear();
-   |    ^^^^^ Member \\"clear\\" doesn't exist in \\"Map\\"
+   |    ^^^^^
 
 
 error: Expected type to be \\"Set<Array<num>>\\", but got \\"MutSet<Array<num>>\\" instead
    --> ../../../examples/tests/invalid/immutable_container_types.test.w:21:27
    |
 21 | let s1: Set<Array<num>> = MutSet<Array<num>>[[1]];
-   |                           ^^^^^^^^^^^^^^^^^^^^^^^ Expected type to be \\"Set<Array<num>>\\", but got \\"MutSet<Array<num>>\\" instead
+   |                           ^^^^^^^^^^^^^^^^^^^^^^^
 
 
 error: Member \\"delete\\" doesn't exist in \\"Set\\"
    --> ../../../examples/tests/invalid/immutable_container_types.test.w:24:4
    |
 24 | s2.delete(\\"a\\");
-   |    ^^^^^^ Member \\"delete\\" doesn't exist in \\"Set\\"
+   |    ^^^^^^
 
 
 error: Member \\"add\\" doesn't exist in \\"Set\\"
    --> ../../../examples/tests/invalid/immutable_container_types.test.w:26:4
    |
 26 | s2.add(\\"d\\");
-   |    ^^^ Member \\"add\\" doesn't exist in \\"Set\\"
+   |    ^^^
 
 
 error: Member \\"copy\\" doesn't exist in \\"Set\\"
    --> ../../../examples/tests/invalid/immutable_container_types.test.w:28:13
    |
 28 | let s3 = s2.copy();
-   |             ^^^^ Member \\"copy\\" doesn't exist in \\"Set\\"
+   |             ^^^^
 
 
 error: Member \\"clear\\" doesn't exist in \\"Set\\"
    --> ../../../examples/tests/invalid/immutable_container_types.test.w:30:4
    |
 30 | s2.clear();
-   |    ^^^^^ Member \\"clear\\" doesn't exist in \\"Set\\"
+   |    ^^^^^
 
 
 error: Expected type to be \\"bool\\", but got \\"Array<num>\\" instead
    --> ../../../examples/tests/invalid/immutable_container_types.test.w:32:31
    |
 32 | let s4: Set<bool> = Set<bool>[[3]];
-   |                               ^^^ Expected type to be \\"bool\\", but got \\"Array<num>\\" instead
+   |                               ^^^
 
 
 
@@ -2073,42 +2073,42 @@ exports[`impl_interface.test.w 1`] = `
   --> ../../../examples/tests/invalid/impl_interface.test.w:3:7
   |
 3 | class A impl cloud.IQueueSetConsumerHandler {
-  |       ^ Class \\"A\\" does not implement method \\"handle\\" of interface \\"IQueueSetConsumerHandler\\"
+  |       ^
 
 
 error: Expected type to be \\"inflight (message: str): void\\", but got \\"inflight (x: num): void\\" instead
   --> ../../../examples/tests/invalid/impl_interface.test.w:8:16
   |
 8 |   pub inflight handle(x: num) {
-  |                ^^^^^^ Expected type to be \\"inflight (message: str): void\\", but got \\"inflight (x: num): void\\" instead
+  |                ^^^^^^
 
 
 error: Expected an interface, instead found type \\"Bucket\\"
    --> ../../../examples/tests/invalid/impl_interface.test.w:14:14
    |
 14 | class C impl cloud.Bucket {
-   |              ^^^^^^^^^^^^ Expected an interface, instead found type \\"Bucket\\"
+   |              ^^^^^^^^^^^^
 
 
 error: Class \\"r\\" does not implement method \\"method1\\" of interface \\"I3\\"
    --> ../../../examples/tests/invalid/impl_interface.test.w:30:7
    |
 30 | class r impl I3 {
-   |       ^ Class \\"r\\" does not implement method \\"method1\\" of interface \\"I3\\"
+   |       ^
 
 
 error: Class \\"r\\" does not implement method \\"method2\\" of interface \\"I3\\"
    --> ../../../examples/tests/invalid/impl_interface.test.w:30:7
    |
 30 | class r impl I3 {
-   |       ^ Class \\"r\\" does not implement method \\"method2\\" of interface \\"I3\\"
+   |       ^
 
 
 error: Class \\"r\\" does not implement method \\"method3\\" of interface \\"I3\\"
    --> ../../../examples/tests/invalid/impl_interface.test.w:30:7
    |
 30 | class r impl I3 {
-   |       ^ Class \\"r\\" does not implement method \\"method3\\" of interface \\"I3\\"
+   |       ^
 
 
 
@@ -2123,7 +2123,7 @@ exports[`indexing.test.w 1`] = `
   --> ../../../examples/tests/invalid/indexing.test.w:6:1
   |
 6 | arr[0] = 5;
-  | ^^^^^^ Cannot update elements of an immutable Array
+  | ^^^^^^
   |
   = hint: Consider using MutArray instead
 
@@ -2132,35 +2132,35 @@ error: Expected type to be \\"num\\", but got \\"str\\" instead
   --> ../../../examples/tests/invalid/indexing.test.w:9:5
   |
 9 | arr[\\"key\\"];
-  |     ^^^^^ Expected type to be \\"num\\", but got \\"str\\" instead
+  |     ^^^^^
 
 
 error: Type \\"Bucket\\" is not indexable
    --> ../../../examples/tests/invalid/indexing.test.w:13:1
    |
 13 | b[0] = 5;
-   | ^ Type \\"Bucket\\" is not indexable
+   | ^
 
 
 error: Type \\"Array<num>?\\" is not indexable
    --> ../../../examples/tests/invalid/indexing.test.w:17:1
    |
 17 | optarr[0] = 5;
-   | ^^^^^^ Type \\"Array<num>?\\" is not indexable
+   | ^^^^^^
 
 
 error: Expected type to be \\"str\\", but got \\"num\\" instead
    --> ../../../examples/tests/invalid/indexing.test.w:21:5
    |
 21 | map[0];
-   |     ^ Expected type to be \\"str\\", but got \\"num\\" instead
+   |     ^
 
 
 error: Cannot update elements of an immutable Map
    --> ../../../examples/tests/invalid/indexing.test.w:25:1
    |
 25 | mutmap[\\"a\\"] = false;
-   | ^^^^^^^^^^^ Cannot update elements of an immutable Map
+   | ^^^^^^^^^^^
    |
    = hint: Consider using MutMap instead
 
@@ -2169,7 +2169,7 @@ error: Cannot update elements of an immutable Json
    --> ../../../examples/tests/invalid/indexing.test.w:29:1
    |
 29 | json[0] = 5;
-   | ^^^^^^^ Cannot update elements of an immutable Json
+   | ^^^^^^^
    |
    = hint: Consider using MutJson instead
 
@@ -2178,28 +2178,28 @@ error: Strings are immutable
    --> ../../../examples/tests/invalid/indexing.test.w:33:1
    |
 33 | s[0] = \\"H\\";
-   | ^^^^ Strings are immutable
+   | ^^^^
 
 
 error: Binary operator '+' cannot be applied to operands of type 'num' and 'str'; only (num, num) and (str, str) are supported
    --> ../../../examples/tests/invalid/indexing.test.w:36:13
    |
 36 | let var x = 3 + \\"hello\\";
-   |             ^^^^^^^^^^^ Binary operator '+' cannot be applied to operands of type 'num' and 'str'; only (num, num) and (str, str) are supported
+   |             ^^^^^^^^^^^
 
 
 error: Unsupported reassignment of element of type unresolved
    --> ../../../examples/tests/invalid/indexing.test.w:37:1
    |
 37 | x[\\"hi\\"] = 4;
-   | ^^^^^^^ Unsupported reassignment of element of type unresolved
+   | ^^^^^^^
 
 
 error: Indexing into an inferred type is not supported
    --> ../../../examples/tests/invalid/indexing.test.w:41:7
    |
 41 |   log(x[0]);
-   |       ^ Indexing into an inferred type is not supported
+   |       ^
 
 
 
@@ -2214,91 +2214,91 @@ exports[`inference.test.w 1`] = `
    --> ../../../examples/tests/invalid/inference.test.w:78:8
    |
 78 |   args(nice) {
-   |        ^^^^ Missing required type annotation for method signature
+   |        ^^^^
 
 
 error: Expected type to be \\"num\\", but got \\"str\\" instead
    --> ../../../examples/tests/invalid/inference.test.w:13:18
    |
 13 | recursiveClosure(\\"\\");
-   |                  ^^ Expected type to be \\"num\\", but got \\"str\\" instead
+   |                  ^^
 
 
 error: Expected type to be \\"str\\", but got \\"num\\" instead
    --> ../../../examples/tests/invalid/inference.test.w:32:19
    |
 32 | stringArray2.push(2);
-   |                   ^ Expected type to be \\"str\\", but got \\"num\\" instead
+   |                   ^
 
 
 error: Expected type to be \\"num\\", but got \\"str\\" instead
    --> ../../../examples/tests/invalid/inference.test.w:38:16
    |
 38 | numArray2.push(\\"2\\");
-   |                ^^^ Expected type to be \\"num\\", but got \\"str\\" instead
+   |                ^^^
 
 
 error: Expected type to be \\"num\\", but got \\"str\\" instead
    --> ../../../examples/tests/invalid/inference.test.w:42:40
    |
 42 | let dependentArray = [numArray2.at(0), stringArray2.at(1)];
-   |                                        ^^^^^^^^^^^^^^^^^^ Expected type to be \\"num\\", but got \\"str\\" instead
+   |                                        ^^^^^^^^^^^^^^^^^^
 
 
 error: Expected type to be \\"num\\", but got \\"str\\" instead
    --> ../../../examples/tests/invalid/inference.test.w:45:60
    |
 45 | let dependentMap = { \\"cool\\" => numArray2.at(0), \\"cool2\\" => stringArray2.at(1) };
-   |                                                            ^^^^^^^^^^^^^^^^^^ Expected type to be \\"num\\", but got \\"str\\" instead
+   |                                                            ^^^^^^^^^^^^^^^^^^
 
 
 error: Expected type to be \\"inflight (key: str, type: BucketEventType): void\\", but got \\"inflight (request: ApiRequest): ApiResponse?\\" instead
    --> ../../../examples/tests/invalid/inference.test.w:57:31
    |
 57 | (new cloud.Bucket()).onCreate(func);
-   |                               ^^^^ Expected type to be \\"inflight (key: str, type: BucketEventType): void\\", but got \\"inflight (request: ApiRequest): ApiResponse?\\" instead
+   |                               ^^^^
 
 
 error: Expected type to be \\"inflight (str): void\\", but got \\"inflight (arg1: num): unknown\\" instead
    --> ../../../examples/tests/invalid/inference.test.w:84:37
    |
 84 | let badFunc: inflight (str): void = inflight (arg1: num) => {};
-   |                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^ Expected type to be \\"inflight (str): void\\", but got \\"inflight (arg1: num): unknown\\" instead
+   |                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 
 error: Unable to infer type
   --> ../../../examples/tests/invalid/inference.test.w:4:29
   |
 4 | let preflightClosureArgs = (nice) => { return true; };
-  |                             ^^^^ Unable to infer type
+  |                             ^^^^
 
 
 error: Unable to infer type
    --> ../../../examples/tests/invalid/inference.test.w:25:44
    |
 25 | let stringInterpolationCannotBeInferred = (nice) => {
-   |                                            ^^^^ Unable to infer type
+   |                                            ^^^^
 
 
 error: Property not found
    --> ../../../examples/tests/invalid/inference.test.w:63:19
    |
 63 |     body: request.body,
-   |                   ^^^^ Property not found
+   |                   ^^^^
 
 
 error: Unable to infer type
    --> ../../../examples/tests/invalid/inference.test.w:60:23
    |
 60 | let func2 = inflight (request) => {
-   |                       ^^^^^^^ Unable to infer type
+   |                       ^^^^^^^
 
 
 error: Unexpected return value from void function. Return type annotations are required for methods.
    --> ../../../examples/tests/invalid/inference.test.w:75:5
    |
 75 |     return true;
-   |     ^^^^^^^^^^^^ Unexpected return value from void function. Return type annotations are required for methods.
+   |     ^^^^^^^^^^^^
 
 
 error: Inferred type Array<str> conflicts with already inferred type Array<num>
@@ -2309,91 +2309,91 @@ error: Inferred type Array<str> conflicts with already inferred type Array<num>
 93 | |     a: a,
 94 | |     b: a,
 95 | |   };
-   | \\\\---^ Inferred type Array<str> conflicts with already inferred type Array<num>
+   | \\\\---^
 
 
 error: Expected type to be \\"str\\", but got \\"num\\" instead
     --> ../../../examples/tests/invalid/inference.test.w:102:16
     |
 102 |   let x: str = returnsNumber();
-    |                ^^^^^^^^^^^^^^^ Expected type to be \\"str\\", but got \\"num\\" instead
+    |                ^^^^^^^^^^^^^^^
 
 
 error: Property not found
     --> ../../../examples/tests/invalid/inference.test.w:109:14
     |
 109 |   return arg.get(\\"a\\");
-    |              ^^^ Property not found
+    |              ^^^
 
 
 error: Unable to infer type
     --> ../../../examples/tests/invalid/inference.test.w:107:19
     |
 107 | let unknownArg = (arg) => {
-    |                   ^^^ Unable to infer type
+    |                   ^^^
 
 
 error: Expected type to be \\"str\\", but got \\"num\\" instead
     --> ../../../examples/tests/invalid/inference.test.w:118:16
     |
 118 |   let s: str = a;
-    |                ^ Expected type to be \\"str\\", but got \\"num\\" instead
+    |                ^
 
 
 error: Expected type to be \\"num\\", but got \\"str\\" instead
     --> ../../../examples/tests/invalid/inference.test.w:120:10
     |
 120 |   return \\"\\";
-    |          ^^ Expected type to be \\"num\\", but got \\"str\\" instead
+    |          ^^
 
 
 error: Unable to infer type
    --> ../../../examples/tests/invalid/inference.test.w:69:5
    |
 69 | let anotherEmptyArray = [];
-   |     ^^^^^^^^^^^^^^^^^ Unable to infer type
+   |     ^^^^^^^^^^^^^^^^^
 
 
 error: Unable to infer type
    --> ../../../examples/tests/invalid/inference.test.w:21:5
    |
 21 | let clonedArray = emptyArray.copyMut();
-   |     ^^^^^^^^^^^ Unable to infer type
+   |     ^^^^^^^^^^^
 
 
 error: Unable to infer type
    --> ../../../examples/tests/invalid/inference.test.w:16:5
    |
 16 | let emptyArray = [];
-   |     ^^^^^^^^^^ Unable to infer type
+   |     ^^^^^^^^^^
 
 
 error: Unable to infer type
    --> ../../../examples/tests/invalid/inference.test.w:60:5
    |
 60 | let func2 = inflight (request) => {
-   |     ^^^^^ Unable to infer type
+   |     ^^^^^
 
 
 error: Unable to infer type
    --> ../../../examples/tests/invalid/inference.test.w:18:5
    |
 18 | let numArray = emptyArray;
-   |     ^^^^^^^^ Unable to infer type
+   |     ^^^^^^^^
 
 
 error: Unable to infer type
   --> ../../../examples/tests/invalid/inference.test.w:4:5
   |
 4 | let preflightClosureArgs = (nice) => { return true; };
-  |     ^^^^^^^^^^^^^^^^^^^^ Unable to infer type
+  |     ^^^^^^^^^^^^^^^^^^^^
 
 
 error: Unable to infer type
    --> ../../../examples/tests/invalid/inference.test.w:25:5
    |
 25 | let stringInterpolationCannotBeInferred = (nice) => {
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Unable to infer type
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 
 
@@ -2408,35 +2408,35 @@ exports[`inflight_class_created_in_preflight.test.w 1`] = `
   --> ../../../examples/tests/invalid/inflight_class_created_in_preflight.test.w:3:1
   |
 3 | new Foo();
-  | ^^^^^^^^^ Cannot create inflight class \\"Foo\\" in preflight phase
+  | ^^^^^^^^^
 
 
 error: Cannot create inflight class \\"Foo\\" in preflight phase
   --> ../../../examples/tests/invalid/inflight_class_created_in_preflight.test.w:8:5
   |
 8 |     new Foo();
-  |     ^^^^^^^^^ Cannot create inflight class \\"Foo\\" in preflight phase
+  |     ^^^^^^^^^
 
 
 error: Cannot create inflight class \\"Foo\\" in preflight phase
    --> ../../../examples/tests/invalid/inflight_class_created_in_preflight.test.w:13:5
    |
 13 |     new Foo();
-   |     ^^^^^^^^^ Cannot create inflight class \\"Foo\\" in preflight phase
+   |     ^^^^^^^^^
 
 
 error: Cannot create preflight class \\"PreflightClass\\" in inflight phase
    --> ../../../examples/tests/invalid/inflight_class_created_in_preflight.test.w:19:3
    |
 19 |   new PreflightClass();
-   |   ^^^^^^^^^^^^^^^^^^^^ Cannot create preflight class \\"PreflightClass\\" in inflight phase
+   |   ^^^^^^^^^^^^^^^^^^^^
 
 
 error: Cannot qualify access to a lifted type \\"PreflightClass\\" (see https://github.com/winglang/wing/issues/76 for more details)
    --> ../../../examples/tests/invalid/inflight_class_created_in_preflight.test.w:19:7
    |
 19 |   new PreflightClass();
-   |       ^^^^^^^^^^^^^^ Cannot qualify access to a lifted type \\"PreflightClass\\" (see https://github.com/winglang/wing/issues/76 for more details)
+   |       ^^^^^^^^^^^^^^
 
 
 
@@ -2453,7 +2453,7 @@ exports[`inflight_class_dup_init.test.w 1`] = `
 6 | /   inflight new() {
 7 | | 
 8 | |   }
-  | \\\\---^ Multiple inflight constructors defined in class Foo
+  | \\\\---^
 
 
 
@@ -2468,7 +2468,7 @@ exports[`inflight_class_in_preflight.test.w 1`] = `
   --> ../../../examples/tests/invalid/inflight_class_in_preflight.test.w:5:1
   |
 5 | new Foo();
-  | ^^^^^^^^^ Cannot create inflight class \\"Foo\\" in preflight phase
+  | ^^^^^^^^^
 
 
 
@@ -2483,7 +2483,7 @@ exports[`inflight_class_interface_structural_typing.test.w 1`] = `
    --> ../../../examples/tests/invalid/inflight_class_interface_structural_typing.test.w:26:17
    |
 26 |   let x: IGoo = new NotGoo();
-   |                 ^^^^^^^^^^^^ Expected type to be \\"IGoo\\", but got \\"NotGoo\\" instead
+   |                 ^^^^^^^^^^^^
 
 
 
@@ -2498,7 +2498,7 @@ exports[`inflight_reassign.test.w 1`] = `
   --> ../../../examples/tests/invalid/inflight_reassign.test.w:5:3
   |
 5 |   xvar = \\"hi\\";
-  |   ^^^^ Variable cannot be reassigned from inflight
+  |   ^^^^
 
 
 error: Variable is not reassignable
@@ -2508,7 +2508,7 @@ error: Variable is not reassignable
   |     ---- defined here (try adding \\"var\\" in front)
   .
 8 |   ylet = 456;
-  |   ^^^^ Variable is not reassignable
+  |   ^^^^
 
 
 
@@ -2523,21 +2523,21 @@ exports[`inflight_ref_explicit_ops.test.w 1`] = `
    --> ../../../examples/tests/invalid/inflight_ref_explicit_ops.test.w:36:5
    |
 36 |     x.put(\\"hello\\", \\"world\\");
-   |     ^ Expression of type \\"Bucket\\" references an unknown preflight object, can't qualify its capabilities. Use \`lift()\` to explicitly qualify the preflight object to disable this error.
+   |     ^
 
 
 error: Expression of type \\"Queue\\" references an unknown preflight object, can't qualify its capabilities. Use \`lift()\` to explicitly qualify the preflight object to disable this error.
    --> ../../../examples/tests/invalid/inflight_ref_explicit_ops.test.w:43:5
    |
 43 |     q.push(\\"push!\\");
-   |     ^ Expression of type \\"Queue\\" references an unknown preflight object, can't qualify its capabilities. Use \`lift()\` to explicitly qualify the preflight object to disable this error.
+   |     ^
 
 
 error: Expression of type \\"Bucket\\" references an unknown preflight object, can't qualify its capabilities. Use \`lift()\` to explicitly qualify the preflight object to disable this error.
    --> ../../../examples/tests/invalid/inflight_ref_explicit_ops.test.w:48:12
    |
 48 |     assert(b.list().length == 0);
-   |            ^ Expression of type \\"Bucket\\" references an unknown preflight object, can't qualify its capabilities. Use \`lift()\` to explicitly qualify the preflight object to disable this error.
+   |            ^
 
 
 
@@ -2552,14 +2552,14 @@ exports[`inflight_ref_resource_sub_method.test.w 1`] = `
    --> ../../../examples/tests/invalid/inflight_ref_resource_sub_method.test.w:32:5
    |
 32 |     q.push(\\"push!\\");
-   |     ^ Expression of type \\"Queue\\" references an unknown preflight object, can't qualify its capabilities. Use \`lift()\` to explicitly qualify the preflight object to disable this error.
+   |     ^
 
 
 error: Expression of type \\"Queue\\" references an unknown preflight object, can't qualify its capabilities. Use \`lift()\` to explicitly qualify the preflight object to disable this error.
    --> ../../../examples/tests/invalid/inflight_ref_resource_sub_method.test.w:35:5
    |
 35 |     q2.push(\\"push!\\");
-   |     ^^ Expression of type \\"Queue\\" references an unknown preflight object, can't qualify its capabilities. Use \`lift()\` to explicitly qualify the preflight object to disable this error.
+   |     ^^
 
 
 
@@ -2574,14 +2574,14 @@ exports[`inflight_ref_unknown_op.test.w 1`] = `
    --> ../../../examples/tests/invalid/inflight_ref_unknown_op.test.w:15:5
    |
 15 |     x.put(\\"hello\\", \\"world\\");
-   |     ^ Expression of type \\"Bucket\\" references an unknown preflight object, can't qualify its capabilities. Use \`lift()\` to explicitly qualify the preflight object to disable this error.
+   |     ^
 
 
 error: Expression of type \\"Bucket\\" references an unknown preflight object, can't qualify its capabilities. Use \`lift()\` to explicitly qualify the preflight object to disable this error.
    --> ../../../examples/tests/invalid/inflight_ref_unknown_op.test.w:19:5
    |
 19 |     y.put(\\"boom\\", \\"shakalaka\\");
-   |     ^ Expression of type \\"Bucket\\" references an unknown preflight object, can't qualify its capabilities. Use \`lift()\` to explicitly qualify the preflight object to disable this error.
+   |     ^
 
 
 
@@ -2596,56 +2596,56 @@ exports[`interface.test.w 1`] = `
    --> ../../../examples/tests/invalid/interface.test.w:32:3
    |
 32 |   bar: str;
-   |   ^^^^^^^^^ Properties are not supported in interfaces
+   |   ^^^^^^^^^
 
 
 error: Access modifiers are not allowed in interfaces
    --> ../../../examples/tests/invalid/interface.test.w:38:3
    |
 38 |   pub method2(): str;  
-   |   ^^^^^^^^^^^^^^^^^^^ Access modifiers are not allowed in interfaces
+   |   ^^^^^^^^^^^^^^^^^^^
 
 
 error: Expected type annotation
    --> ../../../examples/tests/invalid/interface.test.w:44:11
    |
 44 |   method1(a, b): void;
-   |           ^ Expected type annotation
+   |           ^
 
 
 error: Expected type annotation
    --> ../../../examples/tests/invalid/interface.test.w:44:14
    |
 44 |   method1(a, b): void;
-   |              ^ Expected type annotation
+   |              ^
 
 
 error: Unknown parser error
    --> ../../../examples/tests/invalid/interface.test.w:38:14
    |
 38 |   pub method2(): str;  
-   |              ^^ Unknown parser error
+   |              ^^
 
 
 error: Unknown symbol \\"IB\\"
   --> ../../../examples/tests/invalid/interface.test.w:4:22
   |
 4 | interface IA extends IB {
-  |                      ^^ Unknown symbol \\"IB\\"
+  |                      ^^
 
 
 error: Unknown symbol \\"IDontExist\\"
    --> ../../../examples/tests/invalid/interface.test.w:12:26
    |
 12 | interface IExist extends IDontExist {
-   |                          ^^^^^^^^^^ Unknown symbol \\"IDontExist\\"
+   |                          ^^^^^^^^^^
 
 
 error: Unknown symbol \\"ISomeClass\\"
    --> ../../../examples/tests/invalid/interface.test.w:18:34
    |
 18 | interface ISomeInterface extends ISomeClass {
-   |                                  ^^^^^^^^^^ Unknown symbol \\"ISomeClass\\"
+   |                                  ^^^^^^^^^^
 
 
 error: Symbol \\"foo\\" already defined in this scope
@@ -2654,7 +2654,7 @@ error: Symbol \\"foo\\" already defined in this scope
 24 |     foo(): void;
    |     --- previous definition
 25 |     foo(): void;
-   |     ^^^ Symbol \\"foo\\" already defined in this scope
+   |     ^^^
 
 
 error: Symbol \\"foo\\" already defined in this scope
@@ -2664,7 +2664,7 @@ error: Symbol \\"foo\\" already defined in this scope
    |     --- previous definition
    .
 27 |     foo(): num;
-   |     ^^^ Symbol \\"foo\\" already defined in this scope
+   |     ^^^
 
 
 error: Inflight class CImplPreflightIface cannot implement a preflight interface IPreflight
@@ -2673,14 +2673,14 @@ error: Inflight class CImplPreflightIface cannot implement a preflight interface
 52 | / inflight class CImplPreflightIface impl IPreflight {
 53 | |   pub method1(): void {}
 54 | | }
-   | \\\\-^ Inflight class CImplPreflightIface cannot implement a preflight interface IPreflight
+   | \\\\-^
 
 
 error: Expected type to be \\"preflight (): void\\", but got \\"inflight (): void\\" instead
    --> ../../../examples/tests/invalid/interface.test.w:53:7
    |
 53 |   pub method1(): void {}
-   |       ^^^^^^^ Expected type to be \\"preflight (): void\\", but got \\"inflight (): void\\" instead
+   |       ^^^^^^^
    |
    = hint: expected phase to be preflight, but got inflight instead
 
@@ -2689,21 +2689,21 @@ error: Inflight interface IInflightExtendsPreflight cannot extend a preflight in
    --> ../../../examples/tests/invalid/interface.test.w:57:20
    |
 57 | inflight interface IInflightExtendsPreflight extends IPreflight {
-   |                    ^^^^^^^^^^^^^^^^^^^^^^^^^ Inflight interface IInflightExtendsPreflight cannot extend a preflight interface IPreflight
+   |                    ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 
 error: Inflight interface IInflightExtendsJsii cannot extend a preflight interface ISomeInterface
    --> ../../../examples/tests/invalid/interface.test.w:62:20
    |
 62 | inflight interface IInflightExtendsJsii extends jsii_fixture.ISomeInterface {
-   |                    ^^^^^^^^^^^^^^^^^^^^ Inflight interface IInflightExtendsJsii cannot extend a preflight interface ISomeInterface
+   |                    ^^^^^^^^^^^^^^^^^^^^
 
 
 error: Interface \\"IInflightExtendsJsii\\" extends \\"ISomeInterface\\" but has a conflicting member \\"method\\" (preflight (): void != inflight (): void)
    --> ../../../examples/tests/invalid/interface.test.w:62:20
    |
 62 | inflight interface IInflightExtendsJsii extends jsii_fixture.ISomeInterface {
-   |                    ^^^^^^^^^^^^^^^^^^^^ Interface \\"IInflightExtendsJsii\\" extends \\"ISomeInterface\\" but has a conflicting member \\"method\\" (preflight (): void != inflight (): void)
+   |                    ^^^^^^^^^^^^^^^^^^^^
 
 
 error: Inflight class CInflightImplJsii cannot implement a preflight interface ISomeInterface
@@ -2712,14 +2712,14 @@ error: Inflight class CInflightImplJsii cannot implement a preflight interface I
 67 | / inflight class CInflightImplJsii impl jsii_fixture.ISomeInterface {
 68 | |   pub method(): void {}
 69 | | }
-   | \\\\-^ Inflight class CInflightImplJsii cannot implement a preflight interface ISomeInterface
+   | \\\\-^
 
 
 error: Expected type to be \\"preflight (): void\\", but got \\"inflight (): void\\" instead
    --> ../../../examples/tests/invalid/interface.test.w:68:7
    |
 68 |   pub method(): void {}
-   |       ^^^^^^ Expected type to be \\"preflight (): void\\", but got \\"inflight (): void\\" instead
+   |       ^^^^^^
    |
    = hint: expected phase to be preflight, but got inflight instead
 
@@ -2736,7 +2736,7 @@ exports[`invalid compile directory 1`] = `
   --> ../../../examples/tests/invalid/lib/extern_above.w:2:3
   |
 2 |   extern \\"../../valid/external_ts.ts\\" static getGreeting(name: str): str;
-  |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ <ABSOLUTE>/external_ts.ts must be a sub directory of <ABSOLUTE>/lib
+  |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 "
 `;
@@ -2746,7 +2746,7 @@ exports[`issue_2767.test.w 1`] = `
   --> ../../../examples/tests/invalid/issue_2767.test.w:4:16
   |
 4 | x.set(\\"hello\\", new cloud.Bucket());
-  |                ^^^^^^^^^^^^^^^^^^ Expected type to be \\"MutJson\\", but got \\"Bucket\\" instead
+  |                ^^^^^^^^^^^^^^^^^^
 
 
 
@@ -2761,7 +2761,7 @@ exports[`jsii_access_modifiers.test.w 1`] = `
    --> ../../../examples/tests/invalid/jsii_access_modifiers.test.w:13:3
    |
 13 | b.createTopic(cloud.BucketEventType.CREATE);
-   |   ^^^^^^^^^^^ Cannot access protected member \\"createTopic\\" of \\"Bucket\\"
+   |   ^^^^^^^^^^^
    |
    = hint: the definition of \\"createTopic\\" needs a broader access modifier like \\"pub\\" to be used outside of \\"Bucket\\"
 
@@ -2778,70 +2778,70 @@ exports[`json.test.w 1`] = `
    --> ../../../examples/tests/invalid/json.test.w:29:26
    |
 29 | let jsonIncomplete = Json;
-   |                          ^ Json literal must have an element
+   |                          ^
 
 
 error: Expected type to be \\"num\\", but got \\"str\\" instead
   --> ../../../examples/tests/invalid/json.test.w:6:14
   |
 6 | let n: num = j;
-  |              ^ Expected type to be \\"num\\", but got \\"str\\" instead
+  |              ^
 
 
 error: Expected type to be \\"bool\\", but got \\"str\\" instead
   --> ../../../examples/tests/invalid/json.test.w:8:15
   |
 8 | let b: bool = j;
-  |               ^ Expected type to be \\"bool\\", but got \\"str\\" instead
+  |               ^
 
 
 error: Expected type to be \\"Map<str>\\", but got \\"str\\" instead
    --> ../../../examples/tests/invalid/json.test.w:10:19
    |
 10 | let m: Map<str> = j;
-   |                   ^ Expected type to be \\"Map<str>\\", but got \\"str\\" instead
+   |                   ^
 
 
 error: Expected type to be \\"Set<str>\\", but got \\"str\\" instead
    --> ../../../examples/tests/invalid/json.test.w:12:20
    |
 12 | let s2: Set<str> = j;
-   |                    ^ Expected type to be \\"Set<str>\\", but got \\"str\\" instead
+   |                    ^
 
 
 error: Expected type to be \\"Array<str>\\", but got \\"str\\" instead
    --> ../../../examples/tests/invalid/json.test.w:14:21
    |
 14 | let a: Array<str> = j;
-   |                     ^ Expected type to be \\"Array<str>\\", but got \\"str\\" instead
+   |                     ^
 
 
 error: Member \\"set\\" doesn't exist in \\"Json\\"
    --> ../../../examples/tests/invalid/json.test.w:19:13
    |
 19 | foreverJson.set(\\"a\\", \\"world!\\");
-   |             ^^^ Member \\"set\\" doesn't exist in \\"Json\\"
+   |             ^^^
 
 
 error: Expected type to be \\"num?\\", but got \\"str?\\" instead
    --> ../../../examples/tests/invalid/json.test.w:32:20
    |
 32 | let tryNum: num? = j.tryAsStr();
-   |                    ^^^^^^^^^^^^ Expected type to be \\"num?\\", but got \\"str?\\" instead
+   |                    ^^^^^^^^^^^^
 
 
 error: Expected type to be \\"str?\\", but got \\"bool?\\" instead
    --> ../../../examples/tests/invalid/json.test.w:35:20
    |
 35 | let tryStr: str? = j.tryAsBool();
-   |                    ^^^^^^^^^^^^^ Expected type to be \\"str?\\", but got \\"bool?\\" instead
+   |                    ^^^^^^^^^^^^^
 
 
 error: Expected type to be \\"bool?\\", but got \\"num?\\" instead
    --> ../../../examples/tests/invalid/json.test.w:38:22
    |
 38 | let tryBool: bool? = j.tryAsNum();
-   |                      ^^^^^^^^^^^^ Expected type to be \\"bool?\\", but got \\"num?\\" instead
+   |                      ^^^^^^^^^^^^
 
 
 error: Missing required field \\"maybe\\" from \\"StructyJson\\"
@@ -2852,7 +2852,7 @@ error: Missing required field \\"maybe\\" from \\"StructyJson\\"
 56 | |   foo: \\"bar\\",
 57 | |   stuff: [],
 58 | | };
-   | \\\\-^ Missing required field \\"maybe\\" from \\"StructyJson\\"
+   | \\\\-^
 
 
 error: Missing required field \\"maybe\\" from \\"StructyJson\\"
@@ -2862,35 +2862,35 @@ error: Missing required field \\"maybe\\" from \\"StructyJson\\"
 64 | |       foo: \\"bar\\",
 65 | |       stuff: [],
 66 | |     }
-   | \\\\-----^ Missing required field \\"maybe\\" from \\"StructyJson\\"
+   | \\\\-----^
 
 
 error: Expected type to be \\"bool\\", but got \\"num\\" instead
    --> ../../../examples/tests/invalid/json.test.w:76:11
    |
 76 |     good: 2,
-   |           ^ Expected type to be \\"bool\\", but got \\"num\\" instead
+   |           ^
 
 
 error: Expected type to be \\"num\\", but got \\"str\\" instead
    --> ../../../examples/tests/invalid/json.test.w:83:14
    |
 83 |   stuff: [1, \\"hi\\", 3],
-   |              ^^^^ Expected type to be \\"num\\", but got \\"str\\" instead
+   |              ^^^^
 
 
 error: Expected type to be \\"num\\", but got \\"str\\" instead
    --> ../../../examples/tests/invalid/json.test.w:94:8
    |
 94 |     b: \\"\\",
-   |        ^^ Expected type to be \\"num\\", but got \\"str\\" instead
+   |        ^^
 
 
 error: Expected type to be \\"StructyJson\\", but got \\"Json\\" instead
     --> ../../../examples/tests/invalid/json.test.w:107:38
     |
 107 | let mutableJsonStruct: StructyJson = mutableJson;
-    |                                      ^^^^^^^^^^^ Expected type to be \\"StructyJson\\", but got \\"Json\\" instead
+    |                                      ^^^^^^^^^^^
     |
     = hint: use StructyJson.fromJson() to convert dynamic Json\\"
 
@@ -2899,28 +2899,28 @@ error: \\"Array<Json>\\" is not a legal JSON value
    --> ../../../examples/tests/invalid/json.test.w:23:17
    |
 23 | let jArr = Json [bkt];
-   |                 ^^^^^ \\"Array<Json>\\" is not a legal JSON value
+   |                 ^^^^^
 
 
 error: \\"Bucket\\" is not a legal JSON value
    --> ../../../examples/tests/invalid/json.test.w:26:28
    |
 26 | let jsonObj = Json { boom: bkt };
-   |                            ^^^ \\"Bucket\\" is not a legal JSON value
+   |                            ^^^
 
 
 error: \\"Bucket\\" is not a legal JSON value
     --> ../../../examples/tests/invalid/json.test.w:111:6
     |
 111 |   b: new cloud.Bucket()
-    |      ^^^^^^^^^^^^^^^^^^ \\"Bucket\\" is not a legal JSON value
+    |      ^^^^^^^^^^^^^^^^^^
 
 
 error: \\"Bucket\\" is not a legal JSON value
     --> ../../../examples/tests/invalid/json.test.w:115:21
     |
 115 | let isBucket = Json new cloud.Bucket();
-    |                     ^^^^^^^^^^^^^^^^^^ \\"Bucket\\" is not a legal JSON value
+    |                     ^^^^^^^^^^^^^^^^^^
 
 
 
@@ -2935,7 +2935,7 @@ exports[`json_static.test.w 1`] = `
   --> ../../../examples/tests/invalid/json_static.test.w:4:10
   |
 4 | immutObj.set(\\"a\\", \\"foo\\");
-  |          ^^^ Member \\"set\\" doesn't exist in \\"Json\\"
+  |          ^^^
 
 
 
@@ -2950,7 +2950,7 @@ exports[`map_entries.test.w 1`] = `
   --> ../../../examples/tests/invalid/map_entries.test.w:2:20
   |
 2 | let someStr: str = mapToNumber.entries().at(0).value;
-  |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Expected type to be \\"str\\", but got \\"num\\" instead
+  |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 
 
@@ -2968,7 +2968,7 @@ exports[`missing_return.test.w 1`] = `
   | /----------------------------------------^
 2 | |   log(\\"i am not going to return anything!\\");
 3 | | };
-  | \\\\-^ A function whose return type is \\"str\\" must return a value.
+  | \\\\-^
 
 
 error: A function whose return type is \\"str\\" must return a value.
@@ -2980,7 +2980,7 @@ error: A function whose return type is \\"str\\" must return a value.
 30 | |     return \\"what?\\"; // This should be ignored and we should produce a missing return error
 31 | |   };
 32 | | };
-   | \\\\-^ A function whose return type is \\"str\\" must return a value.
+   | \\\\-^
 
 
 error: A function whose return type is \\"str\\" must return a value.
@@ -2994,7 +2994,7 @@ error: A function whose return type is \\"str\\" must return a value.
 40 | |     }
 41 | |   }
 42 | | };
-   | \\\\-^ A function whose return type is \\"str\\" must return a value.
+   | \\\\-^
 
 
 
@@ -3009,21 +3009,21 @@ exports[`missing_semicolon.test.w 1`] = `
   --> ../../../examples/tests/invalid/missing_semicolon.test.w:9:3
   |
 9 | })
-  |   ^ Expected ';'
+  |   ^
 
 
 error: Expected ';'
    --> ../../../examples/tests/invalid/missing_semicolon.test.w:16:10
    |
 16 | let x = 5 //
-   |          ^ Expected ';'
+   |          ^
 
 
 error: Expected '}'
    --> ../../../examples/tests/invalid/missing_semicolon.test.w:19:13
    |
 19 | if (x > 10) {
-   |             ^ Expected '}'
+   |             ^
 
 
 
@@ -3038,84 +3038,84 @@ exports[`mut_container_types.test.w 1`] = `
   --> ../../../examples/tests/invalid/mut_container_types.test.w:2:29
   |
 2 | let arr1 = MutArray<num>[1, \\"2\\", 3];
-  |                             ^^^ Expected type to be \\"num\\", but got \\"str\\" instead
+  |                             ^^^
 
 
 error: Expected type to be \\"MutArray<num>\\", but got \\"Array<num>\\" instead
   --> ../../../examples/tests/invalid/mut_container_types.test.w:3:27
   |
 3 | let arr3: MutArray<num> = [1, 2, 3]; // https://github.com/winglang/wing/issues/1117
-  |                           ^^^^^^^^^ Expected type to be \\"MutArray<num>\\", but got \\"Array<num>\\" instead
+  |                           ^^^^^^^^^
 
 
 error: Expected type to be \\"MutArray<num>\\", but got \\"MutArray<str>\\" instead
   --> ../../../examples/tests/invalid/mut_container_types.test.w:5:27
   |
 5 | let arr5: MutArray<num> = arr4;
-  |                           ^^^^ Expected type to be \\"MutArray<num>\\", but got \\"MutArray<str>\\" instead
+  |                           ^^^^
 
 
 error: Member \\"someMethod\\" doesn't exist in \\"MutArray\\"
   --> ../../../examples/tests/invalid/mut_container_types.test.w:6:6
   |
 6 | arr1.someMethod();
-  |      ^^^^^^^^^^ Member \\"someMethod\\" doesn't exist in \\"MutArray\\"
+  |      ^^^^^^^^^^
 
 
 error: Expected type to be \\"num\\", but got \\"str\\" instead
   --> ../../../examples/tests/invalid/mut_container_types.test.w:9:25
   |
 9 | let s1 = MutSet<num>[1, \\"2\\", 3];
-  |                         ^^^ Expected type to be \\"num\\", but got \\"str\\" instead
+  |                         ^^^
 
 
 error: Expected type to be \\"num\\", but got \\"str\\" instead
    --> ../../../examples/tests/invalid/mut_container_types.test.w:10:25
    |
 10 | let s2 = MutSet<num>[1, \\"2\\", 3];
-   |                         ^^^ Expected type to be \\"num\\", but got \\"str\\" instead
+   |                         ^^^
 
 
 error: Expected type to be \\"MutSet<num>\\", but got \\"MutSet<str>\\" instead
    --> ../../../examples/tests/invalid/mut_container_types.test.w:13:23
    |
 13 | let s5: MutSet<num> = s4;
-   |                       ^^ Expected type to be \\"MutSet<num>\\", but got \\"MutSet<str>\\" instead
+   |                       ^^
 
 
 error: Member \\"someMethod\\" doesn't exist in \\"MutSet\\"
    --> ../../../examples/tests/invalid/mut_container_types.test.w:14:4
    |
 14 | s3.someMethod();
-   |    ^^^^^^^^^^ Member \\"someMethod\\" doesn't exist in \\"MutSet\\"
+   |    ^^^^^^^^^^
 
 
 error: Expected type to be \\"num\\", but got \\"str\\" instead
    --> ../../../examples/tests/invalid/mut_container_types.test.w:17:33
    |
 17 | let m1 = MutMap<num>{\\"hello\\" => \\"world\\"};
-   |                                 ^^^^^^^ Expected type to be \\"num\\", but got \\"str\\" instead
+   |                                 ^^^^^^^
 
 
 error: Expected \\"Array\\" or \\"MutArray\\", found \\"MutMap<str>\\"
    --> ../../../examples/tests/invalid/mut_container_types.test.w:19:10
    |
 19 | let m2 = MutMap<str>[\\"hello\\", \\"world\\"];
-   |          ^^^^^^^^^^^ Expected \\"Array\\" or \\"MutArray\\", found \\"MutMap<str>\\"
+   |          ^^^^^^^^^^^
 
 
 error: Expected type to be \\"MutMap<num>\\", but got \\"Map<str>\\" instead
    --> ../../../examples/tests/invalid/mut_container_types.test.w:21:23
    |
 21 | let m3: MutMap<num> = {\\"hello\\" => \\"world\\"};
-   |                       ^^^^^^^^^^^^^^^^^^^^ Expected type to be \\"MutMap<num>\\", but got \\"Map<str>\\" instead
+   |                       ^^^^^^^^^^^^^^^^^^^^
 
 
 error: Expected type to be \\"MutMap<str>\\", but got \\"MutMap<num>\\" instead
    --> ../../../examples/tests/invalid/mut_container_types.test.w:24:23
    |
 24 | let m5: MutMap<str> = m4;
-   |                       ^^ Expected type to be \\"MutMap<str>\\", but got \\"MutMap<num>\\" instead
+   |                       ^^
 
 
 
@@ -3130,7 +3130,7 @@ exports[`nil.test.w 1`] = `
   --> ../../../examples/tests/invalid/nil.test.w:3:14
   |
 3 | let x: str = nil;
-  |              ^^^ Expected type to be \\"str\\", but got \\"nil\\" instead
+  |              ^^^
   |
   = hint: to allow \\"nil\\" assignment use optional type: \\"str?\\"
 
@@ -3139,28 +3139,28 @@ error: Expected optional type, found \\"nil\\"
    --> ../../../examples/tests/invalid/nil.test.w:24:4
    |
 24 | if nil? {
-   |    ^^^ Expected optional type, found \\"nil\\"
+   |    ^^^
 
 
 error: Cannot assign nil value to variables without explicit optional type
    --> ../../../examples/tests/invalid/nil.test.w:28:18
    |
 28 | let nilWannabe = nil;
-   |                  ^^^ Cannot assign nil value to variables without explicit optional type
+   |                  ^^^
 
 
 error: Cannot assign nil value to variables without explicit optional type
    --> ../../../examples/tests/invalid/nil.test.w:31:17
    |
 31 | let nilGaggle = [nil, nil, nil];
-   |                 ^^^^^^^^^^^^^^^ Cannot assign nil value to variables without explicit optional type
+   |                 ^^^^^^^^^^^^^^^
 
 
 error: Expected type to be \\"num\\", but got \\"nil\\" instead
    --> ../../../examples/tests/invalid/nil.test.w:20:14
    |
 20 |   foo.setBar(nil);
-   |              ^^^ Expected type to be \\"num\\", but got \\"nil\\" instead
+   |              ^^^
    |
    = hint: to allow \\"nil\\" assignment use optional type: \\"num?\\"
 
@@ -3177,119 +3177,119 @@ exports[`optionals.test.w 1`] = `
    --> ../../../examples/tests/invalid/optionals.test.w:98:36
    |
 98 | let optionalFunctionWithNoRetType: ()? = () => {};
-   |                                    ^^ Unexpected 'parameter_type_list'
+   |                                    ^^
 
 
 error: Expected type to be \\"num\\", but got \\"num?\\" instead
    --> ../../../examples/tests/invalid/optionals.test.w:11:3
    |
 11 | f(x);
-   |   ^ Expected type to be \\"num\\", but got \\"num?\\" instead
+   |   ^
 
 
 error: Expected type to be \\"num?\\", but got \\"str\\" instead
    --> ../../../examples/tests/invalid/optionals.test.w:14:11
    |
 14 | fOptional(\\"\\");
-   |           ^^ Expected type to be \\"num?\\", but got \\"str\\" instead
+   |           ^^
 
 
 error: Expected optional type, found \\"bool\\"
    --> ../../../examples/tests/invalid/optionals.test.w:18:4
    |
 18 | if y? {
-   |    ^ Expected optional type, found \\"bool\\"
+   |    ^
 
 
 error: Expected optional type, found \\"bool\\"
    --> ../../../examples/tests/invalid/optionals.test.w:22:9
    |
 22 | let z = y ?? 1;
-   |         ^ Expected optional type, found \\"bool\\"
+   |         ^
 
 
 error: Expected type to be \\"str\\", but got \\"num\\" instead
    --> ../../../examples/tests/invalid/optionals.test.w:25:14
    |
 25 | let w: str = x ?? 3;
-   |              ^^^^^^ Expected type to be \\"str\\", but got \\"num\\" instead
+   |              ^^^^^^
 
 
 error: Expected type to be \\"num\\", but got \\"str\\" instead
    --> ../../../examples/tests/invalid/optionals.test.w:28:6
    |
 28 | x ?? \\"hello\\";
-   |      ^^^^^^^ Expected type to be \\"num\\", but got \\"str\\" instead
+   |      ^^^^^^^
 
 
 error: Expected type to be \\"Sub1\\", but got \\"Sub2\\" instead
    --> ../../../examples/tests/invalid/optionals.test.w:39:17
    |
 39 | optionalSub1 ?? new Sub2();
-   |                 ^^^^^^^^^^ Expected type to be \\"Sub1\\", but got \\"Sub2\\" instead
+   |                 ^^^^^^^^^^
 
 
 error: Expected type to be \\"Sub1\\", but got \\"Super\\" instead
    --> ../../../examples/tests/invalid/optionals.test.w:41:17
    |
 41 | optionalSub1 ?? new Super();
-   |                 ^^^^^^^^^^^ Expected type to be \\"Sub1\\", but got \\"Super\\" instead
+   |                 ^^^^^^^^^^^
 
 
 error: Expected type to be optional, but got \\"bool\\" instead
    --> ../../../examples/tests/invalid/optionals.test.w:45:12
    |
 45 | if let x = true {
-   |            ^^^^ Expected type to be optional, but got \\"bool\\" instead
+   |            ^^^^
 
 
 error: Property access on optional type \\"A?\\" requires optional accessor: \\"?.\\"
    --> ../../../examples/tests/invalid/optionals.test.w:68:9
    |
 68 | let c = b.a.val;
-   |         ^^^ Property access on optional type \\"A?\\" requires optional accessor: \\"?.\\"
+   |         ^^^
 
 
 error: Expected type to be \\"str\\", but got \\"str?\\" instead
    --> ../../../examples/tests/invalid/optionals.test.w:91:16
    |
 91 | let val: str = baz?.bar?.foo?.val;
-   |                ^^^^^^^^^^^^^^^^^^ Expected type to be \\"str\\", but got \\"str?\\" instead
+   |                ^^^^^^^^^^^^^^^^^^
 
 
 error: Cannot call an optional function
    --> ../../../examples/tests/invalid/optionals.test.w:95:1
    |
 95 | optionalFunction();
-   | ^^^^^^^^^^^^^^^^ Cannot call an optional function
+   | ^^^^^^^^^^^^^^^^
 
 
 error: Expected type to be \\"(preflight (num): void)?\\", but got \\"preflight (x: str): void\\" instead
     --> ../../../examples/tests/invalid/optionals.test.w:102:53
     |
 102 | let functionWithOptionalFuncParam1: ((num):void)? = (x: str):void => {};
-    |                                                     ^^^^^^^^^^^^^^^^^^^ Expected type to be \\"(preflight (num): void)?\\", but got \\"preflight (x: str): void\\" instead
+    |                                                     ^^^^^^^^^^^^^^^^^^^
 
 
 error: Expected type to be \\"(preflight (): num)?\\", but got \\"preflight (): str\\" instead
     --> ../../../examples/tests/invalid/optionals.test.w:104:49
     |
 104 | let functionWithOptionalFuncParam2: (():num)? = ():str => { return \\"s\\"; };
-    |                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^ Expected type to be \\"(preflight (): num)?\\", but got \\"preflight (): str\\" instead
+    |                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 
 error: '!' expects an optional type, found \\"num\\"
     --> ../../../examples/tests/invalid/optionals.test.w:110:19
     |
 110 | let unwrapValue = nonOptional!;
-    |                   ^^^^^^^^^^^ '!' expects an optional type, found \\"num\\"
+    |                   ^^^^^^^^^^^
 
 
 error: '!' expects an optional type, found \\"num\\"
     --> ../../../examples/tests/invalid/optionals.test.w:116:21
     |
 116 | let unwrapValueFn = nonOptionalFn()!;
-    |                     ^^^^^^^^^^^^^^^ '!' expects an optional type, found \\"num\\"
+    |                     ^^^^^^^^^^^^^^^
 
 
 error: Variable is not reassignable
@@ -3299,7 +3299,7 @@ error: Variable is not reassignable
    |        -- defined here (try adding \\"var\\" in front)
    .
 53 |   hi = \\"bye\\";
-   |   ^^ Variable is not reassignable
+   |   ^^
 
 
 
@@ -3315,8 +3315,7 @@ User invoked panic'), please report at https://www.winglang.io/contributing/star
   --> ../../../examples/tests/invalid/panic.test.w:6:1
   |
 6 | 😱;
-  | ^^ Compiler bug during type-checking ('panicked at libs/wingc/src/type_check.rs:LINE:COL:
-User invoked panic'), please report at https://www.winglang.io/contributing/start-here/bugs
+  | ^^
 
 
 
@@ -3346,7 +3345,7 @@ exports[`phase_mismatch.test.w 1`] = `
   --> ../../../examples/tests/invalid/phase_mismatch.test.w:2:10
   |
 2 | my_func1((n: num): num => { return n * 2; });
-  |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Expected type to be \\"inflight (num): num\\", but got \\"preflight (n: num): num\\" instead
+  |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = hint: expected phase to be inflight, but got preflight instead
 
@@ -3355,7 +3354,7 @@ error: Expected type to be \\"preflight (num): num\\", but got \\"inflight (n: n
   --> ../../../examples/tests/invalid/phase_mismatch.test.w:5:10
   |
 5 | my_func2(inflight (n: num): num => { return n * 2; });
-  |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Expected type to be \\"preflight (num): num\\", but got \\"inflight (n: num): num\\" instead
+  |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = hint: expected phase to be preflight, but got inflight instead
 
@@ -3364,7 +3363,7 @@ error: Expected type to be \\"inflight (n: num): num\\", but got \\"preflight (n
    --> ../../../examples/tests/invalid/phase_mismatch.test.w:12:10
    |
 12 | my_func3((n: num): num => { return n * 2; });
-   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Expected type to be \\"inflight (n: num): num\\", but got \\"preflight (n: num): num\\" instead
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = hint: expected phase to be inflight, but got preflight instead
 
@@ -3373,7 +3372,7 @@ error: Expected type to be \\"preflight (num): num\\", but got \\"inflight (s: s
    --> ../../../examples/tests/invalid/phase_mismatch.test.w:15:10
    |
 15 | my_func4(inflight (s: str): str => { return s.uppercase(); });
-   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Expected type to be \\"preflight (num): num\\", but got \\"inflight (s: str): str\\" instead
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = hint: expected phase to be preflight, but got inflight instead
 
@@ -3382,7 +3381,7 @@ error: Expected type to be \\"preflight (inflight (str): str): void\\", but got 
    --> ../../../examples/tests/invalid/phase_mismatch.test.w:25:18
    |
 25 | accepts_callback(callback); // error
-   |                  ^^^^^^^^ Expected type to be \\"preflight (inflight (str): str): void\\", but got \\"preflight (inner_fn: preflight (preflight (str): str): void): void\\" instead
+   |                  ^^^^^^^^
 
 
 
@@ -3397,7 +3396,7 @@ exports[`preflight_from_inflight.test.w 1`] = `
    --> ../../../examples/tests/invalid/preflight_from_inflight.test.w:15:5
    |
 15 |     this.r.myPreflight();
-   |     ^^^^^^^^^^^^^^^^^^^^ Cannot call into preflight phase while inflight
+   |     ^^^^^^^^^^^^^^^^^^^^
 
 
 
@@ -3412,21 +3411,21 @@ exports[`primitives.test.w 1`] = `
   --> ../../../examples/tests/invalid/primitives.test.w:6:16
   |
 6 | let join = arr.blabla(\\",\\");
-  |                ^^^^^^ Member \\"blabla\\" doesn't exist in \\"Array\\"
+  |                ^^^^^^
 
 
 error: Member \\"push\\" doesn't exist in \\"Array\\"
   --> ../../../examples/tests/invalid/primitives.test.w:8:5
   |
 8 | arr.push(4);
-  |     ^^^^ Member \\"push\\" doesn't exist in \\"Array\\"
+  |     ^^^^
 
 
 error: Expected type to be \\"str\\", but got \\"num\\" instead
    --> ../../../examples/tests/invalid/primitives.test.w:10:14
    |
 10 | let n: str = arr.at(0);
-   |              ^^^^^^^^^ Expected type to be \\"str\\", but got \\"num\\" instead
+   |              ^^^^^^^^^
 
 
 
@@ -3441,7 +3440,7 @@ exports[`private_constructor.test.w 1`] = `
   --> ../../../examples/tests/invalid/private_constructor.test.w:3:1
   |
 3 | new jsii_fixture.JsiiClassWithPrivateConstructor();
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Constructor for class \\"JsiiClassWithPrivateConstructor\\" is private
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 
 
@@ -3456,28 +3455,28 @@ exports[`protected_access_modifiers.test.w 1`] = `
   --> ../../../examples/tests/invalid/protected_access_modifiers.test.w:1:1
   |
 1 | protected struct MyStruct {}
-  | ^^^^^^^^^ Structs must be public (\\"pub\\") or private
+  | ^^^^^^^^^
 
 
 error: Classes must be public (\\"pub\\") or private
   --> ../../../examples/tests/invalid/protected_access_modifiers.test.w:4:1
   |
 4 | protected class MyClass {}
-  | ^^^^^^^^^ Classes must be public (\\"pub\\") or private
+  | ^^^^^^^^^
 
 
 error: Interfaces must be public (\\"pub\\") or private
   --> ../../../examples/tests/invalid/protected_access_modifiers.test.w:7:1
   |
 7 | protected interface MyInterface {}
-  | ^^^^^^^^^ Interfaces must be public (\\"pub\\") or private
+  | ^^^^^^^^^
 
 
 error: Enums must be public (\\"pub\\") or private
    --> ../../../examples/tests/invalid/protected_access_modifiers.test.w:10:1
    |
 10 | protected enum MyEnum {}
-   | ^^^^^^^^^ Enums must be public (\\"pub\\") or private
+   | ^^^^^^^^^
 
 
 
@@ -3494,7 +3493,7 @@ exports[`reassign_to_nonreassignable.test.w 1`] = `
 2 | let x = 5;
   |     - defined here (try adding \\"var\\" in front)
 3 | x = x + 1;
-  | ^ Variable is not reassignable
+  | ^
 
 
 error: Variable is not reassignable
@@ -3504,7 +3503,7 @@ error: Variable is not reassignable
    |   - defined here (try adding \\"var\\" in front)
    .
 28 |     this.f = this.f + 1;
-   |     ^^^^^^ Variable is not reassignable
+   |     ^^^^^^
 
 
 error: Variable is not reassignable
@@ -3514,7 +3513,7 @@ error: Variable is not reassignable
    |                ----- defined here (try adding \\"var\\" in front)
    .
 30 |     this.innerR.inner = 2;
-   |     ^^^^^^^^^^^^^^^^^ Variable is not reassignable
+   |     ^^^^^^^^^^^^^^^^^
 
 
 error: Variable is not reassignable
@@ -3524,7 +3523,7 @@ error: Variable is not reassignable
    |            --------- defined here (try adding \\"var\\" in front)
    .
 35 |     this.inflightF = this.inflightF + 1;
-   |     ^^^^^^^^^^^^^^ Variable is not reassignable
+   |     ^^^^^^^^^^^^^^
 
 
 error: Variable is not reassignable
@@ -3533,7 +3532,7 @@ error: Variable is not reassignable
 41 | let f = (arg: num):num => {
    |          --- defined here (try adding \\"var\\" in front)
 42 |   arg = 0;
-   |   ^^^ Variable is not reassignable
+   |   ^^^
 
 
 
@@ -3551,7 +3550,6 @@ exports[`redundant_modifiers.w 1`] = `
   |   ^^^^^^^
   |   |   |
   |   |   possible redundant modifier
-  |   Multiple or ambiguous modifiers found
   |   possible redundant modifier
 
 
@@ -3562,7 +3560,6 @@ error: Multiple or ambiguous modifiers found
   |   ^^^^^^^^^^^^^
   |   |   |
   |   |   possible redundant modifier
-  |   Multiple or ambiguous modifiers found
   |   possible redundant modifier
 
 
@@ -3573,7 +3570,6 @@ error: Multiple or ambiguous modifiers found
    |   ^^^^^^^^^^^^^^^^^
    |   |          |
    |   |          possible redundant modifier
-   |   Multiple or ambiguous modifiers found
    |   possible redundant modifier
 
 
@@ -3582,10 +3578,9 @@ error: Multiple or ambiguous modifiers found
    |
 15 |   pub inflight static inflight m4() {}
    |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |   |   |               |
-   |   |   |               possible redundant modifier
-   |   |   possible redundant modifier
-   |   Multiple or ambiguous modifiers found
+   |       |               |
+   |       |               possible redundant modifier
+   |       possible redundant modifier
 
 
 error: Multiple or ambiguous modifiers found
@@ -3593,10 +3588,9 @@ error: Multiple or ambiguous modifiers found
    |
 19 |   static extern \\"x.js\\" pub extern \\"y.js\\" m5();
    |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |   |      |                 |
-   |   |      |                 possible redundant modifier
-   |   |      possible redundant modifier
-   |   Multiple or ambiguous modifiers found
+   |          |                 |
+   |          |                 possible redundant modifier
+   |          possible redundant modifier
 
 
 error: Multiple or ambiguous modifiers found
@@ -3606,7 +3600,6 @@ error: Multiple or ambiguous modifiers found
    |   ^^^^^^^^^^^^^^^^^^^
    |   |         |
    |   |         possible redundant modifier
-   |   Multiple or ambiguous modifiers found
    |   possible redundant modifier
 
 
@@ -3615,10 +3608,9 @@ error: Multiple or ambiguous modifiers found
    |
 27 |   protected inflight inflight f2: str;
    |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |   |         |        |
-   |   |         |        possible redundant modifier
-   |   |         possible redundant modifier
-   |   Multiple or ambiguous modifiers found
+   |             |        |
+   |             |        possible redundant modifier
+   |             possible redundant modifier
 
 
 error: Multiple or ambiguous modifiers found
@@ -3628,7 +3620,6 @@ error: Multiple or ambiguous modifiers found
    |   ^^^^^^^^^^^^^^^^^
    |   |          |
    |   |          possible redundant modifier
-   |   Multiple or ambiguous modifiers found
    |   possible redundant modifier
 
 
@@ -3639,7 +3630,6 @@ error: Multiple or ambiguous modifiers found
    |   ^^^^^^^^^^^
    |   |       |
    |   |       possible redundant modifier
-   |   Multiple or ambiguous modifiers found
    |   possible redundant modifier
 
 
@@ -3650,7 +3640,6 @@ error: Multiple or ambiguous modifiers found
    | ^^^^^^^^^^^^^^^^^
    | |        |
    | |        possible redundant modifier
-   | Multiple or ambiguous modifiers found
    | possible redundant modifier
 
 
@@ -3661,7 +3650,6 @@ error: Multiple or ambiguous modifiers found
    | ^^^^^^^^^^^^^^^^
    | |            |
    | |            possible redundant modifier
-   | Multiple or ambiguous modifiers found
    | possible redundant modifier
 
 
@@ -3677,7 +3665,7 @@ exports[`resource_access_field_as_method.test.w 1`] = `
   --> ../../../examples/tests/invalid/resource_access_field_as_method.test.w:9:1
   |
 9 | x.name();
-  | ^^^^^^ Expected a function or method, found \\"str\\"
+  | ^^^^^^
 
 
 
@@ -3692,14 +3680,14 @@ exports[`resource_captures.test.w 1`] = `
    --> ../../../examples/tests/invalid/resource_captures.test.w:14:5
    |
 14 |     b.put(\\"hello\\", \\"world\\");
-   |     ^ Expression of type \\"Bucket\\" references an unknown preflight object, can't qualify its capabilities. Use \`lift()\` to explicitly qualify the preflight object to disable this error.
+   |     ^
 
 
 error: Expression of type \\"Bucket\\" references an unknown preflight object, can't qualify its capabilities. Use \`lift()\` to explicitly qualify the preflight object to disable this error.
    --> ../../../examples/tests/invalid/resource_captures.test.w:17:5
    |
 17 |     this.collectionOfResources.at(0).put(\\"hello\\", \\"world\\");
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Expression of type \\"Bucket\\" references an unknown preflight object, can't qualify its capabilities. Use \`lift()\` to explicitly qualify the preflight object to disable this error.
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 
 
@@ -3714,14 +3702,14 @@ exports[`resource_inflight.test.w 1`] = `
   --> ../../../examples/tests/invalid/resource_inflight.test.w:4:3
   |
 4 |   new cloud.Bucket(); // Should fail because we can't create resources inflight
-  |   ^^^^^^^^^^^^^^^^^^ Cannot create preflight class \\"Bucket\\" in inflight phase
+  |   ^^^^^^^^^^^^^^^^^^
 
 
 error: Cannot qualify access to a lifted type \\"Bucket\\" (see https://github.com/winglang/wing/issues/76 for more details)
   --> ../../../examples/tests/invalid/resource_inflight.test.w:4:7
   |
 4 |   new cloud.Bucket(); // Should fail because we can't create resources inflight
-  |       ^^^^^^^^^^^^ Cannot qualify access to a lifted type \\"Bucket\\" (see https://github.com/winglang/wing/issues/76 for more details)
+  |       ^^^^^^^^^^^^
 
 
 
@@ -3736,28 +3724,28 @@ exports[`resource_init.test.w 1`] = `
   --> ../../../examples/tests/invalid/resource_init.test.w:3:3
   |
 3 |   new() {}
-  |   ^^^^^^^^ Multiple constructors defined in class R
+  |   ^^^^^^^^
 
 
 error: Multiple inflight constructors defined in class R
   --> ../../../examples/tests/invalid/resource_init.test.w:6:3
   |
 6 |   inflight new() {}
-  |   ^^^^^^^^^^^^^^^^^ Multiple inflight constructors defined in class R
+  |   ^^^^^^^^^^^^^^^^^
 
 
 error: Multiple inflight constructors defined in class R
   --> ../../../examples/tests/invalid/resource_init.test.w:9:3
   |
 9 |   inflight new(x: num) {}
-  |   ^^^^^^^^^^^^^^^^^^^^^^^ Multiple inflight constructors defined in class R
+  |   ^^^^^^^^^^^^^^^^^^^^^^^
 
 
 error: Inflight constructors cannot have parameters
   --> ../../../examples/tests/invalid/resource_init.test.w:9:15
   |
 9 |   inflight new(x: num) {}
-  |               ^^^^^^^^ Inflight constructors cannot have parameters
+  |               ^^^^^^^^
 
 
 
@@ -3772,35 +3760,35 @@ exports[`return_types.test.w 1`] = `
   --> ../../../examples/tests/invalid/return_types.test.w:1:5
   |
 1 |     return 9;
-  |     ^^^^^^^^^ Return statement outside of function cannot return a value
+  |     ^^^^^^^^^
 
 
 error: Return statement outside of function cannot return a value
   --> ../../../examples/tests/invalid/return_types.test.w:4:5
   |
 4 |     return 9;
-  |     ^^^^^^^^^ Return statement outside of function cannot return a value
+  |     ^^^^^^^^^
 
 
 error: Unexpected return value from void function. Return type annotations are required for methods.
   --> ../../../examples/tests/invalid/return_types.test.w:9:3
   |
 9 |   return 9;
-  |   ^^^^^^^^^ Unexpected return value from void function. Return type annotations are required for methods.
+  |   ^^^^^^^^^
 
 
 error: Unexpected return value from void function. Return type annotations are required for methods.
    --> ../../../examples/tests/invalid/return_types.test.w:12:5
    |
 12 |     return 9;
-   |     ^^^^^^^^^ Unexpected return value from void function. Return type annotations are required for methods.
+   |     ^^^^^^^^^
 
 
 error: Unexpected return value from void function. Return type annotations are required for methods.
    --> ../../../examples/tests/invalid/return_types.test.w:19:5
    |
 19 |     return 9;
-   |     ^^^^^^^^^ Unexpected return value from void function. Return type annotations are required for methods.
+   |     ^^^^^^^^^
 
 
 
@@ -3815,28 +3803,28 @@ exports[`scope_and_id.test.w 1`] = `
   --> ../../../examples/tests/invalid/scope_and_id.test.w:6:25
   |
 6 | new PreflightClass() as x;
-  |                         ^ Expected type to be \\"str\\", but got \\"num\\" instead
+  |                         ^
 
 
 error: Expected scope to be a preflight object, instead found \\"num\\"
   --> ../../../examples/tests/invalid/scope_and_id.test.w:8:1
   |
 8 | new PreflightClass() in x;
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^ Expected scope to be a preflight object, instead found \\"num\\"
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 
 error: Inflight classes cannot have an id
    --> ../../../examples/tests/invalid/scope_and_id.test.w:15:26
    |
 15 |   new InflightClass() as \\"hi\\";
-   |                          ^^^^ Inflight classes cannot have an id
+   |                          ^^^^
 
 
 error: Inflight classes cannot have a scope
    --> ../../../examples/tests/invalid/scope_and_id.test.w:17:26
    |
 17 |   new InflightClass() in pc;
-   |                          ^^ Inflight classes cannot have a scope
+   |                          ^^
 
 
 
@@ -3851,28 +3839,28 @@ exports[`simulator_permissions.test.w 1`] = `
    --> ../../../examples/tests/invalid/simulator_permissions.test.w:10:8
    |
 10 |   lift(buckets.at(1), [\\"put\\"]);
-   |        ^^^^^^^^^^^^^ Expected a preflight object as first argument to \`lift\` builtin, found inflight expression instead
+   |        ^^^^^^^^^^^^^
 
 
 error: Expression of type \\"Bucket\\" references an unknown preflight object, can't qualify its capabilities. Use \`lift()\` to explicitly qualify the preflight object to disable this error.
    --> ../../../examples/tests/invalid/simulator_permissions.test.w:15:3
    |
 15 |   buckets.at(i).put(\\"key\\", \\"value\\");
-   |   ^^^^^^^^^^^^^ Expression of type \\"Bucket\\" references an unknown preflight object, can't qualify its capabilities. Use \`lift()\` to explicitly qualify the preflight object to disable this error.
+   |   ^^^^^^^^^^^^^
 
 
 error: Expected a preflight object as first argument to \`lift\` builtin, found inflight expression instead
    --> ../../../examples/tests/invalid/simulator_permissions.test.w:20:8
    |
 20 |   lift(buckets.at(0), [\\"list\\"]);
-   |        ^^^^^^^^^^^^^ Expected a preflight object as first argument to \`lift\` builtin, found inflight expression instead
+   |        ^^^^^^^^^^^^^
 
 
 error: Expression of type \\"Bucket\\" references an unknown preflight object, can't qualify its capabilities. Use \`lift()\` to explicitly qualify the preflight object to disable this error.
    --> ../../../examples/tests/invalid/simulator_permissions.test.w:25:3
    |
 25 |   buckets.at(i).put(\\"key\\", \\"value\\");
-   |   ^^^^^^^^^^^^^ Expression of type \\"Bucket\\" references an unknown preflight object, can't qualify its capabilities. Use \`lift()\` to explicitly qualify the preflight object to disable this error.
+   |   ^^^^^^^^^^^^^
 
 
 
@@ -3887,28 +3875,28 @@ exports[`sorted_errors_no_span.test.w 1`] = `
   --> ../../../examples/tests/invalid/sorted_errors_no_span.test.w:1:14
   |
 1 | let a: num = \\"s\\";
-  |              ^^^ Expected type to be \\"num\\", but got \\"str\\" instead
+  |              ^^^
 
 
 error: Expected \\"b\\" to be a type but it's a variable
   --> ../../../examples/tests/invalid/sorted_errors_no_span.test.w:3:26
   |
 3 | inflight class c extends b {}
-  |                          ^ Expected \\"b\\" to be a type but it's a variable
+  |                          ^
 
 
 error: Expected type to be \\"num\\", but got \\"str\\" instead
   --> ../../../examples/tests/invalid/sorted_errors_no_span.test.w:4:14
   |
 4 | let d: num = \\"s\\";
-  |              ^^^ Expected type to be \\"num\\", but got \\"str\\" instead
+  |              ^^^
 
 
 error: Expected \\"b\\" to be a type but it's a variable
   --> ../../../examples/tests/invalid/sorted_errors_no_span.test.w:5:26
   |
 5 | inflight class e extends b {}
-  |                          ^ Expected \\"b\\" to be a type but it's a variable
+  |                          ^
 
 
 
@@ -3923,28 +3911,28 @@ exports[`statement_invalid_scope.test.w 1`] = `
   --> ../../../examples/tests/invalid/statement_invalid_scope.test.w:3:5
   |
 3 |     break;
-  |     ^^^^^^ Expected break statement to be inside of a loop (while/for)
+  |     ^^^^^^
 
 
 error: Expected break statement to be inside of a loop (while/for)
   --> ../../../examples/tests/invalid/statement_invalid_scope.test.w:7:5
   |
 7 |     break;
-  |     ^^^^^^ Expected break statement to be inside of a loop (while/for)
+  |     ^^^^^^
 
 
 error: Expected continue statement to be inside of a loop (while/for)
    --> ../../../examples/tests/invalid/statement_invalid_scope.test.w:11:5
    |
 11 |     continue;
-   |     ^^^^^^^^^ Expected continue statement to be inside of a loop (while/for)
+   |     ^^^^^^^^^
 
 
 error: Expected continue statement to be inside of a loop (while/for)
    --> ../../../examples/tests/invalid/statement_invalid_scope.test.w:15:5
    |
 15 |     continue;
-   |     ^^^^^^^^^ Expected continue statement to be inside of a loop (while/for)
+   |     ^^^^^^^^^
 
 
 
@@ -3959,21 +3947,21 @@ exports[`statements_if.test.w 1`] = `
   --> ../../../examples/tests/invalid/statements_if.test.w:2:1
   |
 2 | --n;
-  | ^^^ Unexpected unary operator \\"--\\"
+  | ^^^
 
 
 error: Expected type to be \\"bool\\", but got \\"num\\" instead
   --> ../../../examples/tests/invalid/statements_if.test.w:5:5
   |
 5 | if !n {}
-  |     ^ Expected type to be \\"bool\\", but got \\"num\\" instead
+  |     ^
 
 
 error: Expected type to be \\"bool\\", but got \\"num\\" instead
   --> ../../../examples/tests/invalid/statements_if.test.w:8:5
   |
 8 | if !n || true {}
-  |     ^ Expected type to be \\"bool\\", but got \\"num\\" instead
+  |     ^
 
 
 
@@ -3988,7 +3976,7 @@ exports[`std_containers.test.w 1`] = `
   --> ../../../examples/tests/invalid/std_containers.test.w:3:18
   |
 3 | let c = a.concat(b); 
-  |                  ^ Expected type to be \\"Array<num>\\", but got \\"Array<str>\\" instead
+  |                  ^
 
 
 
@@ -4003,7 +3991,7 @@ exports[`stringify.test.w 1`] = `
   --> ../../../examples/tests/invalid/stringify.test.w:3:13
   |
 3 | log(\\"hello {b}\\");
-  |             ^ Expected type to be stringable, but got \\"B\\" instead
+  |             ^
   |
   = hint: str, num, bool, json, and enums are stringable
 
@@ -4012,7 +4000,7 @@ error: Expected type to be stringable, but got \\"str?\\" instead
   --> ../../../examples/tests/invalid/stringify.test.w:7:7
   |
 7 | log(\\"{x}\\");
-  |       ^ Expected type to be stringable, but got \\"str?\\" instead
+  |       ^
   |
   = hint: str? is an optional, try unwrapping it with 'x ?? \\"nil\\"' or 'x!'
 
@@ -4029,28 +4017,28 @@ exports[`struct_expansion.test.w 1`] = `
    --> ../../../examples/tests/invalid/struct_expansion.test.w:11:33
    |
 11 |   bucket1.put(file: \\"file.txt\\", \\"data\\");
-   |                                 ^^^^^^ Positional arguments must come before named arguments
+   |                                 ^^^^^^
 
 
 error: \\"bublic\\" is not a field of \\"BucketProps\\"
   --> ../../../examples/tests/invalid/struct_expansion.test.w:3:15
   |
 3 | let bucket1 = new cloud.Bucket(bublic: false, public: true);
-  |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ \\"bublic\\" is not a field of \\"BucketProps\\"
+  |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 
 error: Expected either a positional argument or named arguments for the last parameter, but got both
   --> ../../../examples/tests/invalid/struct_expansion.test.w:7:15
   |
 7 | let bucket2 = new cloud.Bucket(2, public: true);
-  |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Expected either a positional argument or named arguments for the last parameter, but got both
+  |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 
 error: Expected type to be \\"BucketProps?\\", but got \\"num\\" instead
   --> ../../../examples/tests/invalid/struct_expansion.test.w:7:32
   |
 7 | let bucket2 = new cloud.Bucket(2, public: true);
-  |                                ^ Expected type to be \\"BucketProps?\\", but got \\"num\\" instead
+  |                                ^
 
 
 error: \\"notAField\\" is not a field of \\"ApiResponse\\"
@@ -4062,28 +4050,28 @@ error: \\"notAField\\" is not a field of \\"ApiResponse\\"
 22 | |   notAField: 500,
 23 | | // ^^^^^^^^^^^ \\"notAField\\" is not a field of \\"ApiResponse\\"
 24 | | };
-   | \\\\-^ \\"notAField\\" is not a field of \\"ApiResponse\\"
+   | \\\\-^
 
 
 error: Expected type to be \\"inflight (event: str?): str?\\", but got \\"inflight (event: str): unknown\\" instead
    --> ../../../examples/tests/invalid/struct_expansion.test.w:27:3
    |
 27 |   handler, 
-   |   ^^^^^^^ Expected type to be \\"inflight (event: str?): str?\\", but got \\"inflight (event: str): unknown\\" instead
+   |   ^^^^^^^
 
 
 error: \\"file\\" is not a field of \\"BucketPutOptions\\"
    --> ../../../examples/tests/invalid/struct_expansion.test.w:11:3
    |
 11 |   bucket1.put(file: \\"file.txt\\", \\"data\\");
-   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ \\"file\\" is not a field of \\"BucketPutOptions\\"
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 
 error: Missing required field \\"contentType\\" from \\"BucketPutOptions\\"
    --> ../../../examples/tests/invalid/struct_expansion.test.w:11:3
    |
 11 |   bucket1.put(file: \\"file.txt\\", \\"data\\");
-   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Missing required field \\"contentType\\" from \\"BucketPutOptions\\"
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 
 
@@ -4117,21 +4105,21 @@ exports[`struct_json_conversion.test.w 1`] = `
   --> ../../../examples/tests/invalid/struct_json_conversion.test.w:8:3
   |
 8 | A.fromJson({});
-  |   ^^^^^^^^ Struct \\"A\\" contains field \\"b\\" which cannot be represented in Json
+  |   ^^^^^^^^
 
 
 error: Struct \\"B\\" contains field \\"a\\" which cannot be represented in Json
    --> ../../../examples/tests/invalid/struct_json_conversion.test.w:15:3
    |
 15 | B.fromJson({});
-   |   ^^^^^^^^ Struct \\"B\\" contains field \\"a\\" which cannot be represented in Json
+   |   ^^^^^^^^
 
 
 error: Struct \\"C\\" contains field \\"b\\" which cannot be represented in Json
    --> ../../../examples/tests/invalid/struct_json_conversion.test.w:22:3
    |
 22 | C.fromJson({});
-   |   ^^^^^^^^ Struct \\"C\\" contains field \\"b\\" which cannot be represented in Json
+   |   ^^^^^^^^
 
 
 
@@ -4146,63 +4134,63 @@ exports[`structs.test.w 1`] = `
    --> ../../../examples/tests/invalid/structs.test.w:13:3
    |
 13 |   x: num;
-   |   ^ Struct \\"C\\" extends \\"B\\" which introduces a conflicting member \\"x\\" (str != num)
+   |   ^
 
 
 error: \\"x\\" is not initialized
    --> ../../../examples/tests/invalid/structs.test.w:16:18
    |
 16 | let someStruct = B { y: 5 };
-   |                  ^^^^^^^^^^ \\"x\\" is not initialized
+   |                  ^^^^^^^^^^
 
 
 error: Struct fields must have immutable types
    --> ../../../examples/tests/invalid/structs.test.w:20:3
    |
 20 |   f: MutArray<str>;
-   |   ^ Struct fields must have immutable types
+   |   ^
 
 
 error: Struct fields must have immutable types
    --> ../../../examples/tests/invalid/structs.test.w:25:3
    |
 25 |   f: Map<Array<MutArray<str>>>;
-   |   ^ Struct fields must have immutable types
+   |   ^
 
 
 error: Member \\"badField\\" doesn't exist in \\"A\\"
    --> ../../../examples/tests/invalid/structs.test.w:32:7
    |
 32 | log(a.badField);
-   |       ^^^^^^^^ Member \\"badField\\" doesn't exist in \\"A\\"
+   |       ^^^^^^^^
 
 
 error: Struct \\"Showtime\\" extends \\"Dazzle\\" which introduces a conflicting member \\"a\\" (num != str)
    --> ../../../examples/tests/invalid/structs.test.w:37:3
    |
 37 |   a: str;
-   |   ^ Struct \\"Showtime\\" extends \\"Dazzle\\" which introduces a conflicting member \\"a\\" (num != str)
+   |   ^
 
 
 error: Cannot instantiate type \\"BucketProps\\" because it is a struct and not a class. Use struct instantiation instead.
    --> ../../../examples/tests/invalid/structs.test.w:47:13
    |
 47 | let x = new cloud.BucketProps(1);
-   |             ^^^^^^^^^^^^^^^^^ Cannot instantiate type \\"BucketProps\\" because it is a struct and not a class. Use struct instantiation instead.
+   |             ^^^^^^^^^^^^^^^^^
 
 
 error: struct \\"PreflightStruct\\" must be declared at the top-level of a file
    --> ../../../examples/tests/invalid/structs.test.w:51:10
    |
 51 |   struct PreflightStruct {
-   |          ^^^^^^^^^^^^^^^ struct \\"PreflightStruct\\" must be declared at the top-level of a file
+   |          ^^^^^^^^^^^^^^^
 
 
 error: struct \\"InflightStruct\\" must be declared at the top-level of a file
    --> ../../../examples/tests/invalid/structs.test.w:58:10
    |
 58 |   struct InflightStruct {
-   |          ^^^^^^^^^^^^^^ struct \\"InflightStruct\\" must be declared at the top-level of a file
+   |          ^^^^^^^^^^^^^^
 
 
 
@@ -4217,56 +4205,56 @@ exports[`super_call.test.w 1`] = `
    --> ../../../examples/tests/invalid/super_call.test.w:32:7
    |
 32 | super.do();
-   |       ^^ Cannot call super method because class Construct has no parent
+   |       ^^
 
 
 error: Cannot override private method \\"m1\\" of \\"BaseClass\\"
    --> ../../../examples/tests/invalid/super_call.test.w:47:12
    |
 47 |   inflight m1(): str {
-   |            ^^ Cannot override private method \\"m1\\" of \\"BaseClass\\"
+   |            ^^
 
 
 error: Cannot call super method because class A has no parent
   --> ../../../examples/tests/invalid/super_call.test.w:4:11
   |
 4 |     super.method();
-  |           ^^^^^^ Cannot call super method because class A has no parent
+  |           ^^^^^^
 
 
 error: Cannot call super method because class InflightA has no parent
    --> ../../../examples/tests/invalid/super_call.test.w:12:11
    |
 12 |     super.method();
-   |           ^^^^^^ Cannot call super method because class InflightA has no parent
+   |           ^^^^^^
 
 
 error: super class \\"A\\" does not have a method named \\"child_method\\"
    --> ../../../examples/tests/invalid/super_call.test.w:20:11
    |
 20 |     super.child_method();
-   |           ^^^^^^^^^^^^ super class \\"A\\" does not have a method named \\"child_method\\"
+   |           ^^^^^^^^^^^^
 
 
 error: Cannot call super method because class Construct has no parent
    --> ../../../examples/tests/invalid/super_call.test.w:26:11
    |
 26 |     super.method();
-   |           ^^^^^^ Cannot call super method because class Construct has no parent
+   |           ^^^^^^
 
 
 error: Expected type to be \\"inflight (event: str?): str?\\", but got \\"inflight (s: str): str\\" instead
    --> ../../../examples/tests/invalid/super_call.test.w:55:31
    |
 55 |     return new cloud.Function(inflight_closure);
-   |                               ^^^^^^^^^^^^^^^^ Expected type to be \\"inflight (event: str?): str?\\", but got \\"inflight (s: str): str\\" instead
+   |                               ^^^^^^^^^^^^^^^^
 
 
 error: \`super\` calls inside inflight closures not supported yet, see: https://github.com/winglang/wing/issues/3474
    --> ../../../examples/tests/invalid/super_call.test.w:52:48
    |
 52 |       return \\"this: {this.m1()}, super: {super.m1()}\\";
-   |                                                ^^ \`super\` calls inside inflight closures not supported yet, see: https://github.com/winglang/wing/issues/3474
+   |                                                ^^
 
 
 
@@ -4281,7 +4269,7 @@ exports[`this.w 1`] = `
   --> ../../../examples/tests/invalid/this.w:3:9
   |
 3 |     log(this.node.id);
-  |         ^^^^ Unknown symbol \\"this\\"
+  |         ^^^^
 
 
 
@@ -4296,7 +4284,7 @@ exports[`throw_non_string.test.w 1`] = `
   --> ../../../examples/tests/invalid/throw_non_string.test.w:1:7
   |
 1 | throw 42;
-  |       ^^ Expected type to be \\"str\\", but got \\"num\\" instead
+  |       ^^
 
 
 
@@ -4313,7 +4301,7 @@ exports[`try_no_catch_or_finally.test.w 1`] = `
 1 | / try {
 2 | |   log(\\"Hello World\\");
 3 | | }
-  | \\\\-^ Missing \`catch\` or \`finally\` blocks for this try statement
+  | \\\\-^
 
 
 
@@ -4328,28 +4316,28 @@ exports[`types_strings_arithmetic.test.w 1`] = `
   --> ../../../examples/tests/invalid/types_strings_arithmetic.test.w:1:10
   |
 1 | let e1 = 2 + \\"2\\";
-  |          ^^^^^^^ Binary operator '+' cannot be applied to operands of type 'num' and 'str'; only (num, num) and (str, str) are supported
+  |          ^^^^^^^
 
 
 error: Expected type to be \\"num\\", but got \\"str\\" instead
   --> ../../../examples/tests/invalid/types_strings_arithmetic.test.w:4:10
   |
 4 | let e2 = 2 == \\"2\\";
-  |          ^^^^^^^^ Expected type to be \\"num\\", but got \\"str\\" instead
+  |          ^^^^^^^^
 
 
 error: Expected type to be \\"num\\", but got \\"str\\" instead
    --> ../../../examples/tests/invalid/types_strings_arithmetic.test.w:10:10
    |
 10 | let e3 = \\"{strExample}!\\" * numExample;
-   |          ^^^^^^^^^^^^^^^ Expected type to be \\"num\\", but got \\"str\\" instead
+   |          ^^^^^^^^^^^^^^^
 
 
 error: Expected type to be \\"num\\", but got \\"str\\" instead
    --> ../../../examples/tests/invalid/types_strings_arithmetic.test.w:15:6
    |
 15 | a += b;
-   |      ^ Expected type to be \\"num\\", but got \\"str\\" instead
+   |      ^
 
 
 
@@ -4364,14 +4352,14 @@ exports[`un_mut_lifted_objects.test.w 1`] = `
    --> ../../../examples/tests/invalid/un_mut_lifted_objects.test.w:22:6
    |
 22 |   ar.push(2); // Error: push doesn't exist in Array
-   |      ^^^^ Member \\"push\\" doesn't exist in \\"Array\\"
+   |      ^^^^
 
 
 error: Cannot update elements of an immutable Array
    --> ../../../examples/tests/invalid/un_mut_lifted_objects.test.w:23:3
    |
 23 |   ar[0] = 1; // Error: Cannot update elements of an immutable Array
-   |   ^^^^^ Cannot update elements of an immutable Array
+   |   ^^^^^
    |
    = hint: Consider using MutArray instead
 
@@ -4380,42 +4368,42 @@ error: Member \\"set\\" doesn't exist in \\"Json\\"
    --> ../../../examples/tests/invalid/un_mut_lifted_objects.test.w:24:5
    |
 24 |   j.set(\\"a\\", 3); // Error: set doesn't exist in Json
-   |     ^^^ Member \\"set\\" doesn't exist in \\"Json\\"
+   |     ^^^
 
 
 error: Member \\"add\\" doesn't exist in \\"Set\\"
    --> ../../../examples/tests/invalid/un_mut_lifted_objects.test.w:25:6
    |
 25 |   st.add(4); // Error: add doesn't exist in Set
-   |      ^^^ Member \\"add\\" doesn't exist in \\"Set\\"
+   |      ^^^
 
 
 error: Member \\"set\\" doesn't exist in \\"Map\\"
    --> ../../../examples/tests/invalid/un_mut_lifted_objects.test.w:26:6
    |
 26 |   mp.set(\\"a\\", 3); // Error: set doesn't exist in Map
-   |      ^^^ Member \\"set\\" doesn't exist in \\"Map\\"
+   |      ^^^
 
 
 error: Member \\"push\\" doesn't exist in \\"Array\\"
    --> ../../../examples/tests/invalid/un_mut_lifted_objects.test.w:27:11
    |
 27 |   opt_ar?.push(2); // Error: push doesn't exist in Array
-   |           ^^^^ Member \\"push\\" doesn't exist in \\"Array\\"
+   |           ^^^^
 
 
 error: Member \\"push\\" doesn't exist in \\"Array\\"
    --> ../../../examples/tests/invalid/un_mut_lifted_objects.test.w:28:16
    |
 28 |   recursive_ar.push(MutArray<num>[2]); // Error: push doesn't exist in Array
-   |                ^^^^ Member \\"push\\" doesn't exist in \\"Array\\"
+   |                ^^^^
 
 
 error: Member \\"push\\" doesn't exist in \\"Array\\"
    --> ../../../examples/tests/invalid/un_mut_lifted_objects.test.w:29:22
    |
 29 |   recursive_ar.at(0).push(3); // Error: push doesn't exist in Array
-   |                      ^^^^ Member \\"push\\" doesn't exist in \\"Array\\"
+   |                      ^^^^
 
 
 
@@ -4430,35 +4418,35 @@ exports[`unimplemented_grammar.test.w 1`] = `
   --> ../../../examples/tests/invalid/unimplemented_grammar.test.w:1:8
   |
 1 | let b: any = 0;
-  |        ^^^ builtin \\"any\\" is not supported yet - see https://github.com/winglang/wing/issues/434
+  |        ^^^
 
 
 error: builtin container type \\"Promise\\" is not supported yet - see https://github.com/winglang/wing/issues/529
   --> ../../../examples/tests/invalid/unimplemented_grammar.test.w:2:19
   |
 2 | let somePromise = Promise<str>{};
-  |                   ^^^^^^^^^^^^ builtin container type \\"Promise\\" is not supported yet - see https://github.com/winglang/wing/issues/529
+  |                   ^^^^^^^^^^^^
 
 
 error: expression \\"defer_expression\\" is not supported yet - see https://github.com/winglang/wing/issues/116
   --> ../../../examples/tests/invalid/unimplemented_grammar.test.w:3:9
   |
 3 | let c = defer somePromise();
-  |         ^^^^^^^^^^^^^^^^^^^ expression \\"defer_expression\\" is not supported yet - see https://github.com/winglang/wing/issues/116
+  |         ^^^^^^^^^^^^^^^^^^^
 
 
 error: expression \\"await_expression\\" is not supported yet - see https://github.com/winglang/wing/issues/116
   --> ../../../examples/tests/invalid/unimplemented_grammar.test.w:4:9
   |
 4 | let d = await c;
-  |         ^^^^^^^ expression \\"await_expression\\" is not supported yet - see https://github.com/winglang/wing/issues/116
+  |         ^^^^^^^
 
 
 error: Unable to infer type
   --> ../../../examples/tests/invalid/unimplemented_grammar.test.w:2:5
   |
 2 | let somePromise = Promise<str>{};
-  |     ^^^^^^^^^^^ Unable to infer type
+  |     ^^^^^^^^^^^
 
 
 
@@ -4473,7 +4461,7 @@ exports[`unknown_field.test.w 1`] = `
   --> ../../../examples/tests/invalid/unknown_field.test.w:1:12
   |
 1 | std.String.a.b.c.fromJson();
-  |            ^ Member \\"a\\" doesn't exist in \\"String\\"
+  |            ^
 
 
 
@@ -4488,7 +4476,7 @@ exports[`unknown_submodule.test.w 1`] = `
   --> ../../../examples/tests/invalid/unknown_submodule.test.w:1:1
   |
 1 | std.random.String.fromJson(\\"hello\\");
-  | ^^^ Expected identifier \\"std\\" to be a variable, but it's a namespace
+  | ^^^
 
 
 
@@ -4503,70 +4491,70 @@ exports[`unknown_symbol.test.w 1`] = `
    --> ../../../examples/tests/invalid/unknown_symbol.test.w:43:5
    |
 43 | let let = 2;
-   |     ^^^ Reserved word
+   |     ^^^
 
 
 error: Unknown symbol \\"clod\\"
   --> ../../../examples/tests/invalid/unknown_symbol.test.w:3:18
   |
 3 | let bucket = new clod.Bucket();
-  |                  ^^^^ Unknown symbol \\"clod\\"
+  |                  ^^^^
 
 
 error: Unknown symbol \\"cloudy\\"
   --> ../../../examples/tests/invalid/unknown_symbol.test.w:6:17
   |
 6 | let funky = new cloudy.Funktion(inflight () => { });
-  |                 ^^^^^^ Unknown symbol \\"cloudy\\"
+  |                 ^^^^^^
 
 
 error: Unknown symbol \\"y\\"
   --> ../../../examples/tests/invalid/unknown_symbol.test.w:9:13
   |
 9 | let x = 2 + y;
-  |             ^ Unknown symbol \\"y\\"
+  |             ^
 
 
 error: Unknown symbol \\"B\\"
    --> ../../../examples/tests/invalid/unknown_symbol.test.w:28:17
    |
 28 | class A extends B {
-   |                 ^ Unknown symbol \\"B\\"
+   |                 ^
 
 
 error: Member \\"dodo\\" doesn't exist in \\"SomeResourceChild\\"
    --> ../../../examples/tests/invalid/unknown_symbol.test.w:37:5
    |
 37 | src.dodo();
-   |     ^^^^ Member \\"dodo\\" doesn't exist in \\"SomeResourceChild\\"
+   |     ^^^^
 
 
 error: Unknown symbol \\"unknown\\"
    --> ../../../examples/tests/invalid/unknown_symbol.test.w:40:1
    |
 40 | unknown = 1;
-   | ^^^^^^^ Unknown symbol \\"unknown\\"
+   | ^^^^^^^
 
 
 error: Binary operator '+' cannot be applied to operands of type 'num' and 'str'; only (num, num) and (str, str) are supported
    --> ../../../examples/tests/invalid/unknown_symbol.test.w:20:24
    |
 20 |     this.bucket.assert(2 + \\"2\\");
-   |                        ^^^^^^^ Binary operator '+' cannot be applied to operands of type 'num' and 'str'; only (num, num) and (str, str) are supported
+   |                        ^^^^^^^
 
 
 error: Member \\"assert\\" doesn't exist in \\"Bucket\\"
    --> ../../../examples/tests/invalid/unknown_symbol.test.w:20:17
    |
 20 |     this.bucket.assert(2 + \\"2\\");
-   |                 ^^^^^^ Member \\"assert\\" doesn't exist in \\"Bucket\\"
+   |                 ^^^^^^
 
 
 error: Member \\"methodWhichIsNotPartOfBucketApi\\" doesn't exist in \\"Bucket\\"
    --> ../../../examples/tests/invalid/unknown_symbol.test.w:23:24
    |
 23 |     return this.bucket.methodWhichIsNotPartOfBucketApi(id);
-   |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Member \\"methodWhichIsNotPartOfBucketApi\\" doesn't exist in \\"Bucket\\"
+   |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 
 
@@ -4590,14 +4578,14 @@ exports[`use_before_defined.test.w 1`] = `
   --> ../../../examples/tests/invalid/use_before_defined.test.w:1:7
   |
 1 | log(\\"{y}\\"); // Access y before it's defined
-  |       ^ Unknown symbol \\"y\\"
+  |       ^
 
 
 error: Symbol \\"x\\" used before being defined
   --> ../../../examples/tests/invalid/use_before_defined.test.w:5:9
   |
 5 |   log(\\"{x}\\");
-  |         ^ Symbol \\"x\\" used before being defined
+  |         ^
   .
 8 | let x = \\"hi\\";
   |     - defined later here
@@ -4615,7 +4603,7 @@ exports[`variable_scoping.test.w 1`] = `
   --> ../../../examples/tests/invalid/variable_scoping.test.w:6:11
   |
 6 |   let z = x;
-  |           ^ Unknown symbol \\"x\\"
+  |           ^
 
 
 
@@ -4630,14 +4618,14 @@ exports[`void_in_expression_position.test.w 1`] = `
   --> ../../../examples/tests/invalid/void_in_expression_position.test.w:1:12
   |
 1 | log(\\"hey\\").get(\\"x\\");
-  |            ^^^ Property not found
+  |            ^^^
 
 
 error: Expected type to be stringable, but got \\"void\\" instead
   --> ../../../examples/tests/invalid/void_in_expression_position.test.w:4:22
   |
 4 | let x = \\"my name is {log(\\"mister cloud\\")}\\";
-  |                      ^^^^^^^^^^^^^^^^^^^ Expected type to be stringable, but got \\"void\\" instead
+  |                      ^^^^^^^^^^^^^^^^^^^
   |
   = hint: str, num, bool, json, and enums are stringable
 
@@ -4646,28 +4634,28 @@ error: Binary operator '+' cannot be applied to operands of type 'num' and 'void
   --> ../../../examples/tests/invalid/void_in_expression_position.test.w:7:9
   |
 7 | let y = 5 + log(\\"hello\\");
-  |         ^^^^^^^^^^^^^^^^ Binary operator '+' cannot be applied to operands of type 'num' and 'void'; only (num, num) and (str, str) are supported
+  |         ^^^^^^^^^^^^^^^^
 
 
 error: Cannot assign expression of type \\"void\\" to a variable
    --> ../../../examples/tests/invalid/void_in_expression_position.test.w:11:5
    |
 11 | let z = returnsNothing();
-   |     ^ Cannot assign expression of type \\"void\\" to a variable
+   |     ^
 
 
 error: Cannot assign expression of type \\"void\\" to a variable
    --> ../../../examples/tests/invalid/void_in_expression_position.test.w:15:5
    |
 15 | let w: str? = returnsNothing2();
-   |     ^ Cannot assign expression of type \\"void\\" to a variable
+   |     ^
 
 
 error: Expected type to be \\"str?\\", but got \\"void\\" instead
    --> ../../../examples/tests/invalid/void_in_expression_position.test.w:15:15
    |
 15 | let w: str? = returnsNothing2();
-   |               ^^^^^^^^^^^^^^^^^ Expected type to be \\"str?\\", but got \\"void\\" instead
+   |               ^^^^^^^^^^^^^^^^^
 
 
 


### PR DESCRIPTION
Currently when you get compile errors in the CLI (related to parsing or type checking), the error message appears twice:

```
error: Enum "SomeEnum" does not contain value "FOUR"
  --> examples/tests/invalid/enums.test.w:5:21
  |
5 | let four = SomeEnum.FOUR;
  |                     ^^^^ Enum "SomeEnum" does not contain value "FOUR"
```

The repeated message can make errors look longer and doesn't add any information, so this PR removes the second occurrence of the error message.

## Checklist

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [x] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
