### PR TITLE
chore(docs): removed install instructions from docs

### DIFF
--- a/docs/docs/01-start-here/02-getting-started.md
+++ b/docs/docs/01-start-here/02-getting-started.md
@@ -1,57 +1,19 @@
 ---
 id: getting-started
-title: Getting Started
+title: Creating a project
 keywords: [Getting started, Wing installation, installation, Wing toolchain]
 slug: /
 ---
 
-Welcome, it's great to see you here!
+This guide will walk you through the following: 
 
-As you prepare to start taking flight with Wing 😉, there are a few things you need to do to get set up.
-This guide will walk you through the steps to setup Wing on your machine, create your first project, run it in the Wing Simulator and deploy it to AWS.
+- Creating your first project
+- Running your project using the Wing Simulator
+- Deploying your project to AWS
 
-:::info
-
-Wing is still in active development, and we would love to hear what you think! Please ping us on [Wing Discord](https://t.winglang.io/discord), share what you want to build
-and let us know if you encounter any issues. There's also a cute channel with music recommendations 🎶
-
+:::tip Don't have Wing installed? 
+You can get Wing installed and your IDE setup following our [installation instructions](/install).
 :::
-
-> Did you know that you can also take Wing for a spin without installing anything?
-> Check out the [Wing Playground](https://www.winglang.io/play/).
-
-## Prerequisite
-
-* [Node.js](https://nodejs.org/en/) v20 or later
-
-## Install
-
-The Wing CLI is distributed via [npm](https://www.npmjs.com/package/winglang):
-
-```sh
-npm install -g winglang
-```
-
-Verify your installation:
-```
-wing --version
-```
-
-## IDE Extension
-
-Wing has extended support for two IDEs. They provide syntax highlighting, completions, go-to-definition, etc. and embedded Wing Console support:
-
-- [VSCode](https://marketplace.visualstudio.com/items?itemName=Monada.vscode-wing) - Official extension
-- [IntelliJ](https://plugins.jetbrains.com/plugin/22353-wing) - Community extension
-
-To use Wing in other IDEs, there are a few tools available to help:
-
-- Language server - Running `wing lsp` serves the official language server
-- [TextMate grammar](https://github.com/winglang/wing/blob/main/packages/vscode-wing/syntaxes/wing.tmLanguage.json) - For syntax highlighting
-- [tree-sitter grammar and queries](https://github.com/winglang/wing/tree/main/packages/@winglang/tree-sitter-wing) - For syntax highlighting and more
-- [Syntax Highlighting for GitHub (Chrome extension)](https://chromewebstore.google.com/detail/winglang-syntax-hightligh/gjnleleianfjpmckmmdeahlklhcdlakj) - Adds syntax highlighting to various locations within GitHub
-
-## Create your project
 
 First let's create an empty directory for your project:
 
@@ -88,44 +50,6 @@ queue.setConsumer(inflight (message: str) => {
   log("file wing-{index}.txt created");
 });
 ```
-
-:::info
-
-<details>
-<summary>Experimental TypeScript Support</summary>
-
-If you'd like to use TypeScript instead of winglang, you can add the `--language ts` flag when creating a new project:
-
-```sh
-wing new empty --language ts
-```
-
-Then modify `main.ts` to have the following, equivalent to the above winglang code:
-
-```ts
-import { main, cloud, lift } from "@wingcloud/framework";
-
-main((root) => {
-  const bucket = new cloud.Bucket(root, "Bucket");
-  const counter = new cloud.Counter(root, "Counter");
-  const queue = new cloud.Queue(root, "Queue");
-
-  queue.setConsumer(
-    lift({ bucket, counter }).inflight(async ({ bucket, counter }, message) => {
-      const index = await counter.inc();
-      await bucket.put(`wing-${index}.txt`, `Hello, ${message}`);
-      console.log(`file wing-${index}.txt created`);
-    })
-  );
-});
-```
-
-The rest of the starting guide will be the same!
-See [here](../09-typescript/index.md) for more information on using TypeScript with Wing.
-  
-</details>
-
-:::
 
 Here we defined a queue and a counter. Every time a message is added to the queue, a handler is triggered and creates a file named `wing-{counter-index}.txt` with the content `"Hello, {message}!"`, and the counter is incremented by 1.
 

--- a/docs/docs/01-start-here/_category_.yml
+++ b/docs/docs/01-start-here/_category_.yml
@@ -1,3 +1,3 @@
-label: Start here 
+label: Creating a Wing application
 collapsible: false
 collapsed: false


### PR DESCRIPTION
## Checklist

This removes Wing installation instructions from the docs (as we now have a new page). But this PR requires https://github.com/winglang/docsite/pull/1041 to be merged first.

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [ ] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
