### PR TITLE
fix(compiler): compiler panic when calling namespaced function within index expression

### DIFF
--- a/examples/tests/valid/namspaced-expr-in-index-expr.test.w
+++ b/examples/tests/valid/namspaced-expr-in-index-expr.test.w
@@ -1,0 +1,5 @@
+bring math;
+bring expect;
+
+let s = [1];
+expect.equal(s[math.round(0.2)], 1);

--- a/libs/wingc/src/type_check/type_reference_transform.rs
+++ b/libs/wingc/src/type_check/type_reference_transform.rs
@@ -25,7 +25,9 @@ impl<'a> Fold for TypeReferenceTransformer<'a> {
 					fold::fold_reference(self, node)
 				}
 			}
-			Reference::Identifier(..) | Reference::TypeMember { .. } | Reference::ElementAccess { .. } => node,
+			Reference::Identifier(..) | Reference::TypeMember { .. } | Reference::ElementAccess { .. } => {
+				fold::fold_reference(self, node)
+			}
 		}
 	}
 }

--- a/tools/hangar/__snapshots__/test_corpus/valid/namspaced-expr-in-index-expr.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/namspaced-expr-in-index-expr.test.w_compile_tf-aws.md
@@ -1,0 +1,48 @@
+# [namspaced-expr-in-index-expr.test.w](../../../../../examples/tests/valid/namspaced-expr-in-index-expr.test.w) | compile | tf-aws
+
+## main.tf.json
+```json
+{
+  "//": {
+    "metadata": {
+      "backend": "local",
+      "stackName": "root"
+    },
+    "outputs": {}
+  },
+  "provider": {
+    "aws": [
+      {}
+    ]
+  }
+}
+```
+
+## preflight.cjs
+```cjs
+"use strict";
+const $stdlib = require('@winglang/sdk');
+const $platforms = ((s) => !s ? [] : s.split(';'))(process.env.WING_PLATFORMS);
+const $outdir = process.env.WING_SYNTH_DIR ?? ".";
+const $wing_is_test = process.env.WING_IS_TEST === "true";
+const std = $stdlib.std;
+const $helpers = $stdlib.helpers;
+const $extern = $helpers.createExternRequire(__dirname);
+const $PlatformManager = new $stdlib.platform.PlatformManager({platformPaths: $platforms});
+class $Root extends $stdlib.std.Resource {
+  constructor($scope, $id) {
+    super($scope, $id);
+    $helpers.nodeof(this).root.$preflightTypesMap = { };
+    let $preflightTypesMap = {};
+    const math = $stdlib.math;
+    const expect = $stdlib.expect;
+    $helpers.nodeof(this).root.$preflightTypesMap = $preflightTypesMap;
+    const s = [1];
+    (expect.Util.equal($helpers.lookup(s, (math.Util.round(0.2))), 1));
+  }
+}
+const $APP = $PlatformManager.createApp({ outdir: $outdir, name: "namspaced-expr-in-index-expr.test", rootConstruct: $Root, isTestEnvironment: $wing_is_test, entrypointDir: process.env['WING_SOURCE_DIR'], rootId: process.env['WING_ROOT_ID'] });
+$APP.synth();
+//# sourceMappingURL=preflight.cjs.map
+```
+

--- a/tools/hangar/__snapshots__/test_corpus/valid/namspaced-expr-in-index-expr.test.w_test_sim.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/namspaced-expr-in-index-expr.test.w_test_sim.md
@@ -1,0 +1,12 @@
+# [namspaced-expr-in-index-expr.test.w](../../../../../examples/tests/valid/namspaced-expr-in-index-expr.test.w) | test | sim
+
+## stdout.log
+```log
+pass ─ namspaced-expr-in-index-expr.test.wsim (no tests)
+
+Tests 1 passed (1)
+Snapshots 1 skipped
+Test Files 1 passed (1)
+Duration <DURATION>
+```
+


### PR DESCRIPTION
fixes #6661 
The `TypeReferenceTransformer` uses a fold visitor pattern to visit certain `InstanceMember` references and convert them into `TypeReference` if needed.
The other arm stopped the visiting recursion by just returning the node and not a call to the folder- therefore inner references were never visited. It was fixed by calling the fold visitor at all arms of the reference enum.

## Checklist

- [ ] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [ ] Description explains motivation and solution
- [ ] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
