### PR TITLE
fix(compiler): implicit optional args not working (sometimes) for methods

### DIFF
--- a/examples/tests/valid/function_optional_arguments.test.w
+++ b/examples/tests/valid/function_optional_arguments.test.w
@@ -71,3 +71,18 @@ assert(fn4(opt1: "hey") == "hey 0");
 assert(fn4({}) == "none 0");
 // Use default
 assert(fn4() == "none");
+
+// Test implicitly optional named args used within methods
+class Foo {
+  pub static staticMethod(opts: ImplitictlyOptionalOptions): str {
+    return "{opts.opt1 ?? "none"} {opts.opt2 ?? 0}";
+  }
+
+  pub method(opts: ImplitictlyOptionalOptions): str {
+    return "{opts.opt1 ?? "none"} {opts.opt2 ?? 0}";
+  }
+}
+
+let foo = new Foo();
+assert(foo.method() == "none 0");
+assert(Foo.staticMethod() == "none 0");

--- a/libs/wingc/src/fold.rs
+++ b/libs/wingc/src/fold.rs
@@ -521,15 +521,16 @@ pub fn fold_args<F>(f: &mut F, node: ArgList) -> ArgList
 where
 	F: Fold + ?Sized,
 {
-	ArgList::new(
-		node.pos_args.into_iter().map(|arg| f.fold_expr(arg)).collect(),
-		node
+	ArgList {
+		pos_args: node.pos_args.into_iter().map(|arg| f.fold_expr(arg)).collect(),
+		named_args: node
 			.named_args
 			.into_iter()
 			.map(|(name, arg)| (f.fold_symbol(name), f.fold_expr(arg)))
 			.collect(),
-		node.span,
-	)
+		span: node.span,
+		id: node.id,
+	}
 }
 
 pub fn fold_type_annotation<F>(f: &mut F, node: TypeAnnotation) -> TypeAnnotation

--- a/tools/hangar/__snapshots__/test_corpus/valid/function_optional_arguments.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/function_optional_arguments.test.w_compile_tf-aws.md
@@ -1,5 +1,19 @@
 # [function_optional_arguments.test.w](../../../../../examples/tests/valid/function_optional_arguments.test.w) | compile | tf-aws
 
+## inflight.Foo-1.cjs
+```cjs
+"use strict";
+const $helpers = require("@winglang/sdk/lib/helpers");
+module.exports = function({  }) {
+  class Foo {
+    constructor({  }) {
+    }
+  }
+  return Foo;
+}
+//# sourceMappingURL=inflight.Foo-1.cjs.map
+```
+
 ## main.tf.json
 ```json
 {
@@ -32,6 +46,40 @@ const $extern = $helpers.createExternRequire(__dirname);
 class $Root extends $stdlib.std.Resource {
   constructor($scope, $id) {
     super($scope, $id);
+    class Foo extends $stdlib.std.Resource {
+      constructor($scope, $id, ) {
+        super($scope, $id);
+      }
+      static staticMethod($scope, opts) {
+        return String.raw({ raw: ["", " ", ""] }, (opts.opt1 ?? "none"), (opts.opt2 ?? 0));
+      }
+      method(opts) {
+        return String.raw({ raw: ["", " ", ""] }, (opts.opt1 ?? "none"), (opts.opt2 ?? 0));
+      }
+      static _toInflightType() {
+        return `
+          require("${$helpers.normalPath(__dirname)}/inflight.Foo-1.cjs")({
+          })
+        `;
+      }
+      _toInflight() {
+        return `
+          (await (async () => {
+            const FooClient = ${Foo._toInflightType()};
+            const client = new FooClient({
+            });
+            if (client.$inflight_init) { await client.$inflight_init(); }
+            return client;
+          })())
+        `;
+      }
+      get _liftMap() {
+        return ({
+          "$inflight_init": [
+          ],
+        });
+      }
+    }
     const fn1 = ((opts) => {
       return String.raw({ raw: ["", " ", ""] }, opts.opt1, opts.opt2);
     });
@@ -77,6 +125,9 @@ class $Root extends $stdlib.std.Resource {
     $helpers.assert($helpers.eq((fn4({ opt1: "hey" })), "hey 0"), "fn4(opt1: \"hey\") == \"hey 0\"");
     $helpers.assert($helpers.eq((fn4(({}))), "none 0"), "fn4({}) == \"none 0\"");
     $helpers.assert($helpers.eq((fn4()), "none"), "fn4() == \"none\"");
+    const foo = new Foo(this, "Foo");
+    $helpers.assert($helpers.eq((foo.method({  })), "none 0"), "foo.method() == \"none 0\"");
+    $helpers.assert($helpers.eq((Foo.staticMethod(this, {  })), "none 0"), "Foo.staticMethod() == \"none 0\"");
   }
 }
 const $PlatformManager = new $stdlib.platform.PlatformManager({platformPaths: $platforms});


### PR DESCRIPTION
fixes #6559

The fold mechanism re-generated the IDs used to identify argument lists in the AST. This means that even though we currently detected implicitly optional arguments we lost that information after the closure transform forld operation. I fixed the default fold implementation not to regenerated these IDs, similar to how we preserve expresion IDs during folds, for example.

## Checklist

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [x] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
