### PR TITLE
docs(docs): azure and gcp links updated

### DIFF
--- a/docs/docs/01-start-here/05-aws.md
+++ b/docs/docs/01-start-here/05-aws.md
@@ -23,7 +23,7 @@ resources, using Terraform as the provisioning engine.
 
 :::info Under Construction
 
-:construction: We plan to also support [Azure](https://github.com/winglang/wing/issues?q=is:issue+is:open+sort:updated-desc+label:"☁️ azure") and [Google Cloud](https://github.com/winglang/wing/issues?q=is:issue+is:open+sort:updated-desc+label:"☁️ gcp") as platforms out of
+:construction: We plan to also support [Azure](https://github.com/winglang/wing/issues?q=is:issue+is:open+sort:updated-desc+label:%22☁️%20azure%22) and [Google Cloud](https://github.com/winglang/wing/issues?q=is:issue+is:open+sort:updated-desc+label:%22☁️%20gcp%22) as platforms out of
 the box. In addition, we are planning support for other provisioning engines
 such as AWS CloudFormation and Kubernetes.
 


### PR DESCRIPTION
Fix for #6669.

Look like the Urls needed to be encoded to work on the doc site.

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
