### PR TITLE
fix(console): console waits forever until a first successful compilation

### DIFF
--- a/apps/wing-console/console/ui/src/Console.tsx
+++ b/apps/wing-console/console/ui/src/Console.tsx
@@ -1,5 +1,11 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { httpBatchLink, wsLink, splitLink, createWSClient } from "@trpc/client";
+import {
+  httpBatchLink,
+  wsLink,
+  splitLink,
+  createWSClient,
+  httpLink,
+} from "@trpc/client";
 import type { Mode } from "@wingconsole/design-system";
 import type { Trace } from "@wingconsole/server";
 import { useEffect, useMemo, useState } from "react";
@@ -54,6 +60,7 @@ export const Console = ({
   const [trpcClient] = useState(() =>
     trpc.createClient({
       links: [
+        // For subscriptions, use WebSocket.
         splitLink({
           condition(op) {
             return op.type === "subscription";
@@ -61,8 +68,26 @@ export const Console = ({
           true: wsLink({
             client: wsClient,
           }),
-          false: httpBatchLink({
-            url: trpcUrl,
+          // For the `test.list` query, use a single HTTP link. This is necessary
+          // to avoid a bug where the Console would not display the data until
+          // the app starts correctly. For example, starting a new application
+          // with compilation errors, the Console will be stuck.
+          //
+          // For the rest of the operations, use the batch HTTP link.
+          //
+          // We should be able to use batch HTTP links everywhere if we refactor
+          // the `test.list` operation so it doesn't wait until the Simulator
+          // instance is ready.
+          false: splitLink({
+            condition(op) {
+              return op.path === "test.list";
+            },
+            true: httpLink({
+              url: trpcUrl,
+            }),
+            false: httpBatchLink({
+              url: trpcUrl,
+            }),
           }),
         }),
       ],

--- a/apps/wing-console/console/ui/src/Console.tsx
+++ b/apps/wing-console/console/ui/src/Console.tsx
@@ -68,7 +68,7 @@ export const Console = ({
           true: wsLink({
             client: wsClient,
           }),
-          // For the `test.list` query, use a single HTTP link. This is necessary
+          // For the `test.*` operations, use a single HTTP link. This is necessary
           // to avoid a bug where the Console would not display the data until
           // the app starts correctly. For example, starting a new application
           // with compilation errors, the Console will be stuck.
@@ -76,11 +76,11 @@ export const Console = ({
           // For the rest of the operations, use the batch HTTP link.
           //
           // We should be able to use batch HTTP links everywhere if we refactor
-          // the `test.list` operation so it doesn't wait until the Simulator
+          // the `test.*` operations so they don't wait until the Simulator
           // instance is ready.
           false: splitLink({
             condition(op) {
-              return op.path === "test.list";
+              return op.path.startsWith("test.");
             },
             true: httpLink({
               url: trpcUrl,


### PR DESCRIPTION
Puts any test-related HTTP operations out of the HTTP batch request, freeing all other requests from waiting for test results.

Fixes #6797