### PR TITLE
fix(console): log levels indicator doesn't show "All levels"

### DIFF
--- a/apps/wing-console/console/ui/src/features/logs-pane/console-logs-filters.tsx
+++ b/apps/wing-console/console/ui/src/features/logs-pane/console-logs-filters.tsx
@@ -173,7 +173,7 @@ export const ConsoleLogsFilters = memo(
     }, [resources]);
 
     const logTypeLabel = useMemo(() => {
-      if (selectedLogTypeFilters.length === resourceTypeItems.length) {
+      if (selectedLogTypeFilters.length === LOG_LEVELS.length) {
         return "All levels";
       } else if (
         selectedLogTypeFilters.sort().toString() ===

--- a/apps/wing-console/console/ui/src/features/logs-pane/console-logs-filters.tsx
+++ b/apps/wing-console/console/ui/src/features/logs-pane/console-logs-filters.tsx
@@ -190,7 +190,7 @@ export const ConsoleLogsFilters = memo(
       } else {
         return "Custom levels";
       }
-    }, [resourceTypeItems, selectedLogTypeFilters, defaultLogTypeSelection]);
+    }, [selectedLogTypeFilters, defaultLogTypeSelection]);
 
     const showIncompatibleResourceTypeWarning = useMemo(() => {
       if (!resources || selectedResourceTypes.length === 0) {


### PR DESCRIPTION
The log levels indicator didn't show "All levels" even when every filter was selected.
