### PR TITLE
fix(console): improve explorer out of bounds experience

### DIFF
--- a/apps/wing-console/console/ui/src/features/explorer-pane/map-view.tsx
+++ b/apps/wing-console/console/ui/src/features/explorer-pane/map-view.tsx
@@ -686,7 +686,7 @@ export const MapView = memo(
                   id: "root",
                   layoutOptions: {
                     ...baseLayoutOptions,
-                    "elk.padding": "[top=24,left=20,bottom=20,right=20]",
+                    "elk.padding": "[top=24,left=24,bottom=24,right=24]",
                   },
                 }}
                 edges={edges}

--- a/apps/wing-console/console/ui/src/features/explorer-pane/use-raf-throttle.ts
+++ b/apps/wing-console/console/ui/src/features/explorer-pane/use-raf-throttle.ts
@@ -1,0 +1,40 @@
+import { useRef, useCallback, useEffect } from "react";
+
+/**
+ * A hook that returns a throttled version of the provided callback that uses
+ * `requestAnimationFrame` to throttle the callback.
+ */
+export const useRafThrottle = <ArgumentsType extends any[]>(
+  callback: (...arguments_: ArgumentsType) => void,
+): ((...arguments_: ArgumentsType) => void) => {
+  const requestRef = useRef<number | undefined>(undefined);
+  const callbackRef = useRef(callback);
+
+  // Update the callback reference whenever it changes.
+  useEffect(() => {
+    callbackRef.current = callback;
+  }, [callback]);
+
+  const throttledCallback = useCallback<(...arguments_: ArgumentsType) => void>(
+    (...arguments_) => {
+      if (!requestRef.current) {
+        requestRef.current = requestAnimationFrame(() => {
+          callbackRef.current(...arguments_);
+          requestRef.current = undefined;
+        });
+      }
+    },
+    [],
+  );
+
+  // Cleanup on unmount.
+  useEffect(() => {
+    return () => {
+      if (requestRef.current) {
+        cancelAnimationFrame(requestRef.current);
+      }
+    };
+  }, []);
+
+  return throttledCallback;
+};

--- a/apps/wing-console/console/ui/src/features/explorer-pane/zoom-pane.tsx
+++ b/apps/wing-console/console/ui/src/features/explorer-pane/zoom-pane.tsx
@@ -485,19 +485,13 @@ export const ZoomPane = forwardRef<ZoomPaneRef, ZoomPaneProps>((props, ref) => {
       <div ref={targetRef} className="absolute inset-0 origin-top-left">
         <context.Provider value={{ viewTransform }}>
           <div className="relative inline-block">
-            <AnimatePresence>
-              {outOfBounds && (
-                <motion.div
-                  className={classNames(
-                    "absolute inset-0 w-full h-full rounded-lg shadow-lg bg-slate-250 dark:bg-slate-500 animate-pulse",
-                  )}
-                  initial={{ opacity: 0 }}
-                  animate={{ opacity: 1 }}
-                  exit={{ opacity: 0 }}
-                  transition={{ duration: 0.15 }}
-                />
-              )}
-            </AnimatePresence>
+            {outOfBounds && (
+              <div
+                className={classNames(
+                  "absolute inset-0 w-full h-full rounded-lg shadow-lg bg-slate-250 dark:bg-slate-500 animate-pulse",
+                )}
+              />
+            )}
             {children}
           </div>
         </context.Provider>

--- a/apps/wing-console/console/ui/src/features/explorer-pane/zoom-pane.tsx
+++ b/apps/wing-console/console/ui/src/features/explorer-pane/zoom-pane.tsx
@@ -400,7 +400,7 @@ export const ZoomPane = forwardRef<ZoomPaneRef, ZoomPaneProps>((props, ref) => {
       <AnimatePresence>
         {outOfBounds && (
           <motion.div
-            className="absolute inset-0 z-10 flex justify-around items-center backdrop-blur-[2px]"
+            className="absolute inset-0 z-10 flex justify-around items-center backdrop-blur-[1.5px]"
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
             exit={{ opacity: 0 }}

--- a/apps/wing-console/console/ui/src/features/explorer-pane/zoom-pane.tsx
+++ b/apps/wing-console/console/ui/src/features/explorer-pane/zoom-pane.tsx
@@ -94,7 +94,7 @@ export const useZoomPane = () => {
   return useContext(context);
 };
 
-const boundaryPadding = 64 + 24;
+const boundaryPadding = 24;
 
 export const ZoomPane = forwardRef<ZoomPaneRef, ZoomPaneProps>((props, ref) => {
   const { boundingBox, children, className, onClick, ...divProps } = props;
@@ -116,19 +116,36 @@ export const ZoomPane = forwardRef<ZoomPaneRef, ZoomPaneProps>((props, ref) => {
     (transform: Transform) => {
       const containerWidth = containerRef.current?.clientWidth ?? 0;
       const boundingBoxWidth = boundingBox?.width ?? 0;
-      const x = Math.min(
-        Math.max(transform.x, -containerWidth / transform.z + boundaryPadding),
-        boundingBoxWidth - boundaryPadding,
-      );
-
       const containerHeight = containerRef.current?.clientHeight ?? 0;
       const boundingBoxHeight = boundingBox?.height ?? 0;
+
+      // Sample: adapt the boundary padding to the zoom level.
+      // const x = Math.min(
+      //   Math.max(transform.x, -containerWidth / transform.z + boundaryPadding),
+      //   boundingBoxWidth - boundaryPadding,
+      // );
+      // const y = Math.min(
+      //   Math.max(
+      //     transform.y,
+      //     -(containerHeight - boundaryPadding * transform.z) / transform.z,
+      //   ),
+      //   boundingBoxHeight - boundaryPadding,
+      // );
+
+      // Maintain the boundary padding independently of the zoom level.
+      const x = Math.min(
+        Math.max(
+          transform.x,
+          (-containerWidth + boundaryPadding) / transform.z,
+        ),
+        (boundingBoxWidth * transform.z - boundaryPadding) / transform.z,
+      );
       const y = Math.min(
         Math.max(
           transform.y,
-          -(containerHeight - boundaryPadding * transform.z) / transform.z,
+          (-containerHeight + boundaryPadding) / transform.z,
         ),
-        boundingBoxHeight - boundaryPadding,
+        (boundingBoxHeight * transform.z - boundaryPadding) / transform.z,
       );
       return {
         x,
@@ -427,7 +444,20 @@ export const ZoomPane = forwardRef<ZoomPaneRef, ZoomPaneProps>((props, ref) => {
     };
 
     // Add some extra padding to trigger the out of bounds warning sooner.
-    const padding = boundaryPadding + 24;
+    const extraPaddingPercentage = 1.1;
+
+    // Sample: adapt the boundary padding to the zoom level.
+    // const padding = boundaryPadding * extraPaddingPercentage;
+    // return !boundingBoxOverlap(viewBoundingBox, {
+    //   x: padding,
+    //   y: padding,
+    //   width: boundingBox.width - padding * 2,
+    //   height: boundingBox.height - padding * 2,
+    // });
+
+    // Maintain the boundary padding independently of the zoom level.
+    const padding =
+      (boundaryPadding * extraPaddingPercentage) / viewTransform.z;
     return !boundingBoxOverlap(viewBoundingBox, {
       x: padding,
       y: padding,

--- a/apps/wing-console/console/ui/src/features/explorer-pane/zoom-pane.tsx
+++ b/apps/wing-console/console/ui/src/features/explorer-pane/zoom-pane.tsx
@@ -17,6 +17,7 @@ import type { ReactNode } from "react";
 import { useEvent } from "react-use";
 
 import { MapControls } from "./map-controls.js";
+import { useRafThrottle } from "./use-raf-throttle.js";
 
 export interface Viewport {
   x: number;
@@ -94,7 +95,7 @@ export const useZoomPane = () => {
   return useContext(context);
 };
 
-const boundaryPadding = 24;
+const boundaryPadding = 48;
 
 export const ZoomPane = forwardRef<ZoomPaneRef, ZoomPaneProps>((props, ref) => {
   const { boundingBox, children, className, onClick, ...divProps } = props;
@@ -312,15 +313,19 @@ export const ZoomPane = forwardRef<ZoomPaneRef, ZoomPaneProps>((props, ref) => {
     });
   }, [restrict]);
 
+  const throttledFixViewport = useRafThrottle(fixViewport);
+
   useEffect(() => {
     const myObserver = new ResizeObserver(() => {
-      fixViewport();
+      throttledFixViewport();
     });
 
     myObserver.observe(containerRef.current!);
 
-    return () => myObserver.disconnect();
-  }, [fixViewport]);
+    return () => {
+      myObserver.disconnect();
+    };
+  }, [throttledFixViewport]);
 
   const zoomIn = useCallback(() => {
     const container = containerRef.current;

--- a/apps/wing-console/console/ui/src/features/explorer-pane/zoom-pane.tsx
+++ b/apps/wing-console/console/ui/src/features/explorer-pane/zoom-pane.tsx
@@ -18,6 +18,7 @@ import { useEvent } from "react-use";
 
 import { MapControls } from "./map-controls.js";
 import { useRafThrottle } from "./use-raf-throttle.js";
+import { ArrowsPointingOutIcon } from "@heroicons/react/24/solid";
 
 export interface Viewport {
   x: number;
@@ -515,7 +516,12 @@ export const ZoomPane = forwardRef<ZoomPaneRef, ZoomPaneProps>((props, ref) => {
                 The map is out of bounds
               </p>
               <div className="flex justify-around pointer-events-auto">
-                <Button onClick={() => zoomToFit()}>Fit map to screen</Button>
+                <Button
+                  onClick={() => zoomToFit()}
+                  icon={ArrowsPointingOutIcon}
+                >
+                  Fit map to screen
+                </Button>
               </div>
             </div>
           </motion.div>

--- a/apps/wing-console/console/ui/src/features/explorer-pane/zoom-pane.tsx
+++ b/apps/wing-console/console/ui/src/features/explorer-pane/zoom-pane.tsx
@@ -431,7 +431,7 @@ export const ZoomPane = forwardRef<ZoomPaneRef, ZoomPaneProps>((props, ref) => {
 
   // Whether the bounding box is out of bounds of the transform view.
   const outOfBounds = useMemo(() => {
-    if (!boundingBox) {
+    if (!boundingBox || boundingBox.width === 0 || boundingBox.height === 0) {
       return false;
     }
 
@@ -440,6 +440,9 @@ export const ZoomPane = forwardRef<ZoomPaneRef, ZoomPaneProps>((props, ref) => {
       return false;
     }
     const containerBoundingBox = container.getBoundingClientRect();
+    if (containerBoundingBox.width === 0 || containerBoundingBox.height === 0) {
+      return false;
+    }
 
     const viewBoundingBox = {
       x: viewTransform.x,

--- a/apps/wing-console/console/ui/src/features/explorer-pane/zoom-pane.tsx
+++ b/apps/wing-console/console/ui/src/features/explorer-pane/zoom-pane.tsx
@@ -1,3 +1,4 @@
+import { ArrowsPointingOutIcon } from "@heroicons/react/24/solid";
 import { Button, useTheme } from "@wingconsole/design-system";
 import classNames from "classnames";
 import { AnimatePresence, motion } from "framer-motion";
@@ -18,7 +19,6 @@ import { useEvent } from "react-use";
 
 import { MapControls } from "./map-controls.js";
 import { useRafThrottle } from "./use-raf-throttle.js";
-import { ArrowsPointingOutIcon } from "@heroicons/react/24/solid";
 
 export interface Viewport {
   x: number;

--- a/apps/wing-console/console/ui/src/features/explorer-pane/zoom-pane.tsx
+++ b/apps/wing-console/console/ui/src/features/explorer-pane/zoom-pane.tsx
@@ -289,6 +289,22 @@ export const ZoomPane = forwardRef<ZoomPaneRef, ZoomPaneProps>((props, ref) => {
     containerRef.current,
   );
 
+  const fixViewport = useCallback(() => {
+    setViewTransform((viewTransform) => {
+      return restrict(viewTransform);
+    });
+  }, [restrict]);
+
+  useEffect(() => {
+    const myObserver = new ResizeObserver(() => {
+      fixViewport();
+    });
+
+    myObserver.observe(containerRef.current!);
+
+    return () => myObserver.disconnect();
+  }, [fixViewport]);
+
   const zoomIn = useCallback(() => {
     const container = containerRef.current;
     if (!container) {

--- a/apps/wing-console/console/ui/src/features/explorer-pane/zoom-pane.tsx
+++ b/apps/wing-console/console/ui/src/features/explorer-pane/zoom-pane.tsx
@@ -1,5 +1,6 @@
 import { Button, useTheme } from "@wingconsole/design-system";
 import classNames from "classnames";
+import { AnimatePresence, motion } from "framer-motion";
 import {
   createContext,
   forwardRef,
@@ -372,11 +373,13 @@ export const ZoomPane = forwardRef<ZoomPaneRef, ZoomPaneProps>((props, ref) => {
       height: containerBoundingBox.height / viewTransform.z,
     };
 
+    // Add padding to the view bounding box to prevent the bounding box from being too close to the edge.
+    const padding = 64 + 24;
     return !boundingBoxOverlap(viewBoundingBox, {
-      x: 0,
-      y: 0,
-      width: boundingBox.width,
-      height: boundingBox.height,
+      x: 0 + padding,
+      y: 0 + padding,
+      width: boundingBox.width - padding * 2,
+      height: boundingBox.height - padding * 2,
     });
   }, [viewTransform, boundingBox]);
 
@@ -394,6 +397,39 @@ export const ZoomPane = forwardRef<ZoomPaneRef, ZoomPaneProps>((props, ref) => {
         </context.Provider>
       </div>
 
+      <AnimatePresence>
+        {outOfBounds && (
+          <motion.div
+            className="absolute inset-0 z-10 flex justify-around items-center backdrop-blur-sm"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+          >
+            <div
+              className={classNames(
+                "p-4 rounded flex flex-col justify-around gap-2",
+              )}
+            >
+              <p className={classNames(theme.text1, "px-2 py-0.5 rounded")}>
+                The map is out of bounds
+              </p>
+              <div className="flex justify-around">
+                <Button onClick={() => zoomToFit()}>Fit map to screen</Button>
+              </div>
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+
+      {isSpacePressed && (
+        <div
+          className={classNames("absolute inset-0 z-10", {
+            "cursor-grab": !isDragging,
+            "cursor-grabbing": isDragging,
+          })}
+        ></div>
+      )}
+
       <div className="relative z-10 flex">
         <div className="absolute cursor-grab backdrop-blur right-0">
           <MapControls
@@ -403,38 +439,6 @@ export const ZoomPane = forwardRef<ZoomPaneRef, ZoomPaneProps>((props, ref) => {
           />
         </div>
       </div>
-
-      {outOfBounds && (
-        <div className="absolute inset-0 z-10 flex justify-around items-center">
-          <div
-            className={classNames(
-              "p-4 rounded flex flex-col justify-around gap-2",
-            )}
-          >
-            <p
-              className={classNames(
-                theme.text1,
-                theme.bg4,
-                "px-2 py-0.5 rounded",
-              )}
-            >
-              The map is out of bounds
-            </p>
-            <div className="flex justify-around">
-              <Button onClick={() => zoomToFit()}>Fit map to screen</Button>
-            </div>
-          </div>
-        </div>
-      )}
-
-      {isSpacePressed && (
-        <div
-          className={classNames("absolute inset-0", {
-            "cursor-grab": !isDragging,
-            "cursor-grabbing": isDragging,
-          })}
-        ></div>
-      )}
     </div>
   );
 });

--- a/apps/wing-console/console/ui/src/features/explorer-pane/zoom-pane.tsx
+++ b/apps/wing-console/console/ui/src/features/explorer-pane/zoom-pane.tsx
@@ -400,10 +400,11 @@ export const ZoomPane = forwardRef<ZoomPaneRef, ZoomPaneProps>((props, ref) => {
       <AnimatePresence>
         {outOfBounds && (
           <motion.div
-            className="absolute inset-0 z-10 flex justify-around items-center backdrop-blur-sm"
+            className="absolute inset-0 z-10 flex justify-around items-center backdrop-blur-[2px]"
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
             exit={{ opacity: 0 }}
+            transition={{ duration: 0.15 }}
           >
             <div
               className={classNames(

--- a/apps/wing-console/console/ui/src/features/explorer-pane/zoom-pane.tsx
+++ b/apps/wing-console/console/ui/src/features/explorer-pane/zoom-pane.tsx
@@ -393,15 +393,15 @@ export const ZoomPane = forwardRef<ZoomPaneRef, ZoomPaneProps>((props, ref) => {
 
   // Whether the bounding box is out of bounds of the transform view.
   const outOfBounds = useMemo(() => {
+    if (!boundingBox) {
+      return false;
+    }
+
     const container = containerRef.current;
     if (!container) {
       return false;
     }
     const containerBoundingBox = container.getBoundingClientRect();
-
-    if (!boundingBox) {
-      return false;
-    }
 
     const viewBoundingBox = {
       x: viewTransform.x,
@@ -410,14 +410,13 @@ export const ZoomPane = forwardRef<ZoomPaneRef, ZoomPaneProps>((props, ref) => {
       height: containerBoundingBox.height / viewTransform.z,
     };
 
-    // Add padding to the view bounding box to prevent the bounding box from being too close to the edge.
-    const zoomedBoundaryPadding = boundaryPadding / viewTransform.z;
-    // const zoomedBoundaryPadding = boundaryPadding * viewTransform.z;
+    // Add some extra padding to trigger the out of bounds warning sooner.
+    const padding = boundaryPadding + 24;
     return !boundingBoxOverlap(viewBoundingBox, {
-      x: 0 + zoomedBoundaryPadding * 2,
-      y: 0 + zoomedBoundaryPadding * 2,
-      width: boundingBox.width - zoomedBoundaryPadding * 2,
-      height: boundingBox.height - zoomedBoundaryPadding * 2,
+      x: padding,
+      y: padding,
+      width: boundingBox.width - padding * 2,
+      height: boundingBox.height - padding * 2,
     });
   }, [viewTransform, boundingBox]);
 
@@ -431,17 +430,6 @@ export const ZoomPane = forwardRef<ZoomPaneRef, ZoomPaneProps>((props, ref) => {
     >
       <div ref={targetRef} className="absolute inset-0 origin-top-left">
         <context.Provider value={{ viewTransform }}>
-          {/* <div
-            className={classNames(
-              "transition-all inline-block rounded-lg",
-              // "bg-white dark:bg-slate-550",
-              {
-                "bg-white dark:bg-slate-550 animate-pulse": outOfBounds,
-              },
-            )}
-          >
-            {children}
-          </div> */}
           <div className="relative inline-block">
             <AnimatePresence>
               {outOfBounds && (
@@ -494,7 +482,6 @@ export const ZoomPane = forwardRef<ZoomPaneRef, ZoomPaneProps>((props, ref) => {
           })}
         ></div>
       )}
-
       <div className="relative z-10 flex">
         <div className="absolute cursor-grab backdrop-blur right-0">
           <MapControls


### PR DESCRIPTION
This changeset increases the explorer's threshold used by the "Out of bounds" alert, meaning that it will appear before losing track of the nodes in the explorer. Additionally, the viewport will never leave the rendered area completely, even after resizing the browser window or the panels.

Fixes #4699.
