### PR TITLE
feat(sdk): show `cloud.Api` endpoint functions

### DIFF
--- a/libs/wingsdk/src/target-sim/api.ts
+++ b/libs/wingsdk/src/target-sim/api.ts
@@ -87,7 +87,6 @@ export class Api extends cloud.Api implements ISimulatorResource {
     ) as Function;
     Node.of(fn).sourceModule = SDK_SOURCE_MODULE;
     Node.of(fn).title = `${method.toUpperCase()} ${pathPattern}`;
-    Node.of(fn).hidden = true;
 
     const eventMapping = new EventMapping(
       this,

--- a/libs/wingsdk/test/target-sim/__snapshots__/api.test.ts.snap
+++ b/libs/wingsdk/test/target-sim/__snapshots__/api.test.ts.snap
@@ -283,7 +283,6 @@ exports.handler = async function(event) {
               },
               "display": {
                 "description": "A cloud function (FaaS)",
-                "hidden": true,
                 "sourceModule": "@winglang/sdk",
                 "title": "GET /hello",
               },
@@ -610,7 +609,6 @@ exports.handler = async function(event) {
               },
               "display": {
                 "description": "A cloud function (FaaS)",
-                "hidden": true,
                 "sourceModule": "@winglang/sdk",
                 "title": "GET /hello",
               },
@@ -936,7 +934,6 @@ exports.handler = async function(event) {
               },
               "display": {
                 "description": "A cloud function (FaaS)",
-                "hidden": true,
                 "sourceModule": "@winglang/sdk",
                 "title": "GET /hello",
               },
@@ -1263,7 +1260,6 @@ exports.handler = async function(event) {
               },
               "display": {
                 "description": "A cloud function (FaaS)",
-                "hidden": true,
                 "sourceModule": "@winglang/sdk",
                 "title": "GET /hello",
               },
@@ -1590,7 +1586,6 @@ exports.handler = async function(event) {
               },
               "display": {
                 "description": "A cloud function (FaaS)",
-                "hidden": true,
                 "sourceModule": "@winglang/sdk",
                 "title": "GET /hello",
               },
@@ -1917,7 +1912,6 @@ exports.handler = async function(event) {
               },
               "display": {
                 "description": "A cloud function (FaaS)",
-                "hidden": true,
                 "sourceModule": "@winglang/sdk",
                 "title": "GET /hello",
               },
@@ -2387,7 +2381,6 @@ exports.handler = async function(event) {
               },
               "display": {
                 "description": "A cloud function (FaaS)",
-                "hidden": true,
                 "sourceModule": "@winglang/sdk",
                 "title": "GET /hello",
               },
@@ -2730,7 +2723,6 @@ exports.handler = async function(event) {
               },
               "display": {
                 "description": "A cloud function (FaaS)",
-                "hidden": true,
                 "sourceModule": "@winglang/sdk",
                 "title": "GET /:name/:age",
               },
@@ -3065,7 +3057,6 @@ exports.handler = async function(event) {
               },
               "display": {
                 "description": "A cloud function (FaaS)",
-                "hidden": true,
                 "sourceModule": "@winglang/sdk",
                 "title": "GET /:name",
               },
@@ -3395,7 +3386,6 @@ exports.handler = async function(event) {
               },
               "display": {
                 "description": "A cloud function (FaaS)",
-                "hidden": true,
                 "sourceModule": "@winglang/sdk",
                 "title": "GET /hello/foo",
               },
@@ -3836,7 +3826,6 @@ exports.handler = async function(event) {
               },
               "display": {
                 "description": "A cloud function (FaaS)",
-                "hidden": true,
                 "sourceModule": "@winglang/sdk",
                 "title": "GET /hello",
               },
@@ -3850,7 +3839,6 @@ exports.handler = async function(event) {
               },
               "display": {
                 "description": "A cloud function (FaaS)",
-                "hidden": true,
                 "sourceModule": "@winglang/sdk",
                 "title": "POST /hello",
               },
@@ -4293,7 +4281,6 @@ exports.handler = async function(event) {
               },
               "display": {
                 "description": "A cloud function (FaaS)",
-                "hidden": true,
                 "sourceModule": "@winglang/sdk",
                 "title": "GET /hello/world",
               },
@@ -4307,7 +4294,6 @@ exports.handler = async function(event) {
               },
               "display": {
                 "description": "A cloud function (FaaS)",
-                "hidden": true,
                 "sourceModule": "@winglang/sdk",
                 "title": "GET /hello/wingnuts",
               },
@@ -4633,7 +4619,6 @@ exports.handler = async function(event) {
               },
               "display": {
                 "description": "A cloud function (FaaS)",
-                "hidden": true,
                 "sourceModule": "@winglang/sdk",
                 "title": "GET /hello",
               },
@@ -4968,7 +4953,6 @@ exports.handler = async function(event) {
               },
               "display": {
                 "description": "A cloud function (FaaS)",
-                "hidden": true,
                 "sourceModule": "@winglang/sdk",
                 "title": "GET /users/:name",
               },
@@ -5295,7 +5279,6 @@ exports.handler = async function(event) {
               },
               "display": {
                 "description": "A cloud function (FaaS)",
-                "hidden": true,
                 "sourceModule": "@winglang/sdk",
                 "title": "POST /hello",
               },


### PR DESCRIPTION
This change makes `cloud.Api` endpoint functions visible in the Console's map view.