### PR TITLE
chore(console): dev command now handles terminal signals

### DIFF
--- a/apps/wing-console/console/app/scripts/dev.mjs
+++ b/apps/wing-console/console/app/scripts/dev.mjs
@@ -50,6 +50,19 @@ const options = parseArgs({
     },
   });
 
+  let closing = false;
+  const events = ["beforeExit", "SIGINT", "SIGTERM", "SIGHUP"];
+  for (const event of events) {
+    process.on(event, async () => {
+      if (closing) {
+        return;
+      }
+      closing = true;
+      await consoleServer.close();
+      process.exit();
+    });
+  }
+
   const vite = await createViteServer({
     ...viteConfig,
     server: {


### PR DESCRIPTION
This changeset improves the `dev` script of the console so it closes the console server before shutting everything down.

Related to #5798.