### PR TITLE
fix(sdk): logformat used in awscdk lambda functions is deprecated

### DIFF
--- a/packages/@winglang/platform-awscdk/src/function.ts
+++ b/packages/@winglang/platform-awscdk/src/function.ts
@@ -6,7 +6,7 @@ import {
   Code,
   Runtime,
   LayerVersion,
-  LogFormat,
+  LoggingFormat,
 } from "aws-cdk-lib/aws-lambda";
 import { LogGroup, RetentionDays } from "aws-cdk-lib/aws-logs";
 import { Asset } from "aws-cdk-lib/aws-s3-assets";
@@ -56,8 +56,7 @@ export function addPolicyStatements(
  */
 export class Function
   extends cloud.Function
-  implements IAwsCdkFunction, IAwsFunction
-{
+  implements IAwsCdkFunction, IAwsFunction {
   /** @internal */
   public static _toInflightType(): string {
     return InflightClient.forType(
@@ -180,8 +179,8 @@ export class Function
       props.logRetentionDays === undefined
         ? 30
         : props.logRetentionDays < 0
-        ? RetentionDays.INFINITE // Negative value means Infinite retention
-        : props.logRetentionDays;
+          ? RetentionDays.INFINITE // Negative value means Infinite retention
+          : props.logRetentionDays;
 
     const logs = new LogGroup(this, "LogGroup", {
       retention: logRetentionDays,
@@ -201,7 +200,7 @@ export class Function
       memorySize: props.memory ?? 1024,
       architecture: Architecture.ARM_64,
       logGroup: logs,
-      logFormat: LogFormat.JSON,
+      logFormat: LoggingFormat.JSON,
     });
   }
 

--- a/packages/@winglang/sdk/LICENSE
+++ b/packages/@winglang/sdk/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2024 Wing Cloud
+Copyright (c) 2025 Wing Cloud
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/vscode-wing/LICENSE
+++ b/packages/vscode-wing/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2024 Wing Cloud
+Copyright (c) 2025 Wing Cloud
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/wing-api-checker/LICENSE
+++ b/packages/wing-api-checker/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2024 Wing Cloud
+Copyright (c) 2025 Wing Cloud
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
The LogFormat used in AWS CDK for Lambda Functions is deprecated, and is being changed to LoggingFormat.

## Checklist

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [ ] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
