### PR TITLE
fix: stop using turbo cache misses

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -220,7 +220,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        runner: [ubuntu-latest, macos-13]
+        runner: [ubuntu-latest, macos-13, windows-latest]
         node: ["20", "18"]
         shard: ["1/2", "2/2"]
         full_run:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,6 @@ env:
   CARGO_TERM_COLOR: always
   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
   TURBO_TEAM: ${{ vars.TURBO_TEAM }}
-  TURBO_FORCE: true # force a cache miss until we fix the turbo cache config
   IS_SAME_REPO_PR: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}
 
 jobs:


### PR DESCRIPTION
Removes the `TURBO_FORCE` environment variables from the CI workflows, which forced a cache miss on turbo, meaning that all tasks were always executed no matter what.

Additionally, restores `windows` as an image for the e2e runner.