### PR TITLE
fix(console): empty space at the start of long log lines

### DIFF
--- a/apps/wing-console/console/ui/src/features/logs-pane/console-logs.tsx
+++ b/apps/wing-console/console/ui/src/features/logs-pane/console-logs.tsx
@@ -217,7 +217,10 @@ const LogEntryRow = memo(
                   },
                 }}
               >
-                <TextHighlight text={logText(log, expanded) ?? ""} />
+                <TextHighlight
+                  className="inline-block"
+                  text={logText(log, expanded) ?? ""}
+                />
               </Linkify>
             </pre>
           </div>


### PR DESCRIPTION
The commit 2860cad0f6acc523a19f5e66ab871c227382b94b introduced an error where long log lines are visualized with an empty space at the beginning.
