### PR TITLE
fix(sdk): simulator lockfile race condition during release

### DIFF
--- a/libs/wingsdk/src/simulator/lockfile.ts
+++ b/libs/wingsdk/src/simulator/lockfile.ts
@@ -33,8 +33,6 @@ export class Lockfile {
   private timeout: NodeJS.Timeout | undefined;
   private lastMtime: number | undefined;
   private compromised = false;
-  // private releasing = false;
-  // private lastTask: Promise<void> | undefined;
   private onCompromised?: (
     reason: string,
     error?: unknown
@@ -49,16 +47,6 @@ export class Lockfile {
     if (this.lockfile) {
       return;
     }
-
-    // if (this.releasing) {
-    //   throw new Error(
-    //     "Cannot lock the lockfile while it's being released. Please wait for the release to complete."
-    //   );
-    // }
-
-    // this.lastTask = new Promise(() => {
-
-    // });
 
     this.compromised = false;
 
@@ -151,28 +139,18 @@ export class Lockfile {
       return;
     }
 
-    // if (this.releasing) {
-    //   return;
-    // }
+    clearTimeout(this.timeout);
+    this.timeout = undefined;
 
-    try {
-      // this.releasing = true;
+    fs.closeSync(this.lockfile);
+    this.lockfile = undefined;
+    this.lastMtime = undefined;
 
-      clearTimeout(this.timeout);
-      this.timeout = undefined;
-
-      fs.closeSync(this.lockfile);
-      this.lockfile = undefined;
-      this.lastMtime = undefined;
-
-      // If the lockfile was compromised, we won't remove
-      // it since it belongs to another process now.
-      if (!this.compromised) {
-        fs.rmSync(this.path, { force: true });
-        this.compromised = false;
-      }
-    } finally {
-      // this.releasing = false;
+    // If the lockfile was compromised, we won't remove
+    // it since it belongs to another process now.
+    if (!this.compromised) {
+      fs.rmSync(this.path, { force: true });
+      this.compromised = false;
     }
   }
 

--- a/libs/wingsdk/src/simulator/lockfile.ts
+++ b/libs/wingsdk/src/simulator/lockfile.ts
@@ -90,11 +90,7 @@ export class Lockfile {
       // the lockfile was released before this callback was called.
       //
       // Skip the update if that's the case.
-      if (
-        !this.lockfile ||
-        this.compromised
-        // || this.releasing
-      ) {
+      if (!this.lockfile || this.compromised) {
         return;
       }
 

--- a/libs/wingsdk/src/simulator/simulator.ts
+++ b/libs/wingsdk/src/simulator/simulator.ts
@@ -320,12 +320,12 @@ export class Simulator {
     this._running = "starting";
 
     try {
-      await this.lockfile.lock();
+      this.lockfile.lock();
       await this.startServer();
       await this.startResources();
     } catch (err: any) {
       this.stopServer();
-      await this.lockfile.release();
+      this.lockfile.release();
       this._running = "stopped";
       throw err;
     }
@@ -430,7 +430,7 @@ export class Simulator {
 
     this.stopServer();
 
-    await this.lockfile.release();
+    this.lockfile.release();
 
     this._handles.reset();
     this._running = "stopped";


### PR DESCRIPTION
In some cases, the lockfile would try to update the lockfile utimes while it was being released due to the async nature of the implementation. This changeset refactors the implementation so it's purely sync.

