### PR TITLE
fix(sdk): console stops working when operation is unsupported

### DIFF
--- a/packages/@winglang/sdk/src/cloud/bucket.ts
+++ b/packages/@winglang/sdk/src/cloud/bucket.ts
@@ -152,6 +152,7 @@ export class Bucket extends Resource {
     BucketInflightMethods.TRY_GET,
     BucketInflightMethods.TRY_GET_JSON,
     BucketInflightMethods.TRY_DELETE,
+    BucketInflightMethods.SIGNED_URL,
     BucketInflightMethods.METADATA,
     BucketInflightMethods.COPY,
     BucketInflightMethods.RENAME,

--- a/packages/@winglang/sdk/src/target-sim/bucket.inflight.ts
+++ b/packages/@winglang/sdk/src/target-sim/bucket.inflight.ts
@@ -302,7 +302,7 @@ export class Bucket implements IBucketClient, ISimulatorResourceInstance {
       message: `Signed URL (key=${key})`,
       activity: async () => {
         throw new Error(
-          `signedUrl is not implemented yet for sim (key=${key})`
+          `signedUrl is not implemented yet for the simulator (key=${key})`
         );
       },
     });

--- a/packages/@winglang/sdk/src/target-sim/bucket.ts
+++ b/packages/@winglang/sdk/src/target-sim/bucket.ts
@@ -49,6 +49,7 @@ export class Bucket extends cloud.Bucket implements ISimulatorResource {
       [cloud.BucketInflightMethods.TRY_GET]: [],
       [cloud.BucketInflightMethods.TRY_GET_JSON]: [],
       [cloud.BucketInflightMethods.TRY_DELETE]: [],
+      [cloud.BucketInflightMethods.SIGNED_URL]: [],
       [cloud.BucketInflightMethods.METADATA]: [],
       [cloud.BucketInflightMethods.COPY]: [],
       [cloud.BucketInflightMethods.RENAME]: [],

--- a/packages/@winglang/sdk/test/target-sim/__snapshots__/file-counter.test.ts.snap
+++ b/packages/@winglang/sdk/test/target-sim/__snapshots__/file-counter.test.ts.snap
@@ -89,6 +89,7 @@ async exists(...args) { return this.backend.exists(...args); }
 async tryGet(...args) { return this.backend.tryGet(...args); }
 async tryGetJson(...args) { return this.backend.tryGetJson(...args); }
 async tryDelete(...args) { return this.backend.tryDelete(...args); }
+async signedUrl(...args) { return this.backend.signedUrl(...args); }
 async metadata(...args) { return this.backend.metadata(...args); }
 async copy(...args) { return this.backend.copy(...args); }
 async rename(...args) { return this.backend.rename(...args); }

--- a/packages/@winglang/sdk/test/target-sim/bucket.test.ts
+++ b/packages/@winglang/sdk/test/target-sim/bucket.test.ts
@@ -77,11 +77,6 @@ test("bucket on event creates 3 topics, and sends the right event and key in the
   bucket.onEvent(testInflight);
 
   const s = await app.startSimulator();
-  s.onTrace({
-    callback: (trace) => {
-      console.log(trace);
-    },
-  });
   const client = s.getResource("/my_bucket") as cloud.IBucketClient;
   const logClient = s.getResource("/log_bucket") as cloud.IBucketClient;
 
@@ -941,6 +936,21 @@ test("bucket ignores corrupted state file", async () => {
   // THEN
   // we lost all metadata, but the bucket is still functional
   expect(files).toEqual(["b"]);
+});
+
+test("signedUrl is not implemented for the simulator", async () => {
+  // GIVEN
+  const app = new SimApp();
+  new cloud.Bucket(app, "my_bucket");
+
+  const s = await app.startSimulator();
+  const client = s.getResource("/my_bucket") as cloud.IBucketClient;
+
+  // THEN
+  await expect(() => client.signedUrl("key")).rejects.toThrowError(
+    "signedUrl is not implemented yet"
+  );
+  await s.stop();
 });
 
 // Deceided to seperate this feature in a different release,(see https://github.com/winglang/wing/issues/4143)

--- a/tests/sdk_tests/bucket/signed_url.test.w
+++ b/tests/sdk_tests/bucket/signed_url.test.w
@@ -5,10 +5,6 @@ bring expect;
 
 let bucket = new cloud.Bucket();
 
-new cloud.Function(inflight () => {
-  bucket.signedUrl("key");
-});
-
 // TODO: signedUrl is not implemented for the simulator yet
 // https://github.com/winglang/wing/issues/1383
 if util.env("WING_TARGET") != "sim" {

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/cors.test.w_test_sim.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/cors.test.w_test_sim.md
@@ -2,12 +2,11 @@
 
 ## stdout.log
 ```log
-Error: Resource root/Default/Bucket does not support inflight operation signedUrl.
-It might not be implemented yet.
+pass ─ cors.test.wsim (no tests)
 
-Tests 1 unsupported (1)
+Tests 1 passed (1)
 Snapshots 1 skipped
-Test Files 1 unsupported (1)
+Test Files 1 passed (1)
 Duration <DURATION>
 ```
 

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/signed_url.test.w_test_sim.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/signed_url.test.w_test_sim.md
@@ -2,12 +2,11 @@
 
 ## stdout.log
 ```log
-Error: Resource root/Default/Bucket does not support inflight operation signedUrl.
-It might not be implemented yet.
+pass ─ signed_url.test.wsim (no tests)
 
-Tests 1 unsupported (1)
+Tests 1 passed (1)
 Snapshots 1 skipped
-Test Files 1 unsupported (1)
+Test Files 1 passed (1)
 Duration <DURATION>
 ```
 


### PR DESCRIPTION
Fixes #7130

This PR updates the behavior in the simulator so when an unsupported inflight method is used in an app compiled to the simulator, the app will still compile, and an error will simply be thrown at runtime when the method is called.

`signedUrl` was the only method I could find from the `clodu` module that isn't supported in the simulator (?) so it's the only one I had to update.

## Checklist

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [x] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
