### PR TITLE
fix(sdk): parameter ScheduleExpression is not valid

### DIFF
--- a/docs/api/04-standard-library/cloud/bucket.md
+++ b/docs/api/04-standard-library/cloud/bucket.md
@@ -105,25 +105,27 @@ By default, buckets are configured with CORS for any origin. When a bucket is pr
 
 ```js playground example
 bring cloud;
+bring http;
 
 let uploads = new cloud.Bucket(
   // these are the default values
   public: false,
   cors: true,
   corsOptions: {
-    allowedMethods: [http.HttpMethod.GET, http.HttpMethod.POST, http.HttpMethod.PUT, http.HttpMethod.DELETE, http.HttpMethod.HEAD]
+    allowedMethods: [http.HttpMethod.GET, http.HttpMethod.POST, http.HttpMethod.PUT, http.HttpMethod.DELETE, http.HttpMethod.HEAD],
     allowedOrigins: ["*"],
     allowedHeaders: ["*"],
     exposeHeaders: [],
     maxAge: 0s
   },
-)
+);
 ```
 
 The CORS configuration can be disabled by passing `cors: false` to the constructor. CORS rules can also be configured after the bucket is created by calling the `addCorsRule` method:
 
 ```js playground example
 bring cloud;
+bring http;
 
 let bucket = new cloud.Bucket(
   cors: false, // disable any default CORS rules
@@ -131,6 +133,7 @@ let bucket = new cloud.Bucket(
 
 bucket.addCorsRule({
   allowedOrigins: ["https://example.com"],
+  allowedMethods: [http.HttpMethod.GET],
 });
 ```
 

--- a/packages/@winglang/platform-awscdk/test/__snapshots__/schedule.test.ts.snap
+++ b/packages/@winglang/platform-awscdk/test/__snapshots__/schedule.test.ts.snap
@@ -12,7 +12,7 @@ exports[`convert single dayOfWeek from Unix to AWS 1`] = `
   "Resources": {
     "Schedule251B1F83": {
       "Properties": {
-        "ScheduleExpression": "cron(* * ? * 0 *)",
+        "ScheduleExpression": "cron(* * ? * 1 *)",
         "State": "ENABLED",
         "Targets": [
           {
@@ -167,7 +167,7 @@ exports[`convert the list of dayOfWeek from Unix to AWS 1`] = `
   "Resources": {
     "Schedule251B1F83": {
       "Properties": {
-        "ScheduleExpression": "cron(* * ? * 0,2,4,6 *)",
+        "ScheduleExpression": "cron(* * ? * 1,3,5,7 *)",
         "State": "ENABLED",
         "Targets": [
           {
@@ -322,7 +322,7 @@ exports[`convert the range of dayOfWeek from Unix to AWS 1`] = `
   "Resources": {
     "Schedule251B1F83": {
       "Properties": {
-        "ScheduleExpression": "cron(* * ? * 0-6 *)",
+        "ScheduleExpression": "cron(* * ? * 1-7 *)",
         "State": "ENABLED",
         "Targets": [
           {

--- a/packages/@winglang/platform-awscdk/test/schedule.test.ts
+++ b/packages/@winglang/platform-awscdk/test/schedule.test.ts
@@ -48,7 +48,7 @@ test("convert single dayOfWeek from Unix to AWS", () => {
   // GIVEN
   const app = new AwsCdkApp();
   const schedule = new cloud.Schedule(app, "Schedule", {
-    cron: "* * * * 1",
+    cron: "* * * * 0",
   });
   schedule.onTick(INFLIGHT_CODE);
   const output = app.synth();
@@ -57,7 +57,7 @@ test("convert single dayOfWeek from Unix to AWS", () => {
   const template = Template.fromJSON(JSON.parse(output));
   template.resourceCountIs("AWS::Events::Rule", 1);
   template.hasResourceProperties("AWS::Events::Rule", {
-    ScheduleExpression: "cron(* * ? * 0 *)",
+    ScheduleExpression: "cron(* * ? * 1 *)",
   });
   expect(awscdkSanitize(template)).toMatchSnapshot();
 });
@@ -66,7 +66,7 @@ test("convert the range of dayOfWeek from Unix to AWS", () => {
   // GIVEN
   const app = new AwsCdkApp();
   const schedule = new cloud.Schedule(app, "Schedule", {
-    cron: "* * * * 1-7",
+    cron: "* * * * 0-6",
   });
   schedule.onTick(INFLIGHT_CODE);
   const output = app.synth();
@@ -75,7 +75,7 @@ test("convert the range of dayOfWeek from Unix to AWS", () => {
   const template = Template.fromJSON(JSON.parse(output));
   template.resourceCountIs("AWS::Events::Rule", 1);
   template.hasResourceProperties("AWS::Events::Rule", {
-    ScheduleExpression: "cron(* * ? * 0-6 *)",
+    ScheduleExpression: "cron(* * ? * 1-7 *)",
   });
   expect(awscdkSanitize(template)).toMatchSnapshot();
 });
@@ -84,7 +84,7 @@ test("convert the list of dayOfWeek from Unix to AWS", () => {
   // GIVEN
   const app = new AwsCdkApp();
   const schedule = new cloud.Schedule(app, "Schedule", {
-    cron: "* * * * 1,3,5,7",
+    cron: "* * * * 0,2,4,6",
   });
   schedule.onTick(INFLIGHT_CODE);
   const output = app.synth();
@@ -93,7 +93,7 @@ test("convert the list of dayOfWeek from Unix to AWS", () => {
   const template = Template.fromJSON(JSON.parse(output));
   template.resourceCountIs("AWS::Events::Rule", 1);
   template.hasResourceProperties("AWS::Events::Rule", {
-    ScheduleExpression: "cron(* * ? * 0,2,4,6 *)",
+    ScheduleExpression: "cron(* * ? * 1,3,5,7 *)",
   });
   expect(awscdkSanitize(template)).toMatchSnapshot();
 });

--- a/packages/@winglang/sdk/src/cloud/bucket.md
+++ b/packages/@winglang/sdk/src/cloud/bucket.md
@@ -105,6 +105,7 @@ By default, buckets are configured with CORS for any origin. When a bucket is pr
 
 ```js playground example
 bring cloud;
+bring http;
 
 let uploads = new cloud.Bucket(
   // these are the default values

--- a/packages/@winglang/sdk/src/shared-aws/schedule.ts
+++ b/packages/@winglang/sdk/src/shared-aws/schedule.ts
@@ -59,7 +59,7 @@ const convertDayOfWeekFromUnixToAWS = (dayOfWeek: string): string => {
 
   if (numbers) {
     for (const number of numbers) {
-      dayOfWeek = dayOfWeek.replace(number, (parseInt(number) - 1).toString());
+      dayOfWeek = dayOfWeek.replace(number, (parseInt(number) + 1).toString());
     }
   }
 

--- a/packages/@winglang/sdk/test/target-tf-aws/__snapshots__/schedule.test.ts.snap
+++ b/packages/@winglang/sdk/test/target-tf-aws/__snapshots__/schedule.test.ts.snap
@@ -5,7 +5,7 @@ exports[`convert single dayOfWeek from Unix to AWS 1`] = `
   "resource": {
     "aws_cloudwatch_event_rule": {
       "Schedule_15669BF1": {
-        "schedule_expression": "cron(* * ? * 0 *)",
+        "schedule_expression": "cron(* * ? * 1 *)",
       },
     },
     "aws_cloudwatch_event_target": {
@@ -291,7 +291,7 @@ exports[`convert the list of dayOfWeek from Unix to AWS 1`] = `
   "resource": {
     "aws_cloudwatch_event_rule": {
       "Schedule_15669BF1": {
-        "schedule_expression": "cron(* * ? * 0,2,4,6 *)",
+        "schedule_expression": "cron(* * ? * 1,3,5,7 *)",
       },
     },
     "aws_cloudwatch_event_target": {
@@ -577,7 +577,7 @@ exports[`convert the range of dayOfWeek from Unix to AWS 1`] = `
   "resource": {
     "aws_cloudwatch_event_rule": {
       "Schedule_15669BF1": {
-        "schedule_expression": "cron(* * ? * 0-6 *)",
+        "schedule_expression": "cron(* * ? * 1-7 *)",
       },
     },
     "aws_cloudwatch_event_target": {

--- a/packages/@winglang/sdk/test/target-tf-aws/schedule.test.ts
+++ b/packages/@winglang/sdk/test/target-tf-aws/schedule.test.ts
@@ -85,7 +85,7 @@ test("convert single dayOfWeek from Unix to AWS", () => {
   // GIVEN
   const app = new AwsApp();
   const schedule = new cloud.Schedule(app, "Schedule", {
-    cron: "* * * * 1",
+    cron: "* * * * 0",
   });
   schedule.onTick(CODE_LOG_EVENT);
   const output = app.synth();
@@ -108,7 +108,7 @@ test("convert single dayOfWeek from Unix to AWS", () => {
       output,
       "aws_cloudwatch_event_rule",
       {
-        schedule_expression: "cron(* * ? * 0 *)",
+        schedule_expression: "cron(* * ? * 1 *)",
       }
     )
   ).toEqual(true);
@@ -120,7 +120,7 @@ test("convert the range of dayOfWeek from Unix to AWS", () => {
   // GIVEN
   const app = new AwsApp();
   const schedule = new cloud.Schedule(app, "Schedule", {
-    cron: "* * * * 1-7",
+    cron: "* * * * 0-6",
   });
   schedule.onTick(CODE_LOG_EVENT);
   const output = app.synth();
@@ -143,7 +143,7 @@ test("convert the range of dayOfWeek from Unix to AWS", () => {
       output,
       "aws_cloudwatch_event_rule",
       {
-        schedule_expression: "cron(* * ? * 0-6 *)",
+        schedule_expression: "cron(* * ? * 1-7 *)",
       }
     )
   ).toEqual(true);
@@ -155,7 +155,7 @@ test("convert the list of dayOfWeek from Unix to AWS", () => {
   // GIVEN
   const app = new AwsApp();
   const schedule = new cloud.Schedule(app, "Schedule", {
-    cron: "* * * * 1,3,5,7",
+    cron: "* * * * 0,2,4,6",
   });
   schedule.onTick(CODE_LOG_EVENT);
   const output = app.synth();
@@ -178,7 +178,7 @@ test("convert the list of dayOfWeek from Unix to AWS", () => {
       output,
       "aws_cloudwatch_event_rule",
       {
-        schedule_expression: "cron(* * ? * 0,2,4,6 *)",
+        schedule_expression: "cron(* * ? * 1,3,5,7 *)",
       }
     )
   ).toEqual(true);


### PR DESCRIPTION
Fixes #7115 

There was a bug where we were converting days of the week in the wrong way. The Unix cron format expects days of the week to range from 0-6, and AWS expects them to range from 1-7 (https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-scheduled-rule-pattern.html#eb-cron-expressions) so we need to add +1 to any dates that are found.

## Checklist

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [x] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
