### PR TITLE
fix(console): runtime errors do not appear in the logs

### DIFF
--- a/apps/wing-console/console/app/src/index.ts
+++ b/apps/wing-console/console/app/src/index.ts
@@ -133,7 +133,7 @@ export const createConsoleApp = async (options: CreateConsoleAppOptions) => {
     },
     log: options.log ?? {
       info() {},
-      error: console.error,
+      error() {},
       warning() {},
       verbose() {},
     },

--- a/apps/wing-console/console/server/src/consoleLogger.ts
+++ b/apps/wing-console/console/server/src/consoleLogger.ts
@@ -89,7 +89,7 @@ export const createConsoleLogger = ({
           id: `${nanoid()}`,
           timestamp: Date.now(),
           level: "error",
-          message: `${source} - ${message}`,
+          message,
           source,
           ctx: context,
         });

--- a/apps/wing-console/console/server/src/consoleLogger.ts
+++ b/apps/wing-console/console/server/src/consoleLogger.ts
@@ -20,7 +20,7 @@ export interface LogEntry {
   timestamp?: number;
   level: LogLevel;
   message: string;
-  source: LogSource;
+  source?: LogSource;
   ctx?: LogContext;
 }
 
@@ -84,7 +84,6 @@ export const createConsoleLogger = ({
     error(error, source, context) {
       log.error(error);
       const message = errorMessage(error);
-      if (source === "user") {
         this.messages.push({
           id: `${nanoid()}`,
           timestamp: Date.now(),
@@ -93,7 +92,6 @@ export const createConsoleLogger = ({
           source,
           ctx: context,
         });
-      }
       onLog("error", message);
     },
   };

--- a/apps/wing-console/console/server/src/consoleLogger.ts
+++ b/apps/wing-console/console/server/src/consoleLogger.ts
@@ -84,14 +84,16 @@ export const createConsoleLogger = ({
     error(error, source, context) {
       log.error(error);
       const message = errorMessage(error);
-      this.messages.push({
-        id: `${nanoid()}`,
-        timestamp: Date.now(),
-        level: "error",
-        message,
-        source,
-        ctx: context,
-      });
+      if (source === "user") {
+        this.messages.push({
+          id: `${nanoid()}`,
+          timestamp: Date.now(),
+          level: "error",
+          message: `${source} - ${message}`,
+          source,
+          ctx: context,
+        });
+      }
       onLog("error", message);
     },
   };

--- a/apps/wing-console/console/server/src/consoleLogger.ts
+++ b/apps/wing-console/console/server/src/consoleLogger.ts
@@ -20,7 +20,7 @@ export interface LogEntry {
   timestamp?: number;
   level: LogLevel;
   message: string;
-  source: LogSource;
+  source?: LogSource;
   ctx?: LogContext;
 }
 
@@ -46,54 +46,48 @@ export const createConsoleLogger = ({
   return {
     messages: new Array<LogEntry>(),
     verbose(message, source, context) {
-      log.info(message);
       this.messages.push({
         id: `${nanoid()}`,
         timestamp: Date.now(),
         level: "verbose",
         message,
-        source: source ?? "simulator",
+        source,
         ctx: context,
       });
       onLog("verbose", message);
     },
     log(message, source, context) {
-      log.info(message);
       this.messages.push({
         id: `${nanoid()}`,
         timestamp: Date.now(),
         level: "info",
         message,
-        source: source ?? "simulator",
+        source,
         ctx: context,
       });
       onLog("info", message);
     },
     warning(message, source, context) {
-      log.warning(message);
       this.messages.push({
         id: `${nanoid()}`,
         timestamp: Date.now(),
         level: "warn",
         message,
-        source: source ?? "simulator",
+        source,
         ctx: context,
       });
       onLog("warn", message);
     },
     error(error, source, context) {
-      log.error(error);
       const message = errorMessage(error);
-      if (source === "user") {
-        this.messages.push({
-          id: `${nanoid()}`,
-          timestamp: Date.now(),
-          level: "error",
-          message,
-          source,
-          ctx: context,
-        });
-      }
+      this.messages.push({
+        id: `${nanoid()}`,
+        timestamp: Date.now(),
+        level: "error",
+        message,
+        source,
+        ctx: context,
+      });
       onLog("error", message);
     },
   };

--- a/apps/wing-console/console/server/src/consoleLogger.ts
+++ b/apps/wing-console/console/server/src/consoleLogger.ts
@@ -84,14 +84,14 @@ export const createConsoleLogger = ({
     error(error, source, context) {
       log.error(error);
       const message = errorMessage(error);
-        this.messages.push({
-          id: `${nanoid()}`,
-          timestamp: Date.now(),
-          level: "error",
-          message,
-          source,
-          ctx: context,
-        });
+      this.messages.push({
+        id: `${nanoid()}`,
+        timestamp: Date.now(),
+        level: "error",
+        message,
+        source,
+        ctx: context,
+      });
       onLog("error", message);
     },
   };

--- a/apps/wing-console/console/server/src/consoleLogger.ts
+++ b/apps/wing-console/console/server/src/consoleLogger.ts
@@ -5,7 +5,7 @@ import type { LogInterface } from "./utils/LogInterface.js";
 
 export type LogLevel = "verbose" | "info" | "warn" | "error";
 
-export type LogSource = "compiler" | "console" | "simulator" | "user";
+export type LogSource = "simulator" | "user";
 
 export interface LogContext {
   sourceType?: string;
@@ -52,7 +52,7 @@ export const createConsoleLogger = ({
         timestamp: Date.now(),
         level: "verbose",
         message,
-        source: source ?? "console",
+        source: source ?? "simulator",
         ctx: context,
       });
       onLog("verbose", message);
@@ -64,7 +64,7 @@ export const createConsoleLogger = ({
         timestamp: Date.now(),
         level: "info",
         message,
-        source: source ?? "console",
+        source: source ?? "simulator",
         ctx: context,
       });
       onLog("info", message);
@@ -76,7 +76,7 @@ export const createConsoleLogger = ({
         timestamp: Date.now(),
         level: "warn",
         message,
-        source: source ?? "console",
+        source: source ?? "simulator",
         ctx: context,
       });
       onLog("warn", message);
@@ -93,6 +93,8 @@ export const createConsoleLogger = ({
           source,
           ctx: context,
         });
+      } else {
+        console.log({ source });
       }
       onLog("error", message);
     },

--- a/apps/wing-console/console/server/src/consoleLogger.ts
+++ b/apps/wing-console/console/server/src/consoleLogger.ts
@@ -46,7 +46,6 @@ export const createConsoleLogger = ({
   return {
     messages: new Array<LogEntry>(),
     verbose(message, source, context) {
-      log.info(message);
       this.messages.push({
         id: `${nanoid()}`,
         timestamp: Date.now(),
@@ -58,7 +57,6 @@ export const createConsoleLogger = ({
       onLog("verbose", message);
     },
     log(message, source, context) {
-      log.info(message);
       this.messages.push({
         id: `${nanoid()}`,
         timestamp: Date.now(),
@@ -70,7 +68,6 @@ export const createConsoleLogger = ({
       onLog("info", message);
     },
     warning(message, source, context) {
-      log.warning(message);
       this.messages.push({
         id: `${nanoid()}`,
         timestamp: Date.now(),
@@ -82,7 +79,6 @@ export const createConsoleLogger = ({
       onLog("warn", message);
     },
     error(error, source, context) {
-      log.error(error);
       const message = errorMessage(error);
       if (source === "user") {
         this.messages.push({
@@ -94,7 +90,7 @@ export const createConsoleLogger = ({
           ctx: context,
         });
       } else {
-        console.log({ source });
+        log.error(error);
       }
       onLog("error", message);
     },

--- a/apps/wing-console/console/server/src/consoleLogger.ts
+++ b/apps/wing-console/console/server/src/consoleLogger.ts
@@ -20,7 +20,7 @@ export interface LogEntry {
   timestamp?: number;
   level: LogLevel;
   message: string;
-  source?: LogSource;
+  source: LogSource;
   ctx?: LogContext;
 }
 

--- a/apps/wing-console/console/server/src/consoleLogger.ts
+++ b/apps/wing-console/console/server/src/consoleLogger.ts
@@ -46,6 +46,7 @@ export const createConsoleLogger = ({
   return {
     messages: new Array<LogEntry>(),
     verbose(message, source, context) {
+      log.info(message);
       this.messages.push({
         id: `${nanoid()}`,
         timestamp: Date.now(),
@@ -57,6 +58,7 @@ export const createConsoleLogger = ({
       onLog("verbose", message);
     },
     log(message, source, context) {
+      log.info(message);
       this.messages.push({
         id: `${nanoid()}`,
         timestamp: Date.now(),
@@ -68,6 +70,7 @@ export const createConsoleLogger = ({
       onLog("info", message);
     },
     warning(message, source, context) {
+      log.warning(message);
       this.messages.push({
         id: `${nanoid()}`,
         timestamp: Date.now(),
@@ -79,6 +82,7 @@ export const createConsoleLogger = ({
       onLog("warn", message);
     },
     error(error, source, context) {
+      log.error(error);
       const message = errorMessage(error);
       if (source === "user") {
         this.messages.push({
@@ -89,8 +93,6 @@ export const createConsoleLogger = ({
           source,
           ctx: context,
         });
-      } else {
-        log.error(error);
       }
       onLog("error", message);
     },

--- a/apps/wing-console/console/server/src/index.ts
+++ b/apps/wing-console/console/server/src/index.ts
@@ -256,7 +256,7 @@ export const createConsoleServer = async ({
 
       case "error": {
         const output = trace.data.error
-          ? `${trace.data.message}: ${await formatTraceError(trace.data.error)}`
+          ? await formatTraceError(trace.data.error)
           : message;
 
         consoleLogger.error(output, source, {

--- a/apps/wing-console/console/server/src/index.ts
+++ b/apps/wing-console/console/server/src/index.ts
@@ -353,14 +353,8 @@ export const createConsoleServer = async ({
 };
 
 function logSourceFromTraceType(trace: Trace): LogSource {
-  switch (trace.type) {
-    case "simulator": {
-      return "simulator";
-    }
-
-    case "resource": {
-      return "compiler";
-    }
+  if (trace.type === "simulator") {
+    return "simulator";
   }
 
   return "user";

--- a/apps/wing-console/console/server/src/index.ts
+++ b/apps/wing-console/console/server/src/index.ts
@@ -256,7 +256,7 @@ export const createConsoleServer = async ({
 
       case "error": {
         const output = trace.data.error
-          ? await formatTraceError(trace.data.error)
+          ? `${trace.data.message}: ${await formatTraceError(trace.data.error)}`
           : message;
 
         consoleLogger.error(output, source, {

--- a/apps/wing-console/console/server/src/router/test.ts
+++ b/apps/wing-console/console/server/src/router/test.ts
@@ -19,7 +19,7 @@ const listTests = (simulator: Simulator): Promise<string[]> => {
 };
 
 const reloadSimulator = async (simulator: Simulator, logger: ConsoleLogger) => {
-  logger.verbose("Reloading simulator...", "console", {
+  logger.verbose("Reloading simulator...", "simulator", {
     messageType: "info",
   });
   await simulator.reload(true);
@@ -62,21 +62,21 @@ const runTest = async (
       `Test "${getTestName(resourcePath)}" succeeded (${
         Date.now() - startTime
       }ms)`,
-      "console",
+      "simulator",
       {
         messageType: "success",
       },
     );
   } catch (error: any) {
     let output = await formatTraceError(error?.message);
-    logger.log(output, "console", {
+    logger.log(output, "simulator", {
       messageType: "fail",
     });
     logger.log(
       `Test "${getTestName(resourcePath)}" failed (${
         Date.now() - startTime
       }ms)`,
-      "console",
+      "simulator",
       {
         messageType: "fail",
       },
@@ -159,7 +159,7 @@ export const createTestRouter = () => {
       const time = result.reduce((accumulator, r) => accumulator + r.time, 0);
 
       const message = `Tests completed: ${testPassed.length}/${testList.length} passed. (${time}ms)`;
-      ctx.logger.log(message, "console", {
+      ctx.logger.log(message, "simulator", {
         messageType: "summary",
       });
 

--- a/libs/wingsdk/src/simulator/simulator.ts
+++ b/libs/wingsdk/src/simulator/simulator.ts
@@ -931,7 +931,7 @@ export class Simulator {
               status: "failure",
             },
             type: TraceType.RESOURCE,
-            level: LogLevel.VERBOSE,
+            level: LogLevel.ERROR,
             sourcePath: resourceConfig.path,
             sourceType: resourceConfig.type,
             timestamp: new Date().toISOString(),

--- a/libs/wingsdk/test/simulator/__snapshots__/simulator.test.ts.snap
+++ b/libs/wingsdk/test/simulator/__snapshots__/simulator.test.ts.snap
@@ -115,7 +115,7 @@ exports[`run single test > test failure 1`] = `
         "message": "Error: test failed (Invoke (payload=undefined).)",
         "status": "failure",
       },
-      "level": "verbose",
+      "level": "error",
       "sourcePath": "root/test/Handler",
       "sourceType": "@winglang/sdk.cloud.Function",
       "timestamp": "<TIMESTAMP>",

--- a/tools/hangar/__snapshots__/error.ts.snap
+++ b/tools/hangar/__snapshots__/error.ts.snap
@@ -30,7 +30,52 @@ Duration <DURATION>"
 `;
 
 exports[`inflight_stacktraces.test.w 1`] = `
-"fail ┌ inflight_stacktraces.test.wsim » root/env0/test:assert              
+"[ERROR] assert | Error: assertion failed: false
+  --> ../../../examples/tests/error/inflight_stacktraces.test.w:7:3
+  | let bucket = new cloud.Bucket();
+  | 
+  | test \\"assert\\" {
+7 |   assert(false);
+  |   ^
+at <ABSOLUTE>/inflight_stacktraces.test.w:7:3
+[ERROR] expect.equal | Error: Expected values to be strictly deep-equal:
+
+1 !== 2
+
+   --> ../../../examples/tests/error/inflight_stacktraces.test.w:11:3
+   | }
+   | 
+   | test \\"expect.equal\\" {
+11 |   expect.equal(1,2 );
+   |   ^
+at <ABSOLUTE>/inflight_stacktraces.test.w:11:3
+[ERROR] bucket failed delete | Error: Object does not exist (key=doesn't exist).
+[ERROR] bucket failed delete | Error: Object does not exist (key=doesn't exist).
+   --> ../../../examples/tests/error/inflight_stacktraces.test.w:15:3
+   | }
+   | 
+   | test \\"bucket failed delete\\" {
+15 |   bucket.delete(\\"doesn't exist\\", mustExist: true);
+   |   ^
+at <ABSOLUTE>/inflight_stacktraces.test.w:15:3
+[ERROR] throw from closure | Error: ouch
+   --> ../../../examples/tests/error/inflight_stacktraces.test.w:20:5
+   | 
+   | test \\"throw from closure\\" {
+   |   let closure = inflight () => {
+20 |     throw \\"ouch\\";
+   |     ^
+at closure <ABSOLUTE>/inflight_stacktraces.test.w:20:5
+at <ABSOLUTE>/inflight_stacktraces.test.w:22:3
+[ERROR] assert with message | Error: assertion failed: x is false
+   --> ../../../examples/tests/error/inflight_stacktraces.test.w:27:3
+   | 
+   | test \\"assert with message\\" {
+   |   let x = false;
+27 |   assert(x, \\"x is false\\");
+   |   ^
+at <ABSOLUTE>/inflight_stacktraces.test.w:27:3
+fail ┌ inflight_stacktraces.test.wsim » root/env0/test:assert              
      │ Error: assertion failed: false
      │   --> ../../../examples/tests/error/inflight_stacktraces.test.w:7:3
      │   | let bucket = new cloud.Bucket();

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/copy.test.w_test_sim.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/copy.test.w_test_sim.md
@@ -2,6 +2,7 @@
 
 ## stdout.log
 ```log
+[ERROR] copy() | Error: Source object does not exist (srcKey=no-such-file.txt).
 pass ─ copy.test.wsim » root/env0/test:copy()
 
 Tests 1 passed (1)

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/delete.test.w_test_sim.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/delete.test.w_test_sim.md
@@ -2,6 +2,7 @@
 
 ## stdout.log
 ```log
+[ERROR] delete | Error: Object does not exist (key=file1.json).
 pass ─ delete.test.wsim » root/env0/test:delete
 
 Tests 1 passed (1)

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/get.test.w_test_sim.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/get.test.w_test_sim.md
@@ -2,6 +2,10 @@
 
 ## stdout.log
 ```log
+[ERROR] get range of an object | Error: Object content could not be read as text (key=test2.txt): TypeError: The encoded data was not valid for encoding utf-8
+    at TextDecoder.decode (node:internal/encoding:449:16)
+    at Object.activity (<ABSOLUTE>:LINE:COL)
+    at async Object.withTrace (<ABSOLUTE>:LINE:COL))}
 pass ─ get.test.wsim » root/env0/test:get range of an object
 pass ─ get.test.wsim » root/env1/test:get empty object      
 

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/metadata.test.w_test_sim.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/metadata.test.w_test_sim.md
@@ -2,6 +2,7 @@
 
 ## stdout.log
 ```log
+[ERROR] metadata() | Error: Object does not exist (key=no-such-file.txt).
 pass ─ metadata.test.wsim » root/env0/test:metadata()
 
 Tests 1 passed (1)

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/rename.test.w_test_sim.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/rename.test.w_test_sim.md
@@ -2,6 +2,7 @@
 
 ## stdout.log
 ```log
+[ERROR] rename() | Error: Source object does not exist (srcKey=no-such-obj.txt).
 pass ─ rename.test.wsim » root/env0/test:rename()
 
 Tests 1 passed (1)

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/function/aws-function.test.w_test_sim.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/function/aws-function.test.w_test_sim.md
@@ -2,6 +2,14 @@
 
 ## stdout.log
 ```log
+[ERROR] can access lambda context | Error: fake error
+   --> aws-function.test.w:43:5
+   | 
+   | let fn = new cloud.Function(inflight (msg: str?) => {
+   |   if msg == "error" {
+43 |     throw "fake error";
+   |     ^
+at <ABSOLUTE>/aws-function.test.w:43:5
 pass ─ aws-function.test.wsim » root/env0/test:validates the AWS Function
 pass ─ aws-function.test.wsim » root/env1/test:can access lambda context 
 

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/function/concurrency.test.w_test_sim.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/function/concurrency.test.w_test_sim.md
@@ -2,6 +2,7 @@
 
 ## stdout.log
 ```log
+[ERROR] f1 concurrency limit reached | Error: Too many requests, the function has reached its concurrency limit.
 [INFO] queue applies backpressure to functions with limited concurrency | c: 3
 pass ─ concurrency.test.wsim » root/env0/test:f1 concurrency limit reached                                    
 pass ─ concurrency.test.wsim » root/env1/test:queue applies backpressure to functions with limited concurrency

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/function/timeout.test.w_test_sim.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/function/timeout.test.w_test_sim.md
@@ -2,6 +2,8 @@
 
 ## stdout.log
 ```log
+[ERROR] (no test) | Error: Function timed out (it was configured with a timeout of 1000ms).
+[ERROR] (no test) | Error: Function timed out (it was configured with a timeout of 60000ms).
 pass ─ timeout.test.wsim » root/env0/function invoke throws on timeout
 
 Tests 1 passed (1)

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/queue/push.test.w_test_sim.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/queue/push.test.w_test_sim.md
@@ -2,6 +2,8 @@
 
 ## stdout.log
 ```log
+[ERROR] (no test) | Error: Empty messages are not allowed
+[ERROR] (no test) | Error: Empty messages are not allowed
 pass ─ push.test.wsim » root/env0/push
 
 Tests 1 passed (1)

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/resource/call.test.w_test_sim.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/resource/call.test.w_test_sim.md
@@ -2,11 +2,23 @@
 
 ## stdout.log
 ```log
+[ERROR] resource.call with a field name returns the field value | Error: Property "field1" is not a function
+[ERROR] resource.call with a field name returns the field value | Error: Method or property "invalidField" not found
+[ERROR] resource.call cannot be used to call onStop | Error: Cannot call "onStop"
+[ERROR] exceptions thrown by the resource are caught and rethrown by the caller | Error: Look ma, an error!
+   --> call.test.w:30:5
+   | pub onStop() {}
+   | 
+   | pub throwsError() {
+30 |   throw "Look ma, an error!";
+   |   ^
+at throwsError <ABSOLUTE>/call.test.w:30:5
 [INFO] resource can log messages at different levels | a regular (info) log
 [INFO] resource can log messages at different levels | an info log
 [INFO] resource can log messages at different levels | another info log
 [WARNING] resource can log messages at different levels | a warn log
 [ERROR] resource can log messages at different levels | Error: an error log
+[ERROR] resource.call times out if the method takes too long | Error: Call to resource "root/env5/MyResource/Resource" timed out after 30000ms
 [ERROR] resource.call times out if the method takes too long | Error: Resource is not running (it may have crashed or stopped)
 pass ─ call.test.wsim » root/env0/test:resource.call with a field name returns the field value                
 pass ─ call.test.wsim » root/env1/test:resource.call cannot be used to call onStop                            

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/resource/on-start.test.w_test_sim.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/resource/on-start.test.w_test_sim.md
@@ -12,6 +12,7 @@
 at $inflight_init <ABSOLUTE>/on-start.test.w:6:5
 at <ABSOLUTE>/on-start.test.w:17:18
 [ERROR] method calls fail if the resource fails to start | Error: Resource is not running (it may have crashed or stopped)
+[ERROR] method calls fail if the resource fails to start | Error: Resource is not running (it may have crashed or stopped)
 pass ─ on-start.test.wsim » root/env0/test:method calls fail if the resource fails to start
 
 Tests 1 passed (1)

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/resource/tokens.test.w_test_sim.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/resource/tokens.test.w_test_sim.md
@@ -2,6 +2,14 @@
 
 ## stdout.log
 ```log
+[ERROR] calling resolveToken during a method call emits an error | Error: cannot resolve attributes outside of onStop method
+   --> tokens.test.w:10:5
+   | pub onStop() {}
+   | 
+   | pub foo() {
+10 |   this.ctx.resolveToken("my-attr", "value");
+   |   ^
+at foo <ABSOLUTE>/tokens.test.w:10:5
 pass ─ tokens.test.wsim » root/env0/test:calling resolveToken during a method call emits an error
 
 Tests 1 passed (1)

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/table/get.test.w_test_sim.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/table/get.test.w_test_sim.md
@@ -2,6 +2,7 @@
 
 ## stdout.log
 ```log
+[ERROR] get | Error: Row does not exist (key=bar)
 pass ─ get.test.wsim » root/env0/test:get
 
 Tests 1 passed (1)


### PR DESCRIPTION
In some instances, runtime errors when invoking `cloud.Function` won't appear in the logs, or they may appear under Verbose logs.

Related to #6622 but doesn't close it.