### PR TITLE
chore: remove usage of `$TURBO_DEFAULT$` in turbo.json

### DIFF
--- a/libs/wingc/turbo.json
+++ b/libs/wingc/turbo.json
@@ -23,7 +23,7 @@
       ]
     },
     "dev": {
-      "inputs": ["examples/**/*.rs"],
+      "inputs": ["*.json", "*.toml", "src/**/*.rs", "examples/**/*.rs"],
       "dependsOn": ["@winglang/sdk#compile"]
     }
   }

--- a/libs/wingc/turbo.json
+++ b/libs/wingc/turbo.json
@@ -3,8 +3,11 @@
   "extends": ["//"],
   "pipeline": {
     "compile": {
-      "dependsOn": ["@winglang/wingii#compile", "@winglang/tree-sitter-wing#compile"],
-      "inputs": ["$TURBO_DEFAULT$", "scripts/postcompile.sh"],
+      "dependsOn": [
+        "@winglang/wingii#compile",
+        "@winglang/tree-sitter-wing#compile"
+      ],
+      "inputs": ["*.json", "*.toml", "src/**/*.rs", "scripts/postcompile.sh"],
       "outputs": [
         "../../target/wasm32-wasi/release/wingc.wasm",
         "../../target/wasm32-wasi/release/libwingc.*",
@@ -12,9 +15,15 @@
       ]
     },
     "test": {
-      "dependsOn": ["@winglang/tree-sitter-wing#compile", "@winglang/sdk#compile", "examples-valid#topo", "examples-invalid#topo"]
+      "dependsOn": [
+        "@winglang/tree-sitter-wing#compile",
+        "@winglang/sdk#compile",
+        "examples-valid#topo",
+        "examples-invalid#topo"
+      ]
     },
     "dev": {
+      "inputs": ["examples/**/*.rs"],
       "dependsOn": ["@winglang/sdk#compile"]
     }
   }


### PR DESCRIPTION
Either I misunderstood the usage of `$TURBO_DEFAULT$` or it just doesn't work 🤷
https://turbo.build/repo/docs/reference/configuration#turbo_default

Regardless, adding specific inputs here isn't hard since there are so few

Fixes #6658