### PR TITLE
feat(cli): `wing gen-docs`

### DIFF
--- a/apps/wing/fixtures/valid1/API.md
+++ b/apps/wing/fixtures/valid1/API.md
@@ -1,25 +1,24 @@
-## API Reference
+<h2>API Reference</h2>
 
-### Table of Contents
+<h3>Table of Contents</h3>
 
 - **Classes**
   - <a href="#valid1.Foo">Foo</a>
 
-### Foo (preflight class) <a id="valid1.Foo"></a>
+<h3 id="valid1.Foo">Foo (preflight class)</h3>
 
 A test class
 
-#### Constructor
+<h4>Constructor</h4>
 
 <pre>
 new(): Foo
 </pre>
 
-#### Properties
+<h4>Properties</h4>
 
 *No properties*
 
-#### Methods
+<h4>Methods</h4>
 
 *No methods*
-

--- a/apps/wing/fixtures/valid1/API.md
+++ b/apps/wing/fixtures/valid1/API.md
@@ -1,25 +1,25 @@
-## API Reference
+<h2>API Reference</h2>
 
-### Table of Contents
+<h3>Table of Contents</h3>
 
 - **Classes**
   - <a href="#valid1.Foo">Foo</a>
 
-### Foo (preflight class) <a id="valid1.Foo"></a>
+<h3 id="valid1.Foo">Foo (preflight class)</h3>
 
 A test class
 
-#### Constructor
+<h4>Constructor</h4>
 
 <pre>
 new(): Foo
 </pre>
 
-#### Properties
+<h4>Properties</h4>
 
 *No properties*
 
-#### Methods
+<h4>Methods</h4>
 
 *No methods*
 

--- a/apps/wing/fixtures/valid1/API.md
+++ b/apps/wing/fixtures/valid1/API.md
@@ -1,0 +1,25 @@
+## API Reference
+
+### Table of Contents
+
+- **Classes**
+  - <a href="#valid1.Foo">Foo</a>
+
+### Foo (preflight class) <a id="valid1.Foo"></a>
+
+A test class
+
+#### Constructor
+
+<pre>
+new(): Foo
+</pre>
+
+#### Properties
+
+*No properties*
+
+#### Methods
+
+*No methods*
+

--- a/apps/wing/fixtures/valid1/API.md
+++ b/apps/wing/fixtures/valid1/API.md
@@ -1,24 +1,25 @@
-<h2>API Reference</h2>
+## API Reference
 
-<h3>Table of Contents</h3>
+### Table of Contents
 
 - **Classes**
   - <a href="#valid1.Foo">Foo</a>
 
-<h3 id="valid1.Foo">Foo (preflight class)</h3>
+### Foo (preflight class) <a id="valid1.Foo"></a>
 
 A test class
 
-<h4>Constructor</h4>
+#### Constructor
 
 <pre>
 new(): Foo
 </pre>
 
-<h4>Properties</h4>
+#### Properties
 
 *No properties*
 
-<h4>Methods</h4>
+#### Methods
 
 *No methods*
+

--- a/apps/wing/fixtures/valid1/lib.w
+++ b/apps/wing/fixtures/valid1/lib.w
@@ -1,0 +1,2 @@
+/// A test class
+pub class Foo {}

--- a/apps/wing/src/cli.ts
+++ b/apps/wing/src/cli.ts
@@ -165,6 +165,12 @@ async function main() {
     .action(runSubCommand("lsp"));
 
   program
+    .command("generate-docs")
+    .description("Generate documentation for the current project")
+    .hook("preAction", collectAnalyticsHook)
+    .action(runSubCommand("generateDocs"));
+
+  program
     .command("compile")
     .description("Compiles a Wing program")
     .argument("[entrypoint]", "program .w entrypoint")

--- a/apps/wing/src/cli.ts
+++ b/apps/wing/src/cli.ts
@@ -165,7 +165,7 @@ async function main() {
     .action(runSubCommand("lsp"));
 
   program
-    .command("generate-docs")
+    .command("gen-docs")
     .description("Generate documentation for the current project")
     .hook("preAction", collectAnalyticsHook)
     .action(runSubCommand("generateDocs"));

--- a/apps/wing/src/commands/compile.ts
+++ b/apps/wing/src/commands/compile.ts
@@ -7,7 +7,7 @@ import chalk from "chalk";
 import debug from "debug";
 import { glob } from "glob";
 import { formatDiagnostics } from "./diagnostics";
-import { COLORING } from "src/util";
+import { COLORING } from "../util";
 
 // increase the stack trace limit to 50, useful for debugging Rust panics
 // (not setting the limit too high in case of infinite recursion)

--- a/apps/wing/src/commands/diagnostics.ts
+++ b/apps/wing/src/commands/diagnostics.ts
@@ -1,0 +1,69 @@
+import { readFile } from "fs/promises";
+import { relative } from "path";
+import { WingDiagnostic } from "@winglang/compiler";
+import { Label, File, emitDiagnostic, CHARS_ASCII } from "codespan-wasm";
+import { COLORING } from "../util";
+
+export async function formatDiagnostics(diagnostics: WingDiagnostic[]): Promise<string> {
+  const cwd = process.cwd();
+  const result = [];
+
+  for (const diagnostic of diagnostics) {
+    const { message, span, annotations, hints, severity } = diagnostic;
+    const files: File[] = [];
+    const labels: Label[] = [];
+
+    // file_id might be "" if the span is synthetic (see #2521)
+    if (span?.file_id) {
+      // `span` should only be null if source file couldn't be read etc.
+      const source = await readFile(span.file_id, "utf8");
+      const start = span.start_offset;
+      const end = span.end_offset;
+      const filePath = relative(cwd, span.file_id);
+      files.push({ name: filePath, source });
+      labels.push({
+        fileId: filePath,
+        rangeStart: start,
+        rangeEnd: end,
+        message: "",
+        style: "primary",
+      });
+    }
+
+    for (const annotation of annotations) {
+      // file_id might be "" if the span is synthetic (see #2521)
+      if (!annotation.span?.file_id) {
+        continue;
+      }
+      const source = await readFile(annotation.span.file_id, "utf8");
+      const start = annotation.span.start_offset;
+      const end = annotation.span.end_offset;
+      const filePath = relative(cwd, annotation.span.file_id);
+      files.push({ name: filePath, source });
+      labels.push({
+        fileId: filePath,
+        rangeStart: start,
+        rangeEnd: end,
+        message: annotation.message,
+        style: "secondary",
+      });
+    }
+
+    const diagnosticText = emitDiagnostic(
+      files,
+      {
+        message,
+        severity,
+        labels,
+        notes: hints.map((hint) => `hint: ${hint}`),
+      },
+      {
+        chars: CHARS_ASCII,
+      },
+      COLORING
+    );
+    result.push(diagnosticText);
+  }
+
+  return result.join("\n").trimEnd();
+}

--- a/apps/wing/src/commands/generateDocs.test.ts
+++ b/apps/wing/src/commands/generateDocs.test.ts
@@ -31,7 +31,7 @@ describe("wing gen-docs", () => {
 
     // WHEN
     await generateDocs();
-    
+
     // THEN
     const files = await fs.readdir(projectDir);
     expect(files.findIndex((path) => basename(path) === "API.md")).not.toEqual(-1);

--- a/apps/wing/src/commands/generateDocs.test.ts
+++ b/apps/wing/src/commands/generateDocs.test.ts
@@ -1,0 +1,49 @@
+import * as fs from "fs/promises";
+import { basename, join } from "path";
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { generateDocs } from "./generateDocs";
+
+const fixturesDir = join(__dirname, "..", "..", "fixtures");
+
+console.log = vi.fn();
+
+describe("wing gen-docs", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("throws an error if a project is missing package.json", async () => {
+    // GIVEN
+    const projectDir = join(fixturesDir, "invalid1");
+    process.chdir(projectDir);
+
+    // THEN
+    await expect(generateDocs()).rejects.toThrow("No package.json found in project directory");
+    await expectNoDocs(projectDir);
+  });
+
+  it("generates docs for a Wing library", async () => {
+    // GIVEN
+    const projectDir = join(fixturesDir, "valid1");
+    process.chdir(projectDir);
+
+    await fs.rm(join(projectDir, "API.md"));
+
+    // WHEN
+    await generateDocs();
+    
+    // THEN
+    const files = await fs.readdir(projectDir);
+    expect(files.findIndex((path) => basename(path) === "API.md")).not.toEqual(-1);
+    const apiMd = await fs.readFile(join(projectDir, "API.md"), "utf8");
+    expect(apiMd).toContain("Foo");
+  });
+});
+
+/**
+ * Asserts that no docs were created in the specified directory.
+ */
+async function expectNoDocs(projectDir: string) {
+  const files = await fs.readdir(projectDir);
+  expect(files.findIndex((path) => basename(path) === "API.md")).toEqual(-1);
+}

--- a/apps/wing/src/commands/generateDocs.ts
+++ b/apps/wing/src/commands/generateDocs.ts
@@ -1,0 +1,35 @@
+import { writeFile } from "fs/promises";
+import { relative, resolve } from "path";
+import * as wingCompiler from "@winglang/compiler";
+import chalk from "chalk";
+import debug from "debug";
+import { formatDiagnostics } from "./diagnostics";
+
+const log = debug("wing:generateDocs");
+const color = chalk.supportsColor ? chalk.supportsColor.hasBasic : false;
+
+export async function generateDocs() {
+  // TODO: calculate the workDir by looking up for a wing.toml file
+  // For now, assume the workDir is the current directory
+  const workDir = "."; // TODO: process.cwd()?
+
+  const docs = await wingCompiler.generateWingDocs({
+    projectDir: workDir,
+    color,
+    log,
+  });
+
+  if (docs.diagnostics.length > 0) {
+    await formatDiagnostics(docs.diagnostics);
+  }
+
+  if (docs.diagnostics.some((d) => d.severity === "error")) {
+    process.exitCode = 1;
+    return;
+  }
+
+  const docsFile = resolve(workDir, "API.md");
+  await writeFile(docsFile, docs.docsContents);
+
+  console.log(`Docs generated at ${relative(".", docsFile)}.`);
+}

--- a/apps/wing/src/commands/generateDocs.ts
+++ b/apps/wing/src/commands/generateDocs.ts
@@ -27,7 +27,6 @@ export async function generateDocs() {
     }
   }
 
-
   const docsFile = resolve(workDir, "API.md");
   await writeFile(docsFile, docs.docsContents);
 

--- a/apps/wing/src/commands/generateDocs.ts
+++ b/apps/wing/src/commands/generateDocs.ts
@@ -11,7 +11,7 @@ const color = chalk.supportsColor ? chalk.supportsColor.hasBasic : false;
 export async function generateDocs() {
   // TODO: calculate the workDir by looking up for a wing.toml file
   // For now, assume the workDir is the current directory
-  const workDir = "."; // TODO: process.cwd()?
+  const workDir = ".";
 
   const docs = await wingCompiler.generateWingDocs({
     projectDir: workDir,

--- a/apps/wing/src/commands/generateDocs.ts
+++ b/apps/wing/src/commands/generateDocs.ts
@@ -20,7 +20,7 @@ export async function generateDocs() {
   });
 
   if (docs.diagnostics.length > 0) {
-    await formatDiagnostics(docs.diagnostics);
+    console.error(await formatDiagnostics(docs.diagnostics));
   }
 
   if (docs.diagnostics.some((d) => d.severity === "error")) {

--- a/apps/wing/src/commands/generateDocs.ts
+++ b/apps/wing/src/commands/generateDocs.ts
@@ -20,13 +20,13 @@ export async function generateDocs() {
   });
 
   if (docs.diagnostics.length > 0) {
-    console.error(await formatDiagnostics(docs.diagnostics));
+    if (docs.diagnostics.some((d) => d.severity === "error")) {
+      throw new Error(await formatDiagnostics(docs.diagnostics));
+    } else {
+      console.error(await formatDiagnostics(docs.diagnostics));
+    }
   }
 
-  if (docs.diagnostics.some((d) => d.severity === "error")) {
-    process.exitCode = 1;
-    return;
-  }
 
   const docsFile = resolve(workDir, "API.md");
   await writeFile(docsFile, docs.docsContents);

--- a/apps/wing/src/util.ts
+++ b/apps/wing/src/util.ts
@@ -4,8 +4,11 @@ import * as fs from "fs/promises";
 import { tmpdir } from "os";
 import { join } from "path";
 import { promisify } from "util";
+import chalk from "chalk";
 
 export const DEFAULT_PARALLEL_SIZE = 10;
+
+export const COLORING = chalk.supportsColor ? chalk.supportsColor.hasBasic : false;
 
 /**
  * Normalize windows paths to be posix-like.

--- a/docs/api/02-cli-user-manual.md
+++ b/docs/api/02-cli-user-manual.md
@@ -242,7 +242,17 @@ This will compile your current Wing directory, and bundle it as a tarball that c
 
 See [Libraries](/docs/category/wing-libraries-winglibs) for more details on packaging and consuming Wing libraries.
 
-:::
+## Generate Docs: `wing gen-docs`
+
+The `wing gen-docs` command can be used to generate API documentation for your Wing project.
+
+Usage:
+
+```sh
+$ wing gen-docs
+```
+
+This will generate a file named `API.md` in the root of your project.
 
 ## Store Secrets: `wing secrets`
 

--- a/examples/wing-fixture/API.md
+++ b/examples/wing-fixture/API.md
@@ -1,6 +1,6 @@
-## API Reference
+<h2>API Reference</h2>
 
-### Table of Contents
+<h3>Table of Contents</h3>
 
 - **Classes**
   - <a href="#@winglibs/testfixture.PublicClass">PublicClass</a>
@@ -14,39 +14,39 @@
 - **Enums**
   - <a href="#@winglibs/testfixture.FavoriteNumbers">FavoriteNumbers</a>
 
-### PublicClass (preflight class) <a id="@winglibs/testfixture.PublicClass"></a>
+<h3 id="@winglibs/testfixture.PublicClass">PublicClass (preflight class)</h3>
 
-#### Constructor
+<h4>Constructor</h4>
 
 <pre>
 new(): PublicClass
 </pre>
 
-#### Properties
+<h4>Properties</h4>
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
 | <code>publicField</code> | <code>num</code> | *No description* |
 
-#### Methods
+<h4>Methods</h4>
 
 | **Signature** | **Description** |
 | --- | --- |
 | <code>publicMethod(): void</code> | *No description* |
 
-### Store (preflight class) <a id="@winglibs/testfixture.Store"></a>
+<h3 id="@winglibs/testfixture.Store">Store (preflight class)</h3>
 
-#### Constructor
+<h4>Constructor</h4>
 
 <pre>
 new(options: StoreOptions?): Store
 </pre>
 
-#### Properties
+<h4>Properties</h4>
 
 *No properties*
 
-#### Methods
+<h4>Methods</h4>
 
 | **Signature** | **Description** |
 | --- | --- |
@@ -55,52 +55,52 @@ new(options: StoreOptions?): Store
 | <code>onSet(handler: inflight (str): void): void</code> | *No description* |
 | <code>inflight set(message: str): void</code> | *No description* |
 
-### subdir.Util (preflight class) <a id="@winglibs/testfixture.subdir.Util"></a>
+<h3 id="@winglibs/testfixture.subdir.Util">subdir.Util (preflight class)</h3>
 
-#### Constructor
+<h4>Constructor</h4>
 
 <pre>
 new(): Util
 </pre>
 
-#### Properties
+<h4>Properties</h4>
 
 *No properties*
 
-#### Methods
+<h4>Methods</h4>
 
 | **Signature** | **Description** |
 | --- | --- |
 | <code>static inflight double(msg: str): str</code> | *No description* |
 | <code>static inflight makeKeyInflight(name: str): str</code> | *No description* |
 
-### PublicInterface (interface) <a name=PublicInterface id="@winglibs/testfixture.PublicInterface"></a>
+<h3 id="@winglibs/testfixture.PublicInterface">PublicInterface (interface)</h3>
 
-#### Properties
+<h4>Properties</h4>
 
 *No properties*
 
-#### Methods
+<h4>Methods</h4>
 
 *No methods*
 
-### PublicStruct (struct) <a name=PublicStruct id="@winglibs/testfixture.PublicStruct"></a>
+<h3 id="@winglibs/testfixture.PublicStruct">PublicStruct (struct)</h3>
 
-#### Properties
+<h4>Properties</h4>
 
 *No properties*
 
-### StoreOptions (struct) <a name=StoreOptions id="@winglibs/testfixture.StoreOptions"></a>
+<h3 id="@winglibs/testfixture.StoreOptions">StoreOptions (struct)</h3>
 
-#### Properties
+<h4>Properties</h4>
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
 | <code>name</code> | <code>str?</code> | *No description* |
 
-### FavoriteNumbers (enum) <a name=FavoriteNumbers id="@winglibs/testfixture.FavoriteNumbers"></a>
+<h3 id="@winglibs/testfixture.FavoriteNumbers">FavoriteNumbers (enum)</h3>
 
-#### Values
+<h4>Values</h4>
 
 | **Name** | **Description** |
 | --- | --- |

--- a/examples/wing-fixture/API.md
+++ b/examples/wing-fixture/API.md
@@ -1,0 +1,109 @@
+## API Reference
+
+### Table of Contents
+
+- **Classes**
+  - <a href="#@winglibs/testfixture.PublicClass">PublicClass</a>
+  - <a href="#@winglibs/testfixture.Store">Store</a>
+  - <a href="#@winglibs/testfixture.subdir.Util">subdir.Util</a>
+- **Interfaces**
+  - <a href="#@winglibs/testfixture.PublicInterface">PublicInterface</a>
+- **Structs**
+  - <a href="#@winglibs/testfixture.PublicStruct">PublicStruct</a>
+  - <a href="#@winglibs/testfixture.StoreOptions">StoreOptions</a>
+- **Enums**
+  - <a href="#@winglibs/testfixture.FavoriteNumbers">FavoriteNumbers</a>
+
+### PublicClass (preflight class) <a id="@winglibs/testfixture.PublicClass"></a>
+
+#### Constructor
+
+<pre>
+new(): PublicClass
+</pre>
+
+#### Properties
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code>publicField</code> | <code>num</code> | *No description* |
+
+#### Methods
+
+| **Signature** | **Description** |
+| --- | --- |
+| <code>publicMethod(): void</code> | *No description* |
+
+### Store (preflight class) <a id="@winglibs/testfixture.Store"></a>
+
+#### Constructor
+
+<pre>
+new(options: StoreOptions?): Store
+</pre>
+
+#### Properties
+
+*No properties*
+
+#### Methods
+
+| **Signature** | **Description** |
+| --- | --- |
+| <code>static makeKey(name: str): str</code> | *No description* |
+| <code>static inflight makeKeyInflight(name: str): str</code> | *No description* |
+| <code>onSet(handler: inflight (str): void): void</code> | *No description* |
+| <code>inflight set(message: str): void</code> | *No description* |
+
+### subdir.Util (preflight class) <a id="@winglibs/testfixture.subdir.Util"></a>
+
+#### Constructor
+
+<pre>
+new(): Util
+</pre>
+
+#### Properties
+
+*No properties*
+
+#### Methods
+
+| **Signature** | **Description** |
+| --- | --- |
+| <code>static inflight double(msg: str): str</code> | *No description* |
+| <code>static inflight makeKeyInflight(name: str): str</code> | *No description* |
+
+### PublicInterface (interface) <a name=PublicInterface id="@winglibs/testfixture.PublicInterface"></a>
+
+#### Properties
+
+*No properties*
+
+#### Methods
+
+*No methods*
+
+### PublicStruct (struct) <a name=PublicStruct id="@winglibs/testfixture.PublicStruct"></a>
+
+#### Properties
+
+*No properties*
+
+### StoreOptions (struct) <a name=StoreOptions id="@winglibs/testfixture.StoreOptions"></a>
+
+#### Properties
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code>name</code> | <code>str?</code> | *No description* |
+
+### FavoriteNumbers (enum) <a name=FavoriteNumbers id="@winglibs/testfixture.FavoriteNumbers"></a>
+
+#### Values
+
+| **Name** | **Description** |
+| --- | --- |
+| <code>SEVEN</code> | *No description* |
+| <code>FORTY_TWO</code> | *No description* |
+

--- a/examples/wing-fixture/package.json
+++ b/examples/wing-fixture/package.json
@@ -10,7 +10,7 @@
   },
   "scripts": {
     "compile": "wing compile .",
-    "test": "wing test"
+    "test": "wing test && wing gen-docs"
   },
   "license": "MIT",
   "engines": {

--- a/libs/wingc/examples/generate_docs.rs
+++ b/libs/wingc/examples/generate_docs.rs
@@ -1,0 +1,30 @@
+// Compiles a project directory and generates docs for it.
+
+use camino::Utf8Path;
+use std::{env, process};
+use wingc::{diagnostic::get_diagnostics, generate_docs::generate_docs};
+
+pub fn main() {
+	let args: Vec<String> = env::args().collect();
+
+	if args.len() < 2 {
+		panic!("Usage: cargo run --example generate_docs <project_dir>");
+	}
+
+	let project_dir = Utf8Path::new(&args[1]).canonicalize_utf8().unwrap();
+
+	let docs = generate_docs(&project_dir);
+	let mut diags = get_diagnostics();
+	if !diags.is_empty() {
+		// Sort error messages by line number (ascending)
+		diags.sort();
+		eprintln!(
+			"Compilation failed with {} errors\n{}",
+			diags.len(),
+			diags.iter().map(|d| format!("{}", d)).collect::<Vec<_>>().join("\n")
+		);
+		process::exit(1);
+	}
+
+	println!("{}", docs.unwrap());
+}

--- a/libs/wingc/src/comp_ctx.rs
+++ b/libs/wingc/src/comp_ctx.rs
@@ -65,20 +65,19 @@ impl CompilationContext {
 }
 
 pub fn set_custom_panic_hook() {
-	std::panic::set_hook(Box::new(|pi| {
-		// Print backtrace if RUST_BACKTRACE=1
+	std::panic::set_hook(Box::new(|info| {
 		let bt = Backtrace::capture();
 		if bt.status() == BacktraceStatus::Captured {
 			eprintln!("Panic backtrace:\n{}", bt);
 		} else {
-			eprintln!("Panicked, backtrace not captured: {:?}", bt.status());
+			eprintln!("Panic message:\n{}", info.to_string());
 		}
 
 		report_diagnostic(Diagnostic {
 			message: format!(
 				"Compiler bug during {} ('{}'), please report at https://www.winglang.io/contributing/start-here/bugs",
 				CompilationContext::get_phase(),
-				pi,
+				info,
 			),
 			span: Some(CompilationContext::get_span()),
 			annotations: vec![],

--- a/libs/wingc/src/generate_docs.rs
+++ b/libs/wingc/src/generate_docs.rs
@@ -1,0 +1,195 @@
+use camino::{Utf8Path, Utf8PathBuf};
+use indexmap::IndexMap;
+use wingii::type_system::TypeSystem;
+
+use crate::{
+	ast::{AccessModifier, Scope},
+	closure_transform::ClosureTransformer,
+	diagnostic::{found_errors, report_diagnostic, Diagnostic, DiagnosticSeverity},
+	emit_warning_for_unsupported_package_managers,
+	file_graph::{File, FileGraph},
+	files::Files,
+	fold::Fold,
+	is_absolute_path,
+	jsify::JSifier,
+	lifting::LiftVisitor,
+	parser::{as_wing_library, normalize_path, parse_wing_project},
+	type_check::{
+		type_reference_transform::TypeReferenceTransformer, Namespace, NamespaceRef, SymbolEnvOrNamespace, SymbolKind,
+		TypeRef, Types, UnsafeRef,
+	},
+	type_check_assert::TypeCheckAssert,
+	type_check_file,
+	valid_json_visitor::ValidJsonVisitor,
+	visit::Visit,
+};
+
+/// Generate documentation for the project
+pub fn generate_docs(project_dir: &Utf8Path) -> Result<String, ()> {
+	let source_package = as_wing_library(project_dir);
+	if source_package.is_none() {
+		report_diagnostic(Diagnostic {
+			message: "No package.json found in project directory".to_string(),
+			span: None,
+			annotations: vec![],
+			hints: vec![],
+			severity: DiagnosticSeverity::Error,
+		});
+	}
+	let source_path = normalize_path(&project_dir, None);
+	let source_file = File::new(&source_path, source_path.to_string());
+
+	// -- PARSING PHASE --
+	let mut files = Files::new();
+	let mut file_graph = FileGraph::default();
+	let mut tree_sitter_trees = IndexMap::new();
+	let mut asts = IndexMap::new();
+	let topo_sorted_files = parse_wing_project(
+		&source_file,
+		None,
+		&mut files,
+		&mut file_graph,
+		&mut tree_sitter_trees,
+		&mut asts,
+	);
+
+	emit_warning_for_unsupported_package_managers(&project_dir);
+
+	// -- DESUGARING PHASE --
+
+	// Transform all inflight closures defined in preflight into single-method resources
+	let mut asts = asts
+		.into_iter()
+		.map(|(path, scope)| {
+			let mut inflight_transformer = ClosureTransformer::new();
+			let scope = inflight_transformer.fold_scope(scope);
+			(path, scope)
+		})
+		.collect::<IndexMap<Utf8PathBuf, Scope>>();
+
+	// -- TYPECHECKING PHASE --
+
+	// Create universal types collection (need to keep this alive during entire compilation)
+	let mut types = Types::new();
+	let mut jsii_types = TypeSystem::new();
+
+	// Create a universal JSII import spec (need to keep this alive during entire compilation)
+	let mut jsii_imports = vec![];
+
+	// Type check all files in topological order (start with files that don't bring any other
+	// Wing files, then move on to files that depend on those, and repeat)
+	for file in &topo_sorted_files {
+		let mut scope = asts.swap_remove(&file.path).expect("matching AST not found");
+		type_check_file(
+			&mut scope,
+			&mut types,
+			&file,
+			&file_graph,
+			&mut jsii_types,
+			&mut jsii_imports,
+		);
+
+		// Make sure all type reference are no longer considered references
+		let mut tr_transformer = TypeReferenceTransformer { types: &mut types };
+		let scope = tr_transformer.fold_scope(scope);
+
+		// Validate the type checker didn't miss anything - see `TypeCheckAssert` for details
+		let mut tc_assert = TypeCheckAssert::new(&types, found_errors());
+		tc_assert.check(&scope);
+
+		// Validate all Json literals to make sure their values are legal
+		let mut json_checker = ValidJsonVisitor::new(&types);
+		json_checker.check(&scope);
+
+		asts.insert(file.path.to_owned(), scope);
+	}
+
+	// Verify that the project dir is absolute
+	if !is_absolute_path(&project_dir) {
+		report_diagnostic(Diagnostic {
+			message: format!("Project directory must be absolute: {}", project_dir),
+			span: None,
+			annotations: vec![],
+			hints: vec![],
+			severity: DiagnosticSeverity::Error,
+		});
+		return Err(());
+	}
+
+	let jsifier = JSifier::new(
+		&mut types,
+		&files,
+		&file_graph,
+		&source_path,
+		// out_dir will not be used
+		&source_path,
+	);
+
+	// -- LIFTING PHASE --
+
+	for (_path, scope) in &asts {
+		let mut lift = LiftVisitor::new(&jsifier);
+		lift.visit_scope(&scope);
+	}
+
+	// bail out now (before jsification) if there are errors (no point in jsifying)
+	if found_errors() {
+		return Err(());
+	}
+
+	return generate_docs_helper(&types, project_dir);
+}
+
+fn generate_docs_helper(types: &Types, project_dir: &Utf8Path) -> Result<String, ()> {
+	let docs = String::new();
+	let root_env = types.source_file_envs.get(project_dir).expect("No root env found");
+	let ns = match root_env {
+		SymbolEnvOrNamespace::Namespace(ns) => *ns,
+		SymbolEnvOrNamespace::SymbolEnv(_) => panic!("Root env is not a namespace"),
+		SymbolEnvOrNamespace::Error(diag) => panic!("Error in root env: {}", diag),
+	};
+
+	let namespaces = find_documentable_namespaces_recursive(&ns);
+	for ns in namespaces {
+		println!("{}", ns.name);
+		let public_types = find_public_types_in_namespace(&ns);
+		for (name, typ) in public_types {
+			println!(" - {} ({})", name, typ);
+		}
+	}
+	Ok(docs)
+}
+
+/// Return a list of all of the public namespaces directly in this namespace and all of its children, including
+/// this namespace if it has any public elements.
+pub fn find_documentable_namespaces_recursive(ns: &Namespace) -> Vec<NamespaceRef> {
+	let mut namespaces = vec![];
+	if ns.has_public_api_elements() {
+		namespaces.push(UnsafeRef::from(ns));
+	}
+	for env in ns.envs.iter() {
+		for entry in env.symbol_map.values() {
+			if let SymbolKind::Namespace(child_ns) = entry.kind {
+				if entry.access == AccessModifier::Public {
+					namespaces.extend(find_documentable_namespaces_recursive(&child_ns));
+				}
+			}
+		}
+	}
+	namespaces
+}
+
+/// Return a list of all public types directly in this namespace (does not include types in child namespaces).
+pub fn find_public_types_in_namespace(ns: &Namespace) -> Vec<(String, TypeRef)> {
+	let mut entries = vec![];
+	for env in ns.envs.iter() {
+		for (name, entry) in env.symbol_map.iter() {
+			if entry.access == AccessModifier::Public {
+				if let SymbolKind::Type(typ) = entry.kind {
+					entries.push((name.clone(), typ));
+				}
+			}
+		}
+	}
+	return entries;
+}

--- a/libs/wingc/src/generate_docs.rs
+++ b/libs/wingc/src/generate_docs.rs
@@ -16,8 +16,7 @@ use crate::{
 	parser::{as_wing_library, normalize_path, parse_wing_project},
 	type_check::{
 		type_reference_transform::TypeReferenceTransformer, ClassLike, FunctionSignature, HasFqn, Namespace, NamespaceRef,
-		SymbolEnvOrNamespace, SymbolKind, Type, TypeRef, Types, UnsafeRef, VariableKind, CLASS_INFLIGHT_INIT_NAME,
-		CLASS_INIT_NAME,
+		SymbolEnvOrNamespace, SymbolKind, Type, TypeRef, Types, UnsafeRef, VariableKind,
 	},
 	type_check_assert::TypeCheckAssert,
 	type_check_file,
@@ -138,13 +137,11 @@ pub fn generate_docs(project_dir: &Utf8Path) -> Result<String, ()> {
 	return generate_docs_helper(&types, &source_path);
 }
 
-const HIDDEN_METHODS: [&str; 8] = [
+const HIDDEN_METHODS: [&str; 6] = [
 	"toString",
 	"toJSON",
 	"onLift",
 	"onLiftType",
-	CLASS_INIT_NAME,
-	CLASS_INFLIGHT_INIT_NAME,
 	"toInflight",
 	"isConstruct",
 ];

--- a/libs/wingc/src/generate_docs.rs
+++ b/libs/wingc/src/generate_docs.rs
@@ -27,7 +27,7 @@ use crate::{
 /// Generate documentation for the project
 pub fn generate_docs(project_dir: &Utf8Path) -> Result<String, ()> {
 	let project_dir = find_nearest_wing_project_dir(project_dir);
-	let source_package = as_wing_library(&project_dir);
+	let source_package = as_wing_library(&project_dir, false);
 	if source_package.is_none() {
 		report_diagnostic(Diagnostic {
 			message: "No package.json found in project directory".to_string(),
@@ -36,6 +36,7 @@ pub fn generate_docs(project_dir: &Utf8Path) -> Result<String, ()> {
 			hints: vec![],
 			severity: DiagnosticSeverity::Error,
 		});
+		return Err(());
 	}
 	let source_package = source_package.unwrap();
 	let source_path = normalize_path(&project_dir, None);
@@ -290,9 +291,7 @@ fn print_classes(types: &[TypeRef], docs: &mut String) {
 			docs.push_str(&simplified_fqn(typ));
 			docs.push_str(" (");
 			docs.push_str(&class.phase.to_string());
-			docs.push_str(" class) <a name=");
-			docs.push_str(&simplified_fqn(typ));
-			docs.push_str(" id=\"");
+			docs.push_str(" class) <a id=\"");
 			docs.push_str(&typ.fqn().expect("Type has no FQN"));
 			docs.push_str("\"></a>\n\n");
 

--- a/libs/wingc/src/generate_docs.rs
+++ b/libs/wingc/src/generate_docs.rs
@@ -11,7 +11,6 @@ use crate::{
 	files::Files,
 	find_nearest_wing_project_dir,
 	fold::Fold,
-	is_absolute_path,
 	jsify::JSifier,
 	lifting::LiftVisitor,
 	parser::{as_wing_library, normalize_path, parse_wing_project},
@@ -114,18 +113,6 @@ pub fn generate_docs(project_dir: &Utf8Path) -> Result<String, ()> {
 		asts.insert(file.path.to_owned(), scope);
 	}
 
-	// Verify that the project dir is absolute
-	if !is_absolute_path(&project_dir) {
-		report_diagnostic(Diagnostic {
-			message: format!("Project directory must be absolute: {}", project_dir),
-			span: None,
-			annotations: vec![],
-			hints: vec![],
-			severity: DiagnosticSeverity::Error,
-		});
-		return Err(());
-	}
-
 	let jsifier = JSifier::new(
 		&mut types,
 		&files,
@@ -148,7 +135,7 @@ pub fn generate_docs(project_dir: &Utf8Path) -> Result<String, ()> {
 	}
 
 	// -- DOC GENERATION PHASE --
-	return generate_docs_helper(&types, &project_dir);
+	return generate_docs_helper(&types, &source_path);
 }
 
 const HIDDEN_METHODS: [&str; 8] = [
@@ -429,6 +416,8 @@ fn print_constructors(docs: &mut String, class: &impl ClassLike) {
 		}
 		docs.push_str("</pre>\n");
 	}
+
+	docs.push_str("\n");
 }
 
 fn print_properties(docs: &mut String, class: &impl ClassLike) {

--- a/libs/wingc/src/generate_docs.rs
+++ b/libs/wingc/src/generate_docs.rs
@@ -156,7 +156,7 @@ fn generate_docs_helper(types: &Types, project_dir: &Utf8Path) -> Result<String,
 		SymbolEnvOrNamespace::Error(diag) => panic!("Error in root env: {}", diag),
 	};
 
-	docs.push_str("## API Reference\n\n");
+	docs.push_str("<h2>API Reference</h2>\n\n");
 
 	let mut public_types = vec![];
 	let namespaces = find_documentable_namespaces_recursive(&ns);
@@ -220,7 +220,7 @@ fn simplified_fqn(typ: &TypeRef) -> String {
 }
 
 fn print_table_of_contents(types: &[TypeRef], docs: &mut String) {
-	docs.push_str("### Table of Contents\n\n");
+	docs.push_str("<h3>Table of Contents</h3>\n\n");
 
 	let mut classes = vec![];
 	let mut interfaces = vec![];
@@ -287,13 +287,13 @@ fn print_table_of_contents(types: &[TypeRef], docs: &mut String) {
 fn print_classes(types: &[TypeRef], docs: &mut String) {
 	for typ in types {
 		if let Type::Class(ref class) = **typ {
-			docs.push_str("### ");
+			docs.push_str("<h3 id=\"");
+			docs.push_str(&typ.fqn().expect("Type has no FQN"));
+			docs.push_str("\">");
 			docs.push_str(&simplified_fqn(typ));
 			docs.push_str(" (");
 			docs.push_str(&class.phase.to_string());
-			docs.push_str(" class) <a id=\"");
-			docs.push_str(&typ.fqn().expect("Type has no FQN"));
-			docs.push_str("\"></a>\n\n");
+			docs.push_str(" class)</h3>\n\n");
 
 			let docstring = class.docs.render();
 			if !docstring.is_empty() {
@@ -311,13 +311,11 @@ fn print_classes(types: &[TypeRef], docs: &mut String) {
 fn print_interfaces(types: &[TypeRef], docs: &mut String) {
 	for typ in types {
 		if let Type::Interface(ref interface) = **typ {
-			docs.push_str("### ");
-			docs.push_str(&simplified_fqn(typ));
-			docs.push_str(" (interface) <a name=");
-			docs.push_str(&simplified_fqn(typ));
-			docs.push_str(" id=\"");
+			docs.push_str("<h3 id=\"");
 			docs.push_str(&typ.fqn().expect("Type has no FQN"));
-			docs.push_str("\"></a>\n\n");
+			docs.push_str("\">");
+			docs.push_str(&simplified_fqn(typ));
+			docs.push_str(" (interface)</h3>\n\n");
 
 			let docstring = interface.docs.render();
 			if !docstring.is_empty() {
@@ -334,13 +332,11 @@ fn print_interfaces(types: &[TypeRef], docs: &mut String) {
 fn print_structs(types: &[TypeRef], docs: &mut String) {
 	for typ in types {
 		if let Type::Struct(ref struct_) = **typ {
-			docs.push_str("### ");
-			docs.push_str(&simplified_fqn(typ));
-			docs.push_str(" (struct) <a name=");
-			docs.push_str(&simplified_fqn(typ));
-			docs.push_str(" id=\"");
+			docs.push_str("<h3 id=\"");
 			docs.push_str(&typ.fqn().expect("Type has no FQN"));
-			docs.push_str("\"></a>\n\n");
+			docs.push_str("\">");
+			docs.push_str(&simplified_fqn(typ));
+			docs.push_str(" (struct)</h3>\n\n");
 
 			let docstring = struct_.docs.render();
 			if !docstring.is_empty() {
@@ -356,13 +352,11 @@ fn print_structs(types: &[TypeRef], docs: &mut String) {
 fn print_enums(types: &[TypeRef], docs: &mut String) {
 	for typ in types {
 		if let Type::Enum(ref enum_) = **typ {
-			docs.push_str("### ");
-			docs.push_str(&simplified_fqn(typ));
-			docs.push_str(" (enum) <a name=");
-			docs.push_str(&simplified_fqn(typ));
-			docs.push_str(" id=\"");
+			docs.push_str("<h3 id=\"");
 			docs.push_str(&typ.fqn().expect("Type has no FQN"));
-			docs.push_str("\"></a>\n\n");
+			docs.push_str("\">");
+			docs.push_str(&simplified_fqn(typ));
+			docs.push_str(" (enum)</h3>\n\n");
 
 			let docstring = enum_.docs.render();
 			if !docstring.is_empty() {
@@ -370,7 +364,7 @@ fn print_enums(types: &[TypeRef], docs: &mut String) {
 				docs.push_str("\n\n");
 			}
 
-			docs.push_str("#### Values\n\n");
+			docs.push_str("<h4>Values</h4>\n\n");
 			docs.push_str("| **Name** | **Description** |\n");
 			docs.push_str("| --- | --- |\n");
 			for (name, description) in enum_.values.iter() {
@@ -391,7 +385,7 @@ fn print_enums(types: &[TypeRef], docs: &mut String) {
 }
 
 fn print_constructors(docs: &mut String, class: &impl ClassLike) {
-	docs.push_str("#### Constructor\n\n");
+	docs.push_str("<h4>Constructor</h4>\n\n");
 
 	let mut constructors = class.constructors(true).collect::<Vec<_>>();
 	constructors.retain(|(_, constructor_info)| constructor_info.access == AccessModifier::Public);
@@ -417,7 +411,7 @@ fn print_constructors(docs: &mut String, class: &impl ClassLike) {
 }
 
 fn print_properties(docs: &mut String, class: &impl ClassLike) {
-	docs.push_str("#### Properties\n\n");
+	docs.push_str("<h4>Properties</h4>\n\n");
 
 	let mut fields = class.fields(true).collect::<Vec<_>>();
 	fields.retain(|(_, field_info)| field_info.access == AccessModifier::Public);
@@ -447,7 +441,7 @@ fn print_properties(docs: &mut String, class: &impl ClassLike) {
 }
 
 fn print_methods(docs: &mut String, class: &impl ClassLike) {
-	docs.push_str("#### Methods\n\n");
+	docs.push_str("<h4>Methods</h4>\n\n");
 
 	let mut methods = class.methods(true).collect::<Vec<_>>();
 	methods.retain(|(_, method_info)| method_info.access == AccessModifier::Public);

--- a/libs/wingc/src/lib.rs
+++ b/libs/wingc/src/lib.rs
@@ -17,6 +17,7 @@ use dtsify::extern_dtsify::{is_extern_file, ExternDTSifier};
 use file_graph::{File, FileGraph};
 use files::Files;
 use fold::Fold;
+use generate_docs::generate_docs;
 use indexmap::IndexMap;
 use jsify::JSifier;
 
@@ -56,6 +57,7 @@ mod dtsify;
 mod file_graph;
 mod files;
 pub mod fold;
+pub mod generate_docs;
 pub mod jsify;
 pub mod json_schema_generator;
 mod lifting;
@@ -164,26 +166,6 @@ pub unsafe extern "C" fn wingc_malloc(size: usize) -> *mut u8 {
 	}
 }
 
-const LOCKFILES: [&'static str; 4] = ["pnpm-lock.yaml", "yarn.lock", "bun.lock", "bun.lockb"];
-
-/// Wing sometimes can't find dependencies if they're installed with pnpm/yarn/bun.
-/// Try to anticipate any issues that may arise from using pnpm/yarn/bun with winglibs
-/// by emitting a warning if dependencies were installed with any of these package managers.
-fn emit_warning_for_unsupported_package_managers(project_dir: &Utf8Path) {
-	for lockfile in &LOCKFILES {
-		let lockfile_path = project_dir.join(lockfile);
-		if lockfile_path.exists() {
-			report_diagnostic(Diagnostic {
-				message: "The current project has a pnpm/yarn/bun lockfile. Wing hasn't been tested with package managers besides npm, so it may be unable to resolve dependencies to Wing libraries when using these tools. See https://github.com/winglang/wing/issues/6129 for more details.".to_string(),
-				span: None,
-				annotations: vec![],
-				hints: vec![],
-				severity: DiagnosticSeverity::Warning,
-			});
-		}
-	}
-}
-
 /// Expose a deallocation function to the WASM host
 ///
 /// _This implementation is copied from wasm-bindgen_
@@ -249,7 +231,40 @@ pub unsafe extern "C" fn wingc_compile(ptr: u32, len: u32) -> u64 {
 	}
 }
 
-pub fn type_check(
+#[no_mangle]
+pub unsafe extern "C" fn wingc_generate_docs(ptr: u32, len: u32) -> u64 {
+	let args = ptr_to_str(ptr, len);
+	let project_dir = Utf8Path::new(args);
+	let results = generate_docs(project_dir);
+
+	if let Ok(results) = results {
+		string_to_combined_ptr(serde_json::to_string(&results).unwrap())
+	} else {
+		WASM_RETURN_ERROR
+	}
+}
+
+const LOCKFILES: [&'static str; 4] = ["pnpm-lock.yaml", "yarn.lock", "bun.lock", "bun.lockb"];
+
+/// Wing sometimes can't find dependencies if they're installed with pnpm/yarn/bun.
+/// Try to anticipate any issues that may arise from using pnpm/yarn/bun with winglibs
+/// by emitting a warning if dependencies were installed with any of these package managers.
+fn emit_warning_for_unsupported_package_managers(project_dir: &Utf8Path) {
+	for lockfile in &LOCKFILES {
+		let lockfile_path = project_dir.join(lockfile);
+		if lockfile_path.exists() {
+			report_diagnostic(Diagnostic {
+				message: "The current project has a pnpm/yarn/bun lockfile. Wing hasn't been tested with package managers besides npm, so it may be unable to resolve dependencies to Wing libraries when using these tools. See https://github.com/winglang/wing/issues/6129 for more details.".to_string(),
+				span: None,
+				annotations: vec![],
+				hints: vec![],
+				severity: DiagnosticSeverity::Warning,
+			});
+		}
+	}
+}
+
+pub fn type_check_file(
 	scope: &mut Scope,
 	types: &mut Types,
 	file: &File,
@@ -337,7 +352,7 @@ pub fn compile(
 	// Wing files, then move on to files that depend on those, and repeat)
 	for file in &topo_sorted_files {
 		let mut scope = asts.swap_remove(&file.path).expect("matching AST not found");
-		type_check(
+		type_check_file(
 			&mut scope,
 			&mut types,
 			&file,

--- a/libs/wingc/src/lib.rs
+++ b/libs/wingc/src/lib.rs
@@ -234,7 +234,7 @@ pub unsafe extern "C" fn wingc_generate_docs(ptr: u32, len: u32) -> u64 {
 	let results = generate_docs(project_dir);
 
 	if let Ok(results) = results {
-		string_to_combined_ptr(serde_json::to_string(&results).unwrap())
+		string_to_combined_ptr(results)
 	} else {
 		WASM_RETURN_ERROR
 	}

--- a/libs/wingc/src/lib.rs
+++ b/libs/wingc/src/lib.rs
@@ -327,7 +327,7 @@ pub fn find_nearest_wing_project_dir(source_path: &Utf8Path) -> Utf8PathBuf {
 
 pub fn compile(source_path: &Utf8Path, source_text: Option<String>, out_dir: &Utf8Path) -> Result<CompilerOutput, ()> {
 	let project_dir = find_nearest_wing_project_dir(source_path);
-	let source_package = as_wing_library(&project_dir).unwrap_or_else(|| DEFAULT_PACKAGE_NAME.to_string());
+	let source_package = as_wing_library(&project_dir, false).unwrap_or_else(|| DEFAULT_PACKAGE_NAME.to_string());
 	let source_path = normalize_path(source_path, None);
 	let source_file = File::new(&source_path, source_package.clone());
 

--- a/libs/wingc/src/lib.rs
+++ b/libs/wingc/src/lib.rs
@@ -265,7 +265,7 @@ pub fn type_check_file(
 	types: &mut Types,
 	file: &File,
 	file_graph: &FileGraph,
-	library_roots: &mut IndexMap<String, Utf8PathBuf>,
+	library_roots: &IndexMap<String, Utf8PathBuf>,
 	jsii_types: &mut TypeSystem,
 	jsii_imports: &mut Vec<JsiiImportSpec>,
 ) {

--- a/libs/wingc/src/lsp/snapshots/hovers/class_doc.snap
+++ b/libs/wingc/src/lsp/snapshots/hovers/class_doc.snap
@@ -3,7 +3,7 @@ source: libs/wingc/src/lsp/hover.rs
 ---
 contents:
   kind: markdown
-  value: "```wing\nclass Foo {\n  // No public members\n}\n```\n---\n Class doc"
+  value: "```wing\nclass Foo {\n  // No public members\n}\n```\n---\nClass doc"
 range:
   start:
     line: 2

--- a/libs/wingc/src/lsp/snapshots/hovers/class_doc_with_multiline_and_markdown.snap
+++ b/libs/wingc/src/lsp/snapshots/hovers/class_doc_with_multiline_and_markdown.snap
@@ -3,7 +3,7 @@ source: libs/wingc/src/lsp/hover.rs
 ---
 contents:
   kind: markdown
-  value: "```wing\nclass Foo {\n  a: num;\n}\n```\n---\n Class doc\n With multiline\n ## And markdown"
+  value: "```wing\nclass Foo {\n  a: num;\n}\n```\n---\nClass doc\nWith multiline\n## And markdown"
 range:
   start:
     line: 4

--- a/libs/wingc/src/lsp/snapshots/hovers/class_field_doc.snap
+++ b/libs/wingc/src/lsp/snapshots/hovers/class_field_doc.snap
@@ -3,7 +3,7 @@ source: libs/wingc/src/lsp/hover.rs
 ---
 contents:
   kind: markdown
-  value: "```wing\npreflight field: num\n```\n---\n Class field doc"
+  value: "```wing\npreflight field: num\n```\n---\nClass field doc"
 range:
   start:
     line: 3

--- a/libs/wingc/src/lsp/snapshots/hovers/class_method_doc.snap
+++ b/libs/wingc/src/lsp/snapshots/hovers/class_method_doc.snap
@@ -3,7 +3,7 @@ source: libs/wingc/src/lsp/hover.rs
 ---
 contents:
   kind: markdown
-  value: "```wing\npreflight do(): void\n```\n---\n Class method doc"
+  value: "```wing\npreflight do(): void\n```\n---\nClass method doc"
 range:
   start:
     line: 3

--- a/libs/wingc/src/lsp/snapshots/hovers/ctor_doc.snap
+++ b/libs/wingc/src/lsp/snapshots/hovers/ctor_doc.snap
@@ -3,7 +3,7 @@ source: libs/wingc/src/lsp/hover.rs
 ---
 contents:
   kind: markdown
-  value: "```wing\nnew(): Bob\n```\n---\n I'm bob the constructor"
+  value: "```wing\nnew(): Bob\n```\n---\nI'm bob the constructor"
 range:
   start:
     line: 3

--- a/libs/wingc/src/lsp/snapshots/hovers/ctor_doc_from_new_expr.snap
+++ b/libs/wingc/src/lsp/snapshots/hovers/ctor_doc_from_new_expr.snap
@@ -3,7 +3,7 @@ source: libs/wingc/src/lsp/hover.rs
 ---
 contents:
   kind: markdown
-  value: "```wing\nnew(): Bob\n```\n---\n I'm bob the constructor"
+  value: "```wing\nnew(): Bob\n```\n---\nI'm bob the constructor"
 range:
   start:
     line: 5

--- a/libs/wingc/src/lsp/snapshots/hovers/enum_doc.snap
+++ b/libs/wingc/src/lsp/snapshots/hovers/enum_doc.snap
@@ -3,7 +3,7 @@ source: libs/wingc/src/lsp/hover.rs
 ---
 contents:
   kind: markdown
-  value: "```wing\nenum Foo {\n}\n```\n---\n Enum doc"
+  value: "```wing\nenum Foo {\n}\n```\n---\nEnum doc"
 range:
   start:
     line: 2

--- a/libs/wingc/src/lsp/snapshots/hovers/ignoe_empty_lines_in_doc.snap
+++ b/libs/wingc/src/lsp/snapshots/hovers/ignoe_empty_lines_in_doc.snap
@@ -3,7 +3,7 @@ source: libs/wingc/src/lsp/hover.rs
 ---
 contents:
   kind: markdown
-  value: "```wing\nclass Foo {\n  // No public members\n}\n```\n---\n Class doc with empty lines after it"
+  value: "```wing\nclass Foo {\n  // No public members\n}\n```\n---\nClass doc with empty lines after it"
 range:
   start:
     line: 3

--- a/libs/wingc/src/lsp/snapshots/hovers/inflight_ctor_doc.snap
+++ b/libs/wingc/src/lsp/snapshots/hovers/inflight_ctor_doc.snap
@@ -3,7 +3,7 @@ source: libs/wingc/src/lsp/hover.rs
 ---
 contents:
   kind: markdown
-  value: "```wing\ninflight new(): Bob\n```\n---\n I'm bob the constructor (inflight)"
+  value: "```wing\ninflight new(): Bob\n```\n---\nI'm bob the constructor (inflight)"
 range:
   start:
     line: 3

--- a/libs/wingc/src/lsp/snapshots/hovers/inflight_ctor_doc_from_new_expr.snap
+++ b/libs/wingc/src/lsp/snapshots/hovers/inflight_ctor_doc_from_new_expr.snap
@@ -3,7 +3,7 @@ source: libs/wingc/src/lsp/hover.rs
 ---
 contents:
   kind: markdown
-  value: "```wing\ninflight new(): Bob\n```\n---\n I'm bob the constructor (inflight)"
+  value: "```wing\ninflight new(): Bob\n```\n---\nI'm bob the constructor (inflight)"
 range:
   start:
     line: 5

--- a/libs/wingc/src/lsp/snapshots/hovers/inherited_interface_method_doc.snap
+++ b/libs/wingc/src/lsp/snapshots/hovers/inherited_interface_method_doc.snap
@@ -3,7 +3,7 @@ source: libs/wingc/src/lsp/hover.rs
 ---
 contents:
   kind: markdown
-  value: "```wing\npreflight do(): void\n```\n---\n Parent interface method doc"
+  value: "```wing\npreflight do(): void\n```\n---\nParent interface method doc"
 range:
   start:
     line: 9

--- a/libs/wingc/src/lsp/snapshots/hovers/inherited_struct_field_doc.snap
+++ b/libs/wingc/src/lsp/snapshots/hovers/inherited_struct_field_doc.snap
@@ -3,7 +3,7 @@ source: libs/wingc/src/lsp/hover.rs
 ---
 contents:
   kind: markdown
-  value: "```wing\nfield: num\n```\n---\n Parent struct field doc"
+  value: "```wing\nfield: num\n```\n---\nParent struct field doc"
 range:
   start:
     line: 9

--- a/libs/wingc/src/lsp/snapshots/hovers/interface_doc.snap
+++ b/libs/wingc/src/lsp/snapshots/hovers/interface_doc.snap
@@ -3,7 +3,7 @@ source: libs/wingc/src/lsp/hover.rs
 ---
 contents:
   kind: markdown
-  value: "```wing\ninterface Foo extends IResource {\n  // No public members\n}\n```\n---\n Interface doc"
+  value: "```wing\ninterface Foo extends IResource {\n  // No public members\n}\n```\n---\nInterface doc"
 range:
   start:
     line: 2

--- a/libs/wingc/src/lsp/snapshots/hovers/interface_method_doc.snap
+++ b/libs/wingc/src/lsp/snapshots/hovers/interface_method_doc.snap
@@ -3,7 +3,7 @@ source: libs/wingc/src/lsp/hover.rs
 ---
 contents:
   kind: markdown
-  value: "```wing\npreflight do(): void\n```\n---\n Interface method doc"
+  value: "```wing\npreflight do(): void\n```\n---\nInterface method doc"
 range:
   start:
     line: 3

--- a/libs/wingc/src/lsp/snapshots/hovers/member_doc_on_same_line_as_something_else.snap
+++ b/libs/wingc/src/lsp/snapshots/hovers/member_doc_on_same_line_as_something_else.snap
@@ -3,7 +3,7 @@ source: libs/wingc/src/lsp/hover.rs
 ---
 contents:
   kind: markdown
-  value: "```wing\npreflight field: num\n```\n---\n Member doc in unexpected place"
+  value: "```wing\npreflight field: num\n```\n---\nMember doc in unexpected place"
 range:
   start:
     line: 2

--- a/libs/wingc/src/lsp/snapshots/hovers/struct_doc.snap
+++ b/libs/wingc/src/lsp/snapshots/hovers/struct_doc.snap
@@ -3,7 +3,7 @@ source: libs/wingc/src/lsp/hover.rs
 ---
 contents:
   kind: markdown
-  value: "```wing\nstruct Foo {\n  // No public members\n}\n```\n---\n Struct doc"
+  value: "```wing\nstruct Foo {\n  // No public members\n}\n```\n---\nStruct doc"
 range:
   start:
     line: 2

--- a/libs/wingc/src/lsp/snapshots/hovers/struct_field_doc.snap
+++ b/libs/wingc/src/lsp/snapshots/hovers/struct_field_doc.snap
@@ -3,7 +3,7 @@ source: libs/wingc/src/lsp/hover.rs
 ---
 contents:
   kind: markdown
-  value: "```wing\nfield: num\n```\n---\n Struct field doc"
+  value: "```wing\nfield: num\n```\n---\nStruct field doc"
 range:
   start:
     line: 3

--- a/libs/wingc/src/lsp/sync.rs
+++ b/libs/wingc/src/lsp/sync.rs
@@ -22,7 +22,7 @@ use crate::valid_json_visitor::ValidJsonVisitor;
 use crate::visit::Visit;
 use crate::wasm_util::extern_json_fn;
 use crate::{ast::Scope, type_check::Types};
-use crate::{type_check, DEFAULT_PACKAGE_NAME};
+use crate::{type_check_file, DEFAULT_PACKAGE_NAME};
 
 /// The output of compiling a Wing project with one or more files
 pub struct ProjectData {
@@ -184,7 +184,7 @@ fn partial_compile(
 			.asts
 			.swap_remove(&file.path)
 			.expect("matching AST not found");
-		type_check(
+		type_check_file(
 			&mut scope,
 			&mut types,
 			&file,

--- a/libs/wingc/src/parser.rs
+++ b/libs/wingc/src/parser.rs
@@ -2920,6 +2920,7 @@ struct DocBuilder<'a> {
 	parser: &'a Parser<'a>,
 }
 
+#[derive(Debug)]
 enum DocBuilderResult {
 	Done(Option<String>),
 	Continue,
@@ -2936,12 +2937,15 @@ impl<'a> DocBuilder<'a> {
 
 	fn process_node(&mut self, node: &Node) -> DocBuilderResult {
 		if node.kind() == "doc" {
-			self.doc_lines.push(
-				self
-					.parser
-					.get_child_field(&node, "content")
-					.map_or("", |n| self.parser.node_text(&n)),
-			);
+			let line = self
+				.parser
+				.get_child_field(&node, "content")
+				.map_or("", |n| self.parser.node_text(&n));
+			if line.len() > 0 && line.chars().next() == Some(' ') {
+				self.doc_lines.push(&line[1..]);
+			} else {
+				self.doc_lines.push(line);
+			}
 			DocBuilderResult::Continue
 		} else if node.is_extra() {
 			DocBuilderResult::Skip

--- a/libs/wingc/src/parser.rs
+++ b/libs/wingc/src/parser.rs
@@ -1139,7 +1139,7 @@ impl<'s> Parser<'s> {
 				.insert(module_name_parsed.clone(), module_dir.clone());
 
 			// If the package.json has a `wing` field, then we treat it as a Wing library
-			if let Some(libname) = as_wing_library(&Utf8Path::new(&module_dir)) {
+			if let Some(libname) = as_wing_library(&Utf8Path::new(&module_dir), true) {
 				return if let Some(alias) = alias {
 					// make sure the Wing library is also parsed
 					let module_file = File::new(&module_dir, &libname);
@@ -2989,7 +2989,7 @@ fn get_actual_children_by_field_name<'a>(node: Node<'a>, field_name: &str) -> Ve
 
 /// Check if the package.json in the given directory has a `wing` field.
 /// If so, return the name of the library.
-pub fn as_wing_library(module_dir: &Utf8Path) -> Option<String> {
+pub fn as_wing_library(module_dir: &Utf8Path, require_wing_field: bool) -> Option<String> {
 	let package_json_path = Utf8Path::new(module_dir).join("package.json");
 	if !package_json_path.exists() {
 		return None;
@@ -3007,7 +3007,11 @@ pub fn as_wing_library(module_dir: &Utf8Path) -> Option<String> {
 
 	match package_json.get("wing") {
 		Some(_) => {}
-		None => return None,
+		None => {
+			if require_wing_field {
+				return None;
+			}
+		}
 	}
 
 	match package_json.get("name") {

--- a/libs/wingc/src/type_check.rs
+++ b/libs/wingc/src/type_check.rs
@@ -412,11 +412,14 @@ type ClassLikeIterator<'a> =
 pub trait ClassLike: Display {
 	fn get_env(&self) -> &SymbolEnv;
 
-	// TODO: refactor this to not emit constructors as methods
 	fn methods(&self, with_ancestry: bool) -> ClassLikeIterator<'_> {
 		self.get_env().iter(with_ancestry).filter_map(|(s, sym_kind, ..)| {
 			if sym_kind.as_variable()?.type_.as_function_sig().is_some() {
-				Some((s, sym_kind.as_variable()?.clone()))
+				if s == CLASS_INIT_NAME || s == CLASS_INFLIGHT_INIT_NAME {
+					None
+				} else {
+					Some((s, sym_kind.as_variable()?.clone()))
+				}
 			} else {
 				None
 			}
@@ -5508,7 +5511,7 @@ It should primarily be used in preflight or in inflights that are guaranteed to 
 		let parent_initializer = parent_class
 			.as_class()
 			.unwrap()
-			.methods(false)
+			.constructors(false)
 			.find(|(name, ..)| name == parent_init_name)
 			.unwrap()
 			.1;

--- a/libs/wingc/src/type_check.rs
+++ b/libs/wingc/src/type_check.rs
@@ -306,6 +306,14 @@ pub struct Namespace {
 	pub module_path: ResolveSource,
 }
 
+impl Namespace {
+	/// Returns true if this namespace has any public API elements, like a `pub` class or enum,
+	/// or a namepsace with 1 or more public elements.
+	pub fn has_public_api_elements(&self) -> bool {
+		self.envs.iter().any(|env| env.has_public_api_elements())
+	}
+}
+
 #[derive(Debug)]
 pub enum ResolveSource {
 	/// A wing file within the source tree for this compilation.

--- a/libs/wingc/src/type_check/symbol_env.rs
+++ b/libs/wingc/src/type_check/symbol_env.rs
@@ -517,6 +517,13 @@ impl SymbolEnv {
 	pub fn is_in_function(&self) -> bool {
 		matches!(self.kind, SymbolEnvKind::Function { .. })
 	}
+
+	pub fn has_public_api_elements(&self) -> bool {
+		self
+			.symbol_map
+			.iter()
+			.any(|(_, entry)| entry.access == AccessModifier::Public)
+	}
 }
 
 pub struct SymbolEnvIter<'a> {

--- a/libs/wingcompiler/src/compile.ts
+++ b/libs/wingcompiler/src/compile.ts
@@ -148,8 +148,8 @@ export async function compile(entrypoint: string, options: CompileOptions): Prom
   const targetdir = options.targetDir ?? join(dirname(entrypoint), "target");
   const entrypointFile = resolve(entrypoint);
   log?.("wing file: %s", entrypointFile);
-  const wingDir = resolve(dirname(entrypointFile));
-  log?.("wing dir: %s", wingDir);
+  const projectDir = resolve(dirname(entrypointFile));
+  log?.("wing dir: %s", projectDir);
   const testing = options.testing ?? false;
   log?.("testing: %s", testing);
   const target = determineTargetFromPlatforms(options.platform);
@@ -176,7 +176,7 @@ export async function compile(entrypoint: string, options: CompileOptions): Prom
     return nodeModules;
   };
 
-  let wingNodeModules = nearestNodeModules(wingDir);
+  let wingNodeModules = nearestNodeModules(projectDir);
 
   if (!existsSync(synthDir)) {
     await fs.mkdir(workDir, { recursive: true });
@@ -184,7 +184,7 @@ export async function compile(entrypoint: string, options: CompileOptions): Prom
   const compileForPreflightResult = await compileForPreflight({
     entrypointFile,
     workDir,
-    wingDir,
+    projectDir,
     synthDir,
     color: options.color,
     log,
@@ -202,7 +202,7 @@ export async function compile(entrypoint: string, options: CompileOptions): Prom
       WING_TARGET: target,
       WING_PLATFORMS: resolvePlatformPaths(options.platform),
       WING_SYNTH_DIR: synthDir,
-      WING_SOURCE_DIR: wingDir,
+      WING_SOURCE_DIR: projectDir,
       WING_IS_TEST: process.env["WING_IS_TEST"] ?? testing.toString(),
       WING_VALUES: options.value?.length == 0 ? undefined : options.value,
       WING_VALUES_FILE: options.values ?? defaultValuesFile(),
@@ -266,90 +266,112 @@ interface CompileForPreflightResult {
 async function compileForPreflight(props: {
   entrypointFile: string;
   workDir: string;
-  wingDir: string;
+  projectDir: string;
   synthDir: string;
   color?: boolean;
   log?: (...args: any[]) => void;
 }): Promise<CompileForPreflightResult> {
   if (props.entrypointFile.endsWith(".ts")) {
-    const diagnostics: wingCompiler.WingDiagnostic[] = [];
-    let typescriptFramework;
-    try {
-      typescriptFramework = (await import("@wingcloud/framework")).internal;
-    } catch (err) {
-      return {
-        preflightEntrypoint: "",
-        diagnostics: [
-          {
-            message: `\
+    return await compileTypeScriptForPreflight(props);
+  } else {
+    return await compileWingForPreflight(props);
+  }
+}
+
+async function compileTypeScriptForPreflight(props: {
+  entrypointFile: string;
+  workDir: string;
+  projectDir: string;
+  synthDir: string;
+  color?: boolean;
+  log?: (...args: any[]) => void;
+}): Promise<CompileForPreflightResult> {
+  const diagnostics: wingCompiler.WingDiagnostic[] = [];
+  let typescriptFramework;
+  try {
+    typescriptFramework = (await import("@wingcloud/framework")).internal;
+  } catch (err) {
+    return {
+      preflightEntrypoint: "",
+      diagnostics: [
+        {
+          message: `\
   Failed to load "@wingcloud/framework": ${(err as any).message}
   
   To use Wing with TypeScript files, you must install "@wingcloud/framework" as a dependency of your project.
   npm i @wingcloud/framework
   `,
-            severity: "error",
-            annotations: [],
-            hints: [],
-          },
-        ],
-      };
-    }
-
-    return {
-      preflightEntrypoint: await typescriptFramework.compile({
-        workDir: props.workDir,
-        entrypoint: props.entrypointFile,
-      }),
-      diagnostics,
-    };
-  } else {
-    let env: Record<string, string> = {
-      RUST_BACKTRACE: "full",
-      WING_SYNTH_DIR: normalPath(props.synthDir),
-    };
-    if (props.color !== undefined) {
-      env.CLICOLOR = props.color ? "1" : "0";
-    }
-
-    const wingc = await wingCompiler.load({
-      env,
-      imports: {
-        env: {
-          send_diagnostic,
+          severity: "error",
+          annotations: [],
+          hints: [],
         },
-      },
-    });
-
-    const diagnostics: wingCompiler.WingDiagnostic[] = [];
-
-    function send_diagnostic(data_ptr: number, data_len: number) {
-      const data_buf = Buffer.from(
-        (wingc.exports.memory as WebAssembly.Memory).buffer,
-        data_ptr,
-        data_len
-      );
-      const data_str = new TextDecoder().decode(data_buf);
-      diagnostics.push(JSON.parse(data_str));
-    }
-
-    const arg = `${normalPath(props.entrypointFile)};${normalPath(props.workDir)};${normalPath(
-      props.wingDir
-    )}`;
-    props.log?.(`invoking %s with: "%s"`, WINGC_COMPILE, arg);
-    let compilerOutput: string | number = "";
-    try {
-      compilerOutput = wingCompiler.invoke(wingc, WINGC_COMPILE, arg);
-    } catch (error) {
-      // This is a bug in the compiler, indicate a compilation failure.
-      // The bug details should be part of the diagnostics handling below.
-    }
-
-    return {
-      preflightEntrypoint: join(props.workDir, WINGC_PREFLIGHT),
-      compilerOutput: JSON.parse(compilerOutput as string),
-      diagnostics,
+      ],
     };
   }
+
+  return {
+    preflightEntrypoint: await typescriptFramework.compile({
+      workDir: props.workDir,
+      entrypoint: props.entrypointFile,
+    }),
+    diagnostics,
+  };
+}
+
+async function compileWingForPreflight(props: {
+  entrypointFile: string;
+  workDir: string;
+  projectDir: string;
+  synthDir: string;
+  color?: boolean;
+  log?: (...args: any[]) => void;
+}) {
+  let env: Record<string, string> = {
+    RUST_BACKTRACE: "full",
+    WING_SYNTH_DIR: normalPath(props.synthDir),
+  };
+  if (props.color !== undefined) {
+    env.CLICOLOR = props.color ? "1" : "0";
+  }
+
+  const wingc = await wingCompiler.load({
+    env,
+    imports: {
+      env: {
+        send_diagnostic,
+      },
+    },
+  });
+
+  const diagnostics: wingCompiler.WingDiagnostic[] = [];
+
+  function send_diagnostic(data_ptr: number, data_len: number) {
+    const data_buf = Buffer.from(
+      (wingc.exports.memory as WebAssembly.Memory).buffer,
+      data_ptr,
+      data_len
+    );
+    const data_str = new TextDecoder().decode(data_buf);
+    diagnostics.push(JSON.parse(data_str));
+  }
+
+  const arg = `${normalPath(props.entrypointFile)};${normalPath(props.workDir)};${normalPath(
+    props.projectDir
+  )}`;
+  props.log?.(`invoking %s with: "%s"`, WINGC_COMPILE, arg);
+  let compilerOutput: string | number = "";
+  try {
+    compilerOutput = wingCompiler.invoke(wingc, WINGC_COMPILE, arg);
+  } catch (error) {
+    // This is a bug in the compiler, indicate a compilation failure.
+    // The bug details should be part of the diagnostics handling below.
+  }
+
+  return {
+    preflightEntrypoint: join(props.workDir, WINGC_PREFLIGHT),
+    compilerOutput: JSON.parse(compilerOutput as string),
+    diagnostics,
+  };
 }
 
 /**

--- a/libs/wingcompiler/src/generateDocs.ts
+++ b/libs/wingcompiler/src/generateDocs.ts
@@ -44,15 +44,12 @@ export async function generateWingDocs(props: {
   const arg = normalPath(props.projectDir);
   props.log?.(`invoking %s with: "%s"`, WINGC_GENERATE_DOCS, arg);
   let docsContents: string = "";
-  try {
-    const result = wingCompiler.invoke(wingc, WINGC_GENERATE_DOCS, arg);
-    if (typeof result === "number") {
-      throw new Error(`Error generating docs: ${result}`);
-    }
-    docsContents = result;
-  } catch (error) {
+  const result = wingCompiler.invoke(wingc, WINGC_GENERATE_DOCS, arg);
+  if (typeof result === "number") {
     // This is a bug in the compiler, indicate a compilation failure.
     // The bug details should be part of the diagnostics handling below.
+  } else {
+    docsContents = result;
   }
 
   return {

--- a/libs/wingcompiler/src/generateDocs.ts
+++ b/libs/wingcompiler/src/generateDocs.ts
@@ -1,0 +1,62 @@
+import { normalPath } from "./util";
+import * as wingCompiler from "./wingc";
+
+const WINGC_GENERATE_DOCS = "wingc_generate_docs";
+
+export interface GenerateWingDocsOutput {
+  docsContents: string;
+  diagnostics: wingCompiler.WingDiagnostic[];
+}
+
+export async function generateWingDocs(props: {
+  projectDir: string;
+  color?: boolean;
+  log?: (...args: any[]) => void;
+}): Promise<GenerateWingDocsOutput> {
+  let env: Record<string, string> = {
+    RUST_BACKTRACE: "full",
+  };
+  if (props.color !== undefined) {
+    env.CLICOLOR = props.color ? "1" : "0";
+  }
+
+  const wingc = await wingCompiler.load({
+    env,
+    imports: {
+      env: {
+        send_diagnostic,
+      },
+    },
+  });
+
+  const diagnostics: wingCompiler.WingDiagnostic[] = [];
+
+  function send_diagnostic(data_ptr: number, data_len: number) {
+    const data_buf = Buffer.from(
+      (wingc.exports.memory as WebAssembly.Memory).buffer,
+      data_ptr,
+      data_len
+    );
+    const data_str = new TextDecoder().decode(data_buf);
+    diagnostics.push(JSON.parse(data_str));
+  }
+
+  const arg = normalPath(props.projectDir);
+  props.log?.(`invoking %s with: "%s"`, WINGC_GENERATE_DOCS, arg);
+  let docsContents: string = "";
+  try {
+    const result = wingCompiler.invoke(wingc, WINGC_GENERATE_DOCS, arg);
+    if (typeof result === "number") {
+      throw new Error(`Error generating docs: ${result}`);
+    }
+    docsContents = result;
+  } catch (error) {
+    // This is a bug in the compiler, indicate a compilation failure.
+    // The bug details should be part of the diagnostics handling below.
+  }
+
+  return {
+    docsContents,
+    diagnostics,
+  };
+}

--- a/libs/wingcompiler/src/index.ts
+++ b/libs/wingcompiler/src/index.ts
@@ -1,4 +1,5 @@
-export * from "./errors";
 export * from "./compile";
 export * from "./constants";
+export * from "./errors";
+export * from "./generateDocs";
 export * from "./wingc";

--- a/libs/wingcompiler/src/wingc.ts
+++ b/libs/wingcompiler/src/wingc.ts
@@ -7,6 +7,7 @@ import { promisify } from "util";
 
 export type WingCompilerFunction =
   | "wingc_compile"
+  | "wingc_generate_docs"
   | "wingc_on_did_open_text_document"
   | "wingc_on_did_change_text_document"
   | "wingc_on_completion"

--- a/tools/hangar/__snapshots__/test_corpus/valid/bring_extend_non_entry.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/bring_extend_non_entry.test.w_compile_tf-aws.md
@@ -50,7 +50,7 @@ class $Root extends $stdlib.std.Resource {
     let $preflightTypesMap = {};
     const lib = $helpers.bringJs(`${__dirname}/preflight.extendnonentrypoint-1.cjs`, $preflightTypesMap);
     $helpers.nodeof(this).root.$preflightTypesMap = $preflightTypesMap;
-    const f = globalThis.$ClassFactory.new("rootpkg.Foo", lib.Foo, this, "Foo");
+    const f = globalThis.$ClassFactory.new("examples-valid.Foo", lib.Foo, this, "Foo");
   }
 }
 const $APP = $PlatformManager.createApp({ outdir: $outdir, name: "bring_extend_non_entry.test", rootConstruct: $Root, isTestEnvironment: $wing_is_test, entrypointDir: process.env['WING_SOURCE_DIR'], rootId: process.env['WING_ROOT_ID'] });

--- a/tools/hangar/__snapshots__/test_corpus/valid/bring_local.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/bring_local.test.w_compile_tf-aws.md
@@ -351,7 +351,7 @@ class $Root extends $stdlib.std.Resource {
         return `
           require("${$helpers.normalPath(__dirname)}/inflight.$Closure2-3.cjs")({
             $expect_Util: ${$stdlib.core.liftObject($stdlib.core.toLiftableModuleType(globalThis.$ClassFactory.resolveType("@winglang/sdk.expect.Util") ?? expect.Util, "@winglang/sdk/expect", "Util"))},
-            $file2_Q: ${$stdlib.core.liftObject($stdlib.core.toLiftableModuleType(globalThis.$ClassFactory.resolveType("rootpkg.subdir.Q") ?? file2.Q, "", "Q"))},
+            $file2_Q: ${$stdlib.core.liftObject($stdlib.core.toLiftableModuleType(globalThis.$ClassFactory.resolveType("examples-valid.subdir.Q") ?? file2.Q, "", "Q"))},
           })
         `;
       }
@@ -359,11 +359,11 @@ class $Root extends $stdlib.std.Resource {
         return ({
           "handle": [
             [$stdlib.core.toLiftableModuleType(globalThis.$ClassFactory.resolveType("@winglang/sdk.expect.Util") ?? expect.Util, "@winglang/sdk/expect", "Util"), ["equal"]],
-            [$stdlib.core.toLiftableModuleType(globalThis.$ClassFactory.resolveType("rootpkg.subdir.Q") ?? file2.Q, "", "Q"), ["greet"]],
+            [$stdlib.core.toLiftableModuleType(globalThis.$ClassFactory.resolveType("examples-valid.subdir.Q") ?? file2.Q, "", "Q"), ["greet"]],
           ],
           "$inflight_init": [
             [$stdlib.core.toLiftableModuleType(globalThis.$ClassFactory.resolveType("@winglang/sdk.expect.Util") ?? expect.Util, "@winglang/sdk/expect", "Util"), []],
-            [$stdlib.core.toLiftableModuleType(globalThis.$ClassFactory.resolveType("rootpkg.subdir.Q") ?? file2.Q, "", "Q"), []],
+            [$stdlib.core.toLiftableModuleType(globalThis.$ClassFactory.resolveType("examples-valid.subdir.Q") ?? file2.Q, "", "Q"), []],
           ],
         });
       }
@@ -405,8 +405,8 @@ class $Root extends $stdlib.std.Resource {
         });
       }
     }
-    const store = globalThis.$ClassFactory.new("rootpkg.Store", file1.Store, this, "Store");
-    const q = globalThis.$ClassFactory.new("rootpkg.subdir.Q", file2.Q, this, "Q");
+    const store = globalThis.$ClassFactory.new("examples-valid.Store", file1.Store, this, "Store");
+    const q = globalThis.$ClassFactory.new("examples-valid.subdir.Q", file2.Q, this, "Q");
     (expect.Util.equal((file2.Q.preflightGreet("foo")), "Hello foo"));
     globalThis.$ClassFactory.new("@winglang/sdk.std.Test", std.Test, this, "test:add data to store", new $Closure1(this, "$Closure1"));
     globalThis.$ClassFactory.new("@winglang/sdk.std.Test", std.Test, this, "test:greet", new $Closure2(this, "$Closure2"));

--- a/tools/hangar/__snapshots__/test_corpus/valid/bring_local_dir.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/bring_local_dir.test.w_compile_tf-aws.md
@@ -106,13 +106,13 @@ class $Root extends $stdlib.std.Resource {
     const w = $helpers.bringJs(`${__dirname}/preflight.widget-1.cjs`, $preflightTypesMap);
     const subdir = $helpers.bringJs(`${__dirname}/preflight.subdir2-6.cjs`, $preflightTypesMap);
     $helpers.nodeof(this).root.$preflightTypesMap = $preflightTypesMap;
-    const widget1 = globalThis.$ClassFactory.new("rootpkg.subdir2.inner.Widget", w.Widget, this, "widget1");
+    const widget1 = globalThis.$ClassFactory.new("examples-valid.subdir2.inner.Widget", w.Widget, this, "widget1");
     $helpers.assert($helpers.eq((widget1.compute()), 42), "widget1.compute() == 42");
-    const foo = globalThis.$ClassFactory.new("rootpkg.subdir2.Foo", subdir.Foo, this, "Foo");
+    const foo = globalThis.$ClassFactory.new("examples-valid.subdir2.Foo", subdir.Foo, this, "Foo");
     $helpers.assert($helpers.eq((foo.foo()), "foo"), "foo.foo() == \"foo\"");
-    const bar = globalThis.$ClassFactory.new("rootpkg.subdir2.Bar", subdir.Bar, this, "Bar");
+    const bar = globalThis.$ClassFactory.new("examples-valid.subdir2.Bar", subdir.Bar, this, "Bar");
     $helpers.assert($helpers.eq((bar.bar()), "bar"), "bar.bar() == \"bar\"");
-    const widget2 = globalThis.$ClassFactory.new("rootpkg.subdir2.inner.Widget", subdir.inner.Widget, this, "widget2");
+    const widget2 = globalThis.$ClassFactory.new("examples-valid.subdir2.inner.Widget", subdir.inner.Widget, this, "widget2");
     $helpers.assert($helpers.eq((widget2.compute()), 42), "widget2.compute() == 42");
     $helpers.assert($helpers.eq((foo.checkWidget(widget2)), 1379), "foo.checkWidget(widget2) == 1379");
   }

--- a/tools/hangar/__snapshots__/test_corpus/valid/inflight_class_capture_preflight_object.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/inflight_class_capture_preflight_object.test.w_compile_tf-aws.md
@@ -447,7 +447,7 @@ class $Root extends $stdlib.std.Resource {
       static _toInflightType() {
         return `
           require("${$helpers.normalPath(__dirname)}/inflight.$Closure6-5.cjs")({
-            $subdir_InflightClass: ${$stdlib.core.liftObject($stdlib.core.toLiftableModuleType(globalThis.$ClassFactory.resolveType("rootpkg.subdir2.InflightClass") ?? subdir.InflightClass, "", "InflightClass"))},
+            $subdir_InflightClass: ${$stdlib.core.liftObject($stdlib.core.toLiftableModuleType(globalThis.$ClassFactory.resolveType("examples-valid.subdir2.InflightClass") ?? subdir.InflightClass, "", "InflightClass"))},
           })
         `;
       }
@@ -455,11 +455,11 @@ class $Root extends $stdlib.std.Resource {
         return ({
           "handle": [
             [$helpers.preflightClassSingleton(this, 5), ["method"]],
-            [$stdlib.core.toLiftableModuleType(globalThis.$ClassFactory.resolveType("rootpkg.subdir2.InflightClass") ?? subdir.InflightClass, "", "InflightClass"), []],
+            [$stdlib.core.toLiftableModuleType(globalThis.$ClassFactory.resolveType("examples-valid.subdir2.InflightClass") ?? subdir.InflightClass, "", "InflightClass"), []],
           ],
           "$inflight_init": [
             [$helpers.preflightClassSingleton(this, 5), []],
-            [$stdlib.core.toLiftableModuleType(globalThis.$ClassFactory.resolveType("rootpkg.subdir2.InflightClass") ?? subdir.InflightClass, "", "InflightClass"), []],
+            [$stdlib.core.toLiftableModuleType(globalThis.$ClassFactory.resolveType("examples-valid.subdir2.InflightClass") ?? subdir.InflightClass, "", "InflightClass"), []],
           ],
         });
       }

--- a/tools/hangar/__snapshots__/test_corpus/valid/lift_shared_resource.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/lift_shared_resource.test.w_compile_tf-aws.md
@@ -407,8 +407,8 @@ class $Root extends $stdlib.std.Resource {
       }
     }
     const bucket = globalThis.$ClassFactory.new("@winglang/sdk.cloud.Bucket", cloud.Bucket, this, "Bucket");
-    const b1 = globalThis.$ClassFactory.new("rootpkg.MyBucket", MyBucket, this, "b1", bucket);
-    const b2 = globalThis.$ClassFactory.new("rootpkg.MyBucket", MyBucket, this, "b2", bucket);
+    const b1 = globalThis.$ClassFactory.new("examples-valid.MyBucket", MyBucket, this, "b1", bucket);
+    const b2 = globalThis.$ClassFactory.new("examples-valid.MyBucket", MyBucket, this, "b2", bucket);
     const api = globalThis.$ClassFactory.new("@winglang/sdk.cloud.Api", cloud.Api, this, "Api");
     (api.get("/", new $Closure1(this, "$Closure1")));
     globalThis.$ClassFactory.new("@winglang/sdk.std.Test", std.Test, this, "test:call endpoint", new $Closure2(this, "$Closure2"));

--- a/tools/hangar/__snapshots__/test_corpus/valid/new_in_static.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/new_in_static.test.w_compile_tf-aws.md
@@ -338,7 +338,7 @@ class LibClass extends $stdlib.std.Resource {
     super($scope, $id);
   }
   static createFoo($scope, id) {
-    return globalThis.$ClassFactory.new("rootpkg.Foo", Foo, $scope, id);
+    return globalThis.$ClassFactory.new("examples-valid.Foo", Foo, $scope, id);
   }
   static _toInflightType() {
     return `

--- a/tools/hangar/__snapshots__/test_corpus/valid/new_in_static_lib.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/new_in_static_lib.w_compile_tf-aws.md
@@ -57,7 +57,7 @@ class LibClass extends $stdlib.std.Resource {
     super($scope, $id);
   }
   static createFoo($scope, id) {
-    return globalThis.$ClassFactory.new("rootpkg.Foo", Foo, $scope, id);
+    return globalThis.$ClassFactory.new("examples-valid.Foo", Foo, $scope, id);
   }
   static _toInflightType() {
     return `

--- a/tools/hangar/__snapshots__/test_corpus/valid/struct_from_json.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/struct_from_json.test.w_compile_tf-aws.md
@@ -485,7 +485,7 @@ class $Root extends $stdlib.std.Resource {
     (std.Number.fromJson("cool", { unsafe: true }));
     $macros.__Struct_fromJson(false, Student, ({"obviously": "not a student"}), { unsafe: true });
     globalThis.$ClassFactory.new("@winglang/sdk.std.Test", std.Test, this, "test:unsafe flight", new $Closure5(this, "$Closure5"));
-    globalThis.$ClassFactory.new("rootpkg.subdir.UsesStructInImportedFile", otherExternalStructs.UsesStructInImportedFile, this, "UsesStructInImportedFile");
+    globalThis.$ClassFactory.new("examples-valid.subdir.UsesStructInImportedFile", otherExternalStructs.UsesStructInImportedFile, this, "UsesStructInImportedFile");
   }
 }
 const $APP = $PlatformManager.createApp({ outdir: $outdir, name: "struct_from_json.test", rootConstruct: $Root, isTestEnvironment: $wing_is_test, entrypointDir: process.env['WING_SOURCE_DIR'], rootId: process.env['WING_ROOT_ID'] });


### PR DESCRIPTION
Adds a new `gen-docs` subcommand that generates API documentation for your Wing library. Running `wing gen-docs` will generate an API.md file in your current directory.

Closes #6905

## Checklist

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [x] Tests added (always)
- [x] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
