### PR TITLE
fix: error running wingcli-v2 tests locally

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1657,7 +1657,7 @@ dependencies = [
 
 [[package]]
 name = "wingcli"
-version = "0.59.24"
+version = "0.74.53"
 dependencies = [
  "anstyle",
  "camino",

--- a/apps/wingcli-v2/Cargo.toml
+++ b/apps/wingcli-v2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wingcli"
-version = "0.59.24"
+version = "0.74.53"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/apps/wingcli-v2/package.json
+++ b/apps/wingcli-v2/package.json
@@ -6,7 +6,8 @@
   },
   "dependencies": {
     "@winglang/wingii": "workspace:^",
-    "@winglang/wingc": "workspace:^"
+    "@winglang/wingc": "workspace:^",
+    "@winglang/sdk": "workspace:^"
   },
   "volta": {
     "extends": "../../package.json"

--- a/apps/wingcli-v2/src/main.rs
+++ b/apps/wingcli-v2/src/main.rs
@@ -84,14 +84,11 @@ fn command_build(source_file: Utf8PathBuf, target: Option<Target>) -> Result<(),
 	print_compiling(source_file.as_str());
 
 	let sdk_root = WING_CACHE_DIR.join("node_modules").join("@winglang").join("sdk");
-	if !sdk_root.exists() {
+
+	// Skip installing the SDK here if we're in a unit test since tests may run in parallel
+	// TODO: check if the SDK is up to date
+	if !sdk_root.exists() && !cfg!(test) {
 		install_sdk()?;
-	} else {
-		// TODO: check that the SDK version matches the CLI version
-		if cfg!(test) {
-			// For now, always reinstall the SDK in tests
-			install_sdk()?;
-		}
 	}
 	tracing::info!("Using SDK at {}", sdk_root);
 
@@ -120,15 +117,12 @@ fn install_sdk() -> Result<(), Box<dyn Error>> {
 	std::fs::create_dir_all(WING_CACHE_DIR.as_str())?;
 	let mut install_command = std::process::Command::new("npm");
 	install_command.arg("install").arg("esbuild"); // TODO: should this not be an optional dependency?
-	if cfg!(test) {
-		install_command.arg(format!("file:{}/../../libs/wingsdk", env!("CARGO_MANIFEST_DIR")));
-	} else {
-		install_command.arg(format!("@winglang/sdk@{}", env!("CARGO_PKG_VERSION")));
-	}
-
+	install_command.arg(format!("@winglang/sdk@{}", env!("CARGO_PKG_VERSION")));
 	install_command.current_dir(WING_CACHE_DIR.as_str());
 	install_command.stdout(std::process::Stdio::piped());
 	install_command.stderr(std::process::Stdio::piped());
+
+	tracing::info!("Running command: {:?}", install_command);
 
 	let output = install_command.output()?;
 	if !output.status.success() {
@@ -137,6 +131,7 @@ fn install_sdk() -> Result<(), Box<dyn Error>> {
 		let error_message = format!("Failed to install SDK. stdout: {}. stderr: {}", stdout, stderr);
 		return Err(error_message.into());
 	}
+
 	Ok(())
 }
 
@@ -146,7 +141,19 @@ fn run_javascript_node(source_file: &Utf8Path, target_dir: &Utf8Path, target: Ta
 
 	let mut command = std::process::Command::new("node");
 	command.arg(target_dir.join(".wing").join("preflight.cjs"));
-	command.env("NODE_PATH", WING_CACHE_DIR.join("node_modules").as_str());
+
+	let mut node_path = WING_CACHE_DIR.join("node_modules").to_string();
+
+	// For tests, add the local version of the SDK to the NODE_PATH
+	if cfg!(test) {
+		node_path = format!(
+			"{}:{}",
+			Utf8Path::new(env!("CARGO_MANIFEST_DIR")).join("node_modules"),
+			node_path
+		);
+	}
+
+	command.env("NODE_PATH", node_path);
 	command.env("WING_PLATFORMS", target.to_string());
 	command.env("WING_SOURCE_DIR", source_dir);
 	command.env("WING_SYNTH_DIR", target_dir);
@@ -205,6 +212,7 @@ mod test {
 
 	fn initialize() {
 		INIT.call_once(|| {
+			initialize_logger();
 			install_sdk().expect("Failed to install SDK");
 		});
 	}
@@ -213,13 +221,13 @@ mod test {
 	fn test_compile_sim() {
 		initialize();
 		let res = command_build("../../examples/tests/valid/hello.test.w".into(), Some(Target::Sim));
-		assert!(res.is_ok());
+		res.expect("Failed to compile to sim");
 	}
 
 	#[test]
 	fn test_compile_tfaws() {
 		initialize();
 		let res = command_build("../../examples/tests/valid/hello.test.w".into(), Some(Target::TfAws));
-		assert!(res.is_ok());
+		res.expect("Failed to compile to tf-aws");
 	}
 }

--- a/apps/wingcli-v2/src/main.rs
+++ b/apps/wingcli-v2/src/main.rs
@@ -117,7 +117,11 @@ fn install_sdk() -> Result<(), Box<dyn Error>> {
 	std::fs::create_dir_all(WING_CACHE_DIR.as_str())?;
 	let mut install_command = std::process::Command::new("npm");
 	install_command.arg("install").arg("esbuild"); // TODO: should this not be an optional dependency?
-	install_command.arg(format!("@winglang/sdk@{}", env!("CARGO_PKG_VERSION")));
+
+	// No need to install the latest verison of SDK from npm in tests
+	if !cfg!(test) {
+		install_command.arg(format!("@winglang/sdk@{}", env!("CARGO_PKG_VERSION")));
+	}
 	install_command.current_dir(WING_CACHE_DIR.as_str());
 	install_command.stdout(std::process::Stdio::piped());
 	install_command.stderr(std::process::Stdio::piped());

--- a/apps/wingcli-v2/src/main.rs
+++ b/apps/wingcli-v2/src/main.rs
@@ -93,7 +93,9 @@ fn command_build(source_file: Utf8PathBuf, target: Option<Target>) -> Result<(),
 	tracing::info!("Using SDK at {}", sdk_root);
 
 	// Special pragma used by wingc to find the SDK types
-	std::env::set_var("WINGSDK_MANIFEST_ROOT", &sdk_root);
+	if !cfg!(test) {
+		std::env::set_var("WINGSDK_MANIFEST_ROOT", &sdk_root);
+	}
 
 	let result = compile(&project_dir, &source_file, None, &work_dir);
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -380,7 +380,7 @@ importers:
         version: 5.3.3
       vitest:
         specifier: ^0.34.6
-        version: 0.34.6
+        version: 0.34.6(happy-dom@9.20.3)
 
   apps/wing-api-checker:
     dependencies:
@@ -538,7 +538,7 @@ importers:
         version: 5.2.2
       vite:
         specifier: ^4.5.2
-        version: 4.5.2(@types/node@20.14.0)
+        version: 4.5.2(@types/node@20.11.0)
 
   apps/wing-console/console/design-system:
     dependencies:
@@ -626,7 +626,7 @@ importers:
         version: 5.2.2
       vite:
         specifier: ^4.5.2
-        version: 4.5.2(@types/node@20.14.0)
+        version: 4.5.2(@types/node@20.11.0)
       vitest:
         specifier: ^0.34.6
         version: 0.34.6(happy-dom@9.20.3)
@@ -732,7 +732,7 @@ importers:
         version: 5.2.2
       vitest:
         specifier: ^0.34.6
-        version: 0.34.6
+        version: 0.34.6(happy-dom@9.20.3)
       ws:
         specifier: ^8.13.0
         version: 8.14.2
@@ -904,10 +904,10 @@ importers:
         version: 5.2.2
       vite:
         specifier: ^4.5.2
-        version: 4.5.2(@types/node@20.14.0)
+        version: 4.5.2(@types/node@20.11.0)
       vitest:
         specifier: ^0.34.6
-        version: 0.34.6
+        version: 0.34.6(happy-dom@9.20.3)
       webpack:
         specifier: ^5.88.2
         version: 5.88.2(esbuild@0.19.12)
@@ -1011,6 +1011,9 @@ importers:
 
   apps/wingcli-v2:
     dependencies:
+      '@winglang/sdk':
+        specifier: workspace:^
+        version: link:../../libs/wingsdk
       '@winglang/wingc':
         specifier: workspace:^
         version: link:../../libs/wingc
@@ -1187,7 +1190,7 @@ importers:
         version: 5.3.3
       vitest:
         specifier: ^0.34.6
-        version: 0.34.6
+        version: 0.34.6(happy-dom@9.20.3)
 
   libs/compatibility-spy:
     dependencies:
@@ -1209,7 +1212,7 @@ importers:
         version: 5.3.3
       vitest:
         specifier: ^0.34.6
-        version: 0.34.6
+        version: 0.34.6(happy-dom@9.20.3)
 
   libs/tree-sitter-wing:
     dependencies:
@@ -1271,7 +1274,7 @@ importers:
         version: 5.3.3
       vitest:
         specifier: ^0.34.6
-        version: 0.34.6
+        version: 0.34.6(happy-dom@9.20.3)
 
   libs/wingii: {}
 
@@ -1540,7 +1543,7 @@ importers:
         version: 5.3.3
       vitest:
         specifier: ^0.34.6
-        version: 0.34.6
+        version: 0.34.6(happy-dom@9.20.3)
 
   tools/bump-pack:
     dependencies:
@@ -1589,7 +1592,7 @@ importers:
         version: 5.2.2
       vitest:
         specifier: ^0.34.6
-        version: 0.34.6
+        version: 0.34.6(happy-dom@9.20.3)
 
   tools/compatibility-matrix-automation:
     dependencies:
@@ -1614,7 +1617,7 @@ importers:
         version: 5.3.3
       vitest:
         specifier: ^0.34.6
-        version: 0.34.6
+        version: 0.34.6(happy-dom@9.20.3)
 
   tools/generate-workspace:
     dependencies:
@@ -1690,7 +1693,7 @@ importers:
         version: 4.7.0
       vitest:
         specifier: ^0.34.6
-        version: 0.34.6
+        version: 0.34.6(happy-dom@9.20.3)
       winglang:
         specifier: workspace:^
         version: link:../../apps/wing
@@ -6582,7 +6585,7 @@ packages:
       magic-string: 0.27.0
       react-docgen-typescript: 2.2.2(typescript@5.2.2)
       typescript: 5.2.2
-      vite: 4.5.2(@types/node@20.14.0)
+      vite: 4.5.2(@types/node@20.11.0)
     dev: true
 
   /@jridgewell/gen-mapping@0.3.3:
@@ -10167,7 +10170,7 @@ packages:
       remark-slug: 6.1.0
       rollup: 3.29.4
       typescript: 5.2.2
-      vite: 4.5.2(@types/node@20.14.0)
+      vite: 4.5.2(@types/node@20.11.0)
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -10536,7 +10539,7 @@ packages:
       react: 18.2.0
       react-docgen: 6.0.0-alpha.3
       react-dom: 18.2.0(react@18.2.0)
-      vite: 4.5.2(@types/node@20.14.0)
+      vite: 4.5.2(@types/node@20.11.0)
     transitivePeerDependencies:
       - '@preact/preset-vite'
       - encoding
@@ -12076,7 +12079,7 @@ packages:
       vite: ^4 || ^5
     dependencies:
       '@swc/core': 1.4.2
-      vite: 4.5.2(@types/node@20.14.0)
+      vite: 4.5.2(@types/node@20.11.0)
     transitivePeerDependencies:
       - '@swc/helpers'
     dev: true
@@ -12092,7 +12095,7 @@ packages:
       '@babel/plugin-transform-react-jsx-source': 7.22.5(@babel/core@7.23.9)
       magic-string: 0.27.0
       react-refresh: 0.14.0
-      vite: 4.5.2(@types/node@20.14.0)
+      vite: 4.5.2(@types/node@20.11.0)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -12108,7 +12111,7 @@ packages:
       '@babel/plugin-transform-react-jsx-source': 7.23.3(@babel/core@7.23.9)
       '@types/babel__core': 7.20.5
       react-refresh: 0.14.0
-      vite: 4.5.2(@types/node@20.14.0)
+      vite: 4.5.2(@types/node@20.11.0)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -12124,7 +12127,7 @@ packages:
       magic-string: 0.30.4
       picocolors: 1.0.0
       std-env: 3.4.3
-      vitest: 0.34.6
+      vitest: 0.34.6(happy-dom@9.20.3)
     dev: true
 
   /@vitest/coverage-c8@0.33.0(vitest@0.34.6):
@@ -12138,7 +12141,7 @@ packages:
       magic-string: 0.30.7
       picocolors: 1.0.0
       std-env: 3.7.0
-      vitest: 0.34.6
+      vitest: 0.34.6(happy-dom@9.20.3)
     dev: true
 
   /@vitest/expect@0.34.6:
@@ -14860,7 +14863,7 @@ packages:
     dependencies:
       semver: 7.5.4
       shelljs: 0.8.5
-      typescript: 5.5.0-dev.20240603
+      typescript: 5.6.0-dev.20240612
     dev: true
 
   /dset@3.1.2:
@@ -23578,8 +23581,8 @@ packages:
     hasBin: true
     dev: true
 
-  /typescript@5.5.0-dev.20240603:
-    resolution: {integrity: sha512-gdm3Sh1A+Pjj9ZlfBEJY3o2rs3tvpcSbu3vYqcCijMe09BePQBtZlsuShuPn+zCnP+qBLxdKjFiw5v1tkna3tA==}
+  /typescript@5.6.0-dev.20240612:
+    resolution: {integrity: sha512-C5WDxLlEMZhdyZBkhZkysctw9uOpGnua48Zrq0FxJLx6+tFrNkanXn4Zhatjg1vbKjzk19FYggX4Gc6Wgz5flg==}
     engines: {node: '>=14.17'}
     hasBin: true
     dev: true
@@ -23956,28 +23959,6 @@ packages:
       - terser
     dev: true
 
-  /vite-node@0.34.6(@types/node@20.14.0):
-    resolution: {integrity: sha512-nlBMJ9x6n7/Amaz6F3zJ97EBwR2FkzhBRxF5e+jE6LA3yi6Wtc2lyTij1OnDMIr34v5g/tVQtsVAzhT0jc5ygA==}
-    engines: {node: '>=v14.18.0'}
-    hasBin: true
-    dependencies:
-      cac: 6.7.14
-      debug: 4.3.4(supports-color@5.5.0)
-      mlly: 1.4.2
-      pathe: 1.1.1
-      picocolors: 1.0.0
-      vite: 4.5.2(@types/node@20.14.0)
-    transitivePeerDependencies:
-      - '@types/node'
-      - less
-      - lightningcss
-      - sass
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-    dev: true
-
   /vite-node@1.3.1(@types/node@20.11.0):
     resolution: {integrity: sha512-azbRrqRxlWTJEVbzInZCTchx0X69M/XPTCz4H+TLvlTcR/xH/3hkRqhOakT41fMJCMzXTu4UvegkZiEoJAWvng==}
     engines: {node: ^18.0.0 || >=20.0.0}
@@ -24035,42 +24016,6 @@ packages:
       fsevents: 2.3.3
     dev: true
 
-  /vite@4.5.2(@types/node@20.14.0):
-    resolution: {integrity: sha512-tBCZBNSBbHQkaGyhGCDUGqeo2ph8Fstyp6FMSvTtsXeZSPpSMGlviAOav2hxVTqFcx8Hj/twtWKsMJXNY0xI8w==}
-    engines: {node: ^14.18.0 || >=16.0.0}
-    hasBin: true
-    peerDependencies:
-      '@types/node': '>= 14'
-      less: '*'
-      lightningcss: ^1.21.0
-      sass: '*'
-      stylus: '*'
-      sugarss: '*'
-      terser: ^5.4.0
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      less:
-        optional: true
-      lightningcss:
-        optional: true
-      sass:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      terser:
-        optional: true
-    dependencies:
-      '@types/node': 20.14.0
-      esbuild: 0.18.20
-      postcss: 8.4.35
-      rollup: 3.29.4
-    optionalDependencies:
-      fsevents: 2.3.3
-    dev: true
-
   /vite@5.1.4(@types/node@20.11.0):
     resolution: {integrity: sha512-n+MPqzq+d9nMVTKyewqw6kSt+R3CkvF9QAKY8obiQn8g1fwTscKxyfaYnC632HtBXAQGc1Yjomphwn1dtwGAHg==}
     engines: {node: ^18.0.0 || >=20.0.0}
@@ -24107,7 +24052,7 @@ packages:
       fsevents: 2.3.3
     dev: true
 
-  /vitest@0.34.6:
+  /vitest@0.34.6(happy-dom@9.20.3):
     resolution: {integrity: sha512-+5CALsOvbNKnS+ZHMXtuUC7nL8/7F1F2DnHGjSsszX8zCjWSSviphCb/NuS9Nzf4Q03KyyDRBAXhF/8lffME4Q==}
     engines: {node: '>=v14.18.0'}
     hasBin: true
@@ -24151,6 +24096,7 @@ packages:
       cac: 6.7.14
       chai: 4.3.10
       debug: 4.3.4(supports-color@5.5.0)
+      happy-dom: 9.20.3
       local-pkg: 0.4.3
       magic-string: 0.30.4
       pathe: 1.1.1
@@ -24161,72 +24107,6 @@ packages:
       tinypool: 0.7.0
       vite: 4.5.2(@types/node@20.11.0)
       vite-node: 0.34.6(@types/node@20.11.0)
-      why-is-node-running: 2.2.2
-    transitivePeerDependencies:
-      - less
-      - lightningcss
-      - sass
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-    dev: true
-
-  /vitest@0.34.6(happy-dom@9.20.3):
-    resolution: {integrity: sha512-+5CALsOvbNKnS+ZHMXtuUC7nL8/7F1F2DnHGjSsszX8zCjWSSviphCb/NuS9Nzf4Q03KyyDRBAXhF/8lffME4Q==}
-    engines: {node: '>=v14.18.0'}
-    hasBin: true
-    peerDependencies:
-      '@edge-runtime/vm': '*'
-      '@vitest/browser': '*'
-      '@vitest/ui': '*'
-      happy-dom: '*'
-      jsdom: '*'
-      playwright: '*'
-      safaridriver: '*'
-      webdriverio: '*'
-    peerDependenciesMeta:
-      '@edge-runtime/vm':
-        optional: true
-      '@vitest/browser':
-        optional: true
-      '@vitest/ui':
-        optional: true
-      happy-dom:
-        optional: true
-      jsdom:
-        optional: true
-      playwright:
-        optional: true
-      safaridriver:
-        optional: true
-      webdriverio:
-        optional: true
-    dependencies:
-      '@types/chai': 4.3.6
-      '@types/chai-subset': 1.3.3
-      '@types/node': 20.14.0
-      '@vitest/expect': 0.34.6
-      '@vitest/runner': 0.34.6
-      '@vitest/snapshot': 0.34.6
-      '@vitest/spy': 0.34.6
-      '@vitest/utils': 0.34.6
-      acorn: 8.10.0
-      acorn-walk: 8.2.0
-      cac: 6.7.14
-      chai: 4.3.10
-      debug: 4.3.4(supports-color@5.5.0)
-      happy-dom: 9.20.3
-      local-pkg: 0.4.3
-      magic-string: 0.30.4
-      pathe: 1.1.1
-      picocolors: 1.0.0
-      std-env: 3.4.3
-      strip-literal: 1.3.0
-      tinybench: 2.5.1
-      tinypool: 0.7.0
-      vite: 4.5.2(@types/node@20.14.0)
-      vite-node: 0.34.6(@types/node@20.14.0)
       why-is-node-running: 2.2.2
     transitivePeerDependencies:
       - less


### PR DESCRIPTION
@hasanaburayyan reported an issue running the wingcli-v2 tests locally:

```
running 2 tests
 Installing Wing SDK
test test::test_compile_sim ... FAILED
test test::test_compile_tfaws ... FAILED

failures:

---- test::test_compile_sim stdout ----
thread 'test::test_compile_sim' panicked at apps/wingcli-v2/src/main.rs:208:27:
Failed to install SDK: "Failed to install SDK. stdout: . stderr: npm ERR! code EUNSUPPORTEDPROTOCOL\nnpm ERR! Unsupported URL Type \"workspace:\": workspace:^\n\nnpm ERR! A complete log of this run can be found in: /Users/hasan/.npm/_logs/2024-06-12T16_06_47_837Z-debug-0.log\n"
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

---- test::test_compile_tfaws stdout ----
thread 'test::test_compile_tfaws' panicked at apps/wingcli-v2/src/main.rs:207:14:
Once instance has previously been poisoned
```

After a few hours we weren't able to diagnose the root cause. But as a workaround, we can avoid the issue by adding the locally built SDK to the NODE_PATH instead of using `npm install` to link the locally built SDK to the cache directory.

## Checklist

- [ ] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [ ] Description explains motivation and solution
- [ ] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
