### PR TITLE
fix(compiler): error reported when type (class) defined before `super()` call

### DIFF
--- a/libs/wingc/src/ast.rs
+++ b/libs/wingc/src/ast.rs
@@ -510,6 +510,15 @@ pub enum StmtKind {
 	ExplicitLift(ExplicitLift),
 }
 
+impl StmtKind {
+	pub fn is_type_def(&self) -> bool {
+		matches!(
+			self,
+			StmtKind::Class(_) | StmtKind::Interface(_) | StmtKind::Struct(_) | StmtKind::Enum(_)
+		)
+	}
+}
+
 #[derive(Debug)]
 pub struct ExplicitLift {
 	pub qualifications: Vec<LiftQualification>,

--- a/libs/wingc/src/closure_transform.rs
+++ b/libs/wingc/src/closure_transform.rs
@@ -156,16 +156,12 @@ impl Fold for ClosureTransformer {
 				let class_fields: Vec<ClassField> = vec![];
 				let class_init_params: Vec<FunctionParameter> = vec![];
 
+				let parent_this = format!("{}_{}", PARENT_THIS_NAME, self.closure_counter);
+				let mut this_transform = RenameThisTransformer::new(&parent_this.as_str());
 				let new_func_def = if self.inside_scope_with_this {
 					// If we are inside a class, we transform inflight closures with an extra
 					// `let __parent_this_${CLOSURE_COUNT} = this;` statement before the class definition, and replace references
 					// to `this` with `__parent_this_${CLOSURE_COUNT}` so that they can access the parent class's fields.
-					let parent_this = format!("{}_{}", PARENT_THIS_NAME, self.closure_counter);
-					let mut this_transform = RenameThisTransformer {
-						from: "this",
-						to: parent_this.as_str(),
-						inside_class: false,
-					};
 					this_transform.fold_function_definition(func_def)
 				} else {
 					func_def
@@ -226,11 +222,8 @@ impl Fold for ClosureTransformer {
 
 				// If we are inside a scope with "this", add define `let __parent_this_${CLOSURE_COUNT} = this` which can be
 				// used by the newly-created preflight classes
-				if self.inside_scope_with_this {
-					let parent_this_name = Symbol::new(
-						format!("{}_{}", PARENT_THIS_NAME, self.closure_counter),
-						WingSpan::for_file(file_id),
-					);
+				if self.inside_scope_with_this && this_transform.performed_renames {
+					let parent_this_name = Symbol::new(parent_this, WingSpan::for_file(file_id));
 					let this_name = Symbol::new("this", WingSpan::for_file(file_id));
 					let parent_this_def = Stmt {
 						kind: StmtKind::Let {
@@ -331,34 +324,31 @@ impl Fold for ClosureTransformer {
 struct RenameThisTransformer<'a> {
 	from: &'a str,
 	to: &'a str,
-	// The transform shouldn't change references to `this` inside inflight classes since
-	// they refer to different objects.
-	inside_class: bool,
+	performed_renames: bool,
 }
 
-impl Default for RenameThisTransformer<'_> {
-	fn default() -> Self {
+impl<'a> RenameThisTransformer<'a> {
+	fn new(to: &'a str) -> Self {
 		Self {
 			from: "this",
-			to: PARENT_THIS_NAME,
-			inside_class: false,
+			to,
+			performed_renames: false,
 		}
 	}
 }
 
 impl<'a> Fold for RenameThisTransformer<'a> {
 	fn fold_class(&mut self, node: Class) -> Class {
-		let old_inside_class = self.inside_class;
-		self.inside_class = true;
-		let new_class = fold::fold_class(self, node);
-		self.inside_class = old_inside_class;
-		new_class
+		// The transform shouldn't change references to `this` inside inflight classes since
+		// they refer to different objects. Skip inner class.
+		node
 	}
 
 	fn fold_reference(&mut self, node: Reference) -> Reference {
 		match node {
 			Reference::Identifier(ident) => {
-				if !self.inside_class && ident.name == self.from {
+				if ident.name == self.from {
+					self.performed_renames = true;
 					Reference::Identifier(Symbol {
 						name: self.to.to_string(),
 						span: ident.span,

--- a/libs/wingc/src/jsify.rs
+++ b/libs/wingc/src/jsify.rs
@@ -1681,7 +1681,7 @@ impl<'a> JSifier<'a> {
 		};
 
 		// Check if the first statement is a super constructor call, if not we need to add one
-		let super_called = if let Some(s) = init_statements.statements.first() {
+		let super_called = if let Some(s) = init_statements.statements.iter().find(|s| !s.kind.is_type_def()) {
 			matches!(s.kind, StmtKind::SuperConstructor { .. })
 		} else {
 			false

--- a/libs/wingc/src/jsify/snapshots/allow_type_def_before_super.snap
+++ b/libs/wingc/src/jsify/snapshots/allow_type_def_before_super.snap
@@ -1,0 +1,172 @@
+---
+source: libs/wingc/src/jsify/tests.rs
+---
+## Code
+
+```w
+
+    class Foo {
+      new(x: num) {}
+    }
+    class Bar extends Foo {
+      new() {
+        class Baz {}
+        super(1);
+      }
+    }
+    
+```
+
+## inflight.Bar-1.cjs
+
+```js
+"use strict";
+const $helpers = require("@winglang/sdk/lib/helpers");
+module.exports = function({ $Foo }) {
+  class Bar extends $Foo {
+    constructor({  }) {
+      super({  });
+    }
+  }
+  return Bar;
+}
+//# sourceMappingURL=inflight.Bar-1.cjs.map
+```
+
+## inflight.Baz-1.cjs
+
+```js
+"use strict";
+const $helpers = require("@winglang/sdk/lib/helpers");
+module.exports = function({  }) {
+  class Baz {
+    constructor({  }) {
+    }
+  }
+  return Baz;
+}
+//# sourceMappingURL=inflight.Baz-1.cjs.map
+```
+
+## inflight.Foo-1.cjs
+
+```js
+"use strict";
+const $helpers = require("@winglang/sdk/lib/helpers");
+module.exports = function({  }) {
+  class Foo {
+    constructor({  }) {
+    }
+  }
+  return Foo;
+}
+//# sourceMappingURL=inflight.Foo-1.cjs.map
+```
+
+## preflight.cjs
+
+```js
+"use strict";
+const $stdlib = require('@winglang/sdk');
+const $platforms = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLATFORMS);
+const $outdir = process.env.WING_SYNTH_DIR ?? ".";
+const $wing_is_test = process.env.WING_IS_TEST === "true";
+const std = $stdlib.std;
+const $helpers = $stdlib.helpers;
+const $extern = $helpers.createExternRequire(__dirname);
+class $Root extends $stdlib.std.Resource {
+  constructor($scope, $id) {
+    super($scope, $id);
+    class Foo extends $stdlib.std.Resource {
+      constructor($scope, $id, x) {
+        super($scope, $id);
+      }
+      static _toInflightType() {
+        return `
+          require("${$helpers.normalPath(__dirname)}/inflight.Foo-1.cjs")({
+          })
+        `;
+      }
+      _toInflight() {
+        return `
+          (await (async () => {
+            const FooClient = ${Foo._toInflightType()};
+            const client = new FooClient({
+            });
+            if (client.$inflight_init) { await client.$inflight_init(); }
+            return client;
+          })())
+        `;
+      }
+      get _liftMap() {
+        return ({
+          "$inflight_init": [
+          ],
+        });
+      }
+    }
+    class Bar extends Foo {
+      constructor($scope, $id, ) {
+        class Baz extends $stdlib.std.Resource {
+          constructor($scope, $id, ) {
+            super($scope, $id);
+          }
+          static _toInflightType() {
+            return `
+              require("${$helpers.normalPath(__dirname)}/inflight.Baz-1.cjs")({
+              })
+            `;
+          }
+          _toInflight() {
+            return `
+              (await (async () => {
+                const BazClient = ${Baz._toInflightType()};
+                const client = new BazClient({
+                });
+                if (client.$inflight_init) { await client.$inflight_init(); }
+                return client;
+              })())
+            `;
+          }
+          get _liftMap() {
+            return ({
+              "$inflight_init": [
+              ],
+            });
+          }
+        }
+        super($scope, $id, 1);
+      }
+      static _toInflightType() {
+        return `
+          require("${$helpers.normalPath(__dirname)}/inflight.Bar-1.cjs")({
+            $Foo: ${$stdlib.core.liftObject(Foo)},
+          })
+        `;
+      }
+      _toInflight() {
+        return `
+          (await (async () => {
+            const BarClient = ${Bar._toInflightType()};
+            const client = new BarClient({
+            });
+            if (client.$inflight_init) { await client.$inflight_init(); }
+            return client;
+          })())
+        `;
+      }
+      get _liftMap() {
+        return $stdlib.core.mergeLiftDeps(super._liftMap, {
+          "$inflight_init": [
+          ],
+        });
+      }
+    }
+  }
+}
+const $PlatformManager = new $stdlib.platform.PlatformManager({platformPaths: $platforms});
+const $APP = $PlatformManager.createApp({ outdir: $outdir, name: "main", rootConstruct: $Root, isTestEnvironment: $wing_is_test, entrypointDir: process.env['WING_SOURCE_DIR'], rootId: process.env['WING_ROOT_ID'] });
+$APP.synth();
+//# sourceMappingURL=preflight.cjs.map
+```
+

--- a/libs/wingc/src/jsify/snapshots/closure_field.snap
+++ b/libs/wingc/src/jsify/snapshots/closure_field.snap
@@ -113,7 +113,6 @@ class $Root extends $stdlib.std.Resource {
     class MyResource extends $stdlib.std.Resource {
       constructor($scope, $id, ) {
         super($scope, $id);
-        const __parent_this_1 = this;
         class $Closure1 extends $stdlib.std.AutoIdResource {
           _id = $stdlib.core.closureId();
           constructor($scope, $id, ) {

--- a/libs/wingc/src/jsify/snapshots/lift_inside_preflight_method.snap
+++ b/libs/wingc/src/jsify/snapshots/lift_inside_preflight_method.snap
@@ -82,7 +82,6 @@ class $Root extends $stdlib.std.Resource {
       }
       defineBucket(name) {
         const b = this.node.root.new("@winglang/sdk.cloud.Bucket", cloud.Bucket, this, name);
-        const __parent_this_1 = this;
         class $Closure1 extends $stdlib.std.AutoIdResource {
           _id = $stdlib.core.closureId();
           constructor($scope, $id, ) {

--- a/libs/wingc/src/jsify/tests.rs
+++ b/libs/wingc/src/jsify/tests.rs
@@ -2040,3 +2040,20 @@ fn entrypoint_this() {
     "#
 	);
 }
+
+#[test]
+fn allow_type_def_before_super() {
+	assert_compile_ok!(
+		r#"
+    class Foo {
+      new(x: num) {}
+    }
+    class Bar extends Foo {
+      new() {
+        class Baz {}
+        super(1);
+      }
+    }
+    "#
+	);
+}

--- a/libs/wingc/src/type_check.rs
+++ b/libs/wingc/src/type_check.rs
@@ -4449,21 +4449,39 @@ impl<'a> TypeChecker<'a> {
 				.as_function_sig()
 				.expect("ctor to be a function");
 			if let FunctionBody::Statements(ctor_body) = &ctor_def.body {
-				if parent_ctor_sig.min_parameters() > 0
-					&& !matches!(
-						ctor_body.statements.first(),
-						Some(Stmt {
-							kind: StmtKind::SuperConstructor { .. },
-							..
-						})
-					) {
-					self.spanned_error(
-						ctor_body,
-						format!(
-							"Missing super() call as first statement of {}'s constructor",
-							ast_class.name
-						),
-					);
+				// Make sure there's a `super()` call to the parent ctor
+				if parent_ctor_sig.min_parameters() > 0 {
+					// Find the `super()` call
+					if let Some((idx, super_call)) = ctor_body
+						.statements
+						.iter()
+						.enumerate()
+						.find(|(_, s)| matches!(s.kind, StmtKind::SuperConstructor { .. }))
+					{
+						// We have a super call, make sure it's the first statement (after any type defs)
+						let expected_idx = ctor_body
+							.statements
+							.iter()
+							.position(|s| !s.kind.is_type_def())
+							.expect("at least the super call stmt");
+						if idx != expected_idx {
+							self.spanned_error(
+								super_call,
+								format!(
+									"super() call must be the first statement of {}'s constructor",
+									ast_class.name
+								),
+							);
+						}
+					} else {
+						self.spanned_error(
+							ctor_body,
+							format!(
+								"Missing super() call as first statement of {}'s constructor",
+								ast_class.name
+							),
+						);
+					}
 				}
 			}
 		}

--- a/tools/hangar/__snapshots__/invalid.ts.snap
+++ b/tools/hangar/__snapshots__/invalid.ts.snap
@@ -726,13 +726,6 @@ exports[`class.test.w 1`] = `
    |     ^^^^^^^^
 
 
-error: Call to super constructor must be first statement in constructor
-    --> ../../../examples/tests/invalid/class.test.w:109:5
-    |
-109 |     super(name, major);
-    |     ^^^^^^^^^^^^^^^^^^^
-
-
 error: Call to super constructor can only be done from within class constructor
     --> ../../../examples/tests/invalid/class.test.w:114:5
     |
@@ -887,16 +880,11 @@ error: Unknown symbol \\"C11\\"
    |                   ^^^
 
 
-error: Missing super() call as first statement of PaidStudent's constructor
-    --> ../../../examples/tests/invalid/class.test.w:107:45
-    |  
-107 |     new(name: str, major: str, hrlyWage: num) {
-    | /---------------------------------------------^
-108 | |     this.hrlyWage = hrlyWage;
-109 | |     super(name, major);
-110 | | //  ^^^^^^^^^^^^^^^^^^^ Expected call to super to be first statement in constructor
-111 | |   }
-    | \\\\---^
+error: super() call must be the first statement of PaidStudent's constructor
+    --> ../../../examples/tests/invalid/class.test.w:109:5
+    |
+109 |     super(name, major);
+    |     ^^^^^^^^^^^^^^^^^^^
 
 
 error: Cannot instantiate abstract class \\"Resource\\"

--- a/tools/hangar/__snapshots__/test_corpus/valid/calling_inflight_variants.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/calling_inflight_variants.test.w_compile_tf-aws.md
@@ -117,7 +117,6 @@ class $Root extends $stdlib.std.Resource {
     class Foo extends $stdlib.std.Resource {
       constructor($scope, $id, ) {
         super($scope, $id);
-        const __parent_this_1 = this;
         class $Closure1 extends $stdlib.std.AutoIdResource {
           _id = $stdlib.core.closureId();
           constructor($scope, $id, ) {

--- a/tools/hangar/__snapshots__/test_corpus/valid/capture_reassigable_class_field.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/capture_reassigable_class_field.test.w_compile_tf-aws.md
@@ -163,7 +163,6 @@ class $Root extends $stdlib.std.Resource {
       constructor($scope, $id, ) {
         super($scope, $id);
         this.bucket = this.node.root.new("@winglang/sdk.cloud.Bucket", cloud.Bucket, this, "Bucket");
-        const __parent_this_1 = this;
         class $Closure1 extends $stdlib.std.AutoIdResource {
           _id = $stdlib.core.closureId();
           constructor($scope, $id, ) {

--- a/tools/hangar/__snapshots__/test_corpus/valid/doubler.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/doubler.test.w_compile_tf-aws.md
@@ -328,7 +328,6 @@ class $Root extends $stdlib.std.Resource {
         super($scope, $id);
       }
       makeFunc(handler) {
-        const __parent_this_2 = this;
         class $Closure2 extends $stdlib.std.AutoIdResource {
           _id = $stdlib.core.closureId();
           constructor($scope, $id, ) {

--- a/tools/hangar/__snapshots__/test_corpus/valid/inflight_class_definitions.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/inflight_class_definitions.test.w_compile_tf-aws.md
@@ -343,7 +343,6 @@ class $Root extends $stdlib.std.Resource {
             });
           }
         }
-        const __parent_this_2 = this;
         class $Closure2 extends $stdlib.std.AutoIdResource {
           _id = $stdlib.core.closureId();
           constructor($scope, $id, ) {

--- a/tools/hangar/__snapshots__/test_corpus/valid/inflight_closure_inside_preflight_closure.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/inflight_closure_inside_preflight_closure.test.w_compile_tf-aws.md
@@ -69,7 +69,6 @@ class $Root extends $stdlib.std.Resource {
       constructor($scope, $id, ) {
         super($scope, $id);
         const foo = (() => {
-          const __parent_this_1 = this;
           class $Closure1 extends $stdlib.std.AutoIdResource {
             _id = $stdlib.core.closureId();
             constructor($scope, $id, ) {

--- a/tools/hangar/__snapshots__/test_corpus/valid/inflights_calling_inflights.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/inflights_calling_inflights.test.w_compile_tf-aws.md
@@ -388,7 +388,6 @@ class $Root extends $stdlib.std.Resource {
     class MyResource extends $stdlib.std.Resource {
       constructor($scope, $id, ) {
         super($scope, $id);
-        const __parent_this_4 = this;
         class $Closure4 extends $stdlib.std.AutoIdResource {
           _id = $stdlib.core.closureId();
           constructor($scope, $id, ) {

--- a/tools/hangar/__snapshots__/test_corpus/valid/mutation_after_class_init.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/mutation_after_class_init.test.w_compile_tf-aws.md
@@ -349,7 +349,6 @@ class $Root extends $stdlib.std.Resource {
       constructor($scope, $id, ) {
         super($scope, $id);
         this.data = this.node.root.new("@winglang/sdk.cloud.Bucket", cloud.Bucket, this, "Bucket");
-        const __parent_this_1 = this;
         class $Closure1 extends $stdlib.std.AutoIdResource {
           _id = $stdlib.core.closureId();
           constructor($scope, $id, ) {

--- a/tools/hangar/__snapshots__/test_corpus/valid/symbol_shadow.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/symbol_shadow.test.w_compile_tf-aws.md
@@ -133,7 +133,6 @@ class $Root extends $stdlib.std.Resource {
         super($scope, $id);
         const s = "inResource";
         $helpers.assert($helpers.eq(s, "inResource"), "s == \"inResource\"");
-        const __parent_this_2 = this;
         class $Closure2 extends $stdlib.std.AutoIdResource {
           _id = $stdlib.core.closureId();
           constructor($scope, $id, ) {


### PR DESCRIPTION
This is part of the effort to address #4925.

Because inflight closures turn into class definitions, when they are passed to a `super()` call we use to get an error telling us that `super()` must be the first statement in a ctor. Now this is fixed:
```wing
class Foo {
  new(x: num) {}
}
class Bar extends Foo {
  new() {
    class Baz {} // This is now ok
    super(1);
  }
}
```

## Checklist

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [x] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
