### PR TITLE
feat(sdk): fewer replacements for cloud.Service and sim.Resource

### DIFF
--- a/libs/wingsdk/src/shared/bundling.ts
+++ b/libs/wingsdk/src/shared/bundling.ts
@@ -125,8 +125,6 @@ export function createBundle(
     outfilePath: outfile,
     sourcemapPath: outfileMap,
     inputFiles,
-    // We track the start time so that bundles can be invalidated properly even
-    // if a source file changes after esbuild started bundling.
     time: startTime,
   };
 }

--- a/libs/wingsdk/src/shared/bundling.ts
+++ b/libs/wingsdk/src/shared/bundling.ts
@@ -49,13 +49,15 @@ export function createBundle(
 
   const stats = statSync(normalEntrypoint);
 
+  // Track what time we started bundling so we can invalidate the bundle if any
+  // of the source files are modified after this time.
   let startTime = new Date();
 
   // For unknown reasons, the date created here by JavaScript can sometimes be a
   // few milliseconds before the last modification date of the entrypoint file.
-  // This can cause the bundle to be invalidated when it shouldn't be. To avoid
-  // this, we check if the mtime of the entrypoint file is newer than the start
-  // time, and update the start time if it is.
+  // This can cause the bundle to be invalidated when it shouldn't be. To
+  // prevent this flakiness in unit tests, we check if the modification date of the
+  // entrypoint file and update the start time if it's newer.
   if (stats.mtime > startTime) {
     startTime = stats.mtime;
   }

--- a/libs/wingsdk/src/shared/bundling.ts
+++ b/libs/wingsdk/src/shared/bundling.ts
@@ -7,6 +7,9 @@ import { normalPath } from "./misc";
 
 const SDK_PATH = normalPath(resolve(__dirname, "..", ".."));
 
+// TODO: refactor Bundle into a dedicated class with methods to check if the bundling is
+// finished, invalidated, etc.
+
 export interface Bundle {
   directory: string;
   hash: string;

--- a/libs/wingsdk/src/shared/bundling.ts
+++ b/libs/wingsdk/src/shared/bundling.ts
@@ -1,5 +1,6 @@
 import * as crypto from "crypto";
-import { mkdirSync, realpathSync, writeFileSync } from "fs";
+import { mkdirSync, realpathSync, statSync, writeFileSync } from "fs";
+import { stat } from "fs/promises";
 import { posix, resolve } from "path";
 import { decode, encode } from "vlq";
 import { normalPath } from "./misc";
@@ -45,6 +46,19 @@ export function createBundle(
 
   const outfile = posix.join(outdir, outfileName);
   const outfileMap = posix.join(outdir, soucemapFilename);
+
+  const stats = statSync(normalEntrypoint);
+
+  let startTime = new Date();
+
+  // For unknown reasons, the date created here by JavaScript can sometimes be a
+  // few milliseconds before the last modification date of the entrypoint file.
+  // This can cause the bundle to be invalidated when it shouldn't be. To avoid
+  // this, we check if the mtime of the entrypoint file is newer than the start
+  // time, and update the start time if it is.
+  if (stats.mtime > startTime) {
+    startTime = stats.mtime;
+  }
 
   // eslint-disable-next-line import/no-extraneous-dependencies,@typescript-eslint/no-require-imports
   const esbuilder: typeof import("esbuild") = require("esbuild");
@@ -109,7 +123,9 @@ export function createBundle(
     outfilePath: outfile,
     sourcemapPath: outfileMap,
     inputFiles,
-    time: new Date(),
+    // We track the start time so that bundles can be invalidated properly even
+    // if a source file changes after esbuild started bundling.
+    time: startTime,
   };
 }
 
@@ -208,4 +224,61 @@ export function fixSourcemaps(sourcemapData: SourceMap): void {
   }
 
   sourcemapData.mappings = newMapping;
+}
+
+export async function filesModifiedSince(
+  filePaths: string[],
+  directory: string,
+  dateTime: Date
+): Promise<string[]> {
+  const absolutePaths = filePaths.map((filePath) =>
+    resolve(directory, filePath)
+  );
+
+  try {
+    const statsPromises = absolutePaths.map((filePath) => stat(filePath));
+    const stats = await Promise.all(statsPromises);
+    const changedFiles = new Array<string>();
+
+    for (let i = 0; i < absolutePaths.length; i++) {
+      if (stats[i].mtime > dateTime) {
+        console.error(
+          `File ${absolutePaths[i]} has been modified since the last bundle`,
+          stats[i].mtime,
+          dateTime
+        );
+        changedFiles.push(absolutePaths[i]);
+      }
+    }
+
+    return changedFiles;
+  } catch (error) {
+    console.error("Error checking file modification times:", error);
+    throw error;
+  }
+}
+
+export async function isBundleInvalidated(
+  entrypoint: string,
+  bundle: Bundle,
+  log?: (msg: string) => void
+): Promise<boolean> {
+  const modifiedFiles = await filesModifiedSince(
+    [entrypoint, ...bundle.inputFiles],
+    process.cwd(),
+    bundle.time
+  );
+  if (modifiedFiles.length === 0) {
+    return false;
+  }
+
+  if (process.env.DEBUG) {
+    log?.(
+      `Files modified since last bundling: [${modifiedFiles
+        .map((x) => `"${x}"`)
+        .join(", ")}]`
+    );
+  }
+
+  return true;
 }

--- a/libs/wingsdk/src/shared/sandbox.ts
+++ b/libs/wingsdk/src/shared/sandbox.ts
@@ -80,6 +80,7 @@ process.on("message", async (message) => {${debugShim}
 `;
 
     const wrappedPath = entrypoint.replace(/\.cjs$/, ".sandbox.cjs");
+
     writeFileSync(wrappedPath, contents); // async fsPromises.writeFile "flush" option is not available in Node 20
     const bundle = createBundle(wrappedPath);
 

--- a/libs/wingsdk/src/target-sim/service.inflight.ts
+++ b/libs/wingsdk/src/target-sim/service.inflight.ts
@@ -76,7 +76,6 @@ export class Service implements IServiceClient, ISimulatorResourceInstance {
     await this.ensureBundled();
 
     // Check if any of the bundled files have changed since the last bundling
-    // Check if any of the bundled files have changed since the last bundling
     const bundleInvalidated = await isBundleInvalidated(
       this.resolvedSourceCodeFile,
       this.bundle!,

--- a/libs/wingsdk/src/target-sim/service.inflight.ts
+++ b/libs/wingsdk/src/target-sim/service.inflight.ts
@@ -1,7 +1,7 @@
 import { resolve } from "path";
 import { ServiceAttributes, ServiceSchema } from "./schema-resources";
 import { IServiceClient, SERVICE_FQN } from "../cloud";
-import { Bundle } from "../shared/bundling";
+import { Bundle, isBundleInvalidated } from "../shared/bundling";
 import { Sandbox } from "../shared/sandbox";
 import {
   ISimulatorContext,
@@ -34,6 +34,13 @@ export class Service implements IServiceClient, ISimulatorResourceInstance {
     return this._context;
   }
 
+  private async ensureBundled(): Promise<void> {
+    await this.createBundlePromise;
+    if (!this.bundle) {
+      throw new Error("Bundle not created");
+    }
+  }
+
   private async createBundle(): Promise<void> {
     this.bundle = await Sandbox.createBundle(
       this.resolvedSourceCodeFile,
@@ -60,10 +67,26 @@ export class Service implements IServiceClient, ISimulatorResourceInstance {
 
   public async save(): Promise<void> {}
 
-  public async plan(): Promise<UpdatePlan> {
-    // for now, always replace because we can't determine if the function code
-    // has changed since the last update. see https://github.com/winglang/wing/issues/6116
-    return UpdatePlan.REPLACE;
+  public async plan(invalidated: boolean): Promise<UpdatePlan> {
+    if (invalidated) {
+      return UpdatePlan.REPLACE;
+    }
+
+    // Make sure that we don't have an ongoing bundle operation
+    await this.ensureBundled();
+
+    // Check if any of the bundled files have changed since the last bundling
+    // Check if any of the bundled files have changed since the last bundling
+    const bundleInvalidated = await isBundleInvalidated(
+      this.resolvedSourceCodeFile,
+      this.bundle!,
+      (msg) => this.addTrace(msg, TraceType.SIMULATOR, LogLevel.VERBOSE)
+    );
+    if (bundleInvalidated) {
+      return UpdatePlan.REPLACE;
+    }
+
+    return UpdatePlan.SKIP;
   }
 
   public async start(): Promise<void> {

--- a/libs/wingsdk/test/sim-app.ts
+++ b/libs/wingsdk/test/sim-app.ts
@@ -10,6 +10,10 @@ import { App } from "../src/target-sim/app";
  * @see AppProps
  */
 export interface SimAppProps {
+  /**
+   * The output directory for the synthesized app.
+   * @default - a fresh temporary directory
+   */
   readonly outdir?: string;
   readonly isTestEnvironment?: boolean;
   readonly rootConstruct?: any;

--- a/libs/wingsdk/test/sim-app.ts
+++ b/libs/wingsdk/test/sim-app.ts
@@ -10,6 +10,7 @@ import { App } from "../src/target-sim/app";
  * @see AppProps
  */
 export interface SimAppProps {
+  readonly outdir?: string;
   readonly isTestEnvironment?: boolean;
   readonly rootConstruct?: any;
 }
@@ -26,19 +27,25 @@ export class SimApp extends App {
   private functionIndex: number = 0;
 
   constructor(props: SimAppProps = {}) {
-    const { isTestEnvironment, rootConstruct } = props;
+    const { isTestEnvironment, rootConstruct, outdir } = props;
     super({
-      outdir: mkdtemp(),
+      outdir: outdir ?? mkdtemp(),
       entrypointDir: __dirname,
       isTestEnvironment,
       rootConstruct,
     });
 
     // symlink the node_modules so we can test imports and stuffs
-    fs.symlinkSync(
-      join(__dirname, "..", "node_modules"),
-      join(this.outdir, "node_modules")
-    );
+    try {
+      fs.symlinkSync(
+        join(__dirname, "..", "node_modules"),
+        join(this.outdir, "node_modules")
+      );
+    } catch (e) {
+      if (e.code !== "EEXIST") {
+        throw e;
+      }
+    }
   }
 
   /**

--- a/libs/wingsdk/test/simulator/simulator.test.ts
+++ b/libs/wingsdk/test/simulator/simulator.test.ts
@@ -12,7 +12,7 @@ import {
   OnDeploy,
   Service,
 } from "../../src/cloud";
-import { InflightBindings, inflight, lift } from "../../src/core";
+import { inflight, lift } from "../../src/core";
 import { Simulator } from "../../src/simulator";
 import { ITestRunnerClient, Test, TestResult, TraceType } from "../../src/std";
 import { State } from "../../src/target-sim";
@@ -20,6 +20,9 @@ import { SimApp } from "../sim-app";
 import { mkdtemp } from "../util";
 
 const NOOP = inflight(async () => {});
+const NOOP2 = inflight(async () => {
+  console.log("noop2");
+});
 const OK_200 = inflight(async () => ({ status: 200 }));
 
 describe("run single test", () => {
@@ -633,7 +636,7 @@ describe("in-place updates", () => {
 
     const myState2 = new State(app2, "State");
 
-    const myService2 = new Service(
+    new Service(
       app2,
       "Service",
       lift({ myState: myState2, stateKey })
@@ -702,7 +705,65 @@ describe("in-place updates", () => {
     ]);
   });
 
-  test("cloud.Service is always replaced", async () => {
+  test("cloud.Function is not replaced if its inflight code does not change", async () => {
+    const app = new SimApp();
+    new Function(app, "Function", NOOP);
+
+    const sim = await app.startSimulator();
+
+    // // cloud.Function bundles its code in the background,
+    // // so we're calling the function once to make sure the bundling finishes
+    // const fn = sim.getResource("/Function") as IFunctionClient;
+    // await fn.invoke();
+
+    const app2 = new SimApp();
+    new Function(app2, "Function", NOOP);
+
+    const app2Dir = app2.synth();
+    await sim.update(app2Dir);
+
+    expect(simTraces(sim)).toEqual([
+      "root/Function started",
+      "Update: 0 added, 0 updated, 0 deleted",
+    ]);
+  });
+
+  test("cloud.Function is replaced if its inflight code changes", async () => {
+    const outdir = mkdtemp();
+    console.log("outdir", outdir);
+
+    const app = new SimApp({ outdir });
+    new Function(app, "Function", NOOP);
+
+    const sim = await app.startSimulator();
+
+    // cloud.Function bundles its code in the background. Because of this, it's
+    // possible that the code later in this test that synthesizes a version of
+    // the app with new inflight code could run before the simulator's bundling starts,
+    // in which case no Function replacement would be necessary.
+    //
+    // Since we want to test the case where the Function is replaced, we need to
+    // make sure that the bundling finishes before we synthesize the new app.
+    // So we're calling the function (which blocks until the bundling finishes).
+    const fn = sim.getResource("/Function") as IFunctionClient;
+    await fn.invoke();
+    console.log("invoked function once", new Date());
+
+    const app2 = new SimApp({ outdir });
+    new Function(app2, "Function", NOOP2);
+
+    const app2Dir = app2.synth();
+    await sim.update(app2Dir);
+
+    expect(simTraces(sim)).toEqual([
+      "root/Function started",
+      "Update: 0 added, 1 updated, 0 deleted",
+      "root/Function stopped",
+      "root/Function started",
+    ]);
+  });
+
+  test("cloud.Service is not replaced if its inflight code does not change", async () => {
     const app = new SimApp();
     new Service(app, "Service", NOOP);
 
@@ -710,6 +771,26 @@ describe("in-place updates", () => {
 
     const app2 = new SimApp();
     new Service(app2, "Service", NOOP);
+
+    const app2Dir = app2.synth();
+    await sim.update(app2Dir);
+
+    expect(simTraces(sim)).toEqual([
+      "root/Service started",
+      "Update: 0 added, 0 updated, 0 deleted",
+    ]);
+  });
+
+  test("cloud.Service is replaced if its inflight code changes", async () => {
+    const outdir = mkdtemp();
+
+    const app = new SimApp({ outdir });
+    new Service(app, "Service", NOOP);
+
+    const sim = await app.startSimulator();
+
+    const app2 = new SimApp({ outdir });
+    new Service(app2, "Service", NOOP2);
 
     const app2Dir = app2.synth();
     await sim.update(app2Dir);

--- a/libs/wingsdk/test/simulator/simulator.test.ts
+++ b/libs/wingsdk/test/simulator/simulator.test.ts
@@ -711,11 +711,6 @@ describe("in-place updates", () => {
 
     const sim = await app.startSimulator();
 
-    // // cloud.Function bundles its code in the background,
-    // // so we're calling the function once to make sure the bundling finishes
-    // const fn = sim.getResource("/Function") as IFunctionClient;
-    // await fn.invoke();
-
     const app2 = new SimApp();
     new Function(app2, "Function", NOOP);
 
@@ -744,10 +739,9 @@ describe("in-place updates", () => {
     //
     // Since we want to test the case where the Function is replaced, we need to
     // make sure that the bundling finishes before we synthesize the new app.
-    // So we're calling the function (which blocks until the bundling finishes).
+    // So we invoke the function to block until the bundling finishes.
     const fn = sim.getResource("/Function") as IFunctionClient;
     await fn.invoke();
-    console.log("invoked function once", new Date());
 
     const app2 = new SimApp({ outdir });
     new Function(app2, "Function", NOOP2);


### PR DESCRIPTION
Extends the changes made in https://github.com/winglang/wing/pull/6577 for reducing the time it takes for the simulator to update to cloud.Service and sim.Resource.

## Checklist

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [x] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
