### PR TITLE
chore(docs): fix library name typo

### DIFF
--- a/docs/docs/04-winglibs/02-using-winglibs.md
+++ b/docs/docs/04-winglibs/02-using-winglibs.md
@@ -9,16 +9,16 @@ keywords: [Wing reference, Wing libraries, libraries, packaging, packages]
 
 Wing libraries ([winglibs](https://github.com/winglang/winglibs)) can be installed using the npm command line tool.
 
-Here is an example of installing the [wing-redis winglib](https://github.com/winglang/winglibs/tree/main/redis).
+Here is an example of installing the [redis winglib](https://github.com/winglang/winglibs/tree/main/redis).
 
 ```
-npm i wing-redis
+npm i @winglibs/redis
 ```
 
 Then in your Wing source code, the library can be imported by name using a `bring` statement:
 
 ```js
-bring "wing-redis" as redis;
+bring "@winglibs/redis" as redis;
 
 new redis.Redis();
 ```


### PR DESCRIPTION
The correct name of the library is `@winglibs/redis`, not `wing-redis`.

## Checklist

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [ ] Description explains motivation and solution
- [ ] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
