### PR TITLE
fix(sdk): test execution in aws-cdk

### DIFF
--- a/packages/winglang/src/commands/test/test.ts
+++ b/packages/winglang/src/commands/test/test.ts
@@ -610,7 +610,7 @@ async function testAwsCdk(synthDir: string, options: TestOptions): Promise<std.T
       const { TestRunnerClient } = await import(
         "@winglang/sdk/lib/shared-aws/test-runner.inflight"
       );
-      const runner = new TestRunnerClient(testArns);
+      const runner = new TestRunnerClient({ $tests: testArns });
 
       const allTests = await runner.listTests();
       const filteredTests = filterTests(allTests, testFilter);


### PR DESCRIPTION
The Pull Request v0.79.13 changed the way the lambdas test ARNs are passed to the TestRunnerClient, unfortunately, it was not noticed that the target awscdk should also be changed. This change allowed the tests to be executed correctly.

Closes #7229

## Checklist

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [ ] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
