### PR TITLE
chore(docs): update TypeScript code + typo

### DIFF
--- a/docs/docs/09-typescript/index.md
+++ b/docs/docs/09-typescript/index.md
@@ -5,7 +5,7 @@ id: typescript
 
 Wing's CLI has experimental support for TypeScript.
 
-We see winglang as the ideal language to create Wing apps, but using TypeScript allows you to use many powerful features of wing without fully diving into a new language.
+We see Winglang as the ideal language to create Wing apps, but using TypeScript allows you to use many powerful features of Wing without fully diving into a new language.
 
 ## Getting Started
 
@@ -15,12 +15,12 @@ Follow the [installation guide](../01-start-here/02-installation.md) to install 
 wing new empty --language ts
 ```
 
-## Exploring the entrypoint
+## Exploring the entry point
 
-Wing apps start with an entrypoint file, commonly named `main.ts`. This file can be anywhere, the important part is that it calls `main` from `@wingcloud/framework`:
+Wing apps start with an entry point file, commonly named `main.ts`. This file can be anywhere, the important part is that it calls `main` from `@wingcloud/framework`:
 
 ```ts
-import { main } from "@wingcloud/framework";
+import { main, cloud } from "@wingcloud/framework";
 
 main((root) => {
   // your app goes here!


### PR DESCRIPTION
Without declaring `cloud` in the import, an error is thrown.

```ts
import { main, cloud } from "@wingcloud/framework";

main((root) => {
  // your app goes here!
  new cloud.Bucket(root, "Bucket");
});
```

## Checklist

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [x] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
