### PR TITLE
feat(console): improve running state indicator design

### DIFF
--- a/apps/wing-console/console/ui/src/features/explorer-pane/map-view.tsx
+++ b/apps/wing-console/console/ui/src/features/explorer-pane/map-view.tsx
@@ -151,12 +151,28 @@ const ConstructNode: FunctionComponent<PropsWithChildren<ConstructNodeProps>> =
                   "transition-all",
                 )}
               >
-                <ResourceIcon
-                  className="size-4 -ml-0.5"
-                  resourceType={fqn}
-                  color={color}
-                  icon={icon}
-                />
+                <div className="-ml-0 5">
+                  <div className="relative">
+                    <ResourceIcon
+                      className="size-4"
+                      resourceType={fqn}
+                      color={color}
+                      icon={icon}
+                    />
+                    <div className="absolute -right-0.5 bottom-0">
+                      <RunningStateIndicator
+                        runningState={hierarchichalRunningState}
+                        className={clsx(
+                          "size-1.5 outline outline-2",
+                          depth % 2 === 0 &&
+                            "outline-white dark:outline-slate-700",
+                          depth % 2 === 1 &&
+                            "outline-slate-50 dark:outline-slate-650",
+                        )}
+                      />
+                    </div>
+                  </div>
+                </div>
 
                 <span
                   className={clsx(
@@ -170,10 +186,6 @@ const ConstructNode: FunctionComponent<PropsWithChildren<ConstructNodeProps>> =
                 >
                   {name}
                 </span>
-
-                <RunningStateIndicator
-                  runningState={hierarchichalRunningState}
-                />
 
                 {(hasChildNodes || collapsed) && (
                   <>

--- a/apps/wing-console/console/ui/src/features/explorer-pane/map-view.tsx
+++ b/apps/wing-console/console/ui/src/features/explorer-pane/map-view.tsx
@@ -151,7 +151,7 @@ const ConstructNode: FunctionComponent<PropsWithChildren<ConstructNodeProps>> =
                   "transition-all",
                 )}
               >
-                <div className="-ml-0 5">
+                <div className="-ml-0.5">
                   <div className="relative">
                     <ResourceIcon
                       className="size-4"

--- a/apps/wing-console/console/ui/src/features/hierarchy-pane/use-hierarchy.tsx
+++ b/apps/wing-console/console/ui/src/features/hierarchy-pane/use-hierarchy.tsx
@@ -34,7 +34,10 @@ const createTreeMenuItemFromExplorerTreeItem = (
     ) : undefined,
     expanded: item.display?.expanded,
     secondaryLabel: (
-      <RunningStateIndicator runningState={item.hierarchichalRunningState} />
+      <RunningStateIndicator
+        runningState={item.hierarchichalRunningState}
+        className="size-1.5"
+      />
     ),
     children: item.childItems?.map((item) =>
       createTreeMenuItemFromExplorerTreeItem(item),

--- a/apps/wing-console/console/ui/src/features/inspector-pane/resource-panes/resource-metadata.tsx
+++ b/apps/wing-console/console/ui/src/features/inspector-pane/resource-panes/resource-metadata.tsx
@@ -273,13 +273,22 @@ export const ResourceMetadata = memo(
         <div className="flex flex-col gap-2 py-2">
           <div className="flex items-center gap-2 px-2 ">
             <div className="flex-shrink-0">
+              <div className="relative">
               <ResourceIcon
-                className="w-6 h-6"
+                  className="size-6"
                 resourceType={node.type}
                 resourcePath={node.path}
                 color={node.display?.color}
                 icon={node.display?.icon}
               />
+
+                <div className="absolute -right-0.5 bottom-0">
+                  <RunningStateIndicator
+                    runningState={node.hierarchichalRunningState}
+                    className="size-2 outline outline-2 outline-slate-100 dark:outline-slate-700"
+                  />
+                </div>
+              </div>
             </div>
 
             <div className="flex flex-col min-w-0">
@@ -288,19 +297,6 @@ export const ResourceMetadata = memo(
                 <Pill>{node.type}</Pill>
               </div>
             </div>
-          </div>
-
-          <div className="flex items-center gap-2 px-2">
-            <Attribute className="grow" name="Running Status">
-              <div className="flex gap-2 items-center">
-                <span>
-                  {runningStateToText(node.hierarchichalRunningState)}
-                </span>
-                <RunningStateIndicator
-                  runningState={node.hierarchichalRunningState}
-                />
-              </div>
-            </Attribute>
           </div>
         </div>
 

--- a/apps/wing-console/console/ui/src/features/inspector-pane/resource-panes/resource-metadata.tsx
+++ b/apps/wing-console/console/ui/src/features/inspector-pane/resource-panes/resource-metadata.tsx
@@ -274,13 +274,13 @@ export const ResourceMetadata = memo(
           <div className="flex items-center gap-2 px-2 ">
             <div className="flex-shrink-0">
               <div className="relative">
-              <ResourceIcon
+                <ResourceIcon
                   className="size-6"
-                resourceType={node.type}
-                resourcePath={node.path}
-                color={node.display?.color}
-                icon={node.display?.icon}
-              />
+                  resourceType={node.type}
+                  resourcePath={node.path}
+                  color={node.display?.color}
+                  icon={node.display?.icon}
+                />
 
                 <div className="absolute -right-0.5 bottom-0">
                   <RunningStateIndicator

--- a/apps/wing-console/console/ui/src/features/running-state-indicator/running-state-indicator.tsx
+++ b/apps/wing-console/console/ui/src/features/running-state-indicator/running-state-indicator.tsx
@@ -1,26 +1,46 @@
 import type { ResourceRunningState } from "@winglang/sdk/lib/simulator/simulator.js";
-import type { FunctionComponent } from "react";
+import classNames from "classnames";
+import { useMemo, type FunctionComponent } from "react";
 
 export interface RunningStateIndicatorProps {
   runningState: ResourceRunningState;
+  className?: string;
 }
 
 export const RunningStateIndicator: FunctionComponent<
   RunningStateIndicatorProps
-> = ({ runningState }) => {
-  if (runningState === "error") {
-    return <div className="size-1.5 rounded-full bg-red-500"></div>;
+> = ({ runningState, className }) => {
+  const color = useMemo(() => {
+    if (runningState === "error") {
+      return "bg-red-500";
+    }
+    if (runningState === "starting" || runningState === "stopping") {
+      return "bg-yellow-500";
+    }
+    if (runningState === "stopped") {
+      return "bg-gray-400";
+    }
+  }, [runningState]);
+
+  const ping = useMemo(() => {
+    return runningState === "starting" || runningState === "stopping";
+  }, [runningState]);
+
+  if (!color) {
+    return <></>;
   }
-  if (runningState === "starting" || runningState === "stopping") {
-    return (
-      <div className="relative">
-        <div className="animate-ping absolute inline-flex h-full w-full rounded-full bg-yellow-500 opacity-75"></div>
-        <div className="size-1.5 rounded-full bg-yellow-500"></div>
-      </div>
-    );
-  }
-  if (runningState === "stopped") {
-    return <div className="size-1.5 rounded-full bg-gray-400"></div>;
-  }
-  return <div className="size-1.5"></div>;
+
+  return (
+    <div className={classNames("relative", "rounded-full", className)}>
+      {ping && (
+        <div
+          className={classNames(
+            "animate-ping absolute inline-flex h-full w-full rounded-full opacity-75",
+            color,
+          )}
+        />
+      )}
+      <div className={classNames("rounded-full", color, "w-full h-full")}></div>
+    </div>
+  );
 };


### PR DESCRIPTION
This change moves the running state indicator as an attachment of the resource icon for both the explorer and the inspector panels.