### PR TITLE
feat(compiler)!: remove optional test (x?) operator

### DIFF
--- a/docs/docs/07-examples/05-optionality.md
+++ b/docs/docs/07-examples/05-optionality.md
@@ -16,10 +16,10 @@ let s2: str? = nil; // type str? (optional), value nil
 let s1: str? = "Hello"; // type str? (optional), value "Hello"
 let s2: str? = nil; // type str? (optional), value nil
 
-if s1? {
+if s1 != nil {
   log("x1 is not nil");
 }
-if !s2? {
+if s2 == nil {
   log("x2 is nil");
 }
 ```
@@ -80,10 +80,6 @@ if let value = j.tryGet("broken")?.tryGet("a")?.tryGet("b")?.tryAsStr() {
 ```ts playground example
 let b3: bool? = false; 
 
-if b3? {
-  log("although b3 is false, the if statement here checks for existence of value");
-}
-
 if let b3 = b3  { // unboxing b3 and shadowing original b3 
   if b3 {
     log("b3 is true");
@@ -96,7 +92,6 @@ if let b3 = b3  { // unboxing b3 and shadowing original b3
 
 /**
  * prints:
-  although b3 is false, the if statement here checks for existence of value
   b3 is false
 **/
 ```

--- a/docs/docs/07-examples/07-structs.md
+++ b/docs/docs/07-examples/07-structs.md
@@ -27,7 +27,7 @@ struct Example {
 }
 
 let example = Example { };
-if ! example.a? {
+if example.a == nil {
   log("a is nil"); 
 }
 ```

--- a/examples/tests/doc_examples/valid/05-optionality.md_example_2/main.w
+++ b/examples/tests/doc_examples/valid/05-optionality.md_example_2/main.w
@@ -3,9 +3,9 @@
 let s1: str? = "Hello"; // type str? (optional), value "Hello"
 let s2: str? = nil; // type str? (optional), value nil
 
-if s1? {
+if s1 != nil {
   log("x1 is not nil");
 }
-if !s2? {
+if s2 == nil {
   log("x2 is nil");
 }

--- a/examples/tests/doc_examples/valid/05-optionality.md_example_6/main.w
+++ b/examples/tests/doc_examples/valid/05-optionality.md_example_6/main.w
@@ -2,10 +2,6 @@
 // Example metadata: {"valid":true}
 let b3: bool? = false; 
 
-if b3? {
-  log("although b3 is false, the if statement here checks for existence of value");
-}
-
 if let b3 = b3  { // unboxing b3 and shadowing original b3 
   if b3 {
     log("b3 is true");
@@ -18,6 +14,5 @@ if let b3 = b3  { // unboxing b3 and shadowing original b3
 
 /**
  * prints:
-  although b3 is false, the if statement here checks for existence of value
   b3 is false
 **/

--- a/examples/tests/doc_examples/valid/07-structs.md_example_2/main.w
+++ b/examples/tests/doc_examples/valid/07-structs.md_example_2/main.w
@@ -7,6 +7,6 @@ struct Example {
 }
 
 let example = Example { };
-if ! example.a? {
+if example.a == nil {
   log("a is nil"); 
 }

--- a/examples/tests/invalid/nil.test.w
+++ b/examples/tests/invalid/nil.test.w
@@ -21,10 +21,6 @@ test "nillarooni" {
 //           ^^^ Expected type to be "num", but got "nil" instead (hint: to allow "nil" assignment use optional type: "num?")
 }
 
-if nil? {
-// ^^^ Expected optional type, found "nil"
-}
-
 let nilWannabe = nil;
 //               ^^^ Cannot assign nil value to variables without explicit optional type
 

--- a/examples/tests/invalid/optionals.test.w
+++ b/examples/tests/invalid/optionals.test.w
@@ -15,9 +15,6 @@ fOptional("");
 //        ^^ error: expected num?, got str
 
 let y = true;
-if y? {
- // ^ y isn't optional
-}
 
 let z = y ?? 1;
 //      ^ y isn't optional

--- a/examples/tests/sdk_tests/function/invoke.test.w
+++ b/examples/tests/sdk_tests/function/invoke.test.w
@@ -8,7 +8,7 @@ log("log preflight");
 let f = new cloud.Function(inflight (input): str => {
   log("log inside function\ncontains 2 lines");
   let target = util.tryEnv("WING_TARGET");
-  assert(target?); // make sure WING_TARGET is defined in all environments
+  assert(target != nil); // make sure WING_TARGET is defined in all environments
 
   return "{input ?? "nil"}-response";
 });

--- a/examples/tests/sdk_tests/service/callbacks.test.w
+++ b/examples/tests/sdk_tests/service/callbacks.test.w
@@ -21,7 +21,7 @@ if util.env("WING_TARGET") == "sim" {
   }, autoStart: false);
 
   test "does not start automatically if autoStart is false" {
-    assert(!b.tryGet(status)?);
+    assert(b.tryGet(status) == nil);
   }
 
   test "start() calls onStart() idempotently" {
@@ -38,7 +38,7 @@ if util.env("WING_TARGET") == "sim" {
     
     // we haven't started the service yet, so onStop() should not be called
     s.stop();
-    assert(!b.tryGet(status)?);
+    assert(b.tryGet(status) == nil);
     assert(startCounter.peek() == 0);
 
     // now we are starting..

--- a/examples/tests/sdk_tests/state/get.test.w
+++ b/examples/tests/sdk_tests/state/get.test.w
@@ -12,7 +12,7 @@ if util.env("WING_TARGET") == "sim" {
 
   test "state.tryGet() return nil if there is no value" {
     let v = svc.state.tryGet("foo_bar");
-    assert(!v?);
+    assert(v == nil);
   }
 
 }

--- a/examples/tests/valid/nil.test.w
+++ b/examples/tests/valid/nil.test.w
@@ -26,16 +26,14 @@ class Foo {
 let foo = new Foo();
 
 test "nil return" {
-  assert(foo.returnNil(true)? == true);
-  assert(foo.returnNil(false)? == false);
+  assert(foo.returnNil(true) != nil);
+  assert(foo.returnNil(false) == nil);
 }
 
 test "optional instance variable" {
-  assert(foo.getOptionalValue()? == false);
+  assert(foo.getOptionalValue() == nil);
   foo.setOptionalValue("hello");
-  assert(foo.getOptionalValue()? == true);
   assert(foo.getOptionalValue() != nil);
   foo.setOptionalValue(nil);
-  assert(foo.getOptionalValue()? == false);
   assert(foo.getOptionalValue() == nil);
 }

--- a/examples/tests/valid/optionals.test.w
+++ b/examples/tests/valid/optionals.test.w
@@ -1,10 +1,7 @@
 let x: num? = 4;
-assert(x? == true);
-assert(!x? == false);
-// TODO: add a `x? == false` case when we implement some way to null initialize an optional (https://github.com/winglang/wing/pull/1495)
+assert(x != nil);
 
 assert(x ?? 5 == 4);
-// TODO: add test for optional is nothing case (see https://github.com/winglang/wing/pull/1495)
 
 let y: num = x ?? 5;
 assert(y == 4);
@@ -54,8 +51,8 @@ let tryParseName = (fullName: str): Name? => {
     return nil;
   }
   return Name {
-    first: parts.tryAt(0)??"",
-    last: parts.tryAt(1)??"",
+    first: parts.tryAt(0) ?? "",
+    last: parts.tryAt(1) ?? "",
   };
 };
 
@@ -190,9 +187,9 @@ let payloadWithoutOptions = Payload {a: "a"};
 let payloadWithBucket = Payload {a: "a", c: new cloud.Bucket() as "orange bucket"};
 
 test "t" {
-  assert(payloadWithoutOptions.b? == false);
+  assert(payloadWithoutOptions.b == nil);
 
-  if (payloadWithBucket.c?) {
+  if (payloadWithBucket.c != nil) {
     payloadWithBucket.c?.put("x.txt", "something");
   }
 }

--- a/examples/tests/valid/statements_if.test.w
+++ b/examples/tests/valid/statements_if.test.w
@@ -45,7 +45,7 @@ if true {
   let c: str? = "c";
   if let d = a {
     assert(false);
-  } elif b? {
+  } elif b != nil {
     assert(true);
   } elif let e = c {
     assert(false);
@@ -62,7 +62,7 @@ if true {
     assert(false);
   } elif let e = c {
     assert(true);
-  } elif b? {
+  } elif b != nil {
     assert(false);
   } else {
     assert(false);

--- a/libs/tree-sitter-wing/grammar.js
+++ b/libs/tree-sitter-wing/grammar.js
@@ -11,7 +11,6 @@ const PREC = {
   ADD: 100,
   MULTIPLY: 110,
   UNARY: 120,
-  OPTIONAL_TEST: 130,
   POWER: 140,
   STRUCTURED_ACCESS: 150, // x[y]
   MEMBER: 160,
@@ -384,7 +383,6 @@ module.exports = grammar({
         $.parenthesized_expression,
         $.json_literal,
         $.struct_literal,
-        $.optional_test,
         $.compiler_dbg_panic,
         $.optional_unwrap,
         $.intrinsic
@@ -470,9 +468,6 @@ module.exports = grammar({
           )
         )
       ),
-
-    optional_test: ($) =>
-      prec.right(PREC.OPTIONAL_TEST, seq($.expression, "?")),
 
     compiler_dbg_panic: ($) => "😱",
     compiler_dbg_env: ($) => seq("🗺️", optional(";")),

--- a/libs/tree-sitter-wing/src/grammar.json
+++ b/libs/tree-sitter-wing/src/grammar.json
@@ -2051,10 +2051,6 @@
         },
         {
           "type": "SYMBOL",
-          "name": "optional_test"
-        },
-        {
-          "type": "SYMBOL",
           "name": "compiler_dbg_panic"
         },
         {
@@ -2461,23 +2457,6 @@
                 "value": "u\\{[0-9a-fA-F]+\\}"
               }
             ]
-          }
-        ]
-      }
-    },
-    "optional_test": {
-      "type": "PREC_RIGHT",
-      "value": 130,
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "SYMBOL",
-            "name": "expression"
-          },
-          {
-            "type": "STRING",
-            "value": "?"
           }
         ]
       }

--- a/libs/tree-sitter-wing/test/corpus/expressions.txt
+++ b/libs/tree-sitter-wing/test/corpus/expressions.txt
@@ -489,46 +489,6 @@ let a = A { f1: 3, f2: true };
         (bool)))))
 
 ================================================================================
-Optional test (and precedence)
-================================================================================
-a?;
-!a?;
-(!a)?;
-(a.b.c)?;
-
---------------------------------------------------------------------------------
-
-(source
-  (expression_statement
-    (optional_test
-      (reference
-        (reference_identifier))))
-  (expression_statement
-    (unary_expression
-      arg: (optional_test
-        (reference
-          (reference_identifier)))))
-  (expression_statement
-    (optional_test
-      (parenthesized_expression
-        (unary_expression
-          arg: (reference
-            (reference_identifier))))))
-  (expression_statement
-    (optional_test
-      (parenthesized_expression
-        (reference
-          (nested_identifier
-            object: (reference
-              (nested_identifier
-                object: (reference
-                  (reference_identifier))
-                accessor_type: (accessor)
-                property: (member_identifier)))
-            accessor_type: (accessor)
-            property: (member_identifier)))))))
-
-================================================================================
 Nil
 ================================================================================
 

--- a/libs/tree-sitter-wing/test/corpus/statements/statements.txt
+++ b/libs/tree-sitter-wing/test/corpus/statements/statements.txt
@@ -492,7 +492,7 @@ if let x = y {} elif let x = z {} else {}
 (If Let) (Elif Let) (Elif) (Else)
 ================================================================================
 
-if let x = y {} elif let x = z {} elif v? {} else {}
+if let x = y {} elif let x = z {} elif v {} else {}
 
 --------------------------------------------------------------------------------
 
@@ -508,9 +508,8 @@ if let x = y {} elif let x = z {} elif v? {} else {}
         (reference_identifier))
       block: (block))
     elif_block: (elif_block
-      condition: (optional_test
-        (reference
-          (reference_identifier)))
+      condition: (reference
+        (reference_identifier))
       block: (block))
     else_block: (block)))
 

--- a/libs/wingc/src/ast.rs
+++ b/libs/wingc/src/ast.rs
@@ -817,7 +817,6 @@ impl Scope {
 pub enum UnaryOperator {
 	Minus,
 	Not,
-	OptionalTest,
 	OptionalUnwrap,
 }
 

--- a/libs/wingc/src/jsify.rs
+++ b/libs/wingc/src/jsify.rs
@@ -975,10 +975,6 @@ impl<'a> JSifier<'a> {
 				match op {
 					UnaryOperator::Minus => new_code!(expr_span, "(-", js_exp, ")"),
 					UnaryOperator::Not => new_code!(expr_span, "(!", js_exp, ")"),
-					UnaryOperator::OptionalTest => {
-						// We use the abstract inequality operator here because we want to check for null or undefined
-						new_code!(expr_span, "((", js_exp, ") != null)")
-					}
 					UnaryOperator::OptionalUnwrap => {
 						new_code!(expr_span, "$helpers.unwrap(", js_exp, ")")
 					}

--- a/libs/wingc/src/parser.rs
+++ b/libs/wingc/src/parser.rs
@@ -2482,16 +2482,6 @@ impl<'s> Parser<'s> {
 					expression_span,
 				))
 			}
-			"optional_test" => {
-				let expression = self.build_expression(&expression_node.named_child(0).unwrap(), phase);
-				Ok(Expr::new(
-					ExprKind::Unary {
-						op: UnaryOperator::OptionalTest,
-						exp: Box::new(expression?),
-					},
-					expression_span,
-				))
-			}
 			"optional_unwrap" => {
 				let expression = self.build_expression(&expression_node.named_child(0).unwrap(), phase);
 				Ok(Expr::new(

--- a/libs/wingc/src/type_check.rs
+++ b/libs/wingc/src/type_check.rs
@@ -2301,14 +2301,14 @@ new cloud.Function(@inflight("./handler.ts"), lifts: { bucket: ["put"] });
 						self.spanned_error(
 							exp,
 							format!(
-														"Binary operator '+' cannot be applied to operands of type '{}' and '{}'; only ({}, {}) and ({}, {}) are supported",
-														ltype,
-														rtype,
-														self.types.number(),
-														self.types.number(),
-														self.types.string(),
-														self.types.string(),
-													),
+								"Binary operator '+' cannot be applied to operands of type '{}' and '{}'; only ({}, {}) and ({}, {}) are supported",
+								ltype,
+								rtype,
+								self.types.number(),
+								self.types.number(),
+								self.types.string(),
+								self.types.string(),
+							),
 						);
 					}
 					self.resolved_error()
@@ -2354,12 +2354,6 @@ new cloud.Function(@inflight("./handler.ts"), lifts: { bucket: ["put"] });
 		match op {
 			UnaryOperator::Not => (self.validate_type(type_, self.types.bool(), unary_exp), phase),
 			UnaryOperator::Minus => (self.validate_type(type_, self.types.number(), unary_exp), phase),
-			UnaryOperator::OptionalTest => {
-				if !type_.is_option() {
-					self.spanned_error(unary_exp, format!("Expected optional type, found \"{}\"", type_));
-				}
-				(self.types.bool(), phase)
-			}
 			UnaryOperator::OptionalUnwrap => {
 				if !type_.is_option() {
 					self.spanned_error(unary_exp, format!("'!' expects an optional type, found \"{}\"", type_));

--- a/tools/hangar/__snapshots__/invalid.ts.snap
+++ b/tools/hangar/__snapshots__/invalid.ts.snap
@@ -3506,14 +3506,7 @@ Duration <DURATION>"
 `;
 
 exports[`nil.test.w 1`] = `
-"error: Unknown parser error
-   --> ../../../examples/tests/invalid/nil.test.w:24:7
-   |
-24 | if nil? {
-   |       ^
-
-
-error: Expected type to be "str", but got "nil" instead
+"error: Expected type to be "str", but got "nil" instead
   --> ../../../examples/tests/invalid/nil.test.w:3:14
   |
 3 | let x: str = nil;
@@ -3522,26 +3515,17 @@ error: Expected type to be "str", but got "nil" instead
   = hint: to allow "nil" assignment use optional type: "str?"
 
 
-error: Expected type to be "bool", but got "nil" instead
-   --> ../../../examples/tests/invalid/nil.test.w:24:4
-   |
-24 | if nil? {
-   |    ^^^
-   |
-   = hint: to allow "nil" assignment use optional type: "bool?"
-
-
 error: Cannot assign nil value to variables without explicit optional type
-   --> ../../../examples/tests/invalid/nil.test.w:28:18
+   --> ../../../examples/tests/invalid/nil.test.w:24:18
    |
-28 | let nilWannabe = nil;
+24 | let nilWannabe = nil;
    |                  ^^^
 
 
 error: Cannot assign nil value to variables without explicit optional type
-   --> ../../../examples/tests/invalid/nil.test.w:31:17
+   --> ../../../examples/tests/invalid/nil.test.w:27:17
    |
-31 | let nilGaggle = [nil, nil, nil];
+27 | let nilGaggle = [nil, nil, nil];
    |                 ^^^^^^^^^^^^^^^
 
 
@@ -3562,17 +3546,10 @@ Duration <DURATION>"
 `;
 
 exports[`optionals.test.w 1`] = `
-"error: Unknown parser error
-   --> ../../../examples/tests/invalid/optionals.test.w:18:5
+"error: Unexpected 'parameter_type_list'
+   --> ../../../examples/tests/invalid/optionals.test.w:95:36
    |
-18 | if y? {
-   |     ^
-
-
-error: Unexpected 'parameter_type_list'
-   --> ../../../examples/tests/invalid/optionals.test.w:98:36
-   |
-98 | let optionalFunctionWithNoRetType: ()? = () => {};
+95 | let optionalFunctionWithNoRetType: ()? = () => {};
    |                                    ^^
 
 
@@ -3591,103 +3568,103 @@ error: Expected type to be "num?", but got "str" instead
 
 
 error: Expected optional type, found "bool"
-   --> ../../../examples/tests/invalid/optionals.test.w:22:9
+   --> ../../../examples/tests/invalid/optionals.test.w:19:9
    |
-22 | let z = y ?? 1;
+19 | let z = y ?? 1;
    |         ^
 
 
 error: Expected type to be "str", but got "num" instead
-   --> ../../../examples/tests/invalid/optionals.test.w:25:14
+   --> ../../../examples/tests/invalid/optionals.test.w:22:14
    |
-25 | let w: str = x ?? 3;
+22 | let w: str = x ?? 3;
    |              ^^^^^^
 
 
 error: Expected type to be "num", but got "str" instead
-   --> ../../../examples/tests/invalid/optionals.test.w:28:6
+   --> ../../../examples/tests/invalid/optionals.test.w:25:6
    |
-28 | x ?? "hello";
+25 | x ?? "hello";
    |      ^^^^^^^
 
 
 error: Expected type to be "Sub1", but got "Sub2" instead
-   --> ../../../examples/tests/invalid/optionals.test.w:39:17
+   --> ../../../examples/tests/invalid/optionals.test.w:36:17
    |
-39 | optionalSub1 ?? new Sub2();
+36 | optionalSub1 ?? new Sub2();
    |                 ^^^^^^^^^^
 
 
 error: Expected type to be "Sub1", but got "Super" instead
-   --> ../../../examples/tests/invalid/optionals.test.w:41:17
+   --> ../../../examples/tests/invalid/optionals.test.w:38:17
    |
-41 | optionalSub1 ?? new Super();
+38 | optionalSub1 ?? new Super();
    |                 ^^^^^^^^^^^
 
 
 error: Expected type to be optional, but got "bool" instead
-   --> ../../../examples/tests/invalid/optionals.test.w:45:12
+   --> ../../../examples/tests/invalid/optionals.test.w:42:12
    |
-45 | if let x = true {
+42 | if let x = true {
    |            ^^^^
 
 
 error: Property access on optional type "A?" requires optional accessor: "?."
-   --> ../../../examples/tests/invalid/optionals.test.w:68:9
+   --> ../../../examples/tests/invalid/optionals.test.w:65:9
    |
-68 | let c = b.a.val;
+65 | let c = b.a.val;
    |         ^^^
 
 
 error: Expected type to be "str", but got "str?" instead
-   --> ../../../examples/tests/invalid/optionals.test.w:91:16
+   --> ../../../examples/tests/invalid/optionals.test.w:88:16
    |
-91 | let val: str = baz?.bar?.foo?.val;
+88 | let val: str = baz?.bar?.foo?.val;
    |                ^^^^^^^^^^^^^^^^^^
 
 
 error: Cannot call an optional function
-   --> ../../../examples/tests/invalid/optionals.test.w:95:1
+   --> ../../../examples/tests/invalid/optionals.test.w:92:1
    |
-95 | optionalFunction();
+92 | optionalFunction();
    | ^^^^^^^^^^^^^^^^
 
 
 error: Expected type to be "(preflight (num): void)?", but got "preflight (x: str): void" instead
-    --> ../../../examples/tests/invalid/optionals.test.w:102:53
-    |
-102 | let functionWithOptionalFuncParam1: ((num):void)? = (x: str):void => {};
-    |                                                     ^^^^^^^^^^^^^^^^^^^
+   --> ../../../examples/tests/invalid/optionals.test.w:99:53
+   |
+99 | let functionWithOptionalFuncParam1: ((num):void)? = (x: str):void => {};
+   |                                                     ^^^^^^^^^^^^^^^^^^^
 
 
 error: Expected type to be "(preflight (): num)?", but got "preflight (): str" instead
-    --> ../../../examples/tests/invalid/optionals.test.w:104:49
+    --> ../../../examples/tests/invalid/optionals.test.w:101:49
     |
-104 | let functionWithOptionalFuncParam2: (():num)? = ():str => { return "s"; };
+101 | let functionWithOptionalFuncParam2: (():num)? = ():str => { return "s"; };
     |                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 
 error: '!' expects an optional type, found "num"
-    --> ../../../examples/tests/invalid/optionals.test.w:110:19
+    --> ../../../examples/tests/invalid/optionals.test.w:107:19
     |
-110 | let unwrapValue = nonOptional!;
+107 | let unwrapValue = nonOptional!;
     |                   ^^^^^^^^^^^
 
 
 error: '!' expects an optional type, found "num"
-    --> ../../../examples/tests/invalid/optionals.test.w:116:21
+    --> ../../../examples/tests/invalid/optionals.test.w:113:21
     |
-116 | let unwrapValueFn = nonOptionalFn()!;
+113 | let unwrapValueFn = nonOptionalFn()!;
     |                     ^^^^^^^^^^^^^^^
 
 
 error: Variable is not reassignable
-   --> ../../../examples/tests/invalid/optionals.test.w:53:3
+   --> ../../../examples/tests/invalid/optionals.test.w:50:3
    |
-50 | if let hi = hi {
+47 | if let hi = hi {
    |        -- defined here (try adding "var" in front)
    .
-53 |   hi = "bye";
+50 |   hi = "bye";
    |   ^^
 
 

--- a/tools/hangar/__snapshots__/invalid.ts.snap
+++ b/tools/hangar/__snapshots__/invalid.ts.snap
@@ -3506,7 +3506,14 @@ Duration <DURATION>"
 `;
 
 exports[`nil.test.w 1`] = `
-"error: Expected type to be "str", but got "nil" instead
+"error: Unknown parser error
+   --> ../../../examples/tests/invalid/nil.test.w:24:7
+   |
+24 | if nil? {
+   |       ^
+
+
+error: Expected type to be "str", but got "nil" instead
   --> ../../../examples/tests/invalid/nil.test.w:3:14
   |
 3 | let x: str = nil;
@@ -3515,11 +3522,13 @@ exports[`nil.test.w 1`] = `
   = hint: to allow "nil" assignment use optional type: "str?"
 
 
-error: Expected optional type, found "nil"
+error: Expected type to be "bool", but got "nil" instead
    --> ../../../examples/tests/invalid/nil.test.w:24:4
    |
 24 | if nil? {
    |    ^^^
+   |
+   = hint: to allow "nil" assignment use optional type: "bool?"
 
 
 error: Cannot assign nil value to variables without explicit optional type
@@ -3553,7 +3562,14 @@ Duration <DURATION>"
 `;
 
 exports[`optionals.test.w 1`] = `
-"error: Unexpected 'parameter_type_list'
+"error: Unknown parser error
+   --> ../../../examples/tests/invalid/optionals.test.w:18:5
+   |
+18 | if y? {
+   |     ^
+
+
+error: Unexpected 'parameter_type_list'
    --> ../../../examples/tests/invalid/optionals.test.w:98:36
    |
 98 | let optionalFunctionWithNoRetType: ()? = () => {};
@@ -3572,13 +3588,6 @@ error: Expected type to be "num?", but got "str" instead
    |
 14 | fOptional("");
    |           ^^
-
-
-error: Expected optional type, found "bool"
-   --> ../../../examples/tests/invalid/optionals.test.w:18:4
-   |
-18 | if y? {
-   |    ^
 
 
 error: Expected optional type, found "bool"

--- a/tools/hangar/__snapshots__/test_corpus/valid/nil.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/nil.test.w_compile_tf-aws.md
@@ -12,8 +12,8 @@ module.exports = function({ $foo }) {
       return $obj;
     }
     async handle() {
-      $helpers.assert($helpers.eq((((await $foo.returnNil(true))) != null), true), "foo.returnNil(true)? == true");
-      $helpers.assert($helpers.eq((((await $foo.returnNil(false))) != null), false), "foo.returnNil(false)? == false");
+      $helpers.assert($helpers.neq((await $foo.returnNil(true)), undefined), "foo.returnNil(true) != nil");
+      $helpers.assert($helpers.eq((await $foo.returnNil(false)), undefined), "foo.returnNil(false) == nil");
     }
   }
   return $Closure1;
@@ -33,12 +33,10 @@ module.exports = function({ $foo }) {
       return $obj;
     }
     async handle() {
-      $helpers.assert($helpers.eq((((await $foo.getOptionalValue())) != null), false), "foo.getOptionalValue()? == false");
+      $helpers.assert($helpers.eq((await $foo.getOptionalValue()), undefined), "foo.getOptionalValue() == nil");
       (await $foo.setOptionalValue("hello"));
-      $helpers.assert($helpers.eq((((await $foo.getOptionalValue())) != null), true), "foo.getOptionalValue()? == true");
       $helpers.assert($helpers.neq((await $foo.getOptionalValue()), undefined), "foo.getOptionalValue() != nil");
       (await $foo.setOptionalValue(undefined));
-      $helpers.assert($helpers.eq((((await $foo.getOptionalValue())) != null), false), "foo.getOptionalValue()? == false");
       $helpers.assert($helpers.eq((await $foo.getOptionalValue()), undefined), "foo.getOptionalValue() == nil");
     }
   }

--- a/tools/hangar/__snapshots__/test_corpus/valid/optionals.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/optionals.test.w_compile_tf-aws.md
@@ -4,7 +4,7 @@
 ```cjs
 "use strict";
 const $helpers = require("@winglang/sdk/lib/helpers");
-module.exports = function({ $__payloadWithBucket_c_____null_, $__payloadWithoutOptions_b_____null_, $payloadWithBucket_c }) {
+module.exports = function({ $payloadWithBucket_c, $payloadWithoutOptions_b }) {
   class $Closure1 {
     constructor({  }) {
       const $obj = (...args) => this.handle(...args);
@@ -12,8 +12,8 @@ module.exports = function({ $__payloadWithBucket_c_____null_, $__payloadWithoutO
       return $obj;
     }
     async handle() {
-      $helpers.assert($helpers.eq($__payloadWithoutOptions_b_____null_, false), "payloadWithoutOptions.b? == false");
-      if ($__payloadWithBucket_c_____null_) {
+      $helpers.assert($helpers.eq($payloadWithoutOptions_b, undefined), "payloadWithoutOptions.b == nil");
+      if ($helpers.neq($payloadWithBucket_c, undefined)) {
         (await $payloadWithBucket_c?.put?.("x.txt", "something"));
       }
     }
@@ -257,9 +257,8 @@ class $Root extends $stdlib.std.Resource {
       static _toInflightType() {
         return `
           require("${$helpers.normalPath(__dirname)}/inflight.$Closure1-1.cjs")({
-            $__payloadWithBucket_c_____null_: ${$stdlib.core.liftObject(((payloadWithBucket.c) != null))},
-            $__payloadWithoutOptions_b_____null_: ${$stdlib.core.liftObject(((payloadWithoutOptions.b) != null))},
             $payloadWithBucket_c: ${$stdlib.core.liftObject(payloadWithBucket.c)},
+            $payloadWithoutOptions_b: ${$stdlib.core.liftObject(payloadWithoutOptions.b)},
           })
         `;
       }
@@ -277,21 +276,18 @@ class $Root extends $stdlib.std.Resource {
       get _liftMap() {
         return ({
           "handle": [
-            [((payloadWithBucket.c) != null), []],
-            [((payloadWithoutOptions.b) != null), []],
             [payloadWithBucket.c, ["put"]],
+            [payloadWithoutOptions.b, []],
           ],
           "$inflight_init": [
-            [((payloadWithBucket.c) != null), []],
-            [((payloadWithoutOptions.b) != null), []],
             [payloadWithBucket.c, []],
+            [payloadWithoutOptions.b, []],
           ],
         });
       }
     }
     const x = 4;
-    $helpers.assert($helpers.eq(((x) != null), true), "x? == true");
-    $helpers.assert($helpers.eq((!((x) != null)), false), "!x? == false");
+    $helpers.assert($helpers.neq(x, undefined), "x != nil");
     $helpers.assert($helpers.eq((x ?? 5), 4), "x ?? 5 == 4");
     const y = (x ?? 5);
     $helpers.assert($helpers.eq(y, 4), "y == 4");

--- a/tools/hangar/__snapshots__/test_corpus/valid/statements_if.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/statements_if.test.w_compile_tf-aws.md
@@ -138,7 +138,7 @@ class $Root extends $stdlib.std.Resource {
           const d = $if_let_value;
           $helpers.assert(false, "false");
         }
-        else if (((b) != null)) {
+        else if ($helpers.neq(b, undefined)) {
           $helpers.assert(true, "true");
         }
         else {
@@ -169,7 +169,7 @@ class $Root extends $stdlib.std.Resource {
             const e = $elif_let_value0;
             $helpers.assert(true, "true");
           }
-          else if (((b) != null)) {
+          else if ($helpers.neq(b, undefined)) {
             $helpers.assert(false, "false");
           }
           else {


### PR DESCRIPTION
Closes https://github.com/winglang/wing/issues/5942

BREAKING CHANGE: The optional test syntax, `expr?` has been removed in favor of explicit checking against `nil`. Code can be updated by changing `expr?` to `expr != nil` and `!expr?` to `expr == nil`.

## Checklist

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [x] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
