### PR TITLE
fix(sdk): improve simulator lockfile implementation

### DIFF
--- a/apps/wing-console/console/server/src/utils/simulator.ts
+++ b/apps/wing-console/console/server/src/utils/simulator.ts
@@ -1,4 +1,5 @@
 import { simulator } from "@winglang/sdk";
+import { LogLevel, TraceType } from "@winglang/sdk/lib/std/test-runner.js";
 import Emittery from "emittery";
 
 import type { ResourceLifecycleEvent, Trace } from "../types.js";
@@ -62,7 +63,14 @@ export const createSimulator = (props?: CreateSimulatorProps): Simulator => {
     });
     instance.onTrace({
       callback(trace) {
-        events.emit("trace", trace);
+        if (
+          trace.type === TraceType.SIMULATOR &&
+          trace.level === LogLevel.ERROR
+        ) {
+          events.emit("error", new Error(trace.data.message));
+        } else {
+          events.emit("trace", trace);
+        }
       },
     });
     instance.onResourceLifecycleEvent({

--- a/libs/wingsdk/src/simulator/simulator.ts
+++ b/libs/wingsdk/src/simulator/simulator.ts
@@ -241,6 +241,18 @@ export class Simulator {
         if (error) {
           console.error(error);
         }
+        this.addTrace({
+          data: {
+            message: `Another process is already running the simulator on the same state directory.`,
+            error,
+            status: "failure",
+          },
+          type: TraceType.SIMULATOR,
+          level: LogLevel.ERROR,
+          sourcePath: "",
+          sourceType: "",
+          timestamp: new Date().toISOString(),
+        });
         await this.stop();
       },
     });


### PR DESCRIPTION
This changeset adds the following behavior to the simulator lockfile:

- If the lockfile gets compromised, it will try to acquire the lock again
- If the lockfile gets compromised, the console will show a blue screen of death with an explanation

Fixes #6949.