### PR TITLE
fix(console): prevent default zoom behavior

### DIFF
--- a/apps/wing-console/console/app/web/index.html
+++ b/apps/wing-console/console/app/web/index.html
@@ -3,7 +3,10 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/x-icon" href="./favicon.ico" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0"
+    />
     <title>Wing Console</title>
     <link rel="stylesheet" href="./index.css" />
   </head>

--- a/apps/wing-console/console/ui/src/Console.tsx
+++ b/apps/wing-console/console/ui/src/Console.tsx
@@ -15,6 +15,7 @@ import { AppContext } from "./AppContext.js";
 import { LayoutType } from "./features/layout/layout-provider.js";
 import { WebSocketProvider } from "./features/websocket-state/use-websocket.js";
 import { trpc } from "./trpc.js";
+import { useEvent } from "react-use";
 
 export const Console = ({
   trpcUrl,
@@ -137,6 +138,22 @@ export const Console = ({
       window.removeEventListener("keydown", vscodeCommands);
     };
   }, [layout]);
+
+  // Prevent the default zoom behavior everywhere in the app.
+  // Since the explorer panel handles the zoom manually, sometimes
+  // users may end up zooming the whole app by mistake and end up
+  // with the explorer panel covering the whole screen. This is
+  // a big problem since users won't be able to zoom out of it.
+  useEvent(
+    "wheel",
+    (event) => {
+      if ((event as WheelEvent).ctrlKey) {
+        event.preventDefault();
+      }
+    },
+    document,
+    { passive: false },
+  );
 
   return (
     <AppContext.Provider

--- a/apps/wing-console/console/ui/src/Console.tsx
+++ b/apps/wing-console/console/ui/src/Console.tsx
@@ -9,13 +9,13 @@ import {
 import type { Mode } from "@wingconsole/design-system";
 import type { Trace } from "@wingconsole/server";
 import { useEffect, useMemo, useState } from "react";
+import { useEvent } from "react-use";
 
 import { App } from "./App.js";
 import { AppContext } from "./AppContext.js";
 import { LayoutType } from "./features/layout/layout-provider.js";
 import { WebSocketProvider } from "./features/websocket-state/use-websocket.js";
 import { trpc } from "./trpc.js";
-import { useEvent } from "react-use";
 
 export const Console = ({
   trpcUrl,


### PR DESCRIPTION
Prevent the default zoom behavior everywhere in the app.

Since the explorer panel handles the zoom manually, sometimes users may end up zooming the whole app by mistake and end up with the explorer panel covering the whole screen.

This is a big problem since users won't be able to zoom out of it.
