### PR TITLE
fix(console): some resources are marked as started even though they are stopped

### DIFF
--- a/apps/wing-console/console/server/src/router/app.ts
+++ b/apps/wing-console/console/server/src/router/app.ts
@@ -33,7 +33,7 @@ export interface ExplorerItem {
   type?: string;
   childItems?: ExplorerItem[];
   display?: NodeDisplay;
-  hierarchichalRunningState: ResourceRunningState;
+  hierarchichalRunningState: ResourceRunningState | undefined;
 }
 
 export interface MapItem extends ConstructTreeNode {

--- a/apps/wing-console/console/server/src/utils/constructTreeNodeMap.ts
+++ b/apps/wing-console/console/server/src/utils/constructTreeNodeMap.ts
@@ -1,4 +1,6 @@
-import type { BaseResourceSchema, Simulator } from "../wingsdk.js";
+import type { ResourceRunningState } from "@winglang/sdk/lib/simulator/simulator.js";
+
+import type { Simulator } from "../wingsdk.js";
 
 import type { ConstructInfo, ConstructTreeNode } from "./construct-tree.js";
 
@@ -26,7 +28,7 @@ export interface Node {
   attributes: Record<string, any> | undefined;
   children: string[];
   display?: NodeDisplay;
-  resourceConfig?: BaseResourceSchema;
+  runningState?: ResourceRunningState | undefined;
 }
 
 export interface ConstructTreeNodeRecord {
@@ -95,7 +97,7 @@ export function buildConstructTreeNodeMap(
       attributes: node.attributes,
       constructInfo: node.constructInfo,
       display: node.display,
-      resourceConfig: simulator.tryGetResourceConfig(node.path),
+      runningState: simulator.tryGetResourceRunningState(node.path),
     };
 
     if (!parent) {

--- a/libs/wingsdk/test/target-sim/api.test.ts
+++ b/libs/wingsdk/test/target-sim/api.test.ts
@@ -67,7 +67,6 @@ test("create an api", async () => {
   expect(s.getResourceConfig("/my_api")).toEqual({
     attrs: {
       handle: expect.any(String),
-      runningState: expect.any(String),
       url: expect.any(String),
     },
     path: "root/my_api",

--- a/libs/wingsdk/test/target-sim/bucket.test.ts
+++ b/libs/wingsdk/test/target-sim/bucket.test.ts
@@ -20,7 +20,6 @@ test("create a bucket", async () => {
   expect(s.getResourceConfig("/my_bucket")).toEqual({
     attrs: {
       handle: expect.any(String),
-      runningState: expect.any(String),
     },
     path: "root/my_bucket",
     addr: expect.any(String),

--- a/libs/wingsdk/test/target-sim/function.test.ts
+++ b/libs/wingsdk/test/target-sim/function.test.ts
@@ -37,7 +37,6 @@ test("create a function", async () => {
   expect(s.getResourceConfig("/my_function")).toEqual({
     attrs: {
       handle: expect.any(String),
-      runningState: expect.any(String),
     },
     path: "root/my_function",
     addr: expect.any(String),

--- a/libs/wingsdk/test/target-sim/on-deploy.test.ts
+++ b/libs/wingsdk/test/target-sim/on-deploy.test.ts
@@ -16,7 +16,6 @@ test("create an OnDeploy", async () => {
   expect(s.getResourceConfig("/my_on_deploy")).toEqual({
     attrs: {
       handle: expect.any(String),
-      runningState: expect.any(String),
     },
     deps: ["root/my_on_deploy/Function"],
     path: "root/my_on_deploy",

--- a/libs/wingsdk/test/target-sim/queue.test.ts
+++ b/libs/wingsdk/test/target-sim/queue.test.ts
@@ -27,7 +27,6 @@ test("create a queue", async () => {
   expect(s.getResourceConfig("/my_queue")).toEqual({
     attrs: {
       handle: expect.any(String),
-      runningState: expect.any(String),
     },
     path: "root/my_queue",
     addr: expect.any(String),

--- a/libs/wingsdk/test/target-sim/redis.test.ts
+++ b/libs/wingsdk/test/target-sim/redis.test.ts
@@ -16,7 +16,6 @@ test("create a Redis resource", async () => {
   expect(redisResource).toEqual({
     attrs: {
       handle: expect.any(String),
-      runningState: expect.any(String),
     },
     path: "root/my_redis",
     addr: expect.any(String),

--- a/libs/wingsdk/test/target-sim/schedule.test.ts
+++ b/libs/wingsdk/test/target-sim/schedule.test.ts
@@ -19,7 +19,6 @@ test("create a schedule", async () => {
   expect(s.getResourceConfig("/my_schedule")).toEqual({
     attrs: {
       handle: expect.any(String),
-      runningState: expect.any(String),
     },
     path: "root/my_schedule",
     addr: expect.any(String),
@@ -67,7 +66,6 @@ test("schedule with one task using rate of 10m", async () => {
   expect(s.getResourceConfig("/my_schedule")).toEqual({
     attrs: {
       handle: expect.any(String),
-      runningState: expect.any(String),
     },
     path: "root/my_schedule",
     addr: expect.any(String),
@@ -96,7 +94,6 @@ test("schedule with one task using rate of 3h", async () => {
   expect(s.getResourceConfig("/my_schedule")).toEqual({
     attrs: {
       handle: expect.any(String),
-      runningState: expect.any(String),
     },
     path: "root/my_schedule",
     addr: expect.any(String),

--- a/libs/wingsdk/test/target-sim/secret.test.ts
+++ b/libs/wingsdk/test/target-sim/secret.test.ts
@@ -25,7 +25,6 @@ describe("secrets", () => {
     expect(s.getResourceConfig("/my_secret")).toEqual({
       attrs: {
         handle: expect.any(String),
-        runningState: expect.any(String),
       },
       path: "root/my_secret",
       addr: expect.any(String),

--- a/libs/wingsdk/test/target-sim/service.test.ts
+++ b/libs/wingsdk/test/target-sim/service.test.ts
@@ -24,7 +24,6 @@ test("create a service with on start method", async () => {
   expect(s.getResourceConfig("/my_service")).toEqual({
     attrs: {
       handle: expect.any(String),
-      runningState: expect.any(String),
     },
     path: "root/my_service",
     addr: expect.any(String),
@@ -53,7 +52,6 @@ test("create a service with a on stop method", async () => {
   expect(s.getResourceConfig("/my_service")).toEqual({
     attrs: {
       handle: expect.any(String),
-      runningState: expect.any(String),
     },
     path: "root/my_service",
     addr: expect.any(String),
@@ -95,7 +93,6 @@ test("create a service without autostart", async () => {
   expect(s.getResourceConfig("/my_service")).toEqual({
     attrs: {
       handle: expect.any(String),
-      runningState: expect.any(String),
     },
     path: "root/my_service",
     addr: expect.any(String),

--- a/libs/wingsdk/test/target-sim/table.test.ts
+++ b/libs/wingsdk/test/target-sim/table.test.ts
@@ -19,7 +19,6 @@ test("create a table", async () => {
   expect(s.getResourceConfig("/my_table")).toEqual({
     attrs: {
       handle: expect.any(String),
-      runningState: expect.any(String),
     },
     path: "root/my_table",
     addr: expect.any(String),
@@ -59,7 +58,6 @@ test("insert row", async () => {
   expect(s.getResourceConfig("/my_table")).toEqual({
     attrs: {
       handle: expect.any(String),
-      runningState: expect.any(String),
     },
     path: "root/my_table",
     addr: expect.any(String),
@@ -107,7 +105,6 @@ test("get row", async () => {
   expect(s.getResourceConfig("/my_table")).toEqual({
     attrs: {
       handle: expect.any(String),
-      runningState: expect.any(String),
     },
     path: "root/my_table",
     addr: expect.any(String),
@@ -154,7 +151,6 @@ test("tryGet row", async () => {
   expect(s.getResourceConfig("/my_table")).toEqual({
     attrs: {
       handle: expect.any(String),
-      runningState: expect.any(String),
     },
     path: "root/my_table",
     addr: expect.any(String),
@@ -200,7 +196,6 @@ test("update row", async () => {
   expect(s.getResourceConfig("/my_table")).toEqual({
     attrs: {
       handle: expect.any(String),
-      runningState: expect.any(String),
     },
     path: "root/my_table",
     addr: expect.any(String),
@@ -245,7 +240,6 @@ test("list table", async () => {
   expect(s.getResourceConfig("/my_table")).toEqual({
     attrs: {
       handle: expect.any(String),
-      runningState: expect.any(String),
     },
     path: "root/my_table",
     addr: expect.any(String),
@@ -352,7 +346,6 @@ test("can add row in preflight", async () => {
   expect(s.getResourceConfig("/my_table")).toEqual({
     attrs: {
       handle: expect.any(String),
-      runningState: expect.any(String),
     },
     path: "root/my_table",
     addr: expect.any(String),

--- a/libs/wingsdk/test/target-sim/test.test.ts
+++ b/libs/wingsdk/test/target-sim/test.test.ts
@@ -25,7 +25,6 @@ test("create a test", async () => {
   expect(s.getResourceConfig("/env0/test:my_test/Handler")).toEqual({
     attrs: {
       handle: expect.any(String),
-      runningState: expect.any(String),
     },
     path: "root/env0/test:my_test/Handler",
     addr: expect.any(String),

--- a/libs/wingsdk/test/target-sim/topic.test.ts
+++ b/libs/wingsdk/test/target-sim/topic.test.ts
@@ -15,7 +15,6 @@ test("create a topic", async () => {
   expect(s.getResourceConfig("/my_topic")).toEqual({
     attrs: {
       handle: expect.any(String),
-      runningState: expect.any(String),
     },
     path: "root/my_topic",
     addr: expect.any(String),

--- a/libs/wingsdk/test/target-sim/website.test.ts
+++ b/libs/wingsdk/test/target-sim/website.test.ts
@@ -106,7 +106,7 @@ test("api.url is resolved in website config", async () => {
   expect(s.getResourceConfig("/website")).toEqual({
     attrs: {
       handle: expect.any(String),
-      runningState: expect.any(String),
+
       url: expect.any(String),
     },
     path: "root/website",
@@ -144,7 +144,7 @@ test("multiple tokens are resolved in website config", async () => {
   expect(s.getResourceConfig("/website")).toEqual({
     attrs: {
       handle: expect.any(String),
-      runningState: expect.any(String),
+
       url: expect.any(String),
     },
     path: "root/website",


### PR DESCRIPTION
This changeset fixes the running state of constructs that don't have any kind of runtime code.

The Console UI now understands that some resources may not have a running state at all, and the Simulator sets the running state of new resources as `stopped`.

Fixes https://github.com/winglang/wing/issues/6858. Supersedes #6867.