### PR TITLE
chore(docs): fixed broken links

### DIFF
--- a/docs/docs/01-start-here/02-getting-started.md
+++ b/docs/docs/01-start-here/02-getting-started.md
@@ -93,7 +93,8 @@ queue.setConsumer(inflight (message: str) => {
 
 :::info
 
-<details><summary>Experimental TypeScript Support</summary>
+<details>
+<summary>Experimental TypeScript Support</summary>
 
 If you'd like to use TypeScript instead of winglang, you can add the `--language ts` flag when creating a new project:
 

--- a/docs/docs/06-tools/02-wing-console.md
+++ b/docs/docs/06-tools/02-wing-console.md
@@ -17,7 +17,7 @@ Unlike traditional cloud development iterations that involve time-consuming depl
 
 ## Installation
 
-The Wing Console is installed as part of the [Wing CLI installation](../01-start-here/02-installation.md).
+The Wing Console is installed as part of the [Wing CLI installation](../01-start-here/02-getting-started.md).
 
 ## View And Explore your Wing application 
 The Console offers two primary views to provide a comprehensive understanding of your Wing application: the Explorer view and the Map view.

--- a/docs/docs/09-typescript/01-resources.md
+++ b/docs/docs/09-typescript/01-resources.md
@@ -26,7 +26,7 @@ main((root) => {
 });
 ```
 
-API documentation for the `cloud` namespace is available [here](../04-standard-library/cloud).
+API documentation for the `cloud` namespace is available [here](../04-standard-library/cloud/api.md).
 Note that those docs are meant for The TypeScript API is similar, with two primary differences:
 
 - Resources always have 2 arguments first: the `scope` resource to contain the new one and an `id` for it

--- a/docs/docs/09-typescript/index.md
+++ b/docs/docs/09-typescript/index.md
@@ -9,7 +9,7 @@ We see Winglang as the ideal language to create Wing apps, but using TypeScript 
 
 ## Getting Started
 
-Follow the [installation guide](../01-start-here/02-installation.md) to install Wing and get started with a new project. Make sure to create a new project with the `--language ts` flag in that guide.
+Follow the [installation guide](../01-start-here/02-getting-started.md) to install Wing and get started with a new project. Make sure to create a new project with the `--language ts` flag in that guide.
 
 ```sh
 wing new empty --language ts


### PR DESCRIPTION
Update to some broken links in the docs and some minor mdx component.

Required for docusuarus v3 migration to work (see https://github.com/winglang/docsite/pull/947).

## Checklist

- [x ] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [ ] Description explains motivation and solution
- [ ] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing



*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
