### PR TITLE
chore(docs): replace slack links with discord

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -5,7 +5,7 @@ body:
 - type: markdown
   attributes:
     value: |
-       :pray: Thanks for taking the time to fill out this bug report! Feel free to ping us on [Wing Slack](https://t.winglang.io/slack) if you have any questions or need help.
+       :pray: Thanks for taking the time to fill out this bug report! Feel free to ping us on [Wing Discord](https://t.winglang.io/discord) if you have any questions or need help.
 
 - type: markdown
   attributes:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: true
 contact_links:
-  - name: Community Slack
-    url: https://t.winglang.io/slack
+  - name: Community Discord
+    url: https://t.winglang.io/discord
     about: Come hang out, geek out, ask questions, help friends!

--- a/.github/ISSUE_TEMPLATE/example.yml
+++ b/.github/ISSUE_TEMPLATE/example.yml
@@ -33,4 +33,4 @@ body:
       <!-- Please keep this note for the community -->
       * Please vote by adding a 👍 reaction to the issue to help us prioritize.
       * If you are interested to work on this issue, please leave a comment.
-      * If this issue is labeled **needs-discussion**, it means the spec has not been finalized yet. Please reach out on the #dev channel in the [Wing Slack](https://t.winglang.io/slack).
+      * If this issue is labeled **needs-discussion**, it means the spec has not been finalized yet. Please reach out on the #dev channel in the [Wing Discord](https://t.winglang.io/discord).

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -5,7 +5,7 @@ body:
 - type: markdown
   attributes:
     value: |
-       :pray: Thanks for taking the time to fill out this enhancement request! Feel free to ping us on [Wing Slack](https://t.winglang.io/slack) if you have any questions or need help.
+       :pray: Thanks for taking the time to fill out this enhancement request! Feel free to ping us on [Wing Discord](https://t.winglang.io/discord) if you have any questions or need help.
 
 - type: markdown
   attributes:
@@ -71,4 +71,4 @@ body:
       <!-- Please keep this note for the community -->
       * Please vote by adding a 👍 reaction to the issue to help us prioritize.
       * If you are interested to work on this issue, please leave a comment.
-      * If this issue is labeled **needs-discussion**, it means the spec has not been finalized yet. Please reach out on the #dev channel in the [Wing Slack](https://t.winglang.io/slack).
+      * If this issue is labeled **needs-discussion**, it means the spec has not been finalized yet. Please reach out on the #dev channel in the [Wing Discord](https://t.winglang.io/discord).

--- a/.github/ISSUE_TEMPLATE/incident.yml
+++ b/.github/ISSUE_TEMPLATE/incident.yml
@@ -32,12 +32,12 @@ body:
         - label: WORKAROUND - if there is one, make sure it is documented in the section above.
         - label: PRIORITIZE (P0/P1/P2 - see the definitions [here](https://www.winglang.io/contributing/maintainers/operations#severity-levels)).
         - label: (optional) CONTACT a relevant person who has more information about the incident.
-        - label: (optional) ANNOUNCE major incidents on Slack \#dev or \#general channels. "NOTICE - P0 incident started. {incident-description}. Track on {link to issue}".
+        - label: (optional) ANNOUNCE major incidents on Discord \#dev or \#general channels. "NOTICE - P0 incident started. {incident-description}. Track on {link to issue}".
         - label: HANDLE by reverting or forward fixing.
         - label: UPDATE the team on your actions in the created \#alert Slack thread throughout the incident.
         - label: RESOLVE the incident on [PagerDuty](https://monada.pagerduty.com/incidents) (BetterStack resolves automatically).
         - label: UPDATE the team on the issue closure.
-        - label: (optional) ANNOUNCE closure of major incidents on Slack \#dev or \#general channels. "NOTICE - P0 incident ended. {incident-resolution-description}. Track on {link to issue}".
+        - label: (optional) ANNOUNCE closure of major incidents on Discord \#dev or \#general channels. "NOTICE - P0 incident ended. {incident-resolution-description}. Track on {link to issue}".
         - label: UNPIN the incident issue.
-        - label: LESSONS LEARNED should be shared via the "post-mortem" workflow on \#dev Slack channel.
+        - label: LESSONS LEARNED should be shared via the "post-mortem" workflow on \#dev Discord channel.
         - label: CLOSE the incident issue.

--- a/.github/workflows/close-stale.yml
+++ b/.github/workflows/close-stale.yml
@@ -26,6 +26,6 @@ jobs:
             Hi,
 
             This PR has not seen activity in 20 days. Therefore, we are marking the PR as stale for now. It will be closed after 7 days.
-            If you need help with the PR, do not hesitate to reach out in the winglang community slack at [winglang.slack.com](https://winglang.slack.com).
+            If you need help with the PR, do not hesitate to reach out in the winglang community [Discord](https://t.winglang.io/discord).
             Feel free to re-open this PR when it is still relevant and ready to be worked on again.
             Thanks!

--- a/.github/workflows/new-pull-request-comment.yml
+++ b/.github/workflows/new-pull-request-comment.yml
@@ -20,7 +20,7 @@ jobs:
           message: |
             Thanks for opening this pull request! :tada:
             Please consult the [contributing guidelines](https://www.winglang.io/contributing) for details on how to contribute to this project.
-            If you need any assistence, don't hesitate to ping the relevant owner over [Discord](https://t.winglang.io/discord).
+            If you need any assistance, don't hesitate to ping the relevant owner over [Discord](https://t.winglang.io/discord).
 
             | Topic                                               | Owner                                                         |
             |-----------------------------------------------------|---------------------------------------------------------------|

--- a/.github/workflows/new-pull-request-comment.yml
+++ b/.github/workflows/new-pull-request-comment.yml
@@ -20,7 +20,7 @@ jobs:
           message: |
             Thanks for opening this pull request! :tada:
             Please consult the [contributing guidelines](https://www.winglang.io/contributing) for details on how to contribute to this project.
-            If you need any assistence, don't hesitate to ping the relevant owner over [Slack](https://t.winglang.io/slack).
+            If you need any assistence, don't hesitate to ping the relevant owner over [Discord](https://t.winglang.io/discord).
 
             | Topic                                               | Owner                                                         |
             |-----------------------------------------------------|---------------------------------------------------------------|

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -2,4 +2,4 @@
 
 Wing follows the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md).
 
-Please review before contributing issues, pull requests, or joining the Wing Slack.
+Please review before contributing issues, pull requests, or joining the Wing Discord.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ any kind.
 The [Wing Contributor's Handbook] has tons of relevant information. If you can't find what you need
 here, please let us know by [submitting an issue].
 
-The best way to get started is by asking for help in the #Help channel on
+The best way to get started is by asking for help in the #help channel on
 the [Wing Discord].
 
 ## Quick Links

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,8 +10,8 @@ any kind.
 The [Wing Contributor's Handbook] has tons of relevant information. If you can't find what you need
 here, please let us know by [submitting an issue].
 
-The best way to get started is by asking for help in the [#contrib] channel on
-the [Wing Slack].
+The best way to get started is by asking for help in the #Help channel on
+the [Wing Discord].
 
 ## Quick Links
 
@@ -25,9 +25,8 @@ Here is a curated list of topics from the [Wing Contributor's Handbook]:
 
 ## Code of Conduct
 
-The Wing community follows the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md). Please review it before contributing issues, pull requests, or joining the [Wing Slack].
+The Wing community follows the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md). Please review it before contributing issues, pull requests, or joining the [Wing Discord].
 
-[Wing Slack]: https://t.winglang.io/slack
+[Wing Discord]: https://t.winglang.io/discord
 [Wing Contributor's Handbook]: https://www.winglang.io/contributing/
-[#contrib]: https://winglang.slack.com/archives/C04BJBTVDV4
 [submitting an issue]: https://github.com/winglang/wing/issues/new

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 ▪︎
 <a href="https://www.winglang.io/docs/">Getting Started</a>
 ▪︎
-<a href="http://t.winglang.io/slack">Join Slack</a>
+<a href="http://t.winglang.io/discord">Join Discord</a>
 ▪︎
 <a href="https://www.winglang.io/docs/category/faq">FAQ</a>
 ▪︎
@@ -40,7 +40,7 @@ We also provide you with a set of tools that let you test your code locally, sig
   <img src="./apps/wing/logo/demo.gif" alt="Wing Demo" height="400px">
 </div>
 
-Wing is built by [Elad Ben-Israel](https://github.com/eladb), the guy behind the [AWS CDK](https://github.com/aws/aws-cdk), the gang at the [Wing Cloud team](https://www.wing.cloud/) and an amazing [community](https://t.winglang.io/slack) of contributors (also known as Wingnuts).
+Wing is built by [Elad Ben-Israel](https://github.com/eladb), the guy behind the [AWS CDK](https://github.com/aws/aws-cdk), the gang at the [Wing Cloud team](https://www.wing.cloud/) and an amazing [community](https://t.winglang.io/discord) of contributors (also known as Wingnuts).
 
 Click [here](https://www.youtube.com/watch?v=5_RhWwgGue0) to watch a short video introduction to the Wing language.
 
@@ -128,7 +128,7 @@ Here are some questions we're commonly asked that are covered by our [FAQ](https
 
 ## Community 💬
 
-Join our flock in the [Wing Slack](https://t.winglang.io/slack) community.
+Join our flock in the [Wing Discord](https://t.winglang.io/discord) community.
 We're here to help each other, answer questions, and share our cloud adventures.
 Alternatively, post any questions on [GitHub Discussions](https://github.com/winglang/wing/discussions).
 
@@ -153,4 +153,4 @@ Contributions are made under our [contribution license](./CONTRIBUTION_LICENSE.m
 
 Happy coding, and remember: the sky's the limit with Wing (yes, another pun)! 🌤️🚀
 
-[wing slack]: https://t.winglang.io/slack
+[wing discord]: https://t.winglang.io/discord

--- a/apps/vscode-wing/README.md
+++ b/apps/vscode-wing/README.md
@@ -2,7 +2,7 @@
 <p align="center">
   <a href="https://www.winglang.io/docs/">Docs</a>
   ▪︎
-  <a href="http://t.winglang.io/slack">Community</a>
+  <a href="http://t.winglang.io/discord">Community</a>
   ▪︎
   <a href="https://www.winglang.io/docs/category/faq">FAQ</a>
   ▪︎

--- a/apps/wing/README.md
+++ b/apps/wing/README.md
@@ -4,7 +4,7 @@
   ▪︎
   <a href="https://www.winglang.io/docs/">Getting Started</a>
   ▪︎
-  <a href="http://t.winglang.io/slack">Join Slack</a>
+  <a href="http://t.winglang.io/discord">Join Discord</a>
   ▪︎
   <a href="https://www.winglang.io/docs/category/faq">FAQ</a>
   ▪︎
@@ -32,7 +32,7 @@ We also provide you with a set of tools that let you test your code locally, sig
   <img src="./logo/demo.gif" alt="Wing Demo" height="360px">
 </p>
 
-Wing is built by [Elad Ben-Israel](https://github.com/eladb), the guy behind the [AWS CDK](https://github.com/aws/aws-cdk), the gang at the [Wing Cloud team](https://www.wing.cloud/) and an amazing [community](https://t.winglang.io/slack) of contributors (also known as Wingnuts).
+Wing is built by [Elad Ben-Israel](https://github.com/eladb), the guy behind the [AWS CDK](https://github.com/aws/aws-cdk), the gang at the [Wing Cloud team](https://www.wing.cloud/) and an amazing [community](https://t.winglang.io/discord) of contributors (also known as Wingnuts).
 
 Click [here](https://www.youtube.com/watch?v=5_RhWwgGue0) to watch a short video introduction to the Wing language.
 
@@ -120,7 +120,7 @@ Here are some questions we're commonly asked that are covered by our [FAQ](https
 
 ## Community 💬
 
-Join our flock in the [Wing Slack](https://t.winglang.io/slack) community.
+Join our flock in the [Wing Discord](https://t.winglang.io/discord) community.
 We're here to help each other, answer questions, and share our cloud adventures.
 Alternatively, post any questions on [GitHub Discussions](https://github.com/winglang/wing/discussions).
 
@@ -145,4 +145,4 @@ Contributions are made under our [contribution license](./CONTRIBUTION_LICENSE.m
 
 Happy coding, and remember: the sky's the limit with Wing (yes, another pun)! 🌤️🚀
 
-[wing slack]: https://t.winglang.io/slack
+[wing discord]: https://t.winglang.io/discord

--- a/apps/wing/src/analytics/disclaimer.ts
+++ b/apps/wing/src/analytics/disclaimer.ts
@@ -13,7 +13,7 @@ chance you'll encounter missing pieces, rough edges, performance issues and even
 god forbid, bugs 🐞.
 
 Please don't hesitate to ping us at ${chalk.blueBright.bold.underline(
-  "https://t.winglang.io/slack"
+  "https://t.winglang.io/discord"
 )} or file an issue at
 ${chalk.blueBright.bold.underline(
   "https://github.com/winglang/wing"

--- a/docs/contributing/01-start-here/01-contributing-to-wing.md
+++ b/docs/contributing/01-start-here/01-contributing-to-wing.md
@@ -19,7 +19,7 @@ There are many ways to contribute to Wing:
 * Reporting and fixing [bugs](/contributing/start-here/bugs)
 * Find solutions to common issues in our [troubleshooting guide](/contributing/start-here/troubleshooting)
 * Commenting on [RFCs](/contributing/category/rfcs) or submitting one for major features
-* Asking and answering questions in the [Wing Slack](https://t.winglang.io/slack)
+* Asking and answering questions in the [Wing Discord](https://t.winglang.io/discord)
 * Posting or answering questions in [Wing Discussions](https://github.com/winglang/wing/discussions)
 
 ![](./giphy.webp)

--- a/docs/contributing/01-start-here/02-help.md
+++ b/docs/contributing/01-start-here/02-help.md
@@ -1,14 +1,14 @@
 ---
 title: Get Help
 id: help
-keywords: [help, slack, community, questions]
+keywords: [help, discord, community, questions]
 ---
 
 ## 🙋 Where can I go to ask questions about Wing?
 
-Come on down and hang out in the [Wing Slack]! We're a friendly bunch and we'd love to help you out.
+Come on down and hang out in the [Wing Discord]! We're a friendly bunch and we'd love to help you out.
 There are no stupid questions, so don't be afraid to ask! Don't forget to introduce yourself in the
-[#intro](https://winglang.slack.com/archives/C048QDSMC7L) channel.
+[#intro](https://t.winglang.io/discord) channel.
 
-[Wing Slack]: https://t.winglang.io/slack
+[Wing Discord]: https://t.winglang.io/discord
 

--- a/docs/contributing/01-start-here/03-status.md
+++ b/docs/contributing/01-start-here/03-status.md
@@ -19,7 +19,7 @@ We are working hard to make this a great tool, but there's still a pretty good
 chance you'll encounter missing pieces, rough edges, performance issues and even,
 god forbid, bugs 🐞. 
 
-Please don't hesitate to ping us on [Slack](https://t.winglang.io/slack) or 
+Please don't hesitate to ping us on [Discord](https://t.winglang.io/discord) or 
 [file an issue](https://github.com/winglang/wing). We promise to do our best to
 respond quickly and help out.
 

--- a/docs/contributing/01-start-here/07-wingsdk.md
+++ b/docs/contributing/01-start-here/07-wingsdk.md
@@ -81,9 +81,9 @@ A resource in the SDK has several parts:
 If you are implementing a new resource, or implementing an existing resource for a new cloud provider, try to take a look at code for existing resources (`Bucket`, `Function`, `Queue`) to see how to structure your code.
 
 Feel free to create an issue if you have questions about how to implement a resource or want to discuss the design of a resource.
-You can also join us on our [Wing Slack] to ask questions (or just say hi)!
+You can also join us on our [Wing Discord] to ask questions (or just say hi)!
 
-[Wing Slack]: https://t.winglang.io/slack
+[Wing Discord]: https://t.winglang.io/discord
 
 ## 🏁 How do I add and run tests to the SDK?
 

--- a/docs/contributing/01-start-here/10-code-of-conduct.md
+++ b/docs/contributing/01-start-here/10-code-of-conduct.md
@@ -6,8 +6,8 @@ keywords: [coc, code of conduct]
 
 The Wing community follows the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md).
 
-Please review it before contributing issues, pull requests, or joining the [Wing Slack].
+Please review it before contributing issues, pull requests, or joining the [Wing Discord].
 
-[Wing Slack]: https://t.winglang.io/slack
+[Wing Discord]: https://t.winglang.io/discord
 
 

--- a/docs/contributing/02-maintainers/050-operations.md
+++ b/docs/contributing/02-maintainers/050-operations.md
@@ -30,7 +30,7 @@ Monitoring may take one of two forms:
 
 - Polling monitors via BetterUptime check the status of GitHub actions and hosted sites to make sure they are currently reporting successfully
   - "GitHub Action" checks includes builds, release, and other scheduled jobs that provide additional health verification
-- Manual reports from users via Slack or Github Issues
+- Manual reports from users via Discord or Github Issues
 
 Manual reports also must be manually escalated to become actual incidents by any available maintainers.
 Ideally manual reports should be minimized, and we should constantly look for ways to automate the detection of issues.
@@ -67,7 +67,7 @@ Whatever action(s) are technically, it is useful for the responder to be over-co
 
 Another good response is to reach out to someone who has more information about the issue.
 This could be the person who wrote the code, or someone who has more context about the system.
-It is important to be respectful of maintainer time especially if they are not on-call or during regular working hours for their timezone (listed in Slack).
+It is important to be respectful of maintainer time especially if they are not on-call or during regular working hours for their timezone (listed in Discord).
 In P0 circumstances where no other mitigation is feasible, it is acceptable to ping/call someone on off-hours for help in resolving the issue.
 
 ### Analysis
@@ -125,7 +125,7 @@ Any maintainer should be empowered to take ownership of an incident if they wish
 - (always, immediately) send a Slack message to #alert
 - (always, immediately) notify the primary responder
 - (if not acknowledged within 10 minutes) notify the secondary responder
-- (if not acknowledged) Repeat everything above except for the slack message up to 6 times.
+- (if not acknowledged) Repeat everything above except for the Slack message up to 6 times.
 
 The notification channel and timing is configured per user. It's recommended to configure it in the following way:
 

--- a/docs/contributing/03-stories/story-04.md
+++ b/docs/contributing/03-stories/story-04.md
@@ -203,7 +203,7 @@ guidelines for contributing to the project.
 
 ## Community
 
-We all hang out at the [Wing Slack](https://t.winglang.io/slack). Come as you are, say hi, ask
+We all hang out at the [Wing Discord](https://t.winglang.io/discord). Come as you are, say hi, ask
 questions, help friends, geek out!
 
 ## License

--- a/docs/docs/01-start-here/06-learn-more.md
+++ b/docs/docs/01-start-here/06-learn-more.md
@@ -42,4 +42,4 @@ Put your skills to the test using the [playground](https://docs.winglang.io/gett
 ### Community
 We also have a [YouTube channel](https://www.youtube.com/@winglangio) where we share clips of demos and guest interviews on our [Twitch show](https://www.twitch.tv/winglangio), and a [blog](https://www.winglang.io/blog).
 
-Finally, we encourage you to join our [Wing Slack](http://t.winglang.io/slack) where we help each other, answer questions, and share our cloud adventures.
+Finally, we encourage you to join our [Wing Discord](http://t.winglang.io/discord) where we help each other, answer questions, and share our cloud adventures.

--- a/docs/docs/02-concepts/00-cloud-oriented-programming.md
+++ b/docs/docs/02-concepts/00-cloud-oriented-programming.md
@@ -93,7 +93,7 @@ We are working hard to make this a great tool, but there's still a pretty good
 chance you'll encounter missing pieces, rough edges, performance issues and even,
 god forbid, bugs 🐞. 
 
-Please don't hesitate to ping us on [Slack](https://t.winglang.io/slack) or 
+Please don't hesitate to ping us on [Discord](https://t.winglang.io/discord) or 
 [file an issue](https://github.com/winglang/wing). We promise to do our best to
 respond quickly and help out.
 

--- a/docs/docs/04-standard-library/cloud/workload.md
+++ b/docs/docs/04-standard-library/cloud/workload.md
@@ -36,7 +36,7 @@ orchestration system such as [Amazon ECS](https://aws.amazon.com/ecs/), [fly.io]
 [ControlPlane](https://controlplane.com/).
 
 > :warning: This resource is still experimental. Please ping the team on [Wing
-> Slack](https://t.winglang.io/slack) if you encounter any issues or have any questions and let us
+> Discord](https://t.winglang.io/discord) if you encounter any issues or have any questions and let us
 > know what you think. See [roadmap](#roadmap) below for more details about our plans.
 
 ## Installation

--- a/docs/docs/08-guides/03-react-vite-websockets.md
+++ b/docs/docs/08-guides/03-react-vite-websockets.md
@@ -13,7 +13,7 @@ Our application will have a counter that can be incremented by clicking on it. T
 synchronized in real-time across all users via a distributed cloud counter and WebSockets.
 
 > 🚧 Wing is still under active development, so don't be (too) surprised if you run into issues or bugs
-> along the way. You are invited to [join the Wing Slack](https://t.winglang.io/slack) to say hi, ask questions
+> along the way. You are invited to [join the Wing Discord](https://t.winglang.io/discord) to say hi, ask questions
 > and help your fellow Wingnuts.
 
 ## How to use this guide?

--- a/docs/docs/08-guides/04-private-api-gateway-aws.md
+++ b/docs/docs/08-guides/04-private-api-gateway-aws.md
@@ -31,7 +31,7 @@ wing --version
 0.58.10
 ```
 
-> Before we get going it would be great if you joined the awesome people hanging out on the [Wing slack](https://t.winglang.io/slack).
+> Before we get going it would be great if you joined the awesome people hanging out on the [Wing Discord](https://t.winglang.io/discord).
 
 
 Ok, now that we have the Wing CLI installed, let's create a new project using the `private-api` quickstart:

--- a/docs/docs/999-faq/020-supported-clouds-services-and-engines/021-supported-clouds.md
+++ b/docs/docs/999-faq/020-supported-clouds-services-and-engines/021-supported-clouds.md
@@ -13,7 +13,7 @@ Since Wing is in early stages of development, the Wing SDK supports each cloud w
 * GCP - Partial support. Not all Wing code that compiles for the simulator will compile for GCP. 
 * Azure - Partial support. Not all Wing code that compiles for the simulator will compile for Azure. 
 
-We are working hard on filling the support gap between the different clouds -- check out our [roadmap](https://www.winglang.io/contributing/status) for more details. If there are other clouds you would like supported, please let us know through our GitHub or Slack!
+We are working hard on filling the support gap between the different clouds -- check out our [roadmap](https://www.winglang.io/contributing/status) for more details. If there are other clouds you would like supported, please let us know through our GitHub or Discord!
 
 Beyond the common set of cloud resources in the SDK, you can create resources for any other possible cloud by importing a [CDKTF](https://github.com/hashicorp/terraform-cdk) library corresponding to any given Terraform provider.
 

--- a/docs/docs/999-faq/020-supported-clouds-services-and-engines/022-supported-services.md
+++ b/docs/docs/999-faq/020-supported-clouds-services-and-engines/022-supported-services.md
@@ -16,7 +16,7 @@ We are working hard on filling the support gap between the different services --
 ## Future plans
 You can also check out our [roadmap](https://www.winglang.io/contributing/status) for future plans.
 
-If there are other services you would like to see supported, please let us know through our GitHub or Slack!
+If there are other services you would like to see supported, please let us know through our GitHub or Discord!
 
 ## You can use any Terraform resource
 Beyond the built-in set of resources in the [Wing Cloud Library](../../category/cloud), you can use any Terraform resource by importing a [CDKTF](https://github.com/hashicorp/terraform-cdk) library corresponding to any given Terraform provider.

--- a/libs/wingsdk/README.md
+++ b/libs/wingsdk/README.md
@@ -85,9 +85,9 @@ We welcome community contributions and pull requests. See the [Wing Contributor'
 
 ## 🐣 Getting help
 
-If you need help either using or contributing to this project, please join us on our [Wing Slack].
+If you need help either using or contributing to this project, please join us on our [Wing Discord].
 
-[Wing Slack]: https://t.winglang.io/slack
+[Wing Discord]: https://t.winglang.io/discord
 
 ## ⚖️ License
 

--- a/libs/wingsdk/src/cloud/workload.md
+++ b/libs/wingsdk/src/cloud/workload.md
@@ -36,7 +36,7 @@ orchestration system such as [Amazon ECS](https://aws.amazon.com/ecs/), [fly.io]
 [ControlPlane](https://controlplane.com/).
 
 > :warning: This resource is still experimental. Please ping the team on [Wing
-> Slack](https://t.winglang.io/slack) if you encounter any issues or have any questions and let us
+> Discord](https://t.winglang.io/discord) if you encounter any issues or have any questions and let us
 > know what you think. See [roadmap](#roadmap) below for more details about our plans.
 
 ## Installation


### PR DESCRIPTION
As part of our Discord migration, update docs, workflows and readme files with new Discord links instead of Slack

## Checklist

- [ ] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [ ] Description explains motivation and solution
- [ ] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
