### PR TITLE
fix(compiler): improve error diagnostic for invalid string concat

### DIFF
--- a/examples/tests/invalid/stringify.test.w
+++ b/examples/tests/invalid/stringify.test.w
@@ -7,16 +7,8 @@ struct Foo {
 
 let foo: Foo = {bar: b, baz: "hello"};
 
-let x = 42;
-
 log("hello {b}");
 // ^ Expected type to be "stringable", but got "B" instead 
-
-log("value: " + x);
-// ^ Binary operator '+' cannot be applied to operands of type 'str' and 'num'
-
-log(x + " is the value");
-// ^ Binary operator '+' cannot be applied to operands of type 'str' and 'num'
 
 let x: str? = nil;
 log("{x}");
@@ -27,3 +19,11 @@ log(b);
 
 log(foo);
 // ^ Expected type to be "stringable", but got "Foo" instead
+
+let z = 42;
+
+log("value: " + z);
+// ^ Binary operator '+' cannot be applied to operands of type 'str' and 'num'
+
+log(z + " is the value");
+// ^ Binary operator '+' cannot be applied to operands of type 'str' and 'num'

--- a/examples/tests/invalid/stringify.test.w
+++ b/examples/tests/invalid/stringify.test.w
@@ -7,8 +7,16 @@ struct Foo {
 
 let foo: Foo = {bar: b, baz: "hello"};
 
+let x = 42;
+
 log("hello {b}");
 // ^ Expected type to be "stringable", but got "B" instead 
+
+log("value: " + x);
+// ^ Binary operator '+' cannot be applied to operands of type 'str' and 'num'
+
+log(x + " is the value");
+// ^ Binary operator '+' cannot be applied to operands of type 'str' and 'num'
 
 let x: str? = nil;
 log("{x}");

--- a/libs/wingc/src/type_check.rs
+++ b/libs/wingc/src/type_check.rs
@@ -2296,17 +2296,24 @@ It should primarily be used in preflight or in inflights that are guaranteed to 
 				} else {
 					// If any of the types are unresolved (error) then don't report this assuming the error has already been reported
 					if !ltype.is_unresolved() && !rtype.is_unresolved() {
-						self.spanned_error(
+						let mut hints = vec![];
+						// If one of the operands is a string type, add a hint to use string interpolation
+						if ltype.is_subtype_of(&self.types.string()) || rtype.is_subtype_of(&self.types.string()) {
+							hints.push("Consider using string interpolation: \"Hello, {name}\"".to_string());
+						}
+
+						self.spanned_error_with_hints(
 							exp,
 							format!(
-														"Binary operator '+' cannot be applied to operands of type '{}' and '{}'; only ({}, {}) and ({}, {}) are supported",
-														ltype,
-														rtype,
-														self.types.number(),
-														self.types.number(),
-														self.types.string(),
-														self.types.string(),
-													),
+								"Binary operator '+' cannot be applied to operands of type '{}' and '{}'; only ({}, {}) and ({}, {}) are supported",
+								ltype,
+								rtype,
+								self.types.number(),
+								self.types.number(),
+								self.types.string(),
+								self.types.string(),
+							),
+							&hints,
 						);
 					}
 					self.resolved_error()

--- a/tools/hangar/__snapshots__/invalid.ts.snap
+++ b/tools/hangar/__snapshots__/invalid.ts.snap
@@ -988,6 +988,8 @@ error: Binary operator '+' cannot be applied to operands of type 'num' and 'str'
     |
 185 |     2 + "2";
     |     ^^^^^^^
+    |
+    = hint: Consider using string interpolation: "Hello, {name}"
 
 
 error: Expected type to be "num", but got "str" instead
@@ -1002,6 +1004,8 @@ error: Binary operator '+' cannot be applied to operands of type 'num' and 'str'
     |
 198 |     2 + "2";
     |     ^^^^^^^
+    |
+    = hint: Consider using string interpolation: "Hello, {name}"
 
 
 error: Expected type to be "str", but got "num" instead
@@ -1016,6 +1020,8 @@ error: Binary operator '+' cannot be applied to operands of type 'num' and 'str'
     |
 210 |     2 + "2";
     |     ^^^^^^^
+    |
+    = hint: Consider using string interpolation: "Hello, {name}"
 
 
 error: Expected type to be "num", but got "str" instead
@@ -1030,6 +1036,8 @@ error: Binary operator '+' cannot be applied to operands of type 'num' and 'str'
     |
 221 |     2 + "2";
     |     ^^^^^^^
+    |
+    = hint: Consider using string interpolation: "Hello, {name}"
 
 
 error: Expected type to be "str", but got "num" instead
@@ -2307,6 +2315,8 @@ error: Binary operator '+' cannot be applied to operands of type 'num' and 'str'
    |
 36 | let var x = 3 + "hello";
    |             ^^^^^^^^^^^
+   |
+   = hint: Consider using string interpolation: "Hello, {name}"
 
 
 error: Unsupported reassignment of element of type unresolved
@@ -4629,6 +4639,24 @@ error: Expected type to be "stringable", but got "Foo" instead
    |
    = hint: str, num, bool, json, and enums are stringable
 
+
+error: Binary operator '+' cannot be applied to operands of type 'str' and 'num'; only (num, num) and (str, str) are supported
+   --> ../../../examples/tests/invalid/stringify.test.w:25:5
+   |
+25 | log("value: " + z);
+   |     ^^^^^^^^^^^^^
+   |
+   = hint: Consider using string interpolation: "Hello, {name}"
+
+
+error: Binary operator '+' cannot be applied to operands of type 'num' and 'str'; only (num, num) and (str, str) are supported
+   --> ../../../examples/tests/invalid/stringify.test.w:28:5
+   |
+28 | log(z + " is the value");
+   |     ^^^^^^^^^^^^^^^^^^^
+   |
+   = hint: Consider using string interpolation: "Hello, {name}"
+
 Tests 1 failed (1)
 Snapshots 1 skipped
 Test Files 1 failed (1)
@@ -4974,6 +5002,8 @@ exports[`types_strings_arithmetic.test.w 1`] = `
   |
 1 | let e1 = 2 + "2";
   |          ^^^^^^^
+  |
+  = hint: Consider using string interpolation: "Hello, {name}"
 
 
 error: Expected type to be "num", but got "str" instead
@@ -5188,6 +5218,8 @@ error: Binary operator '+' cannot be applied to operands of type 'num' and 'str'
    |
 20 |     this.bucket.assert(2 + "2");
    |                        ^^^^^^^
+   |
+   = hint: Consider using string interpolation: "Hello, {name}"
 
 
 error: Member "assert" does not exist in "Bucket"


### PR DESCRIPTION
Adds a hint so if it looks like the user might want to try concatenating a non-string value onto a string, the error will suggest using string interpolation to coerce the other value into a string.

In the future we should also support directly converting values to strings: https://github.com/winglang/wing/issues/741

## Checklist

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [x] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
