### PR TITLE
fix(compiler): lsp preview indicates methods have zero params

### DIFF
--- a/libs/wingc/src/docs.rs
+++ b/libs/wingc/src/docs.rs
@@ -620,7 +620,7 @@ fn render_classlike_members(classlike: &impl ClassLike) -> String {
 		let member_name = &member.name.name;
 
 		if let Some(member_sig) = member_type.maybe_unwrap_option().as_function_sig() {
-			let arg_text = "";
+			let arg_text = if member_sig.parameters.len() > 0 { "..." } else { "" };
 			let text = format!(
 				"{static_text}{phase_text}{member_name}{option_text}({arg_text}): {};",
 				member_sig.return_type

--- a/libs/wingc/src/lsp/snapshots/completions/incomplete_inflight_namespace.snap
+++ b/libs/wingc/src/lsp/snapshots/completions/incomplete_inflight_namespace.snap
@@ -5,19 +5,19 @@ source: libs/wingc/src/lsp/completions.rs
   kind: 7
   documentation:
     kind: markdown
-    value: "```wing\nclass Api {\n  url: str;\n  connect(): void;\n  delete(): void;\n  get(): void;\n  head(): void;\n  options(): void;\n  /* ... */\n}\n```\n---\nFunctionality shared between all `Api` implementations."
+    value: "```wing\nclass Api {\n  url: str;\n  connect(...): void;\n  delete(...): void;\n  get(...): void;\n  head(...): void;\n  options(...): void;\n  /* ... */\n}\n```\n---\nFunctionality shared between all `Api` implementations."
   sortText: gg|Api
 - label: Bucket
   kind: 7
   documentation:
     kind: markdown
-    value: "```wing\nclass Bucket {\n  addFile(): void;\n  addObject(): void;\n  onCreate(): void;\n  onDelete(): void;\n  onEvent(): void;\n  onUpdate(): void;\n  /* ... */\n}\n```\n---\nA cloud object store."
+    value: "```wing\nclass Bucket {\n  addFile(...): void;\n  addObject(...): void;\n  onCreate(...): void;\n  onDelete(...): void;\n  onEvent(...): void;\n  onUpdate(...): void;\n  /* ... */\n}\n```\n---\nA cloud object store."
   sortText: gg|Bucket
 - label: Counter
   kind: 7
   documentation:
     kind: markdown
-    value: "```wing\nclass Counter {\n  initial: num;\n  inflight dec(): num;\n  inflight inc(): num;\n  inflight peek(): num;\n  inflight set(): void;\n}\n```\n---\nA distributed atomic counter."
+    value: "```wing\nclass Counter {\n  initial: num;\n  inflight dec(...): num;\n  inflight inc(...): num;\n  inflight peek(...): num;\n  inflight set(...): void;\n}\n```\n---\nA distributed atomic counter."
   sortText: gg|Counter
 - label: Domain
   kind: 7
@@ -35,7 +35,7 @@ source: libs/wingc/src/lsp/completions.rs
   kind: 7
   documentation:
     kind: markdown
-    value: "```wing\nclass Function impl IInflightHost {\n  env: Map<str>;\n  addEnvironment(): void;\n  inflight invoke(): Json?;\n  inflight invokeAsync(): void;\n}\n```\n---\nA function."
+    value: "```wing\nclass Function impl IInflightHost {\n  env: Map<str>;\n  addEnvironment(...): void;\n  inflight invoke(...): Json?;\n  inflight invokeAsync(...): void;\n}\n```\n---\nA function."
   sortText: gg|Function
 - label: OnDeploy
   kind: 7
@@ -47,37 +47,37 @@ source: libs/wingc/src/lsp/completions.rs
   kind: 7
   documentation:
     kind: markdown
-    value: "```wing\nclass Queue {\n  setConsumer(): Function;\n  inflight approxSize(): num;\n  inflight pop(): str?;\n  inflight purge(): void;\n  inflight push(): void;\n}\n```\n---\nA queue."
+    value: "```wing\nclass Queue {\n  setConsumer(...): Function;\n  inflight approxSize(): num;\n  inflight pop(): str?;\n  inflight purge(): void;\n  inflight push(...): void;\n}\n```\n---\nA queue."
   sortText: gg|Queue
 - label: Schedule
   kind: 7
   documentation:
     kind: markdown
-    value: "```wing\nclass Schedule {\n  onTick(): Function;\n}\n```\n---\nA schedule."
+    value: "```wing\nclass Schedule {\n  onTick(...): Function;\n}\n```\n---\nA schedule."
   sortText: gg|Schedule
 - label: Secret
   kind: 7
   documentation:
     kind: markdown
-    value: "```wing\nclass Secret {\n  name?: str;\n  inflight value(): str;\n  inflight valueJson(): Json;\n}\n```\n---\nA cloud secret."
+    value: "```wing\nclass Secret {\n  name?: str;\n  inflight value(...): str;\n  inflight valueJson(...): Json;\n}\n```\n---\nA cloud secret."
   sortText: gg|Secret
 - label: Service
   kind: 7
   documentation:
     kind: markdown
-    value: "```wing\nclass Service impl IInflightHost {\n  env: Map<str>;\n  addEnvironment(): void;\n  inflight start(): void;\n  inflight started(): bool;\n  inflight stop(): void;\n}\n```\n---\nA long-running service."
+    value: "```wing\nclass Service impl IInflightHost {\n  env: Map<str>;\n  addEnvironment(...): void;\n  inflight start(): void;\n  inflight started(): bool;\n  inflight stop(): void;\n}\n```\n---\nA long-running service."
   sortText: gg|Service
 - label: Topic
   kind: 7
   documentation:
     kind: markdown
-    value: "```wing\nclass Topic {\n  onMessage(): Function;\n  subscribeQueue(): void;\n  inflight publish(): void;\n}\n```\n---\nA topic for pub/sub notifications."
+    value: "```wing\nclass Topic {\n  onMessage(...): Function;\n  subscribeQueue(...): void;\n  inflight publish(...): void;\n}\n```\n---\nA topic for pub/sub notifications."
   sortText: gg|Topic
 - label: Website
   kind: 7
   documentation:
     kind: markdown
-    value: "```wing\nclass Website impl IWebsite {\n  path: str;\n  url: str;\n  addFile(): str;\n  addJson(): str;\n}\n```\n---\nA cloud static website."
+    value: "```wing\nclass Website impl IWebsite {\n  path: str;\n  url: str;\n  addFile(...): str;\n  addJson(...): str;\n}\n```\n---\nA cloud static website."
   sortText: gg|Website
 - label: AddFileOptions
   kind: 22
@@ -383,7 +383,7 @@ source: libs/wingc/src/lsp/completions.rs
   kind: 8
   documentation:
     kind: markdown
-    value: "```wing\ninterface IBucketClient {\n  inflight copy(): void;\n  inflight delete(): void;\n  inflight exists(): bool;\n  inflight get(): str;\n  inflight getJson(): Json;\n  inflight list(): Array<str>;\n  /* ... */\n}\n```\n---\nInflight interface for `Bucket`."
+    value: "```wing\ninterface IBucketClient {\n  inflight copy(...): void;\n  inflight delete(...): void;\n  inflight exists(...): bool;\n  inflight get(...): str;\n  inflight getJson(...): Json;\n  inflight list(...): Array<str>;\n  /* ... */\n}\n```\n---\nInflight interface for `Bucket`."
   sortText: ii|IBucketClient
 - label: IBucketEventHandler
   kind: 8
@@ -401,7 +401,7 @@ source: libs/wingc/src/lsp/completions.rs
   kind: 8
   documentation:
     kind: markdown
-    value: "```wing\ninterface ICounterClient {\n  inflight dec(): num;\n  inflight inc(): num;\n  inflight peek(): num;\n  inflight set(): void;\n}\n```\n---\nInflight interface for `Counter`."
+    value: "```wing\ninterface ICounterClient {\n  inflight dec(...): num;\n  inflight inc(...): num;\n  inflight peek(...): num;\n  inflight set(...): void;\n}\n```\n---\nInflight interface for `Counter`."
   sortText: ii|ICounterClient
 - label: IDomainClient
   kind: 8
@@ -419,7 +419,7 @@ source: libs/wingc/src/lsp/completions.rs
   kind: 8
   documentation:
     kind: markdown
-    value: "```wing\ninterface IFunctionClient {\n  inflight invoke(): Json?;\n  inflight invokeAsync(): void;\n}\n```\n---\nInflight interface for `Function`."
+    value: "```wing\ninterface IFunctionClient {\n  inflight invoke(...): Json?;\n  inflight invokeAsync(...): void;\n}\n```\n---\nInflight interface for `Function`."
   sortText: ii|IFunctionClient
 - label: IFunctionHandler
   kind: 8
@@ -455,7 +455,7 @@ source: libs/wingc/src/lsp/completions.rs
   kind: 8
   documentation:
     kind: markdown
-    value: "```wing\ninterface IQueueClient {\n  inflight approxSize(): num;\n  inflight pop(): str?;\n  inflight purge(): void;\n  inflight push(): void;\n}\n```\n---\nInflight interface for `Queue`."
+    value: "```wing\ninterface IQueueClient {\n  inflight approxSize(): num;\n  inflight pop(): str?;\n  inflight purge(): void;\n  inflight push(...): void;\n}\n```\n---\nInflight interface for `Queue`."
   sortText: ii|IQueueClient
 - label: IQueueSetConsumerHandler
   kind: 8
@@ -491,7 +491,7 @@ source: libs/wingc/src/lsp/completions.rs
   kind: 8
   documentation:
     kind: markdown
-    value: "```wing\ninterface ISecretClient {\n  inflight value(): str;\n  inflight valueJson(): Json;\n}\n```\n---\nInflight interface for `Secret`."
+    value: "```wing\ninterface ISecretClient {\n  inflight value(...): str;\n  inflight valueJson(...): Json;\n}\n```\n---\nInflight interface for `Secret`."
   sortText: ii|ISecretClient
 - label: IServiceClient
   kind: 8
@@ -527,7 +527,7 @@ source: libs/wingc/src/lsp/completions.rs
   kind: 8
   documentation:
     kind: markdown
-    value: "```wing\ninterface ITopicClient {\n  inflight publish(): void;\n}\n```\n---\nInflight interface for `Topic`."
+    value: "```wing\ninterface ITopicClient {\n  inflight publish(...): void;\n}\n```\n---\nInflight interface for `Topic`."
   sortText: ii|ITopicClient
 - label: ITopicOnMessageHandler
   kind: 8

--- a/libs/wingc/src/lsp/snapshots/completions/namespace_inflight.snap
+++ b/libs/wingc/src/lsp/snapshots/completions/namespace_inflight.snap
@@ -125,7 +125,7 @@ source: libs/wingc/src/lsp/completions.rs
   kind: 7
   documentation:
     kind: markdown
-    value: "```wing\nclass Util {\n  static inflight connect(): Response;\n  static inflight delete(): Response;\n  static inflight fetch(): Response;\n  static inflight formatUrl(): str;\n  static inflight get(): Response;\n  static inflight parseUrl(): Url;\n  /* ... */\n}\n```\n---\nThe Http class is used for calling different HTTP methods and requesting and sending information online,  as well as testing public accessible resources."
+    value: "```wing\nclass Util {\n  static inflight connect(...): Response;\n  static inflight delete(...): Response;\n  static inflight fetch(...): Response;\n  static inflight formatUrl(...): str;\n  static inflight get(...): Response;\n  static inflight parseUrl(...): Url;\n  /* ... */\n}\n```\n---\nThe Http class is used for calling different HTTP methods and requesting and sending information online,  as well as testing public accessible resources."
   sortText: gg|Util
 - label: FormatUrlOptions
   kind: 22

--- a/libs/wingc/src/lsp/snapshots/completions/namespace_middle_dot.snap
+++ b/libs/wingc/src/lsp/snapshots/completions/namespace_middle_dot.snap
@@ -5,19 +5,19 @@ source: libs/wingc/src/lsp/completions.rs
   kind: 7
   documentation:
     kind: markdown
-    value: "```wing\nclass Api {\n  url: str;\n  connect(): void;\n  delete(): void;\n  get(): void;\n  head(): void;\n  options(): void;\n  /* ... */\n}\n```\n---\nFunctionality shared between all `Api` implementations."
+    value: "```wing\nclass Api {\n  url: str;\n  connect(...): void;\n  delete(...): void;\n  get(...): void;\n  head(...): void;\n  options(...): void;\n  /* ... */\n}\n```\n---\nFunctionality shared between all `Api` implementations."
   sortText: gg|Api
 - label: Bucket
   kind: 7
   documentation:
     kind: markdown
-    value: "```wing\nclass Bucket {\n  addFile(): void;\n  addObject(): void;\n  onCreate(): void;\n  onDelete(): void;\n  onEvent(): void;\n  onUpdate(): void;\n  /* ... */\n}\n```\n---\nA cloud object store."
+    value: "```wing\nclass Bucket {\n  addFile(...): void;\n  addObject(...): void;\n  onCreate(...): void;\n  onDelete(...): void;\n  onEvent(...): void;\n  onUpdate(...): void;\n  /* ... */\n}\n```\n---\nA cloud object store."
   sortText: gg|Bucket
 - label: Counter
   kind: 7
   documentation:
     kind: markdown
-    value: "```wing\nclass Counter {\n  initial: num;\n  inflight dec(): num;\n  inflight inc(): num;\n  inflight peek(): num;\n  inflight set(): void;\n}\n```\n---\nA distributed atomic counter."
+    value: "```wing\nclass Counter {\n  initial: num;\n  inflight dec(...): num;\n  inflight inc(...): num;\n  inflight peek(...): num;\n  inflight set(...): void;\n}\n```\n---\nA distributed atomic counter."
   sortText: gg|Counter
 - label: Domain
   kind: 7
@@ -35,7 +35,7 @@ source: libs/wingc/src/lsp/completions.rs
   kind: 7
   documentation:
     kind: markdown
-    value: "```wing\nclass Function impl IInflightHost {\n  env: Map<str>;\n  addEnvironment(): void;\n  inflight invoke(): Json?;\n  inflight invokeAsync(): void;\n}\n```\n---\nA function."
+    value: "```wing\nclass Function impl IInflightHost {\n  env: Map<str>;\n  addEnvironment(...): void;\n  inflight invoke(...): Json?;\n  inflight invokeAsync(...): void;\n}\n```\n---\nA function."
   sortText: gg|Function
 - label: OnDeploy
   kind: 7
@@ -47,37 +47,37 @@ source: libs/wingc/src/lsp/completions.rs
   kind: 7
   documentation:
     kind: markdown
-    value: "```wing\nclass Queue {\n  setConsumer(): Function;\n  inflight approxSize(): num;\n  inflight pop(): str?;\n  inflight purge(): void;\n  inflight push(): void;\n}\n```\n---\nA queue."
+    value: "```wing\nclass Queue {\n  setConsumer(...): Function;\n  inflight approxSize(): num;\n  inflight pop(): str?;\n  inflight purge(): void;\n  inflight push(...): void;\n}\n```\n---\nA queue."
   sortText: gg|Queue
 - label: Schedule
   kind: 7
   documentation:
     kind: markdown
-    value: "```wing\nclass Schedule {\n  onTick(): Function;\n}\n```\n---\nA schedule."
+    value: "```wing\nclass Schedule {\n  onTick(...): Function;\n}\n```\n---\nA schedule."
   sortText: gg|Schedule
 - label: Secret
   kind: 7
   documentation:
     kind: markdown
-    value: "```wing\nclass Secret {\n  name?: str;\n  inflight value(): str;\n  inflight valueJson(): Json;\n}\n```\n---\nA cloud secret."
+    value: "```wing\nclass Secret {\n  name?: str;\n  inflight value(...): str;\n  inflight valueJson(...): Json;\n}\n```\n---\nA cloud secret."
   sortText: gg|Secret
 - label: Service
   kind: 7
   documentation:
     kind: markdown
-    value: "```wing\nclass Service impl IInflightHost {\n  env: Map<str>;\n  addEnvironment(): void;\n  inflight start(): void;\n  inflight started(): bool;\n  inflight stop(): void;\n}\n```\n---\nA long-running service."
+    value: "```wing\nclass Service impl IInflightHost {\n  env: Map<str>;\n  addEnvironment(...): void;\n  inflight start(): void;\n  inflight started(): bool;\n  inflight stop(): void;\n}\n```\n---\nA long-running service."
   sortText: gg|Service
 - label: Topic
   kind: 7
   documentation:
     kind: markdown
-    value: "```wing\nclass Topic {\n  onMessage(): Function;\n  subscribeQueue(): void;\n  inflight publish(): void;\n}\n```\n---\nA topic for pub/sub notifications."
+    value: "```wing\nclass Topic {\n  onMessage(...): Function;\n  subscribeQueue(...): void;\n  inflight publish(...): void;\n}\n```\n---\nA topic for pub/sub notifications."
   sortText: gg|Topic
 - label: Website
   kind: 7
   documentation:
     kind: markdown
-    value: "```wing\nclass Website impl IWebsite {\n  path: str;\n  url: str;\n  addFile(): str;\n  addJson(): str;\n}\n```\n---\nA cloud static website."
+    value: "```wing\nclass Website impl IWebsite {\n  path: str;\n  url: str;\n  addFile(...): str;\n  addJson(...): str;\n}\n```\n---\nA cloud static website."
   sortText: gg|Website
 - label: AddFileOptions
   kind: 22
@@ -383,7 +383,7 @@ source: libs/wingc/src/lsp/completions.rs
   kind: 8
   documentation:
     kind: markdown
-    value: "```wing\ninterface IBucketClient {\n  inflight copy(): void;\n  inflight delete(): void;\n  inflight exists(): bool;\n  inflight get(): str;\n  inflight getJson(): Json;\n  inflight list(): Array<str>;\n  /* ... */\n}\n```\n---\nInflight interface for `Bucket`."
+    value: "```wing\ninterface IBucketClient {\n  inflight copy(...): void;\n  inflight delete(...): void;\n  inflight exists(...): bool;\n  inflight get(...): str;\n  inflight getJson(...): Json;\n  inflight list(...): Array<str>;\n  /* ... */\n}\n```\n---\nInflight interface for `Bucket`."
   sortText: ii|IBucketClient
 - label: IBucketEventHandler
   kind: 8
@@ -401,7 +401,7 @@ source: libs/wingc/src/lsp/completions.rs
   kind: 8
   documentation:
     kind: markdown
-    value: "```wing\ninterface ICounterClient {\n  inflight dec(): num;\n  inflight inc(): num;\n  inflight peek(): num;\n  inflight set(): void;\n}\n```\n---\nInflight interface for `Counter`."
+    value: "```wing\ninterface ICounterClient {\n  inflight dec(...): num;\n  inflight inc(...): num;\n  inflight peek(...): num;\n  inflight set(...): void;\n}\n```\n---\nInflight interface for `Counter`."
   sortText: ii|ICounterClient
 - label: IDomainClient
   kind: 8
@@ -419,7 +419,7 @@ source: libs/wingc/src/lsp/completions.rs
   kind: 8
   documentation:
     kind: markdown
-    value: "```wing\ninterface IFunctionClient {\n  inflight invoke(): Json?;\n  inflight invokeAsync(): void;\n}\n```\n---\nInflight interface for `Function`."
+    value: "```wing\ninterface IFunctionClient {\n  inflight invoke(...): Json?;\n  inflight invokeAsync(...): void;\n}\n```\n---\nInflight interface for `Function`."
   sortText: ii|IFunctionClient
 - label: IFunctionHandler
   kind: 8
@@ -455,7 +455,7 @@ source: libs/wingc/src/lsp/completions.rs
   kind: 8
   documentation:
     kind: markdown
-    value: "```wing\ninterface IQueueClient {\n  inflight approxSize(): num;\n  inflight pop(): str?;\n  inflight purge(): void;\n  inflight push(): void;\n}\n```\n---\nInflight interface for `Queue`."
+    value: "```wing\ninterface IQueueClient {\n  inflight approxSize(): num;\n  inflight pop(): str?;\n  inflight purge(): void;\n  inflight push(...): void;\n}\n```\n---\nInflight interface for `Queue`."
   sortText: ii|IQueueClient
 - label: IQueueSetConsumerHandler
   kind: 8
@@ -491,7 +491,7 @@ source: libs/wingc/src/lsp/completions.rs
   kind: 8
   documentation:
     kind: markdown
-    value: "```wing\ninterface ISecretClient {\n  inflight value(): str;\n  inflight valueJson(): Json;\n}\n```\n---\nInflight interface for `Secret`."
+    value: "```wing\ninterface ISecretClient {\n  inflight value(...): str;\n  inflight valueJson(...): Json;\n}\n```\n---\nInflight interface for `Secret`."
   sortText: ii|ISecretClient
 - label: IServiceClient
   kind: 8
@@ -527,7 +527,7 @@ source: libs/wingc/src/lsp/completions.rs
   kind: 8
   documentation:
     kind: markdown
-    value: "```wing\ninterface ITopicClient {\n  inflight publish(): void;\n}\n```\n---\nInflight interface for `Topic`."
+    value: "```wing\ninterface ITopicClient {\n  inflight publish(...): void;\n}\n```\n---\nInflight interface for `Topic`."
   sortText: ii|ITopicClient
 - label: ITopicOnMessageHandler
   kind: 8

--- a/libs/wingc/src/lsp/snapshots/completions/new_expression_nested.snap
+++ b/libs/wingc/src/lsp/snapshots/completions/new_expression_nested.snap
@@ -5,7 +5,7 @@ source: libs/wingc/src/lsp/completions.rs
   kind: 7
   documentation:
     kind: markdown
-    value: "```wing\nclass Api {\n  url: str;\n  connect(): void;\n  delete(): void;\n  get(): void;\n  head(): void;\n  options(): void;\n  /* ... */\n}\n```\n---\nFunctionality shared between all `Api` implementations."
+    value: "```wing\nclass Api {\n  url: str;\n  connect(...): void;\n  delete(...): void;\n  get(...): void;\n  head(...): void;\n  options(...): void;\n  /* ... */\n}\n```\n---\nFunctionality shared between all `Api` implementations."
   sortText: gg|Api
   insertText: Api($1)
   insertTextFormat: 2
@@ -16,7 +16,7 @@ source: libs/wingc/src/lsp/completions.rs
   kind: 7
   documentation:
     kind: markdown
-    value: "```wing\nclass Bucket {\n  addFile(): void;\n  addObject(): void;\n  onCreate(): void;\n  onDelete(): void;\n  onEvent(): void;\n  onUpdate(): void;\n  /* ... */\n}\n```\n---\nA cloud object store."
+    value: "```wing\nclass Bucket {\n  addFile(...): void;\n  addObject(...): void;\n  onCreate(...): void;\n  onDelete(...): void;\n  onEvent(...): void;\n  onUpdate(...): void;\n  /* ... */\n}\n```\n---\nA cloud object store."
   sortText: gg|Bucket
   insertText: Bucket($1)
   insertTextFormat: 2
@@ -27,7 +27,7 @@ source: libs/wingc/src/lsp/completions.rs
   kind: 7
   documentation:
     kind: markdown
-    value: "```wing\nclass Counter {\n  initial: num;\n  inflight dec(): num;\n  inflight inc(): num;\n  inflight peek(): num;\n  inflight set(): void;\n}\n```\n---\nA distributed atomic counter."
+    value: "```wing\nclass Counter {\n  initial: num;\n  inflight dec(...): num;\n  inflight inc(...): num;\n  inflight peek(...): num;\n  inflight set(...): void;\n}\n```\n---\nA distributed atomic counter."
   sortText: gg|Counter
   insertText: Counter($1)
   insertTextFormat: 2
@@ -60,7 +60,7 @@ source: libs/wingc/src/lsp/completions.rs
   kind: 7
   documentation:
     kind: markdown
-    value: "```wing\nclass Function impl IInflightHost {\n  env: Map<str>;\n  addEnvironment(): void;\n  inflight invoke(): Json?;\n  inflight invokeAsync(): void;\n}\n```\n---\nA function."
+    value: "```wing\nclass Function impl IInflightHost {\n  env: Map<str>;\n  addEnvironment(...): void;\n  inflight invoke(...): Json?;\n  inflight invokeAsync(...): void;\n}\n```\n---\nA function."
   sortText: gg|Function
   insertText: Function($1)
   insertTextFormat: 2
@@ -82,7 +82,7 @@ source: libs/wingc/src/lsp/completions.rs
   kind: 7
   documentation:
     kind: markdown
-    value: "```wing\nclass Queue {\n  setConsumer(): Function;\n  inflight approxSize(): num;\n  inflight pop(): str?;\n  inflight purge(): void;\n  inflight push(): void;\n}\n```\n---\nA queue."
+    value: "```wing\nclass Queue {\n  setConsumer(...): Function;\n  inflight approxSize(): num;\n  inflight pop(): str?;\n  inflight purge(): void;\n  inflight push(...): void;\n}\n```\n---\nA queue."
   sortText: gg|Queue
   insertText: Queue($1)
   insertTextFormat: 2
@@ -93,7 +93,7 @@ source: libs/wingc/src/lsp/completions.rs
   kind: 7
   documentation:
     kind: markdown
-    value: "```wing\nclass Schedule {\n  onTick(): Function;\n}\n```\n---\nA schedule."
+    value: "```wing\nclass Schedule {\n  onTick(...): Function;\n}\n```\n---\nA schedule."
   sortText: gg|Schedule
   insertText: Schedule($1)
   insertTextFormat: 2
@@ -104,7 +104,7 @@ source: libs/wingc/src/lsp/completions.rs
   kind: 7
   documentation:
     kind: markdown
-    value: "```wing\nclass Secret {\n  name?: str;\n  inflight value(): str;\n  inflight valueJson(): Json;\n}\n```\n---\nA cloud secret."
+    value: "```wing\nclass Secret {\n  name?: str;\n  inflight value(...): str;\n  inflight valueJson(...): Json;\n}\n```\n---\nA cloud secret."
   sortText: gg|Secret
   insertText: Secret($1)
   insertTextFormat: 2
@@ -115,7 +115,7 @@ source: libs/wingc/src/lsp/completions.rs
   kind: 7
   documentation:
     kind: markdown
-    value: "```wing\nclass Service impl IInflightHost {\n  env: Map<str>;\n  addEnvironment(): void;\n  inflight start(): void;\n  inflight started(): bool;\n  inflight stop(): void;\n}\n```\n---\nA long-running service."
+    value: "```wing\nclass Service impl IInflightHost {\n  env: Map<str>;\n  addEnvironment(...): void;\n  inflight start(): void;\n  inflight started(): bool;\n  inflight stop(): void;\n}\n```\n---\nA long-running service."
   sortText: gg|Service
   insertText: Service($1)
   insertTextFormat: 2
@@ -126,7 +126,7 @@ source: libs/wingc/src/lsp/completions.rs
   kind: 7
   documentation:
     kind: markdown
-    value: "```wing\nclass Topic {\n  onMessage(): Function;\n  subscribeQueue(): void;\n  inflight publish(): void;\n}\n```\n---\nA topic for pub/sub notifications."
+    value: "```wing\nclass Topic {\n  onMessage(...): Function;\n  subscribeQueue(...): void;\n  inflight publish(...): void;\n}\n```\n---\nA topic for pub/sub notifications."
   sortText: gg|Topic
   insertText: Topic($1)
   insertTextFormat: 2
@@ -137,7 +137,7 @@ source: libs/wingc/src/lsp/completions.rs
   kind: 7
   documentation:
     kind: markdown
-    value: "```wing\nclass Website impl IWebsite {\n  path: str;\n  url: str;\n  addFile(): str;\n  addJson(): str;\n}\n```\n---\nA cloud static website."
+    value: "```wing\nclass Website impl IWebsite {\n  path: str;\n  url: str;\n  addFile(...): str;\n  addJson(...): str;\n}\n```\n---\nA cloud static website."
   sortText: gg|Website
   insertText: Website($1)
   insertTextFormat: 2

--- a/libs/wingc/src/lsp/snapshots/completions/partial_type_reference_annotation.snap
+++ b/libs/wingc/src/lsp/snapshots/completions/partial_type_reference_annotation.snap
@@ -5,19 +5,19 @@ source: libs/wingc/src/lsp/completions.rs
   kind: 7
   documentation:
     kind: markdown
-    value: "```wing\nclass Api {\n  url: str;\n  connect(): void;\n  delete(): void;\n  get(): void;\n  head(): void;\n  options(): void;\n  /* ... */\n}\n```\n---\nFunctionality shared between all `Api` implementations."
+    value: "```wing\nclass Api {\n  url: str;\n  connect(...): void;\n  delete(...): void;\n  get(...): void;\n  head(...): void;\n  options(...): void;\n  /* ... */\n}\n```\n---\nFunctionality shared between all `Api` implementations."
   sortText: gg|Api
 - label: Bucket
   kind: 7
   documentation:
     kind: markdown
-    value: "```wing\nclass Bucket {\n  addFile(): void;\n  addObject(): void;\n  onCreate(): void;\n  onDelete(): void;\n  onEvent(): void;\n  onUpdate(): void;\n  /* ... */\n}\n```\n---\nA cloud object store."
+    value: "```wing\nclass Bucket {\n  addFile(...): void;\n  addObject(...): void;\n  onCreate(...): void;\n  onDelete(...): void;\n  onEvent(...): void;\n  onUpdate(...): void;\n  /* ... */\n}\n```\n---\nA cloud object store."
   sortText: gg|Bucket
 - label: Counter
   kind: 7
   documentation:
     kind: markdown
-    value: "```wing\nclass Counter {\n  initial: num;\n  inflight dec(): num;\n  inflight inc(): num;\n  inflight peek(): num;\n  inflight set(): void;\n}\n```\n---\nA distributed atomic counter."
+    value: "```wing\nclass Counter {\n  initial: num;\n  inflight dec(...): num;\n  inflight inc(...): num;\n  inflight peek(...): num;\n  inflight set(...): void;\n}\n```\n---\nA distributed atomic counter."
   sortText: gg|Counter
 - label: Domain
   kind: 7
@@ -35,7 +35,7 @@ source: libs/wingc/src/lsp/completions.rs
   kind: 7
   documentation:
     kind: markdown
-    value: "```wing\nclass Function impl IInflightHost {\n  env: Map<str>;\n  addEnvironment(): void;\n  inflight invoke(): Json?;\n  inflight invokeAsync(): void;\n}\n```\n---\nA function."
+    value: "```wing\nclass Function impl IInflightHost {\n  env: Map<str>;\n  addEnvironment(...): void;\n  inflight invoke(...): Json?;\n  inflight invokeAsync(...): void;\n}\n```\n---\nA function."
   sortText: gg|Function
 - label: OnDeploy
   kind: 7
@@ -47,37 +47,37 @@ source: libs/wingc/src/lsp/completions.rs
   kind: 7
   documentation:
     kind: markdown
-    value: "```wing\nclass Queue {\n  setConsumer(): Function;\n  inflight approxSize(): num;\n  inflight pop(): str?;\n  inflight purge(): void;\n  inflight push(): void;\n}\n```\n---\nA queue."
+    value: "```wing\nclass Queue {\n  setConsumer(...): Function;\n  inflight approxSize(): num;\n  inflight pop(): str?;\n  inflight purge(): void;\n  inflight push(...): void;\n}\n```\n---\nA queue."
   sortText: gg|Queue
 - label: Schedule
   kind: 7
   documentation:
     kind: markdown
-    value: "```wing\nclass Schedule {\n  onTick(): Function;\n}\n```\n---\nA schedule."
+    value: "```wing\nclass Schedule {\n  onTick(...): Function;\n}\n```\n---\nA schedule."
   sortText: gg|Schedule
 - label: Secret
   kind: 7
   documentation:
     kind: markdown
-    value: "```wing\nclass Secret {\n  name?: str;\n  inflight value(): str;\n  inflight valueJson(): Json;\n}\n```\n---\nA cloud secret."
+    value: "```wing\nclass Secret {\n  name?: str;\n  inflight value(...): str;\n  inflight valueJson(...): Json;\n}\n```\n---\nA cloud secret."
   sortText: gg|Secret
 - label: Service
   kind: 7
   documentation:
     kind: markdown
-    value: "```wing\nclass Service impl IInflightHost {\n  env: Map<str>;\n  addEnvironment(): void;\n  inflight start(): void;\n  inflight started(): bool;\n  inflight stop(): void;\n}\n```\n---\nA long-running service."
+    value: "```wing\nclass Service impl IInflightHost {\n  env: Map<str>;\n  addEnvironment(...): void;\n  inflight start(): void;\n  inflight started(): bool;\n  inflight stop(): void;\n}\n```\n---\nA long-running service."
   sortText: gg|Service
 - label: Topic
   kind: 7
   documentation:
     kind: markdown
-    value: "```wing\nclass Topic {\n  onMessage(): Function;\n  subscribeQueue(): void;\n  inflight publish(): void;\n}\n```\n---\nA topic for pub/sub notifications."
+    value: "```wing\nclass Topic {\n  onMessage(...): Function;\n  subscribeQueue(...): void;\n  inflight publish(...): void;\n}\n```\n---\nA topic for pub/sub notifications."
   sortText: gg|Topic
 - label: Website
   kind: 7
   documentation:
     kind: markdown
-    value: "```wing\nclass Website impl IWebsite {\n  path: str;\n  url: str;\n  addFile(): str;\n  addJson(): str;\n}\n```\n---\nA cloud static website."
+    value: "```wing\nclass Website impl IWebsite {\n  path: str;\n  url: str;\n  addFile(...): str;\n  addJson(...): str;\n}\n```\n---\nA cloud static website."
   sortText: gg|Website
 - label: AddFileOptions
   kind: 22
@@ -383,7 +383,7 @@ source: libs/wingc/src/lsp/completions.rs
   kind: 8
   documentation:
     kind: markdown
-    value: "```wing\ninterface IBucketClient {\n  inflight copy(): void;\n  inflight delete(): void;\n  inflight exists(): bool;\n  inflight get(): str;\n  inflight getJson(): Json;\n  inflight list(): Array<str>;\n  /* ... */\n}\n```\n---\nInflight interface for `Bucket`."
+    value: "```wing\ninterface IBucketClient {\n  inflight copy(...): void;\n  inflight delete(...): void;\n  inflight exists(...): bool;\n  inflight get(...): str;\n  inflight getJson(...): Json;\n  inflight list(...): Array<str>;\n  /* ... */\n}\n```\n---\nInflight interface for `Bucket`."
   sortText: ii|IBucketClient
 - label: IBucketEventHandler
   kind: 8
@@ -401,7 +401,7 @@ source: libs/wingc/src/lsp/completions.rs
   kind: 8
   documentation:
     kind: markdown
-    value: "```wing\ninterface ICounterClient {\n  inflight dec(): num;\n  inflight inc(): num;\n  inflight peek(): num;\n  inflight set(): void;\n}\n```\n---\nInflight interface for `Counter`."
+    value: "```wing\ninterface ICounterClient {\n  inflight dec(...): num;\n  inflight inc(...): num;\n  inflight peek(...): num;\n  inflight set(...): void;\n}\n```\n---\nInflight interface for `Counter`."
   sortText: ii|ICounterClient
 - label: IDomainClient
   kind: 8
@@ -419,7 +419,7 @@ source: libs/wingc/src/lsp/completions.rs
   kind: 8
   documentation:
     kind: markdown
-    value: "```wing\ninterface IFunctionClient {\n  inflight invoke(): Json?;\n  inflight invokeAsync(): void;\n}\n```\n---\nInflight interface for `Function`."
+    value: "```wing\ninterface IFunctionClient {\n  inflight invoke(...): Json?;\n  inflight invokeAsync(...): void;\n}\n```\n---\nInflight interface for `Function`."
   sortText: ii|IFunctionClient
 - label: IFunctionHandler
   kind: 8
@@ -455,7 +455,7 @@ source: libs/wingc/src/lsp/completions.rs
   kind: 8
   documentation:
     kind: markdown
-    value: "```wing\ninterface IQueueClient {\n  inflight approxSize(): num;\n  inflight pop(): str?;\n  inflight purge(): void;\n  inflight push(): void;\n}\n```\n---\nInflight interface for `Queue`."
+    value: "```wing\ninterface IQueueClient {\n  inflight approxSize(): num;\n  inflight pop(): str?;\n  inflight purge(): void;\n  inflight push(...): void;\n}\n```\n---\nInflight interface for `Queue`."
   sortText: ii|IQueueClient
 - label: IQueueSetConsumerHandler
   kind: 8
@@ -491,7 +491,7 @@ source: libs/wingc/src/lsp/completions.rs
   kind: 8
   documentation:
     kind: markdown
-    value: "```wing\ninterface ISecretClient {\n  inflight value(): str;\n  inflight valueJson(): Json;\n}\n```\n---\nInflight interface for `Secret`."
+    value: "```wing\ninterface ISecretClient {\n  inflight value(...): str;\n  inflight valueJson(...): Json;\n}\n```\n---\nInflight interface for `Secret`."
   sortText: ii|ISecretClient
 - label: IServiceClient
   kind: 8
@@ -527,7 +527,7 @@ source: libs/wingc/src/lsp/completions.rs
   kind: 8
   documentation:
     kind: markdown
-    value: "```wing\ninterface ITopicClient {\n  inflight publish(): void;\n}\n```\n---\nInflight interface for `Topic`."
+    value: "```wing\ninterface ITopicClient {\n  inflight publish(...): void;\n}\n```\n---\nInflight interface for `Topic`."
   sortText: ii|ITopicClient
 - label: ITopicOnMessageHandler
   kind: 8

--- a/libs/wingc/src/lsp/snapshots/completions/util_static_methods.snap
+++ b/libs/wingc/src/lsp/snapshots/completions/util_static_methods.snap
@@ -141,13 +141,13 @@ source: libs/wingc/src/lsp/completions.rs
   kind: 7
   documentation:
     kind: markdown
-    value: "```wing\nclass ChildProcess {\n  pid?: num;\n  kill(): void;\n  wait(): Output;\n}\n```\n---\nHandle to a running child process."
+    value: "```wing\nclass ChildProcess {\n  pid?: num;\n  kill(...): void;\n  wait(): Output;\n}\n```\n---\nHandle to a running child process."
   sortText: gg|ChildProcess
 - label: Util
   kind: 7
   documentation:
     kind: markdown
-    value: "```wing\nclass Util {\n  static base64Decode(): str;\n  static base64Encode(): str;\n  static env(): str;\n  static exec(): Output;\n  static nanoid(): str;\n  static os(): str;\n  /* ... */\n}\n```\n---\nUtility functions."
+    value: "```wing\nclass Util {\n  static base64Decode(...): str;\n  static base64Encode(...): str;\n  static env(...): str;\n  static exec(...): Output;\n  static nanoid(...): str;\n  static os(): str;\n  /* ... */\n}\n```\n---\nUtility functions."
   sortText: gg|Util
 - label: CommandOptions
   kind: 22

--- a/libs/wingc/src/lsp/snapshots/completions/variable_type_annotation_namespace.snap
+++ b/libs/wingc/src/lsp/snapshots/completions/variable_type_annotation_namespace.snap
@@ -5,19 +5,19 @@ source: libs/wingc/src/lsp/completions.rs
   kind: 7
   documentation:
     kind: markdown
-    value: "```wing\nclass Api {\n  url: str;\n  connect(): void;\n  delete(): void;\n  get(): void;\n  head(): void;\n  options(): void;\n  /* ... */\n}\n```\n---\nFunctionality shared between all `Api` implementations."
+    value: "```wing\nclass Api {\n  url: str;\n  connect(...): void;\n  delete(...): void;\n  get(...): void;\n  head(...): void;\n  options(...): void;\n  /* ... */\n}\n```\n---\nFunctionality shared between all `Api` implementations."
   sortText: gg|Api
 - label: Bucket
   kind: 7
   documentation:
     kind: markdown
-    value: "```wing\nclass Bucket {\n  addFile(): void;\n  addObject(): void;\n  onCreate(): void;\n  onDelete(): void;\n  onEvent(): void;\n  onUpdate(): void;\n  /* ... */\n}\n```\n---\nA cloud object store."
+    value: "```wing\nclass Bucket {\n  addFile(...): void;\n  addObject(...): void;\n  onCreate(...): void;\n  onDelete(...): void;\n  onEvent(...): void;\n  onUpdate(...): void;\n  /* ... */\n}\n```\n---\nA cloud object store."
   sortText: gg|Bucket
 - label: Counter
   kind: 7
   documentation:
     kind: markdown
-    value: "```wing\nclass Counter {\n  initial: num;\n  inflight dec(): num;\n  inflight inc(): num;\n  inflight peek(): num;\n  inflight set(): void;\n}\n```\n---\nA distributed atomic counter."
+    value: "```wing\nclass Counter {\n  initial: num;\n  inflight dec(...): num;\n  inflight inc(...): num;\n  inflight peek(...): num;\n  inflight set(...): void;\n}\n```\n---\nA distributed atomic counter."
   sortText: gg|Counter
 - label: Domain
   kind: 7
@@ -35,7 +35,7 @@ source: libs/wingc/src/lsp/completions.rs
   kind: 7
   documentation:
     kind: markdown
-    value: "```wing\nclass Function impl IInflightHost {\n  env: Map<str>;\n  addEnvironment(): void;\n  inflight invoke(): Json?;\n  inflight invokeAsync(): void;\n}\n```\n---\nA function."
+    value: "```wing\nclass Function impl IInflightHost {\n  env: Map<str>;\n  addEnvironment(...): void;\n  inflight invoke(...): Json?;\n  inflight invokeAsync(...): void;\n}\n```\n---\nA function."
   sortText: gg|Function
 - label: OnDeploy
   kind: 7
@@ -47,37 +47,37 @@ source: libs/wingc/src/lsp/completions.rs
   kind: 7
   documentation:
     kind: markdown
-    value: "```wing\nclass Queue {\n  setConsumer(): Function;\n  inflight approxSize(): num;\n  inflight pop(): str?;\n  inflight purge(): void;\n  inflight push(): void;\n}\n```\n---\nA queue."
+    value: "```wing\nclass Queue {\n  setConsumer(...): Function;\n  inflight approxSize(): num;\n  inflight pop(): str?;\n  inflight purge(): void;\n  inflight push(...): void;\n}\n```\n---\nA queue."
   sortText: gg|Queue
 - label: Schedule
   kind: 7
   documentation:
     kind: markdown
-    value: "```wing\nclass Schedule {\n  onTick(): Function;\n}\n```\n---\nA schedule."
+    value: "```wing\nclass Schedule {\n  onTick(...): Function;\n}\n```\n---\nA schedule."
   sortText: gg|Schedule
 - label: Secret
   kind: 7
   documentation:
     kind: markdown
-    value: "```wing\nclass Secret {\n  name?: str;\n  inflight value(): str;\n  inflight valueJson(): Json;\n}\n```\n---\nA cloud secret."
+    value: "```wing\nclass Secret {\n  name?: str;\n  inflight value(...): str;\n  inflight valueJson(...): Json;\n}\n```\n---\nA cloud secret."
   sortText: gg|Secret
 - label: Service
   kind: 7
   documentation:
     kind: markdown
-    value: "```wing\nclass Service impl IInflightHost {\n  env: Map<str>;\n  addEnvironment(): void;\n  inflight start(): void;\n  inflight started(): bool;\n  inflight stop(): void;\n}\n```\n---\nA long-running service."
+    value: "```wing\nclass Service impl IInflightHost {\n  env: Map<str>;\n  addEnvironment(...): void;\n  inflight start(): void;\n  inflight started(): bool;\n  inflight stop(): void;\n}\n```\n---\nA long-running service."
   sortText: gg|Service
 - label: Topic
   kind: 7
   documentation:
     kind: markdown
-    value: "```wing\nclass Topic {\n  onMessage(): Function;\n  subscribeQueue(): void;\n  inflight publish(): void;\n}\n```\n---\nA topic for pub/sub notifications."
+    value: "```wing\nclass Topic {\n  onMessage(...): Function;\n  subscribeQueue(...): void;\n  inflight publish(...): void;\n}\n```\n---\nA topic for pub/sub notifications."
   sortText: gg|Topic
 - label: Website
   kind: 7
   documentation:
     kind: markdown
-    value: "```wing\nclass Website impl IWebsite {\n  path: str;\n  url: str;\n  addFile(): str;\n  addJson(): str;\n}\n```\n---\nA cloud static website."
+    value: "```wing\nclass Website impl IWebsite {\n  path: str;\n  url: str;\n  addFile(...): str;\n  addJson(...): str;\n}\n```\n---\nA cloud static website."
   sortText: gg|Website
 - label: AddFileOptions
   kind: 22
@@ -383,7 +383,7 @@ source: libs/wingc/src/lsp/completions.rs
   kind: 8
   documentation:
     kind: markdown
-    value: "```wing\ninterface IBucketClient {\n  inflight copy(): void;\n  inflight delete(): void;\n  inflight exists(): bool;\n  inflight get(): str;\n  inflight getJson(): Json;\n  inflight list(): Array<str>;\n  /* ... */\n}\n```\n---\nInflight interface for `Bucket`."
+    value: "```wing\ninterface IBucketClient {\n  inflight copy(...): void;\n  inflight delete(...): void;\n  inflight exists(...): bool;\n  inflight get(...): str;\n  inflight getJson(...): Json;\n  inflight list(...): Array<str>;\n  /* ... */\n}\n```\n---\nInflight interface for `Bucket`."
   sortText: ii|IBucketClient
 - label: IBucketEventHandler
   kind: 8
@@ -401,7 +401,7 @@ source: libs/wingc/src/lsp/completions.rs
   kind: 8
   documentation:
     kind: markdown
-    value: "```wing\ninterface ICounterClient {\n  inflight dec(): num;\n  inflight inc(): num;\n  inflight peek(): num;\n  inflight set(): void;\n}\n```\n---\nInflight interface for `Counter`."
+    value: "```wing\ninterface ICounterClient {\n  inflight dec(...): num;\n  inflight inc(...): num;\n  inflight peek(...): num;\n  inflight set(...): void;\n}\n```\n---\nInflight interface for `Counter`."
   sortText: ii|ICounterClient
 - label: IDomainClient
   kind: 8
@@ -419,7 +419,7 @@ source: libs/wingc/src/lsp/completions.rs
   kind: 8
   documentation:
     kind: markdown
-    value: "```wing\ninterface IFunctionClient {\n  inflight invoke(): Json?;\n  inflight invokeAsync(): void;\n}\n```\n---\nInflight interface for `Function`."
+    value: "```wing\ninterface IFunctionClient {\n  inflight invoke(...): Json?;\n  inflight invokeAsync(...): void;\n}\n```\n---\nInflight interface for `Function`."
   sortText: ii|IFunctionClient
 - label: IFunctionHandler
   kind: 8
@@ -455,7 +455,7 @@ source: libs/wingc/src/lsp/completions.rs
   kind: 8
   documentation:
     kind: markdown
-    value: "```wing\ninterface IQueueClient {\n  inflight approxSize(): num;\n  inflight pop(): str?;\n  inflight purge(): void;\n  inflight push(): void;\n}\n```\n---\nInflight interface for `Queue`."
+    value: "```wing\ninterface IQueueClient {\n  inflight approxSize(): num;\n  inflight pop(): str?;\n  inflight purge(): void;\n  inflight push(...): void;\n}\n```\n---\nInflight interface for `Queue`."
   sortText: ii|IQueueClient
 - label: IQueueSetConsumerHandler
   kind: 8
@@ -491,7 +491,7 @@ source: libs/wingc/src/lsp/completions.rs
   kind: 8
   documentation:
     kind: markdown
-    value: "```wing\ninterface ISecretClient {\n  inflight value(): str;\n  inflight valueJson(): Json;\n}\n```\n---\nInflight interface for `Secret`."
+    value: "```wing\ninterface ISecretClient {\n  inflight value(...): str;\n  inflight valueJson(...): Json;\n}\n```\n---\nInflight interface for `Secret`."
   sortText: ii|ISecretClient
 - label: IServiceClient
   kind: 8
@@ -527,7 +527,7 @@ source: libs/wingc/src/lsp/completions.rs
   kind: 8
   documentation:
     kind: markdown
-    value: "```wing\ninterface ITopicClient {\n  inflight publish(): void;\n}\n```\n---\nInflight interface for `Topic`."
+    value: "```wing\ninterface ITopicClient {\n  inflight publish(...): void;\n}\n```\n---\nInflight interface for `Topic`."
   sortText: ii|ITopicClient
 - label: ITopicOnMessageHandler
   kind: 8

--- a/libs/wingc/src/lsp/snapshots/hovers/class_symbol.snap
+++ b/libs/wingc/src/lsp/snapshots/hovers/class_symbol.snap
@@ -3,7 +3,7 @@ source: libs/wingc/src/lsp/hover.rs
 ---
 contents:
   kind: markdown
-  value: "```wing\npreflight bucket: class Bucket {\n  addFile(): void;\n  addObject(): void;\n  onCreate(): void;\n  onDelete(): void;\n  onEvent(): void;\n  onUpdate(): void;\n  /* ... */\n}\n```\n---\nA cloud object store."
+  value: "```wing\npreflight bucket: class Bucket {\n  addFile(...): void;\n  addObject(...): void;\n  onCreate(...): void;\n  onDelete(...): void;\n  onEvent(...): void;\n  onUpdate(...): void;\n  /* ... */\n}\n```\n---\nA cloud object store."
 range:
   start:
     line: 3

--- a/libs/wingc/src/lsp/snapshots/hovers/inside_class_field.snap
+++ b/libs/wingc/src/lsp/snapshots/hovers/inside_class_field.snap
@@ -3,7 +3,7 @@ source: libs/wingc/src/lsp/hover.rs
 ---
 contents:
   kind: markdown
-  value: "```wing\npreflight my_bucket: class Bucket {\n  addFile(): void;\n  addObject(): void;\n  onCreate(): void;\n  onDelete(): void;\n  onEvent(): void;\n  onUpdate(): void;\n  /* ... */\n}\n```\n---\nA cloud object store."
+  value: "```wing\npreflight my_bucket: class Bucket {\n  addFile(...): void;\n  addObject(...): void;\n  onCreate(...): void;\n  onDelete(...): void;\n  onEvent(...): void;\n  onUpdate(...): void;\n  /* ... */\n}\n```\n---\nA cloud object store."
 range:
   start:
     line: 3

--- a/libs/wingc/src/lsp/snapshots/hovers/static_method_root.snap
+++ b/libs/wingc/src/lsp/snapshots/hovers/static_method_root.snap
@@ -3,7 +3,7 @@ source: libs/wingc/src/lsp/hover.rs
 ---
 contents:
   kind: markdown
-  value: "```wing\nclass Json {\n  asBool(): bool;\n  asNum(): num;\n  asStr(): str;\n  get(): Json;\n  getAt(): Json;\n  has(): bool;\n  /* ... */\n}\n```\n---\nImmutable Json."
+  value: "```wing\nclass Json {\n  asBool(): bool;\n  asNum(): num;\n  asStr(): str;\n  get(...): Json;\n  getAt(...): Json;\n  has(...): bool;\n  /* ... */\n}\n```\n---\nImmutable Json."
 range:
   start:
     line: 1


### PR DESCRIPTION
For visual brevity, the preview of a class shown by the LSP only shows a subset of the class's API. However, the preview makes it look like class methods have no parameters, even if they do / even if they're required:

<img width="442" alt="Screenshot 2024-08-05 at 8 40 41 PM" src="https://github.com/user-attachments/assets/00ed90b1-7c67-4aed-a1d8-07b707f1b4eb">

This PR fixes that so if a method has arguments, it will be visually indicated by showing "..." in between the parentheses.

## Checklist

- [ ] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [ ] Description explains motivation and solution
- [ ] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
