### PR TITLE
feat: jsify struct schema with docs

### DIFF
--- a/examples/tests/valid/struct_from_json.test.w
+++ b/examples/tests/valid/struct_from_json.test.w
@@ -282,7 +282,7 @@ assert(myStruct.m2.val == "10");
 let schema = MyStruct.schema();
 schema.validate(jMyStruct); // Should not throw exception
 
-let expectedSchema = {"$id":"/MyStruct","type":"object","description":"","properties":{"m1":{"type":"object","properties":{"val":{"type":"number","description":"```wing\nval: num\n```"}},"required":["val"],"description":"```wing\nm1: struct MyStruct \{\n  val: num;\n}\n```"},"m2":{"type":"object","properties":{"val":{"type":"string","description":"```wing\nval: str\n```"}},"required":["val"],"description":"```wing\nm2: struct MyStruct \{\n  val: str;\n}\n```"}},"required":["m1","m2"]};
+let expectedSchema = {"$id":"/MyStruct","type":"object","properties":{"m1":{"type":"object","properties":{"val":{"type":"number","description":"```wing\nval: num\n```"}},"required":["val"],"description":"```wing\nm1: struct MyStruct \{\n  val: num;\n}\n```"},"m2":{"type":"object","properties":{"val":{"type":"string","description":"```wing\nval: str\n```"}},"required":["val"],"description":"```wing\nm2: struct MyStruct \{\n  val: str;\n}\n```"}},"required":["m1","m2"]};
 
 assert(schema.asStr() == Json.stringify(expectedSchema));
 

--- a/examples/tests/valid/struct_from_json.test.w
+++ b/examples/tests/valid/struct_from_json.test.w
@@ -282,7 +282,7 @@ assert(myStruct.m2.val == "10");
 let schema = MyStruct.schema();
 schema.validate(jMyStruct); // Should not throw exception
 
-let expectedSchema = {"$id":"/MyStruct","type":"object","properties":{"m1":{"type":"object","properties":{"val":{"type":"number"}},"required":["val"]},"m2":{"type":"object","properties":{"val":{"type":"string"}},"required":["val"]}},"required":["m1","m2"]};
+let expectedSchema = {"$id":"/MyStruct","type":"object","description":"","properties":{"m1":{"type":"object","properties":{"val":{"type":"number","description":"```wing\nval: num\n```"}},"required":["val"],"description":"```wing\nm1: struct MyStruct \{\n  val: num;\n}\n```"},"m2":{"type":"object","properties":{"val":{"type":"string","description":"```wing\nval: str\n```"}},"required":["val"],"description":"```wing\nm2: struct MyStruct \{\n  val: str;\n}\n```"}},"required":["m1","m2"]};
 
 assert(schema.asStr() == Json.stringify(expectedSchema));
 

--- a/libs/wingc/src/jsify.rs
+++ b/libs/wingc/src/jsify.rs
@@ -341,7 +341,7 @@ impl<'a> JSifier<'a> {
 
 			code.line(format!(
 				"const {flat_name} = $stdlib.std.Struct._createJsonSchema({});",
-				schema_code.to_string().replace("\n", "").replace(" ", "")
+				schema_code.to_string()
 			));
 		}
 		code

--- a/libs/wingc/src/json_schema_generator.rs
+++ b/libs/wingc/src/json_schema_generator.rs
@@ -1,6 +1,5 @@
 use crate::{
-	jsify::{codemaker::CodeMaker, JSifier},
-	type_check::{symbol_env::SymbolEnv, Struct, Type, UnsafeRef},
+	docs::Documented, jsify::{codemaker::CodeMaker, JSifier}, type_check::{symbol_env::SymbolEnv, Struct, Type, UnsafeRef}
 };
 
 pub(crate) struct JsonSchemaGenerator;
@@ -14,9 +13,10 @@ impl JsonSchemaGenerator {
 		let mut code = CodeMaker::default();
 		for (field_name, entry) in env.symbol_map.iter() {
 			code.line(format!(
-				"{}: {},",
+				"{}: {{ {}, \"description\": \"{}\" }},",
 				field_name,
-				self.get_struct_schema_field(&entry.kind.as_variable().unwrap().type_)
+				self.get_struct_schema_field(&entry.kind.as_variable().unwrap().type_),
+				entry.kind.render_docs().replace("\n", "\\n")
 			));
 		}
 		code
@@ -37,23 +37,19 @@ impl JsonSchemaGenerator {
 	fn get_struct_schema_field(&self, typ: &UnsafeRef<Type>) -> String {
 		match **typ {
 			Type::String | Type::Number | Type::Boolean => {
-				format!("{{ type: \"{}\" }}", JSifier::jsify_type(typ).unwrap())
+				format!(" type: \"{}\" ", JSifier::jsify_type(typ).unwrap())
 			}
 			Type::Struct(ref s) => {
 				let mut code = CodeMaker::default();
-				code.open("{");
 				code.line("type: \"object\",");
 				code.open("properties: {");
 				code.add_code(self.get_struct_env_properties(&s.env));
 				code.close("},");
 				code.add_code(self.get_struct_schema_required_fields(&s.env));
-				code.close("}");
 				code.to_string()
 			}
 			Type::Array(ref t) | Type::Set(ref t) => {
 				let mut code = CodeMaker::default();
-				code.open("{");
-
 				code.line("type: \"array\",");
 
 				if matches!(**typ, Type::Set(_)) {
@@ -62,25 +58,21 @@ impl JsonSchemaGenerator {
 
 				code.line(format!("items: {}", self.get_struct_schema_field(t)));
 
-				code.close("}");
 				code.to_string()
 			}
 			Type::Map(ref t) => {
 				let mut code = CodeMaker::default();
-				code.open("{");
-
 				code.line("type: \"object\",");
 				code.line(format!(
 					"patternProperties: {{ \".*\": {} }}",
 					self.get_struct_schema_field(t)
 				));
 
-				code.close("}");
 				code.to_string()
 			}
 			Type::Optional(t) => self.get_struct_schema_field(&t),
-			Type::Json(_) => "{ type: [\"object\", \"string\", \"boolean\", \"number\", \"array\"] }".to_string(),
-			_ => "{ type: \"null\" }".to_string(),
+			Type::Json(_) => " type: [\"object\", \"string\", \"boolean\", \"number\", \"array\"] ".to_string(),
+			_ => " type: \"null\" ".to_string(),
 		}
 	}
 
@@ -103,7 +95,7 @@ impl JsonSchemaGenerator {
 		// close schema
 		code.close("}");
 
-		let cleaned = code.to_string().replace("\n", "").replace(" ", "");
+		let cleaned = code.to_string();
 
 		CodeMaker::one_line(cleaned)
 	}

--- a/libs/wingc/src/json_schema_generator.rs
+++ b/libs/wingc/src/json_schema_generator.rs
@@ -1,5 +1,5 @@
 use crate::{
-	docs::{self, Documented},
+	docs::{Documented},
 	jsify::{codemaker::CodeMaker, JSifier},
 	type_check::{symbol_env::SymbolEnv, Struct, Type, UnsafeRef},
 };
@@ -14,12 +14,11 @@ impl JsonSchemaGenerator {
 	fn get_struct_env_properties(&self, env: &SymbolEnv) -> CodeMaker {
 		let mut code = CodeMaker::default();
 		for (field_name, entry) in env.symbol_map.iter() {
-			code.line(format!(
-				"\"{}\": {{ ",
-				field_name));
+			code.line(format!("\"{}\": {{ ", field_name));
 			code.line(format!(
 				"  {}, ",
-				self.get_struct_schema_field(&entry.kind.as_variable().unwrap().type_)));
+				self.get_struct_schema_field(&entry.kind.as_variable().unwrap().type_)
+			));
 			let docs = entry.kind.render_docs().replace("\n", "\\n");
 			if docs != "" {
 				code.line(format!("   \"description\": \"{}\" ,", docs));
@@ -92,10 +91,7 @@ impl JsonSchemaGenerator {
 
 		let docs = struct_.docs.render().replace("\n", "\\n");
 		if docs != "" {
-			code.line(format!(
-				"description: \"{}\",",
-				docs
-			));
+			code.line(format!("description: \"{}\",", docs));
 		}
 
 		code.open("properties: {");

--- a/libs/wingc/src/json_schema_generator.rs
+++ b/libs/wingc/src/json_schema_generator.rs
@@ -1,5 +1,7 @@
 use crate::{
-	docs::Documented, jsify::{codemaker::CodeMaker, JSifier}, type_check::{symbol_env::SymbolEnv, Struct, Type, UnsafeRef}
+	docs::Documented,
+	jsify::{codemaker::CodeMaker, JSifier},
+	type_check::{symbol_env::SymbolEnv, Struct, Type, UnsafeRef},
 };
 
 pub(crate) struct JsonSchemaGenerator;
@@ -82,7 +84,10 @@ impl JsonSchemaGenerator {
 		code.open("{");
 		code.line(format!("$id: \"/{}\",", struct_.name));
 		code.line("type: \"object\",".to_string());
-		code.line(format!("description: \"{}\",", struct_.docs.render().replace("\n", "\\n")));
+		code.line(format!(
+			"description: \"{}\",",
+			struct_.docs.render().replace("\n", "\\n")
+		));
 
 		code.open("properties: {");
 

--- a/libs/wingc/src/json_schema_generator.rs
+++ b/libs/wingc/src/json_schema_generator.rs
@@ -1,5 +1,5 @@
 use crate::{
-	docs::{Documented},
+	docs::Documented,
 	jsify::{codemaker::CodeMaker, JSifier},
 	type_check::{symbol_env::SymbolEnv, Struct, Type, UnsafeRef},
 };

--- a/libs/wingc/src/json_schema_generator.rs
+++ b/libs/wingc/src/json_schema_generator.rs
@@ -58,7 +58,7 @@ impl JsonSchemaGenerator {
 					code.line("uniqueItems: true,");
 				}
 
-				code.line(format!("items: {}", self.get_struct_schema_field(t)));
+				code.line(format!("items: {{ {} }}", self.get_struct_schema_field(t)));
 
 				code.to_string()
 			}
@@ -66,7 +66,7 @@ impl JsonSchemaGenerator {
 				let mut code = CodeMaker::default();
 				code.line("type: \"object\",");
 				code.line(format!(
-					"patternProperties: {{ \".*\": {} }}",
+					"patternProperties: {{ \".*\": {{ {} }} }}",
 					self.get_struct_schema_field(t)
 				));
 

--- a/libs/wingc/src/json_schema_generator.rs
+++ b/libs/wingc/src/json_schema_generator.rs
@@ -82,6 +82,7 @@ impl JsonSchemaGenerator {
 		code.open("{");
 		code.line(format!("$id: \"/{}\",", struct_.name));
 		code.line("type: \"object\",".to_string());
+		code.line(format!("description: \"{}\",", struct_.docs.render().replace("\n", "\\n")));
 
 		code.open("properties: {");
 

--- a/tools/hangar/__snapshots__/test_corpus/valid/optionals.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/optionals.test.w_compile_tf-aws.md
@@ -130,10 +130,15 @@ class $Root extends $stdlib.std.Resource {
     const Person = $stdlib.std.Struct._createJsonSchema({
       $id: "/Person",
       type: "object",
-      description: "",
       properties: {
-        age: {  type: "number" , "description": "```wing\nage: num\n```" },
-        name: {  type: "string" , "description": "```wing\nname: str\n```" },
+        "age": { 
+           "type": "number" , 
+           "description": "```wing\nage: num\n```" ,
+        },
+        "name": { 
+           "type": "string" , 
+           "description": "```wing\nname: str\n```" ,
+        },
       },
       required: [
         "age",

--- a/tools/hangar/__snapshots__/test_corpus/valid/optionals.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/optionals.test.w_compile_tf-aws.md
@@ -127,7 +127,19 @@ class $Root extends $stdlib.std.Resource {
     $helpers.nodeof(this).root.$preflightTypesMap = { };
     let $preflightTypesMap = {};
     const cloud = $stdlib.cloud;
-    const Person = $stdlib.std.Struct._createJsonSchema({$id:"/Person",type:"object",properties:{age:{type:"number"},name:{type:"string"},},required:["age","name",]});
+    const Person = $stdlib.std.Struct._createJsonSchema({
+      $id: "/Person",
+      type: "object",
+      description: "",
+      properties: {
+        age: {  type: "number" , "description": "```wing\nage: num\n```" },
+        name: {  type: "string" , "description": "```wing\nname: str\n```" },
+      },
+      required: [
+        "age",
+        "name",
+      ]
+    });
     $helpers.nodeof(this).root.$preflightTypesMap = $preflightTypesMap;
     class Super extends $stdlib.std.Resource {
       constructor($scope, $id, ) {

--- a/tools/hangar/__snapshots__/test_corpus/valid/parameters/nested/parameters.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/parameters/nested/parameters.test.w_compile_tf-aws.md
@@ -38,27 +38,41 @@ class $Root extends $stdlib.std.Resource {
     const MyParams = $stdlib.std.Struct._createJsonSchema({
       $id: "/MyParams",
       type: "object",
-      description: "",
       properties: {
-        houses: { type: "array",
-        items: { type: "object",
+        "houses": { 
+          "type": "array",
+        items: { "type": "object",
         properties: {
-          address: {  type: "string" , "description": "```wing\naddress: str\n```" },
-          residents: { type: "array",
-          items: { type: "object",
+          "address": { 
+             "type": "string" , 
+             "description": "```wing\naddress: str\n```" ,
+          },
+          "residents": { 
+            "type": "array",
+          items: { "type": "object",
           properties: {
-            age: {  type: "number" , "description": "```wing\nage: num\n```" },
-            name: {  type: "string" , "description": "```wing\nname: str\n```" },
+            "age": { 
+               "type": "number" , 
+               "description": "```wing\nage: num\n```" ,
+            },
+            "name": { 
+               "type": "string" , 
+               "description": "```wing\nname: str\n```" ,
+            },
           },
           required: [
             "age",
             "name",
-          ] }, "description": "```wing\nresidents: Array<Person>\n```" },
+          ] }, 
+             "description": "```wing\nresidents: Array<Person>\n```" ,
+          },
         },
         required: [
           "address",
           "residents",
-        ] }, "description": "```wing\nhouses: Array<House>\n```" },
+        ] }, 
+           "description": "```wing\nhouses: Array<House>\n```" ,
+        },
       },
       required: [
         "houses",

--- a/tools/hangar/__snapshots__/test_corpus/valid/parameters/nested/parameters.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/parameters/nested/parameters.test.w_compile_tf-aws.md
@@ -35,7 +35,35 @@ class $Root extends $stdlib.std.Resource {
     super($scope, $id);
     $helpers.nodeof(this).root.$preflightTypesMap = { };
     let $preflightTypesMap = {};
-    const MyParams = $stdlib.std.Struct._createJsonSchema({$id:"/MyParams",type:"object",properties:{houses:{type:"array",items:{type:"object",properties:{address:{type:"string"},residents:{type:"array",items:{type:"object",properties:{age:{type:"number"},name:{type:"string"},},required:["age","name",]}},},required:["address","residents",]}},},required:["houses",]});
+    const MyParams = $stdlib.std.Struct._createJsonSchema({
+      $id: "/MyParams",
+      type: "object",
+      description: "",
+      properties: {
+        houses: { type: "array",
+        items: { type: "object",
+        properties: {
+          address: {  type: "string" , "description": "```wing\naddress: str\n```" },
+          residents: { type: "array",
+          items: { type: "object",
+          properties: {
+            age: {  type: "number" , "description": "```wing\nage: num\n```" },
+            name: {  type: "string" , "description": "```wing\nname: str\n```" },
+          },
+          required: [
+            "age",
+            "name",
+          ] }, "description": "```wing\nresidents: Array<Person>\n```" },
+        },
+        required: [
+          "address",
+          "residents",
+        ] }, "description": "```wing\nhouses: Array<House>\n```" },
+      },
+      required: [
+        "houses",
+      ]
+    });
     $helpers.nodeof(this).root.$preflightTypesMap = $preflightTypesMap;
     const app = $helpers.nodeof(this).app;
     const myParams = $macros.__Struct_fromJson(false, MyParams, (app.parameters.read({ schema: $macros.__Struct_schema(false, MyParams, ) })));

--- a/tools/hangar/__snapshots__/test_corpus/valid/parameters/simple/parameters.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/parameters/simple/parameters.test.w_compile_tf-aws.md
@@ -38,10 +38,15 @@ class $Root extends $stdlib.std.Resource {
     const MyParams = $stdlib.std.Struct._createJsonSchema({
       $id: "/MyParams",
       type: "object",
-      description: "",
       properties: {
-        foo: {  type: "string" , "description": "```wing\nfoo: str?\n```" },
-        meaningOfLife: {  type: "number" , "description": "```wing\nmeaningOfLife: num\n```" },
+        "foo": { 
+           "type": "string" , 
+           "description": "```wing\nfoo: str?\n```" ,
+        },
+        "meaningOfLife": { 
+           "type": "number" , 
+           "description": "```wing\nmeaningOfLife: num\n```" ,
+        },
       },
       required: [
         "meaningOfLife",

--- a/tools/hangar/__snapshots__/test_corpus/valid/parameters/simple/parameters.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/parameters/simple/parameters.test.w_compile_tf-aws.md
@@ -35,7 +35,18 @@ class $Root extends $stdlib.std.Resource {
     super($scope, $id);
     $helpers.nodeof(this).root.$preflightTypesMap = { };
     let $preflightTypesMap = {};
-    const MyParams = $stdlib.std.Struct._createJsonSchema({$id:"/MyParams",type:"object",properties:{foo:{type:"string"},meaningOfLife:{type:"number"},},required:["meaningOfLife",]});
+    const MyParams = $stdlib.std.Struct._createJsonSchema({
+      $id: "/MyParams",
+      type: "object",
+      description: "",
+      properties: {
+        foo: {  type: "string" , "description": "```wing\nfoo: str?\n```" },
+        meaningOfLife: {  type: "number" , "description": "```wing\nmeaningOfLife: num\n```" },
+      },
+      required: [
+        "meaningOfLife",
+      ]
+    });
     $helpers.nodeof(this).root.$preflightTypesMap = $preflightTypesMap;
     const app = $helpers.nodeof(this).app;
     const myParams = $macros.__Struct_fromJson(false, MyParams, (app.parameters.read({ schema: $macros.__Struct_schema(false, MyParams, ) })));

--- a/tools/hangar/__snapshots__/test_corpus/valid/struct_from_json.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/struct_from_json.test.w_compile_tf-aws.md
@@ -198,10 +198,15 @@ class $Root extends $stdlib.std.Resource {
     const Bar = $stdlib.std.Struct._createJsonSchema({
       $id: "/Bar",
       type: "object",
-      description: "",
       properties: {
-        b: {  type: "number" , "description": "```wing\nb: num\n```" },
-        f: {  type: "string" , "description": "```wing\nf: str\n```" },
+        "b": { 
+           "type": "number" , 
+           "description": "```wing\nb: num\n```" ,
+        },
+        "f": { 
+           "type": "string" , 
+           "description": "```wing\nf: str\n```" ,
+        },
       },
       required: [
         "b",
@@ -211,9 +216,11 @@ class $Root extends $stdlib.std.Resource {
     const Foo = $stdlib.std.Struct._createJsonSchema({
       $id: "/Foo",
       type: "object",
-      description: "",
       properties: {
-        f: {  type: "string" , "description": "```wing\nf: str\n```" },
+        "f": { 
+           "type": "string" , 
+           "description": "```wing\nf: str\n```" ,
+        },
       },
       required: [
         "f",
@@ -222,9 +229,11 @@ class $Root extends $stdlib.std.Resource {
     const Foosible = $stdlib.std.Struct._createJsonSchema({
       $id: "/Foosible",
       type: "object",
-      description: "",
       properties: {
-        f: {  type: "string" , "description": "```wing\nf: str?\n```" },
+        "f": { 
+           "type": "string" , 
+           "description": "```wing\nf: str?\n```" ,
+        },
       },
       required: [
       ]
@@ -232,22 +241,33 @@ class $Root extends $stdlib.std.Resource {
     const MyStruct = $stdlib.std.Struct._createJsonSchema({
       $id: "/MyStruct",
       type: "object",
-      description: "",
       properties: {
-        m1: { type: "object",
+        "m1": { 
+          "type": "object",
         properties: {
-          val: {  type: "number" , "description": "```wing\nval: num\n```" },
+          "val": { 
+             "type": "number" , 
+             "description": "```wing\nval: num\n```" ,
+          },
         },
         required: [
           "val",
-        ], "description": "```wing\nm1: struct MyStruct {\n  val: num;\n}\n```" },
-        m2: { type: "object",
+        ], 
+           "description": "```wing\nm1: struct MyStruct {\n  val: num;\n}\n```" ,
+        },
+        "m2": { 
+          "type": "object",
         properties: {
-          val: {  type: "string" , "description": "```wing\nval: str\n```" },
+          "val": { 
+             "type": "string" , 
+             "description": "```wing\nval: str\n```" ,
+          },
         },
         required: [
           "val",
-        ], "description": "```wing\nm2: struct MyStruct {\n  val: str;\n}\n```" },
+        ], 
+           "description": "```wing\nm2: struct MyStruct {\n  val: str;\n}\n```" ,
+        },
       },
       required: [
         "m1",
@@ -257,88 +277,174 @@ class $Root extends $stdlib.std.Resource {
     const Student = $stdlib.std.Struct._createJsonSchema({
       $id: "/Student",
       type: "object",
-      description: "",
       properties: {
-        additionalData: {  type: ["object", "string", "boolean", "number", "array"] , "description": "```wing\nadditionalData: Json?\n```" },
-        advisor: { type: "object",
+        "additionalData": { 
+           "type": ["object", "string", "boolean", "number", "array"] , 
+           "description": "```wing\nadditionalData: Json?\n```" ,
+        },
+        "advisor": { 
+          "type": "object",
         properties: {
-          dob: { type: "object",
+          "dob": { 
+            "type": "object",
           properties: {
-            day: {  type: "number" , "description": "```wing\nday: num\n```" },
-            month: {  type: "number" , "description": "```wing\nmonth: num\n```" },
-            year: {  type: "number" , "description": "```wing\nyear: num\n```" },
+            "day": { 
+               "type": "number" , 
+               "description": "```wing\nday: num\n```" ,
+            },
+            "month": { 
+               "type": "number" , 
+               "description": "```wing\nmonth: num\n```" ,
+            },
+            "year": { 
+               "type": "number" , 
+               "description": "```wing\nyear: num\n```" ,
+            },
           },
           required: [
             "day",
             "month",
             "year",
-          ], "description": "```wing\ndob: struct Date {\n  day: num;\n  month: num;\n  year: num;\n}\n```" },
-          employeeID: {  type: "string" , "description": "```wing\nemployeeID: str\n```" },
-          firstName: {  type: "string" , "description": "```wing\nfirstName: str\n```" },
-          lastName: {  type: "string" , "description": "```wing\nlastName: str\n```" },
+          ], 
+             "description": "```wing\ndob: struct Date {\n  day: num;\n  month: num;\n  year: num;\n}\n```" ,
+          },
+          "employeeID": { 
+             "type": "string" , 
+             "description": "```wing\nemployeeID: str\n```" ,
+          },
+          "firstName": { 
+             "type": "string" , 
+             "description": "```wing\nfirstName: str\n```" ,
+          },
+          "lastName": { 
+             "type": "string" , 
+             "description": "```wing\nlastName: str\n```" ,
+          },
         },
         required: [
           "dob",
           "employeeID",
           "firstName",
           "lastName",
-        ], "description": "```wing\nadvisor: struct Advisor extends Person {\n  dob: Date;\n  employeeID: str;\n  firstName: str;\n  lastName: str;\n}\n```" },
-        coursesTaken: { type: "array",
-        items: { type: "object",
+        ], 
+           "description": "```wing\nadvisor: struct Advisor extends Person {\n  dob: Date;\n  employeeID: str;\n  firstName: str;\n  lastName: str;\n}\n```" ,
+        },
+        "coursesTaken": { 
+          "type": "array",
+        items: { "type": "object",
         properties: {
-          course: { type: "object",
+          "course": { 
+            "type": "object",
           properties: {
-            credits: {  type: "number" , "description": "```wing\ncredits: num\n```" },
-            name: {  type: "string" , "description": "```wing\nname: str\n```" },
+            "credits": { 
+               "type": "number" , 
+               "description": "```wing\ncredits: num\n```" ,
+            },
+            "name": { 
+               "type": "string" , 
+               "description": "```wing\nname: str\n```" ,
+            },
           },
           required: [
             "credits",
             "name",
-          ], "description": "```wing\ncourse: struct Course {\n  credits: num;\n  name: str;\n}\n```" },
-          dateTaken: { type: "object",
+          ], 
+             "description": "```wing\ncourse: struct Course {\n  credits: num;\n  name: str;\n}\n```" ,
+          },
+          "dateTaken": { 
+            "type": "object",
           properties: {
-            day: {  type: "number" , "description": "```wing\nday: num\n```" },
-            month: {  type: "number" , "description": "```wing\nmonth: num\n```" },
-            year: {  type: "number" , "description": "```wing\nyear: num\n```" },
+            "day": { 
+               "type": "number" , 
+               "description": "```wing\nday: num\n```" ,
+            },
+            "month": { 
+               "type": "number" , 
+               "description": "```wing\nmonth: num\n```" ,
+            },
+            "year": { 
+               "type": "number" , 
+               "description": "```wing\nyear: num\n```" ,
+            },
           },
           required: [
             "day",
             "month",
             "year",
-          ], "description": "```wing\ndateTaken: struct Date {\n  day: num;\n  month: num;\n  year: num;\n}\n```" },
-          grade: {  type: "string" , "description": "```wing\ngrade: str\n```" },
+          ], 
+             "description": "```wing\ndateTaken: struct Date {\n  day: num;\n  month: num;\n  year: num;\n}\n```" ,
+          },
+          "grade": { 
+             "type": "string" , 
+             "description": "```wing\ngrade: str\n```" ,
+          },
         },
         required: [
           "course",
           "dateTaken",
           "grade",
-        ] }, "description": "```wing\ncoursesTaken: Array<CourseResults>?\n```" },
-        dob: { type: "object",
+        ] }, 
+           "description": "```wing\ncoursesTaken: Array<CourseResults>?\n```" ,
+        },
+        "dob": { 
+          "type": "object",
         properties: {
-          day: {  type: "number" , "description": "```wing\nday: num\n```" },
-          month: {  type: "number" , "description": "```wing\nmonth: num\n```" },
-          year: {  type: "number" , "description": "```wing\nyear: num\n```" },
+          "day": { 
+             "type": "number" , 
+             "description": "```wing\nday: num\n```" ,
+          },
+          "month": { 
+             "type": "number" , 
+             "description": "```wing\nmonth: num\n```" ,
+          },
+          "year": { 
+             "type": "number" , 
+             "description": "```wing\nyear: num\n```" ,
+          },
         },
         required: [
           "day",
           "month",
           "year",
-        ], "description": "```wing\ndob: struct Date {\n  day: num;\n  month: num;\n  year: num;\n}\n```" },
-        enrolled: {  type: "boolean" , "description": "```wing\nenrolled: bool\n```" },
-        enrolledCourses: { type: "array",
+        ], 
+           "description": "```wing\ndob: struct Date {\n  day: num;\n  month: num;\n  year: num;\n}\n```" ,
+        },
+        "enrolled": { 
+           "type": "boolean" , 
+           "description": "```wing\nenrolled: bool\n```" ,
+        },
+        "enrolledCourses": { 
+          "type": "array",
         uniqueItems: true,
-        items: { type: "object",
+        items: { "type": "object",
         properties: {
-          credits: {  type: "number" , "description": "```wing\ncredits: num\n```" },
-          name: {  type: "string" , "description": "```wing\nname: str\n```" },
+          "credits": { 
+             "type": "number" , 
+             "description": "```wing\ncredits: num\n```" ,
+          },
+          "name": { 
+             "type": "string" , 
+             "description": "```wing\nname: str\n```" ,
+          },
         },
         required: [
           "credits",
           "name",
-        ] }, "description": "```wing\nenrolledCourses: Set<Course>?\n```" },
-        firstName: {  type: "string" , "description": "```wing\nfirstName: str\n```" },
-        lastName: {  type: "string" , "description": "```wing\nlastName: str\n```" },
-        schoolId: {  type: "string" , "description": "```wing\nschoolId: str\n```" },
+        ] }, 
+           "description": "```wing\nenrolledCourses: Set<Course>?\n```" ,
+        },
+        "firstName": { 
+           "type": "string" , 
+           "description": "```wing\nfirstName: str\n```" ,
+        },
+        "lastName": { 
+           "type": "string" , 
+           "description": "```wing\nlastName: str\n```" ,
+        },
+        "schoolId": { 
+           "type": "string" , 
+           "description": "```wing\nschoolId: str\n```" ,
+        },
       },
       required: [
         "dob",
@@ -353,7 +459,10 @@ class $Root extends $stdlib.std.Resource {
       type: "object",
       description: "Options for `Bucket`.",
       properties: {
-        public: {  type: "boolean" , "description": "```wing\npublic: bool?\n```\n---\nWhether the bucket's objects should be publicly accessible." },
+        "public": { 
+           "type": "boolean" , 
+           "description": "```wing\npublic: bool?\n```\n---\nWhether the bucket's objects should be publicly accessible." ,
+        },
       },
       required: [
       ]
@@ -361,15 +470,20 @@ class $Root extends $stdlib.std.Resource {
     const externalStructs_MyOtherStruct = $stdlib.std.Struct._createJsonSchema({
       $id: "/MyOtherStruct",
       type: "object",
-      description: "",
       properties: {
-        data: { type: "object",
+        "data": { 
+          "type": "object",
         properties: {
-          val: {  type: "number" , "description": "```wing\nval: num\n```" },
+          "val": { 
+             "type": "number" , 
+             "description": "```wing\nval: num\n```" ,
+          },
         },
         required: [
           "val",
-        ], "description": "```wing\ndata: struct MyStruct {\n  val: num;\n}\n```" },
+        ], 
+           "description": "```wing\ndata: struct MyStruct {\n  val: num;\n}\n```" ,
+        },
       },
       required: [
         "data",
@@ -637,7 +751,7 @@ class $Root extends $stdlib.std.Resource {
     $helpers.assert($helpers.eq(myStruct.m2.val, "10"), "myStruct.m2.val == \"10\"");
     const schema = $macros.__Struct_schema(false, MyStruct, );
     (schema.validate(jMyStruct));
-    const expectedSchema = ({"$id": "/MyStruct", "type": "object", "description": "", "properties": ({"m1": ({"type": "object", "properties": ({"val": ({"type": "number", "description": "```wing\nval: num\n```"})}), "required": ["val"], "description": "```wing\nm1: struct MyStruct {\n  val: num;\n}\n```"}), "m2": ({"type": "object", "properties": ({"val": ({"type": "string", "description": "```wing\nval: str\n```"})}), "required": ["val"], "description": "```wing\nm2: struct MyStruct {\n  val: str;\n}\n```"})}), "required": ["m1", "m2"]});
+    const expectedSchema = ({"$id": "/MyStruct", "type": "object", "properties": ({"m1": ({"type": "object", "properties": ({"val": ({"type": "number", "description": "```wing\nval: num\n```"})}), "required": ["val"], "description": "```wing\nm1: struct MyStruct {\n  val: num;\n}\n```"}), "m2": ({"type": "object", "properties": ({"val": ({"type": "string", "description": "```wing\nval: str\n```"})}), "required": ["val"], "description": "```wing\nm2: struct MyStruct {\n  val: str;\n}\n```"})}), "required": ["m1", "m2"]});
     $helpers.assert($helpers.eq((schema.asStr()), $macros.__Json_stringify(false, std.Json, expectedSchema)), "schema.asStr() == Json.stringify(expectedSchema)");
     globalThis.$ClassFactory.new("@winglang/sdk.std.Test", std.Test, this, "test:inflight schema usage", new $Closure4(this, "$Closure4"));
     (std.String.fromJson(10, { unsafe: true }));
@@ -678,9 +792,11 @@ let $preflightTypesMap = {};
 const SomeStruct = $stdlib.std.Struct._createJsonSchema({
   $id: "/SomeStruct",
   type: "object",
-  description: "",
   properties: {
-    foo: {  type: "string" , "description": "```wing\nfoo: str\n```" },
+    "foo": { 
+       "type": "string" , 
+       "description": "```wing\nfoo: str\n```" ,
+    },
   },
   required: [
     "foo",

--- a/tools/hangar/__snapshots__/test_corpus/valid/struct_from_json.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/struct_from_json.test.w_compile_tf-aws.md
@@ -195,13 +195,186 @@ class $Root extends $stdlib.std.Resource {
     const cloud = $stdlib.cloud;
     const externalStructs = $helpers.bringJs(`${__dirname}/preflight.structs-1.cjs`, $preflightTypesMap);
     const otherExternalStructs = $helpers.bringJs(`${__dirname}/preflight.structs2-2.cjs`, $preflightTypesMap);
-    const Bar = $stdlib.std.Struct._createJsonSchema({$id:"/Bar",type:"object",properties:{b:{type:"number"},f:{type:"string"},},required:["b","f",]});
-    const Foo = $stdlib.std.Struct._createJsonSchema({$id:"/Foo",type:"object",properties:{f:{type:"string"},},required:["f",]});
-    const Foosible = $stdlib.std.Struct._createJsonSchema({$id:"/Foosible",type:"object",properties:{f:{type:"string"},},required:[]});
-    const MyStruct = $stdlib.std.Struct._createJsonSchema({$id:"/MyStruct",type:"object",properties:{m1:{type:"object",properties:{val:{type:"number"},},required:["val",]},m2:{type:"object",properties:{val:{type:"string"},},required:["val",]},},required:["m1","m2",]});
-    const Student = $stdlib.std.Struct._createJsonSchema({$id:"/Student",type:"object",properties:{additionalData:{type:["object","string","boolean","number","array"]},advisor:{type:"object",properties:{dob:{type:"object",properties:{day:{type:"number"},month:{type:"number"},year:{type:"number"},},required:["day","month","year",]},employeeID:{type:"string"},firstName:{type:"string"},lastName:{type:"string"},},required:["dob","employeeID","firstName","lastName",]},coursesTaken:{type:"array",items:{type:"object",properties:{course:{type:"object",properties:{credits:{type:"number"},name:{type:"string"},},required:["credits","name",]},dateTaken:{type:"object",properties:{day:{type:"number"},month:{type:"number"},year:{type:"number"},},required:["day","month","year",]},grade:{type:"string"},},required:["course","dateTaken","grade",]}},dob:{type:"object",properties:{day:{type:"number"},month:{type:"number"},year:{type:"number"},},required:["day","month","year",]},enrolled:{type:"boolean"},enrolledCourses:{type:"array",uniqueItems:true,items:{type:"object",properties:{credits:{type:"number"},name:{type:"string"},},required:["credits","name",]}},firstName:{type:"string"},lastName:{type:"string"},schoolId:{type:"string"},},required:["dob","enrolled","firstName","lastName","schoolId",]});
-    const cloud_BucketProps = $stdlib.std.Struct._createJsonSchema({$id:"/BucketProps",type:"object",properties:{public:{type:"boolean"},},required:[]});
-    const externalStructs_MyOtherStruct = $stdlib.std.Struct._createJsonSchema({$id:"/MyOtherStruct",type:"object",properties:{data:{type:"object",properties:{val:{type:"number"},},required:["val",]},},required:["data",]});
+    const Bar = $stdlib.std.Struct._createJsonSchema({
+      $id: "/Bar",
+      type: "object",
+      description: "",
+      properties: {
+        b: {  type: "number" , "description": "```wing\nb: num\n```" },
+        f: {  type: "string" , "description": "```wing\nf: str\n```" },
+      },
+      required: [
+        "b",
+        "f",
+      ]
+    });
+    const Foo = $stdlib.std.Struct._createJsonSchema({
+      $id: "/Foo",
+      type: "object",
+      description: "",
+      properties: {
+        f: {  type: "string" , "description": "```wing\nf: str\n```" },
+      },
+      required: [
+        "f",
+      ]
+    });
+    const Foosible = $stdlib.std.Struct._createJsonSchema({
+      $id: "/Foosible",
+      type: "object",
+      description: "",
+      properties: {
+        f: {  type: "string" , "description": "```wing\nf: str?\n```" },
+      },
+      required: [
+      ]
+    });
+    const MyStruct = $stdlib.std.Struct._createJsonSchema({
+      $id: "/MyStruct",
+      type: "object",
+      description: "",
+      properties: {
+        m1: { type: "object",
+        properties: {
+          val: {  type: "number" , "description": "```wing\nval: num\n```" },
+        },
+        required: [
+          "val",
+        ], "description": "```wing\nm1: struct MyStruct {\n  val: num;\n}\n```" },
+        m2: { type: "object",
+        properties: {
+          val: {  type: "string" , "description": "```wing\nval: str\n```" },
+        },
+        required: [
+          "val",
+        ], "description": "```wing\nm2: struct MyStruct {\n  val: str;\n}\n```" },
+      },
+      required: [
+        "m1",
+        "m2",
+      ]
+    });
+    const Student = $stdlib.std.Struct._createJsonSchema({
+      $id: "/Student",
+      type: "object",
+      description: "",
+      properties: {
+        additionalData: {  type: ["object", "string", "boolean", "number", "array"] , "description": "```wing\nadditionalData: Json?\n```" },
+        advisor: { type: "object",
+        properties: {
+          dob: { type: "object",
+          properties: {
+            day: {  type: "number" , "description": "```wing\nday: num\n```" },
+            month: {  type: "number" , "description": "```wing\nmonth: num\n```" },
+            year: {  type: "number" , "description": "```wing\nyear: num\n```" },
+          },
+          required: [
+            "day",
+            "month",
+            "year",
+          ], "description": "```wing\ndob: struct Date {\n  day: num;\n  month: num;\n  year: num;\n}\n```" },
+          employeeID: {  type: "string" , "description": "```wing\nemployeeID: str\n```" },
+          firstName: {  type: "string" , "description": "```wing\nfirstName: str\n```" },
+          lastName: {  type: "string" , "description": "```wing\nlastName: str\n```" },
+        },
+        required: [
+          "dob",
+          "employeeID",
+          "firstName",
+          "lastName",
+        ], "description": "```wing\nadvisor: struct Advisor extends Person {\n  dob: Date;\n  employeeID: str;\n  firstName: str;\n  lastName: str;\n}\n```" },
+        coursesTaken: { type: "array",
+        items: { type: "object",
+        properties: {
+          course: { type: "object",
+          properties: {
+            credits: {  type: "number" , "description": "```wing\ncredits: num\n```" },
+            name: {  type: "string" , "description": "```wing\nname: str\n```" },
+          },
+          required: [
+            "credits",
+            "name",
+          ], "description": "```wing\ncourse: struct Course {\n  credits: num;\n  name: str;\n}\n```" },
+          dateTaken: { type: "object",
+          properties: {
+            day: {  type: "number" , "description": "```wing\nday: num\n```" },
+            month: {  type: "number" , "description": "```wing\nmonth: num\n```" },
+            year: {  type: "number" , "description": "```wing\nyear: num\n```" },
+          },
+          required: [
+            "day",
+            "month",
+            "year",
+          ], "description": "```wing\ndateTaken: struct Date {\n  day: num;\n  month: num;\n  year: num;\n}\n```" },
+          grade: {  type: "string" , "description": "```wing\ngrade: str\n```" },
+        },
+        required: [
+          "course",
+          "dateTaken",
+          "grade",
+        ] }, "description": "```wing\ncoursesTaken: Array<CourseResults>?\n```" },
+        dob: { type: "object",
+        properties: {
+          day: {  type: "number" , "description": "```wing\nday: num\n```" },
+          month: {  type: "number" , "description": "```wing\nmonth: num\n```" },
+          year: {  type: "number" , "description": "```wing\nyear: num\n```" },
+        },
+        required: [
+          "day",
+          "month",
+          "year",
+        ], "description": "```wing\ndob: struct Date {\n  day: num;\n  month: num;\n  year: num;\n}\n```" },
+        enrolled: {  type: "boolean" , "description": "```wing\nenrolled: bool\n```" },
+        enrolledCourses: { type: "array",
+        uniqueItems: true,
+        items: { type: "object",
+        properties: {
+          credits: {  type: "number" , "description": "```wing\ncredits: num\n```" },
+          name: {  type: "string" , "description": "```wing\nname: str\n```" },
+        },
+        required: [
+          "credits",
+          "name",
+        ] }, "description": "```wing\nenrolledCourses: Set<Course>?\n```" },
+        firstName: {  type: "string" , "description": "```wing\nfirstName: str\n```" },
+        lastName: {  type: "string" , "description": "```wing\nlastName: str\n```" },
+        schoolId: {  type: "string" , "description": "```wing\nschoolId: str\n```" },
+      },
+      required: [
+        "dob",
+        "enrolled",
+        "firstName",
+        "lastName",
+        "schoolId",
+      ]
+    });
+    const cloud_BucketProps = $stdlib.std.Struct._createJsonSchema({
+      $id: "/BucketProps",
+      type: "object",
+      description: "Options for `Bucket`.",
+      properties: {
+        public: {  type: "boolean" , "description": "```wing\npublic: bool?\n```\n---\nWhether the bucket's objects should be publicly accessible." },
+      },
+      required: [
+      ]
+    });
+    const externalStructs_MyOtherStruct = $stdlib.std.Struct._createJsonSchema({
+      $id: "/MyOtherStruct",
+      type: "object",
+      description: "",
+      properties: {
+        data: { type: "object",
+        properties: {
+          val: {  type: "number" , "description": "```wing\nval: num\n```" },
+        },
+        required: [
+          "val",
+        ], "description": "```wing\ndata: struct MyStruct {\n  val: num;\n}\n```" },
+      },
+      required: [
+        "data",
+      ]
+    });
     $helpers.nodeof(this).root.$preflightTypesMap = $preflightTypesMap;
     class $Closure1 extends $stdlib.std.AutoIdResource {
       _id = $stdlib.core.closureId();
@@ -464,7 +637,7 @@ class $Root extends $stdlib.std.Resource {
     $helpers.assert($helpers.eq(myStruct.m2.val, "10"), "myStruct.m2.val == \"10\"");
     const schema = $macros.__Struct_schema(false, MyStruct, );
     (schema.validate(jMyStruct));
-    const expectedSchema = ({"$id": "/MyStruct", "type": "object", "properties": ({"m1": ({"type": "object", "properties": ({"val": ({"type": "number"})}), "required": ["val"]}), "m2": ({"type": "object", "properties": ({"val": ({"type": "string"})}), "required": ["val"]})}), "required": ["m1", "m2"]});
+    const expectedSchema = ({"$id": "/MyStruct", "type": "object", "description": "", "properties": ({"m1": ({"type": "object", "properties": ({"val": ({"type": "number", "description": "```wing\nval: num\n```"})}), "required": ["val"], "description": "```wing\nm1: struct MyStruct {\n  val: num;\n}\n```"}), "m2": ({"type": "object", "properties": ({"val": ({"type": "string", "description": "```wing\nval: str\n```"})}), "required": ["val"], "description": "```wing\nm2: struct MyStruct {\n  val: str;\n}\n```"})}), "required": ["m1", "m2"]});
     $helpers.assert($helpers.eq((schema.asStr()), $macros.__Json_stringify(false, std.Json, expectedSchema)), "schema.asStr() == Json.stringify(expectedSchema)");
     globalThis.$ClassFactory.new("@winglang/sdk.std.Test", std.Test, this, "test:inflight schema usage", new $Closure4(this, "$Closure4"));
     (std.String.fromJson(10, { unsafe: true }));
@@ -502,7 +675,17 @@ const std = $stdlib.std;
 const $helpers = $stdlib.helpers;
 const $extern = $helpers.createExternRequire(__dirname);
 let $preflightTypesMap = {};
-const SomeStruct = $stdlib.std.Struct._createJsonSchema({$id:"/SomeStruct",type:"object",properties:{foo:{type:"string"},},required:["foo",]});
+const SomeStruct = $stdlib.std.Struct._createJsonSchema({
+  $id: "/SomeStruct",
+  type: "object",
+  description: "",
+  properties: {
+    foo: {  type: "string" , "description": "```wing\nfoo: str\n```" },
+  },
+  required: [
+    "foo",
+  ]
+});
 class UsesStructInImportedFile extends $stdlib.std.Resource {
   constructor($scope, $id, ) {
     super($scope, $id);


### PR DESCRIPTION
Emits struct docs and struct's fields docs into the generated JSON schema.

For example, this struct will emit the following schema:

```wing
/// AA is a struct
struct AA {
  /// XXX is a string
  xxx: str;
  yyy: num;
}
```

```js
const AA = $stdlib.std.Struct._createJsonSchema({
      $id: "/AA",
      type: "object",
      description: "AA is a struct",
      properties: {
        "xxx": { 
           "type": "string" , 
           "description": "```wing\nxxx: str\n```\n---\n XXX is a string" ,
        },
        "yyy": { 
           "type": "number" , 
           "description": "```wing\nyyy: num\n```" ,
        },
      },
      required: [
        "xxx",
        "yyy",
      ]
    });
```

## Checklist

- [ ] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [ ] Description explains motivation and solution
- [ ] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
