### PR TITLE
fix(compiler): better error message when putting in parenthesis in a catch block

### DIFF
--- a/examples/tests/invalid/try_catch_parenthesis.test.w
+++ b/examples/tests/invalid/try_catch_parenthesis.test.w
@@ -1,0 +1,22 @@
+try {
+  log("Hello World");
+} catch (e) {
+//      ^^^ Unexpected parentheses in catch block. Use 'catch e' instead of 'catch (e)'.
+  log("error");
+}
+
+try {
+  log("Hello World");
+} catch (longError) {
+//      ^^^^^^^^^^^ Unexpected parentheses in catch block. Use 'catch longError' instead of 'catch (longError)'.
+  log("error");
+}
+
+
+try {
+  log("Hello World");
+} catch e {
+  log("error");
+}
+// this is ok^
+

--- a/libs/tree-sitter-wing/grammar.js
+++ b/libs/tree-sitter-wing/grammar.js
@@ -55,7 +55,12 @@ module.exports = grammar({
       choice(braced(optional(repeat($._statement))), $.AUTOMATIC_BLOCK),
     _semicolon: ($) => choice(";", $.AUTOMATIC_SEMICOLON),
     comment: ($) =>
-      token(choice(seq(/\/\/[^\/]/, /.*/), seq("/*", /[^*]*\*+([^/*][^*]*\*+)*/, "/"))),
+      token(
+        choice(
+          seq(/\/\/[^\/]/, /.*/),
+          seq("/*", /[^*]*\*+([^/*][^*]*\*+)*/, "/")
+        )
+      ),
 
     doc: ($) => seq("///", field("content", $.doc_content)),
     doc_content: ($) => /.*/,
@@ -69,6 +74,7 @@ module.exports = grammar({
       ),
 
     identifier: ($) => /([A-Za-z_$][A-Za-z_$0-9]*|[A-Z][A-Z0-9_]*)/,
+    parenthesized_identifier: ($) => seq("(", $.identifier, ")"),
     _type_identifier: ($) => alias($.identifier, $.type_identifier),
     _member_identifier: ($) => alias($.identifier, $.member_identifier),
     _reference_identifier: ($) => alias($.identifier, $.reference_identifier),
@@ -127,7 +133,7 @@ module.exports = grammar({
         $.compiler_dbg_env,
         $.super_constructor_statement,
         $.throw_statement,
-        $.lift_statement,
+        $.lift_statement
       ),
 
     import_statement: ($) =>
@@ -164,11 +170,24 @@ module.exports = grammar({
       seq("throw", optional(field("expression", $.expression)), $._semicolon),
 
     lift_statement: ($) =>
-      seq("lift", field("lift_qualifications", $.lift_qualifications), field("block", $.block)),
+      seq(
+        "lift",
+        field("lift_qualifications", $.lift_qualifications),
+        field("block", $.block)
+      ),
 
-    lift_qualifications: ($) => seq("{", field("qualification", commaSep1($.lift_qualification)), "}"),
+    lift_qualifications: ($) =>
+      seq("{", field("qualification", commaSep1($.lift_qualification)), "}"),
 
-    lift_qualification: ($) => seq(field("obj", $.expression), ":", choice(field("ops", $.identifier), field("ops", seq("[", commaSep1($.identifier), "]")))),
+    lift_qualification: ($) =>
+      seq(
+        field("obj", $.expression),
+        ":",
+        choice(
+          field("ops", $.identifier),
+          field("ops", seq("[", commaSep1($.identifier), "]"))
+        )
+      ),
 
     assignment_operator: ($) => choice("=", "+=", "-="),
 
@@ -334,7 +353,15 @@ module.exports = grammar({
         optional(
           seq(
             "catch",
-            optional(field("exception_identifier", $.identifier)),
+            optional(
+              choice(
+                field("exception_identifier", $.identifier),
+                field(
+                  "parenthesized_exception_identifier",
+                  $.parenthesized_identifier
+                )
+              )
+            ),
             field("catch_block", $.block)
           )
         ),

--- a/libs/tree-sitter-wing/src/grammar.json
+++ b/libs/tree-sitter-wing/src/grammar.json
@@ -139,6 +139,23 @@
       "type": "PATTERN",
       "value": "([A-Za-z_$][A-Za-z_$0-9]*|[A-Z][A-Z0-9_]*)"
     },
+    "parenthesized_identifier": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "("
+        },
+        {
+          "type": "SYMBOL",
+          "name": "identifier"
+        },
+        {
+          "type": "STRING",
+          "value": ")"
+        }
+      ]
+    },
     "_type_identifier": {
       "type": "ALIAS",
       "content": {
@@ -1906,12 +1923,25 @@
                   "type": "CHOICE",
                   "members": [
                     {
-                      "type": "FIELD",
-                      "name": "exception_identifier",
-                      "content": {
-                        "type": "SYMBOL",
-                        "name": "identifier"
-                      }
+                      "type": "CHOICE",
+                      "members": [
+                        {
+                          "type": "FIELD",
+                          "name": "exception_identifier",
+                          "content": {
+                            "type": "SYMBOL",
+                            "name": "identifier"
+                          }
+                        },
+                        {
+                          "type": "FIELD",
+                          "name": "parenthesized_exception_identifier",
+                          "content": {
+                            "type": "SYMBOL",
+                            "name": "parenthesized_identifier"
+                          }
+                        }
+                      ]
                     },
                     {
                       "type": "BLANK"

--- a/libs/wingc/src/parser.rs
+++ b/libs/wingc/src/parser.rs
@@ -688,6 +688,16 @@ impl<'s> Parser<'s> {
 	fn build_try_catch_statement(&self, statement_node: &Node, phase: Phase) -> DiagnosticResult<StmtKind> {
 		let try_statements = self.build_scope(&statement_node.child_by_field_name("block").unwrap(), phase);
 		let catch_block = if let Some(catch_block) = statement_node.child_by_field_name("catch_block") {
+			if let Some(parenthesized_identifier) = statement_node.child_by_field_name("parenthesized_exception_identifier") {
+				return self.with_error::<StmtKind>(
+					format!(
+						"Unexpected parentheses in catch block. Use 'catch {}' instead of 'catch {}'.",
+						self.node_text(&parenthesized_identifier.child(1).expect("no identifier found")),
+						self.node_text(&parenthesized_identifier)
+					),
+					&parenthesized_identifier,
+				);
+			}
 			Some(CatchBlock {
 				statements: self.build_scope(&catch_block, phase),
 				exception_var: if let Some(exception_var_node) = statement_node.child_by_field_name("exception_identifier") {
@@ -705,6 +715,7 @@ impl<'s> Parser<'s> {
 		} else {
 			None
 		};
+		//TODO: here
 
 		// If both catch and finally are missing, report an error
 		if catch_block.is_none() && finally_statements.is_none() {

--- a/libs/wingc/src/parser.rs
+++ b/libs/wingc/src/parser.rs
@@ -715,7 +715,6 @@ impl<'s> Parser<'s> {
 		} else {
 			None
 		};
-		//TODO: here
 
 		// If both catch and finally are missing, report an error
 		if catch_block.is_none() && finally_statements.is_none() {


### PR DESCRIPTION
Fixes #5945 
```
try {
  log("Hello World");
} catch (e) {
//      ^^^ Unexpected parentheses in catch block. Use 'catch e' instead of 'catch (e)'.
  log("error");
}

try {
  log("Hello World");
} catch (longError) {
//      ^^^^^^^^^^^ Unexpected parentheses in catch block. Use 'catch longError' instead of 'catch (longError)'.
  log("error");
}
```
<img width="727" alt="image" src="https://github.com/winglang/wing/assets/39455181/58ccc5ad-0047-49a8-b8cf-6ca6c08a04b5">


## Checklist

- [ ] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [ ] Description explains motivation and solution
- [ ] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
