### PR TITLE
chore: missing import in wing framework docs

### DIFF
--- a/docs/docs/09-typescript/02-inflights.md
+++ b/docs/docs/09-typescript/02-inflights.md
@@ -54,7 +54,7 @@ main((root) => {
 Inflight closures themselves can also be lifted. Once lifted, they can be called like normal closure:
 
 ```ts
-import { main, lift } from "@wingcloud/framework";
+import { main, lift, inflight } from "@wingcloud/framework";
 
 main((root) => {
   const myInflight = inflight(async () => {


### PR DESCRIPTION
I tried this: 

```ts
import { main, lift } from "@wingcloud/framework";

main((root) => {
  const myInflight = inflight(async () => {
    return "Wing!";
  });

  lift({ myInflight }).inflight(async ({ myInflight }) => {
    return myInflight();
  });
});
``` 

And got this: `Cannot find name 'inflight'`

## Checklist

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [x] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
