### PR TITLE
feat: `@target` intrinsic

### DIFF
--- a/docs/api/05-language-reference.md
+++ b/docs/api/05-language-reference.md
@@ -593,6 +593,7 @@ the following properties (given an example intrinsic `@x`):
 | `@assert()`     | checks a condition and _throws_ if evaluated to false                                                                     |
 | `@filename`     | absolute path of the source file                                                                                          |
 | `@dirname`      | absolute path of the source file's directory                                                                              |
+| `@target`       | a string identifying the current target platform                                                                          |
 | `@app`          | the root of the construct tree                                                                                            |
 | `@unsafeCast()` | cast a value into a different type                                                                                        |
 | `@nodeof()`     | obtain the [tree node](/docs/concepts/application-tree) of a preflight object                                             |

--- a/docs/contributing/998-archived/01-compile-targets.md
+++ b/docs/contributing/998-archived/01-compile-targets.md
@@ -74,7 +74,7 @@ new cloud.Function(inflight ()=> {
   // push a message to queue
   queue.push("m");
   // sleep according to target 
-  if util.env("WING_TARGET") == "sim" {
+  if @target == "sim" {
     log("Running on Simulator, sleeping for 1s");
     util.sleep(1s);
   } else {
@@ -85,7 +85,7 @@ new cloud.Function(inflight ()=> {
 });
 ```
 
-In this example, we want to sleep briefly for the Simulator target and for 30 seconds for cloud targets, this is achieved using the `WING_TARGET` environment variable. 
+In this example, we want to sleep briefly for the simulator target and for 30 seconds for cloud targets, this is achieved using the `@target` intrinsic function.
 
 ## Compiler plugins
 

--- a/docs/docs/03-platforms/01-understanding-platforms.md
+++ b/docs/docs/03-platforms/01-understanding-platforms.md
@@ -121,7 +121,7 @@ vpc_api_gateway = true
 
 There might be times when you need to write code that is specific to a particular platform target. For example, you may want to activate a verbose logging service only when testing locally to save on cloud log storage costs.
 
-With the Wing `util` library, you can access environment variables. The `WING_TARGET` environment variable contains the current platform target as it's value, which you can use to conditionally run target-specific code. See the example below:
+The `@target` intrinsic returns the current platform target as a string value, which you can use to conditionally run target-specific code. See the example below:
 
 ```js playground example
 bring cloud;
@@ -138,7 +138,7 @@ new cloud.Function(inflight ()=> {
   // push a message to queue
   queue.push("m");
   // sleep according to target 
-  if util.env("WING_TARGET") == "sim" {
+  if @target == "sim" {
     log("Running on Simulator, sleeping for 1s");
     util.sleep(1s);
   } else {

--- a/packages/@winglang/sdk/src/cloud/function.ts
+++ b/packages/@winglang/sdk/src/cloud/function.ts
@@ -122,10 +122,6 @@ export class Function extends Resource implements IInflightHost {
     const entrypoint = join(workdir, `${assetName}.cjs`);
     this.entrypoint = entrypoint;
 
-    if (process.env.WING_TARGET) {
-      this.addEnvironment("WING_TARGET", process.env.WING_TARGET);
-    }
-
     if (props.concurrency !== undefined && props.concurrency <= 0) {
       throw new Error(
         "concurrency option on cloud.Function must be a positive integer"

--- a/packages/@winglang/sdk/src/cloud/service.ts
+++ b/packages/@winglang/sdk/src/cloud/service.ts
@@ -107,10 +107,6 @@ export class Service extends Resource implements IInflightHost {
     const entrypoint = join(workdir, `${this.assetName}.cjs`);
     this.entrypoint = entrypoint;
 
-    if (process.env.WING_TARGET) {
-      this.addEnvironment("WING_TARGET", process.env.WING_TARGET);
-    }
-
     this.handler = handler;
   }
 

--- a/packages/@winglang/sdk/src/core/lifting.ts
+++ b/packages/@winglang/sdk/src/core/lifting.ts
@@ -423,5 +423,9 @@ export class Lifting {
       // no lift-related methods to call - it's probably a primitive
       // so no capabilities need to be added to the inflight host
     }
+
+    if (process.env.WING_TARGET) {
+      host.addEnvironment("WING_TARGET", process.env.WING_TARGET!);
+    }
   }
 }

--- a/packages/@winglang/sdk/src/target-sim/resource.ts
+++ b/packages/@winglang/sdk/src/target-sim/resource.ts
@@ -120,10 +120,6 @@ export class Resource
     const entrypoint = join(workdir, `${assetName}.cjs`);
     this.entrypoint = entrypoint;
 
-    if (process.env.WING_TARGET) {
-      this.addEnvironment("WING_TARGET", process.env.WING_TARGET);
-    }
-
     this.factory = factory;
   }
 

--- a/packages/@winglang/wingc/src/ast.rs
+++ b/packages/@winglang/wingc/src/ast.rs
@@ -592,6 +592,7 @@ pub enum IntrinsicKind {
 	Dirname,
 	Filename,
 	App,
+	Target,
 }
 
 impl Display for IntrinsicKind {
@@ -601,6 +602,7 @@ impl Display for IntrinsicKind {
 			IntrinsicKind::Dirname => write!(f, "@dirname"),
 			IntrinsicKind::Filename => write!(f, "@filename"),
 			IntrinsicKind::App => write!(f, "@app"),
+			IntrinsicKind::Target => write!(f, "@target"),
 		}
 	}
 }
@@ -611,6 +613,7 @@ impl IntrinsicKind {
 			"@dirname" => IntrinsicKind::Dirname,
 			"@filename" => IntrinsicKind::Filename,
 			"@app" => IntrinsicKind::App,
+			"@target" => IntrinsicKind::Target,
 			_ => IntrinsicKind::Unknown,
 		}
 	}
@@ -630,6 +633,7 @@ impl IntrinsicKind {
 				Phase::Preflight => true,
 				_ => false,
 			},
+			IntrinsicKind::Target => true,
 		}
 	}
 }

--- a/packages/@winglang/wingc/src/jsify.rs
+++ b/packages/@winglang/wingc/src/jsify.rs
@@ -726,6 +726,9 @@ impl<'a> JSifier<'a> {
 				IntrinsicKind::App => {
 					new_code!(expr_span, HELPERS_VAR, ".nodeof(this).app")
 				}
+				IntrinsicKind::Target => {
+					new_code!(expr_span, "process.env.WING_TARGET")
+				}
 			},
 			ExprKind::Call { callee, arg_list } => {
 				let function_type = match callee {

--- a/packages/@winglang/wingc/src/lsp/snapshots/completions/intrinsics.snap
+++ b/packages/@winglang/wingc/src/lsp/snapshots/completions/intrinsics.snap
@@ -22,4 +22,11 @@ source: packages/@winglang/wingc/src/lsp/completions.rs
     kind: markdown
     value: "Get the normalized absolute path of the current Wing source file.\n\nThe resolved path represents a path during preflight only and is not guaranteed to be valid while inflight."
   sortText: bb|@filename
+- label: "@target"
+  kind: 6
+  detail: str
+  documentation:
+    kind: markdown
+    value: "Returns a string identifying the current compilation platform.\n\nThis value is set by the CLI at compile time and can be used to conditionally compile code that is dependent on the target platform."
+  sortText: bb|@target
 

--- a/packages/@winglang/wingc/src/lsp/snapshots/completions/intrinsics_partial.snap
+++ b/packages/@winglang/wingc/src/lsp/snapshots/completions/intrinsics_partial.snap
@@ -22,4 +22,11 @@ source: packages/@winglang/wingc/src/lsp/completions.rs
     kind: markdown
     value: "Get the normalized absolute path of the current Wing source file.\n\nThe resolved path represents a path during preflight only and is not guaranteed to be valid while inflight."
   sortText: bb|@filename
+- label: "@target"
+  kind: 6
+  detail: str
+  documentation:
+    kind: markdown
+    value: "Returns a string identifying the current compilation platform.\n\nThis value is set by the CLI at compile time and can be used to conditionally compile code that is dependent on the target platform."
+  sortText: bb|@target
 

--- a/packages/@winglang/wingc/src/parser.rs
+++ b/packages/@winglang/wingc/src/parser.rs
@@ -2527,7 +2527,7 @@ impl<'s> Parser<'s> {
 		};
 
 		if matches!(kind, IntrinsicKind::Unknown) {
-			self.add_error("Invalid intrinsic", &expression_node);
+			self.add_error(format!("Unknown intrinsic: @{}", name), &expression_node);
 		}
 
 		Ok(Expr::new(

--- a/packages/@winglang/wingc/src/type_check.rs
+++ b/packages/@winglang/wingc/src/type_check.rs
@@ -2333,6 +2333,28 @@ See https://www.winglang.io/docs/concepts/application-tree for more information.
 				AccessModifier::Public,
 				StatementIdx::Top,
 			);
+
+		// @target
+		let _ = self.types
+			.intrinsics
+			.define(
+				&Symbol::global(IntrinsicKind::Target.to_string()),
+				SymbolKind::Variable(VariableInfo {
+					access: AccessModifier::Public,
+					name: Symbol::global(IntrinsicKind::Target.to_string()),
+					docs: Some(Docs::with_summary(
+						r#"Returns a string identifying the current compilation platform.
+
+This value is set by the CLI at compile time and can be used to conditionally compile code that is dependent on the target platform."#,
+					)),
+					kind: VariableKind::StaticMember,
+					phase: Phase::Independent,
+					type_: self.types.string(),
+					reassignable: false,
+				}),
+				AccessModifier::Public,
+				StatementIdx::Top,
+			);
 	}
 
 	fn add_builtin(&mut self, name: &str, typ: Type, scope: &mut Scope) {
@@ -2981,7 +3003,11 @@ See https://www.winglang.io/docs/concepts/application-tree for more information.
 				}
 
 				match intrinsic.kind {
-					IntrinsicKind::Dirname | IntrinsicKind::Filename | IntrinsicKind::App | IntrinsicKind::Unknown => {
+					IntrinsicKind::Dirname
+					| IntrinsicKind::Filename
+					| IntrinsicKind::App
+					| IntrinsicKind::Target
+					| IntrinsicKind::Unknown => {
 						return (sig.return_type, sig.phase);
 					}
 				}

--- a/packages/winglang/project-templates/wing/private-api/main.w
+++ b/packages/winglang/project-templates/wing/private-api/main.w
@@ -1,6 +1,5 @@
 bring cloud;
 bring http;
-bring util;
 
 /**
  * The example below is a simple note-taking app.
@@ -96,7 +95,7 @@ bring util;
 let noteService = new NoteService();
 
 // Consumer functions (not required for the app to work, but useful for testing)
-if util.env("WING_TARGET") == "tf-aws" {
+if @target == "tf-aws" {
   new cloud.Function(inflight (event) => {
     if let event = event?.tryAsStr() {
       let parts = event.split(":");

--- a/tests/doc_examples/valid/01-understanding-platforms.md_example_1/main.w
+++ b/tests/doc_examples/valid/01-understanding-platforms.md_example_1/main.w
@@ -14,7 +14,7 @@ new cloud.Function(inflight ()=> {
   // push a message to queue
   queue.push("m");
   // sleep according to target 
-  if util.env("WING_TARGET") == "sim" {
+  if @target == "sim" {
     log("Running on Simulator, sleeping for 1s");
     util.sleep(1s);
   } else {

--- a/tests/error/invalid-token.test.w
+++ b/tests/error/invalid-token.test.w
@@ -1,5 +1,4 @@
 bring sim;
-bring util;
 
 inflight class MyResourceBackend impl sim.IResource {
   ctx: sim.IResourceContext;
@@ -22,7 +21,7 @@ class MyResource {
 }
 
 // Only run these tests in the simulator
-if util.env("WING_TARGET") == "sim" {
+if @target == "sim" {
   let r = new MyResource();
   let fakeAttr = r.fakeAttr();
 

--- a/tests/sdk_tests/api/aws-api.test.w
+++ b/tests/sdk_tests/api/aws-api.test.w
@@ -1,8 +1,5 @@
 bring cloud;
 bring aws;
-bring util;
-
-let target = util.env("WING_TARGET");
 
 let api = new cloud.Api() as "api";
 api.get("/api", inflight (req: cloud.ApiRequest): cloud.ApiResponse => {

--- a/tests/sdk_tests/api/cycle.test.w
+++ b/tests/sdk_tests/api/cycle.test.w
@@ -5,7 +5,7 @@ bring util;
 // This test checks that an API can have a route whose handler
 // references the API's URL.
 
-if ["sim", "tf-aws", "awscdk"].contains(util.env("WING_TARGET")) {
+if ["sim", "tf-aws", "awscdk"].contains(@target) {
   let api = new cloud.Api();
 
   api.get("/my_url", inflight () => {

--- a/tests/sdk_tests/bucket/aws-bucket.test.w
+++ b/tests/sdk_tests/bucket/aws-bucket.test.w
@@ -1,8 +1,5 @@
 bring cloud;
 bring aws;
-bring util;
-
-let target = util.env("WING_TARGET");
 
 let bucket = new cloud.Bucket() as "aws-wing-bucket";
 
@@ -20,7 +17,7 @@ let bucketInfo = getBucketInfo(bucket);
 
 test "validates the AWS Bucket" {
   if let bucket = bucketInfo {
-    if target == "tf-aws" {
+    if @target == "tf-aws" {
       assert(bucket.get("bucketArn").contains("arn:aws:s3:::aws-wing-bucket"));
       assert(bucket.get("bucketName").contains("aws-wing-bucket"));
     } else { // If it's not a 'tf-aws' target, it's an 'awscdk'

--- a/tests/sdk_tests/bucket/bucket-ref.test.w
+++ b/tests/sdk_tests/bucket/bucket-ref.test.w
@@ -1,7 +1,7 @@
 bring cloud;
 bring aws;
-bring util;
 bring expect;
+
 let b = new cloud.Bucket();
 
 // this will only work if we are testing on tf-aws
@@ -14,7 +14,7 @@ if let name = aws.Bucket.from(b)?.bucketName {
   }
 }
 
-if util.env("WING_TARGET") == "sim" {
+if @target == "sim" {
   let dummyName = "wing-dummy-bucket";
   let dummyArn = "arn:aws:s3:::{dummyName}";
   let br = new aws.BucketRef(dummyName);

--- a/tests/sdk_tests/bucket/events.test.w
+++ b/tests/sdk_tests/bucket/events.test.w
@@ -62,7 +62,7 @@ new std.Test(inflight () => {
   b.delete("c");
 
 // https://github.com/winglang/wing/issues/2724
-  if (util.env("WING_TARGET") != "tf-aws") {
+  if @target != "tf-aws" {
     // assert that onCreate events about the "a", "b", and "c" objects were each produced exactly 1 time
     checkHitCount(key: "a", type: "OnCreate()", source: Source.anyEvent, count: 1);
     checkHitCount(key: "b", type: "OnCreate()", source: Source.anyEvent, count: 1);

--- a/tests/sdk_tests/bucket/signed_url.test.w
+++ b/tests/sdk_tests/bucket/signed_url.test.w
@@ -51,14 +51,13 @@ test "signedUrl PUT" {
 
 test "signedUrl duration option is respected" {
   let isExpiredTokenError = (output: str) => {
-    let target = util.env("WING_TARGET");
     let var result = false;
 
-    if target == "tf-aws" {
+    if @target == "tf-aws" {
       result = output.contains("<Code>AccessDenied</Code><Message>Request has expired</Message>");
-    } else if target == "tf-gcp" {
+    } else if @target == "tf-gcp" {
       result = output.contains("<Code>ExpiredToken</Code><Message>Invalid argument.</Message>");
-    } else if target == "sim" {
+    } else if @target == "sim" {
       result = output.contains("Signed URL has expired");
     }
 

--- a/tests/sdk_tests/container/container.test.w
+++ b/tests/sdk_tests/container/container.test.w
@@ -6,12 +6,10 @@ skipPlatforms:
 
 bring sim;
 bring http;
-bring util;
 bring expect;
 
 // only relevant in simulator
-if util.env("WING_TARGET") == "sim" {
-
+if @target == "sim" {
   let echo = new sim.Container(
     name: "http-echo",
     image: "hashicorp/http-echo",

--- a/tests/sdk_tests/container/entrypoint.test.w
+++ b/tests/sdk_tests/container/entrypoint.test.w
@@ -6,11 +6,10 @@ skipPlatforms:
 
 bring sim;
 bring http;
-bring util;
 bring expect;
 
 // only relevant in simulator
-if util.env("WING_TARGET") == "sim" {
+if @target == "sim" {
   let entrypoint = new sim.Container(
     name: "my-entrypoint-app",
     image: "./my-docker-image",

--- a/tests/sdk_tests/container/mount.test.w
+++ b/tests/sdk_tests/container/mount.test.w
@@ -4,10 +4,9 @@ skipPlatforms:
   - darwin
 \*/
 bring sim;
-bring util;
 
 // only relevant in simulator
-if util.env("WING_TARGET") == "sim" {
+if @target == "sim" {
   let container = new sim.Container(
     name: "postgres",
     image: "postgres:15",

--- a/tests/sdk_tests/container/network.test.w
+++ b/tests/sdk_tests/container/network.test.w
@@ -6,11 +6,10 @@ skipPlatforms:
 
 bring sim;
 bring http;
-bring util;
 bring expect;
 
 // only relevant in simulator
-if util.env("WING_TARGET") == "sim" {
+if @target == "sim" {
   let networkHost = new sim.Container(
     name: "http-echo",
     image: "hashicorp/http-echo",

--- a/tests/sdk_tests/counter/aws-counter.test.w
+++ b/tests/sdk_tests/counter/aws-counter.test.w
@@ -1,8 +1,5 @@
 bring cloud;
 bring aws;
-bring util;
-
-let target = util.env("WING_TARGET");
 
 let counter = new cloud.Counter(initial: 1) as "aws-wing-counter";
 
@@ -20,7 +17,7 @@ let counterInfo = getCounterInfo(counter);
 
 test "validates the AWS counter name" {
   if let counter = counterInfo {
-    if target == "tf-aws" {
+    if @target == "tf-aws" {
       assert(counter.get("dynamoTableArn").contains("arn:aws:dynamodb:"));
       assert(counter.get("dynamoTableArn").contains("aws-wing-counter"));
       assert(counter.get("dynamoTableName").contains("aws-wing-counter"));

--- a/tests/sdk_tests/function/aws-function.test.w
+++ b/tests/sdk_tests/function/aws-function.test.w
@@ -1,9 +1,6 @@
 bring aws;
 bring cloud;
 bring expect;
-bring util;
-
-let target = util.env("WING_TARGET");
 
 let getFunctionInfo = (f: cloud.Function): Map<str>? => {
   if let lambda = aws.Function.from(f) {
@@ -27,7 +24,7 @@ let fn = new cloud.Function(inflight (msg: Json?) => {
     let remainingTime = ctx.remainingTimeInMillis();
     assert(remainingTime > 0);
   } else {
-    if target == "tf-aws" || target == "awscdk" {
+    if @target == "tf-aws" || @target == "awscdk" {
       expect.fail("Expected to have a context object");
     }
   }
@@ -39,18 +36,18 @@ let fnInfo = getFunctionInfo(fn);
 
 new std.Test(inflight () => {
   if let info = fnInfo {
-    if target == "tf-aws" {
+    if @target == "tf-aws" {
       assert(info.get("functionArn").contains("arn:aws:lambda:"));
       assert(info.get("functionArn").contains(":function:"));
       assert(info.get("functionArn").contains("aws-wing-function"));
       assert(info.get("functionName").contains("aws-wing-function"));
-    } else if target == "awscdk" {
+    } else if @target == "awscdk" {
       assert(info.get("functionArn").contains("arn:aws:lambda:"));
       assert(info.get("functionArn").contains(":function:"));
       assert(info.get("functionArn").contains("awswingfunction"));
       assert(info.get("functionName").contains("awswingfunction"));
     } else {
-      expect.fail("Unexpected target " + target);
+      expect.fail("Unexpected target " + @target);
     }
   } else {
     // If the test is not on AWS, it should not fail, so I am returning true.

--- a/tests/sdk_tests/function/aws-layer.test.w
+++ b/tests/sdk_tests/function/aws-layer.test.w
@@ -1,9 +1,8 @@
 bring aws;
 bring cloud;
 bring expect;
-bring util;
 
-if util.env("WING_TARGET") == "tf-aws" {
+if @target == "tf-aws" {
   let fn = new cloud.Function(inflight () => {
     return "Hello world!";
   });

--- a/tests/sdk_tests/function/concurrency.test.w
+++ b/tests/sdk_tests/function/concurrency.test.w
@@ -3,7 +3,7 @@ bring util;
 
 // TODO: support concurrency on AWS
 
-if util.env("WING_TARGET") == "sim" {
+if @target == "sim" {
   let c = new cloud.Counter();
   
   let f1 = new cloud.Function(inflight () => {

--- a/tests/sdk_tests/function/function-ref.test.w
+++ b/tests/sdk_tests/function/function-ref.test.w
@@ -22,7 +22,7 @@ if let arn = aws.Function.from(f)?.functionArn {
   }
 }
 
-if util.env("WING_TARGET") == "sim" {
+if @target == "sim" {
   bring expect;
 
   let dummyArn = "arn:aws:lambda:us-east-1:111111111111:function:Function-11111111";

--- a/tests/sdk_tests/function/timeout.test.w
+++ b/tests/sdk_tests/function/timeout.test.w
@@ -5,9 +5,9 @@ bring expect;
 let c = new cloud.Counter();
 
 let ERROR_MSG_BY_TARGET: Map<str> = {"tf-gcp": "upstream request timeout"};
-let timeoutError = ERROR_MSG_BY_TARGET.tryGet(util.env("WING_TARGET")) ?? "Function timed out";
+let timeoutError = ERROR_MSG_BY_TARGET.tryGet(@target) ?? "Function timed out";
 let TIMEOUT_BY_TARGET: Map<num> = {"tf-gcp": 120}; 
-let timeoutValue = TIMEOUT_BY_TARGET.tryGet(util.env("WING_TARGET")) ?? 60;
+let timeoutValue = TIMEOUT_BY_TARGET.tryGet(@target) ?? 60;
 
 let f1 = new cloud.Function(inflight () => {
   util.sleep(1.5s);

--- a/tests/sdk_tests/queue/aws-queue.test.w
+++ b/tests/sdk_tests/queue/aws-queue.test.w
@@ -2,8 +2,6 @@ bring cloud;
 bring aws;
 bring util;
 
-let target = util.env("WING_TARGET");
-
 let queue = new cloud.Queue() as "aws-wing-queue";
 
 let getQueueInfo = (q: cloud.Queue): Map<str>? => {
@@ -21,7 +19,7 @@ let queueInfo = getQueueInfo(queue);
 
 test "validates the AWS queue name" {
   if let queue = queueInfo {
-    if target == "tf-aws" {
+    if @target == "tf-aws" {
       assert(queue.get("queueArn").contains("arn:aws:sqs:"));
       assert(queue.get("queueArn").contains("aws-wing-queue"));
       assert(queue.get("queueName").contains("aws-wing-queue"));

--- a/tests/sdk_tests/queue/push.test.w
+++ b/tests/sdk_tests/queue/push.test.w
@@ -41,7 +41,7 @@ new std.Test(inflight () => {
   });
 
   q.purge(); 
-  if util.env("WING_TARGET") != "sim" {
+  if @target != "sim" {
     // In a real cloud, purging is expensive so we should wait a minute regardless of .approxSize()
     // e.g. See AWS docs for queue purging (https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/clients/client-sqs/classes/purgequeuecommand.html)
     util.sleep(1m);

--- a/tests/sdk_tests/queue/queue-ref.test.w
+++ b/tests/sdk_tests/queue/queue-ref.test.w
@@ -31,7 +31,7 @@ if let arn = aws.Queue.from(q)?.queueArn {
   }
 }
 
-if util.env("WING_TARGET") == "sim" {
+if @target == "sim" {
   bring expect;
 
   let dummyArn = "arn:aws:sqs:us-east-1:111111111111:Queue-11111111";

--- a/tests/sdk_tests/queue/retention_period.main.w
+++ b/tests/sdk_tests/queue/retention_period.main.w
@@ -2,7 +2,7 @@ bring cloud;
 bring util;
 
 // TODO: timeout is not supported in sim - https://github.com/winglang/wing/issues/2401
-if util.env("WING_TARGET") != "sim" {
+if @target != "sim" {
   let var timeout = 30s;
   let var retentionPeriod = 60s;
 

--- a/tests/sdk_tests/queue/timeout.test.w
+++ b/tests/sdk_tests/queue/timeout.test.w
@@ -7,7 +7,7 @@ bring util;
 
 let var timeout: duration = 30s;
 let var sleep: duration = 31s;
-if (util.env("WING_TARGET") == "sim") {
+if @target == "sim" {
   timeout = 1s;
   sleep = 2s;
 }
@@ -29,7 +29,7 @@ new std.Test(inflight () => {
   util.sleep(duration.fromSeconds(timeout.seconds + 1));
   // The queue should have 2 messages still due to timeout - doesn't work on aws or sim unfortunately
   // for aws- https://github.com/winglang/wing/issues/3354
-  if (util.env("WING_TARGET") != "tf-aws") {
+  if @target != "tf-aws" {
     assert(q.approxSize() == 2);
   }
   }, timeout: 2m) as "timeout";

--- a/tests/sdk_tests/resource/call.test.w
+++ b/tests/sdk_tests/resource/call.test.w
@@ -154,7 +154,7 @@ class MyResource {
 }
 
 // Only run these tests in the simulator
-if util.env("WING_TARGET") == "sim" {
+if @target == "sim" {
   let r1 = new MyResource();
 
   test "resource.call with a field name returns the field value" {

--- a/tests/sdk_tests/resource/no-stop.test.w
+++ b/tests/sdk_tests/resource/no-stop.test.w
@@ -1,6 +1,5 @@
 bring sim;
 bring expect;
-bring util;
 
 class Simple {
   pub foo: str;
@@ -14,7 +13,7 @@ class Simple {
 }
 
 // Only run these tests in the simulator
-if util.env("WING_TARGET") == "sim" {
+if @target == "sim" {
   let s = new Simple();
 
   test "token is resolved" {

--- a/tests/sdk_tests/resource/on-start.test.w
+++ b/tests/sdk_tests/resource/on-start.test.w
@@ -1,5 +1,4 @@
 bring sim;
-bring util;
 
 inflight class OnStartThrowerBackend impl sim.IResource {
   new() {
@@ -24,7 +23,7 @@ class OnStartThrower {
 }
 
 // Only run these tests in the simulator
-if util.env("WING_TARGET") == "sim" {
+if @target == "sim" {
   let r = new OnStartThrower();
 
   test "method calls fail if the resource fails to start" {

--- a/tests/sdk_tests/resource/on-stop.test.w
+++ b/tests/sdk_tests/resource/on-stop.test.w
@@ -1,5 +1,4 @@
 bring sim;
-bring util;
 
 inflight class OnStopThrowerBackend impl sim.IResource {
   pub onStop() {
@@ -23,7 +22,7 @@ class OnStopThrower {
 }
 
 // Only run these tests in the simulator
-if util.env("WING_TARGET") == "sim" {
+if @target == "sim" {
   let r = new OnStopThrower();
 
   test "if a resource throws an error on stopping, it doesn't crash the simulation" {

--- a/tests/sdk_tests/resource/resource.test.w
+++ b/tests/sdk_tests/resource/resource.test.w
@@ -1,6 +1,5 @@
 bring cloud;
 bring sim;
-bring util;
 
 inflight class CounterBackend impl sim.IResource {
   var counter: num;
@@ -59,7 +58,7 @@ class Counter {
 let c = new Counter();
 
 // Only run these tests in the simulator
-if util.env("WING_TARGET") == "sim" {
+if @target == "sim" {
   test "Counter" {
     assert(c.inc() == 0);
     assert(c.inc() == 1);
@@ -80,7 +79,7 @@ class DoubleCounter extends Counter {
 
 let dc = new DoubleCounter();
 
-if util.env("WING_TARGET") == "sim" {
+if @target == "sim" {
   test "DoubleCounter" {
     assert(dc.inc() == 0);
     assert(dc.inc() == 2);

--- a/tests/sdk_tests/resource/state.test.w
+++ b/tests/sdk_tests/resource/state.test.w
@@ -1,6 +1,5 @@
 bring fs;
 bring sim;
-bring util;
 
 inflight class ResourceWithStateBackend impl sim.IResource {
   ctx: sim.IResourceContext;
@@ -37,7 +36,7 @@ class ResourceWithState {
 }
 
 // Only run these tests in the simulator
-if util.env("WING_TARGET") == "sim" {
+if @target == "sim" {
   let r = new ResourceWithState();
 
   test "sim.Resource can read and write state" {

--- a/tests/sdk_tests/resource/tokens.test.w
+++ b/tests/sdk_tests/resource/tokens.test.w
@@ -1,5 +1,4 @@
 bring sim;
-bring util;
 
 inflight class BadTokenResolverBackend impl sim.IResource {
   ctx: sim.IResourceContext;
@@ -26,7 +25,7 @@ class BadTokenResolver {
 }
 
 // Only run these tests in the simulator
-if util.env("WING_TARGET") == "sim" {
+if @target == "sim" {
   let r = new BadTokenResolver();
 
   test "calling resolveToken during a method call emits an error" {

--- a/tests/sdk_tests/schedule/init.test.w
+++ b/tests/sdk_tests/schedule/init.test.w
@@ -1,50 +1,42 @@
-/*\
-skip: true
-\*/
-
 bring cloud;
-bring util;
 bring expect;
 
 new cloud.Schedule( rate: 5m ) as "s0";
 
-// doesn't work on sim: https://github.com/winglang/wing/issues/2732
-if (util.env("WING_TARGET") != "sim") {
-  // Those are testing the many errors in initialization of a cloud.Schedule
-  let var error = "";
-  try {
-      new cloud.Schedule( rate: nil, cron: nil ) as "s1";
-  } catch e {
-      error = e;
-  }
-  expect.equal(error, "rate or cron need to be filled.");
-
-  try {
-      new cloud.Schedule( rate: 2m, cron: "* * * * *" ) as "s2";
-  } catch e {
-      error = e;
-  }
-  expect.equal(error, "rate and cron cannot be configured simultaneously.");
-
-
-  try {
-      new cloud.Schedule( rate: 1s ) as "s3";
-  } catch e {
-      error = e;
-  }
-  expect.equal(error, "rate can not be set to less than 1 minute.");
-
-  try {
-      new cloud.Schedule( cron: "* * * * * *" ) as "s4";
-  } catch e {
-      error = e;
-  }
-  expect.equal(error, "cron string must be in UNIX cron format");
-
-  try {
-      new cloud.Schedule( cron: "* * * * ?" ) as "s5";
-  } catch e {
-      error = e;
-  }
-  expect.equal(error, "cron string must be in UNIX cron format");
+// Those are testing the many errors in initialization of a cloud.Schedule
+let var error = "";
+try {
+    new cloud.Schedule( rate: nil, cron: nil ) as "s1";
+} catch e {
+    error = e;
 }
+expect.equal(error, "rate or cron need to be filled.");
+
+try {
+    new cloud.Schedule( rate: 2m, cron: "* * * * *" ) as "s2";
+} catch e {
+    error = e;
+}
+expect.equal(error, "rate and cron cannot be configured simultaneously.");
+
+
+try {
+    new cloud.Schedule( rate: 1s ) as "s3";
+} catch e {
+    error = e;
+}
+expect.equal(error, "rate can not be set to less than 1 minute.");
+
+try {
+    new cloud.Schedule( cron: "* * * * * *" ) as "s4";
+} catch e {
+    error = e;
+}
+expect.equal(error, "cron string must be in UNIX cron format");
+
+try {
+    new cloud.Schedule( cron: "* * * * ?" ) as "s5";
+} catch e {
+    error = e;
+}
+expect.equal(error, "cron string must be in UNIX cron format");

--- a/tests/sdk_tests/secret/secret-ref.test.w
+++ b/tests/sdk_tests/secret/secret-ref.test.w
@@ -1,8 +1,7 @@
-bring util;
 bring aws;
 bring expect;
 
-if util.env("WING_TARGET") == "tf-aws" {
+if @target == "tf-aws" {
   let someExistingSecretArn = "arn:aws:secretsmanager:::secret:mysecret";
   let secret = new aws.SecretRef(someExistingSecretArn);
 

--- a/tests/sdk_tests/service/callbacks.test.w
+++ b/tests/sdk_tests/service/callbacks.test.w
@@ -1,9 +1,8 @@
 bring cloud;
-bring util;
 bring http;
 
-// hack: only supported in the "sim" target for now
-if util.env("WING_TARGET") == "sim" {
+// only supported in the "sim" target for now
+if @target == "sim" {
   let b = new cloud.Bucket();
   let startCounter = new cloud.Counter();
   let status = "status";

--- a/tests/sdk_tests/service/http-server.test.w
+++ b/tests/sdk_tests/service/http-server.test.w
@@ -1,5 +1,4 @@
 bring cloud;
-bring util;
 bring http;
 
 struct Address {
@@ -12,8 +11,8 @@ inflight interface IHttpServer {
 }
 
 
-// hack: only supported in the "sim" target for now
-if util.env("WING_TARGET") == "sim" {
+// only supported in the "sim" target for now
+if @target == "sim" {
   class MyService {
     b: cloud.Bucket;
     body: str;

--- a/tests/sdk_tests/service/minimal.test.w
+++ b/tests/sdk_tests/service/minimal.test.w
@@ -1,9 +1,7 @@
 bring cloud;
-bring util;
 
 // hack: only supported in the "sim" target for now
-if util.env("WING_TARGET") == "sim" {
-
+if @target == "sim" {
   let s = new cloud.Service(inflight () => {
     log("hello, service!");
 

--- a/tests/sdk_tests/service/stateful.test.w
+++ b/tests/sdk_tests/service/stateful.test.w
@@ -3,7 +3,7 @@ bring util;
 bring http;
 
 // hack: only supported in the "sim" target for now
-if util.env("WING_TARGET") == "sim" {
+if @target == "sim" {
   class MyService {
     b: cloud.Bucket;
     body: str;

--- a/tests/sdk_tests/service/tokens.test.w
+++ b/tests/sdk_tests/service/tokens.test.w
@@ -2,8 +2,8 @@ bring cloud;
 bring util;
 bring http;
 
-// hack: only supported in the "sim" target for now
-if util.env("WING_TARGET") == "sim" {
+// only supported in the "sim" target for now
+if @target == "sim" {
   let b = new cloud.Bucket();
   let api = new cloud.Api();
   api.get("/", inflight () => {

--- a/tests/sdk_tests/state/get.test.w
+++ b/tests/sdk_tests/state/get.test.w
@@ -1,8 +1,6 @@
 bring "./my-service.w" as my;
-bring util;
 
-if util.env("WING_TARGET") == "sim" {
-
+if @target == "sim" {
   let svc = new my.MyService();
 
   test "state.get() returns the runtime value" {

--- a/tests/sdk_tests/state/set.test.w
+++ b/tests/sdk_tests/state/set.test.w
@@ -1,13 +1,10 @@
 bring "./my-service.w" as my;
-bring util;
 
-if util.env("WING_TARGET") == "sim" {
-
+if @target == "sim" {
   let svc = new my.MyService();
 
   test "token resolved at runtime" {
     log(svc.startTime);
     assert(svc.startTime == "2023-10-16T20:47:39.511Z");
   }
-
 }

--- a/tests/sdk_tests/topic/aws-topic.test.w
+++ b/tests/sdk_tests/topic/aws-topic.test.w
@@ -1,8 +1,5 @@
 bring cloud;
 bring aws;
-bring util;
-
-let target = util.env("WING_TARGET");
 
 let topic = new cloud.Topic() as "aws-wing-topic";
 
@@ -20,7 +17,7 @@ let topicInfo = getTopicInfo(topic);
 
 test "validates the AWS topic name" {
   if let topic = topicInfo {
-    if target == "tf-aws" {
+    if @target == "tf-aws" {
       assert(topic.get("topicArn").contains("arn:aws:sns:"));
       assert(topic.get("topicArn").contains("aws-wing-topic"));
       assert(topic.get("topicName").contains("aws-wing-topic"));

--- a/tests/sdk_tests/util/shell.test.w
+++ b/tests/sdk_tests/util/shell.test.w
@@ -2,10 +2,6 @@ bring util;
 bring expect;
 bring fs;
 
-class Util {
-  extern "./util.js" pub static inflight platform(): str;
-}
-
 let assertThrows = inflight (expected: str, block: (): void) => {
   let var error = false;
   try {
@@ -22,7 +18,7 @@ test "shell() with valid command" {
 
   let output = util.shell(command);
   
-  if Util.platform() != "win32" {
+  if util.os() != "win32" {
     expect.equal(output, "Hello, Wing!\n");
   } else {
     expect.equal(output, "Hello, Wing!\r\n");
@@ -51,7 +47,7 @@ test "shell() with explicit non-zero exit status" {
 
 test "shell() with env option" {
   let var command = "";
-  if Util.platform() != "win32" {
+  if util.os() != "win32" {
     command = "echo $WING_TARGET $ENV_VAR";
   } else {
     command = "echo %WING_TARGET% %ENV_VAR%";
@@ -62,7 +58,7 @@ test "shell() with env option" {
 
   let output = util.shell(command, opts);
 
-  if Util.platform() != "win32" {
+  if util.os() != "win32" {
     expect.equal(output, "Wing\n");
   } else {
     expect.equal(output, "%WING_TARGET% Wing\r\n");
@@ -70,10 +66,8 @@ test "shell() with env option" {
 }
 
 test "shell() with inheritEnv option" {
-  let target = util.env("WING_TARGET");
-
   let var command = "";
-  if Util.platform() != "win32" {
+  if util.os() != "win32" {
     command = "echo $WING_TARGET";
   } else {
     command = "echo %WING_TARGET%";
@@ -85,15 +79,15 @@ test "shell() with inheritEnv option" {
   let output1 = util.shell(command);
   let output2 = util.shell(command, opts);
 
-  if Util.platform() != "win32" {
+  if util.os() != "win32" {
     // \n
     expect.equal(output1.length, 1);
   } else {
     // %WING_TARGET%\r\n
     expect.equal(output1.length, 15);
   }
-  assert(output1.contains(target) == false);
-  assert(output2.contains(target) == true);
+  assert(output1.contains(@target) == false);
+  assert(output2.contains(@target) == true);
 }
 
 test "shell() with cwd option" {

--- a/tests/sdk_tests/util/util.extern.d.ts
+++ b/tests/sdk_tests/util/util.extern.d.ts
@@ -1,3 +1,0 @@
-export default interface extern {
-  platform: () => Promise<string>,
-}

--- a/tests/sdk_tests/util/util.js
+++ b/tests/sdk_tests/util/util.js
@@ -1,5 +1,0 @@
-const os = require("os");
-
-exports.platform = function () {
-  return os.platform();
-};

--- a/tests/sdk_tests/website/aws-website.test.w
+++ b/tests/sdk_tests/website/aws-website.test.w
@@ -1,9 +1,5 @@
 bring cloud;
 bring aws;
-bring util;
-
-let target = util.env("WING_TARGET");
-
 
 let website = new cloud.Website(path: "./website") as "aws-wing-website";
 
@@ -21,7 +17,7 @@ let websiteName = getWebsiteInfo(website);
 
 test "validates the AWS bucket name" {
   if let website = websiteName {
-    if target == "tf-aws" {
+    if @target == "tf-aws" {
       assert(website.get("bucketArn").contains("arn:aws:s3:::"));
       assert(website.get("bucketArn").contains("aws-wing-website"));
       assert(website.get("bucketName").contains("aws-wing-website"));

--- a/tests/valid/casting.test.w
+++ b/tests/valid/casting.test.w
@@ -1,10 +1,9 @@
 bring cloud;
-bring util;
 bring "@cdktf/provider-aws" as aws;
 
 let b = new cloud.Bucket();
 
-if util.env("WING_TARGET") == "tf-aws" {
+if @target == "tf-aws" {
   let s3Bucket: aws.s3Bucket.S3Bucket = unsafeCast(nodeof(b).findChild("Default"));
   
   s3Bucket.addOverride("bucket_prefix", "my-prefix-");

--- a/tests/valid/dynamo.test.w
+++ b/tests/valid/dynamo.test.w
@@ -6,7 +6,6 @@ skip: true
 bring "@cdktf/provider-aws" as tfaws;
 bring aws;
 bring cloud;
-bring util;
 
 enum AttributeType {
   String,
@@ -23,9 +22,8 @@ class DynamoTable {
   table: tfaws.dynamodbTable.DynamodbTable;
   tableName: str;
   new() {
-    let target = util.env("WING_TARGET");
-    if target != "tf-aws" {
-      throw "Unsupported target: {target} (expected 'tf-aws')";
+    if @target != "tf-aws" {
+      throw "Unsupported target: {@target} (expected 'tf-aws')";
     }
 
     this.table = new tfaws.dynamodbTable.DynamodbTable(

--- a/tests/valid/dynamo_awscdk.test.w
+++ b/tests/valid/dynamo_awscdk.test.w
@@ -23,9 +23,8 @@ class DynamoTable {
   table: awscdk.aws_dynamodb.Table;
   tableName: str;
   new() {
-    let target = util.env("WING_TARGET");
-    if target != "awscdk" {
-      throw "Unsupported target: {target} (expected 'awscdk')";
+    if @target != "awscdk" {
+      throw "Unsupported target: {@target} (expected 'awscdk')";
     }
 
     this.table = new awscdk.aws_dynamodb.Table(

--- a/tests/valid/inflight_handler_singleton.test.w
+++ b/tests/valid/inflight_handler_singleton.test.w
@@ -30,8 +30,6 @@ let fn2 = new cloud.Function(inflight () => {
   return "{n}-fn2";
 }) as "fn2";
 
-let sim = util.env("WING_TARGET") == "sim";
-
 test "single instance of Foo" {
   let x = fn.invoke("");
   let y = fn.invoke("");
@@ -41,7 +39,7 @@ test "single instance of Foo" {
 
   // the simulator intentionally reuses the sandbox across invocations
   // but we can't trust that this will always happen on the cloud
-  if sim {
+  if @target == "sim" {
     expect.equal(y, "101");
     log("client has been reused");
   }

--- a/tests/valid/intrinsics.test.w
+++ b/tests/valid/intrinsics.test.w
@@ -19,3 +19,8 @@ expect.equal(bar.Bar.getSubdir(), fs.join(@dirname, "subdir"));
 expect.equal(@filename, currentFile);
 expect.equal(fs.dirname(currentFile), @dirname);
 expect.equal(bar.Bar.getSubfile(), fs.join(@dirname, "subdir", "bar.w"));
+
+// @target
+
+// some of the targets we are testing in the monorepo - but any string is valid
+expect.ok(["sim", "tf-aws", "tf-azure", "tf-gcp", "awscdk"].contains(@target));

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/resource/on-start.test.w_test_sim.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/resource/on-start.test.w_test_sim.md
@@ -3,14 +3,14 @@
 ## stdout.log
 ```log
 [ERROR] method calls fail if the resource fails to start | Error: unexpected error!
-  --> on-start.test.w:6:5
+  --> on-start.test.w:5:5
   | 
   | inflight class OnStartThrowerBackend impl sim.IResource {
   |   new() {
-6 |     throw "unexpected error!";
+5 |     throw "unexpected error!";
   |     ^
-at $inflight_init <ABSOLUTE>/on-start.test.w:6:5
-at <ABSOLUTE>/on-start.test.w:17:18
+at $inflight_init <ABSOLUTE>/on-start.test.w:5:5
+at <ABSOLUTE>/on-start.test.w:16:18
 [ERROR] method calls fail if the resource fails to start | Error: root/Default/OnStartThrower/Resource failed to start: Error: unexpected error!
 [ERROR] method calls fail if the resource fails to start | Error: Resource is not running (it may have crashed or stopped)
 pass ─ on-start.test.wsim » root/Default/test:method calls fail if the resource fails to start

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/resource/on-stop.test.w_test_sim.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/resource/on-stop.test.w_test_sim.md
@@ -3,13 +3,13 @@
 ## stdout.log
 ```log
 [ERROR] if a resource throws an error on stopping, it doesn't crash the simulation | Error: unexpected error!
-  --> on-stop.test.w:6:5
+  --> on-stop.test.w:5:5
   | 
   | inflight class OnStopThrowerBackend impl sim.IResource {
   |   pub onStop() {
-6 |     throw "unexpected error!";
+5 |     throw "unexpected error!";
   |     ^
-at onStop <ABSOLUTE>/on-stop.test.w:6:5
+at onStop <ABSOLUTE>/on-stop.test.w:5:5
 pass ─ on-stop.test.wsim » root/Default/test:if a resource throws an error on stopping, it doesn't crash the simulation
 
 Tests 1 passed (1)

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/schedule/init.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/schedule/init.test.w_compile_tf-aws.md
@@ -1,0 +1,33 @@
+# [init.test.w](../../../../../../tests/sdk_tests/schedule/init.test.w) | compile | tf-aws
+
+## main.tf.json
+```json
+{
+  "//": {
+    "metadata": {
+      "backend": "local",
+      "stackName": "root"
+    },
+    "outputs": {}
+  },
+  "provider": {
+    "aws": [
+      {}
+    ]
+  },
+  "resource": {
+    "aws_cloudwatch_event_rule": {
+      "s0_Schedule_7FE1E150": {
+        "//": {
+          "metadata": {
+            "path": "root/Default/Default/s0/Schedule",
+            "uniqueId": "s0_Schedule_7FE1E150"
+          }
+        },
+        "schedule_expression": "rate(5 minutes)"
+      }
+    }
+  }
+}
+```
+

--- a/tools/hangar/__snapshots__/test_corpus/sdk_tests/schedule/init.test.w_test_sim.md
+++ b/tools/hangar/__snapshots__/test_corpus/sdk_tests/schedule/init.test.w_test_sim.md
@@ -1,0 +1,12 @@
+# [init.test.w](../../../../../../tests/sdk_tests/schedule/init.test.w) | test | sim
+
+## stdout.log
+```log
+pass ─ init.test.wsim (no tests)
+
+Tests 1 passed (1)
+Snapshots 1 skipped
+Test Files 1 passed (1)
+Duration <DURATION>
+```
+

--- a/tools/hangar/__snapshots__/test_corpus/valid/casting.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/casting.test.w_compile_tf-aws.md
@@ -85,11 +85,10 @@ class $Root extends $stdlib.std.Resource {
     $helpers.nodeof(this).root.$preflightTypesMap = { };
     let $preflightTypesMap = {};
     const cloud = $stdlib.cloud;
-    const util = $stdlib.util;
     const aws = require("@cdktf/provider-aws");
     $helpers.nodeof(this).root.$preflightTypesMap = $preflightTypesMap;
     const b = globalThis.$ClassFactory.new("@winglang/sdk.cloud.Bucket", cloud.Bucket, this, "Bucket");
-    if ($helpers.eq((util.Util.env("WING_TARGET")), "tf-aws")) {
+    if ($helpers.eq(process.env.WING_TARGET, "tf-aws")) {
       const s3Bucket = ($helpers.nodeof(b).findChild("Default"));
       (s3Bucket.addOverride("bucket_prefix", "my-prefix-"));
       console.log($helpers.nodeof(s3Bucket).path);

--- a/tools/hangar/__snapshots__/test_corpus/valid/inflight_handler_singleton.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/inflight_handler_singleton.test.w_compile_tf-aws.md
@@ -51,7 +51,7 @@ module.exports = function({ $foo }) {
 "use strict";
 const $helpers = require("@winglang/sdk/lib/helpers");
 const $macros = require("@winglang/sdk/lib/macros");
-module.exports = function({ $expect_Util, $fn, $fn2, $sim }) {
+module.exports = function({ $expect_Util, $fn, $fn2 }) {
   class $Closure3 {
     constructor($args) {
       const {  } = $args;
@@ -64,7 +64,7 @@ module.exports = function({ $expect_Util, $fn, $fn2, $sim }) {
       const y = (await $fn.invoke(""));
       const z = (await $fn2.invoke(""));
       (await $expect_Util.equal(x, "100"));
-      if ($sim) {
+      if ($helpers.eq(process.env.WING_TARGET, "sim")) {
         (await $expect_Util.equal(y, "101"));
         console.log("client has been reused");
       }
@@ -546,7 +546,6 @@ class $Root extends $stdlib.std.Resource {
             $expect_Util: ${$stdlib.core.liftObject($stdlib.core.toLiftableModuleType(globalThis.$ClassFactory.resolveType("@winglang/sdk.expect.Util") ?? expect.Util, "@winglang/sdk/expect", "Util"))},
             $fn: ${$stdlib.core.liftObject(fn)},
             $fn2: ${$stdlib.core.liftObject(fn2)},
-            $sim: ${$stdlib.core.liftObject(sim)},
           })
         `;
       }
@@ -556,13 +555,11 @@ class $Root extends $stdlib.std.Resource {
             [$stdlib.core.toLiftableModuleType(globalThis.$ClassFactory.resolveType("@winglang/sdk.expect.Util") ?? expect.Util, "@winglang/sdk/expect", "Util"), ["equal"]],
             [fn, ["invoke"]],
             [fn2, ["invoke"]],
-            [sim, []],
           ],
           "$inflight_init": [
             [$stdlib.core.toLiftableModuleType(globalThis.$ClassFactory.resolveType("@winglang/sdk.expect.Util") ?? expect.Util, "@winglang/sdk/expect", "Util"), []],
             [fn, []],
             [fn2, []],
-            [sim, []],
           ],
         });
       }
@@ -630,7 +627,6 @@ class $Root extends $stdlib.std.Resource {
     const foo = new Foo(this, "Foo");
     const fn = globalThis.$ClassFactory.new("@winglang/sdk.cloud.Function", cloud.Function, this, "Function", new $Closure1(this, "$Closure1"));
     const fn2 = globalThis.$ClassFactory.new("@winglang/sdk.cloud.Function", cloud.Function, this, "fn2", new $Closure2(this, "$Closure2"));
-    const sim = $helpers.eq((util.Util.env("WING_TARGET")), "sim");
     globalThis.$ClassFactory.new("@winglang/sdk.std.Test", std.Test, this, "test:single instance of Foo", new $Closure3(this, "$Closure3"));
     const fn3 = globalThis.$ClassFactory.new("@winglang/sdk.cloud.Function", cloud.Function, this, "fn3", new $Closure4(this, "$Closure4"));
     globalThis.$ClassFactory.new("@winglang/sdk.std.Test", std.Test, this, "test:Foo state is not shared between function invocations", new $Closure5(this, "$Closure5"));

--- a/tools/hangar/__snapshots__/test_corpus/valid/intrinsics.test.w_compile_tf-aws.md
+++ b/tools/hangar/__snapshots__/test_corpus/valid/intrinsics.test.w_compile_tf-aws.md
@@ -134,6 +134,7 @@ class $Root extends $stdlib.std.Resource {
     (expect.Util.equal($helpers.resolve(__dirname, "../../../intrinsics.test.w"), currentFile));
     (expect.Util.equal((fs.Util.dirname(currentFile)), $helpers.resolve(__dirname, "../../..")));
     (expect.Util.equal((bar.Bar.getSubfile(this)), (fs.Util.join($helpers.resolve(__dirname, "../../.."), "subdir", "bar.w"))));
+    (expect.Util.ok($macros.__Array_contains(false, ["sim", "tf-aws", "tf-azure", "tf-gcp", "awscdk"], process.env.WING_TARGET)));
   }
 }
 const $APP = $PlatformManager.createApp({ outdir: $outdir, name: "intrinsics.test", rootConstruct: $Root, isTestEnvironment: $wing_is_test, entrypointDir: process.env['WING_SOURCE_DIR'], rootId: process.env['WING_ROOT_ID'] });


### PR DESCRIPTION
As a more convenient alternative to importing the `util` module and using `util.env("WING_TARGET")` to obtain the current cloud target, this PR adds a dedicated intrinsic function `@target` which does the same thing.

In terms of design, the motivation of the new syntax is to make it clear that this kind of pattern (where you alter application logic or configuration based on the compilation target string) is an intended pattern in Wing and something handy for building abstractions around, not a hacky workaround.

Existing code that uses the WING_TARGET environment variable will continue to work (no current plans to deprecate it).

## Checklist

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [x] Tests added (always)
- [x] Docs updated (only required for features)
- [x] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
