### PR TITLE
chore: ensure wingsdk compiles before running tests

### DIFF
--- a/libs/wingsdk/.eslintrc.json
+++ b/libs/wingsdk/.eslintrc.json
@@ -185,6 +185,19 @@
     },
     {
       "files": [
+        "vitest.config.mts"
+      ],
+      "rules": {
+        "import/no-extraneous-dependencies": [
+          "error",
+          {
+            "devDependencies": true
+          }
+        ]
+      }
+    },
+    {
+      "files": [
         ".projenrc.ts"
       ],
       "rules": {

--- a/libs/wingsdk/.projenrc.ts
+++ b/libs/wingsdk/.projenrc.ts
@@ -166,6 +166,18 @@ project.eslint!.addOverride({
   },
 });
 
+project.eslint!.addOverride({
+  files: ["vitest.config.mts"],
+  rules: {
+    "import/no-extraneous-dependencies": [
+      "error",
+      {
+        devDependencies: true,
+      },
+    ],
+  },
+});
+
 project.package.addField("optionalDependencies", {
   esbuild: "^0.19.12",
 });

--- a/libs/wingsdk/turbo.json
+++ b/libs/wingsdk/turbo.json
@@ -19,7 +19,7 @@
       "dependsOn": ["pre-compile"]
     },
     "test": {
-      "dependsOn": ["pre-compile"]
+      "dependsOn": ["compile"]
     },
     "package": {
       "outputs": ["../../dist/winglang-sdk-*.tgz"]


### PR DESCRIPTION
Several parts of the SDK reference try to `require`/`require.resolve` `@winglang/sdk/lib/...` while inflight (e.g. for inflight clients). This directory only exists after the SDK has been compiled. This means the SDK tests depend on SDK itself being compiled first. This is unfortunate because we also compile parts of the SDK with tsc as the tests start up, and then vitest itself is also compiling/transpiling.
 
This PR is not doing anything to fix all that, but we at least need to ensure turbo is correctly modeling this dependency to avoid false test failures/successes.

As a side fix, I made eslint allow devDeps in test.config.mts to get rid of red squiggles in my IDE.

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
