### PR TITLE
feat(console): expand automatically when there is only one node

### DIFF
--- a/apps/wing-console/console/ui/src/features/hierarchy-pane/use-hierarchy.tsx
+++ b/apps/wing-console/console/ui/src/features/hierarchy-pane/use-hierarchy.tsx
@@ -80,6 +80,10 @@ export const useHierarchy = () => {
   }, [selectedNode, setSelectedItems]);
 
   useEffect(() => {
+    // Expand automatically if there is only one item and it is not explicitly set to be collapsed.
+    if (items?.length === 1 && items[0] && items[0].expanded !== false) {
+      setExpandedItems([items[0].id]);
+    }
     const getExpandedNodes = (items: TreeMenuItem[]): string[] => {
       let expandedNodes: string[] = [];
       for (const item of items) {

--- a/apps/wing-console/console/ui/src/features/hierarchy-pane/use-hierarchy.tsx
+++ b/apps/wing-console/console/ui/src/features/hierarchy-pane/use-hierarchy.tsx
@@ -83,6 +83,7 @@ export const useHierarchy = () => {
     // Expand automatically if there is only one item and it is not explicitly set to be collapsed.
     if (items?.length === 1 && items[0] && items[0].expanded !== false) {
       setExpandedItems([items[0].id]);
+      return;
     }
     const getExpandedNodes = (items: TreeMenuItem[]): string[] => {
       let expandedNodes: string[] = [];


### PR DESCRIPTION
This feature was removed by accident 
[here](https://github.com/winglang/wing/pull/6696/files#diff-d0777fb1e9f89a098ae45c58c33cd7b13945106582d1e8c5ed8aef8258b6fa7cL89-L93)