### PR TITLE
docs(docs): add link to wing templates

### DIFF
--- a/docs/docs/06-tools/01-cli.md
+++ b/docs/docs/06-tools/01-cli.md
@@ -33,7 +33,7 @@ Usage:
 $ wing new <template>
 ```
 
-Run `wing new` without any arguments to view the available templates.
+Run `wing new` without any arguments to view the available templates or you can [view the templates on GitHub](https://github.com/winglang/wing/tree/main/apps/wing/project-templates/wing).
 
 ## Run: `wing run|it`
 


### PR DESCRIPTION
Watching the [latest wing update](https://youtu.be/30DVoyAuwP0?si=plqoNGSMhEkNM-PA&t=478) it was great to see the new slack template, but from what I understand the docs don't explain or link to the templates.

I know we can see templates using the CLI, but this is just small change to help users find templates in other ways.

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
