### PR TITLE
fix(repo): test workflow failing due to bad turbo config

### DIFF
--- a/packages/@winglang/tree-sitter-wing/turbo.json
+++ b/packages/@winglang/tree-sitter-wing/turbo.json
@@ -11,7 +11,7 @@
       "outputs": ["tree-sitter-wing.wasm"]
     },
     "compile": {
-      "dependsOn": ["build:generate"],
+      "dependsOn": ["build:generate", "build:wasm"],
       "inputs": [""]
     },
     "test": {

--- a/packages/@winglang/wingc/turbo.json
+++ b/packages/@winglang/wingc/turbo.json
@@ -2,6 +2,9 @@
   "$schema": "https://turborepo.org/schema.json",
   "extends": ["//"],
   "tasks": {
+    "lint": {
+      "dependsOn": ["^compile"]
+    },
     "compile": {
       "dependsOn": [
         "@winglang/wingii#compile",


### PR DESCRIPTION
The `wingc`'s `lint` task depends on `tree-sitter-wing`'s `build:generate` task, but it wasn't specified in the turbo config. It was working due to the previous build workflow which ran a full build and provided the necessary assets through the cache.