### PR TITLE
fix: fs and util.exec examples do not work on windows

### DIFF
--- a/docs/by-example/30-reading-writing-files.md
+++ b/docs/by-example/30-reading-writing-files.md
@@ -11,7 +11,7 @@ image: /img/wing-by-example.png
 ```js playground example title="main.w"
 bring fs;
 
-let filename: str = "/tmp/test.txt";
+let filename: str = fs.join(@dirname, "test.txt");
 
 log(fs.exists(filename));
 
@@ -29,6 +29,8 @@ fs.appendFile(filename, "testing");
 let extendedValue = fs.readFile(filename);
 
 log(extendedValue);
+
+fs.remove(filename);
 ```
 
 ```bash title="Wing console output"

--- a/docs/by-example/35-exec-processes.md
+++ b/docs/by-example/35-exec-processes.md
@@ -11,6 +11,8 @@ image: /img/wing-by-example.png
 ```js playground example title="main.w"
 bring util;
 
+let dir = @dirname;
+
 test "exec()" {
   let output = util.exec("echo", ["-n", "Hello, Wing!"]);
 
@@ -20,8 +22,8 @@ test "exec()" {
   // exec with inherited environment variables
   let output3 = util.exec("bash", ["--norc", "--noprofile", "-c", "echo $WING_TARGET $ENV_VAR"], { inheritEnv: true });
 
-  // exec with current working directory
-  let output4 = util.exec("bash", ["--norc", "--noprofile", "-c", "echo Hello"], { cwd: "/tmp" });
+  // exec with custom working directory
+  let output4 = util.exec("bash", ["--norc", "--noprofile", "-c", "echo Hello"], { cwd: dir });
 
   log(output);
   log(output2);

--- a/docs/by-example/35-exec-processes.md
+++ b/docs/by-example/35-exec-processes.md
@@ -11,21 +11,23 @@ image: /img/wing-by-example.png
 ```js playground example title="main.w"
 bring util;
 
-let output = util.exec("echo", ["-n", "Hello, Wing!"]);
+test "exec()" {
+  let output = util.exec("echo", ["-n", "Hello, Wing!"]);
 
-// exec with custom environment variables
-let output2 = util.exec("bash", ["--norc", "--noprofile", "-c", "echo $WING_TARGET $ENV_VAR"], { env: { ENV_VAR: "Wing" } });
+  // exec with custom environment variables
+  let output2 = util.exec("bash", ["--norc", "--noprofile", "-c", "echo $WING_TARGET $ENV_VAR"], { env: { ENV_VAR: "Wing" } });
 
-// exec with inherited environment variables
-let output3 = util.exec("bash", ["--norc", "--noprofile", "-c", "echo $WING_TARGET $ENV_VAR"], { inheritEnv: true });
+  // exec with inherited environment variables
+  let output3 = util.exec("bash", ["--norc", "--noprofile", "-c", "echo $WING_TARGET $ENV_VAR"], { inheritEnv: true });
 
-// exec with current working directory
-let output4 = util.exec("bash", ["--norc", "--noprofile", "-c", "echo Hello"], { cwd: "/tmp" });
+  // exec with current working directory
+  let output4 = util.exec("bash", ["--norc", "--noprofile", "-c", "echo Hello"], { cwd: "/tmp" });
 
-log(output);
-log(output2);
-log(output3);
-log(output4);
+  log(output);
+  log(output2);
+  log(output3);
+  log(output4);
+}
 ```
 
 ```bash title="Wing console output"

--- a/tests/doc_examples/valid/30-reading-writing-files.md_example_1/main.w
+++ b/tests/doc_examples/valid/30-reading-writing-files.md_example_1/main.w
@@ -2,7 +2,7 @@
 // Example metadata: {"valid":true}
 bring fs;
 
-let filename: str = "/tmp/test.txt";
+let filename: str = fs.join(@dirname, "test.txt");
 
 log(fs.exists(filename));
 
@@ -20,3 +20,5 @@ fs.appendFile(filename, "testing");
 let extendedValue = fs.readFile(filename);
 
 log(extendedValue);
+
+fs.remove(filename);

--- a/tests/doc_examples/valid/35-exec-processes.md_example_1/main.w
+++ b/tests/doc_examples/valid/35-exec-processes.md_example_1/main.w
@@ -2,18 +2,20 @@
 // Example metadata: {"valid":true}
 bring util;
 
-let output = util.exec("echo", ["-n", "Hello, Wing!"]);
+test "exec()" {
+  let output = util.exec("echo", ["-n", "Hello, Wing!"]);
 
-// exec with custom environment variables
-let output2 = util.exec("bash", ["--norc", "--noprofile", "-c", "echo $WING_TARGET $ENV_VAR"], { env: { ENV_VAR: "Wing" } });
+  // exec with custom environment variables
+  let output2 = util.exec("bash", ["--norc", "--noprofile", "-c", "echo $WING_TARGET $ENV_VAR"], { env: { ENV_VAR: "Wing" } });
 
-// exec with inherited environment variables
-let output3 = util.exec("bash", ["--norc", "--noprofile", "-c", "echo $WING_TARGET $ENV_VAR"], { inheritEnv: true });
+  // exec with inherited environment variables
+  let output3 = util.exec("bash", ["--norc", "--noprofile", "-c", "echo $WING_TARGET $ENV_VAR"], { inheritEnv: true });
 
-// exec with current working directory
-let output4 = util.exec("bash", ["--norc", "--noprofile", "-c", "echo Hello"], { cwd: "/tmp" });
+  // exec with current working directory
+  let output4 = util.exec("bash", ["--norc", "--noprofile", "-c", "echo Hello"], { cwd: "/tmp" });
 
-log(output);
-log(output2);
-log(output3);
-log(output4);
+  log(output);
+  log(output2);
+  log(output3);
+  log(output4);
+}

--- a/tests/doc_examples/valid/35-exec-processes.md_example_1/main.w
+++ b/tests/doc_examples/valid/35-exec-processes.md_example_1/main.w
@@ -2,6 +2,8 @@
 // Example metadata: {"valid":true}
 bring util;
 
+let dir = @dirname;
+
 test "exec()" {
   let output = util.exec("echo", ["-n", "Hello, Wing!"]);
 
@@ -11,8 +13,8 @@ test "exec()" {
   // exec with inherited environment variables
   let output3 = util.exec("bash", ["--norc", "--noprofile", "-c", "echo $WING_TARGET $ENV_VAR"], { inheritEnv: true });
 
-  // exec with current working directory
-  let output4 = util.exec("bash", ["--norc", "--noprofile", "-c", "echo Hello"], { cwd: "/tmp" });
+  // exec with custom working directory
+  let output4 = util.exec("bash", ["--norc", "--noprofile", "-c", "echo Hello"], { cwd: dir });
 
   log(output);
   log(output2);


### PR DESCRIPTION
Some of the examples from our docs don't currently work on Windows, causing them to fail our CI. This PR makes some adjustments to the examples so they should work on both platforms.

One of the issues is a Windows-related bug - I've reopened an issue for tracking it: https://github.com/winglang/wing/issues/6915

## Checklist

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [ ] Tests added (always)
- [ ] Docs updated (only required for features)
- [x] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
