### PR TITLE
chore: pass resolved path to generateDocs

### DIFF
--- a/apps/wing/src/commands/diagnostics.ts
+++ b/apps/wing/src/commands/diagnostics.ts
@@ -3,6 +3,7 @@ import { relative } from "path";
 import { WingDiagnostic } from "@winglang/compiler";
 import { Label, File, emitDiagnostic, CHARS_ASCII } from "codespan-wasm";
 import { COLORING } from "../util";
+import { existsSync, statSync } from "fs";
 
 export async function formatDiagnostics(diagnostics: WingDiagnostic[]): Promise<string> {
   const cwd = process.cwd();
@@ -14,7 +15,7 @@ export async function formatDiagnostics(diagnostics: WingDiagnostic[]): Promise<
     const labels: Label[] = [];
 
     // file_id might be "" if the span is synthetic (see #2521)
-    if (span?.file_id) {
+    if (span?.file_id && existsSync(span.file_id) && statSync(span.file_id).isFile()) {
       // `span` should only be null if source file couldn't be read etc.
       const source = await readFile(span.file_id, "utf8");
       const start = span.start_offset;
@@ -32,7 +33,7 @@ export async function formatDiagnostics(diagnostics: WingDiagnostic[]): Promise<
 
     for (const annotation of annotations) {
       // file_id might be "" if the span is synthetic (see #2521)
-      if (!annotation.span?.file_id) {
+      if (!annotation.span?.file_id || !existsSync(annotation.span.file_id) || !statSync(annotation.span.file_id).isFile()) {
         continue;
       }
       const source = await readFile(annotation.span.file_id, "utf8");

--- a/apps/wing/src/commands/generateDocs.test.ts
+++ b/apps/wing/src/commands/generateDocs.test.ts
@@ -5,8 +5,6 @@ import { generateDocs } from "./generateDocs";
 
 const fixturesDir = join(__dirname, "..", "..", "fixtures");
 
-console.log = vi.fn();
-
 describe("wing gen-docs", () => {
   afterEach(() => {
     vi.restoreAllMocks();

--- a/apps/wing/src/commands/generateDocs.ts
+++ b/apps/wing/src/commands/generateDocs.ts
@@ -11,7 +11,7 @@ const color = chalk.supportsColor ? chalk.supportsColor.hasBasic : false;
 export async function generateDocs() {
   // TODO: calculate the workDir by looking up for a wing.toml file
   // For now, assume the workDir is the current directory
-  const workDir = ".";
+  const workDir = process.cwd();
 
   const docs = await wingCompiler.generateWingDocs({
     projectDir: workDir,

--- a/apps/wing/src/commands/generateDocs.ts
+++ b/apps/wing/src/commands/generateDocs.ts
@@ -9,8 +9,6 @@ const log = debug("wing:generateDocs");
 const color = chalk.supportsColor ? chalk.supportsColor.hasBasic : false;
 
 export async function generateDocs() {
-  // TODO: calculate the workDir by looking up for a wing.toml file
-  // For now, assume the workDir is the current directory
   const workDir = process.cwd();
 
   const docs = await wingCompiler.generateWingDocs({

--- a/apps/wing/src/commands/pack.test.ts
+++ b/apps/wing/src/commands/pack.test.ts
@@ -1,4 +1,5 @@
 import * as fs from "fs/promises";
+import { existsSync } from "fs";
 import { join } from "path";
 import { describe, it, expect, afterEach, vi } from "vitest";
 import { pack } from "./pack";
@@ -135,6 +136,9 @@ describe("wing pack", () => {
     process.chdir(outdir);
 
     // create a file in /target
+    if (existsSync("target")) {
+      await fs.rmdir("target", { recursive: true });
+    }
     await fs.mkdir("target");
     await fs.writeFile("target/index.js", "console.log('hello world');");
 
@@ -143,7 +147,7 @@ describe("wing pack", () => {
     expect(tarballContents["target/index.js"]).toBeUndefined();
   });
 
-  it("packages a valid Wing project to a default path", async () => {
+  it("packages a valid Wing project into a tarball", async () => {
     // GIVEN
     const outdir = await generateTmpDir();
 
@@ -220,7 +224,7 @@ describe("wing pack", () => {
     `);
   });
 
-  it("packages a valid Wing project to a user-specified path", async () => {
+  it("packages a valid Wing project into a tarball with a custom filename", async () => {
     // GIVEN
     const outdir = await generateTmpDir();
 


### PR DESCRIPTION
We noticed an unusual issue where in rare scenarios (depending on the user's file system structure), `wing gen-docs` can hang indefinitely. I believe the cause is related to passing a relative path to the WASI file loader. Using an absolute path as the entrypoint should fix this, though I am not certain.

## Checklist

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [ ] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
