### PR TITLE
fix(docs): remove inflight modifier to docs example

### DIFF
--- a/docs/docs/02-concepts/01-preflight-and-inflight.md
+++ b/docs/docs/02-concepts/01-preflight-and-inflight.md
@@ -213,7 +213,7 @@ inflight () => {
       this.age = age;
     }
 
-    pub inflight greet() {
+    pub greet() {
       log("Hello, {this.name}!");
     }
   }


### PR DESCRIPTION
[This page](https://www.winglang.io/docs/concepts/inflights#combining-preflight-and-inflight-code) shows an example of a inflight class.

The example shows an inflight modifier in the class although the class it defined within an inflight closure.

Removing the modifier to clean up the example.

## Checklist

- [] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [ ] Description explains motivation and solution
- [ ] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
