### PR TITLE
chore: skip artifact upload after cloud tests

### DIFF
--- a/.github/workflows/sdk-spec-test.yml
+++ b/.github/workflows/sdk-spec-test.yml
@@ -219,12 +219,12 @@ jobs:
           cd ${{ matrix.test.directory }}
           $WING_CLI test --snapshots=deploy -t ${{ matrix.target }} -p ${{ (matrix.target == 'tf-azure' && 2 ) || (matrix.target == 'tf-gcp' && 5) || 10 }} --retry 3 $COMPATIBILITY *.test.w -o ../../../../out/${{ matrix.test.name }}-${{ matrix.target }}.json
 
-      - name: Upload Artifacts
-        if: ${{ env.LOCAL_BUILD ==  'true' }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: out
-          path: out/*
+      # - name: Upload Artifacts
+      #   if: ${{ env.LOCAL_BUILD ==  'true' }}
+      #   uses: actions/upload-artifact@v4
+      #   with:
+      #     name: out
+      #     path: out/*
 
       - name: Output Terraform log
         if: failure()


### PR DESCRIPTION
Trying to work around a build error related to updating to the latest version of https://github.com/actions/upload-artifact

## Checklist

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [ ] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
