### PR TITLE
fix: faulty test import

### DIFF
--- a/packages/@winglang/platform-awscdk/test/service.test.ts
+++ b/packages/@winglang/platform-awscdk/test/service.test.ts
@@ -2,7 +2,7 @@ import { Template } from "aws-cdk-lib/assertions";
 import { test, expect } from "vitest";
 import { cloud } from "@winglang/sdk";
 import { AwsCdkApp } from "./util";
-import { inflight } from "@winglang/sdk/src/core";
+import { inflight } from "@winglang/sdk/lib/core";
 
 const INFLIGHT_CODE = inflight(async (_, name) => {
   console.log("Hello " + name);


### PR DESCRIPTION
The test was importing from the `src/` directory of one package, and while this works locally, in the CI setup there's no `src/` anymore but `lib/`.