### PR TITLE
fix(console): add support for ascii colors in the blue screen of death

### DIFF
--- a/apps/wing-console/console/ui/package.json
+++ b/apps/wing-console/console/ui/package.json
@@ -23,6 +23,7 @@
   "scripts": {
     "compile": "tsup",
     "tsc": "tsc --build",
+    "test": "vitest --passWithNoTests",
     "eslint": "eslint --ext .js,.cjs,.ts,.cts,.mts,.tsx --no-error-on-unmatched-pattern . --fix",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
@@ -36,6 +37,7 @@
     "@trpc/client": "^10.45.2",
     "@trpc/react-query": "^10.45.2",
     "@trpc/server": "^10.45.2",
+    "@types/lodash.escape": "^4.0.9",
     "@wingconsole/design-system": "workspace:^",
     "classnames": "^2.5.1",
     "elkjs": "^0.8.2",
@@ -44,6 +46,7 @@
     "linkify-react": "^4.1.3",
     "linkifyjs": "^4.1.3",
     "lodash.debounce": "^4.0.8",
+    "lodash.escape": "^4.0.1",
     "lodash.throttle": "^4.1.1",
     "lodash.uniqby": "^4.7.0",
     "nanoid": "^4.0.2",

--- a/apps/wing-console/console/ui/src/features/blue-screen-of-death/blue-screen-of-death.tsx
+++ b/apps/wing-console/console/ui/src/features/blue-screen-of-death/blue-screen-of-death.tsx
@@ -1,44 +1,58 @@
 import { useNotifications } from "@wingconsole/design-system";
 import classNames from "classnames";
-import { memo, useCallback, useEffect, useMemo, useState } from "react";
+import { memo, useCallback, useMemo } from "react";
 
 import { trpc } from "../../trpc.js";
-import { OpenFileInEditorButton, createHtmlLink } from "../../use-file-link.js";
+
+import type { AsciiColor } from "./turn-ascii-colors-into-html.js";
+import { turnAsciiColorsIntoHtml } from "./turn-ascii-colors-into-html.js";
+import { OpenFileInEditorButton, createHtmlLink } from "./use-file-link.js";
+
+const colors = {
+  black: "text-black-500",
+  red: "text-red-500",
+  green: "text-green-500",
+  yellow: "text-yellow-500",
+  blue: "text-blue-500",
+  magenta: "text-magenta-500",
+  cyan: "text-cyan-500",
+  white: "text-white-500",
+} satisfies Record<AsciiColor, string>;
 
 export const BlueScreenOfDeath = memo(
   ({ displayLinks = true }: { displayLinks?: boolean }) => {
     const errorQuery = trpc["app.error"].useQuery();
 
-    const error = useMemo(() => {
-      return errorQuery.data ?? "";
+    const coloredError = useMemo(() => {
+      return turnAsciiColorsIntoHtml(errorQuery.data ?? "", {
+        colorsTransform: (color) => `class="${colors[color]}"`,
+      });
     }, [errorQuery.data]);
 
-    const [formattedPathsError, setFormattedPathsError] = useState("");
     const { showNotification } = useNotifications();
 
     const copyError = useCallback(() => {
-      navigator.clipboard.writeText(error);
-      showNotification("Error copied to clipboard", { type: "success" });
-    }, [error, showNotification]);
-
-    useEffect(() => {
-      if (!displayLinks) {
-        setFormattedPathsError(error);
-        return;
-      }
-      setFormattedPathsError(
-        createHtmlLink(
-          error,
-          "underline text-slate-300 hover:text-slate-400 cursor-pointer",
-          true,
-        ),
+      navigator.clipboard.writeText(
+        errorQuery.data?.replaceAll(/\u001B\[\d+m/g, "") ?? "",
       );
-    }, [error, displayLinks]);
+      showNotification("Error copied to clipboard", { type: "success" });
+    }, [errorQuery.data, showNotification]);
+
+    const formattedPathsError = useMemo(() => {
+      if (!displayLinks) {
+        return coloredError;
+      }
+
+      return createHtmlLink(
+        coloredError,
+        "underline text-slate-300 hover:text-slate-400 cursor-pointer",
+      );
+    }, [coloredError, displayLinks]);
 
     return (
       <div
         className={classNames(
-          "absolute h-full w-full z-50 px-10 py-10 bg-[#004295] overflow-auto flex justify-center items-center",
+          "absolute h-full w-full z-50 px-10 py-10 bg-[#004295] overflow-auto flex justify-center items-center select-text",
         )}
         data-testid="blue-screen-of-death"
       >
@@ -49,13 +63,14 @@ export const BlueScreenOfDeath = memo(
               className={classNames(
                 "text-center px-4 py-1 transition-all",
                 "bg-slate-400 hover:bg-slate-450 px-4 text-[#004295]",
+                "select-none",
               )}
             >
-              Copy
+              Copy error message
             </button>
           </div>
           <div className="space-y-4">
-            <OpenFileInEditorButton className="cursor-text select-text">
+            <OpenFileInEditorButton className="cursor-text">
               <div className="py-4">
                 <span
                   className="outline-none whitespace-pre-wrap"
@@ -65,7 +80,7 @@ export const BlueScreenOfDeath = memo(
             </OpenFileInEditorButton>
 
             {displayLinks && (
-              <div className="w-full text-center pb-4">
+              <div className="w-full text-center pb-4 select-none">
                 Click on any error reference to navigate to your IDE{" "}
                 <span className="animate-ping">_</span>
               </div>

--- a/apps/wing-console/console/ui/src/features/blue-screen-of-death/turn-ascii-colors-into-html.test.ts
+++ b/apps/wing-console/console/ui/src/features/blue-screen-of-death/turn-ascii-colors-into-html.test.ts
@@ -1,0 +1,37 @@
+import { test } from "vitest";
+
+import { turnAsciiColorsIntoHtml } from "./turn-ascii-colors-into-html.js";
+
+test("turnAsciiColorsIntoHtml", async (t) => {
+  t.expect(
+    turnAsciiColorsIntoHtml(`Error: Expected values to be strictly deep-equal:
+\u001B[32m+ actual\u001B[39m \u001B[31m- expected\u001B[39m
+
+\u001B[32m+\u001B[39m [
+\u001B[32m+\u001B[39m   'en'
+\u001B[32m+\u001B[39m ]
+\u001B[31m-\u001B[39m []
+   --> src/manager.test.w:15:1
+   |   model: model,
+   | );
+   | 
+15 | expect.equal(manager.allLanguages, []);
+   | ^
+at /home/wing/project/src/manager.test.w:15:1
+`),
+  ).toEqual(`Error: Expected values to be strictly deep-equal:
+<span style="color: green">+ actual</span> <span style="color: red">- expected</span>
+
+<span style="color: green">+</span> [
+<span style="color: green">+</span>   'en'
+<span style="color: green">+</span> ]
+<span style="color: red">-</span> []
+   --> src/manager.test.w:15:1
+   |   model: model,
+   | );
+   | 
+15 | expect.equal(manager.allLanguages, []);
+   | ^
+at /home/wing/project/src/manager.test.w:15:1
+`);
+});

--- a/apps/wing-console/console/ui/src/features/blue-screen-of-death/turn-ascii-colors-into-html.ts
+++ b/apps/wing-console/console/ui/src/features/blue-screen-of-death/turn-ascii-colors-into-html.ts
@@ -1,0 +1,63 @@
+import escape from "lodash.escape";
+
+export type AsciiColor =
+  | "black"
+  | "red"
+  | "green"
+  | "yellow"
+  | "blue"
+  | "magenta"
+  | "cyan"
+  | "white";
+
+// Define a mapping of ASCII color codes to HTML color codes
+const colorMap: { [key: string]: AsciiColor | "reset" } = {
+  "\u001B[30m": "black",
+  "\u001B[31m": "red",
+  "\u001B[32m": "green",
+  "\u001B[33m": "yellow",
+  "\u001B[34m": "blue",
+  "\u001B[35m": "magenta",
+  "\u001B[36m": "cyan",
+  "\u001B[37m": "white",
+  "\u001B[39m": "reset",
+  //  "\u001B[0m": "",
+} as const;
+
+const defaultColorsTransform = (color: AsciiColor) => `style="color: ${color}"`;
+
+export interface TurnAsciiColorsIntoHtmlOptions {
+  /**
+   * If `true`, the HTML will be escaped.
+   *
+   * @default true
+   */
+  escapeHtml?: boolean;
+
+  /**
+   * A function that transforms the color into an HTML attributes string.
+   *
+   * @default
+   * ```ts
+   * colorsTransform: (color) => `style="color: ${color}"`
+   * ```
+   */
+  colorsTransform?: (color: AsciiColor) => string;
+}
+
+export const turnAsciiColorsIntoHtml = (
+  asciiString: string,
+  options?: TurnAsciiColorsIntoHtmlOptions,
+): string => {
+  const colorsTransform = options?.colorsTransform ?? defaultColorsTransform;
+
+  return asciiString.replaceAll(/\u001B\[\d+m/g, (match) => {
+    const color = colorMap[match];
+    if (color === "reset") {
+      return "</span>";
+    } else if (color) {
+      return `<span ${colorsTransform(color)}>`;
+    }
+    return options?.escapeHtml === false ? match : escape(match);
+  });
+};

--- a/apps/wing-console/console/ui/src/features/blue-screen-of-death/use-file-link.tsx
+++ b/apps/wing-console/console/ui/src/features/blue-screen-of-death/use-file-link.tsx
@@ -1,23 +1,15 @@
 import classNames from "classnames";
 import type { PropsWithChildren } from "react";
 
-import { trpc } from "./trpc.js";
+import { trpc } from "../../trpc.js";
 
-export const createHtmlLink = (
-  error: string,
-  className: string,
-  expanded: boolean = false,
-) => {
-  return error
-    .replaceAll("<", "&lt;")
-    .replaceAll(">", "&gt;")
-    .replaceAll(
-      /--&gt;\s*([\w./-]+\.w):(\d+):(\d+)/g,
-      (match, path, line, column) => {
-        return `<a class="${className}" path="${path}" line="${line}" column="${column}" >${match}</a>`;
-      },
-    )
-    .replaceAll(/(\r\n|\n|\r)/gm, expanded ? "<br />" : "\n");
+export const createHtmlLink = (text: string, className: string) => {
+  return text.replaceAll(
+    /([\w./-]+\.w):(\d+):(\d+)/g,
+    (match, path, line, column) => {
+      return `<a class="${className}" path="${path}" line="${line}" column="${column}" >${match}</a>`;
+    },
+  );
 };
 
 export const OpenFileInEditorButton = ({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -770,6 +770,9 @@ importers:
       '@trpc/server':
         specifier: ^10.45.2
         version: 10.45.2
+      '@types/lodash.escape':
+        specifier: ^4.0.9
+        version: 4.0.9
       '@wingconsole/design-system':
         specifier: workspace:^
         version: link:../design-system
@@ -794,6 +797,9 @@ importers:
       lodash.debounce:
         specifier: ^4.0.8
         version: 4.0.8
+      lodash.escape:
+        specifier: ^4.0.1
+        version: 4.0.1
       lodash.throttle:
         specifier: ^4.1.1
         version: 4.1.1
@@ -10823,7 +10829,6 @@ packages:
     resolution: {integrity: sha512-YR9R6RU9D36OWrhVZ+r4fY8mMXQtofnLXAcE6CkKIxdH66uiCdEjkhxx/eiJnYpxjOFmPbWBUUvdv8lckO823Q==}
     dependencies:
       '@types/lodash': 4.17.5
-    dev: true
 
   /@types/lodash.once@4.1.9:
     resolution: {integrity: sha512-nvZ7GYfyZB6CUmXL+7HSXg53rFpc49FsKuRmMiCIGhgJB/yyTip8uHk4mxGyVJOl87dXPlf3qy42WsjOcIrnmg==}
@@ -10851,7 +10856,6 @@ packages:
 
   /@types/lodash@4.17.5:
     resolution: {integrity: sha512-MBIOHVZqVqgfro1euRDWX7OO0fBVUUMrN6Pwm8LQsz8cWhEpihlvR70ENj3f40j58TNxZaWv2ndSkInykNBBJw==}
-    dev: true
 
   /@types/long@4.0.2:
     resolution: {integrity: sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==}
@@ -14359,7 +14363,7 @@ packages:
     dependencies:
       semver: 7.6.2
       shelljs: 0.8.5
-      typescript: 5.6.0-dev.20240703
+      typescript: 5.6.0-dev.20240711
     dev: true
 
   /dset@3.1.3:
@@ -22677,8 +22681,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  /typescript@5.6.0-dev.20240703:
-    resolution: {integrity: sha512-AAOGWtykhMpxB4l+5CwojT2aBVAszalz9guzYaZMavmKHWxm3HciR+cIcKqDgR22hR7fPBJHtOti7uFCo4mt4A==}
+  /typescript@5.6.0-dev.20240711:
+    resolution: {integrity: sha512-7P96lBbF9T4qBB2IseUQBz/IakXa9a0zLOywLmWTZQB6EFbRnRMlwa7103Q44mwI8tfvdXRmed3ICuxHxSNUwA==}
     engines: {node: '>=14.17'}
     hasBin: true
     dev: true


### PR DESCRIPTION
This changeset adds support for ASCII colors, normally used in the terminal, to the Console's Blue Screen Of Death.

Also, enables tests for the `@wingconsole/ui` package and improves the experience of using the cursor to copy the Blue Screen Of Death's error message.

Fixes #6582.
