### PR TITLE
chore: disable flakey test on Windows

### DIFF
--- a/examples/tests/sdk_tests/resource/call.test.w
+++ b/examples/tests/sdk_tests/resource/call.test.w
@@ -218,13 +218,16 @@ if util.env("WING_TARGET") == "sim" {
     r1.printLogs();
   }
 
-  test "resource.call times out if the method takes too long" {
-    let var msg = "";
-    try {
-      r1.methodTakesLongTime();
-    } catch err {
-      msg = err;
+  // This test is disabled on Windows because it is known to be flakey on that platform
+  if util.os() != "win32" {
+    test "resource.call times out if the method takes too long" {
+      let var msg = "";
+      try {
+        r1.methodTakesLongTime();
+      } catch err {
+        msg = err;
+      }
+      assert(msg.contains("timed out"));
     }
-    assert(msg.contains("timed out"));
   }
 }

--- a/examples/tests/sdk_tests/resource/call.test.w
+++ b/examples/tests/sdk_tests/resource/call.test.w
@@ -218,16 +218,16 @@ if util.env("WING_TARGET") == "sim" {
     r1.printLogs();
   }
 
-  // This test is disabled on Windows because it is known to be flakey on that platform
-  if util.os() != "win32" {
-    test "resource.call times out if the method takes too long" {
-      let var msg = "";
-      try {
-        r1.methodTakesLongTime();
-      } catch err {
-        msg = err;
-      }
-      assert(msg.contains("timed out"));
-    }
-  }
+  // TODO: this test is skipped because it's flakey on Windows
+  // https://github.com/winglang/wing/issues/6756
+  //
+  // test "resource.call times out if the method takes too long" {
+  //   let var msg = "";
+  //   try {
+  //     r1.methodTakesLongTime();
+  //   } catch err {
+  //     msg = err;
+  //   }
+  //   assert(msg.contains("timed out"));
+  // }
 }

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/resource/call.test.w_test_sim.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/resource/call.test.w_test_sim.md
@@ -7,15 +7,13 @@
 [INFO] resource can log messages at different levels | another info log
 [WARNING] resource can log messages at different levels | a warn log
 [ERROR] resource can log messages at different levels | Error: an error log
-[ERROR] resource.call times out if the method takes too long | Error: Resource is not running (it may have crashed or stopped)
 pass ─ call.test.wsim » root/env0/test:resource.call with a field name returns the field value                
 pass ─ call.test.wsim » root/env1/test:resource.call cannot be used to call onStop                            
 pass ─ call.test.wsim » root/env2/test:exceptions thrown by the resource are caught and rethrown by the caller
 pass ─ call.test.wsim » root/env3/test:resource.call can accept and return various kinds of values            
 pass ─ call.test.wsim » root/env4/test:resource can log messages at different levels                          
-pass ─ call.test.wsim » root/env5/test:resource.call times out if the method takes too long                   
 
-Tests 6 passed (6)
+Tests 5 passed (5)
 Snapshots 1 skipped
 Test Files 1 passed (1)
 Duration <DURATION>


### PR DESCRIPTION
The test named "resource.call times out if the method takes too long" has been flaking since we merged in https://github.com/winglang/wing/pull/6686. Specifically, it sometimes logs additional errors:

```
Resource is not running (it may have crashed or stopped)
Process exited with code null, signal SIGTERM
node:internal/modules/cjs/loader:1148
  throw err;
  ^

Cannot find module 'D:/a/wing/wing/examples/tests/sdk_tests/resource/target/test/call.test.wsim/.wing/resource_c823d293.sandbox.cjs.bundle/index.cjs'

  code: 'MODULE_NOT_FOUND',
  requireStack: []
}

Node.js v20.14.0
```

I have a suspicion the test is already broken in some way because even when I try running the test on my local system, the test logs "Resource is not running (it may have crashed or stopped)" instead of an error saying that the method call timed out: https://github.com/winglang/wing/blob/56010c4f7c5934e7fabdefb8fd91e8896f624f29/libs/wingsdk/src/target-sim/resource.inflight.ts#L179

This PR disables the test until we're able to solve the underlying issue.

## Checklist

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [ ] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
