### PR TITLE
fix(compiler)!: this.node and nodeof(this) have different behaviors

### DIFF
--- a/examples/tests/invalid/constructs.test.w
+++ b/examples/tests/invalid/constructs.test.w
@@ -1,0 +1,13 @@
+bring expect;
+
+class A {
+  new() {
+    this.node.hidden;
+    // ^ Error: member "node" does not exist in A
+
+    nodeof(this).hidden; // OK
+
+    nodeof(this).root.node;
+    // ^ Error: member "node" does not exist in IConstruct
+  }
+}

--- a/examples/tests/sdk_tests/std/array.test.w
+++ b/examples/tests/sdk_tests/std/array.test.w
@@ -25,7 +25,7 @@ test "length" {
 assert(["hello"].at(0) == "hello");
 assert(MutArray<str>["hello", "world"].at(1) == "world");
 
-assert(buckets.at(0).node.id == "myBucket");
+assert(nodeof(buckets.at(0)).id == "myBucket");
 
 test "at()" {
   assert(["hello"].at(0) == "hello");
@@ -150,8 +150,8 @@ assert(d.at(1) == "wing");
 
 let mergedBuckets = buckets.concat(anotherBuckets);
 assert(mergedBuckets.length == 2);
-assert(mergedBuckets.at(0).node.id == "myBucket");
-assert(mergedBuckets.at(1).node.id == "mySecondBucket");
+assert(nodeof(mergedBuckets.at(0)).id == "myBucket");
+assert(nodeof(mergedBuckets.at(1)).id == "mySecondBucket");
 
 test "concatMutArray()" {
   let b = MutArray<str>["hello"];
@@ -265,7 +265,7 @@ assert(o.at(0) == p.at(0));
 
 let copiedBuckets = buckets.copyMut();
 assert(copiedBuckets.length == 1);
-assert(copiedBuckets.at(0).node.id == "myBucket");
+assert(nodeof(copiedBuckets.at(0)).id == "myBucket");
 
 test "copy()" {
   let o = MutArray<str>["hello", "wing"];

--- a/examples/tests/valid/casting.test.w
+++ b/examples/tests/valid/casting.test.w
@@ -5,8 +5,8 @@ bring "@cdktf/provider-aws" as aws;
 let b = new cloud.Bucket();
 
 if util.env("WING_TARGET") == "tf-aws" {
-  let s3Bucket: aws.s3Bucket.S3Bucket = unsafeCast(b.node.findChild("Default"));
+  let s3Bucket: aws.s3Bucket.S3Bucket = unsafeCast(nodeof(b).findChild("Default"));
   
   s3Bucket.addOverride("bucket_prefix", "my-prefix-");
-  log(s3Bucket.node.path);
+  log(nodeof(s3Bucket).path);
 }

--- a/examples/tests/valid/construct-base.test.w
+++ b/examples/tests/valid/construct-base.test.w
@@ -1,16 +1,15 @@
 bring cloud;
-// bring cloud;
 bring "constructs" as cx;
 bring "@cdktf/provider-aws" as aws;
 
 class WingResource {
   new() {
-    log("my id is {this.node.id}");
+    log("my id is {nodeof(this).id}");
   }
 }
 
 let getPath = (c: cx.Construct): str => {
-  return c.node.path;
+  return nodeof(c).path;
 };
 
 let getDisplayName = (r: std.Resource): str? => {
@@ -27,5 +26,4 @@ log("path of wing resource: {getPath(wr)}");
 let title = getDisplayName(wr) ?? "no display name";
 log("display name of wing resource: {title}");
 
-//TODO: Expected type to be "IConstruct", but got "WingResource" instead
-// log(cx.Node.of(wr).path);
+log(cx.Node.of(wr).path);

--- a/examples/tests/valid/custom_obj_id.test.w
+++ b/examples/tests/valid/custom_obj_id.test.w
@@ -3,5 +3,5 @@ class Foo { }
 let foo1 = new Foo();
 let bar2 = new Foo() as "bar2";
 
-assert(foo1.node.id == "Foo");
-assert(bar2.node.id == "bar2");
+assert(nodeof(foo1).id == "Foo");
+assert(nodeof(bar2).id == "bar2");

--- a/examples/tests/valid/dynamo.test.w
+++ b/examples/tests/valid/dynamo.test.w
@@ -29,7 +29,7 @@ class DynamoTable {
     }
 
     this.table = new tfaws.dynamodbTable.DynamodbTable(
-      name: this.node.addr,
+      name: nodeof(this).addr,
       billingMode: "PAY_PER_REQUEST",
       hashKey: "Flavor",
       attribute: [

--- a/examples/tests/valid/dynamo_awscdk.test.w
+++ b/examples/tests/valid/dynamo_awscdk.test.w
@@ -29,7 +29,7 @@ class DynamoTable {
     }
 
     this.table = new awscdk.aws_dynamodb.Table(
-      tableName: this.node.addr,
+      tableName: nodeof(this).addr,
       billingMode: awscdk.aws_dynamodb.BillingMode.PAY_PER_REQUEST,
       removalPolicy: awscdk.RemovalPolicy.DESTROY,
       partitionKey: awscdk.aws_dynamodb.Attribute {

--- a/examples/tests/valid/external_ts.extern.d.ts
+++ b/examples/tests/valid/external_ts.extern.d.ts
@@ -16,6 +16,36 @@ those constructs are deployed before the resources depending ON them are
 deployed. */
 export interface IDependable {
 }
+/** Represents a construct. */
+export interface IConstruct extends IDependable {
+}
+/** Represents the building block of the construct graph.
+All constructs besides the root construct must be created within the scope of
+another construct. */
+export class Construct implements IConstruct {
+  /** Returns a string representation of this construct. */
+  readonly toString: () => string;
+}
+/** Data that can be lifted into inflight. */
+export interface ILiftable {
+}
+/** A resource that can run inflight code. */
+export interface IInflightHost extends IResource {
+  /** Adds an environment variable to the host. */
+  readonly addEnvironment: (name: string, value: string) => void;
+}
+/** A liftable object that needs to be registered on the host as part of the lifting process.
+This is generally used so the host can set up permissions
+to access the lifted object inflight. */
+export interface IHostedLiftable extends ILiftable {
+  /** A hook called by the Wing compiler once for each inflight host that needs to use this object inflight.
+  The list of requested inflight methods
+  needed by the inflight host are given by `ops`.
+  
+  This method is commonly used for adding permissions, environment variables, or
+  other capabilities to the inflight host. */
+  readonly onLift: (host: IInflightHost, ops: (readonly (string)[])) => void;
+}
 /** Options for `construct.addMetadata()`. */
 export interface MetadataOptions {
   /** Include stack trace with metadata entry. */
@@ -150,40 +180,6 @@ export class Node {
   @returns an array of validation error messages associated with this
   construct. */
   readonly validate: () => (readonly (string)[]);
-}
-/** Represents a construct. */
-export interface IConstruct extends IDependable {
-  /** The tree node. */
-  readonly node: Node;
-}
-/** Represents the building block of the construct graph.
-All constructs besides the root construct must be created within the scope of
-another construct. */
-export class Construct implements IConstruct {
-  /** The tree node. */
-  readonly node: Node;
-  /** Returns a string representation of this construct. */
-  readonly toString: () => string;
-}
-/** Data that can be lifted into inflight. */
-export interface ILiftable {
-}
-/** A resource that can run inflight code. */
-export interface IInflightHost extends IResource {
-  /** Adds an environment variable to the host. */
-  readonly addEnvironment: (name: string, value: string) => void;
-}
-/** A liftable object that needs to be registered on the host as part of the lifting process.
-This is generally used so the host can set up permissions
-to access the lifted object inflight. */
-export interface IHostedLiftable extends ILiftable {
-  /** A hook called by the Wing compiler once for each inflight host that needs to use this object inflight.
-  The list of requested inflight methods
-  needed by the inflight host are given by `ops`.
-  
-  This method is commonly used for adding permissions, environment variables, or
-  other capabilities to the inflight host. */
-  readonly onLift: (host: IInflightHost, ops: (readonly (string)[])) => void;
 }
 /** Abstract interface for `Resource`. */
 export interface IResource extends IConstruct, IHostedLiftable {

--- a/examples/tests/valid/function_variadic_arguments.test.w
+++ b/examples/tests/valid/function_variadic_arguments.test.w
@@ -4,7 +4,7 @@ let bucket2 = new cloud.Bucket() as "bucket2";
 let bucket3 = new cloud.Bucket() as "bucket3";
 
 // can use variadic methods from the jsii world
-bucket3.node.addDependency(bucket1, bucket2);
+nodeof(bucket3).addDependency(bucket1, bucket2);
 
 let funcBucket = (...buckets: Array<cloud.Bucket>) => {
   assert(buckets.length == 2);

--- a/examples/tests/valid/resource.test.w
+++ b/examples/tests/valid/resource.test.w
@@ -158,18 +158,18 @@ class ScopeAndIdTestClass {
   new() {
     // Create a Dummy in my scope
     let d1 = new Dummy();
-    assert(d1.node.path.endsWith("/ScopeAndIdTestClass/Dummy"));
+    assert(nodeof(d1).path.endsWith("/ScopeAndIdTestClass/Dummy"));
     // Create a Dummy in someone else's scope
     let d2 = new Dummy() in d1;
-    assert(d2.node.path.endsWith("/ScopeAndIdTestClass/Dummy/Dummy"));
+    assert(nodeof(d2).path.endsWith("/ScopeAndIdTestClass/Dummy/Dummy"));
     // Create a Dummy in someone else's scope (reference)
     let d3 = new Dummy() in Dummy.getInstance(d2);
-    assert(d3.node.path.endsWith("/ScopeAndIdTestClass/Dummy/Dummy/StaticDummy/Dummy"));
+    assert(nodeof(d3).path.endsWith("/ScopeAndIdTestClass/Dummy/Dummy/StaticDummy/Dummy"));
     // Generate multiple Dummys with different id's
     for i in 0..3 {
       let x = new Dummy() as "tc{i}";
       let expected_path = "/ScopeAndIdTestClass/tc{i}";
-      assert(x.node.path.endsWith(expected_path));
+      assert(nodeof(x).path.endsWith(expected_path));
     }
   }
 }

--- a/examples/tests/valid/this.test.w
+++ b/examples/tests/valid/this.test.w
@@ -2,11 +2,11 @@ bring expect;
 
 // Play around with "this"
 
-let path = this.node.path;
+let path = nodeof(this).path;
 
-for c in this.node.children {
-  log(c.node.path);
+for c in nodeof(this).children {
+  log(nodeof(c).path);
 }
 
-expect.notNil(this.node);
-expect.equal(this.node.path.split("/").at(0), "root");
+expect.notNil(nodeof(this));
+expect.equal(nodeof(this).path.split("/").at(0), "root");

--- a/libs/wingc/src/diagnostic.rs
+++ b/libs/wingc/src/diagnostic.rs
@@ -452,6 +452,7 @@ pub struct TypeError {
 	pub message: String,
 	pub span: WingSpan,
 	pub annotations: Vec<DiagnosticAnnotation>,
+	pub hints: Vec<String>,
 }
 
 impl std::fmt::Display for TypeError {

--- a/libs/wingc/src/jsify/snapshots/fails_if_referencing_unknown_field.snap
+++ b/libs/wingc/src/jsify/snapshots/fails_if_referencing_unknown_field.snap
@@ -2,4 +2,4 @@
 source: libs/wingc/src/jsify/tests.rs
 ---
 ## Errors
-Member "b" doesn't exist in "MyInflightClass" 3:13
+Member "b" does not exist in "MyInflightClass" 3:13

--- a/libs/wingc/src/jsify/snapshots/fails_when_referencing_this_from_static.snap
+++ b/libs/wingc/src/jsify/snapshots/fails_when_referencing_this_from_static.snap
@@ -2,4 +2,4 @@
 source: libs/wingc/src/jsify/tests.rs
 ---
 ## Errors
-Member "print" doesn't exist in "Construct" 3:13
+Member "print" does not exist in "Construct" 3:13

--- a/libs/wingc/src/lib.rs
+++ b/libs/wingc/src/lib.rs
@@ -240,6 +240,7 @@ pub fn type_check(
 		None,
 	);
 	tc.add_builtins(scope);
+	tc.patch_constructs();
 
 	// If the file is an entrypoint file, we add "this" to its symbol environment
 	if is_entrypoint_file(file_path) {

--- a/libs/wingc/src/lib.rs
+++ b/libs/wingc/src/lib.rs
@@ -125,6 +125,7 @@ const WINGSDK_SIM_IRESOURCE_FQN: &'static str = formatcp!("{}.{}", WINGSDK_ASSEM
 
 const CONSTRUCT_BASE_CLASS: &'static str = "constructs.Construct";
 const CONSTRUCT_BASE_INTERFACE: &'static str = "constructs.IConstruct";
+const CONSTRUCT_NODE_PROPERTY: &'static str = "node";
 
 const MACRO_REPLACE_SELF: &'static str = "$self$";
 const MACRO_REPLACE_ARGS: &'static str = "$args$";

--- a/libs/wingc/src/type_check.rs
+++ b/libs/wingc/src/type_check.rs
@@ -1935,12 +1935,13 @@ impl<'a> TypeChecker<'a> {
 			message,
 			span,
 			annotations,
+			hints,
 		} = type_error;
 		report_diagnostic(Diagnostic {
 			message,
 			span: Some(span),
 			annotations,
-			hints: vec![],
+			hints,
 		});
 
 		self.types.error()
@@ -2225,6 +2226,7 @@ new cloud.Function(@inflight("./handler.ts"), lifts: { bucket: ["put"] });
 						message: "Panic expression".to_string(),
 						span: exp.span.clone(),
 						annotations: vec![],
+						hints: vec![],
 					}),
 					env.phase,
 				)
@@ -6712,6 +6714,7 @@ fn add_parent_members_to_struct_env(
 				),
 				span: name.span.clone(),
 				annotations: vec![],
+				hints: vec![],
 			});
 		};
 		// Add each member of current parent to the struct's environment (if it wasn't already added by a previous parent)
@@ -6735,6 +6738,7 @@ fn add_parent_members_to_struct_env(
 							name, parent_type, parent_member_name, parent_member_type, existing_type
 						),
 						annotations: vec![],
+						hints: vec![],
 					});
 				}
 			} else {
@@ -6780,6 +6784,7 @@ fn add_parent_members_to_iface_env(
 				),
 				span: name.span.clone(),
 				annotations: vec![],
+				hints: vec![],
 			});
 		};
 		// Add each member of current parent to the interface's environment (if it wasn't already added by a previous parent)
@@ -6800,6 +6805,7 @@ fn add_parent_members_to_iface_env(
 						),
 						span: name.span.clone(),
 						annotations: vec![],
+						hints: vec![],
 					});
 				}
 			} else {
@@ -6843,10 +6849,15 @@ where
 			} else {
 				format!("Unknown symbol \"{s}\"")
 			};
+			let mut hints = vec![];
+			if s.name == "node" {
+				hints.push("use nodeof(x) to access the tree node on a preflight class".to_string());
+			}
 			TypeError {
 				message,
 				span: s.span(),
 				annotations: vec![],
+				hints,
 			}
 		}
 		LookupResult::NotPublic(kind, lookup_info) => TypeError {
@@ -6875,11 +6886,13 @@ where
 				message: "defined here".to_string(),
 				span: lookup_info.span,
 			}],
+			hints: vec![],
 		},
 		LookupResult::MultipleFound => TypeError {
 			message: format!("Ambiguous symbol \"{looked_up_object}\""),
 			span: looked_up_object.span(),
 			annotations: vec![],
+			hints: vec![],
 		},
 		LookupResult::DefinedLater(span) => TypeError {
 			message: format!("Symbol \"{looked_up_object}\" used before being defined"),
@@ -6888,11 +6901,13 @@ where
 				message: "defined later here".to_string(),
 				span,
 			}],
+			hints: vec![],
 		},
 		LookupResult::ExpectedNamespace(ns_name) => TypeError {
 			message: format!("Expected \"{ns_name}\" in \"{looked_up_object}\" to be a namespace"),
 			span: ns_name.span(),
 			annotations: vec![],
+			hints: vec![],
 		},
 		LookupResult::Found(..) => panic!("Expected a lookup error, but found a successful lookup"),
 	}
@@ -6927,6 +6942,7 @@ pub fn resolve_user_defined_type_ref<'a>(
 				message: format!("Expected \"{}\" to be a type but it's a {symb_kind}", symb.name),
 				span: symb.span.clone(),
 				annotations: vec![],
+				hints: vec![],
 			})
 		}
 	} else {
@@ -6957,6 +6973,7 @@ pub fn resolve_super_method(method: &Symbol, env: &SymbolEnv, types: &Types) -> 
 						.to_string(),
 				span: method.span.clone(),
 				annotations: vec![],
+				hints: vec![],
 			});
 		}
 		// Get the parent type of "this" (if it's a preflight class that's directly derived from `std.Resource` it's an implicit derive so we'll treat it as if there's no parent)
@@ -6976,6 +6993,7 @@ pub fn resolve_super_method(method: &Symbol, env: &SymbolEnv, types: &Types) -> 
 					),
 					span: method.span.clone(),
 					annotations: vec![],
+					hints: vec![],
 				})
 			}
 		} else {
@@ -6983,6 +7001,7 @@ pub fn resolve_super_method(method: &Symbol, env: &SymbolEnv, types: &Types) -> 
 				message: format!("Cannot call super method because class {} has no parent", type_),
 				span: method.span.clone(),
 				annotations: vec![],
+				hints: vec![],
 			})
 		}
 	} else {
@@ -6995,6 +7014,7 @@ pub fn resolve_super_method(method: &Symbol, env: &SymbolEnv, types: &Types) -> 
 			.to_string(),
 			span: method.span.clone(),
 			annotations: vec![],
+			hints: vec![],
 		})
 	}
 }

--- a/libs/wingc/src/type_check.rs
+++ b/libs/wingc/src/type_check.rs
@@ -25,10 +25,11 @@ use crate::type_check::symbol_env::SymbolEnvKind;
 use crate::visit_context::{VisitContext, VisitorWithContext};
 use crate::visit_types::{VisitType, VisitTypeMut};
 use crate::{
-	dbg_panic, debug, CONSTRUCT_BASE_CLASS, CONSTRUCT_BASE_INTERFACE, UTIL_CLASS_NAME, WINGSDK_ARRAY,
-	WINGSDK_ASSEMBLY_NAME, WINGSDK_BRINGABLE_MODULES, WINGSDK_DURATION, WINGSDK_GENERIC, WINGSDK_IRESOURCE, WINGSDK_JSON,
-	WINGSDK_MAP, WINGSDK_MUT_ARRAY, WINGSDK_MUT_JSON, WINGSDK_MUT_MAP, WINGSDK_MUT_SET, WINGSDK_NODE, WINGSDK_RESOURCE,
-	WINGSDK_SET, WINGSDK_SIM_IRESOURCE_FQN, WINGSDK_STD_MODULE, WINGSDK_STRING, WINGSDK_STRUCT,
+	dbg_panic, debug, CONSTRUCT_BASE_CLASS, CONSTRUCT_BASE_INTERFACE, CONSTRUCT_NODE_PROPERTY, UTIL_CLASS_NAME,
+	WINGSDK_ARRAY, WINGSDK_ASSEMBLY_NAME, WINGSDK_BRINGABLE_MODULES, WINGSDK_DURATION, WINGSDK_GENERIC,
+	WINGSDK_IRESOURCE, WINGSDK_JSON, WINGSDK_MAP, WINGSDK_MUT_ARRAY, WINGSDK_MUT_JSON, WINGSDK_MUT_MAP, WINGSDK_MUT_SET,
+	WINGSDK_NODE, WINGSDK_RESOURCE, WINGSDK_SET, WINGSDK_SIM_IRESOURCE_FQN, WINGSDK_STD_MODULE, WINGSDK_STRING,
+	WINGSDK_STRUCT,
 };
 use camino::{Utf8Path, Utf8PathBuf};
 use derivative::Derivative;
@@ -1989,7 +1990,7 @@ impl<'a> TypeChecker<'a> {
 		let iface = constructs_iface
 			.as_interface_mut()
 			.expect("constructs.IConstruct was found but it's not a class");
-		iface.env.symbol_map.remove("node");
+		iface.env.symbol_map.remove(CONSTRUCT_NODE_PROPERTY);
 
 		let mut constructs_class = self
 			.types
@@ -2002,7 +2003,7 @@ impl<'a> TypeChecker<'a> {
 		let class = constructs_class
 			.as_class_mut()
 			.expect("constructs.Construct was found but it's not a class");
-		class.env.symbol_map.remove("node");
+		class.env.symbol_map.remove(CONSTRUCT_NODE_PROPERTY);
 	}
 
 	pub fn add_builtins(&mut self, scope: &mut Scope) {
@@ -6850,7 +6851,7 @@ where
 				format!("Unknown symbol \"{s}\"")
 			};
 			let mut hints = vec![];
-			if s.name == "node" {
+			if s.name == CONSTRUCT_NODE_PROPERTY {
 				hints.push("use nodeof(x) to access the tree node on a preflight class".to_string());
 			}
 			TypeError {

--- a/libs/wingc/src/type_check/symbol_env.rs
+++ b/libs/wingc/src/type_check/symbol_env.rs
@@ -267,6 +267,7 @@ impl SymbolEnv {
 					message: "previous definition".to_string(),
 					span: self.symbol_map[&symbol.name].span.clone(),
 				}],
+				hints: vec![],
 			});
 		}
 

--- a/libs/wingc/src/type_check/symbol_env.rs
+++ b/libs/wingc/src/type_check/symbol_env.rs
@@ -35,6 +35,7 @@ pub struct SymbolEnv {
 	statement_idx: usize,
 }
 
+#[derive(Debug)]
 pub struct SymbolEnvEntry {
 	pub statement_idx: StatementIdx,
 	pub span: WingSpan,

--- a/tools/hangar/__snapshots__/invalid.ts.snap
+++ b/tools/hangar/__snapshots__/invalid.ts.snap
@@ -389,14 +389,14 @@ error: Cannot access static property "m" from instance
    |     ^
 
 
-error: Member "instanceField" doesn't exist in "Construct"
+error: Member "instanceField" does not exist in "Construct"
   --> ../../../examples/tests/invalid/access_static_from_instance.test.w:7:10
   |
 7 |     this.instanceField = 1; // Can't access instance fields from static methods
   |          ^^^^^^^^^^^^^
 
 
-error: Member "f" doesn't exist in "Construct"
+error: Member "f" does not exist in "Construct"
   --> ../../../examples/tests/invalid/access_static_from_instance.test.w:8:10
   |
 8 |     this.f = 1; // Can't access static fields through \`this\`
@@ -1089,6 +1089,32 @@ Test Files 1 failed (1)
 Duration <DURATION>"
 `;
 
+exports[`constructs.test.w 1`] = `
+"error: Member "node" does not exist in "A"
+  --> ../../../examples/tests/invalid/constructs.test.w:5:10
+  |
+5 |     this.node.hidden;
+  |          ^^^^
+  |
+  = hint: use nodeof(x) to access the tree node on a preflight class
+
+
+error: Member "node" does not exist in "IConstruct"
+   --> ../../../examples/tests/invalid/constructs.test.w:10:23
+   |
+10 |     nodeof(this).root.node;
+   |                       ^^^^
+   |
+   = hint: use nodeof(x) to access the tree node on a preflight class
+
+
+
+Tests 1 failed (1)
+Snapshots 1 skipped
+Test Files 1 failed (1)
+Duration <DURATION>"
+`;
+
 exports[`container_types.test.w 1`] = `
 "error: Unknown parser error
    --> ../../../examples/tests/invalid/container_types.test.w:14:25
@@ -1132,7 +1158,7 @@ error: Expected type to be "Array<num>", but got "Array<str>" instead
   |                        ^^^^
 
 
-error: Member "someRandomMethod" doesn't exist in "Array"
+error: Member "someRandomMethod" does not exist in "Array"
   --> ../../../examples/tests/invalid/container_types.test.w:6:6
   |
 6 | arr1.someRandomMethod();
@@ -1167,7 +1193,7 @@ error: Expected type to be "Map<num>", but got "Map<str>" instead
    |                    ^^
 
 
-error: Member "someRandomMethod" doesn't exist in "Map"
+error: Member "someRandomMethod" does not exist in "Map"
    --> ../../../examples/tests/invalid/container_types.test.w:17:4
    |
 17 | m1.someRandomMethod();
@@ -1223,7 +1249,7 @@ error: Expected type to be "Set<str>", but got "Set<num>" instead
    |                    ^^
 
 
-error: Member "someRandomMethod" doesn't exist in "Set"
+error: Member "someRandomMethod" does not exist in "Set"
    --> ../../../examples/tests/invalid/container_types.test.w:29:4
    |
 29 | s1.someRandomMethod();
@@ -1244,7 +1270,7 @@ error: Expected type to be "MutMap<num>", but got "Map<num>" instead
    |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 
-error: Member "copyMut" doesn't exist in "MutMap"
+error: Member "copyMut" does not exist in "MutMap"
    --> ../../../examples/tests/invalid/container_types.test.w:37:15
    |
 37 | let mm3 = mm2.copyMut();
@@ -1265,7 +1291,7 @@ error: Expected type to be "num", but got "bool" instead
    |                                    ^^^^
 
 
-error: Member "copyMut" doesn't exist in "MutSet"
+error: Member "copyMut" does not exist in "MutSet"
    --> ../../../examples/tests/invalid/container_types.test.w:46:15
    |
 46 | let ss4 = ss3.copyMut();
@@ -2123,7 +2149,7 @@ Duration <DURATION>"
 `;
 
 exports[`immutable_container_types.test.w 1`] = `
-"error: Member "set" doesn't exist in "Map"
+"error: Member "set" does not exist in "Map"
   --> ../../../examples/tests/invalid/immutable_container_types.test.w:3:4
   |
 3 | m1.set("a", "bye");
@@ -2144,28 +2170,28 @@ error: Expected type to be "bool", but got "str" instead
   |                             ^^^
 
 
-error: Member "set" doesn't exist in "Map"
+error: Member "set" does not exist in "Map"
    --> ../../../examples/tests/invalid/immutable_container_types.test.w:11:4
    |
 11 | m4.set("2", 3);
    |    ^^^
 
 
-error: Member "copy" doesn't exist in "Map"
+error: Member "copy" does not exist in "Map"
    --> ../../../examples/tests/invalid/immutable_container_types.test.w:13:13
    |
 13 | let m5 = m4.copy();
    |             ^^^^
 
 
-error: Member "delete" doesn't exist in "Map"
+error: Member "delete" does not exist in "Map"
    --> ../../../examples/tests/invalid/immutable_container_types.test.w:15:4
    |
 15 | m4.delete("1");
    |    ^^^^^^
 
 
-error: Member "clear" doesn't exist in "Map"
+error: Member "clear" does not exist in "Map"
    --> ../../../examples/tests/invalid/immutable_container_types.test.w:17:4
    |
 17 | m4.clear();
@@ -2179,28 +2205,28 @@ error: Expected type to be "Set<Array<num>>", but got "MutSet<Array<num>>" inste
    |                           ^^^^^^^^^^^^^^^^^^^^^^^
 
 
-error: Member "delete" doesn't exist in "Set"
+error: Member "delete" does not exist in "Set"
    --> ../../../examples/tests/invalid/immutable_container_types.test.w:24:4
    |
 24 | s2.delete("a");
    |    ^^^^^^
 
 
-error: Member "add" doesn't exist in "Set"
+error: Member "add" does not exist in "Set"
    --> ../../../examples/tests/invalid/immutable_container_types.test.w:26:4
    |
 26 | s2.add("d");
    |    ^^^
 
 
-error: Member "copy" doesn't exist in "Set"
+error: Member "copy" does not exist in "Set"
    --> ../../../examples/tests/invalid/immutable_container_types.test.w:28:13
    |
 28 | let s3 = s2.copy();
    |             ^^^^
 
 
-error: Member "clear" doesn't exist in "Set"
+error: Member "clear" does not exist in "Set"
    --> ../../../examples/tests/invalid/immutable_container_types.test.w:30:4
    |
 30 | s2.clear();
@@ -3020,7 +3046,7 @@ error: Expected type to be "Array<str>", but got "str" instead
    |                     ^
 
 
-error: Member "set" doesn't exist in "Json"
+error: Member "set" does not exist in "Json"
    --> ../../../examples/tests/invalid/json.test.w:19:13
    |
 19 | foreverJson.set("a", "world!");
@@ -3142,7 +3168,7 @@ Duration <DURATION>"
 `;
 
 exports[`json_static.test.w 1`] = `
-"error: Member "set" doesn't exist in "Json"
+"error: Member "set" does not exist in "Json"
   --> ../../../examples/tests/invalid/json_static.test.w:4:10
   |
 4 | immutObj.set("a", "foo");
@@ -3266,7 +3292,7 @@ error: Expected type to be "MutArray<num>", but got "MutArray<str>" instead
   |                           ^^^^
 
 
-error: Member "someMethod" doesn't exist in "MutArray"
+error: Member "someMethod" does not exist in "MutArray"
   --> ../../../examples/tests/invalid/mut_container_types.test.w:6:6
   |
 6 | arr1.someMethod();
@@ -3294,7 +3320,7 @@ error: Expected type to be "MutSet<num>", but got "MutSet<str>" instead
    |                       ^^
 
 
-error: Member "someMethod" doesn't exist in "MutSet"
+error: Member "someMethod" does not exist in "MutSet"
    --> ../../../examples/tests/invalid/mut_container_types.test.w:14:4
    |
 14 | s3.someMethod();
@@ -3618,14 +3644,14 @@ Duration <DURATION>"
 `;
 
 exports[`primitives.test.w 1`] = `
-"error: Member "blabla" doesn't exist in "Array"
+"error: Member "blabla" does not exist in "Array"
   --> ../../../examples/tests/invalid/primitives.test.w:6:16
   |
 6 | let join = arr.blabla(",");
   |                ^^^^^^
 
 
-error: Member "push" doesn't exist in "Array"
+error: Member "push" does not exist in "Array"
   --> ../../../examples/tests/invalid/primitives.test.w:8:5
   |
 8 | arr.push(4);
@@ -4696,7 +4722,7 @@ error: Struct fields must have immutable types
    |   ^
 
 
-error: Member "badField" doesn't exist in "A"
+error: Member "badField" does not exist in "A"
    --> ../../../examples/tests/invalid/structs.test.w:32:7
    |
 32 | log(a.badField);
@@ -4908,7 +4934,7 @@ Duration <DURATION>"
 `;
 
 exports[`un_mut_lifted_objects.test.w 1`] = `
-"error: Member "push" doesn't exist in "Array"
+"error: Member "push" does not exist in "Array"
    --> ../../../examples/tests/invalid/un_mut_lifted_objects.test.w:22:6
    |
 22 |   ar.push(2); // Error: push doesn't exist in Array
@@ -4924,42 +4950,42 @@ error: Cannot update elements of an immutable Array
    = hint: Consider using MutArray instead
 
 
-error: Member "set" doesn't exist in "Json"
+error: Member "set" does not exist in "Json"
    --> ../../../examples/tests/invalid/un_mut_lifted_objects.test.w:24:5
    |
 24 |   j.set("a", 3); // Error: set doesn't exist in Json
    |     ^^^
 
 
-error: Member "add" doesn't exist in "Set"
+error: Member "add" does not exist in "Set"
    --> ../../../examples/tests/invalid/un_mut_lifted_objects.test.w:25:6
    |
 25 |   st.add(4); // Error: add doesn't exist in Set
    |      ^^^
 
 
-error: Member "set" doesn't exist in "Map"
+error: Member "set" does not exist in "Map"
    --> ../../../examples/tests/invalid/un_mut_lifted_objects.test.w:26:6
    |
 26 |   mp.set("a", 3); // Error: set doesn't exist in Map
    |      ^^^
 
 
-error: Member "push" doesn't exist in "Array"
+error: Member "push" does not exist in "Array"
    --> ../../../examples/tests/invalid/un_mut_lifted_objects.test.w:27:11
    |
 27 |   opt_ar?.push(2); // Error: push doesn't exist in Array
    |           ^^^^
 
 
-error: Member "push" doesn't exist in "Array"
+error: Member "push" does not exist in "Array"
    --> ../../../examples/tests/invalid/un_mut_lifted_objects.test.w:28:16
    |
 28 |   recursive_ar.push(MutArray<num>[2]); // Error: push doesn't exist in Array
    |                ^^^^
 
 
-error: Member "push" doesn't exist in "Array"
+error: Member "push" does not exist in "Array"
    --> ../../../examples/tests/invalid/un_mut_lifted_objects.test.w:29:22
    |
 29 |   recursive_ar.at(0).push(3); // Error: push doesn't exist in Array
@@ -5017,7 +5043,7 @@ Duration <DURATION>"
 `;
 
 exports[`unknown_field.test.w 1`] = `
-"error: Member "a" doesn't exist in "String"
+"error: Member "a" does not exist in "String"
   --> ../../../examples/tests/invalid/unknown_field.test.w:1:12
   |
 1 | std.String.a.b.c.fromJson();
@@ -5082,7 +5108,7 @@ error: Unknown symbol "B"
    |                 ^
 
 
-error: Member "dodo" doesn't exist in "SomeResourceChild"
+error: Member "dodo" does not exist in "SomeResourceChild"
    --> ../../../examples/tests/invalid/unknown_symbol.test.w:37:5
    |
 37 | src.dodo();
@@ -5103,14 +5129,14 @@ error: Binary operator '+' cannot be applied to operands of type 'num' and 'str'
    |                        ^^^^^^^
 
 
-error: Member "assert" doesn't exist in "Bucket"
+error: Member "assert" does not exist in "Bucket"
    --> ../../../examples/tests/invalid/unknown_symbol.test.w:20:17
    |
 20 |     this.bucket.assert(2 + "2");
    |                 ^^^^^^
 
 
-error: Member "methodWhichIsNotPartOfBucketApi" doesn't exist in "Bucket"
+error: Member "methodWhichIsNotPartOfBucketApi" does not exist in "Bucket"
    --> ../../../examples/tests/invalid/unknown_symbol.test.w:23:24
    |
 23 |     return this.bucket.methodWhichIsNotPartOfBucketApi(id);

--- a/tools/hangar/__snapshots__/test_corpus/valid/casting.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/casting.test.w_compile_tf-aws.md
@@ -56,9 +56,9 @@ class $Root extends $stdlib.std.Resource {
     super($scope, $id);
     const b = this.node.root.new("@winglang/sdk.cloud.Bucket", cloud.Bucket, this, "Bucket");
     if ($helpers.eq((util.Util.env("WING_TARGET")), "tf-aws")) {
-      const s3Bucket = (b.node.findChild("Default"));
+      const s3Bucket = ($helpers.nodeof(b).findChild("Default"));
       (s3Bucket.addOverride("bucket_prefix", "my-prefix-"));
-      console.log(s3Bucket.node.path);
+      console.log($helpers.nodeof(s3Bucket).path);
     }
   }
 }

--- a/tools/hangar/__snapshots__/test_corpus/valid/construct-base.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/construct-base.test.w_compile_tf-aws.md
@@ -64,7 +64,7 @@ class $Root extends $stdlib.std.Resource {
     class WingResource extends $stdlib.std.Resource {
       constructor($scope, $id, ) {
         super($scope, $id);
-        console.log(String.raw({ raw: ["my id is ", ""] }, this.node.id));
+        console.log(String.raw({ raw: ["my id is ", ""] }, $helpers.nodeof(this).id));
       }
       static _toInflightType() {
         return `
@@ -91,7 +91,7 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     const getPath = ((c) => {
-      return c.node.path;
+      return $helpers.nodeof(c).path;
     });
     const getDisplayName = ((r) => {
       return $helpers.nodeof(r).title;
@@ -103,6 +103,7 @@ class $Root extends $stdlib.std.Resource {
     console.log(String.raw({ raw: ["path of wing resource: ", ""] }, (getPath(wr))));
     const title = ((getDisplayName(wr)) ?? "no display name");
     console.log(String.raw({ raw: ["display name of wing resource: ", ""] }, title));
+    console.log((cx.Node.of(wr)).path);
   }
 }
 const $PlatformManager = new $stdlib.platform.PlatformManager({platformPaths: $platforms});

--- a/tools/hangar/__snapshots__/test_corpus/valid/construct-base.test.w_test_sim.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/construct-base.test.w_test_sim.md
@@ -6,6 +6,7 @@ my id is WingResource
 path of sqs.queue: root/env0/SqsQueue
 path of wing resource: root/env0/WingResource
 display name of wing resource: no display name
+root/env0/WingResource
 pass ─ construct-base.test.wsim (no tests)
 
 Tests 1 passed (1)

--- a/tools/hangar/__snapshots__/test_corpus/valid/custom_obj_id.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/custom_obj_id.test.w_compile_tf-aws.md
@@ -76,8 +76,8 @@ class $Root extends $stdlib.std.Resource {
     }
     const foo1 = new Foo(this, "Foo");
     const bar2 = new Foo(this, "bar2");
-    $helpers.assert($helpers.eq(foo1.node.id, "Foo"), "foo1.node.id == \"Foo\"");
-    $helpers.assert($helpers.eq(bar2.node.id, "bar2"), "bar2.node.id == \"bar2\"");
+    $helpers.assert($helpers.eq($helpers.nodeof(foo1).id, "Foo"), "nodeof(foo1).id == \"Foo\"");
+    $helpers.assert($helpers.eq($helpers.nodeof(bar2).id, "bar2"), "nodeof(bar2).id == \"bar2\"");
   }
 }
 const $PlatformManager = new $stdlib.platform.PlatformManager({platformPaths: $platforms});

--- a/tools/hangar/__snapshots__/test_corpus/valid/function_variadic_arguments.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/function_variadic_arguments.test.w_compile_tf-aws.md
@@ -158,7 +158,7 @@ class $Root extends $stdlib.std.Resource {
     const bucket1 = this.node.root.new("@winglang/sdk.cloud.Bucket", cloud.Bucket, this, "bucket1");
     const bucket2 = this.node.root.new("@winglang/sdk.cloud.Bucket", cloud.Bucket, this, "bucket2");
     const bucket3 = this.node.root.new("@winglang/sdk.cloud.Bucket", cloud.Bucket, this, "bucket3");
-    (bucket3.node.addDependency(bucket1, bucket2));
+    ($helpers.nodeof(bucket3).addDependency(bucket1, bucket2));
     const funcBucket = ((...buckets) => {
       $helpers.assert($helpers.eq(buckets.length, 2), "buckets.length == 2");
     });

--- a/tools/hangar/__snapshots__/test_corpus/valid/resource.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/resource.test.w_compile_tf-aws.md
@@ -1096,15 +1096,15 @@ class $Root extends $stdlib.std.Resource {
       constructor($scope, $id, ) {
         super($scope, $id);
         const d1 = new Dummy(this, "Dummy");
-        $helpers.assert(d1.node.path.endsWith("/ScopeAndIdTestClass/Dummy"), "d1.node.path.endsWith(\"/ScopeAndIdTestClass/Dummy\")");
+        $helpers.assert($helpers.nodeof(d1).path.endsWith("/ScopeAndIdTestClass/Dummy"), "nodeof(d1).path.endsWith(\"/ScopeAndIdTestClass/Dummy\")");
         const d2 = new Dummy(d1, "Dummy");
-        $helpers.assert(d2.node.path.endsWith("/ScopeAndIdTestClass/Dummy/Dummy"), "d2.node.path.endsWith(\"/ScopeAndIdTestClass/Dummy/Dummy\")");
+        $helpers.assert($helpers.nodeof(d2).path.endsWith("/ScopeAndIdTestClass/Dummy/Dummy"), "nodeof(d2).path.endsWith(\"/ScopeAndIdTestClass/Dummy/Dummy\")");
         const d3 = new Dummy((Dummy.getInstance(this, d2)), "Dummy");
-        $helpers.assert(d3.node.path.endsWith("/ScopeAndIdTestClass/Dummy/Dummy/StaticDummy/Dummy"), "d3.node.path.endsWith(\"/ScopeAndIdTestClass/Dummy/Dummy/StaticDummy/Dummy\")");
+        $helpers.assert($helpers.nodeof(d3).path.endsWith("/ScopeAndIdTestClass/Dummy/Dummy/StaticDummy/Dummy"), "nodeof(d3).path.endsWith(\"/ScopeAndIdTestClass/Dummy/Dummy/StaticDummy/Dummy\")");
         for (const i of $helpers.range(0,3,false)) {
           const x = new Dummy(this, String.raw({ raw: ["tc", ""] }, i));
           const expected_path = String.raw({ raw: ["/ScopeAndIdTestClass/tc", ""] }, i);
-          $helpers.assert(x.node.path.endsWith(expected_path), "x.node.path.endsWith(expected_path)");
+          $helpers.assert($helpers.nodeof(x).path.endsWith(expected_path), "nodeof(x).path.endsWith(expected_path)");
         }
       }
       static _toInflightType() {

--- a/tools/hangar/__snapshots__/test_corpus/valid/this.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/this.test.w_compile_tf-aws.md
@@ -33,12 +33,12 @@ const expect = $stdlib.expect;
 class $Root extends $stdlib.std.Resource {
   constructor($scope, $id) {
     super($scope, $id);
-    const path = this.node.path;
-    for (const c of this.node.children) {
-      console.log(c.node.path);
+    const path = $helpers.nodeof(this).path;
+    for (const c of $helpers.nodeof(this).children) {
+      console.log($helpers.nodeof(c).path);
     }
-    (expect.Util.notNil(this.node));
-    (expect.Util.equal(((arr, index) => { if (index < 0 || index >= arr.length) throw new Error("Index out of bounds"); return arr[index]; })((this.node.path.split("/")), 0), "root"));
+    (expect.Util.notNil($helpers.nodeof(this)));
+    (expect.Util.equal(((arr, index) => { if (index < 0 || index >= arr.length) throw new Error("Index out of bounds"); return arr[index]; })(($helpers.nodeof(this).path.split("/")), 0), "root"));
   }
 }
 const $PlatformManager = new $stdlib.platform.PlatformManager({platformPaths: $platforms});


### PR DESCRIPTION
To avoid confusion between different APIs and different runtime behavior between the `std.Node` and `constructs.Node` types, we avoid exposing `constructs.Node` in the language where possible.

Fixes #5840

BREAKING CHANGE: `.node` is no longer a directly available field on preflight classes and `IConstruct` values. Use the global function `nodeof()` for accessing tree nodes instead.

## Checklist

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [x] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
