### PR TITLE
fix(console): some resources are marked as started even though they are stopped

### DIFF
--- a/apps/wing-console/console/server/src/router/app.get-hierarchichal-running-state.ts
+++ b/apps/wing-console/console/server/src/router/app.get-hierarchichal-running-state.ts
@@ -20,7 +20,7 @@ export const getHierarchichalRunningState = (
   }
 
   const runningState = (node?.resourceConfig?.attrs?.["runningState"] ??
-    "started") as RunningState;
+    "stopped") as RunningState;
 
   if (node.children?.length > 0) {
     const childrenRunningStates = node.children.map((child) =>

--- a/apps/wing-console/console/server/src/router/app.get-hierarchichal-running-state.ts
+++ b/apps/wing-console/console/server/src/router/app.get-hierarchichal-running-state.ts
@@ -19,8 +19,7 @@ export const getHierarchichalRunningState = (
     return "stopped";
   }
 
-  const runningState = (node?.resourceConfig?.attrs?.["runningState"] ??
-    "stopped") as RunningState;
+  const runningState = node.runningState;
 
   if (node.children?.length > 0) {
     const childrenRunningStates = node.children.map((child) =>

--- a/apps/wing-console/console/server/src/utils/constructTreeNodeMap.ts
+++ b/apps/wing-console/console/server/src/utils/constructTreeNodeMap.ts
@@ -1,3 +1,5 @@
+import type { ResourceRunningState } from "@winglang/sdk/lib/simulator/simulator.js";
+
 import type { BaseResourceSchema, Simulator } from "../wingsdk.js";
 
 import type { ConstructInfo, ConstructTreeNode } from "./construct-tree.js";
@@ -27,6 +29,7 @@ export interface Node {
   children: string[];
   display?: NodeDisplay;
   resourceConfig?: BaseResourceSchema;
+  runningState: ResourceRunningState;
 }
 
 export interface ConstructTreeNodeRecord {
@@ -96,6 +99,8 @@ export function buildConstructTreeNodeMap(
       constructInfo: node.constructInfo,
       display: node.display,
       resourceConfig: simulator.tryGetResourceConfig(node.path),
+      runningState:
+        simulator.tryGetResourceRunningState(node.path) ?? "stopped",
     };
 
     if (!parent) {

--- a/apps/wing-console/console/server/src/utils/constructTreeNodeMap.ts
+++ b/apps/wing-console/console/server/src/utils/constructTreeNodeMap.ts
@@ -28,7 +28,6 @@ export interface Node {
   attributes: Record<string, any> | undefined;
   children: string[];
   display?: NodeDisplay;
-  resourceConfig?: BaseResourceSchema;
   runningState: ResourceRunningState;
 }
 
@@ -98,7 +97,6 @@ export function buildConstructTreeNodeMap(
       attributes: node.attributes,
       constructInfo: node.constructInfo,
       display: node.display,
-      resourceConfig: simulator.tryGetResourceConfig(node.path),
       runningState:
         simulator.tryGetResourceRunningState(node.path) ?? "stopped",
     };

--- a/apps/wing-console/console/ui/src/features/explorer-pane/map-view.tsx
+++ b/apps/wing-console/console/ui/src/features/explorer-pane/map-view.tsx
@@ -87,6 +87,7 @@ const ConstructNode: FunctionComponent<PropsWithChildren<ConstructNodeProps>> =
         [onSelectedNodeIdChange, id],
       );
 
+      const isStarting = hierarchichalRunningState === "starting";
       const hasError = hierarchichalRunningState === "error";
 
       return (
@@ -133,7 +134,12 @@ const ConstructNode: FunctionComponent<PropsWithChildren<ConstructNodeProps>> =
                 "border-slate-200 dark:border-slate-800",
               highlight && !hasError && "border-sky-400 dark:border-sky-500",
               highlight && "outline-4",
-              !hasError && "outline-sky-200/50 dark:outline-sky-500/50",
+              !hasError &&
+                !isStarting &&
+                "outline-sky-200/50 dark:outline-sky-500/50",
+              isStarting &&
+                !hasError &&
+                "border-yellow-500 dark:border-yellow-500 outline-yellow-200/50 dark:outline-yellow-500/50",
               hasError &&
                 "border-red-500 dark:border-red-500 outline-red-200/50 dark:outline-red-500/50",
               "shadow",

--- a/libs/wingsdk/src/simulator/simulator.ts
+++ b/libs/wingsdk/src/simulator/simulator.ts
@@ -331,7 +331,7 @@ export class Simulator {
     // Mark remaining resources as started. This is necessary because
     // `this._model.graph.nodes` only contains resources that have
     // some kind of runtime code to be executed.
-    if (!failed.length) {
+    if (failed.length === 0) {
       const visit = async (node: ConstructTreeNode) => {
         if (node.children) {
           for (const child of Object.values(node.children)) {

--- a/libs/wingsdk/src/simulator/simulator.ts
+++ b/libs/wingsdk/src/simulator/simulator.ts
@@ -451,6 +451,9 @@ export class Simulator {
     }
   }
 
+  /**
+   * Get the running state of a resource.
+   */
   public tryGetResourceRunningState(
     path: string
   ): ResourceRunningState | undefined {


### PR DESCRIPTION
This changeset fixes the running state of constructs that don't have any kind of runtime code.

It basically visits all remaining constructs after successfully starting all resources and marks them as started.

Fixes #6858.