### PR TITLE
fix(console): resolve connections to hidden nodes upwards

### DIFF
--- a/apps/wing-console/console/ui/src/services/use-map.ts
+++ b/apps/wing-console/console/ui/src/services/use-map.ts
@@ -180,6 +180,28 @@ export const useMap = ({}: UseMapOptions = {}) => {
     [hiddenMap],
   );
 
+  const resolveNodePath = useCallback(
+    (path: string) => {
+      const parts = path.split("/");
+      for (const [index, part] of Object.entries(parts)) {
+        const path = parts.slice(0, Number(index) + 1).join("/");
+        if (isNodeHidden(path)) {
+          return parts.slice(0, Number(index)).join("/");
+        }
+      }
+      return path;
+    },
+    [isNodeHidden],
+  );
+
+  const resolveNode = useCallback(
+    (path: string) => {
+      const nodePath = path.match(/^(.+?)#/)?.[1] ?? path;
+      return resolveNodePath(nodePath);
+    },
+    [resolveNodePath],
+  );
+
   const rootNodes = useMemo(() => {
     if (!rawTree) {
       return;
@@ -224,8 +246,17 @@ export const useMap = ({}: UseMapOptions = {}) => {
       getNodeId: (node) => node.id,
       getConnectionId: (connection) =>
         `${connection.source.id}#${connection.source.operation}##${connection.target.id}#${connection.target.operation}`,
+      resolveNode: (node) => {
+        const path = resolveNode(node.id);
+        console.log(node.id, path);
+        return {
+          id: path,
+          nodeFqn: nodeFqns.get(path),
+          operation: node.operation,
+        };
+      },
     });
-  }, [rawConnections, nodeFqns, isNodeHidden]);
+  }, [rawConnections, nodeFqns, isNodeHidden, resolveNode]);
 
   const getConnectionId = useCallback(
     (

--- a/apps/wing-console/console/ui/src/services/use-map.ts
+++ b/apps/wing-console/console/ui/src/services/use-map.ts
@@ -248,14 +248,22 @@ export const useMap = ({}: UseMapOptions = {}) => {
         `${connection.source.id}#${connection.source.operation}##${connection.target.id}#${connection.target.operation}`,
       resolveNode: (node) => {
         const path = resolveNode(node.id);
-        console.log(node.id, path);
         return {
           id: path,
           nodeFqn: nodeFqns.get(path),
-          operation: node.operation,
+          // Make the operation anonymous if the node is hidden.
+          operation: path === node.id ? node.operation : undefined,
         };
       },
-    });
+    })
+      .filter((connection) => {
+        // Filter connections that go to parents.
+        return !connection.source.id.startsWith(`${connection.target.id}/`);
+      })
+      .filter((connection) => {
+        // Filter connections that go to themselves.
+        return connection.source.id !== connection.target.id;
+      });
   }, [rawConnections, nodeFqns, isNodeHidden, resolveNode]);
 
   const getConnectionId = useCallback(


### PR DESCRIPTION
This change resolves connections to hidden nodes upwards, meaning that the connection will be listed to its closest visible parent node.

Fixes #6523.
