### PR TITLE
chore(cli): remove `awscdk` from builtin

### DIFF
--- a/apps/wing/src/cli.ts
+++ b/apps/wing/src/cli.ts
@@ -169,7 +169,7 @@ async function main() {
     .argument("[entrypoint]", "program .w entrypoint")
     .option(
       "-t, --platform <platform> --platform <platform>",
-      "Target platform provider (builtin: sim, tf-aws, tf-azure, tf-gcp, awscdk)",
+      "Target platform provider (builtin: sim, tf-aws, tf-azure, tf-gcp)",
       collectPlatformVariadic,
       DEFAULT_PLATFORM
     )


### PR DESCRIPTION
looks like oversight from when we moved `awscdk` to be external

## Checklist

- [ ] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [ ] Description explains motivation and solution
- [ ] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
