### PR TITLE
chore(docs): compatibility matrix tool now points to correct doc location

### DIFF
--- a/.github/workflows/matrix-update.yml
+++ b/.github/workflows/matrix-update.yml
@@ -46,7 +46,7 @@ jobs:
           base: main
           add-paths: docs/**
           commit-message: |-
-            Updates the [Compatibility Matrix](https://www.winglang.io/docs/standard-library/compatibility-matrix)
+            Updates the [Compatibility Matrix](https://www.winglang.io/docs/api/standard-library/compatibility-matrix)
 
             [Workflow Run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
 

--- a/tools/compatibility-matrix-automation/README.md
+++ b/tools/compatibility-matrix-automation/README.md
@@ -1,6 +1,6 @@
 ## compatibility matrix automation
 
-A small program that is used for taking test output files, and use them in order to update the compatibility matrix (can be found here: https://www.winglang.io/docs/standard-library/compatibility-matrix)
+A small program that is used for taking test output files, and use them in order to update the compatibility matrix (can be found here: https://www.winglang.io/docs/api/standard-library/compatibility-matrix)
 
 To run the script:
 

--- a/tools/compatibility-matrix-automation/src/matrix-automation.ts
+++ b/tools/compatibility-matrix-automation/src/matrix-automation.ts
@@ -6,7 +6,7 @@ import { CompatibilityMatrix, CompatibilitySets } from "./types";
 export const SKIPPED_RESOURCES = ["TestRunner", "State"];
 export const MATRIX_PATH = join(
   __dirname,
-  "../../../docs/docs/04-standard-library/compatibility/compatibility.json"
+  "../../../docs/api/04-standard-library/compatibility/compatibility.json"
 );
 export const OUT_PATH = join(__dirname, "../../../out.json");
 


### PR DESCRIPTION
Fix for the [broken build](https://github.com/winglang/wing/actions/runs/9853241327/job/27205814936).

Includes the new path to the compatibility matrix location in the compatibility matrix tool.

## Checklist

- [ ] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [ ] Description explains motivation and solution
- [ ] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
