### PR TITLE
feat(vscode): automatically add `///` to newlines after doc comment

### DIFF
--- a/apps/vscode-wing/language-configuration.json
+++ b/apps/vscode-wing/language-configuration.json
@@ -51,5 +51,14 @@
     ["(", ")"],
     ["[", "]"],
     ["{", "}"]
+  ],
+  "onEnterRules": [
+    {
+      "beforeText": "^\\s*///.*",
+      "action": {
+        "indent": "none",
+        "appendText": "/// "
+      }
+    }
   ]
 }


### PR DESCRIPTION
Fixes #6452
No clue how to add a test for this, but here's a video

https://github.com/winglang/wing/assets/1237390/0e772e32-49a2-4a5a-9084-b91f13829472

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
