### PR TITLE
feat(sdk): `http.connect()` and `http.trace()`

### DIFF
--- a/docs/docs/04-standard-library/http/api-reference.md
+++ b/docs/docs/04-standard-library/http/api-reference.md
@@ -22,6 +22,7 @@ The Http class is used for calling different HTTP methods and requesting and sen
 
 | **Name** | **Description** |
 | --- | --- |
+| <code><a href="#@winglang/sdk.http.Util.connect">connect</a></code> | Executes a CONNECT request to a specified URL and provides a formatted response. |
 | <code><a href="#@winglang/sdk.http.Util.delete">delete</a></code> | Executes a DELETE request to a specified URL and provides a formatted response. |
 | <code><a href="#@winglang/sdk.http.Util.fetch">fetch</a></code> | Executes a HTTP request to a specified URL and provides a formatted response. |
 | <code><a href="#@winglang/sdk.http.Util.formatUrl">formatUrl</a></code> | Serializes an URL Struct to a String. |
@@ -30,6 +31,33 @@ The Http class is used for calling different HTTP methods and requesting and sen
 | <code><a href="#@winglang/sdk.http.Util.patch">patch</a></code> | Executes a PATCH request to a specified URL and provides a formatted response. |
 | <code><a href="#@winglang/sdk.http.Util.post">post</a></code> | Executes a POST request to a specified URL and provides a formatted response. |
 | <code><a href="#@winglang/sdk.http.Util.put">put</a></code> | Executes a PUT request to a specified URL and provides a formatted response. |
+| <code><a href="#@winglang/sdk.http.Util.trace">trace</a></code> | Executes a TRACE request to a specified URL and provides a formatted response. |
+
+---
+
+##### `connect` <a name="connect" id="@winglang/sdk.http.Util.connect"></a>
+
+```wing
+bring http;
+
+inflight http.connect(url: str, options?: RequestOptions);
+```
+
+Executes a CONNECT request to a specified URL and provides a formatted response.
+
+###### `url`<sup>Required</sup> <a name="url" id="@winglang/sdk.http.Util.connect.parameter.url"></a>
+
+- *Type:* str
+
+The target URL for the CONNECT request.
+
+---
+
+###### `options`<sup>Optional</sup> <a name="options" id="@winglang/sdk.http.Util.connect.parameter.options"></a>
+
+- *Type:* <a href="#@winglang/sdk.http.RequestOptions">RequestOptions</a>
+
+Optional parameters for customizing the CONNECT request.
 
 ---
 
@@ -230,6 +258,32 @@ The target URL for the PUT request.
 - *Type:* <a href="#@winglang/sdk.http.RequestOptions">RequestOptions</a>
 
 ptional parameters for customizing the PUT request.
+
+---
+
+##### `trace` <a name="trace" id="@winglang/sdk.http.Util.trace"></a>
+
+```wing
+bring http;
+
+inflight http.trace(url: str, options?: RequestOptions);
+```
+
+Executes a TRACE request to a specified URL and provides a formatted response.
+
+###### `url`<sup>Required</sup> <a name="url" id="@winglang/sdk.http.Util.trace.parameter.url"></a>
+
+- *Type:* str
+
+The target URL for the TRACE request.
+
+---
+
+###### `options`<sup>Optional</sup> <a name="options" id="@winglang/sdk.http.Util.trace.parameter.options"></a>
+
+- *Type:* <a href="#@winglang/sdk.http.RequestOptions">RequestOptions</a>
+
+Optional parameters for customizing the TRACE request.
 
 ---
 
@@ -681,6 +735,8 @@ The request's method.
 | <code><a href="#@winglang/sdk.http.HttpMethod.POST">POST</a></code> | POST. |
 | <code><a href="#@winglang/sdk.http.HttpMethod.OPTIONS">OPTIONS</a></code> | OPTIONS. |
 | <code><a href="#@winglang/sdk.http.HttpMethod.HEAD">HEAD</a></code> | HEAD. |
+| <code><a href="#@winglang/sdk.http.HttpMethod.CONNECT">CONNECT</a></code> | CONNECT. |
+| <code><a href="#@winglang/sdk.http.HttpMethod.TRACE">TRACE</a></code> | TRACE. |
 
 ---
 
@@ -729,6 +785,20 @@ OPTIONS.
 ##### `HEAD` <a name="HEAD" id="@winglang/sdk.http.HttpMethod.HEAD"></a>
 
 HEAD.
+
+---
+
+
+##### `CONNECT` <a name="CONNECT" id="@winglang/sdk.http.HttpMethod.CONNECT"></a>
+
+CONNECT.
+
+---
+
+
+##### `TRACE` <a name="TRACE" id="@winglang/sdk.http.HttpMethod.TRACE"></a>
+
+TRACE.
 
 ---
 

--- a/libs/wingc/src/lsp/snapshots/completions/namespace_inflight.snap
+++ b/libs/wingc/src/lsp/snapshots/completions/namespace_inflight.snap
@@ -1,6 +1,18 @@
 ---
 source: libs/wingc/src/lsp/completions.rs
 ---
+- label: connect
+  kind: 2
+  detail: "inflight (url: str, options: RequestOptions?): Response"
+  documentation:
+    kind: markdown
+    value: "Executes a CONNECT request to a specified URL and provides a formatted response.\n\n#### Returns\nthe formatted response of the call"
+  sortText: ff|connect
+  insertText: connect($1)
+  insertTextFormat: 2
+  command:
+    title: triggerParameterHints
+    command: editor.action.triggerParameterHints
 - label: delete
   kind: 2
   detail: "inflight (url: str, options: RequestOptions?): Response"
@@ -97,11 +109,23 @@ source: libs/wingc/src/lsp/completions.rs
   command:
     title: triggerParameterHints
     command: editor.action.triggerParameterHints
+- label: trace
+  kind: 2
+  detail: "inflight (url: str, options: RequestOptions?): Response"
+  documentation:
+    kind: markdown
+    value: "Executes a TRACE request to a specified URL and provides a formatted response.\n\n#### Returns\nthe formatted response of the call"
+  sortText: ff|trace
+  insertText: trace($1)
+  insertTextFormat: 2
+  command:
+    title: triggerParameterHints
+    command: editor.action.triggerParameterHints
 - label: Util
   kind: 7
   documentation:
     kind: markdown
-    value: "```wing\nclass Util {\n  static inflight delete(): Response;\n  static inflight fetch(): Response;\n  static inflight formatUrl(): str;\n  static inflight get(): Response;\n  static inflight parseUrl(): Url;\n  static inflight patch(): Response;\n  /* ... */\n}\n```\n---\nThe Http class is used for calling different HTTP methods and requesting and sending information online,  as well as testing public accessible resources."
+    value: "```wing\nclass Util {\n  static inflight connect(): Response;\n  static inflight delete(): Response;\n  static inflight fetch(): Response;\n  static inflight formatUrl(): str;\n  static inflight get(): Response;\n  static inflight parseUrl(): Url;\n  /* ... */\n}\n```\n---\nThe Http class is used for calling different HTTP methods and requesting and sending information online,  as well as testing public accessible resources."
   sortText: gg|Util
 - label: FormatUrlOptions
   kind: 22
@@ -131,7 +155,7 @@ source: libs/wingc/src/lsp/completions.rs
   kind: 13
   documentation:
     kind: markdown
-    value: "```wing\nenum HttpMethod {\n  GET,\n  PUT,\n  DELETE,\n  PATCH,\n  POST,\n  OPTIONS,\n  HEAD,\n}\n```\n---\nThe request's method."
+    value: "```wing\nenum HttpMethod {\n  GET,\n  PUT,\n  DELETE,\n  PATCH,\n  POST,\n  OPTIONS,\n  HEAD,\n  CONNECT,\n  TRACE,\n}\n```\n---\nThe request's method."
   sortText: jj|HttpMethod
 - label: RequestCache
   kind: 13

--- a/libs/wingsdk/src/http/http.ts
+++ b/libs/wingsdk/src/http/http.ts
@@ -91,6 +91,14 @@ export enum HttpMethod {
    * HEAD
    */
   HEAD = "HEAD",
+  /**
+   * CONNECT
+   */
+  CONNECT = "CONNECT",
+  /**
+   * TRACE
+   */
+  TRACE = "TRACE",
 }
 
 /**
@@ -325,6 +333,40 @@ export class Util {
     return this.fetch(url, {
       ...options,
       method: HttpMethod.DELETE,
+    });
+  }
+
+  /**
+   * Executes a CONNECT request to a specified URL and provides a formatted response.
+   * @param url The target URL for the CONNECT request.
+   * @param options Optional parameters for customizing the CONNECT request.
+   * @inflight
+   * @returns the formatted response of the call
+   */
+  public static async connect(
+    url: string,
+    options?: RequestOptions
+  ): Promise<Response> {
+    return this.fetch(url, {
+      ...options,
+      method: HttpMethod.CONNECT,
+    });
+  }
+
+  /**
+   * Executes a TRACE request to a specified URL and provides a formatted response.
+   * @param url The target URL for the TRACE request.
+   * @param options Optional parameters for customizing the TRACE request.
+   * @inflight
+   * @returns the formatted response of the call
+   */
+  public static async trace(
+    url: string,
+    options?: RequestOptions
+  ): Promise<Response> {
+    return this.fetch(url, {
+      ...options,
+      method: HttpMethod.TRACE,
     });
   }
 

--- a/libs/wingsdk/test/http/http.test.ts
+++ b/libs/wingsdk/test/http/http.test.ts
@@ -21,7 +21,7 @@ describe("fetch", () => {
     (global.fetch as Mock).mockClear();
   });
 
-  test("get, post, put, patch and delete return response when supplying a url", async () => {
+  test("get, post, put, patch, delete, connect and trace return response when supplying a url", async () => {
     (global.fetch as Mock).mockImplementation((url) => ({
       url,
       headers: new Headers([["content-type", "application/json"]]),
@@ -41,6 +41,8 @@ describe("fetch", () => {
     expectResponse(await Http.post("url"));
     expectResponse(await Http.patch("url"));
     expectResponse(await Http.delete("url"));
+    expectResponse(await Http.connect("url"));
+    expectResponse(await Http.trace("url"));
   });
 
   test("http.fetch is working with all methods", async () => {


### PR DESCRIPTION
The CONNECT and TRACE methods were not added to the http module yet, as described in https://github.com/winglang/wing/issues/4818
- [x] Description explains motivation and solution
- [x] Tests added (always)
- [x] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
