### PR TITLE
chore: avoid full wasm optimizations in development

### DIFF
--- a/libs/wingc/package.json
+++ b/libs/wingc/package.json
@@ -2,7 +2,7 @@
   "name": "@winglang/wingc",
   "private": true,
   "scripts": {
-    "compile": "cargo build --target wasm32-wasi --release && ../../.cargo/binaryen-version_117/bin/wasm-opt --enable-bulk-memory --strip-debug --strip-producers -O3 -o wingc.wasm ../../target/wasm32-wasi/release/wingc.wasm",
+    "compile": "cargo build --target wasm32-wasi --release && ./scripts/postcompile.sh",
     "dev": "cargo run --example compile --release",
     "test": "cargo test",
     "lint": "cargo fmt && cargo clippy --fix --no-deps --allow-dirty --target wasm32-wasi --release"

--- a/libs/wingc/scripts/postcompile.sh
+++ b/libs/wingc/scripts/postcompile.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+###
+# This script should be run after release build of wingc to the wasm32-wasi target.
+# The end result will be a final wasm file in the wingc directory.
+# If running in CI (env "CI" is set), it will run wasm-opt on the generated wasm file.
+# Otherwise, the wasm file will be copied to the wingc directory from its original output location.
+###
+
+wingc=$(cd $(dirname $0)/.. && pwd)
+
+# Currently we only do release wasm builds
+target="release"
+
+wasm_opt="$wingc/../../.cargo/binaryen-version_117/bin/wasm-opt"
+input_wasm="$wingc/../../target/wasm32-wasi/$target/wingc.wasm"
+output_wasm="$wingc/wingc.wasm"
+
+# If CI env is set, run wasm-opt with extra optimizations
+echo "Optimising wasm..."
+if [ -n "$CI" ]; then
+  $wasm_opt --enable-bulk-memory --strip-debug --strip-producers -O3 -o $output_wasm $input_wasm
+else
+  $wasm_opt --enable-bulk-memory --strip-debug --strip-producers -o $output_wasm $input_wasm
+fi
+echo "Done!"

--- a/libs/wingc/turbo.json
+++ b/libs/wingc/turbo.json
@@ -4,6 +4,7 @@
   "pipeline": {
     "compile": {
       "dependsOn": ["@winglang/wingii#compile", "@winglang/tree-sitter-wing#compile"],
+      "inputs": ["$TURBO_DEFAULT$", "scripts/postcompile.sh"],
       "outputs": [
         "../../target/wasm32-wasi/release/wingc.wasm",
         "../../target/wasm32-wasi/release/libwingc.*",


### PR DESCRIPTION
The `-O3` level optimization for wingc's wasm is pretty slow but worth keeping in for the final build.
For local dev it's still valuable to run wasm-opt with some optimization as it greatly reduces the size of the wasm file, which then improves performance when JS loads it. The base level optimization runs in like 500ms on my machine so it's not much of a problem.

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
