### PR TITLE
fix(sdk): local bucket files can't be accessed in simulator

### DIFF
--- a/packages/@winglang/sdk/src/shared-aws/bucket.inflight.ts
+++ b/packages/@winglang/sdk/src/shared-aws/bucket.inflight.ts
@@ -369,12 +369,6 @@ export class BucketClient implements IAwsBucketClient {
       throw new Error("Cannot provide public url for a non-public bucket");
     }
 
-    if (!(await this.exists(key))) {
-      throw new Error(
-        `Cannot provide public url for a non-existent key (key=${key})`
-      );
-    }
-
     const region = await this.getLocation();
 
     return encodeURI(
@@ -401,11 +395,6 @@ export class BucketClient implements IAwsBucketClient {
     // Set the S3 command
     switch (action) {
       case BucketSignedUrlAction.DOWNLOAD:
-        if (!(await this.exists(key))) {
-          throw new Error(
-            `Cannot provide signed url for a non-existent key (key=${key})`
-          );
-        }
         s3Command = new GetObjectCommand({
           Bucket: this.bucketName,
           Key: key,

--- a/packages/@winglang/sdk/src/shared-azure/bucket.inflight.ts
+++ b/packages/@winglang/sdk/src/shared-azure/bucket.inflight.ts
@@ -247,11 +247,6 @@ export class BucketClient implements IBucketClient {
     if (!accessPolicy?.blobPublicAccess) {
       throw new Error("Cannot provide public url for a non-public bucket");
     }
-    if (!(await this.exists(key))) {
-      throw new Error(
-        `Cannot provide public url for a non-existent key (key=${key})`
-      );
-    }
 
     return encodeURI(
       `https://${this.storageAccount}.blob.core.windows.net/${this.bucketName}/${key}`

--- a/packages/@winglang/sdk/src/shared-gcp/bucket.inflight.ts
+++ b/packages/@winglang/sdk/src/shared-gcp/bucket.inflight.ts
@@ -228,12 +228,6 @@ export class BucketClient implements IBucketClient {
       throw new Error("Cannot provide public url for a non-public bucket");
     }
 
-    if (!(await this.exists(key))) {
-      throw new Error(
-        `Cannot provide public url for a non-existent key (key=${key})`
-      );
-    }
-
     return `https://storage.googleapis.com/${this.bucketName}/${key}`;
   }
 
@@ -257,11 +251,6 @@ export class BucketClient implements IBucketClient {
     // Set the GCS action
     switch (action) {
       case BucketSignedUrlAction.DOWNLOAD:
-        if (!(await this.exists(key))) {
-          throw new Error(
-            `Cannot provide signed url for a non-existent key (key=${key})`
-          );
-        }
         gcsAction = "read";
         break;
       case BucketSignedUrlAction.UPLOAD:

--- a/packages/@winglang/sdk/test/shared-aws/bucket.inflight.test.ts
+++ b/packages/@winglang/sdk/test/shared-aws/bucket.inflight.test.ts
@@ -254,38 +254,6 @@ test("Given a non public bucket when reaching to a key public url it should thro
   );
 });
 
-test("Given a public bucket when reaching to a non-existent key, public url it should throw an error", async () => {
-  // GIVEN
-  let error;
-  const BUCKET_NAME = "BUCKET_NAME";
-  const KEY = "KEY";
-
-  s3Mock.on(GetPublicAccessBlockCommand, { Bucket: BUCKET_NAME }).resolves({
-    PublicAccessBlockConfiguration: {
-      BlockPublicAcls: false,
-      BlockPublicPolicy: false,
-      RestrictPublicBuckets: false,
-      IgnorePublicAcls: false,
-    },
-  });
-  s3Mock
-    .on(HeadObjectCommand, { Bucket: BUCKET_NAME, Key: KEY })
-    .rejects(new NotFound({ message: "Object not found", $metadata: {} }));
-
-  // WHEN
-  const client = new BucketClient({ $bucketName: BUCKET_NAME });
-  try {
-    await client.publicUrl(KEY);
-  } catch (err) {
-    error = err;
-  }
-
-  // THEN
-  expect(error?.message).toBe(
-    "Cannot provide public url for a non-existent key (key=KEY)"
-  );
-});
-
 test("Given a public bucket, when giving one of its keys, we should get its public url", async () => {
   // GIVEN
   const BUCKET_NAME = "BUCKET_NAME";
@@ -555,30 +523,6 @@ test("tryDelete a non-existent object from the bucket", async () => {
 
   // THEN
   expect(objectTryDelete).toEqual(false);
-});
-
-test("Given a bucket when reaching to a non-existent key, signed url it should throw an error", async () => {
-  // GIVEN
-  let error;
-  const BUCKET_NAME = "BUCKET_NAME";
-  const KEY = "KEY";
-
-  s3Mock
-    .on(HeadObjectCommand, { Bucket: BUCKET_NAME, Key: KEY })
-    .rejects(new NotFound({ message: "Object not found", $metadata: {} }));
-
-  // WHEN
-  const client = new BucketClient({ $bucketName: BUCKET_NAME });
-  try {
-    await client.signedUrl(KEY);
-  } catch (err) {
-    error = err;
-  }
-
-  // THEN
-  expect(error?.message).toBe(
-    `Cannot provide signed url for a non-existent key (key=${KEY})`
-  );
 });
 
 // Skipped due to issue with mocking getSignedUrl:

--- a/packages/@winglang/sdk/test/shared-azure/bucket.inflight.test.ts
+++ b/packages/@winglang/sdk/test/shared-azure/bucket.inflight.test.ts
@@ -409,31 +409,6 @@ test("Given a non public bucket when reaching to a key public url it should thro
   );
 });
 
-test("Given a public bucket when reaching to a non existent key, public url it should throw an error", async () => {
-  // GIVEN
-  const BUCKET_NAME = "BUCKET_NAME";
-  const STORAGE_NAME = "STORAGE_NAME";
-  const KEY = "non-existent-key";
-
-  // WHEN
-  const client = new BucketClient({
-    $bucketName: BUCKET_NAME,
-    $storageAccount: STORAGE_NAME,
-    $blobServiceClient: mockBlobServiceClient,
-  });
-  TEST_PATH = "sad";
-  // @ts-expect-error - accessing private property
-  client.containerClient.getAccessPolicy = vi
-    .fn()
-    .mockResolvedValue({ blobPublicAccess: "container" });
-  client.exists = vi.fn().mockResolvedValue(false);
-
-  // THEN
-  await expect(() => client.publicUrl(KEY)).rejects.toThrowError(
-    `Cannot provide public url for a non-existent key (key=${KEY})`
-  );
-});
-
 test("Given a public bucket, when giving one of its keys, we should get its public url", async () => {
   // GIVEN
   const BUCKET_NAME = "BUCKET_NAME";

--- a/tests/sdk_tests/bucket/public_url.test.w
+++ b/tests/sdk_tests/bucket/public_url.test.w
@@ -25,11 +25,7 @@ test "publicUrl" {
 
   let publicUrl = publicBucket.publicUrl("file1.txt");
   assert(publicUrl != "");
-  
-  // TODO: works in aws, doesn't work in sim since publicUrl is returning a path to the file, remove condition when #2833 is resolved.
-  if (util.env("WING_TARGET") != "sim") {
-    assert(http.get(publicUrl).body ==  "Foo");
-  }
+  assert(http.get(publicUrl).body ==  "Foo");
 
   assertThrows(BUCKET_NOT_PUBLIC_ERROR, () => {
     privateBucket.publicUrl("file2.txt");

--- a/tests/sdk_tests/bucket/signed_url.test.w
+++ b/tests/sdk_tests/bucket/signed_url.test.w
@@ -33,25 +33,6 @@ test "signedUrl GET (explicit)" {
   expect.equal(output, VALUE);
 }
 
-test "signedUrl GET with non-existent key" {
-  let assertThrows = (expected: str, block: (): void) => {
-    let var error = false;
-    try {
-      block();
-    } catch actual {
-      expect.equal(actual, expected);
-      error = true;
-    }
-      expect.equal(error, true);
-  };
-  let UNEXISTING_KEY = "no-such-file.txt";
-  let OBJECT_DOES_NOT_EXIST_ERROR = "Cannot provide signed url for a non-existent key (key={UNEXISTING_KEY})";
-
-  assertThrows(OBJECT_DOES_NOT_EXIST_ERROR, () => {
-    bucket.signedUrl(UNEXISTING_KEY);
-  });
-}
-
 test "signedUrl PUT" {
   let KEY = "tempfile.txt";
   let VALUE = "Hello, Wing!";

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/signed_url.test.w_test_sim.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/bucket/signed_url.test.w_test_sim.md
@@ -5,10 +5,9 @@
 pass ─ signed_url.test.wsim » root/Default/test:signedUrl duration option is respected
 pass ─ signed_url.test.wsim » root/Default/test:signedUrl GET (explicit)              
 pass ─ signed_url.test.wsim » root/Default/test:signedUrl GET (implicit)              
-pass ─ signed_url.test.wsim » root/Default/test:signedUrl GET with non-existent key   
 pass ─ signed_url.test.wsim » root/Default/test:signedUrl PUT                         
 
-Tests 5 passed (5)
+Tests 4 passed (4)
 Snapshots 1 skipped
 Test Files 1 passed (1)
 Duration <DURATION>


### PR DESCRIPTION
Closes #4143 

https://github.com/winglang/wing/pull/7137 added the main code structure for serving files through an express server when `cloud.Bucket` is locally simulated. However, existing code like the `publicUrl` method was still returning URLs to your file system instead of to the HTTP server. This fixes that bug.

Fixing this enables other use cases, for example allowing a web app redirect the URL from the signed URL of a file they uploaded to the actual file (if the bucket is public).

Misc:
- Removed the constraint that `publicUrl` can only return URLs to existing files. I'm not sure this is a necessary requirement - the URL structure is effectively part of the contract of `cloud.Bucket` (for all public clouds), and checking if the key exists only hurts performance when apps are compiled to the cloud.

## Checklist

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [x] Tests added (always)
- [ ] Docs updated (only required for features)
- [x] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
