### PR TITLE
chore(docs): remove -V from docs and replaced with --version

### DIFF
--- a/docs/docs/01-start-here/02-getting-started.md
+++ b/docs/docs/01-start-here/02-getting-started.md
@@ -34,7 +34,7 @@ npm install -g winglang
 
 Verify your installation:
 ```
-wing -V
+wing --version
 ```
 
 ## IDE Extension

--- a/docs/docs/08-guides/03-react-vite-websockets.md
+++ b/docs/docs/08-guides/03-react-vite-websockets.md
@@ -101,7 +101,7 @@ Now, we will create our backend for our app:
 
     ```sh
     npm install -g winglang
-    wing -V # should be >= 0.60.1
+    wing --version # should be >= 0.60.1
     ```
 
 2. Create a `backend` directory under the project root:


### PR DESCRIPTION
Seems like the old -V got added back in due to docs refactor. This fixes that issue.

## Checklist

- [ ] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [ ] Description explains motivation and solution
- [ ] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
