### PR TITLE
fix(console): compilation doesn't recover from unresolved token errors

### DIFF
--- a/apps/wing-console/console/server/src/index.ts
+++ b/apps/wing-console/console/server/src/index.ts
@@ -222,6 +222,7 @@ export const createConsoleServer = async ({
     appState = "error";
     invalidateQuery("app.state");
     invalidateQuery("app.error");
+    isStarting = false;
   });
   simulator.on("trace", async (trace) => {
     // TODO: Refactor the whole logs and events so we support all of the fields that the simulator uses.

--- a/apps/wing-console/console/server/src/utils/simulator.ts
+++ b/apps/wing-console/console/server/src/utils/simulator.ts
@@ -92,6 +92,8 @@ export const createSimulator = (props?: CreateSimulatorProps): Simulator => {
         await fullReload(simfile);
       }
     } catch (error) {
+      // After an error, it's likely that the simulator is in a bad state (see https://github.com/winglang/wing/issues/5426).
+      // In order to be safe, we will do a full reload next time.
       needsFullReload = true;
       await events.emit(
         "error",

--- a/apps/wing-console/console/server/src/utils/simulator.ts
+++ b/apps/wing-console/console/server/src/utils/simulator.ts
@@ -48,6 +48,7 @@ const stopSilently = async (simulator: simulator.Simulator) => {
 export const createSimulator = (props?: CreateSimulatorProps): Simulator => {
   const events = new Emittery<SimulatorEvents>();
   let instance: simulator.Simulator | undefined;
+  // The simulator may need to be fully reloaded after an error. See https://github.com/winglang/wing/issues/5426.
   let needsFullReload = false;
   const fullReload = async (simfile: string) => {
     if (instance) {

--- a/apps/wing-console/console/server/src/utils/simulator.ts
+++ b/apps/wing-console/console/server/src/utils/simulator.ts
@@ -48,7 +48,9 @@ const stopSilently = async (simulator: simulator.Simulator) => {
 export const createSimulator = (props?: CreateSimulatorProps): Simulator => {
   const events = new Emittery<SimulatorEvents>();
   let instance: simulator.Simulator | undefined;
-  // The simulator may need to be fully reloaded after an error. See https://github.com/winglang/wing/issues/5426.
+  // The simulator may need to be fully reloaded after an error.
+  // See https://github.com/winglang/wing/issues/5426 for an
+  // example of an error that requires a full reload.
   let needsFullReload = false;
   const fullReload = async (simfile: string) => {
     if (instance) {
@@ -93,7 +95,8 @@ export const createSimulator = (props?: CreateSimulatorProps): Simulator => {
         await fullReload(simfile);
       }
     } catch (error) {
-      // After an error, it's likely that the simulator is in a bad state (see https://github.com/winglang/wing/issues/5426).
+      // After an error, it's likely that the simulator is in a bad state.
+      // See https://github.com/winglang/wing/issues/5426 for an example.
       // In order to be safe, we will do a full reload next time.
       needsFullReload = true;
       await events.emit(

--- a/apps/wing-console/console/server/src/utils/simulator.ts
+++ b/apps/wing-console/console/server/src/utils/simulator.ts
@@ -48,38 +48,51 @@ const stopSilently = async (simulator: simulator.Simulator) => {
 export const createSimulator = (props?: CreateSimulatorProps): Simulator => {
   const events = new Emittery<SimulatorEvents>();
   let instance: simulator.Simulator | undefined;
+  let needsFullReload = false;
+  const fullReload = async (simfile: string) => {
+    if (instance) {
+      await stopSilently(instance);
+    }
+    instance = new simulator.Simulator({
+      simfile,
+      stateDir: props?.stateDir,
+    });
+    instance.onTrace({
+      callback(trace) {
+        events.emit("trace", trace);
+      },
+    });
+    instance.onResourceLifecycleEvent({
+      callback(event) {
+        events.emit("resourceLifecycleEvent", event);
+      },
+    });
+    await events.emit("starting", { instance });
+    await instance.start();
+    await events.emit("started");
+  };
   const handleExistingInstance = async (simfile: string): Promise<boolean> => {
     if (!instance) {
       return true;
     }
-    await events.emit("starting", { instance });
-    await instance.update(simfile);
-    await events.emit("started");
+    if (needsFullReload) {
+      await fullReload(simfile);
+      needsFullReload = false;
+    } else {
+      await events.emit("starting", { instance });
+      await instance.update(simfile);
+      await events.emit("started");
+    }
     return false;
   };
   const start = async (simfile: string) => {
     try {
       const shouldStartSim = await handleExistingInstance(simfile);
       if (shouldStartSim) {
-        instance = new simulator.Simulator({
-          simfile,
-          stateDir: props?.stateDir,
-        });
-        instance.onTrace({
-          callback(trace) {
-            events.emit("trace", trace);
-          },
-        });
-        instance.onResourceLifecycleEvent({
-          callback(event) {
-            events.emit("resourceLifecycleEvent", event);
-          },
-        });
-        await events.emit("starting", { instance });
-        await instance.start();
-        await events.emit("started");
+        await fullReload(simfile);
       }
     } catch (error) {
+      needsFullReload = true;
       await events.emit(
         "error",
         new Error(


### PR DESCRIPTION
- The console didn't reload the simulator in certain occasions after an error
- The console fully reloads the simulator after a simulation error to avoid getting stuck

Fixes #5426.