### PR TITLE
fix(console): respect `node.title` in the map view

### DIFF
--- a/apps/wing-console/console/app/web/index.css
+++ b/apps/wing-console/console/app/web/index.css
@@ -1,8 +1,4 @@
-@import "@ibm/plex/IBM-Plex-Sans/fonts/split/woff2/IBMPlexSans-Regular.css";
-@import "@ibm/plex/IBM-Plex-Sans/fonts/split/woff2/IBMPlexSans-Medium.css";
-@import "@ibm/plex/IBM-Plex-Sans/fonts/split/woff2/IBMPlexSans-Italic.css";
-@import "@ibm/plex/IBM-Plex-Mono/fonts/split/woff2/IBMPlexMono-Regular.css";
-@import "@ibm/plex/IBM-Plex-Mono/fonts/split/woff2/IBMPlexMono-Medium.css";
+@import "@ibm/plex/css/ibm-plex.css";
 
 @tailwind base;
 @tailwind components;

--- a/apps/wing-console/console/design-system/src/resource-icon.tsx
+++ b/apps/wing-console/console/design-system/src/resource-icon.tsx
@@ -1,6 +1,7 @@
 import classNames from "classnames";
 import type { FunctionComponent, SVGProps } from "react";
 
+import type { Colors } from "./utils/colors.js";
 import {
   getResourceIconColors,
   getResourceIconComponent,
@@ -14,6 +15,7 @@ export interface ResourceIconProps extends IconProps {
   darkenOnGroupHover?: boolean;
   forceDarken?: boolean;
   solid?: boolean;
+  color?: Colors | string;
 }
 
 export interface IconComponent extends FunctionComponent<IconProps> {}
@@ -35,6 +37,7 @@ export const ResourceIcon = ({
     resourceType,
     darkenOnGroupHover,
     forceDarken,
+    color: props.color,
   });
   return <Component className={classNames(className, colors)} {...props} />;
 };

--- a/apps/wing-console/console/design-system/src/utils/icon-utils.ts
+++ b/apps/wing-console/console/design-system/src/utils/icon-utils.ts
@@ -157,7 +157,7 @@ export const getResourceIconColors = (options: {
   resourceType: string | undefined;
   darkenOnGroupHover?: boolean;
   forceDarken?: boolean;
-  color?: Colors;
+  color?: Colors | string;
 }) => {
   switch (options.resourceType) {
     case "@winglang/sdk.cloud.Bucket": {
@@ -232,7 +232,9 @@ export const getResourceIconColors = (options: {
     }
     default: {
       let color: Colors =
-        options.color && colors[options.color] ? options.color : "slate";
+        options.color && Object.keys(colors).includes(options.color)
+          ? (options.color as Colors)
+          : "slate";
       return [
         colors[color].default,
         options.darkenOnGroupHover && colors[color].groupHover,

--- a/apps/wing-console/console/server/src/router/app.ts
+++ b/apps/wing-console/console/server/src/router/app.ts
@@ -460,7 +460,12 @@ function createExplorerItemFromConstructTreeNode(
   showTests = false,
   includeHiddens = false,
 ): ExplorerItem {
-  const label = node.display?.title ?? node.id;
+  const cloudResourceType = node.constructInfo?.fqn?.split(".").at(-1);
+
+  const label =
+    node.display?.title === cloudResourceType
+      ? node.id
+      : node.display?.title ?? node.id;
 
   return {
     id: node.path,

--- a/apps/wing-console/console/ui/src/features/map-view.tsx
+++ b/apps/wing-console/console/ui/src/features/map-view.tsx
@@ -205,6 +205,7 @@ interface ConstructNodeProps {
   highlight?: boolean;
   hasChildNodes?: boolean;
   onSelectedNodeIdChange: (id: string | undefined) => void;
+  color?: string;
 }
 
 const ConstructNode: FunctionComponent<PropsWithChildren<ConstructNodeProps>> =
@@ -218,6 +219,7 @@ const ConstructNode: FunctionComponent<PropsWithChildren<ConstructNodeProps>> =
       inflights,
       children,
       hasChildNodes,
+      color,
     }) => {
       const select = useCallback(
         () => onSelectedNodeIdChange(id),
@@ -275,7 +277,11 @@ const ConstructNode: FunctionComponent<PropsWithChildren<ConstructNodeProps>> =
                     "border-b border-slate-200 dark:border-slate-800",
                 )}
               >
-                <ResourceIcon className="size-4 -ml-0.5" resourceType={fqn} />
+                <ResourceIcon
+                  className="size-4 -ml-0.5"
+                  resourceType={fqn}
+                  color={color}
+                />
 
                 <span
                   className={clsx(
@@ -679,14 +685,22 @@ export const MapView = memo(
           props.constructTreeNode.children ?? {},
         ).filter((node) => !isNodeHidden(node.path));
 
+        const fqn = props.constructTreeNode.constructInfo?.fqn;
+
+        const cloudResourceType = fqn?.split(".").at(-1);
+
+        const name =
+          props.constructTreeNode.display?.title === cloudResourceType
+            ? props.constructTreeNode.id
+            : props.constructTreeNode.display?.title ??
+              props.constructTreeNode.id;
+
         return (
           <ConstructNode
             id={props.constructTreeNode.path}
-            name={
-              props.constructTreeNode.display?.title ??
-              props.constructTreeNode.id
-            }
-            fqn={props.constructTreeNode.constructInfo?.fqn ?? ""}
+            name={name ?? ""}
+            fqn={fqn ?? ""}
+            color={props.constructTreeNode.display?.color}
             inflights={info.type === "construct" ? info.inflights : []}
             onSelectedNodeIdChange={props.onSelectedNodeIdChange}
             highlight={props.selectedNodeId === props.constructTreeNode.path}

--- a/apps/wing-console/console/ui/src/features/map-view.tsx
+++ b/apps/wing-console/console/ui/src/features/map-view.tsx
@@ -682,7 +682,10 @@ export const MapView = memo(
         return (
           <ConstructNode
             id={props.constructTreeNode.path}
-            name={props.constructTreeNode.id}
+            name={
+              props.constructTreeNode.display?.title ??
+              props.constructTreeNode.id
+            }
             fqn={props.constructTreeNode.constructInfo?.fqn ?? ""}
             inflights={info.type === "construct" ? info.inflights : []}
             onSelectedNodeIdChange={props.onSelectedNodeIdChange}


### PR DESCRIPTION
Update the display of node names in the MapView component to show the title if available, falling back to the id if not.

Fixes #6457.

