### PR TITLE
fix(compiler): unexpected StripPrefixError

### DIFF
--- a/packages/@winglang/wingc/src/lib.rs
+++ b/packages/@winglang/wingc/src/lib.rs
@@ -24,6 +24,7 @@ use jsify::JSifier;
 use lifting::LiftVisitor;
 use parser::{as_wing_library, is_entrypoint_file, parse_wing_project};
 use serde::Serialize;
+use serde_json::Value;
 use struct_schema::StructSchemaVisitor;
 use type_check::jsii_importer::JsiiImportSpec;
 use type_check::symbol_env::SymbolEnvKind;
@@ -37,7 +38,7 @@ use wingii::type_system::TypeSystem;
 use crate::parser::normalize_path;
 use std::alloc::{alloc, dealloc, Layout};
 
-use std::mem;
+use std::{fs, mem};
 
 use crate::ast::Phase;
 use crate::type_check::symbol_env::SymbolEnv;
@@ -299,7 +300,7 @@ pub fn type_check_file(
 
 /// Infer the root directory of the current Wing application or library.
 ///
-/// Check the current file's directory for a wing.toml file or package.json file,
+/// Check the current file's directory for a wing.toml file or package.json file that has a "wing" field,
 /// and continue searching up the directory tree until we find one.
 /// If we run out of parent directories, fall back to the first directory we found.
 pub fn find_nearest_wing_project_dir(source_path: &Utf8Path) -> Utf8PathBuf {
@@ -314,7 +315,10 @@ pub fn find_nearest_wing_project_dir(source_path: &Utf8Path) -> Utf8PathBuf {
 			return current_dir.to_owned();
 		}
 		if current_dir.join("package.json").exists() {
-			return current_dir.to_owned();
+			let package_json = fs::read_to_string(current_dir.join("package.json")).unwrap();
+			if serde_json::from_str(&package_json).map_or(false, |v: Value| v.get("wing").is_some()) {
+				return current_dir.to_owned();
+			}
 		}
 		if current_dir == "/" {
 			break;

--- a/tests/valid/subdir/bring_outer.main.w
+++ b/tests/valid/subdir/bring_outer.main.w
@@ -1,0 +1,1 @@
+bring "../baz.w" as baz;


### PR DESCRIPTION
Fixes a bug where the compiler can panic in certain situations when files from different directories are loaded. Specifically, the issue happens when a Wing file tries importing another Wing file from a directory that is not a sibling or in a sibling directory.

The issue is related to a facility of the compiler responsible for calculating a FQN (fully-qualified name) for every public type. To calculate the FQN for a public type like a class, we need to know where the file is relative to its package. For example, when a file like `/home/node_modules/@winglibs/dynamodb/aws/table.w` is type checked, the compiler needs to know that it belongs to the library named `@winglibs/dynamodb` and that the root of `@winglibs/dynamodb` is `/home/node_modules/@winglibs/dynamodb`. This way, types defined inside `aws` will get added to the `aws` namespace, and types defined at the root should get added to the root namespace, and if a type is defined outside of the project root, it's an error.

Today, the way we identify what package each source file belongs to is by looking up the file system and seeing if there's a package.json or wing.toml file somewhere up the file tree. But we don't enforce all projects to have these files and we want the language server to work even when these files don't exist. In such cases, we decide that all files that aren't part of a well-defined package are part of an implicit "default" package, and the root of this default package is whatever is the common root of all of its files.

This PR should also slightly improve the stability of the language server.

## Checklist

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [x] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
