### PR TITLE
chore(docs): removed rfcs from search on docs website

### DIFF
--- a/docs/contributing/999-rfcs/2022-05-28-winglang-reqs.md
+++ b/docs/contributing/999-rfcs/2022-05-28-winglang-reqs.md
@@ -1,6 +1,7 @@
 ---
 title: "#3690 Language Requirements (approved)"
 description: The original requirements documents for the wing language experience
+search: false
 ---
 
 - **Author(s):**: @eladb

--- a/docs/contributing/999-rfcs/2022-06-14-polycons.md
+++ b/docs/contributing/999-rfcs/2022-06-14-polycons.md
@@ -1,6 +1,7 @@
 ---
 title: "#3692 Polycons Framework (approved)"
 description: This document describes a dependency injection meta-framework for polymorphic constructs.
+search: false
 ---
 
 > **⚠️ Note:** polycons was an early design for how to support CDK constructs that work across multiple cloud targets.

--- a/docs/contributing/999-rfcs/2022-08-22-resource-naming.md
+++ b/docs/contributing/999-rfcs/2022-08-22-resource-naming.md
@@ -1,6 +1,7 @@
 ---
 title: "#831 Resource Naming (draft)"
 description: How should the Wing SDK assign "physical names" to resources on external cloud providers?
+search: false
 ---
 
 - **Author(s):**: @Chriscbr

--- a/docs/contributing/999-rfcs/2023-01-20-wingsdk-spec.md
+++ b/docs/contributing/999-rfcs/2023-01-20-wingsdk-spec.md
@@ -1,6 +1,7 @@
 ---
 title: "#662 SDK Spec (approved)"
 description: Specification for the Wing SDK
+search: false
 ---
 
 :::caution Not fully implemented yet

--- a/docs/contributing/999-rfcs/2023-01-21-wing-plugins.md
+++ b/docs/contributing/999-rfcs/2023-01-21-wing-plugins.md
@@ -1,6 +1,7 @@
 ---
 title: "#3693 Wing Plugins (approved)"
 description: How to implement wing plugins
+search: false
 ---
 
 # Wing Plugin System

--- a/docs/contributing/999-rfcs/2023-03-08-wing-preview-environment.md
+++ b/docs/contributing/999-rfcs/2023-03-08-wing-preview-environment.md
@@ -1,6 +1,7 @@
 ---
 title: "#3696 Wing Cloud Preview Environments"
 description: This document describes an MVP for the first Wing Cloud product - Wing Cloud Preview Environments.
+search: false
 ---
 
 # Wing Cloud Preview Environments

--- a/docs/contributing/999-rfcs/2023-04-16-website-resource.md
+++ b/docs/contributing/999-rfcs/2023-04-16-website-resource.md
@@ -1,6 +1,7 @@
 ---
 title: "#3694 Website resource (approved)"
 description: How to implement the website resource
+search: false
 ---
 
 # Website resource

--- a/docs/contributing/999-rfcs/2023-06-12-language-spec.md
+++ b/docs/contributing/999-rfcs/2023-06-12-language-spec.md
@@ -3,6 +3,7 @@ title: "#3695 Wing Language Specification (approved)"
 id: language-spec
 description: The Wing Language Specification
 keywords: [Wing reference, Wing language, language, Wing language spec, Wing programming language]
+search: false
 ---
 
 :::caution Not fully implemented yet

--- a/docs/contributing/999-rfcs/2023-10-01-workloads.md
+++ b/docs/contributing/999-rfcs/2023-10-01-workloads.md
@@ -1,6 +1,7 @@
 ---
 title: "#4350 Containerized Workloads - Requirements"
 description: Requirements for containerized workloads in the Wing Cloud Library
+search: false
 ---
 
 # Containerized Workloads - Requirements Specification

--- a/docs/contributing/999-rfcs/2024-01-15-console-sign-in.md
+++ b/docs/contributing/999-rfcs/2024-01-15-console-sign-in.md
@@ -1,6 +1,7 @@
 ---
 title: "Wing Console Sign In"
 description: Requirements for Wing Console Sign In process
+search: false
 ---
 
 # Wing Console Sign In

--- a/docs/contributing/999-rfcs/2024-03-14-explicit-lift-qualification.md
+++ b/docs/contributing/999-rfcs/2024-03-14-explicit-lift-qualification.md
@@ -1,6 +1,7 @@
 ---
 title: "Explicit lift qualification"
 description: Language spec for specifying explicit lift qualifications
+search: false
 ---
 
 # Explicit lift qualification

--- a/docs/contributing/999-rfcs/2024-03-24-snapshot-tests.md
+++ b/docs/contributing/999-rfcs/2024-03-24-snapshot-tests.md
@@ -1,6 +1,7 @@
 ---
 title: "#5958 Cloud Snapshot Tests"
 description: Spec and design for adding cloud snapshots to the Wing test framework
+search: false
 ---
 
 # Cloud Snapshot Tests

--- a/docs/contributing/999-rfcs/2024-03-31-wing-secrets-cli.md
+++ b/docs/contributing/999-rfcs/2024-03-31-wing-secrets-cli.md
@@ -1,6 +1,7 @@
 ---
 title: "#6105 Wing Secrets CLI"
 description: Creating Wing secrets from the CLI
+search: false
 ---
 
 # Wing Secrets CLI

--- a/docs/contributing/999-rfcs/2024-05-07-intrinsics.md
+++ b/docs/contributing/999-rfcs/2024-05-07-intrinsics.md
@@ -1,6 +1,7 @@
 ---
 title: "Intrinsic Functions"
 description: Global compiler intrinsics
+search: false
 ---
 
 # Intrinsics

--- a/docs/contributing/999-rfcs/2024-06-02-ts-client.md
+++ b/docs/contributing/999-rfcs/2024-06-02-ts-client.md
@@ -1,6 +1,7 @@
 ---
 title: "Exported TypeScript Clients Across Wing Applications"
 description: Exported TypeScript Clients Across Wing Applications
+search: false
 ---
 
 # Exported TypeScript Clients Across Wing Applications

--- a/docs/contributing/999-rfcs/2024-06-26-wing-docs-v2.md
+++ b/docs/contributing/999-rfcs/2024-06-26-wing-docs-v2.md
@@ -1,6 +1,7 @@
 ---
 title: Wing documentation v2
 description: RFC for changes to Wing's documentation website. Including new pages and content.
+search: false
 ---
 
 # Wing documentation v2

--- a/docs/contributing/999-rfcs/2819-stdlib.md
+++ b/docs/contributing/999-rfcs/2819-stdlib.md
@@ -1,3 +1,6 @@
+---
+search: false
+---
 # #2819 Wing Utility Library (approved)
 
 - **Author(s):**: @eladb

--- a/docs/contributing/999-rfcs/overview.md
+++ b/docs/contributing/999-rfcs/overview.md
@@ -2,6 +2,7 @@
 title: RFC Workflow
 id: overview
 keywords: [rfcs, rfc, overview, process]
+search: false
 ---
 
 An RFC is short for "request for comments". It's a document that describes a new feature or change

--- a/docs/contributing/999-rfcs/template.md
+++ b/docs/contributing/999-rfcs/template.md
@@ -1,6 +1,7 @@
 ---
 title: RFC Template
 description: Template for creating a new RFC
+search: false
 ---
 
 # #{RFC Number} - {RFC_TITLE}


### PR DESCRIPTION
Attempt to fix #7198, which should remove the RFCs from the search index on the docs site. Need to log into algolia to verify, will give some time for the site to reindex too.