### PR TITLE
fix(console): node ports are not centered

### DIFF
--- a/apps/wing-console/console/ui/src/features/map-view.tsx
+++ b/apps/wing-console/console/ui/src/features/map-view.tsx
@@ -236,6 +236,7 @@ const ConstructNode: FunctionComponent<PropsWithChildren<ConstructNodeProps>> =
               // "elk.layered.layering.strategy": "MIN_WIDTH",
               // "elk.layered.layering.strategy": "NETWORK_SIMPLEX",
               // "elk.layered.layering.strategy": "STRETCH_WIDTH",
+              "elk.portConstraints": "FIXED_SIDE",
             },
           }}
           className={clsx(


### PR DESCRIPTION
The node ports, in some instances, weren't centered as in the image below:

<img width="387" alt="image" src="https://github.com/winglang/wing/assets/1077520/4550f7d8-c40e-482c-96bd-b1b5545f63cf">

This PR fixes the port declaration.