### PR TITLE
Change Linux OS type match pattern to "linux"*

### DIFF
--- a/scripts/setup_wasi.sh
+++ b/scripts/setup_wasi.sh
@@ -11,7 +11,7 @@ SYS_OS=$OSTYPE
 SYS_ARCH=$(uname -m)
 
 # Check if mac or linux
-if [[ "$SYS_OS" == "linux-gnu"* ]]; then
+if [[ "$SYS_OS" == "linux"* ]]; then
     SYS_OS="linux"
 elif [[ "$SYS_OS" == "darwin"* ]]; then
     SYS_OS="macos"


### PR DESCRIPTION
Some Linux distributions doesn't use `linux-gnu` as their `$OSTYPE`, an example is openSUSE Tumbleweed.

Changing it to `linux` to make it works in those distributions.