### PR TITLE
feat(cli): added -v support in cli to get version 

### DIFF
--- a/apps/wing/src/cli.ts
+++ b/apps/wing/src/cli.ts
@@ -93,7 +93,7 @@ async function main() {
     showGlobalOptions: true,
   });
 
-  program.name("wing").version(PACKAGE_VERSION);
+  program.name("wing").version(PACKAGE_VERSION, '-v, --version, -V', 'output the current version');
 
   program
     .option("--debug", "Enable debug logging (same as DEBUG=1)", () => {

--- a/apps/wing/src/cli.ts
+++ b/apps/wing/src/cli.ts
@@ -93,7 +93,7 @@ async function main() {
     showGlobalOptions: true,
   });
 
-  program.name("wing").version(PACKAGE_VERSION, '-v, --version, -V', 'output the current version');
+  program.name("wing").version(PACKAGE_VERSION, "-v, --version, -V", "output the current version");
 
   program
     .option("--debug", "Enable debug logging (same as DEBUG=1)", () => {


### PR DESCRIPTION
fixes #6763

Wing CLI currently supports `-V` and `--version`.

This adds the ability to `-v` to get the current version.


## Checklist

- [ ] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [ ] Description explains motivation and solution
- [ ] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
