### PR TITLE
fix(cli): use dirname intrinsic in react-vite template

### DIFF
--- a/apps/wing/project-templates/wing/react-vite/backend/main.w
+++ b/apps/wing/project-templates/wing/react-vite/backend/main.w
@@ -4,18 +4,12 @@ bring vite;
 bring http;
 bring "./broadcaster.w" as broadcaster;
 
-// Winglang doesn't have a built-in support for __dirname yet, so we use a workaround to get the current directory.
-// @see tracking issue: https://github.com/winglang/wing/issues/3736
-class Utils {
-  extern "utils.js" pub static __dirname(): str;
-}
-
 let myBroadcaster = new broadcaster.Broadcaster() as "Broadcaster";
 let api = new cloud.Api(cors: true);
 let counter = new cloud.Counter();
 
 let website = new vite.Vite(
-  root: "{Utils.__dirname()}/../frontend",
+  root: "{@dirname}/../frontend",
   publicEnv: {
     TITLE: "Wing + Vite + React",
     API_URL: api.url,

--- a/apps/wing/project-templates/wing/react-vite/backend/utils.js
+++ b/apps/wing/project-templates/wing/react-vite/backend/utils.js
@@ -1,1 +1,0 @@
-exports.__dirname = () => __dirname;


### PR DESCRIPTION
Closes #6578

## Checklist

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [ ] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
