### PR TITLE
feat(compiler): support logging stringable values directly

### DIFF
--- a/apps/vscode-wing/syntaxes/wing.tmLanguage.json
+++ b/apps/vscode-wing/syntaxes/wing.tmLanguage.json
@@ -160,7 +160,7 @@
         },
         {
           "name": "support.class.wing",
-          "match": "\\b(void|str|num|bool|any|duration|Map|Set|MutMap|MutSet|Array|MutArray|Promise|Json|MutJson)\\b"
+          "match": "\\b(void|str|num|bool|any|duration|regex|datetime|stringable|Map|Set|MutMap|MutSet|Array|MutArray|Promise|Json|MutJson)\\b"
         }
       ]
     },

--- a/examples/tests/invalid/stringify.test.w
+++ b/examples/tests/invalid/stringify.test.w
@@ -6,3 +6,6 @@ log("hello {b}");
 let x: str? = nil;
 log("{x}");
 // ^ Error: expected type to be stringable
+
+log(b);
+// ^ Error: expected type to be stringable

--- a/examples/tests/valid/stringify.test.w
+++ b/examples/tests/valid/stringify.test.w
@@ -1,0 +1,8 @@
+enum MyEnum { A, B, C }
+
+// If a value's type is stringable, it can be passed directly to the "log" function
+log("my string");
+log(42);
+log(true);
+log(Json { "cool": "beans" });
+log(MyEnum.A);

--- a/libs/wingc/src/docs.rs
+++ b/libs/wingc/src/docs.rs
@@ -133,6 +133,7 @@ impl Documented for TypeRef {
 			| Type::Map(_)
 			| Type::MutMap(_)
 			| Type::Set(_)
+			| Type::Stringable
 			| Type::MutSet(_) => "".to_string(),
 		}
 	}

--- a/libs/wingc/src/dtsify/extern_dtsify.rs
+++ b/libs/wingc/src/dtsify/extern_dtsify.rs
@@ -116,6 +116,9 @@ impl<'a> ExternDTSifier<'a> {
 			Type::Inferred(_) | Type::Unresolved => {
 				panic!("Extern must use resolved types")
 			}
+			Type::Stringable => {
+				panic!("Unsupported type stringable")
+			}
 		}
 	}
 

--- a/libs/wingc/src/lsp/completions.rs
+++ b/libs/wingc/src/lsp/completions.rs
@@ -1087,6 +1087,7 @@ fn format_symbol_kind_as_completion(name: &str, symbol_kind: &SymbolKind) -> Opt
 				Type::Anything
 				| Type::Number
 				| Type::String
+				| Type::Stringable
 				| Type::Duration
 				| Type::Boolean
 				| Type::Void

--- a/libs/wingc/src/lsp/snapshots/completions/empty.snap
+++ b/libs/wingc/src/lsp/snapshots/completions/empty.snap
@@ -22,10 +22,10 @@ source: libs/wingc/src/lsp/completions.rs
     command: editor.action.triggerParameterHints
 - label: log
   kind: 3
-  detail: "(message: str): void"
+  detail: "(value: stringable): void"
   documentation:
     kind: markdown
-    value: "```wing\nlog: (message: str): void\n```\n---\nLogs a message\n### Parameters\n- `message` — `str` — The message to log"
+    value: "```wing\nlog: (value: stringable): void\n```\n---\nLogs a value\n### Parameters\n- `value` — `stringable` — The value to log"
   sortText: cc|log
   insertText: log($1)
   insertTextFormat: 2

--- a/libs/wingc/src/lsp/snapshots/completions/hide_parent_symbols_defined_later.snap
+++ b/libs/wingc/src/lsp/snapshots/completions/hide_parent_symbols_defined_later.snap
@@ -29,10 +29,10 @@ source: libs/wingc/src/lsp/completions.rs
     command: editor.action.triggerParameterHints
 - label: log
   kind: 3
-  detail: "(message: str): void"
+  detail: "(value: stringable): void"
   documentation:
     kind: markdown
-    value: "```wing\nlog: (message: str): void\n```\n---\nLogs a message\n### Parameters\n- `message` — `str` — The message to log"
+    value: "```wing\nlog: (value: stringable): void\n```\n---\nLogs a value\n### Parameters\n- `value` — `stringable` — The value to log"
   sortText: cc|log
   insertText: log($1)
   insertTextFormat: 2

--- a/libs/wingc/src/lsp/symbol_locator.rs
+++ b/libs/wingc/src/lsp/symbol_locator.rs
@@ -126,7 +126,8 @@ impl<'a> SymbolLocator<'a> {
 			| Type::Unresolved
 			| Type::Inferred(_)
 			| Type::Function(_)
-			| Type::Enum(_) => None,
+			| Type::Enum(_)
+			| Type::Stringable => None,
 
 			Type::Array(_)
 			| Type::MutArray(_)

--- a/libs/wingc/src/type_check/inference_visitor.rs
+++ b/libs/wingc/src/type_check/inference_visitor.rs
@@ -107,6 +107,7 @@ impl<'a> crate::visit_types::VisitType<'_> for InferenceVisitor<'a> {
 				Type::Anything
 				| Type::Number
 				| Type::String
+				| Type::Stringable
 				| Type::Duration
 				| Type::Boolean
 				| Type::Void

--- a/libs/wingc/src/visit_types.rs
+++ b/libs/wingc/src/visit_types.rs
@@ -53,7 +53,8 @@ where
 		| Type::MutJson
 		| Type::Nil
 		| Type::Unresolved
-		| Type::Enum(_) => {}
+		| Type::Enum(_)
+		| Type::Stringable => {}
 
 		Type::Inferred(node_unwrap([n])) => {
 			v.visit_inference(n);

--- a/tools/hangar/__snapshots__/invalid.ts.snap
+++ b/tools/hangar/__snapshots__/invalid.ts.snap
@@ -1963,7 +1963,7 @@ error: Variable is not reassignable
    | ^^^
 
 
-error: Expected type to be \\"(message: str): void\\", but got \\"str\\" instead
+error: Expected type to be \\"(value: stringable): void\\", but got \\"str\\" instead
    --> ../../../examples/tests/invalid/global_symbols.test.w:10:7
    |
 10 | log = \\"hi\\";
@@ -2323,13 +2323,6 @@ error: Unable to infer type
   |                             ^^^^
 
 
-error: Unable to infer type
-   --> ../../../examples/tests/invalid/inference.test.w:25:44
-   |
-25 | let stringInterpolationCannotBeInferred = (nice) => {
-   |                                            ^^^^
-
-
 error: Property not found
    --> ../../../examples/tests/invalid/inference.test.w:63:19
    |
@@ -2437,13 +2430,6 @@ error: Unable to infer type
   |
 4 | let preflightClosureArgs = (nice) => { return true; };
   |     ^^^^^^^^^^^^^^^^^^^^
-
-
-error: Unable to infer type
-   --> ../../../examples/tests/invalid/inference.test.w:25:5
-   |
-25 | let stringInterpolationCannotBeInferred = (nice) => {
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 
 
@@ -2803,14 +2789,14 @@ Duration <DURATION>"
 `;
 
 exports[`intrinsics.test.w 1`] = `
-"error: @dirname does not require arguments
+"error: @dirname does not expect arguments
   --> ../../../examples/tests/invalid/intrinsics.test.w:6:20
   |
 6 | let path = @dirname();
   |                    ^^
 
 
-error: @dirname cannot be used while inflight
+error: @dirname cannot be used in inflight
   --> ../../../examples/tests/invalid/intrinsics.test.w:2:11
   |
 2 |   let x = @dirname;
@@ -4405,7 +4391,7 @@ Duration <DURATION>"
 `;
 
 exports[`stringify.test.w 1`] = `
-"error: Expected type to be stringable, but got \\"B\\" instead
+"error: Expected type to be \\"stringable\\", but got \\"B\\" instead
   --> ../../../examples/tests/invalid/stringify.test.w:3:13
   |
 3 | log(\\"hello {b}\\");
@@ -4414,13 +4400,22 @@ exports[`stringify.test.w 1`] = `
   = hint: str, num, bool, json, and enums are stringable
 
 
-error: Expected type to be stringable, but got \\"str?\\" instead
+error: Expected type to be \\"stringable\\", but got \\"str?\\" instead
   --> ../../../examples/tests/invalid/stringify.test.w:7:7
   |
 7 | log(\\"{x}\\");
   |       ^
   |
   = hint: str? is an optional, try unwrapping it with 'x ?? \\"nil\\"' or 'x!'
+
+
+error: Expected type to be \\"stringable\\", but got \\"B\\" instead
+   --> ../../../examples/tests/invalid/stringify.test.w:10:5
+   |
+10 | log(b);
+   |     ^
+   |
+   = hint: str, num, bool, json, and enums are stringable
 
 
 
@@ -5040,7 +5035,7 @@ exports[`void_in_expression_position.test.w 1`] = `
   |            ^^^
 
 
-error: Expected type to be stringable, but got \\"void\\" instead
+error: Expected type to be \\"stringable\\", but got \\"void\\" instead
   --> ../../../examples/tests/invalid/void_in_expression_position.test.w:4:22
   |
 4 | let x = \\"my name is {log(\\"mister cloud\\")}\\";

--- a/tools/hangar/__snapshots__/test_corpus/valid/debug_env.test.w_test_sim.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/debug_env.test.w_test_sim.md
@@ -4,7 +4,7 @@
 ```log
 [symbol environment at debug_env.test.w:7:5]
 level 0: { this => A }
-level 1: { A => A [type], assert => (condition: bool, message: str?): void, cloud => cloud [namespace], log => (message: str): void, nodeof => preflight (construct: IConstruct): Node, std => std [namespace], this => Construct, unsafeCast => (value: any): any }
+level 1: { A => A [type], assert => (condition: bool, message: str?): void, cloud => cloud [namespace], log => (value: stringable): void, nodeof => preflight (construct: IConstruct): Node, std => std [namespace], this => Construct, unsafeCast => (value: any): any }
 ```
 
 ## stdout.log

--- a/tools/hangar/__snapshots__/test_corpus/valid/stringify.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/stringify.test.w_compile_tf-aws.md
@@ -1,0 +1,55 @@
+# [stringify.test.w](../../../../../examples/tests/valid/stringify.test.w) | compile | tf-aws
+
+## main.tf.json
+```json
+{
+  "//": {
+    "metadata": {
+      "backend": "local",
+      "stackName": "root",
+      "version": "0.20.3"
+    },
+    "outputs": {}
+  },
+  "provider": {
+    "aws": [
+      {}
+    ]
+  }
+}
+```
+
+## preflight.cjs
+```cjs
+"use strict";
+const $stdlib = require('@winglang/sdk');
+const $platforms = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLATFORMS);
+const $outdir = process.env.WING_SYNTH_DIR ?? ".";
+const $wing_is_test = process.env.WING_IS_TEST === "true";
+const std = $stdlib.std;
+const $helpers = $stdlib.helpers;
+const $extern = $helpers.createExternRequire(__dirname);
+class $Root extends $stdlib.std.Resource {
+  constructor($scope, $id) {
+    super($scope, $id);
+    const MyEnum =
+      (function (tmp) {
+        tmp["A"] = "A";
+        tmp["B"] = "B";
+        tmp["C"] = "C";
+        return tmp;
+      })({})
+    ;
+    console.log("my string");
+    console.log(42);
+    console.log(true);
+    console.log(({"cool": "beans"}));
+    console.log(MyEnum.A);
+  }
+}
+const $PlatformManager = new $stdlib.platform.PlatformManager({platformPaths: $platforms});
+const $APP = $PlatformManager.createApp({ outdir: $outdir, name: "stringify.test", rootConstruct: $Root, isTestEnvironment: $wing_is_test, entrypointDir: process.env['WING_SOURCE_DIR'], rootId: process.env['WING_ROOT_ID'] });
+$APP.synth();
+//# sourceMappingURL=preflight.cjs.map
+```
+

--- a/tools/hangar/__snapshots__/test_corpus/valid/stringify.test.w_test_sim.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/stringify.test.w_test_sim.md
@@ -1,0 +1,17 @@
+# [stringify.test.w](../../../../../examples/tests/valid/stringify.test.w) | test | sim
+
+## stdout.log
+```log
+my string
+42
+true
+{ cool: 'beans' }
+A
+pass ─ stringify.test.wsim (no tests)
+
+Tests 1 passed (1)
+Snapshots 1 skipped
+Test Files 1 passed (1)
+Duration <DURATION>
+```
+


### PR DESCRIPTION
Adds support for directly logging stringable values without needing to create a interpolated string:

```
let x = 5;

// before
log("{x}");

// now
log(x);
```

To implement the feature, I had to add a new type to the compiler's type system for representing stringable values. At the moment it more or less behaves like `str | num | bool | ...`. For now it's not really something we have concrete plans to expose in userland (to let users write functions with stringable inputs) but it's something we can consider introducing in the future.

## Checklist

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [x] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
