### PR TITLE
fix(console)!: not all diagnostics are errors

### DIFF
--- a/apps/wing-console/console/server/src/utils/format-wing-error.ts
+++ b/apps/wing-console/console/server/src/utils/format-wing-error.ts
@@ -14,7 +14,7 @@ export const formatWingError = async (error: unknown, entryPoint?: string) => {
       const result = [];
 
       for (const error of errors) {
-        const { message, span, annotations, hints } = error;
+        const { message, span, annotations, hints, severity } = error;
         const files: File[] = [];
         const labels: Label[] = [];
         const cwd = process.cwd();
@@ -59,7 +59,7 @@ export const formatWingError = async (error: unknown, entryPoint?: string) => {
           files,
           {
             message,
-            severity: "error",
+            severity,
             labels,
             notes: hints.map((hint) => `hint: ${hint}`),
           },

--- a/apps/wing/src/commands/compile.ts
+++ b/apps/wing/src/commands/compile.ts
@@ -180,8 +180,8 @@ export async function compile(entrypoint?: string, options?: CompileOptions): Pr
     throw error.causedBy;
   }
 
-  if (!compileOutput.success || !compileOutput.outputDir) {
-    // If "success" is false, then one or more errors should have been found, so there must be a logical bug.
+  if (compileOutput.outputDir === undefined) {
+    // If "outputDir" is undefined, then one or more errors should have been found, so there must be a logical bug.
     throw new Error(
       "Internal compilation error. Please report this as a bug on the Wing issue tracker."
     );

--- a/apps/wing/src/commands/compile.ts
+++ b/apps/wing/src/commands/compile.ts
@@ -86,94 +86,106 @@ export async function compile(entrypoint?: string, options?: CompileOptions): Pr
   }
   loadEnvVariables({ cwd: resolve(dirname(entrypoint)) });
   const coloring = chalk.supportsColor ? chalk.supportsColor.hasBasic : false;
-  try {
-    return await wingCompiler.compile(entrypoint, {
-      ...options,
-      log,
-      color: coloring,
-      platform: options?.platform ?? ["sim"],
-    });
-  } catch (error) {
-    if (error instanceof wingCompiler.CompileError) {
-      // This is a bug in the user's code. Print the compiler diagnostics.
-      const diagnostics = error.diagnostics;
-      const cwd = process.cwd();
-      const result = [];
+  const compileOutput = await wingCompiler.compile(entrypoint, {
+    ...options,
+    log,
+    color: coloring,
+    platform: options?.platform ?? ["sim"],
+  });
+  if (compileOutput.wingcErrors.length > 0) {
+    // Print any errors or warnings from the compiler.
+    const diagnostics = compileOutput.wingcErrors;
+    const cwd = process.cwd();
+    const result = [];
 
-      for (const diagnostic of diagnostics) {
-        const { message, span, annotations, hints, severity } = diagnostic;
-        const files: File[] = [];
-        const labels: Label[] = [];
+    for (const diagnostic of diagnostics) {
+      const { message, span, annotations, hints, severity } = diagnostic;
+      const files: File[] = [];
+      const labels: Label[] = [];
 
+      // file_id might be "" if the span is synthetic (see #2521)
+      if (span?.file_id) {
+        // `span` should only be null if source file couldn't be read etc.
+        const source = await fsPromise.readFile(span.file_id, "utf8");
+        const start = span.start_offset;
+        const end = span.end_offset;
+        const filePath = relative(cwd, span.file_id);
+        files.push({ name: filePath, source });
+        labels.push({
+          fileId: filePath,
+          rangeStart: start,
+          rangeEnd: end,
+          message: "",
+          style: "primary",
+        });
+      }
+
+      for (const annotation of annotations) {
         // file_id might be "" if the span is synthetic (see #2521)
-        if (span?.file_id) {
-          // `span` should only be null if source file couldn't be read etc.
-          const source = await fsPromise.readFile(span.file_id, "utf8");
-          const start = span.start_offset;
-          const end = span.end_offset;
-          const filePath = relative(cwd, span.file_id);
-          files.push({ name: filePath, source });
-          labels.push({
-            fileId: filePath,
-            rangeStart: start,
-            rangeEnd: end,
-            message: "",
-            style: "primary",
-          });
+        if (!annotation.span?.file_id) {
+          continue;
         }
-
-        for (const annotation of annotations) {
-          // file_id might be "" if the span is synthetic (see #2521)
-          if (!annotation.span?.file_id) {
-            continue;
-          }
-          const source = await fsPromise.readFile(annotation.span.file_id, "utf8");
-          const start = annotation.span.start_offset;
-          const end = annotation.span.end_offset;
-          const filePath = relative(cwd, annotation.span.file_id);
-          files.push({ name: filePath, source });
-          labels.push({
-            fileId: filePath,
-            rangeStart: start,
-            rangeEnd: end,
-            message: annotation.message,
-            style: "secondary",
-          });
-        }
-
-        const diagnosticText = emitDiagnostic(
-          files,
-          {
-            message,
-            severity,
-            labels,
-            notes: hints.map((hint) => `hint: ${hint}`),
-          },
-          {
-            chars: CHARS_ASCII,
-          },
-          coloring
-        );
-        result.push(diagnosticText);
+        const source = await fsPromise.readFile(annotation.span.file_id, "utf8");
+        const start = annotation.span.start_offset;
+        const end = annotation.span.end_offset;
+        const filePath = relative(cwd, annotation.span.file_id);
+        files.push({ name: filePath, source });
+        labels.push({
+          fileId: filePath,
+          rangeStart: start,
+          rangeEnd: end,
+          message: annotation.message,
+          style: "secondary",
+        });
       }
+
+      const diagnosticText = emitDiagnostic(
+        files,
+        {
+          message,
+          severity,
+          labels,
+          notes: hints.map((hint) => `hint: ${hint}`),
+        },
+        {
+          chars: CHARS_ASCII,
+        },
+        coloring
+      );
+      result.push(diagnosticText);
+    }
+
+    if (compileOutput.wingcErrors.map((e) => e.severity).includes("error")) {
       throw new Error(result.join("\n").trimEnd());
-    } else if (error instanceof wingCompiler.PreflightError) {
-      let output = await prettyPrintError(error.causedBy, {
-        chalk,
-        sourceEntrypoint: resolve(entrypoint ?? "."),
-      });
-
-      if (process.env.DEBUG) {
-        output +=
-          "\n--------------------------------- ORIGINAL STACK TRACE ---------------------------------\n" +
-          (error.causedBy.stack ?? "(no stacktrace available)");
-      }
-
-      error.causedBy.message = output;
-
-      throw error.causedBy;
     } else {
-      throw error;
+      console.error(result.join("\n").trimEnd());
     }
   }
+
+  if (compileOutput.preflightError) {
+    const error = compileOutput.preflightError;
+    let output = await prettyPrintError(error.causedBy, {
+      chalk,
+      sourceEntrypoint: resolve(entrypoint ?? "."),
+    });
+
+    if (process.env.DEBUG) {
+      output +=
+        "\n--------------------------------- ORIGINAL STACK TRACE ---------------------------------\n" +
+        (error.causedBy.stack ?? "(no stacktrace available)");
+    }
+
+    error.causedBy.message = output;
+
+    throw error.causedBy;
+  }
+
+  if (!compileOutput.success || !compileOutput.outputDir) {
+    // If "success" is false, then one or more errors should have been found, so there must be a logical bug.
+    throw new Error(
+      "Internal compilation error. Please report this as a bug on the Wing issue tracker."
+    );
+  }
+
+  return compileOutput.outputDir;
 }

--- a/libs/wingcompiler/src/compile.test.ts
+++ b/libs/wingcompiler/src/compile.test.ts
@@ -3,7 +3,17 @@ import { join, resolve, basename } from "path";
 import { stat, mkdtemp } from "fs/promises";
 import { tmpdir } from "os";
 import { BuiltinPlatform } from "./constants";
-import { compile } from "./compile";
+import { compile, CompileOptions } from "./compile";
+
+const compileOrFail = async (entrypoint: string, options: CompileOptions) => {
+  const result = await compile(entrypoint, options);
+
+  if (!result.outputDir) {
+    throw new Error("Compilation failed");
+  }
+
+  return result.outputDir;
+};
 
 const exampleDir = resolve("../../examples/tests/valid");
 const exampleFilePath = join(exampleDir, "enums.test.w");
@@ -15,7 +25,7 @@ export async function generateTmpDir() {
 describe("compile tests", () => {
   test("should produce stable artifacts for tf-aws", async () => {
     const targetDir = `${await generateTmpDir()}/target`;
-    const artifactDir = await compile(exampleFilePath, {
+    const artifactDir = await compileOrFail(exampleFilePath, {
       platform: [BuiltinPlatform.TF_AWS],
       targetDir,
     });
@@ -28,7 +38,7 @@ describe("compile tests", () => {
 
   test("should produce temp artifacts for tf-aws testing", async () => {
     const targetDir = `${await generateTmpDir()}/target`;
-    const artifactDir = await compile(exampleFilePath, {
+    const artifactDir = await compileOrFail(exampleFilePath, {
       platform: [BuiltinPlatform.TF_AWS],
       targetDir,
       testing: true,
@@ -42,7 +52,7 @@ describe("compile tests", () => {
 
   test("should produce stable artifacts for sim", async () => {
     const targetDir = `${await generateTmpDir()}/target`;
-    const artifactDir = await compile(exampleFilePath, {
+    const artifactDir = await compileOrFail(exampleFilePath, {
       platform: [BuiltinPlatform.SIM],
       targetDir,
     });
@@ -55,7 +65,7 @@ describe("compile tests", () => {
 
   test("should produce stable artifacts for sim testing", async () => {
     const targetDir = `${await generateTmpDir()}/target`;
-    const artifactDir = await compile(exampleFilePath, {
+    const artifactDir = await compileOrFail(exampleFilePath, {
       platform: [BuiltinPlatform.SIM],
       targetDir,
       testing: true,
@@ -69,7 +79,7 @@ describe("compile tests", () => {
 
   test("should be able to override the target directory", async () => {
     const output = `${await generateTmpDir()}/a/b/dir.out`;
-    const artifactDir = await compile(exampleFilePath, {
+    const artifactDir = await compileOrFail(exampleFilePath, {
       platform: [BuiltinPlatform.SIM],
       output,
       testing: true,

--- a/libs/wingcompiler/src/compile.ts
+++ b/libs/wingcompiler/src/compile.ts
@@ -133,7 +133,6 @@ export interface CompileOutput {
   readonly wingcErrors: wingCompiler.WingDiagnostic[];
   // Error that occurred during preflight execution
   readonly preflightError?: PreflightError;
-  readonly success: boolean;
 }
 
 /**
@@ -242,7 +241,6 @@ export async function compile(entrypoint: string, options: CompileOptions): Prom
     outputDir: !failed ? synthDir : undefined,
     wingcErrors,
     preflightError,
-    success: !failed,
   };
 }
 

--- a/libs/wingcompiler/src/compile.ts
+++ b/libs/wingcompiler/src/compile.ts
@@ -6,7 +6,7 @@ import * as wingCompiler from "./wingc";
 import { normalPath } from "./util";
 import { existsSync } from "fs";
 import { BuiltinPlatform } from "./constants";
-import { CompileError, PreflightError } from "./errors";
+import { PreflightError } from "./errors";
 import { readFile } from "fs/promises";
 import { fork } from "child_process";
 
@@ -126,13 +126,23 @@ export function determineTargetFromPlatforms(platforms: string[]): string {
   return _loadCustomPlatform(platform).target;
 }
 
+export interface CompileOutput {
+  readonly outputDir?: string;
+  // List of diagnostics produced by wingc (from parsing, type checking, and generating preflight JS code)
+  // Some of these diagnostics may be warnings.
+  readonly wingcErrors: wingCompiler.WingDiagnostic[];
+  // Error that occurred during preflight execution
+  readonly preflightError?: PreflightError;
+  readonly success: boolean;
+}
+
 /**
  * Compiles a Wing program. Throws an error if compilation fails.
  * @param entrypoint The program .w entrypoint.
  * @param options Compile options.
  * @returns the output directory
  */
-export async function compile(entrypoint: string, options: CompileOptions): Promise<string> {
+export async function compile(entrypoint: string, options: CompileOptions): Promise<CompileOutput> {
   const { log } = options;
   const preflightLog = options.preflightLog ?? process.stdout.write.bind(process.stdout);
   // create a unique temporary directory for the compilation
@@ -148,6 +158,9 @@ export async function compile(entrypoint: string, options: CompileOptions): Prom
   log?.("synth dir: %s", synthDir);
   const workDir = resolve(synthDir, DOT_WING);
   log?.("work dir: %s", workDir);
+
+  let wingcErrors: wingCompiler.WingDiagnostic[] = [];
+  let failed = false;
 
   const nearestNodeModules = (dir: string): string => {
     let nodeModules = join(dir, "node_modules");
@@ -177,11 +190,14 @@ export async function compile(entrypoint: string, options: CompileOptions): Prom
     color: options.color,
     log,
   });
-  if (compileForPreflightResult.diagnostics.length > 0) {
-    throw new CompileError(compileForPreflightResult.diagnostics);
+  wingcErrors = compileForPreflightResult.diagnostics;
+  if (compileForPreflightResult.diagnostics.map((d) => d.severity).includes("error")) {
+    failed = true;
   }
 
-  if (isEntrypointFile(entrypoint)) {
+  let preflightError: PreflightError | undefined;
+
+  if (!failed && isEntrypointFile(entrypoint)) {
     let preflightEnv: Record<string, string | undefined> = {
       ...process.env,
       WING_TARGET: target,
@@ -211,13 +227,23 @@ export async function compile(entrypoint: string, options: CompileOptions): Prom
       }
     }
 
-    await runPreflightCodeInWorkerThread(
+    let [err, finished] = await runPreflightCodeInWorkerThread(
       compileForPreflightResult.preflightEntrypoint,
       preflightEnv,
       (data) => preflightLog?.(data.toString())
     );
+    preflightError = err;
+    if (!finished) {
+      failed = true;
+    }
   }
-  return synthDir;
+
+  return {
+    outputDir: !failed ? synthDir : undefined,
+    wingcErrors,
+    preflightError,
+    success: !failed,
+  };
 }
 
 function isEntrypointFile(path: string) {
@@ -349,11 +375,11 @@ async function runPreflightCodeInWorkerThread(
   entrypoint: string,
   env: Record<string, string | undefined>,
   onStdout: (data: Buffer) => void
-): Promise<void> {
+): Promise<[PreflightError | undefined, boolean]> {
   try {
     env.WING_PREFLIGHT_ENTRYPOINT = JSON.stringify(entrypoint);
 
-    await new Promise((resolve, reject) => {
+    return await new Promise((resolve, reject) => {
       const worker = fork(join(__dirname, "..", "preflight.shim.cjs"), {
         env,
         stdio: "pipe",
@@ -364,7 +390,7 @@ async function runPreflightCodeInWorkerThread(
       worker.on("error", reject);
       worker.on("exit", (code) => {
         if (code === 0) {
-          resolve(undefined);
+          resolve([undefined, true]);
         } else {
           reject(new Error(`Worker stopped with exit code ${code}`));
         }
@@ -372,7 +398,7 @@ async function runPreflightCodeInWorkerThread(
     });
   } catch (error) {
     const artifact = await readFile(entrypoint, "utf-8");
-    throw new PreflightError(error as any, entrypoint, artifact);
+    return [new PreflightError(error as any, entrypoint, artifact), false];
   }
 }
 

--- a/tools/hangar/src/package-manager.test.ts
+++ b/tools/hangar/src/package-manager.test.ts
@@ -19,7 +19,7 @@ test("warning is emitted when an unsupported package manager is used", async () 
     wingFile: wingFile,
     platforms: ["sim"],
     args: ["compile"],
-    expectFailure: true,
+    expectFailure: false,
   });
 
   expect(out.stdout).toMatchSnapshot();


### PR DESCRIPTION
The `compile` function from the `@winglang/compiler` package throws even if the compilation was successful (e.g. the compiler emitted a warning). As result of that behavior, the console shows a blue screen of death when the compiler emits a warning.

This changeset refactors `compile` so it doesn't throw anymore, but returns the output directory (if possible) along with the diagnostics and any preflight errors.