### PR TITLE
docs(docs): community url update

### DIFF
--- a/docs/docs/01-start-here/02-getting-started.md
+++ b/docs/docs/01-start-here/02-getting-started.md
@@ -14,7 +14,7 @@ This guide will walk you through the steps to setup Wing on your machine, create
 
 :::info
 
-Wing is still in active development, and we would love to hear what you think! Please ping us on [Wing Slack](https://t.winglang.io/slack), share what you want to build
+Wing is still in active development, and we would love to hear what you think! Please ping us on [Wing Discord](https://t.winglang.io/discord), share what you want to build
 and let us know if you encounter any issues. There's also a cute channel with music recommendations 🎶
 
 :::


### PR DESCRIPTION
Minor fix to docs. Things have been moved from Slack to Discord. The previous URL was directing to Discord so just changing this to reflect what is happening.

_I see docs are also over on https://github.com/winglang/docsite, which is the source of truth? I assume with the activity this one? Let me know if that's right 👍_

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
