### PR TITLE
fix(compiler): d.ts files missing inflight classes

### DIFF
--- a/libs/wingc/src/dtsify/mod.rs
+++ b/libs/wingc/src/dtsify/mod.rs
@@ -310,9 +310,7 @@ impl<'a> DTSifier<'a> {
 			}
 			StmtKind::Class(class) => {
 				code.line(self.dtsify_class(class, false));
-				if class.phase == Phase::Preflight {
-					code.line(self.dtsify_class(class, true));
-				}
+				code.line(self.dtsify_class(class, true));
 			}
 
 			// No need to emit anything for these

--- a/libs/wingc/src/dtsify/mod.rs
+++ b/libs/wingc/src/dtsify/mod.rs
@@ -202,7 +202,7 @@ impl<'a> DTSifier<'a> {
 			code.line(format!("constructor({constructor_params});"));
 		}
 
-		if !as_inflight && matches!(class.phase, Phase::Preflight) {
+		if !as_inflight {
 			// Emit special preflight marks to tie the inflight side together
 			let inflight_class_name = format!("{class_name}{TYPE_INFLIGHT_POSTFIX}");
 			code.line(format!(

--- a/libs/wingc/src/dtsify/mod.rs
+++ b/libs/wingc/src/dtsify/mod.rs
@@ -416,8 +416,18 @@ pub interface ClassInterface {
 	inflight bar(): void;
 }
 
+pub inflight interface InflightInterface {
+  somethingFun(): void;
+}
+
+pub inflight class InflightClass impl InflightInterface {
+  pub somethingFun() {}
+}
+
 pub class ParentClass impl ClassInterface {
-	pub static inflight static_method() {}
+	pub static inflight static_method(): InflightClass {
+	  return new InflightClass();
+	}
 
 	inflight foo() {}
 	pub inflight bar() {}
@@ -425,9 +435,8 @@ pub class ParentClass impl ClassInterface {
 	pub addHandler(handler: inflight (str): str) {}
 }
 
-pub class Child extends ParentClass impl ClassInterface {
-	
-}"#
+pub class Child extends ParentClass impl ClassInterface {}
+"#
 	);
 }
 

--- a/libs/wingc/src/dtsify/snapshots/declarations.snap
+++ b/libs/wingc/src/dtsify/snapshots/declarations.snap
@@ -21,8 +21,18 @@ pub interface ClassInterface {
   inflight bar(): void;
 }
 
+pub inflight interface InflightInterface {
+  somethingFun(): void;
+}
+
+pub inflight class InflightClass impl InflightInterface {
+  pub somethingFun() {}
+}
+
 pub class ParentClass impl ClassInterface {
-  pub static inflight static_method() {}
+  pub static inflight static_method(): InflightClass {
+    return new InflightClass();
+  }
 
   inflight foo() {}
   pub inflight bar() {}
@@ -30,9 +40,8 @@ pub class ParentClass impl ClassInterface {
   pub addHandler(handler: inflight (str): str) {}
 }
 
-pub class Child extends ParentClass impl ClassInterface {
-  
-}
+pub class Child extends ParentClass impl ClassInterface {}
+
 ```
 
 ## inflight.Child-1.cjs
@@ -51,16 +60,32 @@ module.exports = function({ $ParentClass }) {
 //# sourceMappingURL=inflight.Child-1.cjs.map
 ```
 
-## inflight.ParentClass-1.cjs
+## inflight.InflightClass-1.cjs
 
 ```js
 "use strict";
 const $helpers = require("@winglang/sdk/lib/helpers");
 module.exports = function({  }) {
+  class InflightClass {
+    async somethingFun() {
+    }
+  }
+  return InflightClass;
+}
+//# sourceMappingURL=inflight.InflightClass-1.cjs.map
+```
+
+## inflight.ParentClass-1.cjs
+
+```js
+"use strict";
+const $helpers = require("@winglang/sdk/lib/helpers");
+module.exports = function({ $InflightClass }) {
   class ParentClass {
     constructor({  }) {
     }
     static async static_method() {
+      return (await (async () => {const o = new $InflightClass(); await o.$inflight_init?.(); return o; })());
     }
     async foo() {
     }
@@ -100,6 +125,36 @@ const $stdlib = require('@winglang/sdk');
 const std = $stdlib.std;
 const $helpers = $stdlib.helpers;
 const $extern = $helpers.createExternRequire(__dirname);
+class InflightClass extends $stdlib.std.Resource {
+  constructor($scope, $id, ) {
+    super($scope, $id);
+  }
+  static _toInflightType() {
+    return `
+      require("${$helpers.normalPath(__dirname)}/inflight.InflightClass-1.cjs")({
+      })
+    `;
+  }
+  _toInflight() {
+    return `
+      (await (async () => {
+        const InflightClassClient = ${InflightClass._toInflightType()};
+        const client = new InflightClassClient({
+        });
+        if (client.$inflight_init) { await client.$inflight_init(); }
+        return client;
+      })())
+    `;
+  }
+  get _liftMap() {
+    return ({
+      "somethingFun": [
+      ],
+      "$inflight_init": [
+      ],
+    });
+  }
+}
 class ParentClass extends $stdlib.std.Resource {
   constructor($scope, $id, ) {
     super($scope, $id);
@@ -109,6 +164,7 @@ class ParentClass extends $stdlib.std.Resource {
   static _toInflightType() {
     return `
       require("${$helpers.normalPath(__dirname)}/inflight.ParentClass-1.cjs")({
+        $InflightClass: ${$stdlib.core.liftObject(InflightClass)},
       })
     `;
   }
@@ -169,7 +225,7 @@ class Child extends ParentClass {
     });
   }
 }
-module.exports = { ParentClass, Child };
+module.exports = { InflightClass, ParentClass, Child };
 //# sourceMappingURL=preflight.lib-1.cjs.map
 ```
 
@@ -199,6 +255,23 @@ export interface ClassInterface$Inflight
 {
   readonly bar: () => Promise<void>;
 }
+export interface InflightInterface
+{
+}
+export interface InflightInterface$Inflight
+{
+  readonly somethingFun: () => Promise<void>;
+}
+export class InflightClass implements InflightInterface
+{
+  constructor();
+  [$internal.INFLIGHT_SYMBOL]?: InflightClass$Inflight;
+}
+export class InflightClass$Inflight implements InflightInterface$Inflight
+{
+  constructor();
+  somethingFun: () => Promise<void>;
+}
 export class ParentClass extends std.Resource implements ClassInterface
 {
   constructor(scope: $internal.Construct, id: string);
@@ -208,7 +281,7 @@ export class ParentClass extends std.Resource implements ClassInterface
 export class ParentClass$Inflight implements ClassInterface$Inflight
 {
   constructor();
-  static static_method: () => Promise<void>;
+  static static_method: () => Promise<InflightClass>;
   bar: () => Promise<void>;
 }
 export class Child extends ParentClass implements ClassInterface


### PR DESCRIPTION
Fixes #6600

Pragmatically, inflight classes can basically work like preflight classes.

This partially exposes an implementation detail, which can be cleaned up in the future to improve DX by removing these dummy classes.

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
