### PR TITLE
fix(compiler): compiler allows assigning a json object to a wing array

### DIFF
--- a/examples/tests/invalid/json.test.w
+++ b/examples/tests/invalid/json.test.w
@@ -114,3 +114,12 @@ let notAStruct = {
 
 let isBucket = Json new cloud.Bucket();
 //                  ^^^^^^^^^^^^^^^^^^ "Bucket" is not a legal JSON value
+
+let objInsteadOfArray: StructyJson = {
+  stuff: {a: 1}, // Error: expeced an array but got a JSON object
+  foo: "bar",
+  maybe: {
+    good: true,
+  }
+};
+

--- a/libs/wingc/src/type_check.rs
+++ b/libs/wingc/src/type_check.rs
@@ -1093,7 +1093,7 @@ impl TypeRef {
 	}
 
 	pub fn is_map(&self) -> bool {
-		matches!(**self, Type::Map(_))
+		matches!(**self, Type::Map(_) | Type::MutMap(_))
 	}
 
 	pub fn is_void(&self) -> bool {
@@ -3227,7 +3227,7 @@ impl<'a> TypeChecker<'a> {
 				if expected_type_unwrapped.is_struct() {
 					self.validate_structural_type(fields, expected_type_unwrapped, span);
 					true
-				} else if let Some(inner_expected) = inner_expected {
+				} else if let (Some(inner_expected), true) = (inner_expected, expected_type_unwrapped.is_map()) {
 					// The expected type is a Map
 					for field_info in fields.values() {
 						self.validate_type(field_info.type_, inner_expected, &field_info.span);
@@ -3329,7 +3329,8 @@ impl<'a> TypeChecker<'a> {
 				"to allow \"nil\" assignment use optional type: \"{first_expected_type}?\""
 			));
 		}
-		if return_type.maybe_unwrap_option().is_json() {
+
+		if matches!(**return_type.maybe_unwrap_option(), Type::Json(None) | Type::MutJson) {
 			// known json data is statically known
 			hints.push(format!(
 				"use {first_expected_type}.fromJson() to convert dynamic Json\""

--- a/tools/hangar/__snapshots__/invalid.ts.snap
+++ b/tools/hangar/__snapshots__/invalid.ts.snap
@@ -2924,6 +2924,13 @@ error: Expected type to be \\"StructyJson\\", but got \\"Json\\" instead
     = hint: use StructyJson.fromJson() to convert dynamic Json\\"
 
 
+error: Expected type to be \\"Array<num>\\", but got \\"Json\\" instead
+    --> ../../../examples/tests/invalid/json.test.w:119:10
+    |
+119 |   stuff: {a: 1}, // Error: expeced an array but got a JSON object
+    |          ^^^^^^
+
+
 error: \\"Array<Json>\\" is not a legal JSON value
    --> ../../../examples/tests/invalid/json.test.w:23:17
    |


### PR DESCRIPTION
fixes #6448

stractural Json object assignment can only be assigned to wing maps or structs (not arrays).

Also fixes the diagnostic hint about using `fromJson` for dynamic json conversion to be shown only for actual dynamic jsons.

## Checklist

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [x] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
