### PR TITLE
fix(console): highlight json blobs in the logs

### DIFF
--- a/apps/wing-console/console/design-system/src/text-highlight.tsx
+++ b/apps/wing-console/console/design-system/src/text-highlight.tsx
@@ -22,14 +22,7 @@ const palette = {
 const CHAR_LIMIT = 100_000;
 
 const highlightJson = (value: string, theme: Theme) => {
-  let formatted;
-  try {
-    formatted = JSON.stringify(JSON.parse(value), undefined, 2);
-  } catch {
-    return;
-  }
-
-  return `${formatted
+  return `${value
     .slice(0, CHAR_LIMIT)
     .replaceAll(
       /("(\\u[\dA-Za-z]{4}|\\[^u]|[^"\\])*"(\s*:)?|\b(true|false|null)\b|-?\d+(?:\.\d*)?(?:[Ee][+\-]?\d+)?)/g,
@@ -44,7 +37,7 @@ const highlightJson = (value: string, theme: Theme) => {
         }
         return `<span class="${className}">${escape(match)}</span>`;
       },
-    )}${formatted.slice(CHAR_LIMIT)}`;
+    )}${value.slice(CHAR_LIMIT)}`;
 };
 
 export const TextHighlight = memo(

--- a/apps/wing-console/console/ui/src/features/logs-pane/console-logs.tsx
+++ b/apps/wing-console/console/ui/src/features/logs-pane/console-logs.tsx
@@ -3,7 +3,11 @@ import {
   ChevronRightIcon,
   XCircleIcon,
 } from "@heroicons/react/24/outline";
-import { useTheme, ResourceIcon } from "@wingconsole/design-system";
+import {
+  useTheme,
+  ResourceIcon,
+  TextHighlight,
+} from "@wingconsole/design-system";
 import type { LogEntry } from "@wingconsole/server";
 import classNames from "classnames";
 import Linkify from "linkify-react";
@@ -213,7 +217,7 @@ const LogEntryRow = memo(
                   },
                 }}
               >
-                {logText(log, expanded)}
+                <TextHighlight text={logText(log, expanded) ?? ""} />
               </Linkify>
             </pre>
           </div>


### PR DESCRIPTION
Highlights JSON blobs in the logs section using a low fidelity, regex-based parser.

Fixes #6580.