### PR TITLE
chore: enabling gcp spec tests to run after release

### DIFF
--- a/.github/workflows/sdk-spec-test.yml
+++ b/.github/workflows/sdk-spec-test.yml
@@ -1,9 +1,9 @@
 name: SDK Spec Tests
 run-name: SDK Spec Tests (${{ inputs.repo || github.repository }}/${{inputs.ref || github.ref}}) for ${{inputs.target || 'all'}}
 on:
-  # release: #TODO: uncomment to enable unstable targets, at this moment there are none
-  # types:
-  # - published # runs only unstable targets
+  release:
+    types:
+      - published # runs only unstable targets
   workflow_call: {}
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
## Checklist

- [ ] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [ ] Description explains motivation and solution
- [ ] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
