### PR TITLE
chore(repo): skip issues marked `roadmap` from stale checks

### DIFF
--- a/.github/workflows/close-stale.yml
+++ b/.github/workflows/close-stale.yml
@@ -16,6 +16,7 @@ jobs:
         with:
           days-before-issue-stale: 90
           days-before-pr-stale: 20
+          exempt-issue-labels: roadmap
           stale-issue-message: |
             Hi,
 


### PR DESCRIPTION
Do not check for staleness for issues marked with `roadmap`.

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
