### PR TITLE
fix(sdk): cannot use relative paths for container images

### DIFF
--- a/libs/wingsdk/src/shared/misc.ts
+++ b/libs/wingsdk/src/shared/misc.ts
@@ -51,5 +51,5 @@ export async function shell(
 
 export function isPath(s: string) {
   s = normalPath(s);
-  return s.startsWith("./") || s.startsWith("/");
+  return s.startsWith("./") || s.startsWith("../") || s.startsWith("/");
 }

--- a/libs/wingsdk/test/misc.test.ts
+++ b/libs/wingsdk/test/misc.test.ts
@@ -1,0 +1,10 @@
+import { expect, test } from "vitest";
+import { isPath } from "../src/shared/misc";
+
+test("isPath", () => {
+  expect(isPath("foo")).toBeFalsy();
+  expect(isPath("./hello")).toBeTruthy();
+  expect(isPath("../hello")).toBeTruthy();
+  expect(isPath(".././../hello")).toBeTruthy();
+  expect(isPath("/hello/world")).toBeTruthy();
+});


### PR DESCRIPTION
The `isPath` utility didn't take into account `../` as an option. Meh!

## Checklist

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [x] Tests added (always)
- [x] Docs updated (only required for features)
- [x] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
