### PR TITLE
fix(sdk): cloud.Service test when using tf-aws target

### DIFF
--- a/packages/@winglang/sdk/src/target-tf-aws/ecs-cluster.ts
+++ b/packages/@winglang/sdk/src/target-tf-aws/ecs-cluster.ts
@@ -16,7 +16,7 @@ export class EcsCluster {
       app.dockerProvider;
 
       clusterInstance = new Cluster(scope, "ECSCluster", {
-        name: `${app.node.id}_cluster`,
+        name: `${app.node.id.replace(".", "_")}_cluster`,
       });
 
       new EcsClusterCapacityProviders(scope, "EcsClusterCapacityProviders", {


### PR DESCRIPTION
I try to run this test whit the command `wing test --platform tf-aws minimal.test.w`

```w
bring cloud;

let s = new cloud.Service(inflight () => {
  log("hello, service!");

  return () => {
    log("stopping!");
  };
});

test "start and stop" {
  assert(s.started());
  s.stop();
  assert(!s.started());
}
```

but I get this error

```shell
$ wing test --platform tf-aws minimal.test.w
✔ Compiling minimal.test.w to tf-aws...

✔ terraform init

✖ terraform apply

Command failed: terraform apply -auto-approve
╷
│ Error: creating ECS Cluster (Test.mfet8zI2Z4_cluster): InvalidParameterException: Cluster name must match ^[a-zA-Z0-9\-_]{1,255}$, but was Test.mfet8zI2Z4_cluster
│
│   with aws_ecs_cluster.Testmfet8zI2Z4_env0_Service_ECSCluster_1D77BD98,
│   on main.tf.json line 116, in resource.aws_ecs_cluster.Testmfet8zI2Z4_env0_Service_ECSCluster_1D77BD98:
│  116:       }
│
╵

✔ terraform destroy


Tests 1 failed (1)
Snapshots 1 skipped
Test Files 1 failed (1)
Duration 3m29.12s
```

When objects are generated for the test, the default is to generate the cluster name like this Test.mfet8zI2Z4_cluster. 
However, the cluster name cannot have a `.`, so I made a small adjustment to replace `.` with `_` to avoid this error


## Checklist

- [x] Title matches [Winglang's style guide](https://www.winglang.io/contributing/start-here/pull_requests#how-are-pull-request-titles-formatted)
- [x] Description explains motivation and solution
- [ ] Tests added (always)
- [ ] Docs updated (only required for features)
- [ ] Added `pr/e2e-full` label if this feature requires end-to-end testing

*By submitting this pull request, I confirm that my contribution is made under the terms of the [Wing Cloud Contribution License](https://github.com/winglang/wing/blob/main/CONTRIBUTION_LICENSE.md)*.
