### PR TITLE
fix(vscode): error connecting to lsp in windows

### DIFF
--- a/packages/vscode-wing/src/lsp.ts
+++ b/packages/vscode-wing/src/lsp.ts
@@ -34,6 +34,8 @@ export class LanguageServerManager {
         env: {
           ...process.env,
         },
+        // Node will throw `EINVAL` in Windows if `shell` is not true. See https://github.com/winglang/wing/issues/7231.
+        shell: true,
       },
     };
     const serverOptions: ServerOptions = {


### PR DESCRIPTION
Define `shell: true` in the options used to spawn the language server.

Fixes #7231.