### PR TITLE
chore(sdk): use `cloud.Function` instead of `sim.Function`

### DIFF
--- a/libs/wingsdk/src/target-sim/api.ts
+++ b/libs/wingsdk/src/target-sim/api.ts
@@ -1,7 +1,7 @@
 import { Construct } from "constructs";
 import { App } from "./app";
 import { EventMapping } from "./event-mapping";
-import { Function } from "./function";
+import { Function } from "../cloud";
 import { Policy } from "./policy";
 import { ISimulatorResource } from "./resource";
 import { ApiRoute, ApiSchema } from "./schema-resources";

--- a/libs/wingsdk/src/target-sim/api.ts
+++ b/libs/wingsdk/src/target-sim/api.ts
@@ -1,12 +1,12 @@
 import { Construct } from "constructs";
 import { App } from "./app";
 import { EventMapping } from "./event-mapping";
-import { Function } from "../cloud";
 import { Policy } from "./policy";
 import { ISimulatorResource } from "./resource";
 import { ApiRoute, ApiSchema } from "./schema-resources";
 import { simulatorAttrToken } from "./tokens";
 import { bindSimulatorResource, makeSimulatorJsClient } from "./util";
+import { Function } from "../cloud";
 import * as cloud from "../cloud";
 import { lift } from "../core";
 import { ToSimulatorOutput } from "../simulator/simulator";

--- a/libs/wingsdk/src/target-sim/queue.ts
+++ b/libs/wingsdk/src/target-sim/queue.ts
@@ -2,7 +2,6 @@ import { Construct } from "constructs";
 import { App } from "./app";
 import { EventMapping } from "./event-mapping";
 import {
-  Function,
   FunctionInflightMethods as SimFunctionInflightMethods,
 } from "./function";
 import { Policy } from "./policy";
@@ -80,7 +79,7 @@ export class Queue extends cloud.Queue implements ISimulatorResource {
     props: cloud.QueueSetConsumerOptions = {}
   ): cloud.Function {
     const functionHandler = QueueSetConsumerHandler.toFunctionHandler(inflight);
-    const fn = new Function(
+    const fn = new cloud.Function(
       this,
       App.of(this).makeId(this, "Consumer"),
       functionHandler,

--- a/libs/wingsdk/src/target-sim/queue.ts
+++ b/libs/wingsdk/src/target-sim/queue.ts
@@ -1,9 +1,7 @@
 import { Construct } from "constructs";
 import { App } from "./app";
 import { EventMapping } from "./event-mapping";
-import {
-  FunctionInflightMethods as SimFunctionInflightMethods,
-} from "./function";
+import { FunctionInflightMethods as SimFunctionInflightMethods } from "./function";
 import { Policy } from "./policy";
 import { ISimulatorResource } from "./resource";
 import { QueueSchema } from "./schema-resources";

--- a/libs/wingsdk/src/target-sim/schedule.ts
+++ b/libs/wingsdk/src/target-sim/schedule.ts
@@ -1,7 +1,7 @@
 import { Construct } from "constructs";
 import { App } from "./app";
 import { EventMapping } from "./event-mapping";
-import { Function } from "./function";
+import { Function } from "../cloud";
 import { Policy } from "./policy";
 import { ISimulatorResource } from "./resource";
 import { ScheduleSchema } from "./schema-resources";

--- a/libs/wingsdk/src/target-sim/schedule.ts
+++ b/libs/wingsdk/src/target-sim/schedule.ts
@@ -1,7 +1,6 @@
 import { Construct } from "constructs";
 import { App } from "./app";
 import { EventMapping } from "./event-mapping";
-import { Function } from "../cloud";
 import { Policy } from "./policy";
 import { ISimulatorResource } from "./resource";
 import { ScheduleSchema } from "./schema-resources";
@@ -10,6 +9,7 @@ import {
   makeSimulatorJsClient,
   convertDurationToCronExpression,
 } from "./util";
+import { Function } from "../cloud";
 import * as cloud from "../cloud";
 import { lift } from "../core";
 import { ToSimulatorOutput } from "../simulator";

--- a/libs/wingsdk/src/target-sim/topic.ts
+++ b/libs/wingsdk/src/target-sim/topic.ts
@@ -1,11 +1,11 @@
 import { Construct } from "constructs";
 import { App } from "./app";
 import { EventMapping } from "./event-mapping";
-import { Function } from "../cloud";
 import { Policy } from "./policy";
 import { ISimulatorResource } from "./resource";
 import { TopicSchema } from "./schema-resources";
 import { bindSimulatorResource, makeSimulatorJsClient } from "./util";
+import { Function } from "../cloud";
 import * as cloud from "../cloud";
 import { lift, LiftMap } from "../core";
 import { ToSimulatorOutput } from "../simulator";

--- a/libs/wingsdk/src/target-sim/topic.ts
+++ b/libs/wingsdk/src/target-sim/topic.ts
@@ -1,7 +1,7 @@
 import { Construct } from "constructs";
 import { App } from "./app";
 import { EventMapping } from "./event-mapping";
-import { Function } from "./function";
+import { Function } from "../cloud";
 import { Policy } from "./policy";
 import { ISimulatorResource } from "./resource";
 import { TopicSchema } from "./schema-resources";


### PR DESCRIPTION
Gives platforms a chance to override the default sim function

## Checklist

- [ ] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [ ] Description explains motivation and solution
- [ ] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
